### PR TITLE
Added saved member views to members-forward

### DIFF
--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -270,7 +270,7 @@ describe("useUserPreferences", () => {
             await waitForQuerySettled(result);
 
             expect(result.current.data).toEqual({
-                expanded: { posts: false },
+                expanded: { posts: false, members: true },
                 menu: { visible: true },
             });
         });
@@ -337,7 +337,7 @@ describe("useEditUserPreferences", () => {
             const { query, mutation } = await setup({
                 accessibility: JSON.stringify({
                     navigation: {
-                        expanded: { posts: false },
+                        expanded: { posts: false, members: false },
                         menu: { visible: true },
                     },
                     nightShift: true,
@@ -353,7 +353,7 @@ describe("useEditUserPreferences", () => {
             await waitFor(() => {
                 expect(query.current.data).toEqual({
                     navigation: {
-                        expanded: { posts: true },
+                        expanded: { posts: true, members: false },
                         menu: { visible: true }, // Preserved
                     },
                     nightShift: true, // Preserved

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -11,13 +11,14 @@ const WhatsNewPreferencesSchema = z.looseObject({
 });
 
 export const DEFAULT_NAVIGATION_PREFERENCES = {
-    expanded: { posts: true },
+    expanded: { posts: true, members: true },
     menu: { visible: true },
 } as const;
 
 export const NavigationPreferencesSchema = z.looseObject({
     expanded: z.object({
         posts: z.boolean(),
+        members: z.boolean().default(true),
     }),
     menu: z.object({
         visible: z.boolean(),

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -1,4 +1,4 @@
-import { useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
+import { DEFAULT_NAVIGATION_PREFERENCES, useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
 import { useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
 
 
@@ -29,6 +29,7 @@ export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['
     const setExpanded = async (value: boolean) => {
         return editNavigationPreferences({
             expanded: {
+                ...(navigationPreferences?.expanded ?? DEFAULT_NAVIGATION_PREFERENCES.expanded),
                 [expandedKey]: value
             },
         });

--- a/apps/admin/src/layout/app-sidebar/member-sidebar-views.ts
+++ b/apps/admin/src/layout/app-sidebar/member-sidebar-views.ts
@@ -1,0 +1,40 @@
+import {useLocation} from '@tryghost/admin-x-framework';
+import {useMemo} from 'react';
+import {type NavSavedView} from './nav-saved-views';
+import {type SharedView, useSharedViews} from './shared-views';
+
+interface MemberSidebarView extends SharedView {
+    route: 'members';
+    filter: Record<string, string | null> & {
+        filter: string;
+    };
+}
+
+function isMemberSidebarView(view: SharedView): view is MemberSidebarView {
+    return view.route === 'members' && typeof view.filter.filter === 'string' && view.filter.filter.length > 0;
+}
+
+function getMemberViewUrl(filter: string) {
+    return `members-forward?${new URLSearchParams({filter}).toString()}`;
+}
+
+function isMemberViewActive(currentSearch: string, filter: string) {
+    return new URLSearchParams(currentSearch).get('filter') === filter;
+}
+
+export function useMemberSidebarViews() {
+    const location = useLocation();
+    const sharedViews = useSharedViews('members');
+    const isOnMembersForward = location.pathname === '/members-forward';
+
+    return useMemo<NavSavedView[]>(() => {
+        return sharedViews
+            .filter(isMemberSidebarView)
+            .map((view) => ({
+                key: `${view.name}:${view.filter.filter}`,
+                name: view.name,
+                to: getMemberViewUrl(view.filter.filter),
+                isActive: isOnMembersForward && isMemberViewActive(location.search, view.filter.filter)
+            }));
+    }, [isOnMembersForward, location.search, sharedViews]);
+}

--- a/apps/admin/src/layout/app-sidebar/nav-content.helpers.test.ts
+++ b/apps/admin/src/layout/app-sidebar/nav-content.helpers.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, it} from 'vitest';
+import {getMembersNavActiveRoutes, isMembersNavActive} from './nav-content.helpers';
+
+describe('getMembersNavActiveRoutes', () => {
+    it('includes members-forward route when members forward is enabled', () => {
+        expect(getMembersNavActiveRoutes(true)).toEqual([
+            'members-forward',
+            'members',
+            'member',
+            'member.new'
+        ]);
+    });
+
+    it('does not include members-forward route when members forward is disabled', () => {
+        expect(getMembersNavActiveRoutes(false)).toEqual([
+            'members',
+            'member',
+            'member.new'
+        ]);
+    });
+});
+
+describe('isMembersNavActive', () => {
+    it('uses the legacy route active state when members forward is disabled', () => {
+        expect(isMembersNavActive({
+            membersForwardEnabled: false,
+            isOnMembersForward: false,
+            hasActiveMemberView: false,
+            isLegacyMembersRouteActive: true
+        })).toBe(true);
+    });
+
+    it('marks the base Members link inactive when a saved member view is active', () => {
+        expect(isMembersNavActive({
+            membersForwardEnabled: true,
+            isOnMembersForward: true,
+            hasActiveMemberView: true,
+            isLegacyMembersRouteActive: false
+        })).toBe(false);
+    });
+
+    it('falls back to the base Members link when no saved member view is active', () => {
+        expect(isMembersNavActive({
+            membersForwardEnabled: true,
+            isOnMembersForward: true,
+            hasActiveMemberView: false,
+            isLegacyMembersRouteActive: false
+        })).toBe(true);
+    });
+});

--- a/apps/admin/src/layout/app-sidebar/nav-content.helpers.test.ts
+++ b/apps/admin/src/layout/app-sidebar/nav-content.helpers.test.ts
@@ -2,17 +2,9 @@ import {describe, expect, it} from 'vitest';
 import {getMembersNavActiveRoutes, isMembersNavActive} from './nav-content.helpers';
 
 describe('getMembersNavActiveRoutes', () => {
-    it('includes members-forward route when members forward is enabled', () => {
-        expect(getMembersNavActiveRoutes(true)).toEqual([
+    it('always includes members-forward alongside the legacy members routes', () => {
+        expect(getMembersNavActiveRoutes()).toEqual([
             'members-forward',
-            'members',
-            'member',
-            'member.new'
-        ]);
-    });
-
-    it('does not include members-forward route when members forward is disabled', () => {
-        expect(getMembersNavActiveRoutes(false)).toEqual([
             'members',
             'member',
             'member.new'

--- a/apps/admin/src/layout/app-sidebar/nav-content.helpers.ts
+++ b/apps/admin/src/layout/app-sidebar/nav-content.helpers.ts
@@ -1,0 +1,29 @@
+export function getMembersNavActiveRoutes(membersForwardEnabled: boolean): string[] {
+    if (membersForwardEnabled) {
+        return ['members-forward', 'members', 'member', 'member.new'];
+    }
+
+    return ['members', 'member', 'member.new'];
+}
+
+export function isMembersNavActive({
+    membersForwardEnabled,
+    isOnMembersForward,
+    hasActiveMemberView,
+    isLegacyMembersRouteActive
+}: {
+    membersForwardEnabled: boolean;
+    isOnMembersForward: boolean;
+    hasActiveMemberView: boolean;
+    isLegacyMembersRouteActive: boolean;
+}): boolean {
+    if (!membersForwardEnabled) {
+        return isLegacyMembersRouteActive;
+    }
+
+    if (isOnMembersForward) {
+        return !hasActiveMemberView;
+    }
+
+    return isLegacyMembersRouteActive;
+}

--- a/apps/admin/src/layout/app-sidebar/nav-content.helpers.ts
+++ b/apps/admin/src/layout/app-sidebar/nav-content.helpers.ts
@@ -1,9 +1,6 @@
-export function getMembersNavActiveRoutes(membersForwardEnabled: boolean): string[] {
-    if (membersForwardEnabled) {
-        return ['members-forward', 'members', 'member', 'member.new'];
-    }
-
-    return ['members', 'member', 'member.new'];
+export function getMembersNavActiveRoutes(): string[] {
+    // TODO: Remove members-forward once the membersForward flag and legacy route split are gone.
+    return ['members-forward', 'members', 'member', 'member.new'];
 }
 
 export function isMembersNavActive({

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -9,6 +9,7 @@ import {
     SidebarMenu,
     SidebarMenuBadge
 } from "@tryghost/shade"
+import { useLocation } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { canManageMembers, canManageTags } from "@tryghost/admin-x-framework/api/users";
 import { NavMenuItem } from "./nav-menu-item";
@@ -16,12 +17,19 @@ import NavSubMenu from "./nav-sub-menu";
 import { useMemberCount } from "./hooks/use-member-count";
 import { useNavigationExpanded } from "./hooks/use-navigation-preferences";
 import { NavCustomViews } from "./nav-custom-views";
+import { NavMemberViews } from "./nav-member-views";
+import { getMembersNavActiveRoutes, isMembersNavActive } from "./nav-content.helpers";
+import { isMemberViewSearchActive, useMemberViews } from "@tryghost/posts/src/views/members/hooks/use-member-views";
 import { useEmberRouting } from "@/ember-bridge";
 import { useFeatureFlag } from "@/hooks/use-feature-flag";
 
 function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const { data: currentUser } = useCurrentUser();
     const [postsExpanded, setPostsExpanded] = useNavigationExpanded('posts');
+    const [membersExpanded, setMembersExpanded] = useNavigationExpanded('members');
+    const memberViews = useMemberViews();
+    const hasMemberViews = memberViews.length > 0;
+    const location = useLocation();
     const memberCount = useMemberCount();
     const routing = useEmberRouting();
     const commentModerationEnabled = useFeatureFlag('commentModeration');
@@ -29,6 +37,16 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
 
     const showTags = currentUser && canManageTags(currentUser);
     const showMembers = currentUser && canManageMembers(currentUser);
+    const isOnMembersForward = location.pathname === '/members-forward';
+    const hasActiveMemberView = isOnMembersForward && memberViews.some(view =>
+        isMemberViewSearchActive(location.search, view)
+    );
+    const membersNavActive = isMembersNavActive({
+        membersForwardEnabled,
+        isOnMembersForward,
+        hasActiveMemberView,
+        isLegacyMembersRouteActive: routing.isRouteActive(getMembersNavActiveRoutes(membersForwardEnabled))
+    });
 
     return (
         <SidebarGroup {...props}>
@@ -127,18 +145,44 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                     )}
 
                     {showMembers && (
-                        <NavMenuItem>
-                            <NavMenuItem.Link
-                                to={membersForwardEnabled ? 'members-forward' : routing.getRouteUrl('members')}
-                                isActive={routing.isRouteActive(['members', 'member', 'member.new'])}
-                            >
-                                <LucideIcon.Users />
-                                <NavMenuItem.Label>Members</NavMenuItem.Label>
-                            </NavMenuItem.Link>
-                            {memberCount != null && (
-                                <SidebarMenuBadge>{(formatNumber as (value: number) => string)(memberCount)}</SidebarMenuBadge>
+                        <>
+                            <NavMenuItem>
+                                {membersForwardEnabled && hasMemberViews && (
+                                    <Button
+                                        aria-controls="members-submenu"
+                                        aria-expanded={membersExpanded}
+                                        aria-label="Toggle member views"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-[34px]! absolute sidebar:opacity-0 group-hover/menu-item:opacity-100 focus-visible:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto text-sidebar-accent-foreground hover:text-gray-black hover:bg-transparent"
+                                        onClick={() =>
+                                            void setMembersExpanded(!membersExpanded)
+                                        }
+                                    >
+                                        <LucideIcon.ChevronRight
+                                            size={16}
+                                            className={`transition-all ${membersExpanded && 'rotate-[90deg]'}`}
+                                        />
+                                    </Button>
+                                )}
+                                <NavMenuItem.Link
+                                    to={membersForwardEnabled ? 'members-forward' : routing.getRouteUrl('members')}
+                                    isActive={membersNavActive}
+                                >
+                                    <LucideIcon.Users className={membersForwardEnabled && hasMemberViews ? "opacity-0 sidebar:opacity-100 sidebar:group-hover/menu-item:opacity-0 pointer-events-none transition-all" : ""} />
+                                    <NavMenuItem.Label>Members</NavMenuItem.Label>
+                                </NavMenuItem.Link>
+                                {memberCount != null && (
+                                    <SidebarMenuBadge>{(formatNumber as (value: number) => string)(memberCount)}</SidebarMenuBadge>
+                                )}
+                            </NavMenuItem>
+
+                            {membersForwardEnabled && hasMemberViews && (
+                                <NavSubMenu id="members-submenu" isExpanded={membersExpanded}>
+                                    <NavMemberViews />
+                                </NavSubMenu>
                             )}
-                        </NavMenuItem>
+                        </>
                     )}
 
                     {showMembers && commentModerationEnabled && (

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -26,7 +26,7 @@ import { useFeatureFlag } from "@/hooks/use-feature-flag";
 function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const { data: currentUser } = useCurrentUser();
     const [postsExpanded, setPostsExpanded] = useNavigationExpanded('posts');
-    const [membersExpanded, setMembersExpanded] = useNavigationExpanded('members');
+    const [savedMembersExpanded, setMembersExpanded] = useNavigationExpanded('members');
     const memberViews = useMemberSidebarViews();
     const hasMemberViews = memberViews.length > 0;
     const location = useLocation();
@@ -39,6 +39,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const showMembers = currentUser && canManageMembers(currentUser);
     const isOnMembersForward = location.pathname === '/members-forward';
     const hasActiveMemberView = isOnMembersForward && memberViews.some(view => view.isActive);
+    const membersExpanded = savedMembersExpanded || hasActiveMemberView;
     const membersNavActive = isMembersNavActive({
         membersForwardEnabled,
         isOnMembersForward,

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -18,8 +18,8 @@ import { useMemberCount } from "./hooks/use-member-count";
 import { useNavigationExpanded } from "./hooks/use-navigation-preferences";
 import { NavCustomViews } from "./nav-custom-views";
 import { NavMemberViews } from "./nav-member-views";
+import { useMemberSidebarViews } from "./member-sidebar-views";
 import { getMembersNavActiveRoutes, isMembersNavActive } from "./nav-content.helpers";
-import { isMemberViewSearchActive, useMemberViews } from "@tryghost/posts/src/views/members/hooks/use-member-views";
 import { useEmberRouting } from "@/ember-bridge";
 import { useFeatureFlag } from "@/hooks/use-feature-flag";
 
@@ -27,7 +27,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const { data: currentUser } = useCurrentUser();
     const [postsExpanded, setPostsExpanded] = useNavigationExpanded('posts');
     const [membersExpanded, setMembersExpanded] = useNavigationExpanded('members');
-    const memberViews = useMemberViews();
+    const memberViews = useMemberSidebarViews();
     const hasMemberViews = memberViews.length > 0;
     const location = useLocation();
     const memberCount = useMemberCount();
@@ -38,14 +38,12 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const showTags = currentUser && canManageTags(currentUser);
     const showMembers = currentUser && canManageMembers(currentUser);
     const isOnMembersForward = location.pathname === '/members-forward';
-    const hasActiveMemberView = isOnMembersForward && memberViews.some(view =>
-        isMemberViewSearchActive(location.search, view)
-    );
+    const hasActiveMemberView = isOnMembersForward && memberViews.some(view => view.isActive);
     const membersNavActive = isMembersNavActive({
         membersForwardEnabled,
         isOnMembersForward,
         hasActiveMemberView,
-        isLegacyMembersRouteActive: routing.isRouteActive(getMembersNavActiveRoutes(membersForwardEnabled))
+        isLegacyMembersRouteActive: routing.isRouteActive(getMembersNavActiveRoutes())
     });
 
     return (

--- a/apps/admin/src/layout/app-sidebar/nav-custom-views.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-custom-views.tsx
@@ -1,89 +1,29 @@
 import { useMemo } from 'react';
-import { z } from 'zod';
-import { useBrowseSettings, getSettingValue } from '@tryghost/admin-x-framework/api/settings';
-import { NavMenuItem } from './nav-menu-item';
+import { NavSavedViews } from './nav-saved-views';
+import { useSharedViews } from './shared-views';
 import { useEmberRouting } from '@/ember-bridge';
-
-const customViewSchema = z.object({
-    name: z.string(),
-    route: z.string(),
-    color: z.string(),
-    icon: z.string().optional(),
-    filter: z.record(z.string(), z.string().nullable())
-});
-const customViewsArraySchema = z.array(customViewSchema);
-
-function getColorHex(color: string): string {
-    const colorMap: Record<string, string> = {
-        'midgrey': '#7C8B9A',
-        'blue': '#14b8ff',
-        'green': '#30cf43',
-        'red': '#f50b23',
-        'teal': '#4dcddc',
-        'purple': '#8e42ff',
-        'yellow': '#ffb41f',
-        'orange': '#fe8b05',
-        'pink': '#fb2d8d'
-    };
-    return colorMap[color] || '#7C8B9A';
-}
 
 interface NavCustomViewsProps {
     route?: 'posts' | 'pages';
 }
 
 export function NavCustomViews({ route = 'posts' }: NavCustomViewsProps) {
-    const { data: settingsData } = useBrowseSettings();
     const routing = useEmberRouting();
+    const sharedViews = useSharedViews(route);
 
     const customViews = useMemo(() => {
-        const sharedViewsJson = getSettingValue<string>(settingsData?.settings, 'shared_views') ?? '[]';
+        return sharedViews.map((view) => {
+            const to = routing.getRouteUrl(route, view.filter);
 
-        try {
-            const parsed: unknown = JSON.parse(sharedViewsJson);
-            const result = customViewsArraySchema.safeParse(parsed);
+            return {
+                key: to,
+                name: view.name,
+                to,
+                isActive: routing.isRouteActive(route, view.filter),
+                color: view.color
+            };
+        });
+    }, [route, routing, sharedViews]);
 
-            if (!result.success) {
-                console.error('Failed to validate shared_views setting:', result.error);
-                return [];
-            }
-
-            return result.data.filter(view => view.route === route);
-        } catch (e) {
-            console.error('Failed to parse shared_views setting:', e);
-            return [];
-        }
-    }, [settingsData, route]);
-
-    if (customViews.length === 0) {
-        return null;
-    }
-
-    return (
-        <>
-            {customViews.map((view) => {
-                const viewUrl = routing.getRouteUrl(route, view.filter);
-                const isActive = routing.isRouteActive(route, view.filter);
-
-                return (
-                    <NavMenuItem key={viewUrl}>
-                        <NavMenuItem.Link
-                            className="pl-9"
-                            to={viewUrl}
-                            isActive={isActive}
-                        >
-                            <NavMenuItem.Label className="grow">{view.name}</NavMenuItem.Label>
-                            <span
-                                className="size-2 rounded-full shrink-0 mx-0.5"
-                                style={{backgroundColor: getColorHex(view.color)}}
-                                data-color={view.color}
-                                aria-hidden="true"
-                            />
-                        </NavMenuItem.Link>
-                    </NavMenuItem>
-                );
-            })}
-        </>
-    );
+    return <NavSavedViews views={customViews} />;
 }
-

--- a/apps/admin/src/layout/app-sidebar/nav-member-views.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-member-views.tsx
@@ -1,49 +1,7 @@
-import {useLocation} from '@tryghost/admin-x-framework';
-import {NavMenuItem} from './nav-menu-item';
-import {filterRecordToSearchParams, isMemberViewSearchActive, useMemberViews, type MemberView} from '@tryghost/posts/src/views/members/hooks/use-member-views';
-
-function MemberViewItem({view, isOnMembersForward, currentSearch}: {
-    view: MemberView;
-    isOnMembersForward: boolean;
-    currentSearch: string;
-}) {
-    const searchString = filterRecordToSearchParams(view.filter).toString();
-    const to = searchString ? `members-forward?${searchString}` : 'members-forward';
-    const active = isOnMembersForward && isMemberViewSearchActive(currentSearch, view);
-
-    return (
-        <NavMenuItem>
-            <NavMenuItem.Link
-                className="pl-9"
-                to={to}
-                isActive={active}
-            >
-                <NavMenuItem.Label>{view.name}</NavMenuItem.Label>
-            </NavMenuItem.Link>
-        </NavMenuItem>
-    );
-}
+import {NavSavedViews} from './nav-saved-views';
+import {useMemberSidebarViews} from './member-sidebar-views';
 
 export function NavMemberViews() {
-    const memberViews = useMemberViews();
-    const location = useLocation();
-
-    if (memberViews.length === 0) {
-        return null;
-    }
-
-    const isOnMembersForward = location.pathname === '/members-forward';
-
-    return (
-        <>
-            {memberViews.map(view => (
-                <MemberViewItem
-                    key={`${view.name}:${view.filter.filter}`}
-                    currentSearch={location.search}
-                    isOnMembersForward={isOnMembersForward}
-                    view={view}
-                />
-            ))}
-        </>
-    );
+    const memberViews = useMemberSidebarViews();
+    return <NavSavedViews views={memberViews} />;
 }

--- a/apps/admin/src/layout/app-sidebar/nav-member-views.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-member-views.tsx
@@ -1,0 +1,49 @@
+import {useLocation} from '@tryghost/admin-x-framework';
+import {NavMenuItem} from './nav-menu-item';
+import {filterRecordToSearchParams, isMemberViewSearchActive, useMemberViews, type MemberView} from '@tryghost/posts/src/views/members/hooks/use-member-views';
+
+function MemberViewItem({view, isOnMembersForward, currentSearch}: {
+    view: MemberView;
+    isOnMembersForward: boolean;
+    currentSearch: string;
+}) {
+    const searchString = filterRecordToSearchParams(view.filter).toString();
+    const to = searchString ? `members-forward?${searchString}` : 'members-forward';
+    const active = isOnMembersForward && isMemberViewSearchActive(currentSearch, view);
+
+    return (
+        <NavMenuItem>
+            <NavMenuItem.Link
+                className="pl-9"
+                to={to}
+                isActive={active}
+            >
+                <NavMenuItem.Label>{view.name}</NavMenuItem.Label>
+            </NavMenuItem.Link>
+        </NavMenuItem>
+    );
+}
+
+export function NavMemberViews() {
+    const memberViews = useMemberViews();
+    const location = useLocation();
+
+    if (memberViews.length === 0) {
+        return null;
+    }
+
+    const isOnMembersForward = location.pathname === '/members-forward';
+
+    return (
+        <>
+            {memberViews.map(view => (
+                <MemberViewItem
+                    key={`${view.name}:${view.filter.filter}`}
+                    currentSearch={location.search}
+                    isOnMembersForward={isOnMembersForward}
+                    view={view}
+                />
+            ))}
+        </>
+    );
+}

--- a/apps/admin/src/layout/app-sidebar/nav-saved-views.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-saved-views.tsx
@@ -1,0 +1,44 @@
+import {NavMenuItem} from './nav-menu-item';
+import {getColorHex} from './shared-views';
+
+export interface NavSavedView {
+    key: string;
+    name: string;
+    to: string;
+    isActive: boolean;
+    color?: string;
+}
+
+interface NavSavedViewsProps {
+    views: NavSavedView[];
+}
+
+export function NavSavedViews({views}: NavSavedViewsProps) {
+    if (views.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            {views.map((view) => (
+                <NavMenuItem key={view.key}>
+                    <NavMenuItem.Link
+                        className="pl-9"
+                        to={view.to}
+                        isActive={view.isActive}
+                    >
+                        <NavMenuItem.Label className={view.color ? 'grow' : undefined}>{view.name}</NavMenuItem.Label>
+                        {view.color && (
+                            <span
+                                className="size-2 rounded-full shrink-0 mx-0.5"
+                                style={{backgroundColor: getColorHex(view.color)}}
+                                data-color={view.color}
+                                aria-hidden="true"
+                            />
+                        )}
+                    </NavMenuItem.Link>
+                </NavMenuItem>
+            ))}
+        </>
+    );
+}

--- a/apps/admin/src/layout/app-sidebar/shared-views.ts
+++ b/apps/admin/src/layout/app-sidebar/shared-views.ts
@@ -1,18 +1,8 @@
 import {useMemo} from 'react';
-import {z} from 'zod';
+import {parseAllSharedViewsJSON} from '@tryghost/posts/src/views/members/shared-views';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 
-export const sharedViewSchema = z.object({
-    name: z.string(),
-    route: z.string(),
-    color: z.string().optional(),
-    icon: z.string().optional(),
-    filter: z.record(z.string(), z.string().nullable())
-});
-
-const sharedViewsArraySchema = z.array(sharedViewSchema);
-
-export type SharedView = z.infer<typeof sharedViewSchema>;
+export type {SharedView} from '@tryghost/posts/src/views/members/shared-views';
 
 export function getColorHex(color: string): string {
     const colorMap: Record<string, string> = {
@@ -34,25 +24,19 @@ export function useSharedViews(route?: string) {
     const {data: settingsData} = useBrowseSettings();
 
     return useMemo(() => {
+        // TODO: Consolidate shared view parsing once the admin and posts apps are merged.
         const sharedViewsJson = getSettingValue<string>(settingsData?.settings, 'shared_views') ?? '[]';
+        const parsed = parseAllSharedViewsJSON(sharedViewsJson);
 
-        try {
-            const parsed: unknown = JSON.parse(sharedViewsJson);
-            const result = sharedViewsArraySchema.safeParse(parsed);
-
-            if (!result.success) {
-                console.error('Failed to validate shared_views setting:', result.error);
-                return [];
-            }
-
-            if (!route) {
-                return result.data;
-            }
-
-            return result.data.filter(view => view.route === route);
-        } catch (error) {
-            console.error('Failed to parse shared_views setting:', error);
+        if (!parsed.ok) {
+            console.error('Failed to parse shared_views setting:', parsed.error);
             return [];
         }
+
+        if (!route) {
+            return parsed.views;
+        }
+
+        return parsed.views.filter(view => view.route === route);
     }, [settingsData, route]);
 }

--- a/apps/admin/src/layout/app-sidebar/shared-views.ts
+++ b/apps/admin/src/layout/app-sidebar/shared-views.ts
@@ -1,0 +1,58 @@
+import {useMemo} from 'react';
+import {z} from 'zod';
+import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+
+export const sharedViewSchema = z.object({
+    name: z.string(),
+    route: z.string(),
+    color: z.string().optional(),
+    icon: z.string().optional(),
+    filter: z.record(z.string(), z.string().nullable())
+});
+
+const sharedViewsArraySchema = z.array(sharedViewSchema);
+
+export type SharedView = z.infer<typeof sharedViewSchema>;
+
+export function getColorHex(color: string): string {
+    const colorMap: Record<string, string> = {
+        midgrey: '#7C8B9A',
+        blue: '#14b8ff',
+        green: '#30cf43',
+        red: '#f50b23',
+        teal: '#4dcddc',
+        purple: '#8e42ff',
+        yellow: '#ffb41f',
+        orange: '#fe8b05',
+        pink: '#fb2d8d'
+    };
+
+    return colorMap[color] || '#7C8B9A';
+}
+
+export function useSharedViews(route?: string) {
+    const {data: settingsData} = useBrowseSettings();
+
+    return useMemo(() => {
+        const sharedViewsJson = getSettingValue<string>(settingsData?.settings, 'shared_views') ?? '[]';
+
+        try {
+            const parsed: unknown = JSON.parse(sharedViewsJson);
+            const result = sharedViewsArraySchema.safeParse(parsed);
+
+            if (!result.success) {
+                console.error('Failed to validate shared_views setting:', result.error);
+                return [];
+            }
+
+            if (!route) {
+                return result.data;
+            }
+
+            return result.data.filter(view => view.route === route);
+        } catch (error) {
+            console.error('Failed to parse shared_views setting:', error);
+            return [];
+        }
+    }, [settingsData, route]);
+}

--- a/apps/posts/src/views/members/components/manage-view-popover.tsx
+++ b/apps/posts/src/views/members/components/manage-view-popover.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {Button, Input, Popover, PopoverContent, PopoverTrigger} from '@tryghost/shade';
 import {type MemberView, useDeleteMemberView, useSaveMemberView} from '../hooks/use-member-views';
 
@@ -9,9 +9,12 @@ interface ManageViewPopoverProps {
     onDeleted?: () => void;
 }
 
-const ManageViewPopover: React.FC<ManageViewPopoverProps> = ({filter, existingViews, activeView, onDeleted}) => {
-    const [open, setOpen] = useState(false);
-    const [name, setName] = useState('');
+interface ManageViewPopoverContentProps extends ManageViewPopoverProps {
+    onClose: () => void;
+}
+
+const ManageViewPopoverContent: React.FC<ManageViewPopoverContentProps> = ({filter, existingViews, activeView, onDeleted, onClose}) => {
+    const [name, setName] = useState(() => activeView?.name ?? '');
     const [error, setError] = useState('');
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
@@ -20,12 +23,6 @@ const ManageViewPopover: React.FC<ManageViewPopoverProps> = ({filter, existingVi
     const deleteMemberView = useDeleteMemberView();
 
     const isEditing = Boolean(activeView);
-
-    useEffect(() => {
-        if (open && activeView) {
-            setName(activeView.name);
-        }
-    }, [open, activeView]);
 
     const handleSave = async () => {
         const trimmed = name.trim();
@@ -48,9 +45,7 @@ const ManageViewPopover: React.FC<ManageViewPopoverProps> = ({filter, existingVi
 
         try {
             await saveMemberView(trimmed, filter, activeView ?? undefined);
-            setName('');
-            setError('');
-            setOpen(false);
+            onClose();
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to save view');
         } finally {
@@ -67,10 +62,7 @@ const ManageViewPopover: React.FC<ManageViewPopoverProps> = ({filter, existingVi
 
         try {
             await deleteMemberView(activeView);
-            setName('');
-            setError('');
-            setConfirmingDelete(false);
-            setOpen(false);
+            onClose();
             onDeleted?.();
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to delete view');
@@ -87,102 +79,112 @@ const ManageViewPopover: React.FC<ManageViewPopoverProps> = ({filter, existingVi
     };
 
     return (
-        <Popover open={open} onOpenChange={(isOpen) => {
-            setOpen(isOpen);
+        <PopoverContent align="end" className="w-72">
+            <div className="flex flex-col gap-3">
+                <h3 className="text-sm font-semibold">{isEditing ? 'Edit view' : 'Save view'}</h3>
+                <div className="flex flex-col gap-1.5">
+                    <Input
+                        placeholder="View name"
+                        value={name}
+                        autoFocus
+                        onChange={(event) => {
+                            setName(event.target.value);
 
-            if (!isOpen) {
-                setName('');
-                setError('');
-                setConfirmingDelete(false);
-            }
-        }}>
-            <PopoverTrigger asChild>
-                <Button variant="outline">
-                    {isEditing ? 'Edit view' : 'Save view'}
-                </Button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-72">
-                <div className="flex flex-col gap-3">
-                    <h3 className="text-sm font-semibold">{isEditing ? 'Edit view' : 'Save view'}</h3>
-                    <div className="flex flex-col gap-1.5">
-                        <Input
-                            placeholder="View name"
-                            value={name}
-                            autoFocus
-                            onChange={(event) => {
-                                setName(event.target.value);
-
-                                if (error) {
-                                    setError('');
-                                }
-                            }}
-                            onKeyDown={handleKeyDown}
-                        />
-                        {error && (
-                            <p className="text-xs text-red-500">{error}</p>
-                        )}
-                    </div>
-                    {isEditing ? (
-                        confirmingDelete ? (
-                            <div className="flex items-center justify-between">
-                                <span className="text-sm text-muted-foreground">Delete view?</span>
-                                <div className="flex items-center gap-2">
-                                    <Button
-                                        size="sm"
-                                        variant="outline"
-                                        onClick={() => setConfirmingDelete(false)}
-                                    >
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        disabled={deleting}
-                                        size="sm"
-                                        variant="destructive"
-                                        onClick={() => void handleDelete()}
-                                    >
-                                        {deleting ? 'Deleting...' : 'Delete'}
-                                    </Button>
-                                </div>
-                            </div>
-                        ) : (
-                            <div className="flex items-center justify-between">
-                                <Button
-                                    className="text-red hover:bg-red/5 hover:text-red"
-                                    size="sm"
-                                    variant="ghost"
-                                    onClick={() => setConfirmingDelete(true)}
-                                >
-                                    Delete
-                                </Button>
-                                <div className="flex items-center gap-2">
-                                    <Button
-                                        size="sm"
-                                        variant="outline"
-                                        onClick={() => setOpen(false)}
-                                    >
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        disabled={saving || !name.trim()}
-                                        size="sm"
-                                        onClick={() => void handleSave()}
-                                    >
-                                        {saving ? 'Saving...' : 'Save'}
-                                    </Button>
-                                </div>
-                            </div>
-                        )
-                    ) : (
-                        <Button
-                            className="w-full"
-                            disabled={saving || !name.trim()}
-                            onClick={() => void handleSave()}
-                        >
-                            {saving ? 'Saving...' : 'Save'}
-                        </Button>
+                            if (error) {
+                                setError('');
+                            }
+                        }}
+                        onKeyDown={handleKeyDown}
+                    />
+                    {error && (
+                        <p className="text-xs text-red-500">{error}</p>
                     )}
                 </div>
-            </PopoverContent>
+                {isEditing ? (
+                    confirmingDelete ? (
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm text-muted-foreground">Delete view?</span>
+                            <div className="flex items-center gap-2">
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => setConfirmingDelete(false)}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    disabled={deleting}
+                                    size="sm"
+                                    variant="destructive"
+                                    onClick={() => void handleDelete()}
+                                >
+                                    {deleting ? 'Deleting...' : 'Delete'}
+                                </Button>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="flex items-center justify-between">
+                            <Button
+                                className="text-red hover:bg-red/5 hover:text-red"
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => setConfirmingDelete(true)}
+                            >
+                                Delete
+                            </Button>
+                            <div className="flex items-center gap-2">
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={onClose}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    disabled={saving || !name.trim()}
+                                    size="sm"
+                                    onClick={() => void handleSave()}
+                                >
+                                    {saving ? 'Saving...' : 'Save'}
+                                </Button>
+                            </div>
+                        </div>
+                    )
+                ) : (
+                    <Button
+                        className="w-full"
+                        disabled={saving || !name.trim()}
+                        onClick={() => void handleSave()}
+                    >
+                        {saving ? 'Saving...' : 'Save'}
+                    </Button>
+                )}
+            </div>
+        </PopoverContent>
+    );
+};
+
+const ManageViewPopover: React.FC<ManageViewPopoverProps> = ({filter, existingViews, activeView, onDeleted}) => {
+    const [open, setOpen] = useState(false);
+    const contentKey = activeView ? `edit:${activeView.name}:${activeView.filter.filter}` : `save:${filter}`;
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+                <Button variant="outline">
+                    {activeView ? 'Edit view' : 'Save view'}
+                </Button>
+            </PopoverTrigger>
+            {open && (
+                <ManageViewPopoverContent
+                    key={contentKey}
+                    activeView={activeView}
+                    existingViews={existingViews}
+                    filter={filter}
+                    onClose={() => setOpen(false)}
+                    onDeleted={onDeleted}
+                />
+            )}
         </Popover>
     );
 };

--- a/apps/posts/src/views/members/components/manage-view-popover.tsx
+++ b/apps/posts/src/views/members/components/manage-view-popover.tsx
@@ -1,0 +1,190 @@
+import React, {useEffect, useState} from 'react';
+import {Button, Input, Popover, PopoverContent, PopoverTrigger} from '@tryghost/shade';
+import {type MemberView, useDeleteMemberView, useSaveMemberView} from '../hooks/use-member-views';
+
+interface ManageViewPopoverProps {
+    filter: string;
+    existingViews: MemberView[];
+    activeView?: MemberView | null;
+    onDeleted?: () => void;
+}
+
+const ManageViewPopover: React.FC<ManageViewPopoverProps> = ({filter, existingViews, activeView, onDeleted}) => {
+    const [open, setOpen] = useState(false);
+    const [name, setName] = useState('');
+    const [error, setError] = useState('');
+    const [saving, setSaving] = useState(false);
+    const [deleting, setDeleting] = useState(false);
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
+    const saveMemberView = useSaveMemberView();
+    const deleteMemberView = useDeleteMemberView();
+
+    const isEditing = Boolean(activeView);
+
+    useEffect(() => {
+        if (open && activeView) {
+            setName(activeView.name);
+        }
+    }, [open, activeView]);
+
+    const handleSave = async () => {
+        const trimmed = name.trim();
+
+        if (!trimmed) {
+            setError('Please enter a name');
+            return;
+        }
+
+        if (!isEditing) {
+            const duplicate = existingViews.find(view => view.name.trim().toLowerCase() === trimmed.toLowerCase());
+
+            if (duplicate) {
+                setError('A view with this name already exists');
+                return;
+            }
+        }
+
+        setSaving(true);
+
+        try {
+            await saveMemberView(trimmed, filter, activeView ?? undefined);
+            setName('');
+            setError('');
+            setOpen(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to save view');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!activeView) {
+            return;
+        }
+
+        setDeleting(true);
+
+        try {
+            await deleteMemberView(activeView);
+            setName('');
+            setError('');
+            setConfirmingDelete(false);
+            setOpen(false);
+            onDeleted?.();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to delete view');
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            void handleSave();
+        }
+    };
+
+    return (
+        <Popover open={open} onOpenChange={(isOpen) => {
+            setOpen(isOpen);
+
+            if (!isOpen) {
+                setName('');
+                setError('');
+                setConfirmingDelete(false);
+            }
+        }}>
+            <PopoverTrigger asChild>
+                <Button variant="outline">
+                    {isEditing ? 'Edit view' : 'Save view'}
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-72">
+                <div className="flex flex-col gap-3">
+                    <h3 className="text-sm font-semibold">{isEditing ? 'Edit view' : 'Save view'}</h3>
+                    <div className="flex flex-col gap-1.5">
+                        <Input
+                            placeholder="View name"
+                            value={name}
+                            autoFocus
+                            onChange={(event) => {
+                                setName(event.target.value);
+
+                                if (error) {
+                                    setError('');
+                                }
+                            }}
+                            onKeyDown={handleKeyDown}
+                        />
+                        {error && (
+                            <p className="text-xs text-red-500">{error}</p>
+                        )}
+                    </div>
+                    {isEditing ? (
+                        confirmingDelete ? (
+                            <div className="flex items-center justify-between">
+                                <span className="text-sm text-muted-foreground">Delete view?</span>
+                                <div className="flex items-center gap-2">
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() => setConfirmingDelete(false)}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        disabled={deleting}
+                                        size="sm"
+                                        variant="destructive"
+                                        onClick={() => void handleDelete()}
+                                    >
+                                        {deleting ? 'Deleting...' : 'Delete'}
+                                    </Button>
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="flex items-center justify-between">
+                                <Button
+                                    className="text-red hover:bg-red/5 hover:text-red"
+                                    size="sm"
+                                    variant="ghost"
+                                    onClick={() => setConfirmingDelete(true)}
+                                >
+                                    Delete
+                                </Button>
+                                <div className="flex items-center gap-2">
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() => setOpen(false)}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        disabled={saving || !name.trim()}
+                                        size="sm"
+                                        onClick={() => void handleSave()}
+                                    >
+                                        {saving ? 'Saving...' : 'Save'}
+                                    </Button>
+                                </div>
+                            </div>
+                        )
+                    ) : (
+                        <Button
+                            className="w-full"
+                            disabled={saving || !name.trim()}
+                            onClick={() => void handleSave()}
+                        >
+                            {saving ? 'Saving...' : 'Save'}
+                        </Button>
+                    )}
+                </div>
+            </PopoverContent>
+        </Popover>
+    );
+};
+
+export default ManageViewPopover;

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -1,3 +1,4 @@
+import ManageViewPopover from './manage-view-popover';
 import React, {useCallback, useMemo} from 'react';
 import {Filter, Filters, LucideIcon} from '@tryghost/shade';
 import {
@@ -14,10 +15,14 @@ import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters'
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useResourceSearch} from '../hooks/use-resource-search';
+import type {MemberView} from '../hooks/use-member-views';
 
 interface MembersFiltersProps {
     filters: Filter[];
+    nql?: string;
     onFiltersChange: (filters: Filter[]) => void;
+    savedViews?: MemberView[];
+    activeView?: MemberView | null;
 }
 
 const EMPTY_OFFERS: typeof buildOfferOptions extends (offers: infer T) => unknown ? T : never = [];
@@ -40,7 +45,10 @@ function mapOfferRedemptionFilters(
 
 const MembersFilters: React.FC<MembersFiltersProps> = ({
     filters,
-    onFiltersChange
+    nql,
+    onFiltersChange,
+    savedViews = [],
+    activeView
 }) => {
     const {data: labelsData} = useBrowseLabels({searchParams: {limit: '100'}});
     const {data: tiersData} = useBrowseTiers({searchParams: {limit: '100'}});
@@ -114,16 +122,34 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     });
 
     const hasFilters = filters.length > 0;
+    const clearAndSaveButtons = hasFilters ? (
+        <div className="flex shrink-0 items-center gap-2 sm:absolute sm:right-0 sm:top-0">
+            <button
+                className="flex items-center gap-1 text-sm font-normal text-muted-foreground hover:text-foreground"
+                type="button"
+                onClick={() => onFiltersChange([])}
+            >
+                <LucideIcon.X className="size-4" />
+                Clear
+            </button>
+            {nql && (
+                <ManageViewPopover
+                    activeView={activeView}
+                    existingViews={savedViews}
+                    filter={nql}
+                    onDeleted={() => onFiltersChange([])}
+                />
+            )}
+        </div>
+    ) : undefined;
 
     return (
         <Filters
             addButtonIcon={hasFilters ? <LucideIcon.FunnelPlus /> : <LucideIcon.Funnel />}
             addButtonText={hasFilters ? 'Add filter' : 'Filter'}
             allowMultiple={true}
-            className={`[&>button]:order-last ${hasFilters ? '[&>button]:border-none' : 'w-auto'}`}
-            clearButtonClassName="font-normal text-muted-foreground"
-            clearButtonIcon={<LucideIcon.X />}
-            clearButtonText="Clear"
+            className={`[&>button]:order-last ${hasFilters ? 'sm:!pr-40 [&>button]:border-none' : 'w-auto'}`}
+            clearButton={clearAndSaveButtons}
             fields={filterFields}
             filters={displayFilters}
             keyboardShortcut="f"

--- a/apps/posts/src/views/members/hooks/use-member-views.ts
+++ b/apps/posts/src/views/members/hooks/use-member-views.ts
@@ -3,10 +3,10 @@ import {
     type SharedViewsParseResult,
     buildViewsForDelete,
     buildViewsForSave,
-    parseAllSharedViewsJSON,
     parseSharedViewsJSON
 } from '../member-views';
 import {getSettingValue, useBrowseSettings, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
+import {parseAllSharedViewsJSON} from '../shared-views';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 

--- a/apps/posts/src/views/members/hooks/use-member-views.ts
+++ b/apps/posts/src/views/members/hooks/use-member-views.ts
@@ -1,0 +1,114 @@
+import {
+    type MemberView,
+    type SharedViewsParseResult,
+    buildViewsForDelete,
+    buildViewsForSave,
+    parseAllSharedViewsJSON,
+    parseSharedViewsJSON
+} from '../member-views';
+import {getSettingValue, useBrowseSettings, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+
+export {
+    buildViewsForDelete,
+    buildViewsForSave,
+    filterRecordToSearchParams,
+    isMemberViewSearchActive,
+    parseSharedViewsJSON
+} from '../member-views';
+export type {MemberView, SharedViewsParseResult} from '../member-views';
+
+const SHARED_VIEWS_INVALID_ERROR = 'Cannot modify saved views because shared_views is invalid';
+
+function getSharedViewsJSON(settingsData: {settings: Array<{key: string; value: string | boolean | null}>} | undefined): string {
+    return getSettingValue<string>(settingsData?.settings ?? null, 'shared_views') ?? '[]';
+}
+
+export function useMemberViews(): MemberView[] {
+    const {data: settingsData} = useBrowseSettings();
+    const handleError = useHandleError();
+    const sharedViewsJson = getSharedViewsJSON(settingsData);
+    const lastReportedInvalidPayload = useRef<string | null>(null);
+
+    const parsedMemberViews = useMemo<SharedViewsParseResult>(() => {
+        return parseSharedViewsJSON(sharedViewsJson);
+    }, [sharedViewsJson]);
+
+    useEffect(() => {
+        if (parsedMemberViews.ok || lastReportedInvalidPayload.current === sharedViewsJson) {
+            return;
+        }
+
+        lastReportedInvalidPayload.current = sharedViewsJson;
+        handleError(parsedMemberViews.error, {withToast: false});
+    }, [handleError, parsedMemberViews, sharedViewsJson]);
+
+    return parsedMemberViews.ok ? parsedMemberViews.views : [];
+}
+
+export function useSaveMemberView() {
+    const {data: settingsData} = useBrowseSettings();
+    const {mutateAsync: editSettings} = useEditSettings();
+    const handleError = useHandleError();
+
+    return useCallback(async (name: string, filter: string, originalView?: MemberView) => {
+        const parsedSharedViews = parseAllSharedViewsJSON(getSharedViewsJSON(settingsData));
+
+        if (!parsedSharedViews.ok) {
+            const error = new Error(SHARED_VIEWS_INVALID_ERROR, {cause: parsedSharedViews.error});
+            handleError(error, {withToast: false});
+            throw error;
+        }
+
+        const updatedViews = buildViewsForSave(parsedSharedViews.views, name, filter, originalView);
+
+        try {
+            await editSettings([{
+                key: 'shared_views',
+                value: JSON.stringify(updatedViews)
+            }]);
+        } catch (error) {
+            handleError(error, {withToast: false});
+            throw error;
+        }
+    }, [settingsData, editSettings, handleError]);
+}
+
+export function useDeleteMemberView() {
+    const {data: settingsData} = useBrowseSettings();
+    const {mutateAsync: editSettings} = useEditSettings();
+    const handleError = useHandleError();
+
+    return useCallback(async (view: MemberView) => {
+        const parsedSharedViews = parseAllSharedViewsJSON(getSharedViewsJSON(settingsData));
+
+        if (!parsedSharedViews.ok) {
+            const error = new Error(SHARED_VIEWS_INVALID_ERROR, {cause: parsedSharedViews.error});
+            handleError(error, {withToast: false});
+            throw error;
+        }
+
+        const updatedViews = buildViewsForDelete(parsedSharedViews.views, view);
+
+        try {
+            await editSettings([{
+                key: 'shared_views',
+                value: JSON.stringify(updatedViews)
+            }]);
+        } catch (error) {
+            handleError(error, {withToast: false});
+            throw error;
+        }
+    }, [settingsData, editSettings, handleError]);
+}
+
+export function useActiveMemberView(views: MemberView[], nql: string | undefined): MemberView | null {
+    return useMemo(() => {
+        if (!nql || views.length === 0) {
+            return null;
+        }
+
+        return views.find(view => view.filter.filter === nql) ?? null;
+    }, [views, nql]);
+}

--- a/apps/posts/src/views/members/member-views.test.ts
+++ b/apps/posts/src/views/members/member-views.test.ts
@@ -1,0 +1,138 @@
+import {
+    type MemberView,
+    buildViewsForDelete,
+    buildViewsForSave,
+    isMemberViewSearchActive,
+    parseSharedViewsJSON
+} from './member-views';
+import {describe, expect, it} from 'vitest';
+
+describe('member-views', () => {
+    describe('parseSharedViewsJSON', () => {
+        it('returns only valid member views', () => {
+            const result = parseSharedViewsJSON(JSON.stringify([
+                {
+                    name: 'Paid members',
+                    route: 'members',
+                    filter: {filter: 'status:paid'}
+                },
+                {
+                    name: 'Posts view',
+                    route: 'posts',
+                    filter: {type: 'draft'}
+                },
+                {
+                    name: 'Broken member view',
+                    route: 'members',
+                    filter: {}
+                }
+            ]));
+
+            expect(result.ok).toBe(true);
+            expect(result.ok && result.views).toEqual([
+                {
+                    name: 'Paid members',
+                    route: 'members',
+                    filter: {filter: 'status:paid'}
+                }
+            ]);
+        });
+
+        it('returns an error when shared_views is not valid JSON', () => {
+            const result = parseSharedViewsJSON('{');
+
+            expect(result.ok).toBe(false);
+        });
+    });
+
+    describe('isMemberViewSearchActive', () => {
+        const view: MemberView = {
+            name: 'Paid members',
+            route: 'members',
+            filter: {filter: 'status:paid'}
+        };
+
+        it('matches when the canonical filter query param matches exactly', () => {
+            expect(isMemberViewSearchActive('?filter=status%3Apaid', view)).toBe(true);
+        });
+
+        it('ignores non-filter query params', () => {
+            expect(isMemberViewSearchActive('?filter=status%3Apaid&page=2&search=jamie', view)).toBe(true);
+        });
+
+        it('does not match when the current filter differs', () => {
+            expect(isMemberViewSearchActive('?filter=status%3Afree', view)).toBe(false);
+        });
+
+        it('does not match when no canonical filter query param is present', () => {
+            expect(isMemberViewSearchActive('?search=jamie', view)).toBe(false);
+        });
+    });
+
+    describe('buildViewsForSave', () => {
+        it('creates a new member view using the canonical filter payload', () => {
+            expect(buildViewsForSave([], 'Paid members', 'status:paid')).toEqual([
+                {
+                    name: 'Paid members',
+                    route: 'members',
+                    filter: {filter: 'status:paid'}
+                }
+            ]);
+        });
+
+        it('rejects duplicate names for different member views', () => {
+            expect(() => {
+                buildViewsForSave([
+                    {
+                        name: 'Paid members',
+                        route: 'members',
+                        filter: {filter: 'status:paid'}
+                    }
+                ], 'paid members', 'status:free');
+            }).toThrow('A view with this name already exists');
+        });
+
+        it('updates an existing member view when the original view is provided', () => {
+            const originalView: MemberView = {
+                name: 'Paid members',
+                route: 'members',
+                filter: {filter: 'status:paid'}
+            };
+
+            expect(buildViewsForSave([originalView], 'VIP members', 'label:[vip]', originalView)).toEqual([
+                {
+                    name: 'VIP members',
+                    route: 'members',
+                    filter: {filter: 'label:[vip]'}
+                }
+            ]);
+        });
+    });
+
+    describe('buildViewsForDelete', () => {
+        it('removes the targeted member view', () => {
+            const memberView: MemberView = {
+                name: 'Paid members',
+                route: 'members',
+                filter: {filter: 'status:paid'}
+            };
+
+            expect(buildViewsForDelete([
+                memberView,
+                {
+                    name: 'Drafts',
+                    route: 'posts',
+                    color: 'blue',
+                    filter: {type: 'draft'}
+                }
+            ], memberView)).toEqual([
+                {
+                    name: 'Drafts',
+                    route: 'posts',
+                    color: 'blue',
+                    filter: {type: 'draft'}
+                }
+            ]);
+        });
+    });
+});

--- a/apps/posts/src/views/members/member-views.ts
+++ b/apps/posts/src/views/members/member-views.ts
@@ -1,18 +1,19 @@
+import {
+    type SharedView,
+    findMatchingSharedViewIndexes,
+    hasSharedViewNameConflict,
+    parseAllSharedViewsJSON,
+    sharedViewSchema
+} from './shared-views';
 import {z} from 'zod';
 
-export const sharedViewSchema = z.object({
-    name: z.string(),
-    route: z.string(),
-    color: z.string().optional(),
-    icon: z.string().optional(),
-    filter: z.record(z.string(), z.string().nullable())
+const memberViewSchema = sharedViewSchema.extend({
+    route: z.literal('members'),
+    filter: z.record(z.string(), z.string().nullable()).refine((filter) => {
+        return typeof filter.filter === 'string' && filter.filter.length > 0;
+    })
 });
 
-export const memberViewSchema = sharedViewSchema.refine((view) => {
-    return view.route === 'members' && typeof view.filter.filter === 'string' && view.filter.filter.length > 0;
-});
-
-export type SharedView = z.infer<typeof sharedViewSchema>;
 export interface MemberView extends Omit<SharedView, 'route' | 'filter'> {
     route: 'members';
     filter: Record<string, string | null> & {
@@ -24,25 +25,11 @@ export type SharedViewsParseResult =
     | {ok: true; views: MemberView[]}
     | {ok: false; error: Error};
 
-export type AllSharedViewsParseResult =
-    | {ok: true; views: SharedView[]}
-    | {ok: false; error: Error};
-
 const VIEW_EXISTS_ERROR = 'A view with this name already exists';
 const VIEW_UPDATE_NOT_FOUND_ERROR = 'Saved view could not be found for update';
 const VIEW_UPDATE_AMBIGUOUS_ERROR = 'Multiple saved views matched update target';
 const VIEW_DELETE_NOT_FOUND_ERROR = 'Saved view could not be found for delete';
 const VIEW_DELETE_AMBIGUOUS_ERROR = 'Multiple saved views matched delete target';
-
-function normalizeViewName(name: string): string {
-    return name.trim().toLowerCase();
-}
-
-function getViewFilterValue(view: SharedView): string | null {
-    return typeof view.filter.filter === 'string' && view.filter.filter
-        ? view.filter.filter
-        : null;
-}
 
 function isMemberView(view: SharedView): view is MemberView {
     return memberViewSchema.safeParse(view).success;
@@ -58,25 +45,6 @@ export function filterRecordToSearchParams(filter: Record<string, string | null>
     }
 
     return params;
-}
-
-export function parseAllSharedViewsJSON(json: string): AllSharedViewsParseResult {
-    try {
-        const parsed: unknown = JSON.parse(json);
-
-        if (!Array.isArray(parsed)) {
-            return {ok: false, error: new Error('shared_views is not an array')};
-        }
-
-        const views = parsed.flatMap((item) => {
-            const result = sharedViewSchema.safeParse(item);
-            return result.success ? [result.data] : [];
-        });
-
-        return {ok: true, views};
-    } catch {
-        return {ok: false, error: new Error('shared_views JSON parse failed')};
-    }
 }
 
 export function parseSharedViewsJSON(json: string): SharedViewsParseResult {
@@ -104,30 +72,11 @@ function buildMemberView(name: string, filter: string): MemberView {
     };
 }
 
-function findMatchingViewIndexes(views: SharedView[], target: MemberView): number[] {
-    return views.flatMap((view, index) => {
-        if (view.route !== target.route) {
-            return [];
-        }
-
-        if (normalizeViewName(view.name) !== normalizeViewName(target.name)) {
-            return [];
-        }
-
-        if (getViewFilterValue(view) !== target.filter.filter) {
-            return [];
-        }
-
-        return [index];
-    });
-}
-
 export function buildViewsForSave(allViews: SharedView[], name: string, filter: string, originalView?: MemberView): SharedView[] {
-    const normalizedName = normalizeViewName(name);
     const nextView = buildMemberView(name, filter);
 
     if (originalView) {
-        const matchingIndexes = findMatchingViewIndexes(allViews, originalView);
+        const matchingIndexes = findMatchingSharedViewIndexes(allViews, originalView);
 
         if (matchingIndexes.length === 0) {
             throw new Error(VIEW_UPDATE_NOT_FOUND_ERROR);
@@ -138,13 +87,7 @@ export function buildViewsForSave(allViews: SharedView[], name: string, filter: 
         }
 
         const targetIndex = matchingIndexes[0];
-        const duplicate = allViews.find((view, index) => {
-            return index !== targetIndex &&
-                view.route === 'members' &&
-                normalizeViewName(view.name) === normalizedName;
-        });
-
-        if (duplicate) {
+        if (hasSharedViewNameConflict(allViews, nextView, targetIndex)) {
             throw new Error(VIEW_EXISTS_ERROR);
         }
 
@@ -153,12 +96,7 @@ export function buildViewsForSave(allViews: SharedView[], name: string, filter: 
         });
     }
 
-    const duplicate = allViews.find((view) => {
-        return view.route === 'members' &&
-            normalizeViewName(view.name) === normalizedName;
-    });
-
-    if (duplicate) {
+    if (hasSharedViewNameConflict(allViews, nextView)) {
         throw new Error(VIEW_EXISTS_ERROR);
     }
 
@@ -166,7 +104,7 @@ export function buildViewsForSave(allViews: SharedView[], name: string, filter: 
 }
 
 export function buildViewsForDelete(allViews: SharedView[], view: MemberView): SharedView[] {
-    const matchingIndexes = findMatchingViewIndexes(allViews, view);
+    const matchingIndexes = findMatchingSharedViewIndexes(allViews, view);
 
     if (matchingIndexes.length === 0) {
         throw new Error(VIEW_DELETE_NOT_FOUND_ERROR);

--- a/apps/posts/src/views/members/member-views.ts
+++ b/apps/posts/src/views/members/member-views.ts
@@ -1,0 +1,181 @@
+import {z} from 'zod';
+
+export const sharedViewSchema = z.object({
+    name: z.string(),
+    route: z.string(),
+    color: z.string().optional(),
+    icon: z.string().optional(),
+    filter: z.record(z.string(), z.string().nullable())
+});
+
+export const memberViewSchema = sharedViewSchema.refine((view) => {
+    return view.route === 'members' && typeof view.filter.filter === 'string' && view.filter.filter.length > 0;
+});
+
+export type SharedView = z.infer<typeof sharedViewSchema>;
+export interface MemberView extends Omit<SharedView, 'route' | 'filter'> {
+    route: 'members';
+    filter: Record<string, string | null> & {
+        filter: string;
+    };
+}
+
+export type SharedViewsParseResult =
+    | {ok: true; views: MemberView[]}
+    | {ok: false; error: Error};
+
+export type AllSharedViewsParseResult =
+    | {ok: true; views: SharedView[]}
+    | {ok: false; error: Error};
+
+const VIEW_EXISTS_ERROR = 'A view with this name already exists';
+const VIEW_UPDATE_NOT_FOUND_ERROR = 'Saved view could not be found for update';
+const VIEW_UPDATE_AMBIGUOUS_ERROR = 'Multiple saved views matched update target';
+const VIEW_DELETE_NOT_FOUND_ERROR = 'Saved view could not be found for delete';
+const VIEW_DELETE_AMBIGUOUS_ERROR = 'Multiple saved views matched delete target';
+
+function normalizeViewName(name: string): string {
+    return name.trim().toLowerCase();
+}
+
+function getViewFilterValue(view: SharedView): string | null {
+    return typeof view.filter.filter === 'string' && view.filter.filter
+        ? view.filter.filter
+        : null;
+}
+
+function isMemberView(view: SharedView): view is MemberView {
+    return memberViewSchema.safeParse(view).success;
+}
+
+export function filterRecordToSearchParams(filter: Record<string, string | null>): URLSearchParams {
+    const params = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(filter)) {
+        if (value !== null && value !== undefined && value !== '') {
+            params.set(key, value);
+        }
+    }
+
+    return params;
+}
+
+export function parseAllSharedViewsJSON(json: string): AllSharedViewsParseResult {
+    try {
+        const parsed: unknown = JSON.parse(json);
+
+        if (!Array.isArray(parsed)) {
+            return {ok: false, error: new Error('shared_views is not an array')};
+        }
+
+        const views = parsed.flatMap((item) => {
+            const result = sharedViewSchema.safeParse(item);
+            return result.success ? [result.data] : [];
+        });
+
+        return {ok: true, views};
+    } catch {
+        return {ok: false, error: new Error('shared_views JSON parse failed')};
+    }
+}
+
+export function parseSharedViewsJSON(json: string): SharedViewsParseResult {
+    const parsed = parseAllSharedViewsJSON(json);
+
+    if (!parsed.ok) {
+        return parsed;
+    }
+
+    return {
+        ok: true,
+        views: parsed.views.filter(isMemberView)
+    };
+}
+
+export function isMemberViewSearchActive(currentSearch: string, view: MemberView): boolean {
+    return new URLSearchParams(currentSearch).get('filter') === view.filter.filter;
+}
+
+function buildMemberView(name: string, filter: string): MemberView {
+    return {
+        name: name.trim(),
+        route: 'members',
+        filter: {filter}
+    };
+}
+
+function findMatchingViewIndexes(views: SharedView[], target: MemberView): number[] {
+    return views.flatMap((view, index) => {
+        if (view.route !== target.route) {
+            return [];
+        }
+
+        if (normalizeViewName(view.name) !== normalizeViewName(target.name)) {
+            return [];
+        }
+
+        if (getViewFilterValue(view) !== target.filter.filter) {
+            return [];
+        }
+
+        return [index];
+    });
+}
+
+export function buildViewsForSave(allViews: SharedView[], name: string, filter: string, originalView?: MemberView): SharedView[] {
+    const normalizedName = normalizeViewName(name);
+    const nextView = buildMemberView(name, filter);
+
+    if (originalView) {
+        const matchingIndexes = findMatchingViewIndexes(allViews, originalView);
+
+        if (matchingIndexes.length === 0) {
+            throw new Error(VIEW_UPDATE_NOT_FOUND_ERROR);
+        }
+
+        if (matchingIndexes.length > 1) {
+            throw new Error(VIEW_UPDATE_AMBIGUOUS_ERROR);
+        }
+
+        const targetIndex = matchingIndexes[0];
+        const duplicate = allViews.find((view, index) => {
+            return index !== targetIndex &&
+                view.route === 'members' &&
+                normalizeViewName(view.name) === normalizedName;
+        });
+
+        if (duplicate) {
+            throw new Error(VIEW_EXISTS_ERROR);
+        }
+
+        return allViews.map((view, index) => {
+            return index === targetIndex ? nextView : view;
+        });
+    }
+
+    const duplicate = allViews.find((view) => {
+        return view.route === 'members' &&
+            normalizeViewName(view.name) === normalizedName;
+    });
+
+    if (duplicate) {
+        throw new Error(VIEW_EXISTS_ERROR);
+    }
+
+    return [...allViews, nextView];
+}
+
+export function buildViewsForDelete(allViews: SharedView[], view: MemberView): SharedView[] {
+    const matchingIndexes = findMatchingViewIndexes(allViews, view);
+
+    if (matchingIndexes.length === 0) {
+        throw new Error(VIEW_DELETE_NOT_FOUND_ERROR);
+    }
+
+    if (matchingIndexes.length > 1) {
+        throw new Error(VIEW_DELETE_AMBIGUOUS_ERROR);
+    }
+
+    const targetIndex = matchingIndexes[0];
+    return allViews.filter((_, index) => index !== targetIndex);
+}

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -10,6 +10,7 @@ import {buildMemberListSearchParams} from './member-query-params';
 import {canBulkDeleteMembers, shouldShowMembersLoading} from './members-view-state';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {shouldDelayMembersDateFilterHydration, useMembersFilterState} from './hooks/use-members-filter-state';
+import {useActiveMemberView, useMemberViews} from './hooks/use-member-views';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useBrowseMembersInfinite} from '@tryghost/admin-x-framework/api/members';
 import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
@@ -18,6 +19,8 @@ import {useSearchParams} from 'react-router';
 const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
     const {filters, nql, search, setFilters, hasFilterOrSearch, clearAll} = useMembersFilterState(timezone);
     const {data: configData} = useBrowseConfig();
+    const savedViews = useMemberViews();
+    const activeView = useActiveMemberView(savedViews, nql);
 
     // Check if email analytics is enabled
     const emailAnalyticsEnabled = configData?.config?.emailAnalytics === true;
@@ -76,7 +79,10 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
                         {/* When no filters, show filter button inline with other actions */}
                         {!hasFilters && (
                             <MembersFilters
+                                activeView={activeView}
                                 filters={filters}
+                                nql={nql}
+                                savedViews={savedViews}
                                 onFiltersChange={setFilters}
                             />
                         )}
@@ -97,7 +103,10 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
                 {hasFilters && (
                     <div className={filtersClassName}>
                         <MembersFilters
+                            activeView={activeView}
                             filters={filters}
+                            nql={nql}
+                            savedViews={savedViews}
                             onFiltersChange={setFilters}
                         />
                     </div>

--- a/apps/posts/src/views/members/shared-views.test.ts
+++ b/apps/posts/src/views/members/shared-views.test.ts
@@ -1,0 +1,98 @@
+import {
+    type SharedView,
+    findMatchingSharedViewIndexes,
+    hasSharedViewNameConflict,
+    isSharedViewEqual
+} from './shared-views';
+import {describe, expect, it} from 'vitest';
+
+describe('shared-views', () => {
+    describe('isSharedViewEqual', () => {
+        it('matches views by route and filter payload', () => {
+            const left: SharedView = {
+                name: 'Paid members',
+                route: 'members',
+                filter: {filter: 'status:paid'}
+            };
+            const right: SharedView = {
+                name: 'VIP members',
+                route: 'members',
+                filter: {filter: 'status:paid'}
+            };
+
+            expect(isSharedViewEqual(left, right)).toBe(true);
+        });
+
+        it('does not match when the route differs', () => {
+            const left: SharedView = {
+                name: 'Paid members',
+                route: 'members',
+                filter: {filter: 'status:paid'}
+            };
+            const right: SharedView = {
+                name: 'Paid posts',
+                route: 'posts',
+                filter: {filter: 'status:paid'}
+            };
+
+            expect(isSharedViewEqual(left, right)).toBe(false);
+        });
+    });
+
+    describe('findMatchingSharedViewIndexes', () => {
+        it('returns indexes for views with the same route and filter payload', () => {
+            const target: SharedView = {
+                name: 'Paid members',
+                route: 'members',
+                filter: {filter: 'status:paid'}
+            };
+
+            expect(findMatchingSharedViewIndexes([
+                target,
+                {
+                    name: 'VIP members',
+                    route: 'members',
+                    filter: {filter: 'label:[vip]'}
+                },
+                {
+                    name: 'Another paid members',
+                    route: 'members',
+                    filter: {filter: 'status:paid'}
+                }
+            ], target)).toEqual([0, 2]);
+        });
+    });
+
+    describe('hasSharedViewNameConflict', () => {
+        it('checks duplicate names within the same route only', () => {
+            expect(hasSharedViewNameConflict([
+                {
+                    name: 'Paid members',
+                    route: 'members',
+                    filter: {filter: 'status:paid'}
+                },
+                {
+                    name: 'Paid members',
+                    route: 'posts',
+                    filter: {type: 'draft'}
+                }
+            ], {
+                name: 'paid members',
+                route: 'members'
+            })).toBe(true);
+        });
+
+        it('ignores the excluded index when checking duplicate names', () => {
+            expect(hasSharedViewNameConflict([
+                {
+                    name: 'Paid members',
+                    route: 'members',
+                    filter: {filter: 'status:paid'}
+                }
+            ], {
+                name: 'paid members',
+                route: 'members'
+            }, 0)).toBe(false);
+        });
+    });
+});

--- a/apps/posts/src/views/members/shared-views.ts
+++ b/apps/posts/src/views/members/shared-views.ts
@@ -1,0 +1,69 @@
+import {z} from 'zod';
+
+export const sharedViewSchema = z.object({
+    name: z.string(),
+    route: z.string(),
+    color: z.string().optional(),
+    icon: z.string().optional(),
+    filter: z.record(z.string(), z.string().nullable())
+});
+
+export type SharedView = z.infer<typeof sharedViewSchema>;
+type SharedViewIdentity = Pick<SharedView, 'route' | 'filter'>;
+type SharedViewName = Pick<SharedView, 'route' | 'name'>;
+
+export type AllSharedViewsParseResult =
+    | {ok: true; views: SharedView[]}
+    | {ok: false; error: Error};
+
+export function normalizeSharedViewName(name: string): string {
+    return name.trim().toLowerCase();
+}
+
+export function isSharedViewFilterEqual(filterA: Record<string, string | null>, filterB: Record<string, string | null>): boolean {
+    const keysA = Object.keys(filterA);
+    const keysB = Object.keys(filterB);
+
+    if (keysA.length !== keysB.length) {
+        return false;
+    }
+
+    return keysA.every(key => filterA[key] === filterB[key]);
+}
+
+export function isSharedViewEqual(viewA: SharedViewIdentity, viewB: SharedViewIdentity): boolean {
+    return viewA.route === viewB.route && isSharedViewFilterEqual(viewA.filter, viewB.filter);
+}
+
+export function findMatchingSharedViewIndexes(views: SharedView[], target: SharedViewIdentity): number[] {
+    return views.flatMap((view, index) => (isSharedViewEqual(view, target) ? [index] : []));
+}
+
+export function hasSharedViewNameConflict(views: SharedView[], target: SharedViewName, excludedIndex?: number): boolean {
+    const normalizedName = normalizeSharedViewName(target.name);
+
+    return views.some((view, index) => {
+        return index !== excludedIndex &&
+            view.route === target.route &&
+            normalizeSharedViewName(view.name) === normalizedName;
+    });
+}
+
+export function parseAllSharedViewsJSON(json: string): AllSharedViewsParseResult {
+    try {
+        const parsed: unknown = JSON.parse(json);
+
+        if (!Array.isArray(parsed)) {
+            return {ok: false, error: new Error('shared_views is not an array')};
+        }
+
+        const views = parsed.flatMap((item) => {
+            const result = sharedViewSchema.safeParse(item);
+            return result.success ? [result.data] : [];
+        });
+
+        return {ok: true, views};
+    } catch {
+        return {ok: false, error: new Error('shared_views JSON parse failed')};
+    }
+}

--- a/apps/posts/src/views/members/shared-views.ts
+++ b/apps/posts/src/views/members/shared-views.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod';
 
+// TODO: Consolidate shared view parsing once the admin and posts apps are merged.
 export const sharedViewSchema = z.object({
     name: z.string(),
     route: z.string(),

--- a/apps/posts/test/unit/views/members/manage-view-popover.test.tsx
+++ b/apps/posts/test/unit/views/members/manage-view-popover.test.tsx
@@ -1,5 +1,4 @@
 import ManageViewPopover from '@src/views/members/components/manage-view-popover';
-import React from 'react';
 import {describe, expect, it, vi} from 'vitest';
 import {fireEvent, render, screen} from '@testing-library/react';
 

--- a/apps/posts/test/unit/views/members/manage-view-popover.test.tsx
+++ b/apps/posts/test/unit/views/members/manage-view-popover.test.tsx
@@ -1,0 +1,47 @@
+import ManageViewPopover from '@src/views/members/components/manage-view-popover';
+import React from 'react';
+import {describe, expect, it, vi} from 'vitest';
+import {fireEvent, render, screen} from '@testing-library/react';
+
+const saveMemberView = vi.fn();
+const deleteMemberView = vi.fn();
+
+vi.mock('@src/views/members/hooks/use-member-views', () => ({
+    useSaveMemberView: () => saveMemberView,
+    useDeleteMemberView: () => deleteMemberView
+}));
+
+describe('ManageViewPopover', () => {
+    it('resets the name when switching from an active saved view to save mode', async () => {
+        const activeFilter = 'email:\'test\'';
+        const unsavedFilter = 'email:\'test\'+label:\'vip\'';
+        const activeView = {
+            name: 'Existing view',
+            route: 'members' as const,
+            filter: {filter: activeFilter}
+        };
+
+        const {rerender} = render(
+            <ManageViewPopover
+                activeView={activeView}
+                existingViews={[activeView]}
+                filter={activeFilter}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', {name: 'Edit view'}));
+
+        expect(screen.getByRole('textbox', {name: ''})).toHaveValue('Existing view');
+
+        rerender(
+            <ManageViewPopover
+                activeView={null}
+                existingViews={[activeView]}
+                filter={unsavedFilter}
+            />
+        );
+
+        expect(screen.getByRole('heading', {name: 'Save view'})).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('View name')).toHaveValue('');
+    });
+});

--- a/e2e/tests/admin/members/custom-views.test.ts
+++ b/e2e/tests/admin/members/custom-views.test.ts
@@ -1,0 +1,70 @@
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {SidebarPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright/fixture';
+import type {Page} from '@playwright/test';
+
+async function addFilter(page: Page, filterName: 'Name' | 'Email' | 'Label', value: string) {
+    await page.getByRole('button', {name: /^(Filter|Add filter)$/}).click();
+    await page.getByRole('option', {name: filterName, exact: true}).click();
+
+    if (filterName === 'Name') {
+        await page.getByRole('textbox', {name: 'Enter name...'}).fill(value);
+        return;
+    }
+
+    if (filterName === 'Email') {
+        await page.getByRole('textbox', {name: 'Enter email...'}).fill(value);
+        return;
+    }
+
+    await page.getByRole('option', {name: value, exact: true}).click();
+}
+
+async function saveCurrentView(page: Page, name: string) {
+    await page.getByRole('button', {name: 'Save view'}).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.waitFor({state: 'visible'});
+    await dialog.getByRole('textbox', {name: 'View name'}).fill(name);
+    await dialog.getByRole('button', {name: 'Save'}).click();
+    await dialog.waitFor({state: 'hidden'});
+}
+
+test.describe('Ghost Admin - Member Saved Views', () => {
+    test.use({labs: {membersForward: true}});
+
+    let memberFactory: MemberFactory;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+    });
+
+    test('exact filter match controls active saved view and falls back to Members', async ({page}) => {
+        test.slow();
+
+        await memberFactory.create({
+            name: 'Active Nav Member',
+            email: 'active-nav-member@example.com',
+            labels: ['Active Nav Label']
+        });
+
+        const sidebar = new SidebarPage(page);
+        await page.goto('/ghost/#/members-forward');
+
+        await addFilter(page, 'Name', 'active-nav');
+        await saveCurrentView(page, 'View A');
+
+        await expect(sidebar.getNavLink('View A')).toHaveAttribute('aria-current', 'page');
+
+        await addFilter(page, 'Email', 'example.com');
+        await saveCurrentView(page, 'View B');
+
+        await expect(sidebar.getNavLink('View B')).toHaveAttribute('aria-current', 'page');
+        await expect(sidebar.getNavLink('View A')).not.toHaveAttribute('aria-current', 'page');
+
+        await addFilter(page, 'Label', 'Active Nav Label');
+
+        await expect(sidebar.getNavLink('View A')).not.toHaveAttribute('aria-current', 'page');
+        await expect(sidebar.getNavLink('View B')).not.toHaveAttribute('aria-current', 'page');
+        await expect(sidebar.getNavLink('Members')).toHaveAttribute('aria-current', 'page');
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3346/let-users-save-filtered-member-views

## Summary
- rebuilt member saved views on top of the canonical members filter model stored in `shared_views`
- added save, edit, delete, and exact-match sidebar navigation for member views in `members-forward`
- added regression coverage for member view parsing, navigation active state, and the members custom view flow

## Test Plan
- yarn workspace @tryghost/posts vitest run src/views/members
- yarn workspace @tryghost/admin vitest run src/layout/app-sidebar/nav-content.helpers.test.ts src/hooks/user-preferences.test.tsx
- yarn workspace @tryghost/admin typecheck
- yarn workspace @tryghost/e2e test:types
- Manual: headed local browser flow in `members-forward` covering save, fallback to base Members on filter drift, delete, and reload of an existing saved view
