### PR TITLE
Disallow unused variables in email renderer

### DIFF
--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 /* eslint-disable no-shadow */
 
 const logging = require('@tryghost/logging');
@@ -8,7 +7,7 @@ const clsx = require('clsx');
 function isUnsplashImage(url) {
     return /images\.unsplash\.com/.test(url);
 }
-const {textColorForBackgroundColor, darkenToContrastThreshold} = require('@tryghost/color-utils');
+const {textColorForBackgroundColor} = require('@tryghost/color-utils');
 const {DateTime} = require('luxon');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const EmailAddressParser = require('../email-address/email-address-parser');
@@ -591,10 +590,8 @@ class EmailRenderer {
 
     /**
      * createManageAccountUrl
-     *
-     * @param {string} [uuid] member uuid
      */
-    createManageAccountUrl(uuid) {
+    createManageAccountUrl() {
         const siteUrl = this.#urlUtils.urlFor('home', true);
         const url = new URL(siteUrl);
         url.hash = '#/portal/account';
@@ -705,8 +702,8 @@ class EmailRenderer {
             },
             {
                 id: 'manage_account_url',
-                getValue: (member) => {
-                    return this.createManageAccountUrl(member.uuid);
+                getValue: () => {
+                    return this.createManageAccountUrl();
                 }
             },
             {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1163

We disabled ESLint's `no-unused-vars` rule. Let's re-enable the rule for a little more code safety.

I think this is a useful change on its own, but will make it easier for me to work in this file soon.
