### PR TITLE
Added e2e Stripe offer checkout support

### DIFF
--- a/e2e/helpers/pages/public/public-page.ts
+++ b/e2e/helpers/pages/public/public-page.ts
@@ -60,6 +60,7 @@ class PortalSection extends BasePage {
 export class PublicPage extends BasePage {
     public readonly portalRoot: Locator;
     public readonly portalIframe: Locator;
+    public readonly portalPopupFrame: Locator;
     public readonly portalScript: Locator;
     private readonly subscribeLink: Locator;
     private readonly signInLink: Locator;
@@ -72,6 +73,7 @@ export class PublicPage extends BasePage {
         this.portal = new PortalSection(page);
         this.portalRoot = this.portal.portalRoot;
         this.portalIframe = page.locator('#ghost-portal-root div iframe');
+        this.portalPopupFrame = page.locator('[data-testid="portal-popup-frame"]');
         this.portalScript = page.locator('script[data-ghost][data-key][data-api]');
         this.subscribeLink = page.locator('a[href="#/portal/signup"]').first();
         this.signInLink = page.locator('a[href="#/portal/signin"]').first();
@@ -145,5 +147,9 @@ export class PublicPage extends BasePage {
 
     async gotoPortalSupport(options?: pageGotoOptions): Promise<null | Response> {
         return await this.goto('/#/portal/support', options);
+    }
+
+    async gotoOfferCode(code: string, options?: pageGotoOptions): Promise<null | Response> {
+        return await this.goto(`/${code}`, options);
     }
 }

--- a/e2e/helpers/services/members/members-service.ts
+++ b/e2e/helpers/services/members/members-service.ts
@@ -14,6 +14,27 @@ export interface MemberSubscription {
         currency: string;
         interval: string;
     };
+    offer?: {
+        id: string;
+        amount: number;
+        duration: 'once' | 'repeating' | 'forever' | 'trial';
+        duration_in_months: number | null;
+        type: 'fixed' | 'percent' | 'trial';
+    } | null;
+    offer_redemptions?: Array<{id: string}>;
+    next_payment?: {
+        original_amount: number;
+        amount: number;
+        interval: string;
+        currency: string;
+        discount: {
+            offer_id: string;
+            duration: 'once' | 'repeating' | 'forever';
+            duration_in_months: number | null;
+            type: 'fixed' | 'percent';
+            amount: number;
+        } | null;
+    } | null;
 }
 
 export interface MemberWithSubscriptions extends Member {

--- a/e2e/helpers/services/offers/index.ts
+++ b/e2e/helpers/services/offers/index.ts
@@ -1,0 +1,1 @@
+export * from './offers-service';

--- a/e2e/helpers/services/offers/offers-service.ts
+++ b/e2e/helpers/services/offers/offers-service.ts
@@ -1,0 +1,83 @@
+import {HttpClient as APIRequest} from '@/data-factory';
+
+// TODO: Convert this helper into an OfferFactory-backed setup API instead of keeping
+// thin admin CRUD wrappers under helpers/services. Offers are Ghost test data, so
+// they fit the data-factory model better than the service layer.
+
+export interface AdminOffer {
+    id: string;
+    name: string;
+    code: string;
+    cadence: 'month' | 'year';
+    status: 'active' | 'archived';
+    display_title: string | null;
+    display_description: string | null;
+    type: 'fixed' | 'percent' | 'trial';
+    amount: number;
+    duration: 'once' | 'repeating' | 'forever' | 'trial';
+    duration_in_months: number | null;
+    currency: string | null;
+    stripe_coupon_id?: string | null;
+    tier: {
+        id: string;
+    } | null;
+}
+
+export interface OffersResponse {
+    offers: AdminOffer[];
+}
+
+export interface OfferCreateInput {
+    name: string;
+    code: string;
+    cadence: 'month' | 'year';
+    amount: number;
+    duration: 'once' | 'repeating' | 'forever' | 'trial';
+    type: 'fixed' | 'percent' | 'trial';
+    tierId: string;
+    currency?: string | null;
+    display_title?: string | null;
+    display_description?: string | null;
+    duration_in_months?: number | null;
+    status?: 'active' | 'archived';
+}
+
+export class OffersService {
+    private readonly request: APIRequest;
+    private readonly adminEndpoint: string;
+
+    constructor(request: APIRequest) {
+        this.request = request;
+        this.adminEndpoint = '/ghost/api/admin';
+    }
+
+    async createOffer(input: OfferCreateInput): Promise<AdminOffer> {
+        const response = await this.request.post(`${this.adminEndpoint}/offers`, {
+            data: {
+                offers: [{
+                    name: input.name,
+                    code: input.code,
+                    cadence: input.cadence,
+                    status: input.status ?? 'active',
+                    currency: input.currency ?? null,
+                    type: input.type,
+                    amount: input.amount,
+                    duration: input.duration,
+                    duration_in_months: input.duration_in_months ?? null,
+                    display_title: input.display_title ?? input.name,
+                    display_description: input.display_description ?? null,
+                    tier: {
+                        id: input.tierId
+                    }
+                }]
+            }
+        });
+
+        if (!response.ok()) {
+            throw new Error(`Failed to create offer: ${response.status()}`);
+        }
+
+        const data = await response.json() as OffersResponse;
+        return data.offers[0];
+    }
+}

--- a/e2e/helpers/services/offers/offers-service.ts
+++ b/e2e/helpers/services/offers/offers-service.ts
@@ -9,6 +9,7 @@ export interface AdminOffer {
     name: string;
     code: string;
     cadence: 'month' | 'year';
+    redemption_type?: 'signup' | 'retention';
     status: 'active' | 'archived';
     display_title: string | null;
     display_description: string | null;
@@ -34,11 +35,16 @@ export interface OfferCreateInput {
     amount: number;
     duration: 'once' | 'repeating' | 'forever' | 'trial';
     type: 'fixed' | 'percent' | 'trial';
-    tierId: string;
+    tierId?: string | null;
     currency?: string | null;
     display_title?: string | null;
     display_description?: string | null;
     duration_in_months?: number | null;
+    redemption_type?: 'signup' | 'retention';
+    status?: 'active' | 'archived';
+}
+
+export interface OfferUpdateInput {
     status?: 'active' | 'archived';
 }
 
@@ -59,6 +65,7 @@ export class OffersService {
                     code: input.code,
                     cadence: input.cadence,
                     status: input.status ?? 'active',
+                    redemption_type: input.redemption_type ?? 'signup',
                     currency: input.currency ?? null,
                     type: input.type,
                     amount: input.amount,
@@ -66,15 +73,28 @@ export class OffersService {
                     duration_in_months: input.duration_in_months ?? null,
                     display_title: input.display_title ?? input.name,
                     display_description: input.display_description ?? null,
-                    tier: {
-                        id: input.tierId
-                    }
+                    tier: input.tierId ? {id: input.tierId} : null
                 }]
             }
         });
 
         if (!response.ok()) {
             throw new Error(`Failed to create offer: ${response.status()}`);
+        }
+
+        const data = await response.json() as OffersResponse;
+        return data.offers[0];
+    }
+
+    async updateOffer(offerId: string, input: OfferUpdateInput): Promise<AdminOffer> {
+        const response = await this.request.put(`${this.adminEndpoint}/offers/${offerId}`, {
+            data: {
+                offers: [input]
+            }
+        });
+
+        if (!response.ok()) {
+            throw new Error(`Failed to update offer: ${response.status()}`);
         }
 
         const data = await response.json() as OffersResponse;

--- a/e2e/helpers/services/offers/offers-service.ts
+++ b/e2e/helpers/services/offers/offers-service.ts
@@ -57,6 +57,26 @@ export class OffersService {
         this.adminEndpoint = '/ghost/api/admin';
     }
 
+    private extractFirstOfferOrThrow(action: string, status: number, data: unknown): AdminOffer {
+        const offers = (data as OffersResponse | undefined)?.offers;
+
+        if (!Array.isArray(offers) || offers.length === 0) {
+            let responseBody = '[unserializable]';
+
+            try {
+                responseBody = JSON.stringify(data);
+            } catch {
+                // Ignore serialization errors and keep fallback marker.
+            }
+
+            throw new Error(
+                `Failed to ${action}: expected response.offers to be a non-empty array (status ${status}). Response: ${responseBody}`
+            );
+        }
+
+        return offers[0];
+    }
+
     async createOffer(input: OfferCreateInput): Promise<AdminOffer> {
         const response = await this.request.post(`${this.adminEndpoint}/offers`, {
             data: {
@@ -82,8 +102,8 @@ export class OffersService {
             throw new Error(`Failed to create offer: ${response.status()}`);
         }
 
-        const data = await response.json() as OffersResponse;
-        return data.offers[0];
+        const data = await response.json() as unknown;
+        return this.extractFirstOfferOrThrow('create offer', response.status(), data);
     }
 
     async updateOffer(offerId: string, input: OfferUpdateInput): Promise<AdminOffer> {
@@ -97,7 +117,7 @@ export class OffersService {
             throw new Error(`Failed to update offer: ${response.status()}`);
         }
 
-        const data = await response.json() as OffersResponse;
-        return data.offers[0];
+        const data = await response.json() as unknown;
+        return this.extractFirstOfferOrThrow('update offer', response.status(), data);
     }
 }

--- a/e2e/helpers/services/stripe/builders.ts
+++ b/e2e/helpers/services/stripe/builders.ts
@@ -161,16 +161,12 @@ export function buildCoupon(overrides: Partial<StripeCoupon> = {}): StripeCoupon
 
 export function buildDiscount(opts: {
     coupon: StripeCoupon;
-    recurringInterval?: StripePriceInterval | null;
     start?: number;
 }): StripeDiscount {
     const start = opts.start ?? Math.floor(Date.now() / 1000);
     let end: number | null = null;
 
-    if (opts.coupon.duration === 'once') {
-        const months = opts.recurringInterval === 'year' ? 12 : 1;
-        end = addMonthsToTimestamp(start, months);
-    } else if (opts.coupon.duration === 'repeating' && typeof opts.coupon.duration_in_months === 'number' && opts.coupon.duration_in_months > 0) {
+    if (opts.coupon.duration === 'repeating' && typeof opts.coupon.duration_in_months === 'number' && opts.coupon.duration_in_months > 0) {
         end = addMonthsToTimestamp(start, opts.coupon.duration_in_months);
     }
 
@@ -232,17 +228,22 @@ export function buildSubscription(opts: {
     });
     const startDate = Math.floor(Date.now() / 1000);
     const trialDays = typeof opts.trialDays === 'number' && opts.trialDays > 0 ? opts.trialDays : null;
+    const status = opts.status ?? (trialDays ? 'trialing' : 'active');
+    const trialEnd = trialDays ? startDate + (60 * 60 * 24 * trialDays) : null;
+    const currentPeriodEnd = trialDays && status === 'trialing' && trialEnd
+        ? trialEnd
+        : startDate + (60 * 60 * 24 * 31);
 
     return {
         id: opts.id ?? generateId('sub'),
         object: 'subscription',
-        status: opts.status ?? (trialDays ? 'trialing' : 'active'),
+        status,
         cancel_at_period_end: false,
         canceled_at: null,
-        current_period_end: startDate + (60 * 60 * 24 * 31),
+        current_period_end: currentPeriodEnd,
         start_date: startDate,
         trial_start: trialDays ? startDate : null,
-        trial_end: trialDays ? startDate + (60 * 60 * 24 * trialDays) : null,
+        trial_end: trialEnd,
         discount: opts.discount ?? null,
         metadata: {},
         default_payment_method: opts.paymentMethod?.id ?? null,

--- a/e2e/helpers/services/stripe/builders.ts
+++ b/e2e/helpers/services/stripe/builders.ts
@@ -17,12 +17,31 @@ type StripeCustomUnitAmount = {
     preset: number | null;
 };
 
+function addMonthsToTimestamp(start: number, months: number): number {
+    const date = new Date(start * 1000);
+    date.setUTCMonth(date.getUTCMonth() + months);
+    return Math.floor(date.getTime() / 1000);
+}
+
 export type StripeProduct = Pick<Stripe.Product, 'active' | 'id' | 'name' | 'object'>;
 
 export type StripePrice = Omit<Pick<Stripe.Price, 'active' | 'currency' | 'id' | 'nickname' | 'object' | 'product' | 'recurring' | 'type' | 'unit_amount'>, 'product' | 'recurring'> & {
     custom_unit_amount: StripeCustomUnitAmount | null;
     product: string;
     recurring: {interval: StripePriceInterval} | null;
+};
+
+export type StripeCoupon = Omit<Pick<Stripe.Coupon, 'amount_off' | 'currency' | 'duration' | 'duration_in_months' | 'id' | 'name' | 'object' | 'percent_off'>, 'amount_off' | 'currency' | 'duration_in_months' | 'name' | 'percent_off'> & {
+    amount_off: number | null;
+    currency: string | null;
+    duration_in_months: number | null;
+    name: string | null;
+    percent_off: number | null;
+};
+
+export type StripeDiscount = Omit<Pick<Stripe.Discount, 'coupon' | 'end' | 'id' | 'object' | 'start'>, 'coupon' | 'end'> & {
+    coupon: StripeCoupon;
+    end: number | null;
 };
 
 export type StripePaymentMethod = Omit<Pick<Stripe.PaymentMethod, 'billing_details' | 'card' | 'id' | 'object' | 'type'>, 'billing_details' | 'card' | 'type'> & {
@@ -37,9 +56,10 @@ type StripeSubscriptionItem = Omit<Pick<Stripe.SubscriptionItem, 'price'>, 'pric
     price: StripePrice;
 };
 
-export type StripeSubscription = Omit<Pick<Stripe.Subscription, 'cancel_at_period_end' | 'canceled_at' | 'current_period_end' | 'customer' | 'default_payment_method' | 'id' | 'items' | 'metadata' | 'object' | 'start_date' | 'status' | 'trial_end' | 'trial_start'>, 'customer' | 'default_payment_method' | 'items' | 'metadata'> & {
+export type StripeSubscription = Omit<Pick<Stripe.Subscription, 'cancel_at_period_end' | 'canceled_at' | 'current_period_end' | 'customer' | 'default_payment_method' | 'discount' | 'id' | 'items' | 'metadata' | 'object' | 'start_date' | 'status' | 'trial_end' | 'trial_start'>, 'customer' | 'default_payment_method' | 'discount' | 'items' | 'metadata'> & {
     customer: string;
     default_payment_method: string | null;
+    discount: StripeDiscount | null;
     items: StripeList<StripeSubscriptionItem>;
     metadata: Stripe.Metadata;
 };
@@ -65,6 +85,7 @@ export type StripeCheckoutSessionResponse = Omit<Pick<Stripe.Checkout.Session, '
 };
 
 export interface StripeCheckoutSessionRequest {
+    discounts?: Array<{coupon: string}>;
     line_items?: Array<{price: string; quantity: number}>;
     subscription_data?: {
         items: Array<{plan: string}>;
@@ -124,6 +145,44 @@ export function buildPrice(overrides: Partial<StripePrice> = {}): StripePrice {
     };
 }
 
+export function buildCoupon(overrides: Partial<StripeCoupon> = {}): StripeCoupon {
+    return {
+        id: generateId('coupon'),
+        object: 'coupon',
+        amount_off: null,
+        currency: null,
+        duration: 'once',
+        duration_in_months: null,
+        name: 'Test Coupon',
+        percent_off: 10,
+        ...overrides
+    };
+}
+
+export function buildDiscount(opts: {
+    coupon: StripeCoupon;
+    recurringInterval?: StripePriceInterval | null;
+    start?: number;
+}): StripeDiscount {
+    const start = opts.start ?? Math.floor(Date.now() / 1000);
+    let end: number | null = null;
+
+    if (opts.coupon.duration === 'once') {
+        const months = opts.recurringInterval === 'year' ? 12 : 1;
+        end = addMonthsToTimestamp(start, months);
+    } else if (opts.coupon.duration === 'repeating' && typeof opts.coupon.duration_in_months === 'number' && opts.coupon.duration_in_months > 0) {
+        end = addMonthsToTimestamp(start, opts.coupon.duration_in_months);
+    }
+
+    return {
+        id: generateId('di'),
+        object: 'discount',
+        coupon: opts.coupon,
+        start,
+        end
+    };
+}
+
 export function buildPaymentMethod(overrides: {id?: string; name?: string} = {}): StripePaymentMethod {
     return {
         id: overrides.id ?? generateId('pm'),
@@ -158,28 +217,33 @@ export function buildCustomer(opts: {id?: string; email: string; name: string}):
 export function buildSubscription(opts: {
     id?: string;
     customerId: string;
+    discount?: StripeDiscount | null;
     itemId?: string;
     paymentMethod?: StripePaymentMethod | null;
     price?: StripePrice;
     priceId?: string;
     productId?: string;
     status?: Stripe.Subscription.Status;
+    trialDays?: number;
 }): StripeSubscription {
     const price = opts.price ?? buildPrice({
         id: opts.priceId,
         product: opts.productId ?? generateId('prod')
     });
+    const startDate = Math.floor(Date.now() / 1000);
+    const trialDays = typeof opts.trialDays === 'number' && opts.trialDays > 0 ? opts.trialDays : null;
 
     return {
         id: opts.id ?? generateId('sub'),
         object: 'subscription',
-        status: opts.status ?? 'active',
+        status: opts.status ?? (trialDays ? 'trialing' : 'active'),
         cancel_at_period_end: false,
         canceled_at: null,
-        current_period_end: Math.floor(Date.now() / 1000) + (60 * 60 * 24 * 31),
-        start_date: Math.floor(Date.now() / 1000),
-        trial_start: null,
-        trial_end: null,
+        current_period_end: startDate + (60 * 60 * 24 * 31),
+        start_date: startDate,
+        trial_start: trialDays ? startDate : null,
+        trial_end: trialDays ? startDate + (60 * 60 * 24 * trialDays) : null,
+        discount: opts.discount ?? null,
         metadata: {},
         default_payment_method: opts.paymentMethod?.id ?? null,
         items: {

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -3,12 +3,14 @@ import express from 'express';
 import http from 'http';
 import {
     type RecordedStripeCheckoutSession,
+    type StripeCoupon,
     type StripeCustomer,
     type StripePaymentMethod,
     type StripePrice,
     type StripeProduct,
     type StripeSubscription,
     buildCheckoutSession,
+    buildCoupon,
     buildCustomer,
     buildPrice,
     buildProduct
@@ -23,6 +25,7 @@ export class FakeStripeServer {
     private _port: number;
     private readonly products: Map<string, StripeProduct> = new Map();
     private readonly prices: Map<string, StripePrice> = new Map();
+    private readonly coupons: Map<string, StripeCoupon> = new Map();
     private readonly customers: Map<string, StripeCustomer> = new Map();
     private readonly subscriptions: Map<string, StripeSubscription> = new Map();
     private readonly paymentMethods: Map<string, StripePaymentMethod> = new Map();
@@ -43,6 +46,10 @@ export class FakeStripeServer {
 
     upsertPrice(price: StripePrice): void {
         this.prices.set(price.id, price);
+    }
+
+    upsertCoupon(coupon: StripeCoupon): void {
+        this.coupons.set(coupon.id, coupon);
     }
 
     upsertCustomer(customer: StripeCustomer): void {
@@ -67,6 +74,10 @@ export class FakeStripeServer {
 
     getPrices(): StripePrice[] {
         return Array.from(this.prices.values());
+    }
+
+    getCoupons(): StripeCoupon[] {
+        return Array.from(this.coupons.values());
     }
 
     getCustomers(): StripeCustomer[] {
@@ -235,6 +246,25 @@ export class FakeStripeServer {
             res.status(200).json(customer);
         });
 
+        this.app.post('/v1/coupons', (req, res) => {
+            const duration = this.parseCouponDuration(req.body.duration);
+            const amountOff = this.parseNumber(req.body.amount_off);
+            const percentOff = this.parseNumber(req.body.percent_off);
+
+            const coupon = buildCoupon({
+                name: this.parseString(req.body.name) ?? null,
+                duration,
+                duration_in_months: duration === 'repeating' ? (this.parseNumber(req.body.duration_in_months) ?? null) : null,
+                amount_off: typeof amountOff === 'number' ? amountOff : null,
+                currency: this.parseString(req.body.currency)?.toLowerCase() ?? null,
+                percent_off: typeof percentOff === 'number' ? percentOff : null
+            });
+
+            this.upsertCoupon(coupon);
+            debug(`Created coupon: ${coupon.id}`);
+            res.status(200).json(coupon);
+        });
+
         this.app.get('/v1/subscriptions/:id', (req, res) => {
             const subscriptionId = req.params.id;
             const subscription = this.subscriptions.get(subscriptionId);
@@ -380,8 +410,20 @@ export class FakeStripeServer {
 
         this.app.post('/v1/checkout/sessions', (req, res) => {
             const mode = this.parseCheckoutMode(req.body.mode);
+            const discounts = this.parseDiscounts(req.body.discounts) ?? [];
+            const missingCouponId = discounts.find((discount) => {
+                return !this.coupons.has(discount.coupon);
+            })?.coupon;
+
+            if (missingCouponId) {
+                debug(`Cannot create checkout session with missing coupon: ${missingCouponId}`);
+                res.status(400).json({error: {type: 'invalid_request_error', message: 'No such coupon'}});
+                return;
+            }
+
             const session = buildCheckoutSession({
                 request: {
+                    discounts,
                     custom_fields: this.parseCustomFields(req.body.custom_fields),
                     invoice_creation: this.parseInvoiceCreation(req.body.invoice_creation),
                     submit_type: this.parseSubmitType(req.body.submit_type),
@@ -600,6 +642,25 @@ export class FakeStripeServer {
         };
     }
 
+    private parseDiscounts(value: unknown): RecordedStripeCheckoutSession['request']['discounts'] {
+        if (!value || typeof value !== 'object') {
+            return undefined;
+        }
+
+        const discounts = Array.isArray(value)
+            ? value
+            : Object.values(value as Record<string, {coupon?: string}>);
+
+        return discounts
+            .filter((item): item is {coupon?: string} => item !== null && typeof item === 'object')
+            .map((item) => {
+                return {
+                    coupon: this.parseString(item.coupon) ?? ''
+                };
+            })
+            .filter(item => item.coupon);
+    }
+
     private parseLineItems(value: unknown): RecordedStripeCheckoutSession['request']['line_items'] {
         if (!value || typeof value !== 'object') {
             return undefined;
@@ -698,6 +759,14 @@ export class FakeStripeServer {
     private parseSubmitType(value: unknown): RecordedStripeCheckoutSession['request']['submit_type'] {
         if (value !== 'auto' && value !== 'book' && value !== 'donate' && value !== 'pay' && value !== 'send') {
             return undefined;
+        }
+
+        return value;
+    }
+
+    private parseCouponDuration(value: unknown): StripeCoupon['duration'] {
+        if (value !== 'forever' && value !== 'once' && value !== 'repeating') {
+            return 'once';
         }
 
         return value;

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -247,16 +247,78 @@ export class FakeStripeServer {
         });
 
         this.app.post('/v1/coupons', (req, res) => {
+            const badRequest = (message: string, param?: string): void => {
+                res.status(400).json({
+                    error: {
+                        type: 'invalid_request_error',
+                        message,
+                        ...(param ? {param} : {})
+                    }
+                });
+            };
+
             const duration = this.parseCouponDuration(req.body.duration);
-            const amountOff = this.parseNumber(req.body.amount_off);
-            const percentOff = this.parseNumber(req.body.percent_off);
+            const amountOffRaw = req.body.amount_off;
+            const percentOffRaw = req.body.percent_off;
+            const hasAmountOff = amountOffRaw !== undefined && amountOffRaw !== null && amountOffRaw !== '';
+            const hasPercentOff = percentOffRaw !== undefined && percentOffRaw !== null && percentOffRaw !== '';
+
+            if (!duration) {
+                return badRequest(
+                    "Invalid coupon duration. Must be one of 'forever', 'once', or 'repeating'.",
+                    'duration'
+                );
+            }
+
+            if (!hasAmountOff && !hasPercentOff) {
+                return badRequest(
+                    'You must provide exactly one of percent_off or amount_off.',
+                    'percent_off'
+                );
+            }
+
+            if (hasAmountOff && hasPercentOff) {
+                return badRequest(
+                    'You cannot provide both percent_off and amount_off.',
+                    'percent_off'
+                );
+            }
+
+            const amountOff = hasAmountOff ? this.parseNumber(amountOffRaw) : undefined;
+            const percentOff = hasPercentOff ? this.parseNumber(percentOffRaw) : undefined;
+
+            if (hasAmountOff && typeof amountOff !== 'number') {
+                return badRequest('Invalid amount_off. Expected a numeric value.', 'amount_off');
+            }
+
+            if (hasPercentOff && typeof percentOff !== 'number') {
+                return badRequest('Invalid percent_off. Expected a numeric value.', 'percent_off');
+            }
+
+            const currency = this.parseString(req.body.currency)?.toLowerCase() ?? null;
+            if (hasAmountOff && !currency) {
+                return badRequest('currency is required when amount_off is provided.', 'currency');
+            }
+
+            let durationInMonths: number | null = null;
+            if (duration === 'repeating') {
+                const parsedDurationInMonths = this.parseNumber(req.body.duration_in_months);
+                if (typeof parsedDurationInMonths !== 'number' || !Number.isInteger(parsedDurationInMonths) || parsedDurationInMonths <= 0) {
+                    return badRequest(
+                        'duration_in_months must be a positive integer when duration is repeating.',
+                        'duration_in_months'
+                    );
+                }
+
+                durationInMonths = parsedDurationInMonths;
+            }
 
             const coupon = buildCoupon({
                 name: this.parseString(req.body.name) ?? null,
                 duration,
-                duration_in_months: duration === 'repeating' ? (this.parseNumber(req.body.duration_in_months) ?? null) : null,
+                duration_in_months: durationInMonths,
                 amount_off: typeof amountOff === 'number' ? amountOff : null,
-                currency: this.parseString(req.body.currency)?.toLowerCase() ?? null,
+                currency,
                 percent_off: typeof percentOff === 'number' ? percentOff : null
             });
 
@@ -764,9 +826,9 @@ export class FakeStripeServer {
         return value;
     }
 
-    private parseCouponDuration(value: unknown): StripeCoupon['duration'] {
+    private parseCouponDuration(value: unknown): StripeCoupon['duration'] | undefined {
         if (value !== 'forever' && value !== 'once' && value !== 'repeating') {
-            return 'once';
+            return undefined;
         }
 
         return value;

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -265,7 +265,7 @@ export class FakeStripeServer {
 
             if (!duration) {
                 return badRequest(
-                    "Invalid coupon duration. Must be one of 'forever', 'once', or 'repeating'.",
+                    'Invalid coupon duration. Must be one of "forever", "once", or "repeating".',
                     'duration'
                 );
             }

--- a/e2e/helpers/services/stripe/index.ts
+++ b/e2e/helpers/services/stripe/index.ts
@@ -18,8 +18,10 @@ export {
 } from './builders';
 export type {
     RecordedStripeCheckoutSession,
+    StripeCoupon,
     StripeProduct,
     StripeCustomer,
+    StripeDiscount,
     StripeSubscription,
     StripePrice,
     StripePaymentMethod,

--- a/e2e/helpers/services/stripe/stripe-service.ts
+++ b/e2e/helpers/services/stripe/stripe-service.ts
@@ -198,7 +198,7 @@ export class StripeTestService {
 
         const customer = this.resolveCheckoutCustomer(session, opts.name);
         const paymentMethod = buildPaymentMethod({name: opts.name ?? customer.name});
-        const discount = this.resolveCheckoutDiscount(session, price);
+        const discount = this.resolveCheckoutDiscount(session);
         const trialDays = session.request.subscription_data?.trial_period_days;
         const subscription = buildSubscription({
             customerId: customer.id,
@@ -323,7 +323,7 @@ export class StripeTestService {
         }
     }
 
-    private resolveCheckoutDiscount(session: RecordedStripeCheckoutSession, price: StripePrice): StripeDiscount | null {
+    private resolveCheckoutDiscount(session: RecordedStripeCheckoutSession): StripeDiscount | null {
         const couponId = session.request.discounts?.[0]?.coupon;
 
         if (!couponId) {

--- a/e2e/helpers/services/stripe/stripe-service.ts
+++ b/e2e/helpers/services/stripe/stripe-service.ts
@@ -337,8 +337,7 @@ export class StripeTestService {
         }
 
         return buildDiscount({
-            coupon,
-            recurringInterval: price.recurring?.interval ?? null
+            coupon
         });
     }
 }

--- a/e2e/helpers/services/stripe/stripe-service.ts
+++ b/e2e/helpers/services/stripe/stripe-service.ts
@@ -4,6 +4,7 @@ import {WebhookClient} from './webhook-client';
 import {
     buildCheckoutSessionCompletedEvent,
     buildCustomer,
+    buildDiscount,
     buildDonationCheckoutCompletedEvent,
     buildInvoicePaymentSucceededEvent,
     buildPaymentMethod,
@@ -15,7 +16,9 @@ import {
 } from './builders';
 import type {
     RecordedStripeCheckoutSession,
+    StripeCoupon,
     StripeCustomer,
+    StripeDiscount,
     StripePaymentMethod,
     StripePrice,
     StripeProduct,
@@ -46,6 +49,10 @@ export class StripeTestService {
 
     getPrices(): StripePrice[] {
         return this.server.getPrices();
+    }
+
+    getCoupons(): StripeCoupon[] {
+        return this.server.getCoupons();
     }
 
     getCustomers(): StripeCustomer[] {
@@ -191,10 +198,14 @@ export class StripeTestService {
 
         const customer = this.resolveCheckoutCustomer(session, opts.name);
         const paymentMethod = buildPaymentMethod({name: opts.name ?? customer.name});
+        const discount = this.resolveCheckoutDiscount(session, price);
+        const trialDays = session.request.subscription_data?.trial_period_days;
         const subscription = buildSubscription({
             customerId: customer.id,
+            discount,
             price,
-            paymentMethod
+            paymentMethod,
+            trialDays
         });
 
         customer.subscriptions.data.push(subscription);
@@ -310,5 +321,24 @@ export class StripeTestService {
             const body = await subscriptionResponse.text();
             throw new Error(`customer.subscription.created webhook failed (${subscriptionResponse.status}): ${body}`);
         }
+    }
+
+    private resolveCheckoutDiscount(session: RecordedStripeCheckoutSession, price: StripePrice): StripeDiscount | null {
+        const couponId = session.request.discounts?.[0]?.coupon;
+
+        if (!couponId) {
+            return null;
+        }
+
+        const coupon = this.getCoupons().find(item => item.id === couponId);
+
+        if (!coupon) {
+            throw new Error(`No recorded Stripe coupon found for ${couponId}`);
+        }
+
+        return buildDiscount({
+            coupon,
+            recurringInterval: price.recurring?.interval ?? null
+        });
     }
 }

--- a/e2e/helpers/services/tiers/tiers-service.ts
+++ b/e2e/helpers/services/tiers/tiers-service.ts
@@ -1,5 +1,9 @@
 import {HttpClient as APIRequest, Tier} from '@/data-factory';
 
+// TODO: Convert this helper into a TierFactory-backed setup API instead of keeping
+// thin admin CRUD wrappers under helpers/services. Tiers are Ghost test data, so
+// they fit the data-factory model better than the service layer.
+
 export interface AdminTier extends Tier {
     description?: string | null;
     visibility?: 'public' | 'none';

--- a/e2e/tests/public/portal-offers.test.ts
+++ b/e2e/tests/public/portal-offers.test.ts
@@ -1,0 +1,56 @@
+import {OffersService} from '@/helpers/services/offers/offers-service';
+import {PublicPage} from '@/helpers/pages';
+import {createPaidPortalTier, expect, test} from '@/helpers/playwright';
+
+test.describe('Ghost Public - Portal Offers', () => {
+    test.use({stripeEnabled: true});
+
+    test('archived offer link opens site - does not open portal offer flow', async ({page}) => {
+        const publicPage = new PublicPage(page);
+        const offersService = new OffersService(page.request);
+        const tier = await createPaidPortalTier(page.request, {
+            name: `Archived Offer Tier ${Date.now()}`,
+            currency: 'usd',
+            monthly_price: 600,
+            yearly_price: 6000
+        });
+        const offer = await offersService.createOffer({
+            name: 'Archived Offer',
+            code: `archived-offer-${Date.now()}`,
+            cadence: 'month',
+            amount: 10,
+            duration: 'once',
+            type: 'percent',
+            tierId: tier.id
+        });
+
+        await offersService.updateOffer(offer.id, {status: 'archived'});
+
+        await publicPage.gotoOfferCode(offer.code);
+        await publicPage.portalRoot.waitFor({state: 'attached'});
+
+        await expect(publicPage.portalPopupFrame).toHaveCount(0);
+        await expect(page).not.toHaveURL(/#\/portal\/offers\//);
+    });
+
+    test('retention offer link opens site - does not open portal offer flow', async ({page}) => {
+        const publicPage = new PublicPage(page);
+        const offersService = new OffersService(page.request);
+        const offer = await offersService.createOffer({
+            name: 'Retention Offer',
+            code: `retention-offer-${Date.now()}`,
+            cadence: 'month',
+            amount: 10,
+            duration: 'once',
+            type: 'percent',
+            redemption_type: 'retention',
+            tierId: null
+        });
+
+        await publicPage.gotoOfferCode(offer.code);
+        await publicPage.portalRoot.waitFor({state: 'attached'});
+
+        await expect(publicPage.portalPopupFrame).toHaveCount(0);
+        await expect(page).not.toHaveURL(/#\/portal\/offers\//);
+    });
+});

--- a/e2e/tests/public/stripe-offer-checkout.test.ts
+++ b/e2e/tests/public/stripe-offer-checkout.test.ts
@@ -1,0 +1,84 @@
+import {MembersService} from '@/helpers/services/members/members-service';
+import {OffersService} from '@/helpers/services/offers/offers-service';
+import {TiersService} from '@/helpers/services/tiers/tiers-service';
+import {expect, test} from '@/helpers/playwright';
+
+interface CheckoutSessionResponse {
+    url: string;
+}
+
+// This is a harness smoke test for the e2e Stripe tooling rather than a long-term
+// product-facing spec. Migrated offer tests should carry the readable behavior
+// coverage, and this should stay thin or be removed if it becomes redundant.
+// TODO: REMOVE TEST
+
+test.describe('Ghost Public - Stripe Offer Checkout', () => {
+    test.use({stripeEnabled: true});
+
+    test('offer checkout creates a fake stripe coupon - redeemed offer is linked to the subscription', async ({page, stripe}) => {
+        const tiersService = new TiersService(page.request);
+        const offersService = new OffersService(page.request);
+        const membersService = new MembersService(page.request);
+        const tierName = `Offer Tier ${Date.now()}`;
+        const memberEmail = `offer-checkout-${Date.now()}@example.com`;
+
+        const tier = await tiersService.createTier({
+            name: tierName,
+            currency: 'usd',
+            monthly_price: 600,
+            yearly_price: 6000
+        });
+
+        const offer = await offersService.createOffer({
+            name: 'Spring Offer',
+            code: `spring-offer-${Date.now()}`,
+            cadence: 'month',
+            amount: 10,
+            duration: 'repeating',
+            duration_in_months: 3,
+            type: 'percent',
+            tierId: tier.id
+        });
+
+        const response = await page.request.post('/members/api/create-stripe-checkout-session/', {
+            data: {
+                customerEmail: memberEmail,
+                offerId: offer.id,
+                successUrl: 'http://localhost/success',
+                cancelUrl: 'http://localhost/cancel'
+            }
+        });
+
+        expect(response.ok()).toBe(true);
+
+        const sessionResponse = await response.json() as CheckoutSessionResponse;
+        const session = stripe!.getCheckoutSessions().at(-1);
+
+        expect(session).toBeDefined();
+        expect(sessionResponse.url).toBe(session?.response.url);
+        expect(session?.response.metadata.offer).toBe(offer.id);
+
+        const couponId = session?.request.discounts?.[0]?.coupon;
+        expect(couponId).toBeDefined();
+
+        const coupon = stripe!.getCoupons().find(item => item.id === couponId);
+        expect(coupon).toBeDefined();
+        expect(coupon?.duration).toBe('repeating');
+        expect(coupon?.duration_in_months).toBe(3);
+        expect(coupon?.percent_off).toBe(10);
+        expect(session?.request.subscription_data?.items).toHaveLength(1);
+
+        const createdMember = await stripe!.completeLatestSubscriptionCheckout({name: 'Offer Member'});
+        expect(createdMember.subscription.discount?.coupon.id).toBe(coupon?.id);
+        expect(createdMember.subscription.discount?.end).not.toBeNull();
+
+        const member = await membersService.getByEmailWithSubscriptions(memberEmail);
+        const subscription = member.subscriptions[0];
+
+        expect(subscription.offer?.id).toBe(offer.id);
+        expect(subscription.offer_redemptions?.some(item => item.id === offer.id)).toBe(true);
+        expect(subscription.next_payment?.original_amount).toBe(600);
+        expect(subscription.next_payment?.amount).toBe(540);
+        expect(subscription.next_payment?.discount?.offer_id).toBe(offer.id);
+    });
+});

--- a/ghost/core/test/e2e-browser/portal/offers.spec.js
+++ b/ghost/core/test/e2e-browser/portal/offers.spec.js
@@ -1,8 +1,6 @@
 const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 const {deleteAllMembers, createTier, createOffer, completeStripeSubscription} = require('../utils');
-const offersService = require('../../../core/server/services/offers');
-const ObjectID = require('bson-objectid').default;
 
 test.describe('Portal', () => {
     test.setTimeout(90000); // override the default 60s in the config as these retries can run close to 60s
@@ -317,68 +315,6 @@ test.describe('Portal', () => {
             // 1 member, should be Testy, on Portal Tier
             await expect(await sharedPage.getByRole('link', {name: 'Testy McTesterson testy+forever@example.com'}), 'Should have 1 paid member').toBeVisible();
             await expect(await sharedPage.getByRole('link', {name: tierName}), `Paid member should be on ${tierName}`).toBeVisible();
-        });
-
-        test('Archiving an offer', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-
-            // Create a new tier to attach offer to
-            const tierName = 'Archive Test Tier';
-            await createTier(sharedPage, {
-                name: tierName,
-                monthlyPrice: 6,
-                yearlyPrice: 60
-            });
-
-            // Create an offer. This will be archived
-            const {offerLink} = await createOffer(sharedPage, {
-                name: 'To be archived',
-                tierName: tierName,
-                offerType: 'discount',
-                amount: 10
-            });
-
-            // Archive all existing offers by creating a new offer. Using the createOffer util auto-archives all existing offers
-            await createOffer(sharedPage, {
-                name: 'Dummy Active Offer',
-                tierName: tierName,
-                offerType: 'discount',
-                amount: 10
-            });
-            // Open the offer URL and make sure portal popup doesn't load
-            await sharedPage.goto(offerLink);
-            const portalPopup = await sharedPage.locator('[data-testid="portal-popup-frame"]').isVisible();
-            await expect(portalPopup).toBeFalsy();
-        });
-
-        test('Retention offers do not trigger the offer redemption popup when visiting the offer URL', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-            await deleteAllMembers(sharedPage);
-
-            const suffix = new ObjectID().toHexString().slice(0, 8);
-            const offerCode = `retention-${suffix}`;
-
-            await offersService.api.createOffer({
-                name: `Retention Offer ${suffix}`,
-                code: offerCode,
-                display_title: 'Stay with us',
-                display_description: 'Retention offer',
-                type: 'percent',
-                cadence: 'month',
-                amount: 10,
-                duration: 'once',
-                duration_in_months: null,
-                status: 'active',
-                tier: null,
-                redemption_type: 'retention'
-            });
-
-            const siteUrl = new URL(sharedPage.url()).origin;
-            await sharedPage.goto(`${siteUrl}/${offerCode}`);
-            await sharedPage.waitForLoadState('load');
-
-            await expect(sharedPage.locator('[data-testid="portal-popup-frame"]')).not.toBeVisible();
-            await expect(sharedPage).not.toHaveURL(/#\/portal\/offers/);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-9/
- adds fake Stripe coupon support for offer-backed checkout sessions
- records checkout discounts and carries them into fake subscription state
- adds a minimal admin offers helper for top-level e2e setup
- adds a thin offer checkout smoke test to prove the capability end to end