### PR TITLE
Fixed members-forward filter gating parity

### DIFF
--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -9,7 +9,6 @@ import {
 } from '../use-member-filter-fields';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
-import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useBrowseLabels} from '@tryghost/admin-x-framework/api/labels';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
@@ -55,15 +54,13 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const {data: offersData} = useBrowseOffers({});
     const {data: newslettersData} = useBrowseNewsletters({searchParams: {limit: '100'}});
     const {data: settingsData} = useBrowseSettings({});
-    const {data: configData} = useBrowseConfig({});
 
     const settings = settingsData?.settings || [];
     const paidMembersEnabled = getSettingValue<boolean>(settings, 'paid_members_enabled') === true;
-    const emailAnalyticsEnabled = configData?.config?.emailAnalytics === true;
+    const emailFiltersEnabled = getSettingValue<string>(settings, 'editor_default_email_recipients') !== 'disabled';
     const membersTrackSources = getSettingValue<boolean>(settings, 'members_track_sources') === true;
     const emailTrackOpens = getSettingValue<boolean>(settings, 'email_track_opens') === true;
     const emailTrackClicks = getSettingValue<boolean>(settings, 'email_track_clicks') === true;
-    const audienceFeedbackEnabled = configData?.config?.labs?.audienceFeedback === true;
     const siteTimezone = getSiteTimezone(settings);
 
     const labels = labelsData?.labels || [];
@@ -102,7 +99,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         hydratedNewsletterSlugs,
         hasMultipleTiers,
         paidMembersEnabled,
-        emailAnalyticsEnabled,
+        emailFiltersEnabled,
         labelsOptions: labels.map(label => ({value: label.slug, label: label.name})),
         tiersOptions: activePaidTiers.map(tier => ({value: tier.id, label: tier.name})),
         offers,
@@ -117,7 +114,6 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         membersTrackSources,
         emailTrackOpens,
         emailTrackClicks,
-        audienceFeedbackEnabled,
         siteTimezone
     });
 

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -26,7 +26,7 @@ describe('useMemberFilterFields', () => {
             labelsOptions: [{value: 'vip', label: 'VIP'}],
             newsletters: [{slug: 'weekly', name: 'Weekly', status: 'active'}],
             paidMembersEnabled: true,
-            emailAnalyticsEnabled: true,
+            emailFiltersEnabled: true,
             postResourceOptions: [{value: 'post_1', label: 'Welcome'}],
             onPostResourceSearchChange: vi.fn(),
             postResourceSearchValue: 'wel',
@@ -39,7 +39,6 @@ describe('useMemberFilterFields', () => {
             membersTrackSources: true,
             emailTrackOpens: true,
             emailTrackClicks: true,
-            audienceFeedbackEnabled: true,
             siteTimezone: 'UTC'
         }));
 
@@ -66,6 +65,42 @@ describe('useMemberFilterFields', () => {
         });
 
         expect(emailPostField).toMatchObject({
+            options: [{value: 'email_1', label: 'Launch'}],
+            searchValue: 'lau',
+            isLoading: false
+        });
+    });
+
+    it('shows the Email group when email sending is enabled', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            emailFiltersEnabled: true,
+            siteTimezone: 'UTC'
+        }));
+
+        const emailGroup = result.current.find(group => group.group === 'Email');
+
+        expect(emailGroup?.fields.map(field => field.key)).toEqual([
+            'email_count',
+            'email_opened_count',
+            'emails.post_id',
+            'newsletter_feedback'
+        ]);
+    });
+
+    it('keeps the feedback filter visible without a separate feature flag', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            emailFiltersEnabled: true,
+            emailResourceOptions: [{value: 'email_1', label: 'Launch'}],
+            onEmailResourceSearchChange: vi.fn(),
+            emailResourceSearchValue: 'lau',
+            emailResourceLoading: false,
+            siteTimezone: 'UTC'
+        }));
+
+        const emailFields = result.current.find(group => group.group === 'Email')?.fields ?? [];
+        const feedbackField = emailFields.find(field => field.key === 'newsletter_feedback');
+
+        expect(feedbackField).toMatchObject({
             options: [{value: 'email_1', label: 'Launch'}],
             searchValue: 'lau',
             isLoading: false

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -12,7 +12,7 @@ interface UseMemberFilterFieldsOptions {
     hydratedNewsletterSlugs?: string[];
     hasMultipleTiers?: boolean;
     paidMembersEnabled?: boolean;
-    emailAnalyticsEnabled?: boolean;
+    emailFiltersEnabled?: boolean;
     postResourceOptions?: FilterOption[];
     onPostResourceSearchChange?: (search: string) => void;
     postResourceSearchValue?: string;
@@ -25,7 +25,6 @@ interface UseMemberFilterFieldsOptions {
     membersTrackSources?: boolean;
     emailTrackOpens?: boolean;
     emailTrackClicks?: boolean;
-    audienceFeedbackEnabled?: boolean;
     siteTimezone?: string;
 }
 
@@ -295,7 +294,7 @@ export function useMemberFilterFields({
     hydratedNewsletterSlugs = [],
     hasMultipleTiers = false,
     paidMembersEnabled = false,
-    emailAnalyticsEnabled = false,
+    emailFiltersEnabled = false,
     postResourceOptions = [],
     onPostResourceSearchChange,
     postResourceSearchValue,
@@ -308,7 +307,6 @@ export function useMemberFilterFields({
     membersTrackSources = false,
     emailTrackOpens = false,
     emailTrackClicks = false,
-    audienceFeedbackEnabled = false,
     siteTimezone = 'UTC'
 }: UseMemberFilterFieldsOptions): FilterFieldGroup[] {
     return useMemo(() => {
@@ -430,7 +428,7 @@ export function useMemberFilterFields({
             groups.push({group: 'Subscription', fields: subscriptionFields});
         }
 
-        if (emailAnalyticsEnabled) {
+        if (emailFiltersEnabled) {
             const emailFields: FilterFieldConfig[] = [
                 createFieldConfig('email_count', {}, NUMBER_OPERATOR_LABELS),
                 createFieldConfig('email_opened_count', {}, NUMBER_OPERATOR_LABELS)
@@ -465,22 +463,19 @@ export function useMemberFilterFields({
                 )));
             }
 
-            if (audienceFeedbackEnabled) {
-                emailFields.push(createFieldConfig('newsletter_feedback', createSearchableFieldOverrides(
-                    emailResourceOptions,
-                    onEmailResourceSearchChange,
-                    emailResourceSearchValue,
-                    emailResourceLoading
-                )));
-            }
+            emailFields.push(createFieldConfig('newsletter_feedback', createSearchableFieldOverrides(
+                emailResourceOptions,
+                onEmailResourceSearchChange,
+                emailResourceSearchValue,
+                emailResourceLoading
+            )));
 
             groups.push({group: 'Email', fields: emailFields});
         }
 
         return groups;
     }, [
-        audienceFeedbackEnabled,
-        emailAnalyticsEnabled,
+        emailFiltersEnabled,
         emailResourceLoading,
         emailResourceOptions,
         emailResourceSearchValue,


### PR DESCRIPTION
This updates `members-forward` so the Email filter group follows the same availability rule as Ember, based on whether member email sending is enabled. It also removes the extra React-only feedback gate, so `Responded with feedback` is available again with the `More like this` and `Less like this` operators whenever the Email filters are shown.

I added focused hook tests to cover that gating behavior.

ref https://linear.app/ghost/issue/BER-3456/responded-with-feedback-filter-is-missing-in-members-forward

Tested with `yarn --cwd apps/posts vitest run src/views/members/use-member-filter-fields.test.ts` and `yarn --cwd apps/posts eslint src/views/members/use-member-filter-fields.ts src/views/members/components/members-filters.tsx src/views/members/use-member-filter-fields.test.ts`.