### PR TITLE
Migrated Portal offer URL behavior to e2e

### DIFF
--- a/e2e/helpers/pages/public/public-page.ts
+++ b/e2e/helpers/pages/public/public-page.ts
@@ -60,6 +60,7 @@ class PortalSection extends BasePage {
 export class PublicPage extends BasePage {
     public readonly portalRoot: Locator;
     public readonly portalIframe: Locator;
+    public readonly portalPopupFrame: Locator;
     public readonly portalScript: Locator;
     private readonly subscribeLink: Locator;
     private readonly signInLink: Locator;
@@ -72,6 +73,7 @@ export class PublicPage extends BasePage {
         this.portal = new PortalSection(page);
         this.portalRoot = this.portal.portalRoot;
         this.portalIframe = page.locator('#ghost-portal-root div iframe');
+        this.portalPopupFrame = page.locator('[data-testid="portal-popup-frame"]');
         this.portalScript = page.locator('script[data-ghost][data-key][data-api]');
         this.subscribeLink = page.locator('a[href="#/portal/signup"]').first();
         this.signInLink = page.locator('a[href="#/portal/signin"]').first();
@@ -145,5 +147,9 @@ export class PublicPage extends BasePage {
 
     async gotoPortalSupport(options?: pageGotoOptions): Promise<null | Response> {
         return await this.goto('/#/portal/support', options);
+    }
+
+    async gotoOfferCode(code: string, options?: pageGotoOptions): Promise<null | Response> {
+        return await this.goto(`/${code}`, options);
     }
 }

--- a/e2e/helpers/services/offers/offers-service.ts
+++ b/e2e/helpers/services/offers/offers-service.ts
@@ -9,6 +9,7 @@ export interface AdminOffer {
     name: string;
     code: string;
     cadence: 'month' | 'year';
+    redemption_type?: 'signup' | 'retention';
     status: 'active' | 'archived';
     display_title: string | null;
     display_description: string | null;
@@ -34,11 +35,16 @@ export interface OfferCreateInput {
     amount: number;
     duration: 'once' | 'repeating' | 'forever' | 'trial';
     type: 'fixed' | 'percent' | 'trial';
-    tierId: string;
+    tierId?: string | null;
     currency?: string | null;
     display_title?: string | null;
     display_description?: string | null;
     duration_in_months?: number | null;
+    redemption_type?: 'signup' | 'retention';
+    status?: 'active' | 'archived';
+}
+
+export interface OfferUpdateInput {
     status?: 'active' | 'archived';
 }
 
@@ -59,6 +65,7 @@ export class OffersService {
                     code: input.code,
                     cadence: input.cadence,
                     status: input.status ?? 'active',
+                    redemption_type: input.redemption_type ?? 'signup',
                     currency: input.currency ?? null,
                     type: input.type,
                     amount: input.amount,
@@ -66,15 +73,28 @@ export class OffersService {
                     duration_in_months: input.duration_in_months ?? null,
                     display_title: input.display_title ?? input.name,
                     display_description: input.display_description ?? null,
-                    tier: {
-                        id: input.tierId
-                    }
+                    tier: input.tierId ? {id: input.tierId} : null
                 }]
             }
         });
 
         if (!response.ok()) {
             throw new Error(`Failed to create offer: ${response.status()}`);
+        }
+
+        const data = await response.json() as OffersResponse;
+        return data.offers[0];
+    }
+
+    async updateOffer(offerId: string, input: OfferUpdateInput): Promise<AdminOffer> {
+        const response = await this.request.put(`${this.adminEndpoint}/offers/${offerId}`, {
+            data: {
+                offers: [input]
+            }
+        });
+
+        if (!response.ok()) {
+            throw new Error(`Failed to update offer: ${response.status()}`);
         }
 
         const data = await response.json() as OffersResponse;

--- a/e2e/tests/public/portal-offers.test.ts
+++ b/e2e/tests/public/portal-offers.test.ts
@@ -1,0 +1,56 @@
+import {OffersService} from '@/helpers/services/offers/offers-service';
+import {PublicPage} from '@/helpers/pages';
+import {createPaidPortalTier, expect, test} from '@/helpers/playwright';
+
+test.describe('Ghost Public - Portal Offers', () => {
+    test.use({stripeEnabled: true});
+
+    test('archived offer link opens site - does not open portal offer flow', async ({page}) => {
+        const publicPage = new PublicPage(page);
+        const offersService = new OffersService(page.request);
+        const tier = await createPaidPortalTier(page.request, {
+            name: `Archived Offer Tier ${Date.now()}`,
+            currency: 'usd',
+            monthly_price: 600,
+            yearly_price: 6000
+        });
+        const offer = await offersService.createOffer({
+            name: 'Archived Offer',
+            code: `archived-offer-${Date.now()}`,
+            cadence: 'month',
+            amount: 10,
+            duration: 'once',
+            type: 'percent',
+            tierId: tier.id
+        });
+
+        await offersService.updateOffer(offer.id, {status: 'archived'});
+
+        await publicPage.gotoOfferCode(offer.code);
+        await publicPage.portalRoot.waitFor({state: 'attached'});
+
+        await expect(publicPage.portalPopupFrame).toHaveCount(0);
+        await expect(page).not.toHaveURL(/#\/portal\/offers\//);
+    });
+
+    test('retention offer link opens site - does not open portal offer flow', async ({page}) => {
+        const publicPage = new PublicPage(page);
+        const offersService = new OffersService(page.request);
+        const offer = await offersService.createOffer({
+            name: 'Retention Offer',
+            code: `retention-offer-${Date.now()}`,
+            cadence: 'month',
+            amount: 10,
+            duration: 'once',
+            type: 'percent',
+            redemption_type: 'retention',
+            tierId: null
+        });
+
+        await publicPage.gotoOfferCode(offer.code);
+        await publicPage.portalRoot.waitFor({state: 'attached'});
+
+        await expect(publicPage.portalPopupFrame).toHaveCount(0);
+        await expect(page).not.toHaveURL(/#\/portal\/offers\//);
+    });
+});

--- a/ghost/core/test/e2e-browser/portal/offers.spec.js
+++ b/ghost/core/test/e2e-browser/portal/offers.spec.js
@@ -1,8 +1,6 @@
 const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 const {deleteAllMembers, createTier, createOffer, completeStripeSubscription} = require('../utils');
-const offersService = require('../../../core/server/services/offers');
-const ObjectID = require('bson-objectid').default;
 
 test.describe('Portal', () => {
     test.setTimeout(90000); // override the default 60s in the config as these retries can run close to 60s
@@ -317,68 +315,6 @@ test.describe('Portal', () => {
             // 1 member, should be Testy, on Portal Tier
             await expect(await sharedPage.getByRole('link', {name: 'Testy McTesterson testy+forever@example.com'}), 'Should have 1 paid member').toBeVisible();
             await expect(await sharedPage.getByRole('link', {name: tierName}), `Paid member should be on ${tierName}`).toBeVisible();
-        });
-
-        test('Archiving an offer', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-
-            // Create a new tier to attach offer to
-            const tierName = 'Archive Test Tier';
-            await createTier(sharedPage, {
-                name: tierName,
-                monthlyPrice: 6,
-                yearlyPrice: 60
-            });
-
-            // Create an offer. This will be archived
-            const {offerLink} = await createOffer(sharedPage, {
-                name: 'To be archived',
-                tierName: tierName,
-                offerType: 'discount',
-                amount: 10
-            });
-
-            // Archive all existing offers by creating a new offer. Using the createOffer util auto-archives all existing offers
-            await createOffer(sharedPage, {
-                name: 'Dummy Active Offer',
-                tierName: tierName,
-                offerType: 'discount',
-                amount: 10
-            });
-            // Open the offer URL and make sure portal popup doesn't load
-            await sharedPage.goto(offerLink);
-            const portalPopup = await sharedPage.locator('[data-testid="portal-popup-frame"]').isVisible();
-            await expect(portalPopup).toBeFalsy();
-        });
-
-        test('Retention offers do not trigger the offer redemption popup when visiting the offer URL', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-            await deleteAllMembers(sharedPage);
-
-            const suffix = new ObjectID().toHexString().slice(0, 8);
-            const offerCode = `retention-${suffix}`;
-
-            await offersService.api.createOffer({
-                name: `Retention Offer ${suffix}`,
-                code: offerCode,
-                display_title: 'Stay with us',
-                display_description: 'Retention offer',
-                type: 'percent',
-                cadence: 'month',
-                amount: 10,
-                duration: 'once',
-                duration_in_months: null,
-                status: 'active',
-                tier: null,
-                redemption_type: 'retention'
-            });
-
-            const siteUrl = new URL(sharedPage.url()).origin;
-            await sharedPage.goto(`${siteUrl}/${offerCode}`);
-            await sharedPage.waitForLoadState('load');
-
-            await expect(sharedPage.locator('[data-testid="portal-popup-frame"]')).not.toBeVisible();
-            await expect(sharedPage).not.toHaveURL(/#\/portal\/offers/);
         });
     });
 });


### PR DESCRIPTION
## What this does
- migrates the archived offer URL behavior into top-level e2e
- migrates the retention offer URL behavior into top-level e2e
- adds minimal offer update support for the test setup
- removes the matching browser cases from ghost/core/test/e2e-browser/portal/offers.spec.js

## Why
This is the M5-B slice on top of the offer capability PR. It reduces the remaining offers browser surface before the full redemption migration.

## Testing
- cd e2e && yarn eslint helpers/pages/public/public-page.ts helpers/services/offers/offers-service.ts tests/public/portal-offers.test.ts
- cd e2e && yarn test:types
- cd ghost/core && yarn eslint test/e2e-browser/portal/offers.spec.js
- cd /Users/slars/dev/ghost/Ghost/e2e && GHOST_E2E_SKIP_BUILD=1 yarn test tests/public/portal-offers.test.ts