### PR TITLE
Added dynamic columns to members list based on active filters

### DIFF
--- a/apps/posts/src/views/members/components/members-list-item.tsx
+++ b/apps/posts/src/views/members/components/members-list-item.tsx
@@ -61,7 +61,7 @@ function MembersListItemName({item, onClick}: { item: Member; onClick?: (memberI
             />
             <div className="min-w-0">
                 <a
-                    className="cursor-pointer before:absolute before:left-0 before:top-0 before:z-10 before:h-full before:w-[100vw]"
+                    className="cursor-pointer before:absolute before:left-0 before:top-0 before:z-10 before:h-full before:w-[calc(100vw-300px-64px)]"
                     href={`#/members/${item.id}`}
                     onClick={onClick ? (e) => {
                         if (

--- a/apps/posts/src/views/members/components/members-list-item.tsx
+++ b/apps/posts/src/views/members/components/members-list-item.tsx
@@ -2,6 +2,9 @@ import moment from 'moment-timezone';
 
 import {Member} from '@tryghost/admin-x-framework/api/members';
 import {MemberAvatar} from '@components/member-avatar';
+import {TableCell, TableRow, cn} from '@tryghost/shade';
+import {getActiveColumnValue} from '../member-query-params';
+import type {ActiveColumn} from '../member-query-params';
 
 // --- Helpers ---
 
@@ -48,7 +51,7 @@ function getStatusLabel(status: Member['status']): string {
 
 // --- Sub-components ---
 
-function MembersListItemName({item}: { item: Member }) {
+function MembersListItemName({item, onClick}: { item: Member; onClick?: (memberId: string) => void }) {
     return (
         <div className="flex items-center gap-3">
             <MemberAvatar
@@ -57,9 +60,27 @@ function MembersListItemName({item}: { item: Member }) {
                 memberId={item.id}
             />
             <div className="min-w-0">
-                <div className="truncate font-medium">
-                    {item.name || item.email || 'Anonymous'}
-                </div>
+                <a
+                    className="cursor-pointer before:absolute before:left-0 before:top-0 before:z-10 before:h-full before:w-[100vw]"
+                    href={`#/members/${item.id}`}
+                    onClick={onClick ? (e) => {
+                        if (
+                            e.button !== 0 ||
+                            e.metaKey ||
+                            e.ctrlKey ||
+                            e.shiftKey ||
+                            e.altKey
+                        ) {
+                            return;
+                        }
+                        e.preventDefault();
+                        onClick(item.id);
+                    } : undefined}
+                >
+                    <span className="block truncate font-medium">
+                        {item.name || item.email || 'Anonymous'}
+                    </span>
+                </a>
                 {item.name && item.email && (
                     <div
                         className="truncate text-sm text-muted-foreground"
@@ -84,7 +105,7 @@ function MembersListItemStatus({
     return (
         <div className="flex justify-end lg:justify-start">
             <div className="min-w-0">
-                <div className="text-sm">{getStatusLabel(status)}</div>
+                <div className="truncate text-sm">{getStatusLabel(status)}</div>
                 {tierNames && (
                     <div className="truncate text-xs text-muted-foreground">
                         {tierNames}
@@ -103,9 +124,7 @@ function MembersListItemOpenRate({
     const isKnown = emailOpenRate !== null && emailOpenRate !== undefined;
     return (
         <div
-            className={`hidden text-sm lg:block ${
-                isKnown ? 'text-foreground' : 'text-muted-foreground'
-            }`}
+            className={cn('text-sm', isKnown ? 'text-foreground' : 'text-muted-foreground')}
         >
             {isKnown ? `${Math.round(emailOpenRate)}%` : 'N/A'}
         </div>
@@ -121,9 +140,7 @@ function MembersListItemLocation({
 
     return (
         <div
-            className={`hidden truncate text-sm lg:block ${
-                location.isKnown ? 'text-foreground' : 'text-muted-foreground'
-            }`}
+            className={cn('truncate text-sm', location.isKnown ? 'text-foreground' : 'text-muted-foreground')}
         >
             {location.text}
         </div>
@@ -132,7 +149,7 @@ function MembersListItemLocation({
 
 function MembersListItemCreated({createdAt}: { createdAt: string }) {
     return (
-        <div className="hidden lg:block">
+        <div>
             <div className="text-sm">
                 {moment.utc(createdAt).format('D MMM YYYY')}
             </div>
@@ -143,38 +160,86 @@ function MembersListItemCreated({createdAt}: { createdAt: string }) {
     );
 }
 
+function MembersListItemDynamicColumn({
+    column,
+    member,
+    timezone
+}: {
+    column: ActiveColumn;
+    member: Member;
+    timezone: string;
+}) {
+    const value = getActiveColumnValue(column, member, timezone);
+
+    if (!value) {
+        return (
+            <span className="text-sm text-muted-foreground">-</span>
+        );
+    }
+
+    return (
+        <div className="min-w-0">
+            <div className="truncate text-sm">{value.text}</div>
+            {value.subtext && (
+                <div className="truncate text-xs text-muted-foreground">
+                    {value.subtext}
+                </div>
+            )}
+        </div>
+    );
+}
+
 // --- Main component ---
 
 interface MembersListItemProps {
     item: Member;
-    gridCols: string;
+    activeColumns: ActiveColumn[];
     showEmailOpenRate: boolean;
+    timezone: string;
     onClick: (memberId: string) => void;
 }
 
 function MembersListItem({
     item,
-    gridCols,
+    activeColumns,
     showEmailOpenRate,
+    timezone,
     onClick,
     ...props
 }: MembersListItemProps &
-    Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>) {
+    Omit<React.HTMLAttributes<HTMLTableRowElement>, 'onClick'>) {
     return (
-        <div
+        <TableRow
             {...props}
-            className={`hover:bg-muted/50 grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_7rem] items-center gap-2 border-b px-4 py-3 lg:gap-4 ${gridCols}`}
             data-testid="members-list-item"
-            onClick={() => onClick(item.id)}
         >
-            <MembersListItemName item={item} />
-            <MembersListItemStatus status={item.status} tiers={item.tiers} />
+            <TableCell className="px-4 py-3">
+                <MembersListItemName item={item} onClick={onClick} />
+            </TableCell>
+            <TableCell className="px-4 py-3">
+                <MembersListItemStatus status={item.status} tiers={item.tiers} />
+            </TableCell>
             {showEmailOpenRate && (
-                <MembersListItemOpenRate emailOpenRate={item.email_open_rate} />
+                <TableCell className="hidden px-4 py-3 lg:table-cell">
+                    <MembersListItemOpenRate emailOpenRate={item.email_open_rate} />
+                </TableCell>
             )}
-            <MembersListItemLocation geolocation={item.geolocation} />
-            <MembersListItemCreated createdAt={item.created_at} />
-        </div>
+            <TableCell className="hidden px-4 py-3 lg:table-cell">
+                <MembersListItemLocation geolocation={item.geolocation} />
+            </TableCell>
+            <TableCell className="hidden px-4 py-3 lg:table-cell">
+                <MembersListItemCreated createdAt={item.created_at} />
+            </TableCell>
+            {activeColumns.map(col => (
+                <TableCell key={col.key} className="hidden px-4 py-3 lg:table-cell">
+                    <MembersListItemDynamicColumn
+                        column={col}
+                        member={item}
+                        timezone={timezone}
+                    />
+                </TableCell>
+            ))}
+        </TableRow>
     );
 }
 
@@ -184,5 +249,6 @@ export {
     MembersListItemStatus,
     MembersListItemOpenRate,
     MembersListItemLocation,
-    MembersListItemCreated
+    MembersListItemCreated,
+    MembersListItemDynamicColumn
 };

--- a/apps/posts/src/views/members/components/members-list.tsx
+++ b/apps/posts/src/views/members/components/members-list.tsx
@@ -1,35 +1,35 @@
 import MembersListItem from './members-list-item';
 import {Member} from '@tryghost/admin-x-framework/api/members';
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade';
 import {forwardRef, useRef} from 'react';
 import {useInfiniteVirtualScroll} from '@components/virtual-table/use-infinite-virtual-scroll';
 import {useScrollRestoration} from '@components/virtual-table/use-scroll-restoration';
+import type {ActiveColumn} from '../member-query-params';
 
 const SpacerRow = ({height}: { height: number }) => (
-    <div aria-hidden="true" className="flex">
-        <div className="flex" style={{height}} />
-    </div>
+    <tr aria-hidden="true" style={{height}}>
+        <td colSpan={999} />
+    </tr>
 );
 
-const PlaceholderRow = forwardRef<HTMLDivElement>(function PlaceholderRow(
-    props,
-    ref
-) {
-    return (
-        <div
-            ref={ref}
-            {...props}
-            aria-hidden="true"
-            className="relative flex flex-col"
-        >
-            <div className="relative z-10 h-[72px] animate-pulse">
-                <div
-                    className="h-full rounded-md bg-muted"
-                    data-testid="loading-placeholder"
-                />
-            </div>
-        </div>
-    );
-});
+const PlaceholderRow = forwardRef<HTMLTableRowElement>(
+    function PlaceholderRow(props, ref) {
+        return (
+            <TableRow
+                ref={ref}
+                {...props}
+                aria-hidden="true"
+            >
+                <TableCell className="h-[72px] px-4 py-3" colSpan={999}>
+                    <div
+                        className="h-full animate-pulse rounded-md bg-muted"
+                        data-testid="loading-placeholder"
+                    />
+                </TableCell>
+            </TableRow>
+        );
+    }
+);
 
 interface MembersListProps {
     items: Member[];
@@ -39,6 +39,8 @@ interface MembersListProps {
     fetchNextPage: () => void;
     isLoading?: boolean;
     showEmailOpenRate?: boolean;
+    activeColumns: ActiveColumn[];
+    timezone: string;
     onRowClick?: (memberId: string) => void;
 }
 
@@ -50,6 +52,8 @@ function MembersList({
     fetchNextPage,
     isLoading,
     showEmailOpenRate = true,
+    activeColumns,
+    timezone,
     onRowClick
 }: MembersListProps) {
     const parentRef = useRef<HTMLDivElement>(null);
@@ -75,40 +79,49 @@ function MembersList({
         }
     };
 
-    const gridColsWithOpenRate = 'lg:grid-cols-[3fr_1fr_1fr_1.5fr_1.5fr]';
-    const gridColsWithoutOpenRate = 'lg:grid-cols-[3fr_1fr_1.5fr_1.5fr]';
-    const gridCols = showEmailOpenRate
-        ? gridColsWithOpenRate
-        : gridColsWithoutOpenRate;
-
     return (
-        <div ref={parentRef} className="overflow-hidden">
-            <div className="flex flex-col" data-testid="members-list">
-                {/* Table Header */}
-                <div
-                    className={`sticky top-0 z-10 hidden border-b bg-background lg:grid lg:gap-4 lg:px-4 lg:py-3 ${gridCols}`}
-                >
-                    <div className="text-xs font-medium uppercase tracking-wide text-gray-700">
-                        Member
-                    </div>
-                    <div className="text-xs font-medium uppercase tracking-wide text-gray-700">
-                        Status
-                    </div>
-                    {showEmailOpenRate && (
-                        <div className="text-xs font-medium uppercase tracking-wide text-gray-700">
-                            Open rate
-                        </div>
-                    )}
-                    <div className="text-xs font-medium uppercase tracking-wide text-gray-700">
-                        Location
-                    </div>
-                    <div className="text-xs font-medium uppercase tracking-wide text-gray-700">
-                        Created
-                    </div>
-                </div>
-
-                {/* Table Body */}
-                <div className="flex flex-col">
+        <div ref={parentRef} className="overflow-x-auto">
+            <Table
+                className="border-collapse lg:table-fixed"
+                data-testid="members-list"
+            >
+                <colgroup className="hidden lg:table-column-group">
+                    <col className="w-[30%] min-w-[360px]" />
+                    <col className="w-[110px]" />
+                    {showEmailOpenRate && <col className="w-[90px]" />}
+                    <col className="w-[150px]" />
+                    <col className="w-[120px]" />
+                    {activeColumns.map(col => (
+                        <col key={col.key} className="w-[250px]" />
+                    ))}
+                </colgroup>
+                <TableHeader className="sticky top-0 z-10 hidden border-b bg-background lg:table-header-group">
+                    <TableRow>
+                        <TableHead className="px-4 py-3">
+                            Member
+                        </TableHead>
+                        <TableHead className="px-4 py-3">
+                            Status
+                        </TableHead>
+                        {showEmailOpenRate && (
+                            <TableHead className="px-4 py-3">
+                                Open rate
+                            </TableHead>
+                        )}
+                        <TableHead className="px-4 py-3">
+                            Location
+                        </TableHead>
+                        <TableHead className="px-4 py-3">
+                            Created
+                        </TableHead>
+                        {activeColumns.map(col => (
+                            <TableHead key={col.key} className="px-4 py-3">
+                                {col.label}
+                            </TableHead>
+                        ))}
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
                     <SpacerRow height={spaceBefore} />
                     {visibleItems.map(({key, virtualItem, item, props}) => {
                         const shouldRenderPlaceholder =
@@ -122,16 +135,17 @@ function MembersList({
                             <MembersListItem
                                 key={key}
                                 {...props}
-                                gridCols={gridCols}
+                                activeColumns={activeColumns}
                                 item={item}
                                 showEmailOpenRate={showEmailOpenRate}
+                                timezone={timezone}
                                 onClick={handleRowClick}
                             />
                         );
                     })}
                     <SpacerRow height={spaceAfter} />
-                </div>
-            </div>
+                </TableBody>
+            </Table>
         </div>
     );
 }

--- a/apps/posts/src/views/members/components/members-list.tsx
+++ b/apps/posts/src/views/members/components/members-list.tsx
@@ -80,19 +80,19 @@ function MembersList({
     };
 
     return (
-        <div ref={parentRef} className="overflow-x-auto">
+        <div ref={parentRef} className="-mx-8 -mb-8 h-[calc(100%+32px)] max-w-[calc(100vw-300px)] overflow-auto">
             <Table
-                className="border-collapse lg:table-fixed"
+                className="ml-8 max-w-[calc(100vw-300px-64px)] border-collapse lg:table-fixed"
                 data-testid="members-list"
             >
                 <colgroup className="hidden lg:table-column-group">
-                    <col className="w-[30%] min-w-[360px]" />
-                    <col className="w-[110px]" />
-                    {showEmailOpenRate && <col className="w-[90px]" />}
-                    <col className="w-[150px]" />
-                    <col className="w-[120px]" />
+                    <col className="w-full min-w-[360px]" />
+                    <col className="w-[50%] min-w-[160px]" />
+                    {showEmailOpenRate && <col className="w-[50%] min-w-[110px]" />}
+                    <col className="w-[50%] min-w-[150px]" />
+                    <col className="w-[50%] min-w-[120px]" />
                     {activeColumns.map(col => (
-                        <col key={col.key} className="w-[250px]" />
+                        <col key={col.key} className="w-[50%] min-w-[250px]" />
                     ))}
                 </colgroup>
                 <TableHeader className="sticky top-0 z-10 hidden border-b bg-background lg:table-header-group">

--- a/apps/posts/src/views/members/member-query-params.ts
+++ b/apps/posts/src/views/members/member-query-params.ts
@@ -1,11 +1,22 @@
+import moment from 'moment-timezone';
 import {memberFields} from './member-fields';
 import {resolveField} from '../filters/resolve-field';
 import type {FilterPredicate} from '../filters/filter-types';
+import type {Member, MemberSubscription} from '@tryghost/admin-x-framework/api/members';
 
-type ActiveColumn = {
+const MAX_ACTIVE_COLUMNS = 2;
+
+const ACTIVE_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing', 'unpaid', 'past_due']);
+
+export type ActiveColumn = {
     key: string;
     label: string;
     include?: string;
+};
+
+export type ColumnValue = {
+    text: string;
+    subtext?: string;
 };
 
 interface BuildMemberListSearchParamsOptions {
@@ -30,7 +41,7 @@ export function getMemberActiveColumns(filters: FilterPredicate[]): ActiveColumn
         }
     }
 
-    return Array.from(columns.values());
+    return Array.from(columns.values()).slice(0, MAX_ACTIVE_COLUMNS);
 }
 
 function getMemberIncludes(filters: FilterPredicate[]): string {
@@ -76,4 +87,120 @@ export function buildMemberOperationParams({nql, search}: BuildMemberOperationPa
         ...(nql ? {filter: nql} : {}),
         ...(search ? {search} : {})
     };
+}
+
+export function mostRelevantSubscription(
+    subscriptions: MemberSubscription[] | undefined
+): MemberSubscription | null {
+    if (!subscriptions?.length) {
+        return null;
+    }
+
+    const withId = subscriptions.filter(s => s.id);
+
+    if (!withId.length) {
+        return null;
+    }
+
+    const sorted = [...withId].sort((a, b) => {
+        const aActive = ACTIVE_SUBSCRIPTION_STATUSES.has(a.status);
+        const bActive = ACTIVE_SUBSCRIPTION_STATUSES.has(b.status);
+
+        if (aActive && !bActive) {
+            return -1;
+        }
+        if (!aActive && bActive) {
+            return 1;
+        }
+
+        const aEnd = new Date(a.current_period_end).getTime();
+        const bEnd = new Date(b.current_period_end).getTime();
+
+        if (Number.isNaN(aEnd) && Number.isNaN(bEnd)) {
+            return 0;
+        }
+        if (Number.isNaN(aEnd)) {
+            return 1;
+        }
+        if (Number.isNaN(bEnd)) {
+            return -1;
+        }
+
+        return bEnd - aEnd;
+    });
+
+    return sorted[0];
+}
+
+function formatDateColumn(date: string | undefined, timezone: string): ColumnValue | null {
+    if (!date) {
+        return null;
+    }
+    return {
+        text: moment.tz(date, timezone).format('D MMM YYYY'),
+        subtext: moment(date).fromNow()
+    };
+}
+
+export function getActiveColumnValue(
+    column: ActiveColumn,
+    member: Member,
+    timezone: string
+): ColumnValue | null {
+    switch (column.key) {
+    case 'labels':
+        return member.labels?.length
+            ? {text: member.labels.map(l => l.name).join(', ')}
+            : null;
+
+    case 'tiers':
+        return member.tiers?.length
+            ? {text: member.tiers.map(t => t.name).join(', ')}
+            : null;
+
+    case 'subscriptions.plan_interval': {
+        const interval = mostRelevantSubscription(member.subscriptions)?.plan?.interval;
+        if (!interval) {
+            return null;
+        }
+        return {text: interval === 'month' ? 'Monthly' : 'Yearly'};
+    }
+
+    case 'subscriptions.status': {
+        const status = mostRelevantSubscription(member.subscriptions)?.status;
+        if (!status) {
+            return null;
+        }
+        return {
+            text: status
+                .split('_')
+                .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+                .join(' ')
+        };
+    }
+
+    case 'subscriptions.start_date':
+        return formatDateColumn(
+            mostRelevantSubscription(member.subscriptions)?.start_date,
+            timezone
+        );
+
+    case 'subscriptions.current_period_end':
+        return formatDateColumn(
+            mostRelevantSubscription(member.subscriptions)?.current_period_end,
+            timezone
+        );
+
+    case 'offer_redemptions': {
+        const offers = member.subscriptions
+            ?.map(s => s.offer?.name)
+            .filter(Boolean);
+        return offers?.length
+            ? {text: offers.join(', ')}
+            : null;
+    }
+
+    default:
+        return null;
+    }
 }

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -6,7 +6,7 @@ import MembersLayout from './components/members-layout';
 import MembersList from './components/members-list';
 import React, {useMemo} from 'react';
 import {Button, EmptyIndicator, Header, LoadingIndicator, LucideIcon, cn} from '@tryghost/shade';
-import {buildMemberListSearchParams} from './member-query-params';
+import {buildMemberListSearchParams, getMemberActiveColumns} from './member-query-params';
 import {canBulkDeleteMembers, shouldShowMembersLoading} from './members-view-state';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {shouldDelayMembersDateFilterHydration, useMembersFilterState} from './hooks/use-members-filter-state';
@@ -21,6 +21,11 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
 
     // Check if email analytics is enabled
     const emailAnalyticsEnabled = configData?.config?.emailAnalytics === true;
+
+    // Extract active columns from filters (max 2)
+    const activeColumns = useMemo(() => {
+        return getMemberActiveColumns(filters);
+    }, [filters]);
 
     // Check if bulk delete is permitted (not allowed if subscription filters are active)
     const canBulkDelete = useMemo(() => {
@@ -143,12 +148,14 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
                     </div>
                 ) : (
                     <MembersList
+                        activeColumns={activeColumns}
                         fetchNextPage={fetchNextPage}
                         hasNextPage={hasNextPage}
                         isFetchingNextPage={isFetchingNextPage}
                         isLoading={isFetching && !isFetchingNextPage}
                         items={data.members}
                         showEmailOpenRate={emailAnalyticsEnabled}
+                        timezone={timezone}
                         totalItems={totalMembers}
                     />
                 )}


### PR DESCRIPTION
When filtering the members list by properties like labels, tiers, subscription status, or billing period, the relevant data wasn't visible in the table itself. Users had to click into individual member records to confirm whether the filter was showing the right results. This made bulk review workflows slow and frustrating.

This change inspects the active filter predicates and automatically appends up to two extra columns to the members table that surface the filtered-on data. For example, filtering by `label:vip` adds a "Labels" column showing each member's labels, and filtering by `subscriptions.status:active` adds a "Subscription status" column. The column definitions are derived from the existing `memberFields` registry, so any field that already knows how to resolve from NQL also knows how to render its value in a table cell. A `mostRelevantSubscription` helper picks the best subscription to display when a member has multiple (preferring active ones, then sorting by period end date).

The members list markup was migrated from a CSS Grid of `div` elements to a proper `table` / `thead` / `tbody` / `tr` / `td` structure. This was necessary to support a variable number of columns cleanly with `colgroup` width hints and `table-fixed` layout, while keeping the existing virtual scroll and infinite loading behaviour intact. The dynamic columns are hidden on mobile via `lg:table-cell` to avoid cramping the compact layout.