### PR TITLE
Added server-side search and infinite scroll for filter select dropdowns

### DIFF
--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -24,15 +24,10 @@ export const useBrowseLabels = createQuery<LabelsResponseType>({
 export const useBrowseInfiniteLabels = createInfiniteQuery<LabelsResponseType & {isEnd: boolean}>({
     dataType: 'InfiniteLabelsResponseType',
     path: '/labels/',
-    defaultNextPageParams: (lastPage, otherParams) => {
-        if (!lastPage.meta?.pagination.next) {
-            return undefined;
-        }
-        return {
-            ...otherParams,
-            page: lastPage.meta.pagination.next.toString()
-        };
-    },
+    defaultNextPageParams: (lastPage, otherParams) => ({
+        ...otherParams,
+        page: (lastPage.meta?.pagination.next || 1).toString()
+    }),
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<LabelsResponseType>;
         const labels = pages.flatMap(page => page.labels);

--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -1,4 +1,5 @@
-import {Meta, createMutation, createQuery} from '../utils/api/hooks';
+import {InfiniteData} from '@tanstack/react-query';
+import {Meta, createInfiniteQuery, createMutation, createQuery} from '../utils/api/hooks';
 
 export type Label = {
     id: string;
@@ -18,6 +19,26 @@ const dataType = 'LabelsResponseType';
 export const useBrowseLabels = createQuery<LabelsResponseType>({
     dataType,
     path: '/labels/'
+});
+
+export const useBrowseInfiniteLabels = createInfiniteQuery<LabelsResponseType & {isEnd: boolean}>({
+    dataType: 'InfiniteLabelsResponseType',
+    path: '/labels/',
+    defaultNextPageParams: (lastPage, otherParams) => ({
+        ...otherParams,
+        page: (lastPage.meta?.pagination.next || 1).toString()
+    }),
+    returnData: (originalData) => {
+        const {pages} = originalData as InfiniteData<LabelsResponseType>;
+        const labels = pages.flatMap(page => page.labels);
+        const meta = pages[pages.length - 1].meta;
+
+        return {
+            labels,
+            meta,
+            isEnd: meta ? meta.pagination.pages === meta.pagination.page : true
+        };
+    }
 });
 
 export const useCreateLabel = createMutation<LabelsResponseType, Pick<Label, 'name'>>({

--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -24,10 +24,15 @@ export const useBrowseLabels = createQuery<LabelsResponseType>({
 export const useBrowseInfiniteLabels = createInfiniteQuery<LabelsResponseType & {isEnd: boolean}>({
     dataType: 'InfiniteLabelsResponseType',
     path: '/labels/',
-    defaultNextPageParams: (lastPage, otherParams) => ({
-        ...otherParams,
-        page: (lastPage.meta?.pagination.next || 1).toString()
-    }),
+    defaultNextPageParams: (lastPage, otherParams) => {
+        if (!lastPage.meta?.pagination.next) {
+            return undefined;
+        }
+        return {
+            ...otherParams,
+            page: lastPage.meta.pagination.next.toString()
+        };
+    },
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<LabelsResponseType>;
         const labels = pages.flatMap(page => page.labels);

--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -1,5 +1,5 @@
 import {InfiniteData} from '@tanstack/react-query';
-import {Meta, createInfiniteQuery, createMutation, createQuery} from '../utils/api/hooks';
+import {Meta, createInfiniteQuery, createMutation} from '../utils/api/hooks';
 
 export type Label = {
     id: string;
@@ -16,13 +16,8 @@ export interface LabelsResponseType {
 
 const dataType = 'LabelsResponseType';
 
-export const useBrowseLabels = createQuery<LabelsResponseType>({
-    dataType,
-    path: '/labels/'
-});
-
 export const useBrowseInfiniteLabels = createInfiniteQuery<LabelsResponseType & {isEnd: boolean}>({
-    dataType: 'InfiniteLabelsResponseType',
+    dataType,
     path: '/labels/',
     defaultNextPageParams: (lastPage, otherParams) => (lastPage.meta?.pagination.next
         ? {
@@ -47,42 +42,18 @@ export const useCreateLabel = createMutation<LabelsResponseType, Pick<Label, 'na
     method: 'POST',
     path: () => '/labels/',
     body: label => ({labels: [label]}),
-    updateQueries: {
-        dataType,
-        emberUpdateType: 'createOrUpdate',
-        update: (newData, currentData) => {
-            const current = currentData as LabelsResponseType;
-            return current && {...current, labels: current.labels.concat(newData.labels)};
-        }
-    }
+    invalidateQueries: {dataType}
 });
 
 export const useEditLabel = createMutation<LabelsResponseType, Pick<Label, 'id' | 'name'>>({
     method: 'PUT',
     path: label => `/labels/${label.id}/`,
     body: label => ({labels: [label]}),
-    updateQueries: {
-        dataType,
-        emberUpdateType: 'createOrUpdate',
-        update: (newData, currentData) => {
-            const current = currentData as LabelsResponseType;
-            return current && {
-                ...current,
-                labels: current.labels.map(label => newData.labels.find(({id}) => id === label.id) || label)
-            };
-        }
-    }
+    invalidateQueries: {dataType}
 });
 
 export const useDeleteLabel = createMutation<void, string>({
     method: 'DELETE',
     path: id => `/labels/${id}/`,
-    updateQueries: {
-        dataType,
-        emberUpdateType: 'delete',
-        update: (_, currentData, id) => {
-            const current = currentData as LabelsResponseType;
-            return current && {...current, labels: current.labels.filter(label => label.id !== id)};
-        }
-    }
+    invalidateQueries: {dataType}
 });

--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -24,10 +24,12 @@ export const useBrowseLabels = createQuery<LabelsResponseType>({
 export const useBrowseInfiniteLabels = createInfiniteQuery<LabelsResponseType & {isEnd: boolean}>({
     dataType: 'InfiniteLabelsResponseType',
     path: '/labels/',
-    defaultNextPageParams: (lastPage, otherParams) => ({
-        ...otherParams,
-        page: (lastPage.meta?.pagination.next || 1).toString()
-    }),
+    defaultNextPageParams: (lastPage, otherParams) => (lastPage.meta?.pagination.next
+        ? {
+            ...otherParams,
+            page: lastPage.meta.pagination.next.toString()
+        }
+        : undefined),
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<LabelsResponseType>;
         const labels = pages.flatMap(page => page.labels);

--- a/apps/admin-x-framework/src/api/tiers.ts
+++ b/apps/admin-x-framework/src/api/tiers.ts
@@ -34,15 +34,10 @@ const dataType = 'TiersResponseType';
 export const useBrowseTiers = createInfiniteQuery<TiersResponseType & {isEnd: boolean}>({
     dataType,
     path: '/tiers/',
-    defaultNextPageParams: (lastPage, otherParams) => {
-        if (!lastPage.meta?.pagination.next) {
-            return undefined;
-        }
-        return {
-            ...otherParams,
-            page: lastPage.meta.pagination.next.toString()
-        };
-    },
+    defaultNextPageParams: (lastPage, otherParams) => ({
+        ...otherParams,
+        page: (lastPage.meta?.pagination.next || 1).toString()
+    }),
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<TiersResponseType>;
         const tiers = pages.flatMap(page => page.tiers);

--- a/apps/admin-x-framework/src/api/tiers.ts
+++ b/apps/admin-x-framework/src/api/tiers.ts
@@ -34,10 +34,15 @@ const dataType = 'TiersResponseType';
 export const useBrowseTiers = createInfiniteQuery<TiersResponseType & {isEnd: boolean}>({
     dataType,
     path: '/tiers/',
-    defaultNextPageParams: (lastPage, otherParams) => ({
-        ...otherParams,
-        page: (lastPage.meta?.pagination.next || 1).toString()
-    }),
+    defaultNextPageParams: (lastPage, otherParams) => {
+        if (!lastPage.meta?.pagination.next) {
+            return undefined;
+        }
+        return {
+            ...otherParams,
+            page: lastPage.meta.pagination.next.toString()
+        };
+    },
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<TiersResponseType>;
         const tiers = pages.flatMap(page => page.tiers);

--- a/apps/admin-x-framework/src/api/tiers.ts
+++ b/apps/admin-x-framework/src/api/tiers.ts
@@ -34,10 +34,12 @@ const dataType = 'TiersResponseType';
 export const useBrowseTiers = createInfiniteQuery<TiersResponseType & {isEnd: boolean}>({
     dataType,
     path: '/tiers/',
-    defaultNextPageParams: (lastPage, otherParams) => ({
-        ...otherParams,
-        page: (lastPage.meta?.pagination.next || 1).toString()
-    }),
+    defaultNextPageParams: (lastPage, otherParams) => (lastPage.meta?.pagination.next
+        ? {
+            ...otherParams,
+            page: lastPage.meta.pagination.next.toString()
+        }
+        : undefined),
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<TiersResponseType>;
         const tiers = pages.flatMap(page => page.tiers);

--- a/apps/admin-x-framework/src/hooks.ts
+++ b/apps/admin-x-framework/src/hooks.ts
@@ -8,3 +8,4 @@ export {useKoenigFetchEmbed} from './hooks/use-koenig-fetch-embed';
 export type {KoenigFileUploadType} from './hooks/use-koenig-file-upload';
 export {useKoenigLinkSuggestions} from './hooks/use-koenig-link-suggestions';
 export {usePinturaConfig} from './hooks/use-pintura-config';
+export type {InfiniteQueryHookOptions} from './utils/api/hooks';

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -111,7 +111,7 @@ type InfiniteQueryOptions<ResponseData> = Omit<QueryOptions<ResponseData>, 'retu
     defaultNextPageParams?: (data: ResponseData, params: Record<string, string>) => Record<string, string> | undefined;
 }
 
-type InfiniteQueryHookOptions<ResponseData> = UseInfiniteQueryOptions<ResponseData> & {
+export type InfiniteQueryHookOptions<ResponseData> = UseInfiniteQueryOptions<ResponseData> & {
     searchParams?: Record<string, string>;
     defaultErrorHandler?: boolean;
     getNextPageParams?: (data: ResponseData, params: Record<string, string>) => Record<string, string> | undefined;

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -11,12 +11,16 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({values, onC
 
     return (
         <LabelPicker
+            hasMore={picker.hasMore}
             isDuplicateName={picker.isDuplicateName}
+            isLoadingMore={picker.isLoadingMore}
             labels={picker.labels}
             selectedSlugs={picker.selectedSlugs}
             inline
             onDelete={picker.deleteLabel}
             onEdit={picker.editLabel}
+            onLoadMore={picker.onLoadMore}
+            onSearchChange={picker.onSearchChange}
             onToggle={picker.toggleLabel}
         />
     );

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -13,6 +13,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({values, onC
         <LabelPicker
             hasMore={picker.hasMore}
             isDuplicateName={picker.isDuplicateName}
+            isLoading={picker.isLoading}
             isLoadingMore={picker.isLoadingMore}
             labels={picker.labels}
             selectedSlugs={picker.selectedSlugs}

--- a/apps/posts/src/components/label-picker/label-picker.test.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.test.tsx
@@ -1,0 +1,131 @@
+import LabelPicker from './label-picker';
+import {beforeAll, describe, expect, it, vi} from 'vitest';
+import {fireEvent, render, screen} from '@testing-library/react';
+import type {Label} from '@tryghost/admin-x-framework/api/labels';
+
+// cmdk uses scrollIntoView which jsdom doesn't implement
+beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+});
+
+const makeLabel = (id: string, name: string, slug?: string): Label => ({
+    id,
+    name,
+    slug: slug || name.toLowerCase().replace(/\s+/g, '-'),
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z'
+});
+
+const labels: Label[] = [
+    makeLabel('1', 'Alpha'),
+    makeLabel('2', 'Beta'),
+    makeLabel('3', 'Gamma')
+];
+
+describe('LabelPicker', () => {
+    it('does client-side filtering when onSearchChange is not provided', () => {
+        render(
+            <LabelPicker
+                labels={labels}
+                selectedSlugs={[]}
+                inline
+                onToggle={vi.fn()}
+            />
+        );
+
+        // Open the popover
+        fireEvent.click(screen.getByRole('button'));
+
+        // Type in the search
+        const searchInput = screen.getByPlaceholderText('Search labels...');
+        fireEvent.change(searchInput, {target: {value: 'alp'}});
+
+        // Alpha should be visible, Beta and Gamma should not
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+        expect(screen.queryByText('Gamma')).not.toBeInTheDocument();
+    });
+
+    it('skips client-side filtering when onSearchChange is provided (server search)', () => {
+        const onSearchChange = vi.fn();
+
+        render(
+            <LabelPicker
+                labels={labels}
+                selectedSlugs={[]}
+                inline
+                onSearchChange={onSearchChange}
+                onToggle={vi.fn()}
+            />
+        );
+
+        // Open the popover
+        fireEvent.click(screen.getByRole('button'));
+
+        // Type in the search
+        const searchInput = screen.getByPlaceholderText('Search labels...');
+        fireEvent.change(searchInput, {target: {value: 'alp'}});
+
+        // All labels should still be visible (server-side filtering, not client)
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+        expect(screen.getByText('Beta')).toBeInTheDocument();
+        expect(screen.getByText('Gamma')).toBeInTheDocument();
+
+        // onSearchChange should have been called
+        expect(onSearchChange).toHaveBeenCalledWith('alp');
+    });
+
+    it('shows loading spinner when isLoadingMore is true', () => {
+        render(
+            <LabelPicker
+                isLoadingMore={true}
+                labels={labels}
+                selectedSlugs={[]}
+                inline
+                onSearchChange={vi.fn()}
+                onToggle={vi.fn()}
+            />
+        );
+
+        // Open the popover
+        fireEvent.click(screen.getByRole('button'));
+
+        // The Loader2 icon should be rendered (it renders as an SVG with animate-spin class)
+        const spinner = document.querySelector('.animate-spin');
+        expect(spinner).toBeInTheDocument();
+    });
+
+    it('calls onLoadMore when scrolled to bottom', () => {
+        const onLoadMore = vi.fn();
+
+        render(
+            <LabelPicker
+                hasMore={true}
+                labels={labels}
+                selectedSlugs={[]}
+                inline
+                onLoadMore={onLoadMore}
+                onSearchChange={vi.fn()}
+                onToggle={vi.fn()}
+            />
+        );
+
+        // Open the popover
+        fireEvent.click(screen.getByRole('button'));
+
+        // Find the scrollable CommandList
+        const commandList = document.querySelector('[cmdk-list]');
+        expect(commandList).toBeTruthy();
+
+        if (commandList) {
+            // Simulate scroll to bottom
+            Object.defineProperty(commandList, 'scrollTop', {value: 200, writable: true});
+            Object.defineProperty(commandList, 'clientHeight', {value: 256, writable: true});
+            Object.defineProperty(commandList, 'scrollHeight', {value: 450, writable: true});
+
+            fireEvent.scroll(commandList);
+
+            expect(onLoadMore).toHaveBeenCalled();
+        }
+    });
+});

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -511,28 +511,23 @@ const InlinePopover: React.FC<InlinePopoverProps> = ({
                 </button>
             </PopoverTrigger>
             <PopoverContent align={align} alignOffset={alignOffset} className="w-64 p-0">
-                {isLoading ? (
-                    <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
-                        Loading labels...
-                    </div>
-                ) : (
-                    <InlineList
-                        canCreateFromSearch={canCreateFromSearch}
-                        hasMore={hasMore}
-                        isCreating={isCreating}
-                        isDuplicateName={isDuplicateName}
-                        isLoadingMore={isLoadingMore}
-                        labels={labels}
-                        selectedLabels={selectedLabels}
-                        selectedSlugs={selectedSlugs}
-                        onCreate={onCreate}
-                        onDelete={onDelete}
-                        onEdit={onEdit}
-                        onLoadMore={onLoadMore}
-                        onSearchChange={onSearchChange}
-                        onToggle={onToggle}
-                    />
-                )}
+                <InlineList
+                    canCreateFromSearch={canCreateFromSearch}
+                    hasMore={hasMore}
+                    isCreating={isCreating}
+                    isDuplicateName={isDuplicateName}
+                    isLoading={isLoading}
+                    isLoadingMore={isLoadingMore}
+                    labels={labels}
+                    selectedLabels={selectedLabels}
+                    selectedSlugs={selectedSlugs}
+                    onCreate={onCreate}
+                    onDelete={onDelete}
+                    onEdit={onEdit}
+                    onLoadMore={onLoadMore}
+                    onSearchChange={onSearchChange}
+                    onToggle={onToggle}
+                />
             </PopoverContent>
         </Popover>
     );
@@ -545,6 +540,7 @@ interface InlineListProps {
     selectedLabels: Label[];
     selectedSlugs: string[];
     onToggle: (slug: string) => void;
+    isLoading?: boolean;
     canCreateFromSearch?: (inputValue: string) => boolean;
     onCreate?: (name: string) => Promise<Label | undefined>;
     isCreating?: boolean;
@@ -557,7 +553,7 @@ interface InlineListProps {
     isLoadingMore?: boolean;
 }
 
-const InlineList: React.FC<InlineListProps> = ({selectedLabels, onSearchChange, onLoadMore, hasMore, isLoadingMore, ...rest}) => {
+const InlineList: React.FC<InlineListProps> = ({selectedLabels, isLoading, onSearchChange, onLoadMore, hasMore, isLoadingMore, ...rest}) => {
     const [search, setSearch] = useState('');
     const handleScrollEnd = useScrollEndDetection(onLoadMore, hasMore, isLoadingMore);
 
@@ -584,16 +580,23 @@ const InlineList: React.FC<InlineListProps> = ({selectedLabels, onSearchChange, 
                 />
             </div>
             <CommandList className="max-h-64 overflow-y-auto" onScroll={handleScrollEnd}>
-                <LabelListItems
-                    {...rest}
-                    isLoadingMore={isLoadingMore}
-                    search={search}
-                    serverSearch={!!onSearchChange}
-                    onSearchClear={() => {
-                        setSearch('');
-                        onSearchChange?.('');
-                    }}
-                />
+                {isLoading ? (
+                    <div className="flex items-center justify-center px-2 py-1.5 text-sm text-muted-foreground">
+                        <LucideIcon.Loader2 className="mr-2 size-4 animate-spin" />
+                        Loading...
+                    </div>
+                ) : (
+                    <LabelListItems
+                        {...rest}
+                        isLoadingMore={isLoadingMore}
+                        search={search}
+                        serverSearch={!!onSearchChange}
+                        onSearchClear={() => {
+                            setSearch('');
+                            onSearchChange?.('');
+                        }}
+                    />
+                )}
             </CommandList>
         </Command>
     );

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -30,6 +30,11 @@ export interface LabelPickerProps {
     // Layout
     inline?: boolean;
     align?: 'start' | 'end';
+    // Server-side search + infinite scroll
+    onSearchChange?: (search: string) => void;
+    onLoadMore?: () => void;
+    hasMore?: boolean;
+    isLoadingMore?: boolean;
 }
 
 // --- EditRow ---
@@ -230,6 +235,9 @@ interface LabelListItemsProps {
     onCreate?: (name: string) => Promise<Label | undefined>;
     isCreating?: boolean;
     onSearchClear?: () => void;
+    // When true, skip client-side filtering (server handles it)
+    serverSearch?: boolean;
+    isLoadingMore?: boolean;
 }
 
 const LabelListItems: React.FC<LabelListItemsProps> = ({
@@ -243,11 +251,15 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
     canCreateFromSearch,
     onCreate,
     isCreating,
-    onSearchClear
+    onSearchClear,
+    serverSearch = false,
+    isLoadingMore = false
 }) => {
     const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
 
-    const filteredLabels = labels.filter(l => l.name.toLowerCase().includes(search.toLowerCase()));
+    const filteredLabels = serverSearch
+        ? labels
+        : labels.filter(l => l.name.toLowerCase().includes(search.toLowerCase()));
     const showCreate = !!onCreate && search.trim() && canCreateFromSearch?.(search);
     const showEdit = !!onEdit;
 
@@ -315,6 +327,11 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
                     </CommandItem>
                 </CommandGroup>
             )}
+            {isLoadingMore && (
+                <div className="flex items-center justify-center py-2 text-sm text-muted-foreground">
+                    <LucideIcon.Loader2 className="mr-2 size-4 animate-spin" />
+                </div>
+            )}
         </>
     );
 };
@@ -359,7 +376,11 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
     onDelete,
     isDuplicateName,
     inline = false,
-    align = 'start'
+    align = 'start',
+    onSearchChange,
+    onLoadMore,
+    hasMore,
+    isLoadingMore
 }) => {
     const selectedLabels = selectedSlugs
         .map(slug => labels.find(l => l.slug === slug))
@@ -371,15 +392,19 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
             <InlinePopover
                 align={align}
                 canCreateFromSearch={canCreateFromSearch}
+                hasMore={hasMore}
                 isCreating={isCreating}
                 isDuplicateName={isDuplicateName}
                 isLoading={isLoading}
+                isLoadingMore={isLoadingMore}
                 labels={labels}
                 selectedLabels={selectedLabels}
                 selectedSlugs={selectedSlugs}
                 onCreate={onCreate}
                 onDelete={onDelete}
                 onEdit={onEdit}
+                onLoadMore={onLoadMore}
+                onSearchChange={onSearchChange}
                 onToggle={onToggle}
             />
         );
@@ -389,15 +414,19 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
     return (
         <ComboboxPicker
             canCreateFromSearch={canCreateFromSearch}
+            hasMore={hasMore}
             isCreating={isCreating}
             isDuplicateName={isDuplicateName}
             isLoading={isLoading}
+            isLoadingMore={isLoadingMore}
             labels={labels}
             selectedLabels={selectedLabels}
             selectedSlugs={selectedSlugs}
             onCreate={onCreate}
             onDelete={onDelete}
             onEdit={onEdit}
+            onLoadMore={onLoadMore}
+            onSearchChange={onSearchChange}
             onToggle={onToggle}
         />
     );
@@ -418,6 +447,10 @@ interface InlinePopoverProps {
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
     isDuplicateName?: (name: string, excludeId?: string) => boolean;
+    onSearchChange?: (search: string) => void;
+    onLoadMore?: () => void;
+    hasMore?: boolean;
+    isLoadingMore?: boolean;
 }
 
 const InlinePopover: React.FC<InlinePopoverProps> = ({
@@ -432,7 +465,11 @@ const InlinePopover: React.FC<InlinePopoverProps> = ({
     isCreating,
     onEdit,
     onDelete,
-    isDuplicateName
+    isDuplicateName,
+    onSearchChange,
+    onLoadMore,
+    hasMore,
+    isLoadingMore
 }) => {
     const triggerRef = useRef<HTMLButtonElement>(null);
     const [alignOffset, setAlignOffset] = useState(0);
@@ -480,14 +517,18 @@ const InlinePopover: React.FC<InlinePopoverProps> = ({
                 ) : (
                     <InlineList
                         canCreateFromSearch={canCreateFromSearch}
+                        hasMore={hasMore}
                         isCreating={isCreating}
                         isDuplicateName={isDuplicateName}
+                        isLoadingMore={isLoadingMore}
                         labels={labels}
                         selectedLabels={selectedLabels}
                         selectedSlugs={selectedSlugs}
                         onCreate={onCreate}
                         onDelete={onDelete}
                         onEdit={onEdit}
+                        onLoadMore={onLoadMore}
+                        onSearchChange={onSearchChange}
                         onToggle={onToggle}
                     />
                 )}
@@ -509,10 +550,30 @@ interface InlineListProps {
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
     isDuplicateName?: (name: string, excludeId?: string) => boolean;
+    onSearchChange?: (search: string) => void;
+    onLoadMore?: () => void;
+    hasMore?: boolean;
+    isLoadingMore?: boolean;
 }
 
-const InlineList: React.FC<InlineListProps> = ({selectedLabels, ...rest}) => {
+const InlineList: React.FC<InlineListProps> = ({selectedLabels, onSearchChange, onLoadMore, hasMore, isLoadingMore, ...rest}) => {
     const [search, setSearch] = useState('');
+
+    const handleSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setSearch(value);
+        onSearchChange?.(value);
+    };
+
+    const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+        if (!onLoadMore || !hasMore || isLoadingMore) {
+            return;
+        }
+        const target = e.currentTarget;
+        if (target.scrollTop + target.clientHeight >= target.scrollHeight - 50) {
+            onLoadMore();
+        }
+    }, [onLoadMore, hasMore, isLoadingMore]);
 
     return (
         <Command shouldFilter={false}>
@@ -527,14 +588,19 @@ const InlineList: React.FC<InlineListProps> = ({selectedLabels, ...rest}) => {
                     className="outline-hidden flex h-9 w-full bg-transparent py-3 text-sm placeholder:text-muted-foreground"
                     placeholder="Search labels..."
                     value={search}
-                    onChange={e => setSearch(e.target.value)}
+                    onChange={handleSearchInput}
                 />
             </div>
-            <CommandList className="max-h-64 overflow-y-auto">
+            <CommandList className="max-h-64 overflow-y-auto" onScroll={handleScroll}>
                 <LabelListItems
                     {...rest}
+                    isLoadingMore={isLoadingMore}
                     search={search}
-                    onSearchClear={() => setSearch('')}
+                    serverSearch={!!onSearchChange}
+                    onSearchClear={() => {
+                        setSearch('');
+                        onSearchChange?.('');
+                    }}
                 />
             </CommandList>
         </Command>
@@ -555,6 +621,10 @@ interface ComboboxPickerProps {
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
     isDuplicateName?: (name: string, excludeId?: string) => boolean;
+    onSearchChange?: (search: string) => void;
+    onLoadMore?: () => void;
+    hasMore?: boolean;
+    isLoadingMore?: boolean;
 }
 
 const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
@@ -568,7 +638,11 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     isCreating,
     onEdit,
     onDelete,
-    isDuplicateName
+    isDuplicateName,
+    onSearchChange,
+    onLoadMore,
+    hasMore,
+    isLoadingMore
 }) => {
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState('');
@@ -619,6 +693,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
                     value={search}
                     onChange={(e) => {
                         setSearch(e.target.value);
+                        onSearchChange?.(e.target.value);
                         if (!open) {
                             setOpen(true);
                         }
@@ -635,18 +710,34 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
                         </div>
                     ) : (
                         <Command shouldFilter={false}>
-                            <CommandList className="max-h-64 overflow-y-auto">
+                            <CommandList
+                                className="max-h-64 overflow-y-auto"
+                                onScroll={(e) => {
+                                    if (!onLoadMore || !hasMore || isLoadingMore) {
+                                        return;
+                                    }
+                                    const target = e.currentTarget;
+                                    if (target.scrollTop + target.clientHeight >= target.scrollHeight - 50) {
+                                        onLoadMore();
+                                    }
+                                }}
+                            >
                                 <LabelListItems
                                     canCreateFromSearch={canCreateFromSearch}
                                     isCreating={isCreating}
                                     isDuplicateName={isDuplicateName}
+                                    isLoadingMore={isLoadingMore}
                                     labels={labels}
                                     search={search}
                                     selectedSlugs={selectedSlugs}
+                                    serverSearch={!!onSearchChange}
                                     onCreate={onCreate}
                                     onDelete={onDelete}
                                     onEdit={onEdit}
-                                    onSearchClear={() => setSearch('')}
+                                    onSearchClear={() => {
+                                        setSearch('');
+                                        onSearchChange?.('');
+                                    }}
                                     onToggle={onToggle}
                                 />
                             </CommandList>

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -10,7 +10,8 @@ import {
     LucideIcon,
     Popover,
     PopoverContent,
-    PopoverTrigger
+    PopoverTrigger,
+    useScrollEndDetection
 } from '@tryghost/shade';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
 
@@ -558,22 +559,13 @@ interface InlineListProps {
 
 const InlineList: React.FC<InlineListProps> = ({selectedLabels, onSearchChange, onLoadMore, hasMore, isLoadingMore, ...rest}) => {
     const [search, setSearch] = useState('');
+    const handleScrollEnd = useScrollEndDetection(onLoadMore, hasMore, isLoadingMore);
 
     const handleSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
         setSearch(value);
         onSearchChange?.(value);
     };
-
-    const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-        if (!onLoadMore || !hasMore || isLoadingMore) {
-            return;
-        }
-        const target = e.currentTarget;
-        if (target.scrollTop + target.clientHeight >= target.scrollHeight - 50) {
-            onLoadMore();
-        }
-    }, [onLoadMore, hasMore, isLoadingMore]);
 
     return (
         <Command shouldFilter={false}>
@@ -591,7 +583,7 @@ const InlineList: React.FC<InlineListProps> = ({selectedLabels, onSearchChange, 
                     onChange={handleSearchInput}
                 />
             </div>
-            <CommandList className="max-h-64 overflow-y-auto" onScroll={handleScroll}>
+            <CommandList className="max-h-64 overflow-y-auto" onScroll={handleScrollEnd}>
                 <LabelListItems
                     {...rest}
                     isLoadingMore={isLoadingMore}
@@ -646,6 +638,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
 }) => {
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState('');
+    const handleScrollEnd = useScrollEndDetection(onLoadMore, hasMore, isLoadingMore);
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
@@ -712,15 +705,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
                         <Command shouldFilter={false}>
                             <CommandList
                                 className="max-h-64 overflow-y-auto"
-                                onScroll={(e) => {
-                                    if (!onLoadMore || !hasMore || isLoadingMore) {
-                                        return;
-                                    }
-                                    const target = e.currentTarget;
-                                    if (target.scrollTop + target.clientHeight >= target.scrollHeight - 50) {
-                                        onLoadMore();
-                                    }
-                                }}
+                                onScroll={handleScrollEnd}
                             >
                                 <LabelListItems
                                     canCreateFromSearch={canCreateFromSearch}

--- a/apps/posts/src/hooks/use-infinite-search.ts
+++ b/apps/posts/src/hooks/use-infinite-search.ts
@@ -1,0 +1,106 @@
+import {useCallback, useMemo, useRef, useState} from 'react';
+import {useDebounce} from 'use-debounce';
+import type {InfiniteQueryHookOptions} from '@tryghost/admin-x-framework/hooks';
+
+export interface UseInfiniteSearchOptions<T> {
+    useQuery: (options?: InfiniteQueryHookOptions<T>) => {
+        data: T | undefined;
+        isLoading: boolean;
+        isFetching: boolean;
+        fetchNextPage: () => void;
+        hasNextPage?: boolean;
+        isFetchingNextPage: boolean;
+    };
+    baseFilter?: string;
+    buildSearchFilter?: (term: string) => string;
+    limit?: string;
+    debounceMs?: number;
+    /** Return true when the query data contains at least one item. Used to decide
+     *  whether to switch to local search. Defaults to checking data is non-undefined. */
+    hasData?: (data: T) => boolean;
+}
+
+export interface UseInfiniteSearchReturn<T> {
+    data: T | undefined;
+    isLoading: boolean;
+    isSearchLoading: boolean;
+    searchValue: string;
+    onSearchChange: (value: string) => void;
+    onLoadMore: () => void;
+    hasMore: boolean;
+    isLoadingMore: boolean;
+    isLocalSearch: boolean;
+}
+
+export function useInfiniteSearch<T>({
+    useQuery,
+    baseFilter,
+    buildSearchFilter,
+    limit = '100',
+    debounceMs = 250,
+    hasData = () => true
+}: UseInfiniteSearchOptions<T>): UseInfiniteSearchReturn<T> {
+    const [inputValue, setInputValue] = useState('');
+
+    // Decided once on the first unfiltered page load: if all items fit on a
+    // single page we use local search for the lifetime of this hook instance.
+    // Using refs (rather than state) avoids an extra re-render cycle since
+    // `serverSearchTerm` reads `isUsingLocalSearchRef` synchronously.
+    const searchModeDecidedRef = useRef(false);
+    const isUsingLocalSearchRef = useRef(false);
+
+    const [debouncedValue] = useDebounce(inputValue, debounceMs);
+    const serverSearchTerm = isUsingLocalSearchRef.current ? '' : debouncedValue;
+
+    const searchParams = useMemo(() => {
+        const params: Record<string, string> = {limit};
+        const filters: string[] = [];
+
+        if (baseFilter) {
+            filters.push(baseFilter);
+        }
+
+        if (serverSearchTerm.trim() && buildSearchFilter) {
+            filters.push(buildSearchFilter(serverSearchTerm.trim()));
+        }
+
+        if (filters.length > 0) {
+            params.filter = filters.join('+');
+        }
+
+        return params;
+    }, [limit, baseFilter, serverSearchTerm, buildSearchFilter]);
+
+    const {data, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
+
+    // On the first unfiltered data load, decide whether to use local or server
+    // search.  Only evaluated once — subsequent searches that happen to return a
+    // single page should not flip the mode.  Set during render (not useEffect)
+    // so `serverSearchTerm` reads the updated value in the same render pass.
+    const isInitialPageLoad = !searchModeDecidedRef.current && !isLoading && data && hasData(data) && !serverSearchTerm.trim();
+    if (isInitialPageLoad) {
+        searchModeDecidedRef.current = true;
+        isUsingLocalSearchRef.current = !hasNextPage;
+    }
+
+    const onLoadMore = useCallback(() => {
+        if (hasNextPage && !isFetchingNextPage) {
+            fetchNextPage();
+        }
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+    const isSearchPending = !isUsingLocalSearchRef.current && inputValue !== debouncedValue && inputValue.trim() !== '';
+    const isSearchFetching = !isUsingLocalSearchRef.current && debouncedValue.trim() !== '' && isFetching;
+
+    return {
+        data,
+        isLoading,
+        isSearchLoading: isSearchPending || isSearchFetching,
+        searchValue: inputValue,
+        onSearchChange: setInputValue,
+        onLoadMore,
+        hasMore: hasNextPage ?? false,
+        isLoadingMore: isFetchingNextPage,
+        isLocalSearch: isUsingLocalSearchRef.current
+    };
+}

--- a/apps/posts/src/hooks/use-label-picker.test.ts
+++ b/apps/posts/src/hooks/use-label-picker.test.ts
@@ -1,0 +1,214 @@
+import {act, renderHook} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import {useLabelPicker} from './use-label-picker';
+import type {Label} from '@tryghost/admin-x-framework/api/labels';
+
+// --- Mocks ---
+
+const makeLabel = (id: string, name: string, slug?: string): Label => ({
+    id,
+    name,
+    slug: slug || name.toLowerCase().replace(/\s+/g, '-'),
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z'
+});
+
+const mockLabels = [
+    makeLabel('1', 'Alpha', 'alpha'),
+    makeLabel('2', 'Beta', 'beta'),
+    makeLabel('3', 'Gamma', 'gamma')
+];
+
+let mockQueryData = {labels: mockLabels, isEnd: true, meta: undefined};
+let mockCreateResult: {labels: Label[]} = {labels: []};
+let mockEditResult: {labels: Label[]} = {labels: []};
+
+vi.mock('@tryghost/admin-x-framework/api/labels', () => ({
+    useBrowseInfiniteLabels: () => ({
+        data: mockQueryData,
+        isLoading: false,
+        isFetching: false,
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false
+    }),
+    useCreateLabel: () => ({
+        mutateAsync: vi.fn().mockImplementation(() => Promise.resolve(mockCreateResult)),
+        isLoading: false
+    }),
+    useEditLabel: () => ({
+        mutateAsync: vi.fn().mockImplementation(() => Promise.resolve(mockEditResult))
+    }),
+    useDeleteLabel: () => ({
+        mutateAsync: vi.fn().mockImplementation(() => Promise.resolve())
+    })
+}));
+
+describe('useLabelPicker', () => {
+    it('returns labels from the query', () => {
+        const {result} = renderHook(() => useLabelPicker({
+            selectedSlugs: [],
+            onSelectionChange: vi.fn()
+        }));
+
+        expect(result.current.labels).toHaveLength(3);
+        expect(result.current.labels.map(l => l.slug)).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('toggleLabel adds and removes slugs', () => {
+        const onSelectionChange = vi.fn();
+        const {result} = renderHook(() => useLabelPicker({
+            selectedSlugs: ['alpha'],
+            onSelectionChange
+        }));
+
+        // Remove existing
+        act(() => {
+            result.current.toggleLabel('alpha');
+        });
+        expect(onSelectionChange).toHaveBeenCalledWith([]);
+
+        // Add new
+        onSelectionChange.mockClear();
+        act(() => {
+            result.current.toggleLabel('beta');
+        });
+        expect(onSelectionChange).toHaveBeenCalledWith(['alpha', 'beta']);
+    });
+
+    it('isDuplicateName checks against existing labels', () => {
+        const {result} = renderHook(() => useLabelPicker({
+            selectedSlugs: [],
+            onSelectionChange: vi.fn()
+        }));
+
+        expect(result.current.isDuplicateName('Alpha')).toBe(true);
+        expect(result.current.isDuplicateName('alpha')).toBe(true);
+        expect(result.current.isDuplicateName('New Label')).toBe(false);
+        // Excluding an id
+        expect(result.current.isDuplicateName('Alpha', '1')).toBe(false);
+    });
+
+    it('canCreateFromSearch rejects duplicates and empty strings', () => {
+        const {result} = renderHook(() => useLabelPicker({
+            selectedSlugs: [],
+            onSelectionChange: vi.fn()
+        }));
+
+        expect(result.current.canCreateFromSearch('')).toBe(false);
+        expect(result.current.canCreateFromSearch('  ')).toBe(false);
+        expect(result.current.canCreateFromSearch('Alpha')).toBe(false);
+        expect(result.current.canCreateFromSearch('New Label')).toBe(true);
+    });
+
+    it('createLabel returns new label and adds it to the cache immediately', async () => {
+        const newLabel = makeLabel('4', 'Delta', 'delta');
+        mockCreateResult = {labels: [newLabel]};
+
+        const onSelectionChange = vi.fn();
+        const {result, rerender} = renderHook(
+            ({slugs}) => useLabelPicker({selectedSlugs: slugs, onSelectionChange}),
+            {initialProps: {slugs: [] as string[]}}
+        );
+
+        // Create the label
+        let created: Label | undefined;
+        await act(async () => {
+            created = await result.current.createLabel('Delta');
+        });
+
+        expect(created).toEqual(newLabel);
+
+        // Simulate what the picker does: toggle the new label's slug
+        // The query hasn't refetched yet, but the label should be in the cache
+        rerender({slugs: ['delta']});
+
+        // The new label should be resolvable in labels despite not being in query results
+        const delta = result.current.labels.find(l => l.slug === 'delta');
+        expect(delta).toBeDefined();
+        expect(delta?.name).toBe('Delta');
+    });
+
+    it('createLabel rejects duplicates', async () => {
+        const {result} = renderHook(() => useLabelPicker({
+            selectedSlugs: [],
+            onSelectionChange: vi.fn()
+        }));
+
+        let created: Label | undefined;
+        await act(async () => {
+            created = await result.current.createLabel('Alpha');
+        });
+
+        expect(created).toBeUndefined();
+    });
+
+    it('editLabel updates the cache so edited label is resolvable before refetch', async () => {
+        const updatedLabel = makeLabel('1', 'Alpha Renamed', 'alpha-renamed');
+        mockEditResult = {labels: [updatedLabel]};
+
+        const onSelectionChange = vi.fn();
+        const {result, rerender} = renderHook(
+            ({slugs}) => useLabelPicker({selectedSlugs: slugs, onSelectionChange}),
+            {initialProps: {slugs: ['alpha']}}
+        );
+
+        await act(async () => {
+            await result.current.editLabel('1', 'Alpha Renamed');
+        });
+
+        // Should have swapped the slug in selection
+        expect(onSelectionChange).toHaveBeenCalledWith(['alpha-renamed']);
+
+        // Re-render with the updated slugs
+        rerender({slugs: ['alpha-renamed']});
+
+        // The renamed label should be resolvable from the cache
+        const renamed = result.current.labels.find(l => l.slug === 'alpha-renamed');
+        expect(renamed).toBeDefined();
+        expect(renamed?.name).toBe('Alpha Renamed');
+    });
+
+    it('deleteLabel removes from cache and deselects', async () => {
+        const onSelectionChange = vi.fn();
+        const {result} = renderHook(() => useLabelPicker({
+            selectedSlugs: ['alpha'],
+            onSelectionChange
+        }));
+
+        await act(async () => {
+            await result.current.deleteLabel('1');
+        });
+
+        expect(onSelectionChange).toHaveBeenCalledWith([]);
+    });
+
+    it('preserves selected labels when they are not in query results', () => {
+        // Simulate server search narrowing results: only Beta is returned
+        const originalData = mockQueryData;
+        mockQueryData = {labels: [mockLabels[1]], isEnd: true, meta: undefined};
+
+        const {result, rerender} = renderHook(
+            ({slugs}) => useLabelPicker({selectedSlugs: slugs, onSelectionChange: vi.fn()}),
+            {initialProps: {slugs: ['alpha']}}
+        );
+
+        // Alpha was selected but is in the original query results, so it
+        // should have been cached on a previous render.  We need to first
+        // render with the full data to populate the cache.
+        mockQueryData = originalData;
+        rerender({slugs: ['alpha']});
+
+        // Now narrow query results (simulating server search)
+        mockQueryData = {labels: [mockLabels[1]], isEnd: true, meta: undefined};
+        rerender({slugs: ['alpha']});
+
+        // Alpha should still be resolvable from the cache
+        const alpha = result.current.labels.find(l => l.slug === 'alpha');
+        expect(alpha).toBeDefined();
+        expect(alpha?.name).toBe('Alpha');
+
+        // Restore
+        mockQueryData = originalData;
+    });
+});

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,6 +1,7 @@
 import {Label, useBrowseInfiniteLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
-import {useCallback, useMemo, useRef, useState} from 'react';
-import {useDebounce} from 'use-debounce';
+import {escapeNqlValue} from '@src/utils/nql';
+import {useCallback, useMemo, useRef} from 'react';
+import {useInfiniteSearch} from './use-infinite-search';
 
 export interface UseLabelPickerOptions {
     selectedSlugs: string[];
@@ -28,35 +29,44 @@ export interface UseLabelPickerResult {
     isLoadingMore: boolean;
 }
 
-function escapeNqlValue(term: string): string {
-    return term.replace(/'/g, '\'\'');
-}
+const buildLabelSearchFilter = (term: string) => `name:~'${escapeNqlValue(term)}'`;
 
 export function useLabelPicker({
     selectedSlugs,
     onSelectionChange
 }: UseLabelPickerOptions): UseLabelPickerResult {
-    const [searchValue, setSearchValue] = useState('');
-    const useLocalSearchRef = useRef(false);
+    const search = useInfiniteSearch({
+        useQuery: useBrowseInfiniteLabels,
+        buildSearchFilter: buildLabelSearchFilter,
+        limit: '100',
+        hasData: data => (data?.labels?.length ?? 0) > 0
+    });
 
-    const [debouncedSearch] = useDebounce(searchValue, 250);
-    const serverSearchTerm = useLocalSearchRef.current ? '' : debouncedSearch;
+    const queryLabels = useMemo(() => search.data?.labels || [], [search.data]);
 
-    const searchParams = useMemo(() => {
-        const params: Record<string, string> = {limit: '100'};
-        if (serverSearchTerm.trim()) {
-            params.filter = `name:~'${escapeNqlValue(serverSearchTerm.trim())}'`;
+    // Cache labels that have been selected so they remain resolvable when
+    // server-side search narrows the result set.
+    const selectedLabelCacheRef = useRef<Map<string, Label>>(new Map());
+    for (const label of queryLabels) {
+        if (selectedSlugs.includes(label.slug)) {
+            selectedLabelCacheRef.current.set(label.slug, label);
         }
-        return params;
-    }, [serverSearchTerm]);
-
-    const {data: labelsData, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useBrowseInfiniteLabels({searchParams});
-    const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
-
-    // Once the initial load completes with all items on one page, switch to local search
-    if (!isLoading && !hasNextPage && labels.length > 0 && !serverSearchTerm.trim()) {
-        useLocalSearchRef.current = true;
     }
+    // Remove cached entries for labels that are no longer selected
+    for (const slug of selectedLabelCacheRef.current.keys()) {
+        if (!selectedSlugs.includes(slug)) {
+            selectedLabelCacheRef.current.delete(slug);
+        }
+    }
+
+    // Merge query results with cached selected labels so the UI can always
+    // resolve selectedSlugs → Label, even during a search that excludes them.
+    const labels = useMemo(() => {
+        const slugsInQuery = new Set(queryLabels.map(l => l.slug));
+        const missingSelected = [...selectedLabelCacheRef.current.values()]
+            .filter(l => !slugsInQuery.has(l.slug));
+        return missingSelected.length > 0 ? [...queryLabels, ...missingSelected] : queryLabels;
+    }, [queryLabels]);
 
     const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
     const {mutateAsync: editLabelMutation} = useEditLabel();
@@ -66,12 +76,6 @@ export function useLabelPicker({
     // avoiding stale closures and keeping callbacks stable
     const selectedSlugsRef = useRef(selectedSlugs);
     selectedSlugsRef.current = selectedSlugs;
-
-    const onLoadMore = useCallback(() => {
-        if (hasNextPage && !isFetchingNextPage) {
-            fetchNextPage();
-        }
-    }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
     const toggleLabel = useCallback((slug: string) => {
         const current = selectedSlugsRef.current;
@@ -133,13 +137,10 @@ export function useLabelPicker({
         }
     }, [deleteLabelMutation, labels, onSelectionChange]);
 
-    const isSearchPending = !useLocalSearchRef.current && searchValue !== debouncedSearch && searchValue.trim() !== '';
-    const isSearchFetching = !useLocalSearchRef.current && debouncedSearch.trim() !== '' && isFetching;
-
     return {
         labels,
         selectedSlugs,
-        isLoading: isLoading || isSearchPending || isSearchFetching,
+        isLoading: search.isLoading || search.isSearchLoading,
         toggleLabel,
         createLabel,
         editLabel,
@@ -148,10 +149,10 @@ export function useLabelPicker({
         canCreateFromSearch,
         isCreating,
         // Return undefined when using local search so the picker uses client-side filtering
-        onSearchChange: useLocalSearchRef.current ? undefined : setSearchValue,
-        searchValue,
-        onLoadMore,
-        hasMore: hasNextPage ?? false,
-        isLoadingMore: isFetchingNextPage
+        onSearchChange: search.isLocalSearch ? undefined : search.onSearchChange,
+        searchValue: search.searchValue,
+        onLoadMore: search.onLoadMore,
+        hasMore: search.hasMore,
+        isLoadingMore: search.isLoadingMore
     };
 }

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -54,7 +54,7 @@ export function useLabelPicker({
     const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
 
     // Once the initial load completes with all items on one page, switch to local search
-    if (!isLoading && labelsData?.isEnd && labels.length > 0 && !serverSearchTerm.trim()) {
+    if (!isLoading && !hasNextPage && labels.length > 0 && !serverSearchTerm.trim()) {
         useLocalSearchRef.current = true;
     }
 

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -55,7 +55,7 @@ export function useLabelPicker({
         return params;
     }, [debouncedSearch]);
 
-    const {data: labelsData, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = useBrowseInfiniteLabels({searchParams});
+    const {data: labelsData, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useBrowseInfiniteLabels({searchParams});
     const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
 
     const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
@@ -145,10 +145,13 @@ export function useLabelPicker({
         }
     }, [deleteLabelMutation, labels, onSelectionChange]);
 
+    const isSearchPending = searchValue !== debouncedSearch && searchValue.trim() !== '';
+    const isSearchFetching = debouncedSearch.trim() !== '' && isFetching;
+
     return {
         labels,
         selectedSlugs,
-        isLoading,
+        isLoading: isLoading || isSearchPending || isSearchFetching,
         toggleLabel,
         createLabel,
         editLabel,

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,5 +1,5 @@
 import {Label, useBrowseInfiniteLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
-import {escapeNqlValue} from '@src/utils/nql';
+import {escapeNqlString} from '@src/views/filters/filter-normalization';
 import {useCallback, useMemo, useRef} from 'react';
 import {useInfiniteSearch} from './use-infinite-search';
 
@@ -29,7 +29,7 @@ export interface UseLabelPickerResult {
     isLoadingMore: boolean;
 }
 
-const buildLabelSearchFilter = (term: string) => `name:~'${escapeNqlValue(term)}'`;
+const buildLabelSearchFilter = (term: string) => `name:~${escapeNqlString(term)}`;
 
 export function useLabelPicker({
     selectedSlugs,

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -60,7 +60,7 @@ export function useLabelPicker({
     const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
 
     // Once the initial load completes with all items on one page, switch to local search
-    if (!isLoading && !hasNextPage && labels.length > 0 && !debouncedSearch.trim()) {
+    if (!isLoading && labelsData?.isEnd && labels.length > 0 && !debouncedSearch.trim()) {
         useLocalSearchRef.current = true;
     }
 

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -63,10 +63,12 @@ export function useLabelPicker({
     // resolve selectedSlugs → Label, even during a search that excludes them.
     const labels = useMemo(() => {
         const slugsInQuery = new Set(queryLabels.map(l => l.slug));
-        const missingSelected = [...selectedLabelCacheRef.current.values()]
-            .filter(l => !slugsInQuery.has(l.slug));
+        const missingSelected = selectedSlugs
+            .filter(slug => !slugsInQuery.has(slug))
+            .map(slug => selectedLabelCacheRef.current.get(slug))
+            .filter((l): l is Label => !!l);
         return missingSelected.length > 0 ? [...queryLabels, ...missingSelected] : queryLabels;
-    }, [queryLabels]);
+    }, [queryLabels, selectedSlugs]);
 
     const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
     const {mutateAsync: editLabelMutation} = useEditLabel();

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -47,14 +47,15 @@ export function useLabelPicker({
     // Cache labels that have been selected so they remain resolvable when
     // server-side search narrows the result set.
     const selectedLabelCacheRef = useRef<Map<string, Label>>(new Map());
+    const selectedSet = new Set(selectedSlugs);
     for (const label of queryLabels) {
-        if (selectedSlugs.includes(label.slug)) {
+        if (selectedSet.has(label.slug)) {
             selectedLabelCacheRef.current.set(label.slug, label);
         }
     }
     // Remove cached entries for labels that are no longer selected
     for (const slug of selectedLabelCacheRef.current.keys()) {
-        if (!selectedSlugs.includes(slug)) {
+        if (!selectedSet.has(slug)) {
             selectedLabelCacheRef.current.delete(slug);
         }
     }

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -151,7 +151,7 @@ export function useLabelPicker({
         onSearchChange,
         searchValue,
         onLoadMore,
-        hasMore: hasNextPage,
+        hasMore: hasNextPage ?? false,
         isLoadingMore: isFetchingNextPage
     };
 }

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,5 +1,6 @@
 import {Label, useBrowseInfiniteLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
+import {useDebounce} from 'use-debounce';
 
 export interface UseLabelPickerOptions {
     selectedSlugs: string[];
@@ -36,31 +37,24 @@ export function useLabelPicker({
     onSelectionChange
 }: UseLabelPickerOptions): UseLabelPickerResult {
     const [searchValue, setSearchValue] = useState('');
-    const [debouncedSearch, setDebouncedSearch] = useState('');
-    const timerRef = useRef<ReturnType<typeof setTimeout>>();
     const useLocalSearchRef = useRef(false);
 
-    useEffect(() => {
-        return () => {
-            if (timerRef.current) {
-                clearTimeout(timerRef.current);
-            }
-        };
-    }, []);
+    const [debouncedSearch] = useDebounce(searchValue, 250);
+    const serverSearchTerm = useLocalSearchRef.current ? '' : debouncedSearch;
 
     const searchParams = useMemo(() => {
         const params: Record<string, string> = {limit: '100'};
-        if (!useLocalSearchRef.current && debouncedSearch.trim()) {
-            params.filter = `name:~'${escapeNqlValue(debouncedSearch.trim())}'`;
+        if (serverSearchTerm.trim()) {
+            params.filter = `name:~'${escapeNqlValue(serverSearchTerm.trim())}'`;
         }
         return params;
-    }, [debouncedSearch]);
+    }, [serverSearchTerm]);
 
     const {data: labelsData, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useBrowseInfiniteLabels({searchParams});
     const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
 
     // Once the initial load completes with all items on one page, switch to local search
-    if (!isLoading && labelsData?.isEnd && labels.length > 0 && !debouncedSearch.trim()) {
+    if (!isLoading && labelsData?.isEnd && labels.length > 0 && !serverSearchTerm.trim()) {
         useLocalSearchRef.current = true;
     }
 
@@ -72,22 +66,6 @@ export function useLabelPicker({
     // avoiding stale closures and keeping callbacks stable
     const selectedSlugsRef = useRef(selectedSlugs);
     selectedSlugsRef.current = selectedSlugs;
-
-    const onSearchChange = useCallback((search: string) => {
-        setSearchValue(search);
-
-        if (timerRef.current) {
-            clearTimeout(timerRef.current);
-        }
-
-        if (useLocalSearchRef.current) {
-            return;
-        }
-
-        timerRef.current = setTimeout(() => {
-            setDebouncedSearch(search);
-        }, 250);
-    }, []);
 
     const onLoadMore = useCallback(() => {
         if (hasNextPage && !isFetchingNextPage) {
@@ -170,7 +148,7 @@ export function useLabelPicker({
         canCreateFromSearch,
         isCreating,
         // Return undefined when using local search so the picker uses client-side filtering
-        onSearchChange: useLocalSearchRef.current ? undefined : onSearchChange,
+        onSearchChange: useLocalSearchRef.current ? undefined : setSearchValue,
         searchValue,
         onLoadMore,
         hasMore: hasNextPage ?? false,

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,5 +1,5 @@
 import {Label, useBrowseInfiniteLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 export interface UseLabelPickerOptions {
     selectedSlugs: string[];
@@ -38,6 +38,14 @@ export function useLabelPicker({
     const [searchValue, setSearchValue] = useState('');
     const [debouncedSearch, setDebouncedSearch] = useState('');
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        return () => {
+            if (timerRef.current) {
+                clearTimeout(timerRef.current);
+            }
+        };
+    }, []);
 
     const searchParams = useMemo(() => {
         const params: Record<string, string> = {limit: '100'};

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -19,8 +19,8 @@ export interface UseLabelPickerResult {
     canCreateFromSearch: (inputValue: string) => boolean;
     isCreating: boolean;
 
-    // Server-side search + infinite scroll
-    onSearchChange: (search: string) => void;
+    // Search + infinite scroll (undefined onSearchChange = local filtering)
+    onSearchChange: ((search: string) => void) | undefined;
     searchValue: string;
     onLoadMore: () => void;
     hasMore: boolean;
@@ -38,6 +38,7 @@ export function useLabelPicker({
     const [searchValue, setSearchValue] = useState('');
     const [debouncedSearch, setDebouncedSearch] = useState('');
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
+    const useLocalSearchRef = useRef(false);
 
     useEffect(() => {
         return () => {
@@ -49,7 +50,7 @@ export function useLabelPicker({
 
     const searchParams = useMemo(() => {
         const params: Record<string, string> = {limit: '100'};
-        if (debouncedSearch.trim()) {
+        if (!useLocalSearchRef.current && debouncedSearch.trim()) {
             params.filter = `name:~'${escapeNqlValue(debouncedSearch.trim())}'`;
         }
         return params;
@@ -57,6 +58,11 @@ export function useLabelPicker({
 
     const {data: labelsData, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useBrowseInfiniteLabels({searchParams});
     const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
+
+    // Once the initial load completes with all items on one page, switch to local search
+    if (!isLoading && !hasNextPage && labels.length > 0 && !debouncedSearch.trim()) {
+        useLocalSearchRef.current = true;
+    }
 
     const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
     const {mutateAsync: editLabelMutation} = useEditLabel();
@@ -72,6 +78,10 @@ export function useLabelPicker({
 
         if (timerRef.current) {
             clearTimeout(timerRef.current);
+        }
+
+        if (useLocalSearchRef.current) {
+            return;
         }
 
         timerRef.current = setTimeout(() => {
@@ -145,8 +155,8 @@ export function useLabelPicker({
         }
     }, [deleteLabelMutation, labels, onSelectionChange]);
 
-    const isSearchPending = searchValue !== debouncedSearch && searchValue.trim() !== '';
-    const isSearchFetching = debouncedSearch.trim() !== '' && isFetching;
+    const isSearchPending = !useLocalSearchRef.current && searchValue !== debouncedSearch && searchValue.trim() !== '';
+    const isSearchFetching = !useLocalSearchRef.current && debouncedSearch.trim() !== '' && isFetching;
 
     return {
         labels,
@@ -159,7 +169,8 @@ export function useLabelPicker({
         isDuplicateName,
         canCreateFromSearch,
         isCreating,
-        onSearchChange,
+        // Return undefined when using local search so the picker uses client-side filtering
+        onSearchChange: useLocalSearchRef.current ? undefined : onSearchChange,
         searchValue,
         onLoadMore,
         hasMore: hasNextPage ?? false,

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,5 +1,5 @@
-import {Label, useBrowseLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
-import {useCallback, useMemo, useRef} from 'react';
+import {Label, useBrowseInfiniteLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
+import {useCallback, useMemo, useRef, useState} from 'react';
 
 export interface UseLabelPickerOptions {
     selectedSlugs: string[];
@@ -18,13 +18,36 @@ export interface UseLabelPickerResult {
     isDuplicateName: (name: string, excludeId?: string) => boolean;
     canCreateFromSearch: (inputValue: string) => boolean;
     isCreating: boolean;
+
+    // Server-side search + infinite scroll
+    onSearchChange: (search: string) => void;
+    searchValue: string;
+    onLoadMore: () => void;
+    hasMore: boolean;
+    isLoadingMore: boolean;
+}
+
+function escapeNqlValue(term: string): string {
+    return term.replace(/'/g, '\'\'');
 }
 
 export function useLabelPicker({
     selectedSlugs,
     onSelectionChange
 }: UseLabelPickerOptions): UseLabelPickerResult {
-    const {data: labelsData, isLoading} = useBrowseLabels({searchParams: {limit: '100'}});
+    const [searchValue, setSearchValue] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    const searchParams = useMemo(() => {
+        const params: Record<string, string> = {limit: '100'};
+        if (debouncedSearch.trim()) {
+            params.filter = `name:~'${escapeNqlValue(debouncedSearch.trim())}'`;
+        }
+        return params;
+    }, [debouncedSearch]);
+
+    const {data: labelsData, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = useBrowseInfiniteLabels({searchParams});
     const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
 
     const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
@@ -35,6 +58,24 @@ export function useLabelPicker({
     // avoiding stale closures and keeping callbacks stable
     const selectedSlugsRef = useRef(selectedSlugs);
     selectedSlugsRef.current = selectedSlugs;
+
+    const onSearchChange = useCallback((search: string) => {
+        setSearchValue(search);
+
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+        }
+
+        timerRef.current = setTimeout(() => {
+            setDebouncedSearch(search);
+        }, 250);
+    }, []);
+
+    const onLoadMore = useCallback(() => {
+        if (hasNextPage && !isFetchingNextPage) {
+            fetchNextPage();
+        }
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
     const toggleLabel = useCallback((slug: string) => {
         const current = selectedSlugsRef.current;
@@ -106,6 +147,11 @@ export function useLabelPicker({
         deleteLabel,
         isDuplicateName,
         canCreateFromSearch,
-        isCreating
+        isCreating,
+        onSearchChange,
+        searchValue,
+        onLoadMore,
+        hasMore: hasNextPage,
+        isLoadingMore: isFetchingNextPage
     };
 }

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -106,6 +106,12 @@ export function useLabelPicker({
         }
         const result = await createLabelMutation({name: trimmed});
         const newLabel = result?.labels?.[0];
+        // Add to cache immediately so the label is resolvable before the
+        // invalidation refetch completes (the picker toggles the slug right
+        // after this returns).
+        if (newLabel) {
+            selectedLabelCacheRef.current.set(newLabel.slug, newLabel);
+        }
         return newLabel;
     }, [createLabelMutation, isDuplicateName]);
 
@@ -117,11 +123,16 @@ export function useLabelPicker({
         const oldLabel = labels.find(l => l.id === id);
         const result = await editLabelMutation({id, name: trimmed});
         const updatedLabel = result?.labels?.[0];
-        // If the slug changed and the old slug was selected, swap it
-        if (oldLabel && updatedLabel && oldLabel.slug !== updatedLabel.slug) {
-            const current = selectedSlugsRef.current;
-            if (current.includes(oldLabel.slug)) {
-                onSelectionChange(current.map(s => (s === oldLabel.slug ? updatedLabel.slug : s)));
+        if (oldLabel && updatedLabel) {
+            // Update cache so the edited label is resolvable before refetch
+            selectedLabelCacheRef.current.delete(oldLabel.slug);
+            selectedLabelCacheRef.current.set(updatedLabel.slug, updatedLabel);
+            // If the slug changed and the old slug was selected, swap it
+            if (oldLabel.slug !== updatedLabel.slug) {
+                const current = selectedSlugsRef.current;
+                if (current.includes(oldLabel.slug)) {
+                    onSelectionChange(current.map(s => (s === oldLabel.slug ? updatedLabel.slug : s)));
+                }
             }
         }
     }, [editLabelMutation, isDuplicateName, labels, onSelectionChange]);
@@ -130,6 +141,7 @@ export function useLabelPicker({
         const label = labels.find(l => l.id === id);
         await deleteLabelMutation(id);
         if (label) {
+            selectedLabelCacheRef.current.delete(label.slug);
             const current = selectedSlugsRef.current;
             if (current.includes(label.slug)) {
                 onSelectionChange(current.filter(s => s !== label.slug));

--- a/apps/posts/src/utils/nql.ts
+++ b/apps/posts/src/utils/nql.ts
@@ -1,7 +1,0 @@
-/**
- * Escape a value for use in NQL filter expressions.
- * Single quotes are doubled to prevent injection.
- */
-export function escapeNqlValue(term: string): string {
-    return term.replace(/'/g, '\'\'');
-}

--- a/apps/posts/src/utils/nql.ts
+++ b/apps/posts/src/utils/nql.ts
@@ -1,0 +1,7 @@
+/**
+ * Escape a value for use in NQL filter expressions.
+ * Single quotes are doubled to prevent injection.
+ */
+export function escapeNqlValue(term: string): string {
+    return term.replace(/'/g, '\'\'');
+}

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -53,9 +53,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         extractItems: useCallback((data: LabelsResponseType) => {
             return data.labels.map(label => ({value: label.slug, label: label.name}));
         }, []),
-        buildSearchFilter: useCallback((term: string) => {
-            return `name:~'${term}'`;
-        }, []),
+        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
         limit: '100'
     });
 
@@ -66,9 +64,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
                 .filter(tier => tier.type === 'paid' && tier.active)
                 .map(tier => ({value: tier.id, label: tier.name}));
         }, []),
-        buildSearchFilter: useCallback((term: string) => {
-            return `name:~'${term}'`;
-        }, []),
+        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
         limit: '100'
     });
 

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -78,7 +78,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
 
     const newsletters = newslettersData?.newsletters || [];
     const offers = useMemo(() => offersData?.offers ?? EMPTY_OFFERS, [offersData?.offers]);
-    const hasMultipleTiers = tierSearch.options.length > 1;
+    const hasMultipleTiers = tierSearch.initialCount > 1;
 
     const offersOptions = useMemo(() => {
         return buildOfferOptions(offers);

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -62,7 +62,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         extractItems: useCallback((data: TiersResponseType) => {
             return data.tiers.map(tier => ({value: tier.id, label: tier.name}));
         }, []),
-        baseFilter: 'type:paid+active:true',
+        baseFilter: 'type:paid',
         buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
         limit: '100'
     });

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -6,6 +6,7 @@ import {
     toOfferFilterDisplayValues,
     useMemberFilterFields
 } from '../use-member-filter-fields';
+import {escapeNqlValue} from '@src/utils/nql';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
@@ -53,7 +54,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         dataKey: 'labels',
         valueKey: 'slug',
         labelKey: 'name',
-        buildSearchFilter: (term: string) => `name:~'${term}'`,
+        buildSearchFilter: (term: string) => `name:~'${escapeNqlValue(term)}'`,
         limit: '100'
     });
 
@@ -63,7 +64,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         valueKey: 'id',
         labelKey: 'name',
         baseFilter: 'type:paid',
-        buildSearchFilter: (term: string) => `name:~'${term}'`,
+        buildSearchFilter: (term: string) => `name:~'${escapeNqlValue(term)}'`,
         limit: '100'
     });
 

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -50,17 +50,25 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
 
     const labelSearch = useFilterSearch({
         useQuery: useBrowseInfiniteLabels,
-        extractItems: useCallback(
-            (data: LabelsResponseType) => data.labels.map(l => ({value: l.slug, label: l.name})), []),
-        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
+        extractItems: useCallback((data: LabelsResponseType) => {
+            return data.labels.map(label => ({value: label.slug, label: label.name}));
+        }, []),
+        buildSearchFilter: useCallback((term: string) => {
+            return `name:~'${term}'`;
+        }, []),
         limit: '100'
     });
 
     const tierSearch = useFilterSearch({
         useQuery: useBrowseTiers,
-        extractItems: useCallback(
-            (data: TiersResponseType) => data.tiers.filter(t => t.type === 'paid' && t.active).map(t => ({value: t.id, label: t.name})), []),
-        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
+        extractItems: useCallback((data: TiersResponseType) => {
+            return data.tiers
+                .filter(tier => tier.type === 'paid' && tier.active)
+                .map(tier => ({value: tier.id, label: tier.name}));
+        }, []),
+        buildSearchFilter: useCallback((term: string) => {
+            return `name:~'${term}'`;
+        }, []),
         limit: '100'
     });
 

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -60,10 +60,9 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const tierSearch = useFilterSearch({
         useQuery: useBrowseTiers,
         extractItems: useCallback((data: TiersResponseType) => {
-            return data.tiers
-                .filter(tier => tier.type === 'paid' && tier.active)
-                .map(tier => ({value: tier.id, label: tier.name}));
+            return data.tiers.map(tier => ({value: tier.id, label: tier.name}));
         }, []),
+        baseFilter: 'type:paid+active:true',
         buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
         limit: '100'
     });

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -13,7 +13,7 @@ import {useBrowseInfiniteLabels} from '@tryghost/admin-x-framework/api/labels';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
-import {useFilterSearch} from '../hooks/use-filter-search';
+import {useFilterSearch, useFilterSearchParams} from '../hooks/use-filter-search';
 import {useResourceSearch} from '../hooks/use-resource-search';
 
 interface MembersFiltersProps {
@@ -48,21 +48,18 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const {data: settingsData} = useBrowseSettings({});
     const {data: configData} = useBrowseConfig({});
 
-    const labelSearch = useFilterSearch({
-        useQuery: useBrowseInfiniteLabels,
-        extractItems: useCallback(
-            (data: {labels: Array<{slug: string; name: string}>}) => data.labels.map(l => ({value: l.slug, label: l.name})), []),
-        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
-        limit: '100'
-    });
+    const buildNameFilter = useCallback((term: string) => `name:~'${term}'`, []);
+    const labelSearchParams = useFilterSearchParams(buildNameFilter);
+    const labelQueryResult = useBrowseInfiniteLabels({searchParams: {limit: '100', ...labelSearchParams.searchParams}});
+    const extractLabels = useCallback(
+        (data: {labels: Array<{slug: string; name: string}>}) => data.labels.map(l => ({value: l.slug, label: l.name})), []);
+    const labelSearch = {...useFilterSearch({queryResult: labelQueryResult, extractItems: extractLabels}), ...labelSearchParams};
 
-    const tierSearch = useFilterSearch({
-        useQuery: useBrowseTiers,
-        extractItems: useCallback(
-            (data: {tiers: Array<{id: string; name: string; type: string; active: boolean}>}) => data.tiers.filter(t => t.type === 'paid' && t.active).map(t => ({value: t.id, label: t.name})), []),
-        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
-        limit: '100'
-    });
+    const tierSearchParams = useFilterSearchParams(buildNameFilter);
+    const tierQueryResult = useBrowseTiers({searchParams: {limit: '100', ...tierSearchParams.searchParams}});
+    const extractTiers = useCallback(
+        (data: {tiers: Array<{id: string; name: string; type: string; active: boolean}>}) => data.tiers.filter(t => t.type === 'paid' && t.active).map(t => ({value: t.id, label: t.name})), []);
+    const tierSearch = {...useFilterSearch({queryResult: tierQueryResult, extractItems: extractTiers}), ...tierSearchParams};
 
     const settings = settingsData?.settings || [];
     const paidMembersEnabled = getSettingValue<boolean>(settings, 'paid_members_enabled') === true;

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -1,7 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
 import {Filter, Filters, LucideIcon} from '@tryghost/shade';
-import {LabelsResponseType, useBrowseInfiniteLabels} from '@tryghost/admin-x-framework/api/labels';
-import {TiersResponseType, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {
     buildOfferOptions,
     fromOfferFilterDisplayValues,
@@ -11,8 +9,10 @@ import {
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useBrowseInfiniteLabels} from '@tryghost/admin-x-framework/api/labels';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
+import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useFilterSearch} from '../hooks/use-filter-search';
 import {useResourceSearch} from '../hooks/use-resource-search';
 
@@ -50,20 +50,20 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
 
     const labelSearch = useFilterSearch({
         useQuery: useBrowseInfiniteLabels,
-        extractItems: useCallback((data: LabelsResponseType) => {
-            return data.labels.map(label => ({value: label.slug, label: label.name}));
-        }, []),
-        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
+        dataKey: 'labels',
+        valueKey: 'slug',
+        labelKey: 'name',
+        buildSearchFilter: (term: string) => `name:~'${term}'`,
         limit: '100'
     });
 
     const tierSearch = useFilterSearch({
         useQuery: useBrowseTiers,
-        extractItems: useCallback((data: TiersResponseType) => {
-            return data.tiers.map(tier => ({value: tier.id, label: tier.name}));
-        }, []),
+        dataKey: 'tiers',
+        valueKey: 'id',
+        labelKey: 'name',
         baseFilter: 'type:paid',
-        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
+        buildSearchFilter: (term: string) => `name:~'${term}'`,
         limit: '100'
     });
 

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -13,7 +13,7 @@ import {useBrowseInfiniteLabels} from '@tryghost/admin-x-framework/api/labels';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
-import {useFilterSearch, useFilterSearchParams} from '../hooks/use-filter-search';
+import {useFilterSearch} from '../hooks/use-filter-search';
 import {useResourceSearch} from '../hooks/use-resource-search';
 
 interface MembersFiltersProps {
@@ -48,18 +48,21 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const {data: settingsData} = useBrowseSettings({});
     const {data: configData} = useBrowseConfig({});
 
-    const buildNameFilter = useCallback((term: string) => `name:~'${term}'`, []);
-    const labelSearchParams = useFilterSearchParams(buildNameFilter);
-    const labelQueryResult = useBrowseInfiniteLabels({searchParams: {limit: '100', ...labelSearchParams.searchParams}});
-    const extractLabels = useCallback(
-        (data: {labels: Array<{slug: string; name: string}>}) => data.labels.map(l => ({value: l.slug, label: l.name})), []);
-    const labelSearch = {...useFilterSearch({queryResult: labelQueryResult, extractItems: extractLabels}), ...labelSearchParams};
+    const labelSearch = useFilterSearch({
+        useQuery: useBrowseInfiniteLabels,
+        extractItems: useCallback(
+            (data: {labels: Array<{slug: string; name: string}>}) => data.labels.map(l => ({value: l.slug, label: l.name})), []),
+        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
+        limit: '100'
+    });
 
-    const tierSearchParams = useFilterSearchParams(buildNameFilter);
-    const tierQueryResult = useBrowseTiers({searchParams: {limit: '100', ...tierSearchParams.searchParams}});
-    const extractTiers = useCallback(
-        (data: {tiers: Array<{id: string; name: string; type: string; active: boolean}>}) => data.tiers.filter(t => t.type === 'paid' && t.active).map(t => ({value: t.id, label: t.name})), []);
-    const tierSearch = {...useFilterSearch({queryResult: tierQueryResult, extractItems: extractTiers}), ...tierSearchParams};
+    const tierSearch = useFilterSearch({
+        useQuery: useBrowseTiers,
+        extractItems: useCallback(
+            (data: {tiers: Array<{id: string; name: string; type: string; active: boolean}>}) => data.tiers.filter(t => t.type === 'paid' && t.active).map(t => ({value: t.id, label: t.name})), []),
+        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
+        limit: '100'
+    });
 
     const settings = settingsData?.settings || [];
     const paidMembersEnabled = getSettingValue<boolean>(settings, 'paid_members_enabled') === true;

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -9,10 +9,11 @@ import {
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
-import {useBrowseLabels} from '@tryghost/admin-x-framework/api/labels';
+import {useBrowseInfiniteLabels} from '@tryghost/admin-x-framework/api/labels';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {useFilterSearch} from '../hooks/use-filter-search';
 import {useResourceSearch} from '../hooks/use-resource-search';
 
 interface MembersFiltersProps {
@@ -42,12 +43,26 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     filters,
     onFiltersChange
 }) => {
-    const {data: labelsData} = useBrowseLabels({searchParams: {limit: '100'}});
-    const {data: tiersData} = useBrowseTiers({searchParams: {limit: '100'}});
     const {data: offersData} = useBrowseOffers({});
     const {data: newslettersData} = useBrowseNewsletters({searchParams: {limit: '100'}});
     const {data: settingsData} = useBrowseSettings({});
     const {data: configData} = useBrowseConfig({});
+
+    const labelSearch = useFilterSearch({
+        useQuery: useBrowseInfiniteLabels,
+        extractItems: useCallback(
+            (data: {labels: Array<{slug: string; name: string}>}) => data.labels.map(l => ({value: l.slug, label: l.name})), []),
+        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
+        limit: '100'
+    });
+
+    const tierSearch = useFilterSearch({
+        useQuery: useBrowseTiers,
+        extractItems: useCallback(
+            (data: {tiers: Array<{id: string; name: string; type: string; active: boolean}>}) => data.tiers.filter(t => t.type === 'paid' && t.active).map(t => ({value: t.id, label: t.name})), []),
+        buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
+        limit: '100'
+    });
 
     const settings = settingsData?.settings || [];
     const paidMembersEnabled = getSettingValue<boolean>(settings, 'paid_members_enabled') === true;
@@ -58,12 +73,9 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const audienceFeedbackEnabled = configData?.config?.labs?.audienceFeedback === true;
     const siteTimezone = getSiteTimezone(settings);
 
-    const labels = labelsData?.labels || [];
-    const tiers = tiersData?.tiers || [];
     const newsletters = newslettersData?.newsletters || [];
     const offers = useMemo(() => offersData?.offers ?? EMPTY_OFFERS, [offersData?.offers]);
-    const activePaidTiers = tiers.filter(tier => tier.type === 'paid' && tier.active);
-    const hasMultipleTiers = activePaidTiers.length > 1;
+    const hasMultipleTiers = tierSearch.options.length > 1;
 
     const offersOptions = useMemo(() => {
         return buildOfferOptions(offers);
@@ -95,8 +107,24 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         hasMultipleTiers,
         paidMembersEnabled,
         emailAnalyticsEnabled,
-        labelsOptions: labels.map(label => ({value: label.slug, label: label.name})),
-        tiersOptions: activePaidTiers.map(tier => ({value: tier.id, label: tier.name})),
+        labelsOptions: labelSearch.options,
+        labelSearchProps: {
+            onSearchChange: labelSearch.onSearchChange,
+            searchValue: labelSearch.searchValue,
+            isLoading: labelSearch.isLoading,
+            onLoadMore: labelSearch.onLoadMore,
+            hasMore: labelSearch.hasMore,
+            isLoadingMore: labelSearch.isLoadingMore
+        },
+        tiersOptions: tierSearch.options,
+        tierSearchProps: {
+            onSearchChange: tierSearch.onSearchChange,
+            searchValue: tierSearch.searchValue,
+            isLoading: tierSearch.isLoading,
+            onLoadMore: tierSearch.onLoadMore,
+            hasMore: tierSearch.hasMore,
+            isLoadingMore: tierSearch.isLoadingMore
+        },
         offers,
         postResourceOptions: postSearch.options,
         onPostResourceSearchChange: postSearch.onSearchChange,

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -1,5 +1,7 @@
 import React, {useCallback, useMemo} from 'react';
 import {Filter, Filters, LucideIcon} from '@tryghost/shade';
+import {LabelsResponseType, useBrowseInfiniteLabels} from '@tryghost/admin-x-framework/api/labels';
+import {TiersResponseType, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {
     buildOfferOptions,
     fromOfferFilterDisplayValues,
@@ -9,10 +11,8 @@ import {
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
-import {useBrowseInfiniteLabels} from '@tryghost/admin-x-framework/api/labels';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
-import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useFilterSearch} from '../hooks/use-filter-search';
 import {useResourceSearch} from '../hooks/use-resource-search';
 
@@ -51,7 +51,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const labelSearch = useFilterSearch({
         useQuery: useBrowseInfiniteLabels,
         extractItems: useCallback(
-            (data: {labels: Array<{slug: string; name: string}>}) => data.labels.map(l => ({value: l.slug, label: l.name})), []),
+            (data: LabelsResponseType) => data.labels.map(l => ({value: l.slug, label: l.name})), []),
         buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
         limit: '100'
     });
@@ -59,7 +59,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const tierSearch = useFilterSearch({
         useQuery: useBrowseTiers,
         extractItems: useCallback(
-            (data: {tiers: Array<{id: string; name: string; type: string; active: boolean}>}) => data.tiers.filter(t => t.type === 'paid' && t.active).map(t => ({value: t.id, label: t.name})), []),
+            (data: TiersResponseType) => data.tiers.filter(t => t.type === 'paid' && t.active).map(t => ({value: t.id, label: t.name})), []),
         buildSearchFilter: useCallback((term: string) => `name:~'${term}'`, []),
         limit: '100'
     });

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -6,7 +6,7 @@ import {
     toOfferFilterDisplayValues,
     useMemberFilterFields
 } from '../use-member-filter-fields';
-import {escapeNqlValue} from '@src/utils/nql';
+import {escapeNqlString} from '@src/views/filters/filter-normalization';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
@@ -54,7 +54,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         dataKey: 'labels',
         valueKey: 'slug',
         labelKey: 'name',
-        buildSearchFilter: (term: string) => `name:~'${escapeNqlValue(term)}'`,
+        buildSearchFilter: (term: string) => `name:~${escapeNqlString(term)}`,
         limit: '100'
     });
 
@@ -64,7 +64,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         valueKey: 'id',
         labelKey: 'name',
         baseFilter: 'type:paid',
-        buildSearchFilter: (term: string) => `name:~'${escapeNqlValue(term)}'`,
+        buildSearchFilter: (term: string) => `name:~${escapeNqlString(term)}`,
         limit: '100'
     });
 

--- a/apps/posts/src/views/members/hooks/use-filter-search.test.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.test.ts
@@ -12,13 +12,13 @@ interface MockResponse {
     isEnd?: boolean;
 }
 
-function createMockQuery(items: MockItem[] = [], {isEnd = true}: {isEnd?: boolean} = {}) {
+function createMockQuery(items: MockItem[] = [], {isEnd = true, hasNextPage = false}: {isEnd?: boolean; hasNextPage?: boolean} = {}) {
     return vi.fn().mockReturnValue({
         data: {items, isEnd} as MockResponse,
         isLoading: false,
         isFetching: false,
         fetchNextPage: vi.fn(),
-        hasNextPage: false,
+        hasNextPage,
         isFetchingNextPage: false
     });
 }
@@ -97,11 +97,15 @@ describe('useFilterSearch', () => {
 
         act(() => {
             result.current.onSearchChange('test');
+        });
+        act(() => {
             vi.advanceTimersByTime(300);
         });
 
         act(() => {
             result.current.onSearchChange('');
+        });
+        act(() => {
             vi.advanceTimersByTime(300);
         });
 
@@ -162,7 +166,7 @@ describe('useFilterSearch', () => {
         expect(fetchNextPage).toHaveBeenCalledOnce();
     });
 
-    it('escapes single quotes in search terms', () => {
+    it('passes raw search term to buildSearchFilter (caller handles escaping)', () => {
         const useQuery = createMockQuery();
         const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
 
@@ -176,10 +180,12 @@ describe('useFilterSearch', () => {
 
         act(() => {
             result.current.onSearchChange('it\'s');
+        });
+        act(() => {
             vi.advanceTimersByTime(300);
         });
 
-        expect(buildSearchFilter).toHaveBeenCalledWith('it\'\'s');
+        expect(buildSearchFilter).toHaveBeenCalledWith('it\'s');
     });
 
     it('reports isLoading only when there are no options and query is loading', () => {
@@ -202,8 +208,9 @@ describe('useFilterSearch', () => {
         expect(result.current.isLoading).toBe(true);
     });
 
-    it('reports isLoading while debouncing a search term', () => {
-        const useQuery = createMockQuery([{id: 'a', name: 'Alpha'}]);
+    it('reports isLoading while debouncing a search term (server search)', () => {
+        // hasNextPage: true forces server search (local search would be instant, no loading)
+        const useQuery = createMockQuery([{id: 'a', name: 'Alpha'}], {hasNextPage: true});
 
         const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
             useQuery,
@@ -219,7 +226,7 @@ describe('useFilterSearch', () => {
             result.current.onSearchChange('alp');
         });
 
-        // Should be loading while debouncing
+        // Should be loading while debouncing (server search pending)
         expect(result.current.isLoading).toBe(true);
 
         act(() => {
@@ -230,13 +237,14 @@ describe('useFilterSearch', () => {
         expect(result.current.isLoading).toBe(false);
     });
 
-    it('reports isLoading while query is fetching search results', () => {
+    it('reports isLoading while query is fetching search results (server search)', () => {
+        // hasNextPage: true forces server search
         const useQuery = vi.fn().mockReturnValue({
             data: {items: [{id: 'a', name: 'Alpha'}]} as MockResponse,
             isLoading: false,
             isFetching: true,
             fetchNextPage: vi.fn(),
-            hasNextPage: false,
+            hasNextPage: true,
             isFetchingNextPage: false
         });
 
@@ -251,6 +259,8 @@ describe('useFilterSearch', () => {
         // Trigger a search and advance past debounce
         act(() => {
             result.current.onSearchChange('alp');
+        });
+        act(() => {
             vi.advanceTimersByTime(300);
         });
 
@@ -276,6 +286,26 @@ describe('useFilterSearch', () => {
         }));
 
         // isFetching but no search term — should not show loading
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('does not report isLoading for search when local search is active', () => {
+        // hasNextPage: false + items → local search activates
+        const useQuery = createMockQuery([{id: 'a', name: 'Alpha'}]);
+
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+            useQuery,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name',
+            buildSearchFilter: (term: string) => `name:~'${term}'`
+        }));
+
+        act(() => {
+            result.current.onSearchChange('alp');
+        });
+
+        // Local search is instant — no loading state
         expect(result.current.isLoading).toBe(false);
     });
 
@@ -313,6 +343,8 @@ describe('useFilterSearch', () => {
         // Search adds to the base filter
         act(() => {
             result.current.onSearchChange('gold');
+        });
+        act(() => {
             vi.advanceTimersByTime(300);
         });
 
@@ -372,6 +404,8 @@ describe('useFilterSearch', () => {
 
             act(() => {
                 result.current.onSearchChange('alp');
+            });
+            act(() => {
                 vi.advanceTimersByTime(300);
             });
 

--- a/apps/posts/src/views/members/hooks/use-filter-search.test.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.test.ts
@@ -9,11 +9,12 @@ interface MockItem {
 
 interface MockResponse {
     items: MockItem[];
+    isEnd?: boolean;
 }
 
-function createMockQuery(items: MockItem[] = []) {
+function createMockQuery(items: MockItem[] = [], {isEnd = true}: {isEnd?: boolean} = {}) {
     return vi.fn().mockReturnValue({
-        data: {items} as MockResponse,
+        data: {items, isEnd} as MockResponse,
         isLoading: false,
         isFetching: false,
         fetchNextPage: vi.fn(),
@@ -353,7 +354,7 @@ describe('useFilterSearch', () => {
         it('uses server search when initial query has more pages', () => {
             const items = [{id: 'a', name: 'Alpha'}, {id: 'b', name: 'Beta'}];
             const useQuery = vi.fn().mockReturnValue({
-                data: {items} as MockResponse,
+                data: {items, isEnd: false} as MockResponse,
                 isLoading: false,
                 isFetching: false,
                 fetchNextPage: vi.fn(),

--- a/apps/posts/src/views/members/hooks/use-filter-search.test.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.test.ts
@@ -1,18 +1,8 @@
 import {act, renderHook} from '@testing-library/react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {useFilterSearch} from './use-filter-search';
+import {useFilterSearch, useFilterSearchParams} from './use-filter-search';
 
-function createMockQuery(items: Array<{value: string; label: string}> = []) {
-    return vi.fn().mockReturnValue({
-        data: {items},
-        isLoading: false,
-        fetchNextPage: vi.fn(),
-        hasNextPage: false,
-        isFetchingNextPage: false
-    });
-}
-
-describe('useFilterSearch', () => {
+describe('useFilterSearchParams', () => {
     beforeEach(() => {
         vi.useFakeTimers();
     });
@@ -21,29 +11,19 @@ describe('useFilterSearch', () => {
         vi.useRealTimers();
     });
 
-    it('returns initial page of results when no search term', () => {
-        const items = [{value: 'a', label: 'Alpha'}, {value: 'b', label: 'Beta'}];
-        const useQuery = createMockQuery(items);
+    it('returns empty searchParams when no search term', () => {
+        const buildFilter = (term: string) => `name:~'${term}'`;
 
-        const {result} = renderHook(() => useFilterSearch({
-            useQuery,
-            extractItems: (data: {items: typeof items}) => data.items
-        }));
+        const {result} = renderHook(() => useFilterSearchParams(buildFilter));
 
-        expect(result.current.options).toEqual(items);
         expect(result.current.searchValue).toBe('');
-        expect(result.current.isLoading).toBe(false);
+        expect(result.current.searchParams).toEqual({});
     });
 
     it('debounces search input', () => {
-        const useQuery = createMockQuery();
-        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
+        const buildFilter = vi.fn((term: string) => `name:~'${term}'`);
 
-        const {result} = renderHook(() => useFilterSearch({
-            useQuery,
-            extractItems: (data: {items: never[]}) => data.items,
-            buildSearchFilter
-        }));
+        const {result} = renderHook(() => useFilterSearchParams(buildFilter));
 
         act(() => {
             result.current.onSearchChange('hel');
@@ -52,84 +32,124 @@ describe('useFilterSearch', () => {
         // Search value updates immediately
         expect(result.current.searchValue).toBe('hel');
 
-        // But the query should not have received the filter yet (still debouncing)
-        const lastCallBeforeDebounce = useQuery.mock.calls[useQuery.mock.calls.length - 1];
-        expect(lastCallBeforeDebounce[0].searchParams.filter).toBeUndefined();
+        // But searchParams should not have filter yet (still debouncing)
+        expect(result.current.searchParams).toEqual({});
 
         // Fast-forward past debounce
         act(() => {
             vi.advanceTimersByTime(300);
         });
 
-        const lastCallAfterDebounce = useQuery.mock.calls[useQuery.mock.calls.length - 1];
-        expect(lastCallAfterDebounce[0].searchParams.filter).toBe('name:~\'hel\'');
+        expect(result.current.searchParams).toEqual({filter: 'name:~\'hel\''});
     });
 
     it('clears filter param when search term is cleared', () => {
-        const useQuery = createMockQuery();
-        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
+        const buildFilter = (term: string) => `name:~'${term}'`;
 
-        const {result} = renderHook(() => useFilterSearch({
-            useQuery,
-            extractItems: (data: {items: never[]}) => data.items,
-            buildSearchFilter
-        }));
+        const {result} = renderHook(() => useFilterSearchParams(buildFilter));
 
-        // Type then debounce
         act(() => {
             result.current.onSearchChange('test');
             vi.advanceTimersByTime(300);
         });
 
-        // Clear
+        expect(result.current.searchParams.filter).toBeDefined();
+
         act(() => {
             result.current.onSearchChange('');
             vi.advanceTimersByTime(300);
         });
 
-        const lastCall = useQuery.mock.calls[useQuery.mock.calls.length - 1];
-        expect(lastCall[0].searchParams.filter).toBeUndefined();
+        expect(result.current.searchParams).toEqual({});
     });
 
-    it('exposes fetchNextPage/hasMore/isLoadingMore from the infinite query', () => {
+    it('escapes single quotes in search terms', () => {
+        const buildFilter = vi.fn((term: string) => `name:~'${term}'`);
+
+        const {result} = renderHook(() => useFilterSearchParams(buildFilter));
+
+        act(() => {
+            result.current.onSearchChange('it\'s');
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(buildFilter).toHaveBeenCalledWith('it\'\'s');
+    });
+});
+
+describe('useFilterSearch', () => {
+    it('returns options from query result', () => {
+        const items = [{value: 'a', label: 'Alpha'}, {value: 'b', label: 'Beta'}];
+        const queryResult = {
+            data: {items},
+            isLoading: false,
+            fetchNextPage: vi.fn(),
+            hasNextPage: false,
+            isFetchingNextPage: false
+        };
+
+        const {result} = renderHook(() => useFilterSearch({
+            queryResult,
+            extractItems: (data: {items: typeof items}) => data.items
+        }));
+
+        expect(result.current.options).toEqual(items);
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('exposes hasMore/isLoadingMore from the query result', () => {
+        const queryResult = {
+            data: {items: []},
+            isLoading: false,
+            fetchNextPage: vi.fn(),
+            hasNextPage: true,
+            isFetchingNextPage: true
+        };
+
+        const {result} = renderHook(() => useFilterSearch({
+            queryResult,
+            extractItems: () => []
+        }));
+
+        expect(result.current.hasMore).toBe(true);
+        expect(result.current.isLoadingMore).toBe(true);
+    });
+
+    it('does not call fetchNextPage when already fetching', () => {
         const fetchNextPage = vi.fn();
-        const useQuery = vi.fn().mockReturnValue({
+        const queryResult = {
             data: {items: []},
             isLoading: false,
             fetchNextPage,
             hasNextPage: true,
             isFetchingNextPage: true
-        });
+        };
 
         const {result} = renderHook(() => useFilterSearch({
-            useQuery,
-            extractItems: (data: {items: never[]}) => data.items
+            queryResult,
+            extractItems: () => []
         }));
-
-        expect(result.current.hasMore).toBe(true);
-        expect(result.current.isLoadingMore).toBe(true);
 
         act(() => {
             result.current.onLoadMore();
         });
 
-        // Should not call fetchNextPage because isFetchingNextPage is true
         expect(fetchNextPage).not.toHaveBeenCalled();
     });
 
-    it('calls fetchNextPage when hasNextPage is true and not already fetching', () => {
+    it('calls fetchNextPage when hasNextPage is true and not fetching', () => {
         const fetchNextPage = vi.fn();
-        const useQuery = vi.fn().mockReturnValue({
+        const queryResult = {
             data: {items: []},
             isLoading: false,
             fetchNextPage,
             hasNextPage: true,
             isFetchingNextPage: false
-        });
+        };
 
         const {result} = renderHook(() => useFilterSearch({
-            useQuery,
-            extractItems: (data: {items: never[]}) => data.items
+            queryResult,
+            extractItems: () => []
         }));
 
         act(() => {
@@ -139,38 +159,37 @@ describe('useFilterSearch', () => {
         expect(fetchNextPage).toHaveBeenCalledOnce();
     });
 
-    it('escapes single quotes in search terms', () => {
-        const useQuery = createMockQuery();
-        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
-
-        const {result} = renderHook(() => useFilterSearch({
-            useQuery,
-            extractItems: (data: {items: never[]}) => data.items,
-            buildSearchFilter
-        }));
-
-        act(() => {
-            result.current.onSearchChange('it\'s');
-            vi.advanceTimersByTime(300);
-        });
-
-        expect(buildSearchFilter).toHaveBeenCalledWith('it\'\'s');
-    });
-
     it('reports isLoading only when there are no options and query is loading', () => {
-        const useQuery = vi.fn().mockReturnValue({
+        const queryResult = {
             data: undefined,
             isLoading: true,
             fetchNextPage: vi.fn(),
-            hasNextPage: false,
+            hasNextPage: undefined,
             isFetchingNextPage: false
-        });
+        };
 
         const {result} = renderHook(() => useFilterSearch({
-            useQuery,
+            queryResult,
             extractItems: () => []
         }));
 
         expect(result.current.isLoading).toBe(true);
+    });
+
+    it('defaults hasMore to false when hasNextPage is undefined', () => {
+        const queryResult = {
+            data: undefined,
+            isLoading: true,
+            fetchNextPage: vi.fn(),
+            hasNextPage: undefined,
+            isFetchingNextPage: false
+        };
+
+        const {result} = renderHook(() => useFilterSearch({
+            queryResult,
+            extractItems: () => []
+        }));
+
+        expect(result.current.hasMore).toBe(false);
     });
 });

--- a/apps/posts/src/views/members/hooks/use-filter-search.test.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.test.ts
@@ -1,0 +1,176 @@
+import {act, renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {useFilterSearch} from './use-filter-search';
+
+function createMockQuery(items: Array<{value: string; label: string}> = []) {
+    return vi.fn().mockReturnValue({
+        data: {items},
+        isLoading: false,
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false
+    });
+}
+
+describe('useFilterSearch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns initial page of results when no search term', () => {
+        const items = [{value: 'a', label: 'Alpha'}, {value: 'b', label: 'Beta'}];
+        const useQuery = createMockQuery(items);
+
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: typeof items}) => data.items
+        }));
+
+        expect(result.current.options).toEqual(items);
+        expect(result.current.searchValue).toBe('');
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('debounces search input', () => {
+        const useQuery = createMockQuery();
+        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
+
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items,
+            buildSearchFilter
+        }));
+
+        act(() => {
+            result.current.onSearchChange('hel');
+        });
+
+        // Search value updates immediately
+        expect(result.current.searchValue).toBe('hel');
+
+        // But the query should not have received the filter yet (still debouncing)
+        const lastCallBeforeDebounce = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+        expect(lastCallBeforeDebounce[0].searchParams.filter).toBeUndefined();
+
+        // Fast-forward past debounce
+        act(() => {
+            vi.advanceTimersByTime(300);
+        });
+
+        const lastCallAfterDebounce = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+        expect(lastCallAfterDebounce[0].searchParams.filter).toBe('name:~\'hel\'');
+    });
+
+    it('clears filter param when search term is cleared', () => {
+        const useQuery = createMockQuery();
+        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
+
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items,
+            buildSearchFilter
+        }));
+
+        // Type then debounce
+        act(() => {
+            result.current.onSearchChange('test');
+            vi.advanceTimersByTime(300);
+        });
+
+        // Clear
+        act(() => {
+            result.current.onSearchChange('');
+            vi.advanceTimersByTime(300);
+        });
+
+        const lastCall = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+        expect(lastCall[0].searchParams.filter).toBeUndefined();
+    });
+
+    it('exposes fetchNextPage/hasMore/isLoadingMore from the infinite query', () => {
+        const fetchNextPage = vi.fn();
+        const useQuery = vi.fn().mockReturnValue({
+            data: {items: []},
+            isLoading: false,
+            fetchNextPage,
+            hasNextPage: true,
+            isFetchingNextPage: true
+        });
+
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items
+        }));
+
+        expect(result.current.hasMore).toBe(true);
+        expect(result.current.isLoadingMore).toBe(true);
+
+        act(() => {
+            result.current.onLoadMore();
+        });
+
+        // Should not call fetchNextPage because isFetchingNextPage is true
+        expect(fetchNextPage).not.toHaveBeenCalled();
+    });
+
+    it('calls fetchNextPage when hasNextPage is true and not already fetching', () => {
+        const fetchNextPage = vi.fn();
+        const useQuery = vi.fn().mockReturnValue({
+            data: {items: []},
+            isLoading: false,
+            fetchNextPage,
+            hasNextPage: true,
+            isFetchingNextPage: false
+        });
+
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items
+        }));
+
+        act(() => {
+            result.current.onLoadMore();
+        });
+
+        expect(fetchNextPage).toHaveBeenCalledOnce();
+    });
+
+    it('escapes single quotes in search terms', () => {
+        const useQuery = createMockQuery();
+        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
+
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items,
+            buildSearchFilter
+        }));
+
+        act(() => {
+            result.current.onSearchChange('it\'s');
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(buildSearchFilter).toHaveBeenCalledWith('it\'\'s');
+    });
+
+    it('reports isLoading only when there are no options and query is loading', () => {
+        const useQuery = vi.fn().mockReturnValue({
+            data: undefined,
+            isLoading: true,
+            fetchNextPage: vi.fn(),
+            hasNextPage: false,
+            isFetchingNextPage: false
+        });
+
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: () => []
+        }));
+
+        expect(result.current.isLoading).toBe(true);
+    });
+});

--- a/apps/posts/src/views/members/hooks/use-filter-search.test.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.test.ts
@@ -318,4 +318,110 @@ describe('useFilterSearch', () => {
         const searchCall = useQuery.mock.calls[useQuery.mock.calls.length - 1];
         expect(searchCall[0].searchParams.filter).toBe('type:paid+name:~\'gold\'');
     });
+
+    describe('local search fallback', () => {
+        it('filters locally when initial query returns all items (no next page)', () => {
+            const items = [{id: 'a', name: 'Alpha'}, {id: 'b', name: 'Beta'}, {id: 'c', name: 'Charlie'}];
+            const useQuery = createMockQuery(items);
+
+            const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+                useQuery,
+                dataKey: 'items',
+                valueKey: 'id',
+                labelKey: 'name',
+                buildSearchFilter: (term: string) => `name:~'${term}'`
+            }));
+
+            // All 3 items returned, hasNextPage is false — local search should activate
+            expect(result.current.options).toHaveLength(3);
+
+            act(() => {
+                result.current.onSearchChange('alp');
+            });
+
+            // Should filter immediately without debounce
+            expect(result.current.options).toEqual([
+                {value: 'a', label: 'Alpha'}
+            ]);
+            expect(result.current.isLoading).toBe(false);
+
+            // Should NOT have triggered a new server query with search filter
+            const lastCall = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+            expect(lastCall[0].searchParams.filter).toBeUndefined();
+        });
+
+        it('uses server search when initial query has more pages', () => {
+            const items = [{id: 'a', name: 'Alpha'}, {id: 'b', name: 'Beta'}];
+            const useQuery = vi.fn().mockReturnValue({
+                data: {items} as MockResponse,
+                isLoading: false,
+                isFetching: false,
+                fetchNextPage: vi.fn(),
+                hasNextPage: true,
+                isFetchingNextPage: false
+            });
+
+            const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+                useQuery,
+                dataKey: 'items',
+                valueKey: 'id',
+                labelKey: 'name',
+                buildSearchFilter: (term: string) => `name:~'${term}'`
+            }));
+
+            act(() => {
+                result.current.onSearchChange('alp');
+                vi.advanceTimersByTime(300);
+            });
+
+            // Should use server search (debounced query with filter)
+            const lastCall = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+            expect(lastCall[0].searchParams.filter).toBe('name:~\'alp\'');
+        });
+
+        it('shows all items when local search is cleared', () => {
+            const items = [{id: 'a', name: 'Alpha'}, {id: 'b', name: 'Beta'}];
+            const useQuery = createMockQuery(items);
+
+            const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+                useQuery,
+                dataKey: 'items',
+                valueKey: 'id',
+                labelKey: 'name',
+                buildSearchFilter: (term: string) => `name:~'${term}'`
+            }));
+
+            act(() => {
+                result.current.onSearchChange('alp');
+            });
+
+            expect(result.current.options).toHaveLength(1);
+
+            act(() => {
+                result.current.onSearchChange('');
+            });
+
+            expect(result.current.options).toHaveLength(2);
+        });
+
+        it('local search is case-insensitive', () => {
+            const items = [{id: 'a', name: 'Alpha'}, {id: 'b', name: 'BETA'}];
+            const useQuery = createMockQuery(items);
+
+            const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+                useQuery,
+                dataKey: 'items',
+                valueKey: 'id',
+                labelKey: 'name'
+            }));
+
+            act(() => {
+                result.current.onSearchChange('beta');
+            });
+
+            expect(result.current.options).toEqual([
+                {value: 'b', label: 'BETA'}
+            ]);
+        });
+    });
 });

--- a/apps/posts/src/views/members/hooks/use-filter-search.test.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.test.ts
@@ -2,9 +2,18 @@ import {act, renderHook} from '@testing-library/react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {useFilterSearch} from './use-filter-search';
 
-function createMockQuery(items: Array<{value: string; label: string}> = []) {
+interface MockItem {
+    id: string;
+    name: string;
+}
+
+interface MockResponse {
+    items: MockItem[];
+}
+
+function createMockQuery(items: MockItem[] = []) {
     return vi.fn().mockReturnValue({
-        data: {items},
+        data: {items} as MockResponse,
         isLoading: false,
         fetchNextPage: vi.fn(),
         hasNextPage: false,
@@ -22,15 +31,20 @@ describe('useFilterSearch', () => {
     });
 
     it('returns initial page of results when no search term', () => {
-        const items = [{value: 'a', label: 'Alpha'}, {value: 'b', label: 'Beta'}];
+        const items = [{id: 'a', name: 'Alpha'}, {id: 'b', name: 'Beta'}];
         const useQuery = createMockQuery(items);
 
-        const {result} = renderHook(() => useFilterSearch({
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
             useQuery,
-            extractItems: (data: {items: typeof items}) => data.items
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name'
         }));
 
-        expect(result.current.options).toEqual(items);
+        expect(result.current.options).toEqual([
+            {value: 'a', label: 'Alpha'},
+            {value: 'b', label: 'Beta'}
+        ]);
         expect(result.current.searchValue).toBe('');
         expect(result.current.isLoading).toBe(false);
     });
@@ -39,9 +53,11 @@ describe('useFilterSearch', () => {
         const useQuery = createMockQuery();
         const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
 
-        const {result} = renderHook(() => useFilterSearch({
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
             useQuery,
-            extractItems: (data: {items: never[]}) => data.items,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name',
             buildSearchFilter
         }));
 
@@ -69,9 +85,11 @@ describe('useFilterSearch', () => {
         const useQuery = createMockQuery();
         const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
 
-        const {result} = renderHook(() => useFilterSearch({
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
             useQuery,
-            extractItems: (data: {items: never[]}) => data.items,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name',
             buildSearchFilter
         }));
 
@@ -89,19 +107,21 @@ describe('useFilterSearch', () => {
         expect(lastCall[0].searchParams.filter).toBeUndefined();
     });
 
-    it('exposes fetchNextPage/hasMore/isLoadingMore from the infinite query', () => {
+    it('does not call fetchNextPage when already fetching', () => {
         const fetchNextPage = vi.fn();
         const useQuery = vi.fn().mockReturnValue({
-            data: {items: []},
+            data: {items: []} as MockResponse,
             isLoading: false,
             fetchNextPage,
             hasNextPage: true,
             isFetchingNextPage: true
         });
 
-        const {result} = renderHook(() => useFilterSearch({
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
             useQuery,
-            extractItems: (data: {items: never[]}) => data.items
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name'
         }));
 
         expect(result.current.hasMore).toBe(true);
@@ -111,23 +131,24 @@ describe('useFilterSearch', () => {
             result.current.onLoadMore();
         });
 
-        // Should not call fetchNextPage because isFetchingNextPage is true
         expect(fetchNextPage).not.toHaveBeenCalled();
     });
 
     it('calls fetchNextPage when hasNextPage is true and not already fetching', () => {
         const fetchNextPage = vi.fn();
         const useQuery = vi.fn().mockReturnValue({
-            data: {items: []},
+            data: {items: []} as MockResponse,
             isLoading: false,
             fetchNextPage,
             hasNextPage: true,
             isFetchingNextPage: false
         });
 
-        const {result} = renderHook(() => useFilterSearch({
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
             useQuery,
-            extractItems: (data: {items: never[]}) => data.items
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name'
         }));
 
         act(() => {
@@ -141,9 +162,11 @@ describe('useFilterSearch', () => {
         const useQuery = createMockQuery();
         const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
 
-        const {result} = renderHook(() => useFilterSearch({
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
             useQuery,
-            extractItems: (data: {items: never[]}) => data.items,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name',
             buildSearchFilter
         }));
 
@@ -157,18 +180,47 @@ describe('useFilterSearch', () => {
 
     it('reports isLoading only when there are no options and query is loading', () => {
         const useQuery = vi.fn().mockReturnValue({
-            data: undefined,
+            data: undefined as MockResponse | undefined,
             isLoading: true,
             fetchNextPage: vi.fn(),
             hasNextPage: false,
             isFetchingNextPage: false
         });
 
-        const {result} = renderHook(() => useFilterSearch({
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
             useQuery,
-            extractItems: () => []
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name'
         }));
 
         expect(result.current.isLoading).toBe(true);
+    });
+
+    it('combines baseFilter with search filter', () => {
+        const useQuery = createMockQuery();
+        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
+
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+            useQuery,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name',
+            baseFilter: 'type:paid',
+            buildSearchFilter
+        }));
+
+        // Base filter should always be present
+        const initialCall = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+        expect(initialCall[0].searchParams.filter).toBe('type:paid');
+
+        // Search adds to the base filter
+        act(() => {
+            result.current.onSearchChange('gold');
+            vi.advanceTimersByTime(300);
+        });
+
+        const searchCall = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+        expect(searchCall[0].searchParams.filter).toBe('type:paid+name:~\'gold\'');
     });
 });

--- a/apps/posts/src/views/members/hooks/use-filter-search.test.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.test.ts
@@ -1,8 +1,18 @@
 import {act, renderHook} from '@testing-library/react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {useFilterSearch, useFilterSearchParams} from './use-filter-search';
+import {useFilterSearch} from './use-filter-search';
 
-describe('useFilterSearchParams', () => {
+function createMockQuery(items: Array<{value: string; label: string}> = []) {
+    return vi.fn().mockReturnValue({
+        data: {items},
+        isLoading: false,
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false
+    });
+}
+
+describe('useFilterSearch', () => {
     beforeEach(() => {
         vi.useFakeTimers();
     });
@@ -11,19 +21,29 @@ describe('useFilterSearchParams', () => {
         vi.useRealTimers();
     });
 
-    it('returns empty searchParams when no search term', () => {
-        const buildFilter = (term: string) => `name:~'${term}'`;
+    it('returns initial page of results when no search term', () => {
+        const items = [{value: 'a', label: 'Alpha'}, {value: 'b', label: 'Beta'}];
+        const useQuery = createMockQuery(items);
 
-        const {result} = renderHook(() => useFilterSearchParams(buildFilter));
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: typeof items}) => data.items
+        }));
 
+        expect(result.current.options).toEqual(items);
         expect(result.current.searchValue).toBe('');
-        expect(result.current.searchParams).toEqual({});
+        expect(result.current.isLoading).toBe(false);
     });
 
     it('debounces search input', () => {
-        const buildFilter = vi.fn((term: string) => `name:~'${term}'`);
+        const useQuery = createMockQuery();
+        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
 
-        const {result} = renderHook(() => useFilterSearchParams(buildFilter));
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items,
+            buildSearchFilter
+        }));
 
         act(() => {
             result.current.onSearchChange('hel');
@@ -32,124 +52,82 @@ describe('useFilterSearchParams', () => {
         // Search value updates immediately
         expect(result.current.searchValue).toBe('hel');
 
-        // But searchParams should not have filter yet (still debouncing)
-        expect(result.current.searchParams).toEqual({});
+        // But the query should not have received the filter yet (still debouncing)
+        const lastCallBeforeDebounce = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+        expect(lastCallBeforeDebounce[0].searchParams.filter).toBeUndefined();
 
         // Fast-forward past debounce
         act(() => {
             vi.advanceTimersByTime(300);
         });
 
-        expect(result.current.searchParams).toEqual({filter: 'name:~\'hel\''});
+        const lastCallAfterDebounce = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+        expect(lastCallAfterDebounce[0].searchParams.filter).toBe('name:~\'hel\'');
     });
 
     it('clears filter param when search term is cleared', () => {
-        const buildFilter = (term: string) => `name:~'${term}'`;
+        const useQuery = createMockQuery();
+        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
 
-        const {result} = renderHook(() => useFilterSearchParams(buildFilter));
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items,
+            buildSearchFilter
+        }));
 
         act(() => {
             result.current.onSearchChange('test');
             vi.advanceTimersByTime(300);
         });
 
-        expect(result.current.searchParams.filter).toBeDefined();
-
         act(() => {
             result.current.onSearchChange('');
             vi.advanceTimersByTime(300);
         });
 
-        expect(result.current.searchParams).toEqual({});
+        const lastCall = useQuery.mock.calls[useQuery.mock.calls.length - 1];
+        expect(lastCall[0].searchParams.filter).toBeUndefined();
     });
 
-    it('escapes single quotes in search terms', () => {
-        const buildFilter = vi.fn((term: string) => `name:~'${term}'`);
-
-        const {result} = renderHook(() => useFilterSearchParams(buildFilter));
-
-        act(() => {
-            result.current.onSearchChange('it\'s');
-            vi.advanceTimersByTime(300);
-        });
-
-        expect(buildFilter).toHaveBeenCalledWith('it\'\'s');
-    });
-});
-
-describe('useFilterSearch', () => {
-    it('returns options from query result', () => {
-        const items = [{value: 'a', label: 'Alpha'}, {value: 'b', label: 'Beta'}];
-        const queryResult = {
-            data: {items},
-            isLoading: false,
-            fetchNextPage: vi.fn(),
-            hasNextPage: false,
-            isFetchingNextPage: false
-        };
-
-        const {result} = renderHook(() => useFilterSearch({
-            queryResult,
-            extractItems: (data: {items: typeof items}) => data.items
-        }));
-
-        expect(result.current.options).toEqual(items);
-        expect(result.current.isLoading).toBe(false);
-    });
-
-    it('exposes hasMore/isLoadingMore from the query result', () => {
-        const queryResult = {
-            data: {items: []},
-            isLoading: false,
-            fetchNextPage: vi.fn(),
-            hasNextPage: true,
-            isFetchingNextPage: true
-        };
-
-        const {result} = renderHook(() => useFilterSearch({
-            queryResult,
-            extractItems: () => []
-        }));
-
-        expect(result.current.hasMore).toBe(true);
-        expect(result.current.isLoadingMore).toBe(true);
-    });
-
-    it('does not call fetchNextPage when already fetching', () => {
+    it('exposes fetchNextPage/hasMore/isLoadingMore from the infinite query', () => {
         const fetchNextPage = vi.fn();
-        const queryResult = {
+        const useQuery = vi.fn().mockReturnValue({
             data: {items: []},
             isLoading: false,
             fetchNextPage,
             hasNextPage: true,
             isFetchingNextPage: true
-        };
+        });
 
         const {result} = renderHook(() => useFilterSearch({
-            queryResult,
-            extractItems: () => []
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items
         }));
+
+        expect(result.current.hasMore).toBe(true);
+        expect(result.current.isLoadingMore).toBe(true);
 
         act(() => {
             result.current.onLoadMore();
         });
 
+        // Should not call fetchNextPage because isFetchingNextPage is true
         expect(fetchNextPage).not.toHaveBeenCalled();
     });
 
-    it('calls fetchNextPage when hasNextPage is true and not fetching', () => {
+    it('calls fetchNextPage when hasNextPage is true and not already fetching', () => {
         const fetchNextPage = vi.fn();
-        const queryResult = {
+        const useQuery = vi.fn().mockReturnValue({
             data: {items: []},
             isLoading: false,
             fetchNextPage,
             hasNextPage: true,
             isFetchingNextPage: false
-        };
+        });
 
         const {result} = renderHook(() => useFilterSearch({
-            queryResult,
-            extractItems: () => []
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items
         }));
 
         act(() => {
@@ -159,37 +137,38 @@ describe('useFilterSearch', () => {
         expect(fetchNextPage).toHaveBeenCalledOnce();
     });
 
+    it('escapes single quotes in search terms', () => {
+        const useQuery = createMockQuery();
+        const buildSearchFilter = vi.fn((term: string) => `name:~'${term}'`);
+
+        const {result} = renderHook(() => useFilterSearch({
+            useQuery,
+            extractItems: (data: {items: never[]}) => data.items,
+            buildSearchFilter
+        }));
+
+        act(() => {
+            result.current.onSearchChange('it\'s');
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(buildSearchFilter).toHaveBeenCalledWith('it\'\'s');
+    });
+
     it('reports isLoading only when there are no options and query is loading', () => {
-        const queryResult = {
+        const useQuery = vi.fn().mockReturnValue({
             data: undefined,
             isLoading: true,
             fetchNextPage: vi.fn(),
-            hasNextPage: undefined,
+            hasNextPage: false,
             isFetchingNextPage: false
-        };
+        });
 
         const {result} = renderHook(() => useFilterSearch({
-            queryResult,
+            useQuery,
             extractItems: () => []
         }));
 
         expect(result.current.isLoading).toBe(true);
-    });
-
-    it('defaults hasMore to false when hasNextPage is undefined', () => {
-        const queryResult = {
-            data: undefined,
-            isLoading: true,
-            fetchNextPage: vi.fn(),
-            hasNextPage: undefined,
-            isFetchingNextPage: false
-        };
-
-        const {result} = renderHook(() => useFilterSearch({
-            queryResult,
-            extractItems: () => []
-        }));
-
-        expect(result.current.hasMore).toBe(false);
     });
 });

--- a/apps/posts/src/views/members/hooks/use-filter-search.test.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.test.ts
@@ -15,6 +15,7 @@ function createMockQuery(items: MockItem[] = []) {
     return vi.fn().mockReturnValue({
         data: {items} as MockResponse,
         isLoading: false,
+        isFetching: false,
         fetchNextPage: vi.fn(),
         hasNextPage: false,
         isFetchingNextPage: false
@@ -112,6 +113,7 @@ describe('useFilterSearch', () => {
         const useQuery = vi.fn().mockReturnValue({
             data: {items: []} as MockResponse,
             isLoading: false,
+            isFetching: false,
             fetchNextPage,
             hasNextPage: true,
             isFetchingNextPage: true
@@ -139,6 +141,7 @@ describe('useFilterSearch', () => {
         const useQuery = vi.fn().mockReturnValue({
             data: {items: []} as MockResponse,
             isLoading: false,
+            isFetching: false,
             fetchNextPage,
             hasNextPage: true,
             isFetchingNextPage: false
@@ -182,6 +185,7 @@ describe('useFilterSearch', () => {
         const useQuery = vi.fn().mockReturnValue({
             data: undefined as MockResponse | undefined,
             isLoading: true,
+            isFetching: true,
             fetchNextPage: vi.fn(),
             hasNextPage: false,
             isFetchingNextPage: false
@@ -195,6 +199,97 @@ describe('useFilterSearch', () => {
         }));
 
         expect(result.current.isLoading).toBe(true);
+    });
+
+    it('reports isLoading while debouncing a search term', () => {
+        const useQuery = createMockQuery([{id: 'a', name: 'Alpha'}]);
+
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+            useQuery,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name',
+            buildSearchFilter: (term: string) => `name:~'${term}'`
+        }));
+
+        expect(result.current.isLoading).toBe(false);
+
+        act(() => {
+            result.current.onSearchChange('alp');
+        });
+
+        // Should be loading while debouncing
+        expect(result.current.isLoading).toBe(true);
+
+        act(() => {
+            vi.advanceTimersByTime(300);
+        });
+
+        // After debounce, not fetching so not loading
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('reports isLoading while query is fetching search results', () => {
+        const useQuery = vi.fn().mockReturnValue({
+            data: {items: [{id: 'a', name: 'Alpha'}]} as MockResponse,
+            isLoading: false,
+            isFetching: true,
+            fetchNextPage: vi.fn(),
+            hasNextPage: false,
+            isFetchingNextPage: false
+        });
+
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+            useQuery,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name',
+            buildSearchFilter: (term: string) => `name:~'${term}'`
+        }));
+
+        // Trigger a search and advance past debounce
+        act(() => {
+            result.current.onSearchChange('alp');
+            vi.advanceTimersByTime(300);
+        });
+
+        // Should be loading because isFetching is true and there's a search term
+        expect(result.current.isLoading).toBe(true);
+    });
+
+    it('does not report isLoading when isFetching on initial load with no search', () => {
+        const useQuery = vi.fn().mockReturnValue({
+            data: {items: [{id: 'a', name: 'Alpha'}]} as MockResponse,
+            isLoading: false,
+            isFetching: true,
+            fetchNextPage: vi.fn(),
+            hasNextPage: false,
+            isFetchingNextPage: false
+        });
+
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+            useQuery,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name'
+        }));
+
+        // isFetching but no search term — should not show loading
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('tracks initialCount from first unfiltered results', () => {
+        const items = [{id: 'a', name: 'Alpha'}, {id: 'b', name: 'Beta'}, {id: 'c', name: 'Charlie'}];
+        const useQuery = createMockQuery(items);
+
+        const {result} = renderHook(() => useFilterSearch<MockResponse, 'items'>({
+            useQuery,
+            dataKey: 'items',
+            valueKey: 'id',
+            labelKey: 'name'
+        }));
+
+        expect(result.current.initialCount).toBe(3);
     });
 
     it('combines baseFilter with search filter', () => {

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {FilterOption} from '@tryghost/shade';
 import type {InfiniteQueryHookOptions} from '@tryghost/admin-x-framework/hooks';
 
@@ -49,6 +49,14 @@ export function useFilterSearch<T, K extends keyof T & string>({
     const [inputValue, setInputValue] = useState('');
     const [debouncedValue, setDebouncedValue] = useState('');
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        return () => {
+            if (timerRef.current) {
+                clearTimeout(timerRef.current);
+            }
+        };
+    }, []);
 
     const onSearchChange = useCallback((search: string) => {
         setInputValue(search);

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -11,6 +11,7 @@ export interface UseFilterSearchOptions<T> {
         isFetchingNextPage: boolean;
     };
     extractItems: (data: T) => Array<{ value: string; label: string }>;
+    baseFilter?: string;
     buildSearchFilter?: (term: string) => string;
     limit?: string;
     debounceMs?: number;
@@ -33,6 +34,7 @@ function escapeNqlValue(term: string): string {
 export function useFilterSearch<T>({
     useQuery,
     extractItems,
+    baseFilter,
     buildSearchFilter,
     limit = '100',
     debounceMs = 250
@@ -55,13 +57,22 @@ export function useFilterSearch<T>({
 
     const searchParams = useMemo(() => {
         const params: Record<string, string> = {limit};
+        const filters: string[] = [];
+
+        if (baseFilter) {
+            filters.push(baseFilter);
+        }
 
         if (debouncedValue.trim() && buildSearchFilter) {
-            params.filter = buildSearchFilter(escapeNqlValue(debouncedValue.trim()));
+            filters.push(buildSearchFilter(escapeNqlValue(debouncedValue.trim())));
+        }
+
+        if (filters.length > 0) {
+            params.filter = filters.join('+');
         }
 
         return params;
-    }, [limit, debouncedValue, buildSearchFilter]);
+    }, [limit, baseFilter, debouncedValue, buildSearchFilter]);
 
     const {data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
 

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -2,7 +2,10 @@ import {useCallback, useMemo, useRef, useState} from 'react';
 import type {FilterOption} from '@tryghost/shade';
 import type {InfiniteQueryHookOptions} from '@tryghost/admin-x-framework/hooks';
 
-export interface UseFilterSearchOptions<T> {
+// Extract the item type from an array property on T
+type ArrayItem<T, K extends keyof T> = T[K] extends Array<infer Item> ? Item : never;
+
+export interface UseFilterSearchOptions<T, K extends keyof T & string> {
     useQuery: (options?: InfiniteQueryHookOptions<T>) => {
         data: T | undefined;
         isLoading: boolean;
@@ -10,7 +13,9 @@ export interface UseFilterSearchOptions<T> {
         hasNextPage?: boolean;
         isFetchingNextPage: boolean;
     };
-    extractItems: (data: T) => Array<{ value: string; label: string }>;
+    dataKey: K;
+    valueKey: keyof ArrayItem<T, K> & string;
+    labelKey: keyof ArrayItem<T, K> & string;
     baseFilter?: string;
     buildSearchFilter?: (term: string) => string;
     limit?: string;
@@ -31,14 +36,16 @@ function escapeNqlValue(term: string): string {
     return term.replace(/'/g, '\'\'');
 }
 
-export function useFilterSearch<T>({
+export function useFilterSearch<T, K extends keyof T & string>({
     useQuery,
-    extractItems,
+    dataKey,
+    valueKey,
+    labelKey,
     baseFilter,
     buildSearchFilter,
     limit = '100',
     debounceMs = 250
-}: UseFilterSearchOptions<T>): UseFilterSearchReturn {
+}: UseFilterSearchOptions<T, K>): UseFilterSearchReturn {
     const [inputValue, setInputValue] = useState('');
     const [debouncedValue, setDebouncedValue] = useState('');
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
@@ -80,8 +87,15 @@ export function useFilterSearch<T>({
         if (!data) {
             return [];
         }
-        return extractItems(data);
-    }, [data, extractItems]);
+        const items = data[dataKey];
+        if (!Array.isArray(items)) {
+            return [];
+        }
+        return items.map((item: ArrayItem<T, K>) => ({
+            value: String(item[valueKey]),
+            label: String(item[labelKey])
+        }));
+    }, [data, dataKey, valueKey, labelKey]);
 
     const onLoadMore = useCallback(() => {
         if (hasNextPage && !isFetchingNextPage) {

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -116,8 +116,11 @@ export function useFilterSearch<T, K extends keyof T & string>({
         }));
     }, [data, dataKey, valueKey, labelKey]);
 
-    // Once the initial load completes with all items on one page, switch to local search
-    if (!isLoading && !hasNextPage && allOptions.length > 0 && !debouncedValue.trim()) {
+    // Once the initial load completes with all items on one page, switch to local search.
+    // Uses the isEnd flag from the query's returnData rather than hasNextPage, which
+    // can be unreliable when defaultNextPageParams doesn't return undefined.
+    const isEnd = data && typeof data === 'object' && 'isEnd' in data && (data as Record<string, unknown>).isEnd === true;
+    if (!isLoading && isEnd && allOptions.length > 0 && !debouncedValue.trim()) {
         useLocalSearchRef.current = true;
     }
 

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -1,0 +1,92 @@
+import {useCallback, useMemo, useRef, useState} from 'react';
+import type {FilterOption} from '@tryghost/shade';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InfiniteQueryHook<T> = (options?: any) => {
+    data: T | undefined;
+    isLoading: boolean;
+    fetchNextPage: () => void;
+    hasNextPage: boolean;
+    isFetchingNextPage: boolean;
+};
+
+export interface UseFilterSearchOptions<T> {
+    useQuery: InfiniteQueryHook<T>;
+    extractItems: (data: T) => Array<{ value: string; label: string }>;
+    buildSearchFilter?: (term: string) => string;
+    limit?: string;
+    debounceMs?: number;
+}
+
+export interface UseFilterSearchReturn {
+    options: FilterOption<string>[];
+    isLoading: boolean;
+    searchValue: string;
+    onSearchChange: (search: string) => void;
+    onLoadMore: () => void;
+    hasMore: boolean;
+    isLoadingMore: boolean;
+}
+
+function escapeNqlValue(term: string): string {
+    return term.replace(/'/g, '\'\'');
+}
+
+export function useFilterSearch<T>({
+    useQuery,
+    extractItems,
+    buildSearchFilter,
+    limit = '100',
+    debounceMs = 250
+}: UseFilterSearchOptions<T>): UseFilterSearchReturn {
+    const [inputValue, setInputValue] = useState('');
+    const [debouncedValue, setDebouncedValue] = useState('');
+    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    const onSearchChange = useCallback((search: string) => {
+        setInputValue(search);
+
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+        }
+
+        timerRef.current = setTimeout(() => {
+            setDebouncedValue(search);
+        }, debounceMs);
+    }, [debounceMs]);
+
+    const searchParams = useMemo(() => {
+        const params: Record<string, string> = {limit};
+
+        if (debouncedValue.trim() && buildSearchFilter) {
+            params.filter = buildSearchFilter(escapeNqlValue(debouncedValue.trim()));
+        }
+
+        return params;
+    }, [limit, debouncedValue, buildSearchFilter]);
+
+    const {data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
+
+    const options = useMemo(() => {
+        if (!data) {
+            return [];
+        }
+        return extractItems(data);
+    }, [data, extractItems]);
+
+    const onLoadMore = useCallback(() => {
+        if (hasNextPage && !isFetchingNextPage) {
+            fetchNextPage();
+        }
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+    return {
+        options,
+        isLoading: options.length === 0 && isLoading,
+        searchValue: inputValue,
+        onSearchChange,
+        onLoadMore,
+        hasMore: hasNextPage,
+        isLoadingMore: isFetchingNextPage
+    };
+}

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -1,5 +1,5 @@
-import {useCallback, useMemo, useRef, useState} from 'react';
-import {useDebounce} from 'use-debounce';
+import {useInfiniteSearch} from '@src/hooks/use-infinite-search';
+import {useMemo, useRef} from 'react';
 import type {FilterOption} from '@tryghost/shade';
 import type {InfiniteQueryHookOptions} from '@tryghost/admin-x-framework/hooks';
 
@@ -35,10 +35,6 @@ export interface UseFilterSearchReturn {
     isLoadingMore: boolean;
 }
 
-function escapeNqlValue(term: string): string {
-    return term.replace(/'/g, '\'\'');
-}
-
 export function useFilterSearch<T, K extends keyof T & string>({
     useQuery,
     dataKey,
@@ -49,39 +45,20 @@ export function useFilterSearch<T, K extends keyof T & string>({
     limit = '100',
     debounceMs = 250
 }: UseFilterSearchOptions<T, K>): UseFilterSearchReturn {
-    const [inputValue, setInputValue] = useState('');
-    const useLocalSearchRef = useRef(false);
-
-    // Debounce is only used for server-side search; local search filters immediately
-    const [debouncedValue] = useDebounce(inputValue, debounceMs);
-    const serverSearchTerm = useLocalSearchRef.current ? '' : debouncedValue;
-
-    const searchParams = useMemo(() => {
-        const params: Record<string, string> = {limit};
-        const filters: string[] = [];
-
-        if (baseFilter) {
-            filters.push(baseFilter);
-        }
-
-        if (serverSearchTerm.trim() && buildSearchFilter) {
-            filters.push(buildSearchFilter(escapeNqlValue(serverSearchTerm.trim())));
-        }
-
-        if (filters.length > 0) {
-            params.filter = filters.join('+');
-        }
-
-        return params;
-    }, [limit, baseFilter, serverSearchTerm, buildSearchFilter]);
-
-    const {data, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
+    const search = useInfiniteSearch({
+        useQuery,
+        baseFilter,
+        buildSearchFilter,
+        limit,
+        debounceMs,
+        hasData: data => Array.isArray(data[dataKey]) && (data[dataKey] as unknown[]).length > 0
+    });
 
     const allOptions = useMemo(() => {
-        if (!data) {
+        if (!search.data) {
             return [];
         }
-        const items = data[dataKey];
+        const items = search.data[dataKey];
         if (!Array.isArray(items)) {
             return [];
         }
@@ -89,44 +66,32 @@ export function useFilterSearch<T, K extends keyof T & string>({
             value: String(item[valueKey]),
             label: String(item[labelKey])
         }));
-    }, [data, dataKey, valueKey, labelKey]);
+    }, [search.data, dataKey, valueKey, labelKey]);
 
-    // Once the initial load completes with all items on one page, switch to local search
-    if (!isLoading && !hasNextPage && allOptions.length > 0 && !serverSearchTerm.trim()) {
-        useLocalSearchRef.current = true;
-    }
-
+    // Track count from initial unfiltered results.  Set during render (not
+    // useEffect) so the value is available in the same render pass.
     const initialCountRef = useRef(0);
-    if (!serverSearchTerm.trim() && allOptions.length > 0) {
+    if (allOptions.length > 0 && (search.isLocalSearch || search.searchValue.trim() === '')) {
         initialCountRef.current = allOptions.length;
     }
 
     // Apply local filtering when all items are loaded
     const options = useMemo(() => {
-        if (useLocalSearchRef.current && inputValue.trim()) {
-            const term = inputValue.trim().toLowerCase();
+        if (search.isLocalSearch && search.searchValue.trim()) {
+            const term = search.searchValue.trim().toLowerCase();
             return allOptions.filter(opt => opt.label.toLowerCase().includes(term));
         }
         return allOptions;
-    }, [allOptions, inputValue]);
-
-    const onLoadMore = useCallback(() => {
-        if (hasNextPage && !isFetchingNextPage) {
-            fetchNextPage();
-        }
-    }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
-
-    const isSearchPending = !useLocalSearchRef.current && inputValue !== debouncedValue && inputValue.trim() !== '';
-    const isSearchFetching = !useLocalSearchRef.current && debouncedValue.trim() !== '' && isFetching;
+    }, [allOptions, search.isLocalSearch, search.searchValue]);
 
     return {
         options,
         initialCount: initialCountRef.current,
-        isLoading: (allOptions.length === 0 && isLoading) || isSearchPending || isSearchFetching,
-        searchValue: inputValue,
-        onSearchChange: setInputValue,
-        onLoadMore,
-        hasMore: hasNextPage ?? false,
-        isLoadingMore: isFetchingNextPage
+        isLoading: (allOptions.length === 0 && search.isLoading) || search.isSearchLoading,
+        searchValue: search.searchValue,
+        onSearchChange: search.onSearchChange,
+        onLoadMore: search.onLoadMore,
+        hasMore: search.hasMore,
+        isLoadingMore: search.isLoadingMore
     };
 }

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -9,6 +9,7 @@ export interface UseFilterSearchOptions<T, K extends keyof T & string> {
     useQuery: (options?: InfiniteQueryHookOptions<T>) => {
         data: T | undefined;
         isLoading: boolean;
+        isFetching: boolean;
         fetchNextPage: () => void;
         hasNextPage?: boolean;
         isFetchingNextPage: boolean;
@@ -24,6 +25,7 @@ export interface UseFilterSearchOptions<T, K extends keyof T & string> {
 
 export interface UseFilterSearchReturn {
     options: FilterOption<string>[];
+    initialCount: number;
     isLoading: boolean;
     searchValue: string;
     onSearchChange: (search: string) => void;
@@ -89,7 +91,7 @@ export function useFilterSearch<T, K extends keyof T & string>({
         return params;
     }, [limit, baseFilter, debouncedValue, buildSearchFilter]);
 
-    const {data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
+    const {data, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
 
     const options = useMemo(() => {
         if (!data) {
@@ -105,15 +107,24 @@ export function useFilterSearch<T, K extends keyof T & string>({
         }));
     }, [data, dataKey, valueKey, labelKey]);
 
+    const initialCountRef = useRef(0);
+    if (!debouncedValue.trim() && options.length > 0) {
+        initialCountRef.current = options.length;
+    }
+
     const onLoadMore = useCallback(() => {
         if (hasNextPage && !isFetchingNextPage) {
             fetchNextPage();
         }
     }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
+    const isSearchPending = inputValue !== debouncedValue && inputValue.trim() !== '';
+    const isSearchFetching = debouncedValue.trim() !== '' && isFetching;
+
     return {
         options,
-        isLoading: options.length === 0 && isLoading,
+        initialCount: initialCountRef.current,
+        isLoading: (options.length === 0 && isLoading) || isSearchPending || isSearchFetching,
         searchValue: inputValue,
         onSearchChange,
         onLoadMore,

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -91,11 +91,8 @@ export function useFilterSearch<T, K extends keyof T & string>({
         }));
     }, [data, dataKey, valueKey, labelKey]);
 
-    // Once the initial load completes with all items on one page, switch to local search.
-    // Uses the isEnd flag from the query's returnData rather than hasNextPage, which
-    // can be unreliable when defaultNextPageParams doesn't return undefined.
-    const isEnd = data && typeof data === 'object' && 'isEnd' in data && (data as Record<string, unknown>).isEnd === true;
-    if (!isLoading && isEnd && allOptions.length > 0 && !serverSearchTerm.trim()) {
+    // Once the initial load completes with all items on one page, switch to local search
+    if (!isLoading && !hasNextPage && allOptions.length > 0 && !serverSearchTerm.trim()) {
         useLocalSearchRef.current = true;
     }
 

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -52,6 +52,9 @@ export function useFilterSearch<T, K extends keyof T & string>({
     const [debouncedValue, setDebouncedValue] = useState('');
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
+    // Track whether the initial (no-search) query returned all items
+    const useLocalSearchRef = useRef(false);
+
     useEffect(() => {
         return () => {
             if (timerRef.current) {
@@ -67,11 +70,17 @@ export function useFilterSearch<T, K extends keyof T & string>({
             clearTimeout(timerRef.current);
         }
 
+        // Skip debounce + server query when filtering locally
+        if (useLocalSearchRef.current) {
+            return;
+        }
+
         timerRef.current = setTimeout(() => {
             setDebouncedValue(search);
         }, debounceMs);
     }, [debounceMs]);
 
+    // Only include search filter in query params when using server-side search
     const searchParams = useMemo(() => {
         const params: Record<string, string> = {limit};
         const filters: string[] = [];
@@ -80,7 +89,7 @@ export function useFilterSearch<T, K extends keyof T & string>({
             filters.push(baseFilter);
         }
 
-        if (debouncedValue.trim() && buildSearchFilter) {
+        if (!useLocalSearchRef.current && debouncedValue.trim() && buildSearchFilter) {
             filters.push(buildSearchFilter(escapeNqlValue(debouncedValue.trim())));
         }
 
@@ -93,7 +102,7 @@ export function useFilterSearch<T, K extends keyof T & string>({
 
     const {data, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
 
-    const options = useMemo(() => {
+    const allOptions = useMemo(() => {
         if (!data) {
             return [];
         }
@@ -107,10 +116,24 @@ export function useFilterSearch<T, K extends keyof T & string>({
         }));
     }, [data, dataKey, valueKey, labelKey]);
 
-    const initialCountRef = useRef(0);
-    if (!debouncedValue.trim() && options.length > 0) {
-        initialCountRef.current = options.length;
+    // Once the initial load completes with all items on one page, switch to local search
+    if (!isLoading && !hasNextPage && allOptions.length > 0 && !debouncedValue.trim()) {
+        useLocalSearchRef.current = true;
     }
+
+    const initialCountRef = useRef(0);
+    if (!debouncedValue.trim() && allOptions.length > 0) {
+        initialCountRef.current = allOptions.length;
+    }
+
+    // Apply local filtering when all items are loaded
+    const options = useMemo(() => {
+        if (useLocalSearchRef.current && inputValue.trim()) {
+            const term = inputValue.trim().toLowerCase();
+            return allOptions.filter(opt => opt.label.toLowerCase().includes(term));
+        }
+        return allOptions;
+    }, [allOptions, inputValue]);
 
     const onLoadMore = useCallback(() => {
         if (hasNextPage && !isFetchingNextPage) {
@@ -118,13 +141,13 @@ export function useFilterSearch<T, K extends keyof T & string>({
         }
     }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-    const isSearchPending = inputValue !== debouncedValue && inputValue.trim() !== '';
-    const isSearchFetching = debouncedValue.trim() !== '' && isFetching;
+    const isSearchPending = !useLocalSearchRef.current && inputValue !== debouncedValue && inputValue.trim() !== '';
+    const isSearchFetching = !useLocalSearchRef.current && debouncedValue.trim() !== '' && isFetching;
 
     return {
         options,
         initialCount: initialCountRef.current,
-        isLoading: (options.length === 0 && isLoading) || isSearchPending || isSearchFetching,
+        isLoading: (allOptions.length === 0 && isLoading) || isSearchPending || isSearchFetching,
         searchValue: inputValue,
         onSearchChange,
         onLoadMore,

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -1,5 +1,20 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import type {FilterOption} from '@tryghost/shade';
+import type {InfiniteQueryHookOptions} from '@tryghost/admin-x-framework/hooks';
+
+export interface UseFilterSearchOptions<T> {
+    useQuery: (options?: InfiniteQueryHookOptions<T>) => {
+        data: T | undefined;
+        isLoading: boolean;
+        fetchNextPage: () => void;
+        hasNextPage?: boolean;
+        isFetchingNextPage: boolean;
+    };
+    extractItems: (data: T) => Array<{ value: string; label: string }>;
+    buildSearchFilter?: (term: string) => string;
+    limit?: string;
+    debounceMs?: number;
+}
 
 export interface UseFilterSearchReturn {
     options: FilterOption<string>[];
@@ -15,22 +30,13 @@ function escapeNqlValue(term: string): string {
     return term.replace(/'/g, '\'\'');
 }
 
-interface UseFilterSearchOptions<T> {
-    queryResult: {
-        data: T | undefined;
-        isLoading: boolean;
-        fetchNextPage: () => void;
-        hasNextPage?: boolean;
-        isFetchingNextPage: boolean;
-    };
-    extractItems: (data: T) => Array<{ value: string; label: string }>;
-}
-
-/**
- * Build a debounced NQL filter param for server-side search.
- * Returns `searchParams` to merge into the query hook call.
- */
-export function useFilterSearchParams(buildSearchFilter: (term: string) => string) {
+export function useFilterSearch<T>({
+    useQuery,
+    extractItems,
+    buildSearchFilter,
+    limit = '100',
+    debounceMs = 250
+}: UseFilterSearchOptions<T>): UseFilterSearchReturn {
     const [inputValue, setInputValue] = useState('');
     const [debouncedValue, setDebouncedValue] = useState('');
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
@@ -44,35 +50,20 @@ export function useFilterSearchParams(buildSearchFilter: (term: string) => strin
 
         timerRef.current = setTimeout(() => {
             setDebouncedValue(search);
-        }, 250);
-    }, []);
+        }, debounceMs);
+    }, [debounceMs]);
 
     const searchParams = useMemo(() => {
-        const params: Record<string, string> = {};
+        const params: Record<string, string> = {limit};
 
-        if (debouncedValue.trim()) {
+        if (debouncedValue.trim() && buildSearchFilter) {
             params.filter = buildSearchFilter(escapeNqlValue(debouncedValue.trim()));
         }
 
         return params;
-    }, [debouncedValue, buildSearchFilter]);
+    }, [limit, debouncedValue, buildSearchFilter]);
 
-    return {
-        searchValue: inputValue,
-        onSearchChange,
-        searchParams
-    };
-}
-
-/**
- * Combine an infinite query result with search state into a unified
- * filter-search return value.
- */
-export function useFilterSearch<T>({
-    queryResult,
-    extractItems
-}: UseFilterSearchOptions<T>): Omit<UseFilterSearchReturn, 'searchValue' | 'onSearchChange'> {
-    const {data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = queryResult;
+    const {data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
 
     const options = useMemo(() => {
         if (!data) {
@@ -90,6 +81,8 @@ export function useFilterSearch<T>({
     return {
         options,
         isLoading: options.length === 0 && isLoading,
+        searchValue: inputValue,
+        onSearchChange,
         onLoadMore,
         hasMore: hasNextPage ?? false,
         isLoadingMore: isFetchingNextPage

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -1,23 +1,6 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import type {FilterOption} from '@tryghost/shade';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type InfiniteQueryHook<T> = (options?: any) => {
-    data: T | undefined;
-    isLoading: boolean;
-    fetchNextPage: () => void;
-    hasNextPage: boolean;
-    isFetchingNextPage: boolean;
-};
-
-export interface UseFilterSearchOptions<T> {
-    useQuery: InfiniteQueryHook<T>;
-    extractItems: (data: T) => Array<{ value: string; label: string }>;
-    buildSearchFilter?: (term: string) => string;
-    limit?: string;
-    debounceMs?: number;
-}
-
 export interface UseFilterSearchReturn {
     options: FilterOption<string>[];
     isLoading: boolean;
@@ -32,13 +15,22 @@ function escapeNqlValue(term: string): string {
     return term.replace(/'/g, '\'\'');
 }
 
-export function useFilterSearch<T>({
-    useQuery,
-    extractItems,
-    buildSearchFilter,
-    limit = '100',
-    debounceMs = 250
-}: UseFilterSearchOptions<T>): UseFilterSearchReturn {
+interface UseFilterSearchOptions<T> {
+    queryResult: {
+        data: T | undefined;
+        isLoading: boolean;
+        fetchNextPage: () => void;
+        hasNextPage?: boolean;
+        isFetchingNextPage: boolean;
+    };
+    extractItems: (data: T) => Array<{ value: string; label: string }>;
+}
+
+/**
+ * Build a debounced NQL filter param for server-side search.
+ * Returns `searchParams` to merge into the query hook call.
+ */
+export function useFilterSearchParams(buildSearchFilter: (term: string) => string) {
     const [inputValue, setInputValue] = useState('');
     const [debouncedValue, setDebouncedValue] = useState('');
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
@@ -52,20 +44,35 @@ export function useFilterSearch<T>({
 
         timerRef.current = setTimeout(() => {
             setDebouncedValue(search);
-        }, debounceMs);
-    }, [debounceMs]);
+        }, 250);
+    }, []);
 
     const searchParams = useMemo(() => {
-        const params: Record<string, string> = {limit};
+        const params: Record<string, string> = {};
 
-        if (debouncedValue.trim() && buildSearchFilter) {
+        if (debouncedValue.trim()) {
             params.filter = buildSearchFilter(escapeNqlValue(debouncedValue.trim()));
         }
 
         return params;
-    }, [limit, debouncedValue, buildSearchFilter]);
+    }, [debouncedValue, buildSearchFilter]);
 
-    const {data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
+    return {
+        searchValue: inputValue,
+        onSearchChange,
+        searchParams
+    };
+}
+
+/**
+ * Combine an infinite query result with search state into a unified
+ * filter-search return value.
+ */
+export function useFilterSearch<T>({
+    queryResult,
+    extractItems
+}: UseFilterSearchOptions<T>): Omit<UseFilterSearchReturn, 'searchValue' | 'onSearchChange'> {
+    const {data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage} = queryResult;
 
     const options = useMemo(() => {
         if (!data) {
@@ -83,10 +90,8 @@ export function useFilterSearch<T>({
     return {
         options,
         isLoading: options.length === 0 && isLoading,
-        searchValue: inputValue,
-        onSearchChange,
         onLoadMore,
-        hasMore: hasNextPage,
+        hasMore: hasNextPage ?? false,
         isLoadingMore: isFetchingNextPage
     };
 }

--- a/apps/posts/src/views/members/hooks/use-filter-search.ts
+++ b/apps/posts/src/views/members/hooks/use-filter-search.ts
@@ -1,4 +1,5 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
+import {useDebounce} from 'use-debounce';
 import type {FilterOption} from '@tryghost/shade';
 import type {InfiniteQueryHookOptions} from '@tryghost/admin-x-framework/hooks';
 
@@ -49,38 +50,12 @@ export function useFilterSearch<T, K extends keyof T & string>({
     debounceMs = 250
 }: UseFilterSearchOptions<T, K>): UseFilterSearchReturn {
     const [inputValue, setInputValue] = useState('');
-    const [debouncedValue, setDebouncedValue] = useState('');
-    const timerRef = useRef<ReturnType<typeof setTimeout>>();
-
-    // Track whether the initial (no-search) query returned all items
     const useLocalSearchRef = useRef(false);
 
-    useEffect(() => {
-        return () => {
-            if (timerRef.current) {
-                clearTimeout(timerRef.current);
-            }
-        };
-    }, []);
+    // Debounce is only used for server-side search; local search filters immediately
+    const [debouncedValue] = useDebounce(inputValue, debounceMs);
+    const serverSearchTerm = useLocalSearchRef.current ? '' : debouncedValue;
 
-    const onSearchChange = useCallback((search: string) => {
-        setInputValue(search);
-
-        if (timerRef.current) {
-            clearTimeout(timerRef.current);
-        }
-
-        // Skip debounce + server query when filtering locally
-        if (useLocalSearchRef.current) {
-            return;
-        }
-
-        timerRef.current = setTimeout(() => {
-            setDebouncedValue(search);
-        }, debounceMs);
-    }, [debounceMs]);
-
-    // Only include search filter in query params when using server-side search
     const searchParams = useMemo(() => {
         const params: Record<string, string> = {limit};
         const filters: string[] = [];
@@ -89,8 +64,8 @@ export function useFilterSearch<T, K extends keyof T & string>({
             filters.push(baseFilter);
         }
 
-        if (!useLocalSearchRef.current && debouncedValue.trim() && buildSearchFilter) {
-            filters.push(buildSearchFilter(escapeNqlValue(debouncedValue.trim())));
+        if (serverSearchTerm.trim() && buildSearchFilter) {
+            filters.push(buildSearchFilter(escapeNqlValue(serverSearchTerm.trim())));
         }
 
         if (filters.length > 0) {
@@ -98,7 +73,7 @@ export function useFilterSearch<T, K extends keyof T & string>({
         }
 
         return params;
-    }, [limit, baseFilter, debouncedValue, buildSearchFilter]);
+    }, [limit, baseFilter, serverSearchTerm, buildSearchFilter]);
 
     const {data, isLoading, isFetching, fetchNextPage, hasNextPage, isFetchingNextPage} = useQuery({searchParams});
 
@@ -120,12 +95,12 @@ export function useFilterSearch<T, K extends keyof T & string>({
     // Uses the isEnd flag from the query's returnData rather than hasNextPage, which
     // can be unreliable when defaultNextPageParams doesn't return undefined.
     const isEnd = data && typeof data === 'object' && 'isEnd' in data && (data as Record<string, unknown>).isEnd === true;
-    if (!isLoading && isEnd && allOptions.length > 0 && !debouncedValue.trim()) {
+    if (!isLoading && isEnd && allOptions.length > 0 && !serverSearchTerm.trim()) {
         useLocalSearchRef.current = true;
     }
 
     const initialCountRef = useRef(0);
-    if (!debouncedValue.trim() && allOptions.length > 0) {
+    if (!serverSearchTerm.trim() && allOptions.length > 0) {
         initialCountRef.current = allOptions.length;
     }
 
@@ -152,7 +127,7 @@ export function useFilterSearch<T, K extends keyof T & string>({
         initialCount: initialCountRef.current,
         isLoading: (allOptions.length === 0 && isLoading) || isSearchPending || isSearchFetching,
         searchValue: inputValue,
-        onSearchChange,
+        onSearchChange: setInputValue,
         onLoadMore,
         hasMore: hasNextPage ?? false,
         isLoadingMore: isFetchingNextPage

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -153,6 +153,74 @@ describe('useMemberFilterFields', () => {
         expect(offerField?.customValueRenderer).toBeTypeOf('function');
     });
 
+    it('wires label search/scroll props when provided', () => {
+        const labelSearchProps = {
+            onSearchChange: vi.fn(),
+            searchValue: 'vip',
+            isLoading: false,
+            onLoadMore: vi.fn(),
+            hasMore: true,
+            isLoadingMore: false
+        };
+
+        const {result} = renderHook(() => useMemberFilterFields({
+            labelsOptions: [{value: 'vip', label: 'VIP'}],
+            labelSearchProps,
+            siteTimezone: 'UTC'
+        }));
+
+        const basicFields = result.current.find(group => group.group === 'Basic')?.fields ?? [];
+        const labelField = basicFields.find(field => field.key === 'label');
+
+        expect(labelField?.onSearchChange).toBe(labelSearchProps.onSearchChange);
+        expect(labelField?.searchValue).toBe('vip');
+        expect(labelField?.onLoadMore).toBe(labelSearchProps.onLoadMore);
+        expect(labelField?.hasMore).toBe(true);
+        expect(labelField?.isLoadingMore).toBe(false);
+    });
+
+    it('wires tier search/scroll props when provided', () => {
+        const tierSearchProps = {
+            onSearchChange: vi.fn(),
+            searchValue: 'gold',
+            isLoading: false,
+            onLoadMore: vi.fn(),
+            hasMore: false,
+            isLoadingMore: false
+        };
+
+        const {result} = renderHook(() => useMemberFilterFields({
+            tiersOptions: [{value: 't1', label: 'Gold'}],
+            tierSearchProps,
+            hasMultipleTiers: true,
+            paidMembersEnabled: true,
+            siteTimezone: 'UTC'
+        }));
+
+        const subscriptionFields = result.current.find(group => group.group === 'Subscription')?.fields ?? [];
+        const tierField = subscriptionFields.find(field => field.key === 'tier_id');
+
+        expect(tierField?.onSearchChange).toBe(tierSearchProps.onSearchChange);
+        expect(tierField?.searchValue).toBe('gold');
+        expect(tierField?.onLoadMore).toBe(tierSearchProps.onLoadMore);
+        expect(tierField?.hasMore).toBe(false);
+    });
+
+    it('does not include search/scroll props when not provided (backward compat)', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            labelsOptions: [{value: 'vip', label: 'VIP'}],
+            siteTimezone: 'UTC'
+        }));
+
+        const basicFields = result.current.find(group => group.group === 'Basic')?.fields ?? [];
+        const labelField = basicFields.find(field => field.key === 'label');
+
+        expect(labelField?.onSearchChange).toBeUndefined();
+        expect(labelField?.onLoadMore).toBeUndefined();
+        expect(labelField?.hasMore).toBeUndefined();
+        expect(labelField?.isLoadingMore).toBeUndefined();
+    });
+
     it('renders direct retention offer ids with the fetched offer label', () => {
         const {result} = renderHook(() => useMemberFilterFields({
             paidMembersEnabled: true,

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -5,9 +5,13 @@ import {CustomRendererProps, FilterFieldConfig, FilterFieldGroup, FilterOption, 
 import {memberFields} from './member-fields';
 import type {Offer} from '@tryghost/admin-x-framework/api/offers';
 
+type FilterSearchProps = Pick<FilterFieldConfig, 'onSearchChange' | 'searchValue' | 'isLoading' | 'onLoadMore' | 'hasMore' | 'isLoadingMore'>;
+
 interface UseMemberFilterFieldsOptions {
     labelsOptions?: FilterOption[];
+    labelSearchProps?: FilterSearchProps;
     tiersOptions?: FilterOption[];
+    tierSearchProps?: FilterSearchProps;
     newsletters?: Array<{slug: string; name: string; status?: string}>;
     hydratedNewsletterSlugs?: string[];
     hasMultipleTiers?: boolean;
@@ -290,7 +294,9 @@ function renderOfferFilterValues(values: string[], options: OfferOption[], offer
 
 export function useMemberFilterFields({
     labelsOptions = [],
+    labelSearchProps,
     tiersOptions = [],
+    tierSearchProps,
     newsletters = [],
     hydratedNewsletterSlugs = [],
     hasMultipleTiers = false,
@@ -333,11 +339,12 @@ export function useMemberFilterFields({
             createFieldConfig('email')
         ];
 
-        if (labelsOptions.length > 0) {
+        if (labelsOptions.length > 0 || labelSearchProps) {
             basicFields.push(createFieldConfig('label', {
                 type: 'select',
                 options: labelsOptions,
-                customRenderer: props => React.createElement(LabelFilterRenderer, props as CustomRendererProps<string>)
+                customRenderer: props => React.createElement(LabelFilterRenderer, props as CustomRendererProps<string>),
+                ...labelSearchProps
             }));
         }
 
@@ -399,7 +406,8 @@ export function useMemberFilterFields({
 
             if (hasMultipleTiers) {
                 subscriptionFields.push(createFieldConfig('tier_id', {
-                    options: tiersOptions
+                    options: tiersOptions,
+                    ...tierSearchProps
                 }));
             }
 
@@ -487,6 +495,7 @@ export function useMemberFilterFields({
         emailTrackClicks,
         emailTrackOpens,
         hasMultipleTiers,
+        labelSearchProps,
         labelsOptions,
         membersTrackSources,
         newsletters,
@@ -499,6 +508,7 @@ export function useMemberFilterFields({
         postResourceOptions,
         postResourceSearchValue,
         siteTimezone,
+        tierSearchProps,
         tiersOptions
     ]);
 }

--- a/apps/shade/src/components/ui/filters.tsx
+++ b/apps/shade/src/components/ui/filters.tsx
@@ -1126,7 +1126,7 @@ function SelectOptionsPopover<T = unknown>({
                     )}
                     <CommandList className="outline-hidden" onScroll={handleScrollEnd}>
                         {field.isLoading ? (
-                            <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                            <div className="flex items-center justify-center px-2 py-1.5 text-sm text-muted-foreground">
                                 <Loader2 className="mr-2 size-4 animate-spin" />
                                 {context.i18n.loading}
                             </div>
@@ -1284,7 +1284,7 @@ function SelectOptionsPopover<T = unknown>({
                     )}
                     <CommandList className="outline-hidden" onScroll={handleScrollEnd}>
                         {field.isLoading ? (
-                            <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                            <div className="flex items-center justify-center px-2 py-1.5 text-sm text-muted-foreground">
                                 <Loader2 className="mr-2 size-4 animate-spin" />
                                 {context.i18n.loading}
                             </div>
@@ -1753,7 +1753,7 @@ function FilterValueSelector<T = unknown>({field, values, onChange, operator}: F
                     )}
                     <CommandList className="outline-hidden">
                         {field.isLoading ? (
-                            <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                            <div className="flex items-center justify-center px-2 py-1.5 text-sm text-muted-foreground">
                                 <Loader2 className="mr-2 size-4 animate-spin" />
                                 {context.i18n.loading}
                             </div>

--- a/apps/shade/src/components/ui/filters.tsx
+++ b/apps/shade/src/components/ui/filters.tsx
@@ -1004,7 +1004,7 @@ interface SelectOptionsPopoverProps<T = unknown> {
     inline?: boolean;
 }
 
-function useScrollEndDetection(onLoadMore?: () => void, hasMore?: boolean, isLoadingMore?: boolean) {
+export function useScrollEndDetection(onLoadMore?: () => void, hasMore?: boolean, isLoadingMore?: boolean) {
     const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
         if (!onLoadMore || !hasMore || isLoadingMore) {
             return;

--- a/apps/shade/src/components/ui/filters.tsx
+++ b/apps/shade/src/components/ui/filters.tsx
@@ -762,6 +762,10 @@ export interface FilterFieldConfig<T = unknown> {
     onValueChange?: (values: T[]) => void;
     // Auto-close dropdown after selection (even for multiselect types)
     autoCloseOnSelect?: boolean;
+    // Infinite scroll support
+    onLoadMore?: () => void;
+    hasMore?: boolean;
+    isLoadingMore?: boolean;
 }
 
 // Helper functions to handle both flat and grouped field configurations
@@ -1000,6 +1004,20 @@ interface SelectOptionsPopoverProps<T = unknown> {
     inline?: boolean;
 }
 
+function useScrollEndDetection(onLoadMore?: () => void, hasMore?: boolean, isLoadingMore?: boolean) {
+    const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+        if (!onLoadMore || !hasMore || isLoadingMore) {
+            return;
+        }
+        const target = e.currentTarget;
+        if (target.scrollTop + target.clientHeight >= target.scrollHeight - 50) {
+            onLoadMore();
+        }
+    }, [onLoadMore, hasMore, isLoadingMore]);
+
+    return handleScroll;
+}
+
 function SelectOptionsPopover<T = unknown>({
     field,
     values,
@@ -1012,6 +1030,8 @@ function SelectOptionsPopover<T = unknown>({
     // Track selected options separately so they persist during async search
     const [cachedSelectedOptions, setCachedSelectedOptions] = useState<FilterOption<T>[]>([]);
     const context = useFilterContext();
+
+    const handleScrollEnd = useScrollEndDetection(field.onLoadMore, field.hasMore, field.isLoadingMore);
 
     // Sync searchInput with controlled searchValue
     useEffect(() => {
@@ -1104,7 +1124,7 @@ function SelectOptionsPopover<T = unknown>({
                             onValueChange={handleSearchChange}
                         />
                     )}
-                    <CommandList className="outline-hidden">
+                    <CommandList className="outline-hidden" onScroll={handleScrollEnd}>
                         {field.isLoading ? (
                             <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
                                 <Loader2 className="mr-2 size-4 animate-spin" />
@@ -1196,6 +1216,12 @@ function SelectOptionsPopover<T = unknown>({
                                 </CommandGroup>
                             </>
                         )}
+
+                        {field.isLoadingMore && (
+                            <div className="flex items-center justify-center py-2 text-sm text-muted-foreground">
+                                <Loader2 className="mr-2 size-4 animate-spin" />
+                            </div>
+                        )}
                     </CommandList>
                 </Command>
             </div>
@@ -1256,7 +1282,7 @@ function SelectOptionsPopover<T = unknown>({
                             onValueChange={handleSearchChange}
                         />
                     )}
-                    <CommandList className="outline-hidden">
+                    <CommandList className="outline-hidden" onScroll={handleScrollEnd}>
                         {field.isLoading ? (
                             <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
                                 <Loader2 className="mr-2 size-4 animate-spin" />
@@ -1334,6 +1360,12 @@ function SelectOptionsPopover<T = unknown>({
                                     ))}
                                 </CommandGroup>
                             </>
+                        )}
+
+                        {field.isLoadingMore && (
+                            <div className="flex items-center justify-center py-2 text-sm text-muted-foreground">
+                                <Loader2 className="mr-2 size-4 animate-spin" />
+                            </div>
                         )}
                     </CommandList>
                 </Command>


### PR DESCRIPTION
refs https://linear.app/ghost/issue/BER-3334/

## Summary
- Added server-side search and infinite scroll for label and tier filter dropdowns in the members view
- Added `useFilterSearch` hook that wraps any infinite query with debounced search, pagination, and loading states
- When all items fit on a single page, automatically switches to instant local filtering instead of making server round-trips
- Added loading indicators during search (covering debounce wait and fetch) for both the standard select popovers and the label picker's custom renderer
- Fixed `defaultNextPageParams` in labels and tiers infinite queries to return `undefined` when there are no more pages, matching the existing pattern in tags/comments/members
- Used `initialCount` from the unfiltered query for `hasMultipleTiers` so the tier filter doesn't disappear when search narrows results
- Removed unused `useBrowseLabels` query and consolidated the infinite query + mutations under a single `dataType`. Label mutations now use `invalidateQueries` (triggering a refetch) instead of `updateQueries` (optimistic cache patching), matching the pattern used by tiers. The optimistic patching was inherited from the original simple query and would have needed reworking to handle the `InfiniteData` page structure anyway.
- Cached selected labels in `useLabelPicker` so they stay visible when server-side search narrows the result set