### PR TITLE
Improved reliability of tag importing test

### DIFF
--- a/ghost/core/core/server/data/seeders/importers/tags-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/tags-importer.js
@@ -21,7 +21,7 @@ class TagsImporter extends TableImporter {
     }
 
     generate() {
-        let name = `${faker.color.human()} ${faker.name.jobType()} ${faker.random.numeric(3)}`;
+        let name = `${faker.color.human()} ${faker.name.jobType()} ${faker.random.numeric(10)}`;
         name = `${name[0].toUpperCase()}${name.slice(1)}`;
         const threeYearsAgo = new Date();
         threeYearsAgo.setFullYear(threeYearsAgo.getFullYear() - 3);


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/23513197056/job/68439336819

[A test recently failed because a `UNIQUE` constraint in the tags table was violated.][0] This is because we actually generated a duplicate tag!

Before this change, we had a ~0.04% chance of doing this.[^1] After this change, the chance is ~0.000000004%.

[^1]: This is an instance of the [birthday problem][1]. `N` was the number of choices in `faker.color.human()`, `faker.name.jobType()`, and `faker.random.numeric(3)`—744,000. `K` looks like it's 24 by default. This patch effectively increases `N`.

[0]: https://github.com/TryGhost/Ghost/actions/runs/23513197056/job/68439336819
[1]: https://en.wikipedia.org/wiki/Birthday_problem
