### PR TITLE
Added test to prevent migrations in previous versions

### DIFF
--- a/ghost/core/test/unit/server/data/migrations/version-consistency.test.js
+++ b/ghost/core/test/unit/server/data/migrations/version-consistency.test.js
@@ -1,20 +1,29 @@
 const assert = require('node:assert/strict');
+const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const semver = require('semver');
+
+const migrationsDir = path.join(
+    __dirname, '../../../../../core/server/data/migrations/versions'
+);
+
+function getVersionFolders() {
+    return fs.readdirSync(migrationsDir)
+        .filter(f => fs.statSync(path.join(migrationsDir, f)).isDirectory())
+        .filter(f => /^\d+\.\d+$/.test(f));
+}
+
+function getLatestVersionFolder(folders) {
+    return folders.sort((a, b) => semver.compare(semver.coerce(a), semver.coerce(b))).pop();
+}
 
 describe('Migration version consistency', function () {
     it('all migration folders should be runnable at current package.json version', function () {
         const pkg = require('../../../../../package.json');
         const safeVersion = pkg.version.match(/^(\d+\.)?(\d+)/)[0];
 
-        const migrationsDir = path.join(
-            __dirname, '../../../../../core/server/data/migrations/versions'
-        );
-
-        const folders = fs.readdirSync(migrationsDir)
-            .filter(f => fs.statSync(path.join(migrationsDir, f)).isDirectory())
-            .filter(f => /^\d+\.\d+$/.test(f));
+        const folders = getVersionFolders();
 
         const orphaned = folders.filter((folder) => {
             // Same comparison knex-migrator uses: folder > currentVersion
@@ -28,6 +37,47 @@ describe('Migration version consistency', function () {
             `${orphaned.join(', ')}\n` +
             `Run \`slimer migration\` which handles the version bump automatically, ` +
             `or manually bump package.json to the next minor rc.`
+        );
+    });
+
+    it('new migrations should only be added to the latest version folder', function () {
+        const folders = getVersionFolders();
+        const latestVersion = getLatestVersionFolder(folders);
+
+        // Get newly added migration files compared to origin/main
+        let newFiles;
+        try {
+            const diff = execSync(
+                'git diff origin/main --name-only --diff-filter=A -- ghost/core/core/server/data/migrations/versions/',
+                {cwd: path.join(__dirname, '../../../../../../..'), encoding: 'utf8'}
+            );
+            newFiles = diff.trim().split('\n').filter(Boolean);
+        } catch (err) {
+            // If origin/main is not available (e.g. shallow clone), skip
+            this.skip();
+            return;
+        }
+
+        if (newFiles.length === 0) {
+            return;
+        }
+
+        // Extract version folder from each new migration file path
+        const migrationsInOldVersions = newFiles.filter((file) => {
+            const match = file.match(/migrations\/versions\/(\d+\.\d+)\//);
+            if (!match) {
+                return false;
+            }
+            return match[1] !== latestVersion;
+        });
+
+        assert.equal(
+            migrationsInOldVersions.length,
+            0,
+            `New migrations must be added to the latest version folder (${latestVersion}), ` +
+            `but found new migrations in previous versions:\n` +
+            migrationsInOldVersions.map(f => `  - ${f}`).join('\n') + '\n' +
+            `Adding migrations to previous versions can cause them to not run or corrupt the database.`
         );
     });
 });

--- a/ghost/core/test/unit/server/data/migrations/version-consistency.test.js
+++ b/ghost/core/test/unit/server/data/migrations/version-consistency.test.js
@@ -14,10 +14,6 @@ function getVersionFolders() {
         .filter(f => /^\d+\.\d+$/.test(f));
 }
 
-function getLatestVersionFolder(folders) {
-    return folders.sort((a, b) => semver.compare(semver.coerce(a), semver.coerce(b))).pop();
-}
-
 describe('Migration version consistency', function () {
     it('all migration folders should be runnable at current package.json version', function () {
         const pkg = require('../../../../../package.json');
@@ -40,9 +36,9 @@ describe('Migration version consistency', function () {
         );
     });
 
-    it('new migrations should only be added to the latest version folder', function () {
-        const folders = getVersionFolders();
-        const latestVersion = getLatestVersionFolder(folders);
+    it('new migrations should only target the next minor version', function () {
+        const pkg = require('../../../../../package.json');
+        const currentVersion = pkg.version.match(/^(\d+\.)?(\d+)/)[0];
 
         // Get newly added migration files compared to origin/main
         let newFiles;
@@ -62,22 +58,23 @@ describe('Migration version consistency', function () {
             return;
         }
 
-        // Extract version folder from each new migration file path
+        // New migrations must be in a version folder greater than the current package.json version
         const migrationsInOldVersions = newFiles.filter((file) => {
             const match = file.match(/migrations\/versions\/(\d+\.\d+)\//);
             if (!match) {
                 return false;
             }
-            return match[1] !== latestVersion;
+            const folderVersion = match[1];
+            return !semver.gt(semver.coerce(folderVersion), semver.coerce(currentVersion));
         });
 
         assert.equal(
             migrationsInOldVersions.length,
             0,
-            `New migrations must be added to the latest version folder (${latestVersion}), ` +
-            `but found new migrations in previous versions:\n` +
+            `New migrations must target the next minor version (greater than ${currentVersion}), ` +
+            `but found new migrations in current or previous versions:\n` +
             migrationsInOldVersions.map(f => `  - ${f}`).join('\n') + '\n' +
-            `Adding migrations to previous versions can cause them to not run or corrupt the database.`
+            `Adding migrations to current or previous versions can cause them to not run or corrupt the database.`
         );
     });
 });


### PR DESCRIPTION
## Summary

- Added new test to catch PRs that add migrations to previous version folders
- Extracts latest version folder by comparing all existing migration directories with semver
- Uses `git diff origin/main` to identify newly added migration files
- Fails with clear error message if new migrations are added to any folder except the latest
- Also refactored common logic into helper functions to reduce duplication

## Why

Ghost migrations can cause database corruption or fail silently if added to previous versions instead of the current version. This test runs in CI to automatically catch the issue before merge.