### PR TITLE
Fixed sidebar flicker during navigation preference updates

### DIFF
--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -274,6 +274,89 @@ describe("useUserPreferences", () => {
                 menu: { visible: true },
             });
         });
+
+        queryTest("keeps previous data during unrelated accessibility updates", async ({ server, wrapper }) => {
+            server.use(
+                http.get(USERS_API_URL, () => {
+                    return HttpResponse.json({
+                        users: [
+                            {
+                                ...mockUser,
+                                accessibility: JSON.stringify({
+                                    navigation: DEFAULT_NAVIGATION_PREFERENCES,
+                                    whatsNew: {
+                                        lastSeenDate: "2025-01-01T00:00:00.000Z",
+                                    },
+                                }),
+                            },
+                        ],
+                    });
+                }),
+                http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(USER_UPDATE_API_URL, async ({ request }) => {
+                    const body = await request.json();
+
+                    await new Promise(resolve => setTimeout(resolve, 25));
+
+                    return HttpResponse.json({
+                        users: [
+                            {
+                                ...mockUser,
+                                accessibility: body.users[0]?.accessibility ?? "",
+                            },
+                        ],
+                    });
+                })
+            );
+
+            const snapshots: Array<ReturnType<typeof useUserPreferences>["data"]> = [];
+
+            const { result } = renderHook(() => {
+                const query = useUserPreferences();
+                const mutation = useEditUserPreferences();
+
+                snapshots.push(query.data);
+
+                return {query, mutation};
+            }, { wrapper });
+
+            await waitFor(() => {
+                expect(result.current.query.data).toEqual({
+                    navigation: DEFAULT_NAVIGATION_PREFERENCES,
+                    whatsNew: {
+                        lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
+                    },
+                });
+            });
+
+            snapshots.length = 0;
+
+            await act(async () => {
+                await result.current.mutation.mutateAsync({
+                    navigation: {
+                        expanded: {
+                            posts: false,
+                        },
+                    },
+                });
+            });
+
+            await waitFor(() => {
+                expect(result.current.query.data).toEqual({
+                    navigation: {
+                        ...DEFAULT_NAVIGATION_PREFERENCES,
+                        expanded: {
+                            ...DEFAULT_NAVIGATION_PREFERENCES.expanded,
+                            posts: false,
+                        },
+                    },
+                    whatsNew: {
+                        lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
+                    },
+                });
+            });
+
+            expect(snapshots).not.toContain(undefined);
+        });
     });
 });
 

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -55,6 +55,7 @@ export function useUserPreferences<TData = Preferences>(
             return PreferencesSchema.parse(parsed);
         },
         enabled: !!user,
+        keepPreviousData: true,
         staleTime: Infinity,
         // Query key includes user?.accessibility to automatically react to changes from ANY source
         // (our mutation, other code calling editUser, external updates, etc.). When accessibility


### PR DESCRIPTION
This fixes a sidebar flicker that happens when expanding or collapsing sidebar sections updates the current user's `accessibility` preferences. `useUserPreferences()` would briefly drop its data during unrelated preference updates, which in turn made dependent sidebar UI such as the What's New banner and user-menu indicators disappear and reappear.

The fix keeps the previous user preference data while the accessibility-backed query key changes. I also added one focused regression test at the `useUserPreferences()` boundary to lock that behavior in place.

Verification:
- `../../node_modules/.bin/vitest run src/hooks/user-preferences.accessibility-updates.test.tsx` from `apps/admin`
- `../../node_modules/.bin/eslint src/hooks/user-preferences.ts src/hooks/user-preferences.accessibility-updates.test.tsx` from `apps/admin`

Fixes https://linear.app/ghost/issue/BER-3464/prevent-sidebar-flicker-during-navigation-preference-updates
