### PR TITLE
Added private.min.js to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ test/functional/*.png
 /ghost/core/core/frontend/public/comment-counts.min.js
 /ghost/core/core/frontend/public/member-attribution.min.js
 /ghost/core/core/frontend/public/ghost-stats.min.js
+/ghost/core/core/frontend/public/private.min.js
 # Caddyfile - for local development with ssl + caddy
 Caddyfile
 !docker/caddy/Caddyfile


### PR DESCRIPTION
no refs

This build artifact shouldn't be committed since it's generated as part of the build pipeline, but it wasn't included in `.gitignore`. This adds it to prevent anyone from accidentally committing it. 