### PR TITLE
Added theme helpers for subscription pricing and offer duration

### DIFF
--- a/ghost/core/core/frontend/helpers/offer_duration.js
+++ b/ghost/core/core/frontend/helpers/offer_duration.js
@@ -15,7 +15,7 @@ function formatDate(isoDate) {
         return '';
     }
     const event = new Date(isoDate);
-    const options = {year: 'numeric', month: 'short', day: 'numeric'};
+    const options = {year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'};
     return event.toLocaleDateString('en-GB', options);
 }
 

--- a/ghost/core/core/frontend/helpers/offer_duration.js
+++ b/ghost/core/core/frontend/helpers/offer_duration.js
@@ -1,0 +1,61 @@
+// # {{offer_duration}} Helper
+// Usage: `{{offer_duration}}`
+//
+// Should be used inside of a subscription context, e.g.:
+// `{{#foreach @member.subscriptions}} {{price next_payment interval="true"}} — {{offer_duration}} {{/foreach}}`
+//
+// Outputs the duration context of an active discount on a subscription.
+// Returns "Forever", "Ends {date}", or an empty string if no active discount.
+// Consistent with the duration part of Portal's offer label on the member account page.
+const {SafeString} = require('../services/handlebars');
+const {labs} = require('../services/proxy');
+
+function formatDate(isoDate) {
+    if (!isoDate) {
+        return '';
+    }
+    const event = new Date(isoDate);
+    const options = {year: 'numeric', month: 'short', day: 'numeric'};
+    return event.toLocaleDateString('en-GB', options);
+}
+
+function offer_duration() { // eslint-disable-line camelcase
+    const nextPayment = this.next_payment;
+
+    if (!nextPayment) {
+        return '';
+    }
+
+    const discount = nextPayment.discount;
+
+    if (!discount) {
+        return '';
+    }
+
+    let durationLabel = '';
+    if (discount.duration === 'forever') {
+        durationLabel = 'Forever';
+    } else if (discount.duration === 'repeating' && discount.end) {
+        durationLabel = `Ends ${formatDate(discount.end)}`;
+    } else if (discount.duration === 'once' && this.current_period_end) {
+        // By design, "once" offers don't have a discount end in Stripe.
+        // They expire at the end of the current billing period.
+        durationLabel = `Ends ${formatDate(this.current_period_end)}`;
+    }
+
+    return new SafeString(durationLabel);
+}
+
+module.exports = function offerDurationLabsWrapper() {
+    let self = this;
+    let args = arguments;
+
+    return labs.enabledHelper({
+        flagKey: 'members',
+        flagName: 'Members',
+        helperName: 'offer_duration',
+        helpUrl: 'https://ghost.org/docs/themes/members/'
+    }, () => {
+        return offer_duration.apply(self, args); // eslint-disable-line camelcase
+    });
+};

--- a/ghost/core/core/frontend/helpers/price.js
+++ b/ghost/core/core/frontend/helpers/price.js
@@ -72,7 +72,7 @@ module.exports = function price(planOrAmount, options) {
             locale
         });
 
-        if (interval === 'true' && plan.interval) {
+        if (interval && interval !== 'false' && plan.interval) {
             result = `${result}/${plan.interval}`;
         }
 

--- a/ghost/core/core/frontend/helpers/price.js
+++ b/ghost/core/core/frontend/helpers/price.js
@@ -5,11 +5,14 @@
 // Usage: `{{price plan numberFormat="long"}}`
 // Usage: `{{price plan currencyFormat="code"}}`
 // Usage: `{{price plan currencyFormat="name"}}`
+// Usage: `{{price plan interval="true"}}`
 // Usage: `{{price 500 currency="USD"}}`
 // Usage: `{{price currency="USD"}}`
 //
 // Returns amount equal to the dominant denomination of the currency.
 // For example, if 2100 is passed, it will return 21.
+// When interval="true" is passed with a plan object that has an .interval property,
+// the interval is appended to the output (e.g. "$5/month").
 const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const _ = require('lodash');
@@ -59,15 +62,21 @@ module.exports = function price(planOrAmount, options) {
     options = options || {};
     options.hash = options.hash || {};
 
-    const {currency, numberFormat = 'short', currencyFormat = 'symbol', locale = _.get(options, 'data.site.locale', 'en')} = options.hash;
+    const {currency, numberFormat = 'short', currencyFormat = 'symbol', interval, locale = _.get(options, 'data.site.locale', 'en')} = options.hash;
     if (plan) {
-        return formatter({
+        let result = formatter({
             amount: plan.amount && (plan.amount / 100),
             currency: currency || plan.currency,
             currencyFormat,
             numberFormat,
             locale
         });
+
+        if (interval === 'true' && plan.interval) {
+            result = `${result}/${plan.interval}`;
+        }
+
+        return result;
     }
 
     if (currency) {

--- a/ghost/core/test/unit/frontend/helpers/offer-duration.test.js
+++ b/ghost/core/test/unit/frontend/helpers/offer-duration.test.js
@@ -1,0 +1,191 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const offer_duration = require('../../../../core/frontend/helpers/offer_duration');
+const labs = require('../../../../core/shared/labs');
+const logging = require('@tryghost/logging');
+
+describe('{{offer_duration}} helper', function () {
+    let labsStub;
+
+    beforeEach(function () {
+        labsStub = sinon.stub(labs, 'isSet').returns(true);
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('returns empty string when no next_payment', function () {
+        const rendered = offer_duration.call({});
+        assert.equal(rendered, '');
+    });
+
+    it('returns empty string when next_payment has no discount', function () {
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 500,
+                currency: 'USD',
+                interval: 'month',
+                discount: null
+            }
+        });
+        assert.equal(rendered, '');
+    });
+
+    it('returns "Forever" for forever discount', function () {
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 500,
+                currency: 'USD',
+                interval: 'month',
+                discount: {
+                    duration: 'forever',
+                    type: 'percent',
+                    amount: 20,
+                    start: '2026-01-01T00:00:00.000Z',
+                    end: null
+                }
+            }
+        });
+        assert.equal(rendered.string, 'Forever');
+    });
+
+    it('returns "Ends {date}" for repeating discount using discount.end', function () {
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 500,
+                currency: 'USD',
+                interval: 'month',
+                discount: {
+                    duration: 'repeating',
+                    duration_in_months: 3,
+                    type: 'percent',
+                    amount: 20,
+                    start: '2026-01-01T00:00:00.000Z',
+                    end: '2026-05-03T00:00:00.000Z'
+                }
+            },
+            current_period_end: '2026-04-03T00:00:00.000Z'
+        });
+        assert.equal(rendered.string, 'Ends 3 May 2026');
+    });
+
+    it('returns "Ends {date}" for once discount using current_period_end', function () {
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 500,
+                currency: 'USD',
+                interval: 'month',
+                discount: {
+                    duration: 'once',
+                    type: 'percent',
+                    amount: 50,
+                    start: '2026-01-01T00:00:00.000Z',
+                    end: null
+                }
+            },
+            current_period_end: '2026-04-02T00:00:00.000Z'
+        });
+        assert.equal(rendered.string, 'Ends 2 Apr 2026');
+    });
+
+    it('returns empty string for repeating discount without discount.end', function () {
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 500,
+                currency: 'USD',
+                interval: 'month',
+                discount: {
+                    duration: 'repeating',
+                    duration_in_months: 3,
+                    type: 'percent',
+                    amount: 20,
+                    start: '2026-01-01T00:00:00.000Z',
+                    end: null
+                }
+            },
+            current_period_end: '2026-04-03T00:00:00.000Z'
+        });
+        assert.equal(rendered.string, '');
+    });
+
+    it('returns empty string for once discount without current_period_end', function () {
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 500,
+                currency: 'USD',
+                interval: 'month',
+                discount: {
+                    duration: 'once',
+                    type: 'percent',
+                    amount: 50,
+                    start: '2026-01-01T00:00:00.000Z',
+                    end: null
+                }
+            }
+        });
+        assert.equal(rendered.string, '');
+    });
+
+    it('handles free months offer (100% off repeating)', function () {
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 0,
+                currency: 'USD',
+                interval: 'month',
+                discount: {
+                    duration: 'repeating',
+                    duration_in_months: 3,
+                    type: 'percent',
+                    amount: 100,
+                    start: '2026-01-01T00:00:00.000Z',
+                    end: '2026-05-03T00:00:00.000Z'
+                }
+            },
+            current_period_end: '2026-04-03T00:00:00.000Z'
+        });
+        assert.equal(rendered.string, 'Ends 3 May 2026');
+    });
+
+    it('handles fixed discount forever', function () {
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 800,
+                currency: 'USD',
+                interval: 'month',
+                discount: {
+                    duration: 'forever',
+                    type: 'fixed',
+                    amount: 200,
+                    start: '2026-01-01T00:00:00.000Z',
+                    end: null
+                }
+            }
+        });
+        assert.equal(rendered.string, 'Forever');
+    });
+
+    it('is disabled if labs flag is not set', function () {
+        labsStub.returns(false);
+        const loggingStub = sinon.stub(logging, 'error');
+
+        const rendered = offer_duration.call({
+            next_payment: {
+                amount: 500,
+                currency: 'USD',
+                interval: 'month',
+                discount: {
+                    duration: 'forever',
+                    type: 'percent',
+                    amount: 20,
+                    start: '2026-01-01T00:00:00.000Z',
+                    end: null
+                }
+            }
+        });
+
+        assert.match(rendered.string, /^<script/);
+        assert.match(rendered.string, /helper is not available/);
+        sinon.assert.calledOnce(loggingStub);
+    });
+});

--- a/ghost/core/test/unit/frontend/helpers/price.test.js
+++ b/ghost/core/test/unit/frontend/helpers/price.test.js
@@ -106,4 +106,65 @@ describe('{{price}} helper', function () {
         const rendered = price.call({}, 500, {hash: {currency: 'USD', currencyFormat: 'name'}});
         assert.equal(rendered, '5 US dollars');
     });
+
+    describe('interval option', function () {
+        it('will append interval when interval="true" and plan has interval', function () {
+            const plan = {
+                amount: 500,
+                interval: 'month',
+                currency: 'USD'
+            };
+            const rendered = price.call({}, plan, {hash: {interval: 'true'}});
+            assert.equal(rendered, '$5/month');
+        });
+
+        it('will append yearly interval', function () {
+            const plan = {
+                amount: 5000,
+                interval: 'year',
+                currency: 'USD'
+            };
+            const rendered = price.call({}, plan, {hash: {interval: 'true'}});
+            assert.equal(rendered, '$50/year');
+        });
+
+        it('will not append interval when interval is not "true"', function () {
+            const plan = {
+                amount: 500,
+                interval: 'month',
+                currency: 'USD'
+            };
+            const rendered = price.call({}, plan, {hash: {}});
+            assert.equal(rendered, '$5');
+        });
+
+        it('will not append interval when plan has no interval property', function () {
+            const plan = {
+                amount: 500,
+                currency: 'USD'
+            };
+            const rendered = price.call({}, plan, {hash: {interval: 'true'}});
+            assert.equal(rendered, '$5');
+        });
+
+        it('will work with next_payment object', function () {
+            const nextPayment = {
+                amount: 800,
+                interval: 'month',
+                currency: 'USD'
+            };
+            const rendered = price.call({}, nextPayment, {hash: {interval: 'true'}});
+            assert.equal(rendered, '$8/month');
+        });
+
+        it('will work with long number format and interval', function () {
+            const plan = {
+                amount: 500,
+                interval: 'month',
+                currency: 'USD'
+            };
+            const rendered = price.call({}, plan, {hash: {interval: 'true', numberFormat: 'long'}});
+            assert.equal(rendered, '$5.00/month');
+        });
+    });
 });

--- a/ghost/core/test/unit/frontend/helpers/price.test.js
+++ b/ghost/core/test/unit/frontend/helpers/price.test.js
@@ -128,13 +128,33 @@ describe('{{price}} helper', function () {
             assert.equal(rendered, '$50/year');
         });
 
-        it('will not append interval when interval is not "true"', function () {
+        it('will append interval when interval is boolean true', function () {
+            const plan = {
+                amount: 500,
+                interval: 'month',
+                currency: 'USD'
+            };
+            const rendered = price.call({}, plan, {hash: {interval: true}});
+            assert.equal(rendered, '$5/month');
+        });
+
+        it('will not append interval when interval is not set', function () {
             const plan = {
                 amount: 500,
                 interval: 'month',
                 currency: 'USD'
             };
             const rendered = price.call({}, plan, {hash: {}});
+            assert.equal(rendered, '$5');
+        });
+
+        it('will not append interval when interval is "false"', function () {
+            const plan = {
+                amount: 500,
+                interval: 'month',
+                currency: 'USD'
+            };
+            const rendered = price.call({}, plan, {hash: {interval: 'false'}});
             assert.equal(rendered, '$5');
         });
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
@@ -13,7 +13,7 @@ describe('Helpers', function () {
         'asset', 'authors', 'body_class', 'cancel_link', 'color_to_rgba', 'concat', 'content', 'content_api_key', 'content_api_url', 'contrast_text_color', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
         'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'json', 'link', 'link_class', 'meta_description', 'meta_title', 'navigation',
         'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'price', 'raw', 'reading_time', 'split', 't', 'tags', 'title','total_members', 'total_paid_members', 'twitter_url',
-        'url', 'comment_count', 'collection', 'recommendations', 'readable_url', 'social_url'
+        'url', 'comment_count', 'collection', 'recommendations', 'readable_url', 'social_url', 'offer_duration'
     ];
     const experimentalHelpers = ['match', 'tiers', 'comments', 'search'];
 
@@ -39,7 +39,8 @@ describe('Helpers', function () {
     describe('gscan compatibility', function () {
         // Ghost helpers that are intentionally absent from gscan's knownHelpers.
         const internalHelpers = [
-            'collection' // experimental, not yet stable for themes
+            'collection', // experimental, not yet stable for themes
+            'offer_duration' // pending gscan update (BER-3462)
         ];
 
         it('all theme-facing helpers should be known to gscan', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3384/add-interval-option-to-price-helper
ref https://linear.app/ghost/issue/BER-3461/new-offer-duration-helper

Adds two small helpers to make it easier for theme developers to build custom account pages that display subscription pricing and active discounts.

  **1. `interval` option on `{{price}}`**

  `{{price plan interval="true"}}` now outputs `$10/month` instead of requiring manual concatenation (`{{price plan}}/{{plan.interval}}`). Works with any object that has `.amount`, `.currency`, and `.interval` —
  including `plan` and `next_payment`.

  **2. New `{{offer_duration}}` helper**

  Outputs the duration context of an active discount: "Forever", "Ends 2 May 2026", or empty string if no discount. Used inside a subscription loop alongside `{{price}}` to match Portal's offer label format.

  Together, displaying a discounted subscription in a theme becomes:

  ```handlebars
  {{#foreach @member.subscriptions}}
    {{#if next_payment.discount}}
      <s>{{price plan interval="true"}}</s>
      <p>{{price next_payment interval="true"}} — {{offer_duration}}</p>
    {{else}}
      <p>{{price plan interval="true"}}</p>
    {{/if}}
  {{/foreach}}