### PR TITLE
Fixed S3Storage.exists() crash when called without targetDir

### DIFF
--- a/ghost/core/core/server/adapters/storage/S3Storage.ts
+++ b/ghost/core/core/server/adapters/storage/S3Storage.ts
@@ -310,14 +310,14 @@ export default class S3Storage extends StorageBase {
         return relativePath.slice(this.storagePath.length + 1);
     }
 
-    async exists(fileName: string, targetDir: string): Promise<boolean> {
+    async exists(fileName: string, targetDir?: string): Promise<boolean> {
         if (!fileName?.trim()) {
             throw new errors.IncorrectUsageError({
                 message: tpl(messages.emptyFileName, {method: 'exists'})
             });
         }
 
-        const relativePath = path.posix.join(targetDir, fileName);
+        const relativePath = targetDir ? path.posix.join(targetDir, fileName) : fileName;
         const key = this.buildKey(relativePath);
 
         try {
@@ -348,14 +348,14 @@ export default class S3Storage extends StorageBase {
         };
     }
 
-    async delete(fileName: string, targetDir: string): Promise<void> {
+    async delete(fileName: string, targetDir?: string): Promise<void> {
         if (!fileName?.trim()) {
             throw new errors.IncorrectUsageError({
                 message: tpl(messages.emptyFileName, {method: 'delete'})
             });
         }
 
-        const relativePath = path.posix.join(targetDir, fileName);
+        const relativePath = targetDir ? path.posix.join(targetDir, fileName) : fileName;
         const key = this.buildKey(relativePath);
 
         try {

--- a/ghost/core/test/unit/server/adapters/storage/s3-storage.test.ts
+++ b/ghost/core/test/unit/server/adapters/storage/s3-storage.test.ts
@@ -316,6 +316,28 @@ describe('S3Storage', function () {
         assert.equal(missing, false);
     });
 
+    it('exists works without targetDir parameter', async function () {
+        const {storage, sendStub} = createStorage();
+        const {HeadObjectCommand: HeadObjectCmd} = await import('@aws-sdk/client-s3');
+
+        // handle-image-sizes middleware calls exists(req.url) with a single path argument
+        sendStub.resolves({});
+        const exists = await storage.exists('/size/w1200/2024/06/photo.jpg');
+        assert.equal(exists, true, 'should resolve to true when object exists');
+
+        const command = sendStub.firstCall.args[0] as InstanceType<typeof HeadObjectCmd>;
+        assert.equal(
+            command.input.Key,
+            'configurable/prefix/content/files/size/w1200/2024/06/photo.jpg',
+            'should build key using fileName directly as relative path'
+        );
+
+        sendStub.resetHistory();
+        sendStub.rejects(createNotFoundError());
+        const missing = await storage.exists('/size/w1200/2024/06/missing.jpg');
+        assert.equal(missing, false, 'should resolve to false when object does not exist');
+    });
+
     it('delete removes objects using derived key', async function () {
         const {storage, sendStub} = createStorage();
 


### PR DESCRIPTION
## Summary

- Made `targetDir` optional in `S3Storage.exists()` and `S3Storage.delete()`, matching `LocalStorageBase`'s behavior
- When `targetDir` is omitted, uses `fileName` directly as the relative path instead of crashing in `path.posix.join(undefined, fileName)`
- Fixes breakage in `handle-image-sizes` middleware and `image-size` service which both call `exists(path)` with a single argument

## Context

Several callers pass a single path to `exists()` rather than separate `fileName` + `targetDir` args. This works fine with `LocalStorageBase` (which defaults to `this.storagePath` when `targetDir` is undefined) but crashes with `S3Storage`. Both `saveRaw` and `exists` go through `buildKey` with the same input, so the S3 keys match correctly.