### PR TITLE
Fixed price formatting bug with {{price}} helper

### DIFF
--- a/ghost/core/core/frontend/helpers/price.js
+++ b/ghost/core/core/frontend/helpers/price.js
@@ -26,7 +26,11 @@ function formatter({amount, currency, numberFormat = 'short', currencyFormat = '
         currencyDisplay: currencyFormat
     };
     if (numberFormat === 'short') {
-        formatterOptions.minimumFractionDigits = 0;
+        if (_.isNumber(amount) && amount % 1 !== 0) {
+            formatterOptions.minimumFractionDigits = 2;
+        } else {
+            formatterOptions.minimumFractionDigits = 0;
+        }
     }
     if (_.isNumber(amount)) {
         return new Intl.NumberFormat(locale, formatterOptions).format(amount);

--- a/ghost/core/test/unit/frontend/helpers/price.test.js
+++ b/ghost/core/test/unit/frontend/helpers/price.test.js
@@ -102,6 +102,11 @@ describe('{{price}} helper', function () {
         assert.equal(rendered, '€5');
     });
 
+    it('will format with short number format preserving trailing zero', function () {
+        const rendered = price.call({}, 3540, {hash: {currency: 'USD', numberFormat: 'short'}});
+        assert.equal(rendered, '$35.40');
+    });
+
     it('will format with name currency format', function () {
         const rendered = price.call({}, 500, {hash: {currency: 'USD', currencyFormat: 'name'}});
         assert.equal(rendered, '5 US dollars');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3469/price-formatting-bug-with-price-helper

Discounted prices with trailing zeros (e.g. $35.40) were rendered without the trailing zero ($35.4) in the `{{price}}` theme helper. This is because the short number format used `minimumFractionDigits: 0`, which allowed `Intl.NumberFormat` to drop trailing zeros.                                                                                                                                                               
                                                                                                                                                                                                                     
Now enforces 2 decimal places when the amount has a fractional part, while still hiding decimals for whole amounts (e.g. $5 stays as $5).