### PR TITLE
Removed unused values from email renderer design options

### DIFF
--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -331,30 +331,9 @@ class EmailRenderer {
             postUrl
         };
 
-        const accentColor = this.#getAccentColor();
-        const accentContrastColor = this.#getAccentContrastColor();
-
         renderOptions.design = {
-            accentColor,
-            accentContrastColor,
-            backgroundColor: newsletter?.get('background_color'),
-            backgroundIsDark: this.#checkIfBackgroundIsDark(newsletter),
-            headerBackgroundColor: this.#getHeaderBackgroundColor(newsletter, accentColor),
             buttonCorners: newsletter?.get('button_corners'),
-            buttonStyle: newsletter?.get('button_style'),
-            titleFontWeight: newsletter?.get('title_font_weight'),
-            linkStyle: newsletter?.get('link_style'),
-            imageCorners: newsletter?.get('image_corners'),
-            postTitleColor: this.#getPostTitleColor(newsletter, accentColor),
-            sectionTitleColor: newsletter?.get('section_title_color'),
-            linkColor: newsletter?.get('link_color'),
-            // TODO:
-            // if the other options above have default or calculated values we
-            // should follow the same pattern as the options below to avoid
-            //duplicating magic values or logic in renderers
-            dividerColor: this.#getDividerColor(newsletter),
-            buttonColor: this.#getButtonColor(newsletter, accentColor),
-            buttonTextColor: this.#getButtonTextColor(newsletter, accentColor)
+            buttonStyle: newsletter?.get('button_style')
         };
 
         let html;

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2212,22 +2212,8 @@ describe('Email renderer', function () {
         it('passes expected data through to lexical renderer', async function () {
             await testLexicalRenderDesignOptions({
                 expectedObject: {
-                    accentColor: '#ffffff',
-                    accentContrastColor: '#000000',
-                    backgroundColor: '#000000',
-                    backgroundIsDark: true,
-                    headerBackgroundColor: '#000044',
                     buttonCorners: 'square',
-                    buttonStyle: 'outline',
-                    titleFontWeight: 'semibold',
-                    linkStyle: 'normal',
-                    imageCorners: 'rounded',
-                    postTitleColor: '#000022',
-                    sectionTitleColor: '#000011',
-                    linkColor: '#000033',
-                    dividerColor: '#e0e7eb',
-                    buttonColor: '#ffffff',
-                    buttonTextColor: '#000000'
+                    buttonStyle: 'outline'
                 }
             });
         });


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1163

We pass a number of options when we render the email's base HTML: accent color, background color, link style...but most of them are completely unused! Let's remove them.

I think this is a useful change on its own, but it also makes [an upcoming one][0] easier.

In addition to the existing automated tests, I also did a manual newsletter test and everything looks the same.

[0]: https://linear.app/ghost/issue/NY-1163
