### PR TITLE
Fixed shared views fallback parsing

### DIFF
--- a/apps/posts/src/views/members/member-views.test.ts
+++ b/apps/posts/src/views/members/member-views.test.ts
@@ -5,7 +5,7 @@ import {
     isMemberViewSearchActive,
     parseSharedViewsJSON
 } from './member-views';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 describe('member-views', () => {
     describe('parseSharedViewsJSON', () => {
@@ -42,6 +42,15 @@ describe('member-views', () => {
             const result = parseSharedViewsJSON('{');
 
             expect(result.ok).toBe(false);
+        });
+
+        it('falls back to an empty array when shared_views is not an array', () => {
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const result = parseSharedViewsJSON('{}');
+
+            expect(result).toEqual({ok: true, views: []});
+
+            errorSpy.mockRestore();
         });
     });
 

--- a/apps/posts/src/views/members/shared-views.test.ts
+++ b/apps/posts/src/views/members/shared-views.test.ts
@@ -2,11 +2,24 @@ import {
     type SharedView,
     findMatchingSharedViewIndexes,
     hasSharedViewNameConflict,
-    isSharedViewEqual
+    isSharedViewEqual,
+    parseAllSharedViewsJSON
 } from './shared-views';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 describe('shared-views', () => {
+    describe('parseAllSharedViewsJSON', () => {
+        it('falls back to an empty array and logs when shared_views is not an array', () => {
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const result = parseAllSharedViewsJSON('{}');
+
+            expect(result).toEqual({ok: true, views: []});
+            expect(errorSpy).toHaveBeenCalledWith('Failed to parse shared_views setting:', new Error('shared_views is not an array'));
+
+            errorSpy.mockRestore();
+        });
+    });
+
     describe('isSharedViewEqual', () => {
         it('matches views by route and filter payload', () => {
             const left: SharedView = {

--- a/apps/posts/src/views/members/shared-views.ts
+++ b/apps/posts/src/views/members/shared-views.ts
@@ -55,7 +55,9 @@ export function parseAllSharedViewsJSON(json: string): AllSharedViewsParseResult
         const parsed: unknown = JSON.parse(json);
 
         if (!Array.isArray(parsed)) {
-            return {ok: false, error: new Error('shared_views is not an array')};
+            // eslint-disable-next-line no-console
+            console.error('Failed to parse shared_views setting:', new Error('shared_views is not an array'));
+            return {ok: true, views: []};
         }
 
         const views = parsed.flatMap((item) => {


### PR DESCRIPTION
## Summary
- fall back to `[]` when `shared_views` parses to a non-array payload such as `{}`
- keep logging the malformed `shared_views` data so installs with bad defaults are still visible
- cover the fallback behavior in the shared and member view parser tests

## Test Plan
- `yarn vitest run apps/posts/src/views/members/shared-views.test.ts apps/posts/src/views/members/member-views.test.ts`