### PR TITLE
Fixed outdated Yarn lockfile after Tailwind ESLint change

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19433,6 +19433,14 @@ eslint-plugin-storybook@9.1.10:
   dependencies:
     "@typescript-eslint/utils" "^8.8.1"
 
+eslint-plugin-tailwindcss@3.18.2:
+  version "3.18.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.18.2.tgz#c67ff432cfad470dae54998b3bc6811af81f9087"
+  integrity sha512-QbkMLDC/OkkjFQ1iz/5jkMdHfiMu/uwujUHLAJK5iwNHD8RTxVTlsUezE0toTZ6VhybNBsk+gYGPDq2agfeRNA==
+  dependencies:
+    fast-glob "^3.2.5"
+    postcss "^8.4.4"
+
 eslint-plugin-tailwindcss@4.0.0-beta.0:
   version "4.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-4.0.0-beta.0.tgz#b46159c1db47b863a2e68d0cf95675b395e708b9"


### PR DESCRIPTION
ref 10a99e9a5418defd4d0f02505a7b1e9d7b325a6d

Looks like we didn't run `yarn` at some point. That's all I did for this change.
