### PR TITLE
🐛 Fixed attribution on links in email-only posts

### DIFF
--- a/ghost/admin/app/components/member/subscription-detail-box.hbs
+++ b/ghost/admin/app/components/member/subscription-detail-box.hbs
@@ -14,9 +14,15 @@
                 Source&nbsp;&mdash;&nbsp;<span>{{@sub.attribution.referrerSource}}</span>
             </p>
             {{/if}}
-            {{#if (and @sub.attribution @sub.attribution.url @sub.attribution.title)}}
+            {{#if (and @sub.attribution @sub.attribution.title)}}
             <p>
+                {{#if (and @sub.attribution.id (eq @sub.attribution.type "post"))}}
+                Page&nbsp;&mdash;&nbsp;<a href="/ghost/#/posts/analytics/{{@sub.attribution.id}}">{{ @sub.attribution.title }}</a>
+                {{else if @sub.attribution.url}}
                 Page&nbsp;&mdash;&nbsp;<a href="{{@sub.attribution.url}}" target="_blank" rel="noopener noreferrer">{{ @sub.attribution.title }}</a>
+                {{else}}
+                Page&nbsp;&mdash;&nbsp;{{ @sub.attribution.title }}
+                {{/if}}
             </p>
             {{/if}}
         </div>

--- a/ghost/core/core/server/services/member-attribution/attribution-builder.js
+++ b/ghost/core/core/server/services/member-attribution/attribution-builder.js
@@ -96,12 +96,7 @@ class Attribution {
             };
         }
 
-        // Email-only posts (status:sent) have no public URL — the URL service
-        // returns /404/ for them. Use the /email/:uuid path instead.
-        const isEmailOnly = this.type === 'post' && model.get('status') === 'sent';
-        const updatedUrl = isEmailOnly
-            ? this.#urlTranslator.relativeToAbsolute(`/email/${model.get('uuid')}/`)
-            : this.#urlTranslator.getUrlByResourceId(this.id, {absolute: true});
+        const updatedUrl = this.#urlTranslator.getResourceUrl(this.id, this.type, model, {absolute: true});
 
         return {
             id: model.id,

--- a/ghost/core/core/server/services/member-attribution/attribution-builder.js
+++ b/ghost/core/core/server/services/member-attribution/attribution-builder.js
@@ -96,7 +96,12 @@ class Attribution {
             };
         }
 
-        const updatedUrl = this.#urlTranslator.getUrlByResourceId(this.id, {absolute: true});
+        // Email-only posts (status:sent) have no public URL — the URL service
+        // returns /404/ for them. Use the /email/:uuid path instead.
+        const isEmailOnly = this.type === 'post' && model.get('status') === 'sent';
+        const updatedUrl = isEmailOnly
+            ? this.#urlTranslator.relativeToAbsolute(`/email/${model.get('uuid')}/`)
+            : this.#urlTranslator.getUrlByResourceId(this.id, {absolute: true});
 
         return {
             id: model.id,

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -61,13 +61,10 @@ class UrlTranslator {
         if (item.type) {
             const resource = await this.getResourceById(item.id, item.type);
             if (resource) {
-                // Email-only posts (status:sent) have no public URL — the URL
-                // service returns /404/ for them. Use the /email/:uuid path instead.
-                const isEmailOnly = item.type === 'post' && resource.get('status') === 'sent';
                 return {
                     type: item.type,
                     id: item.id,
-                    url: isEmailOnly ? `/email/${resource.get('uuid')}/` : this.getUrlByResourceId(item.id, {absolute: false})
+                    url: this.getResourceUrl(item.id, item.type, resource, {absolute: false})
                 };
             }
 
@@ -129,6 +126,19 @@ class UrlTranslator {
 
     getUrlByResourceId(id, options = {absolute: true}) {
         return this.urlService.getUrlByResourceId(id, options);
+    }
+
+    /**
+     * Get the URL for a resource, handling email-only posts which have no
+     * public URL (the URL service returns /404/ for them).
+     */
+    getResourceUrl(id, type, model, {absolute = true} = {}) {
+        const isEmailOnly = type === 'post' && model.get('status') === 'sent';
+        if (isEmailOnly) {
+            const emailPath = `/email/${model.get('uuid')}/`;
+            return absolute ? this.relativeToAbsolute(emailPath) : emailPath;
+        }
+        return this.getUrlByResourceId(id, {absolute});
     }
 
     async getResourceById(id, type) {

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -61,10 +61,13 @@ class UrlTranslator {
         if (item.type) {
             const resource = await this.getResourceById(item.id, item.type);
             if (resource) {
+                // Email-only posts (status:sent) have no public URL — the URL
+                // service returns /404/ for them. Use the /email/:uuid path instead.
+                const isEmailOnly = item.type === 'post' && resource.get('status') === 'sent';
                 return {
                     type: item.type,
                     id: item.id,
-                    url: this.getUrlByResourceId(item.id, {absolute: false})
+                    url: isEmailOnly ? `/email/${resource.get('uuid')}/` : this.getUrlByResourceId(item.id, {absolute: false})
                 };
             }
 
@@ -132,7 +135,7 @@ class UrlTranslator {
         switch (type) {
         case 'post':
         case 'page': {
-            const post = await this.models.Post.findOne({id}, {require: false});
+            const post = await this.models.Post.findOne({id}, {require: false, context: {internal: true}});
             if (!post) {
                 return null;
             }

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -135,12 +135,7 @@ class UrlTranslator {
         switch (type) {
         case 'post':
         case 'page': {
-            // First try default lookup (finds published posts and pages)
-            let post = await this.models.Post.findOne({id}, {require: false});
-            if (!post) {
-                // Try email-only posts (status:sent) which are excluded by default filters
-                post = await this.models.Post.findOne({id, status: 'sent'}, {require: false});
-            }
+            const post = await this.models.Post.findOne({id}, {require: false, filter: 'type:[post,page]+status:[published,sent]'});
             if (!post) {
                 return null;
             }

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -135,7 +135,12 @@ class UrlTranslator {
         switch (type) {
         case 'post':
         case 'page': {
-            const post = await this.models.Post.findOne({id}, {require: false, filter: 'status:[published,sent]'});
+            // First try default lookup (finds published posts and pages)
+            let post = await this.models.Post.findOne({id}, {require: false});
+            if (!post) {
+                // Try email-only posts (status:sent) which are excluded by default filters
+                post = await this.models.Post.findOne({id, status: 'sent'}, {require: false});
+            }
             if (!post) {
                 return null;
             }

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -135,7 +135,7 @@ class UrlTranslator {
         switch (type) {
         case 'post':
         case 'page': {
-            const post = await this.models.Post.findOne({id}, {require: false, context: {internal: true}});
+            const post = await this.models.Post.findOne({id}, {require: false, filter: 'status:[published,sent]'});
             if (!post) {
                 return null;
             }

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -185,6 +185,73 @@ describe('Member Attribution Service', function () {
                     title: author.get('name')
                 });
             });
+
+            it('resolves email-only posts via id and type', async function () {
+                // Simulates the offer link flow: member-attribution.js extracts
+                // attribution_id and attribution_type from the URL search params
+                // and stores them as {id, type} entries in the URL history
+                const id = fixtureManager.get('posts', 0).id;
+                const post = await models.Post.where('id', id).fetch({require: true});
+
+                // Make the post email-only (must set email_only flag first,
+                // otherwise the model rejects the 'sent' status)
+                await models.Post.edit({posts_meta: {email_only: true}, status: 'published'}, {id});
+                await models.Post.edit({status: 'sent'}, {id});
+
+                try {
+                    const attribution = await memberAttributionService.service.getAttribution([
+                        {
+                            id: post.id,
+                            type: 'post',
+                            time: Date.now()
+                        }
+                    ]);
+
+                    // Should resolve to the post, not fall through to homepage
+                    assertObjectMatches(attribution, {
+                        id: post.id,
+                        url: `/email/${post.get('uuid')}/`,
+                        type: 'post'
+                    });
+
+                    const resource = await attribution.fetchResource();
+                    const expectedUrl = urlUtils.createUrl(`/email/${post.get('uuid')}/`, true);
+
+                    assertObjectMatches(resource, {
+                        id: post.id,
+                        url: expectedUrl,
+                        type: 'post',
+                        title: post.get('title')
+                    });
+                } finally {
+                    await models.Post.edit({posts_meta: {email_only: false}, status: 'published'}, {id});
+                }
+            });
+
+            it('does not resolve draft posts via id and type', async function () {
+                const id = fixtureManager.get('posts', 0).id;
+                const post = await models.Post.where('id', id).fetch({require: true});
+
+                await models.Post.edit({status: 'draft'}, {id});
+
+                try {
+                    const attribution = await memberAttributionService.service.getAttribution([
+                        {
+                            id: post.id,
+                            type: 'post',
+                            time: Date.now()
+                        }
+                    ]);
+
+                    // Draft posts should not resolve — falls through to null attribution
+                    assertObjectMatches(attribution, {
+                        id: null,
+                        type: null
+                    });
+                } finally {
+                    await models.Post.edit({status: 'published'}, {id});
+                }
+            });
         });
 
         describe('with subdirectory', function () {

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -90,14 +90,14 @@ describe('Member Attribution Service', function () {
                     type: 'post'
                 });
 
-                // Unpublish this post — attribution should still resolve
-                // because we use internal context to find posts regardless of status
+                // Unpublish this post
                 await models.Post.edit({status: 'draft'}, {id});
 
                 assertObjectMatches(await attribution.fetchResource(), {
-                    id: post.id,
-                    type: 'post',
-                    title: post.get('title')
+                    id: null,
+                    url: absoluteUrl,
+                    type: 'url',
+                    title: urlWithoutSubdirectory
                 });
 
                 await models.Post.edit({status: 'published'}, {id});

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -90,14 +90,14 @@ describe('Member Attribution Service', function () {
                     type: 'post'
                 });
 
-                // Unpublish this post
+                // Unpublish this post — attribution should still resolve
+                // because we use internal context to find posts regardless of status
                 await models.Post.edit({status: 'draft'}, {id});
 
                 assertObjectMatches(await attribution.fetchResource(), {
-                    id: null,
-                    url: absoluteUrl,
-                    type: 'url',
-                    title: urlWithoutSubdirectory
+                    id: post.id,
+                    type: 'post',
+                    title: post.get('title')
                 });
 
                 await models.Post.edit({status: 'published'}, {id});

--- a/ghost/core/test/unit/server/services/member-attribution/attribution.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/attribution.test.js
@@ -71,6 +71,9 @@ describe('AttributionBuilder', function () {
             getUrlByResourceId() {
                 return 'https://absolute/dir/path';
             },
+            getResourceUrl() {
+                return 'https://absolute/dir/path';
+            },
             relativeToAbsolute(path) {
                 return 'https://absolute/dir' + path;
             },


### PR DESCRIPTION
refs https://linear.app/ghost/issue/ONC-1569/post-attribution-for-links-in-emails-seems-to-be-broken-on-pro
closes https://linear.app/ghost/issue/ONC-1568/email-only-post-attribution-incorrectly-resolves-to-url-type-instead

## Problem

Attribution for links in email-only posts does not correctly resolve to the post itself. For example, if a free member clicks a link in an email-only post they received, then upgrade to a paid membership within the same browser session, the newly created subscription should be attributed to the email only post. Currently though, the subscription would be attributed as a `url` and, depending on the link, the URL might be the `/email/:uuid` route of the post, or the Homepage.

## Root cause

In `/ghost/core/core/server/services/member-attribution/url-translator.js`, Ghost had previously been filtering out email only posts, because the Post.findOne() query implicitly filters to only `published` posts, while an email-only post will have a status of `sent`.

## Fix

Updated the query in the url-translator to filter for `status:[published,sent]` and `type:[post,page]`. With this change, the attribution correctly resolves to the `post` itself, rather than the generic `url`.

There is also a change to the attribution builder to support this: since email only post's don't have a URL registered in the URL service, the `attribution_url` was being set to `null`. This adds a conditional to check if the post is email only, and if so, it sets the `attribution_url` to `/email/:uuid` for the post.

Finally, it also updated the link on the members page to the post to point to the Post Analytics, rather than the post on the frontend. This change is made for regular `published` posts in addition to the `sent` posts for consistency.


### Files changed
- **`url-translator.js`** — Added fallback `findOne` query with `status:sent` for email-only posts; added `/email/:uuid/` URL for sent posts
- **`attribution-builder.js`** — Use `/email/:uuid/` URL when resolving attribution for email-only posts at read time

## Test plan
- [ ] Send an email-only post containing an offer link
- [ ] Redeem the offer via the email link
- [ ] Verify the subscription attribution shows the post title, not "Homepage"
- [ ] Verify the attribution URL is `/email/:uuid/` (not `/404/`)
- [ ] Repeat with a published+sent post and verify attribution works correctly
- [ ] Verify page attribution still resolves correctly (not broken by the query change)
- [ ] Verify draft post attribution still degrades gracefully to URL type