### PR TITLE
Simplified usage of next payment object for Portal and themes

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.66.10",
+  "version": "2.67.0",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -59,10 +59,7 @@ const PaidAccountActions = () => {
             );
         }
 
-        let offerLabelStr = getOfferLabel({
-            nextPayment,
-            currentPeriodEnd: subscription?.current_period_end
-        });
+        let offerLabelStr = getOfferLabel({nextPayment});
 
         if (offerLabelStr) {
             oldPriceClassName = 'gh-portal-account-old-price';
@@ -212,14 +209,13 @@ function FreeTrialLabel({subscription}) {
  * @param {'once'|'repeating'|'forever'} nextPayment.discount.duration
  * @param {number|null} nextPayment.discount.duration_in_months - Discount duration in months for "repeating" offers
  * @param {string} nextPayment.discount.start - Discount start date (ISO 8601 date string)
- * @param {string|null} nextPayment.discount.end - Discount end date (ISO 8601 date string), null for forever / once offers
+ * @param {string|null} nextPayment.discount.end - Discount end date (ISO 8601 date string), null for forever offers
  * @param {'fixed'|'percent'} nextPayment.discount.type
  * @param {number} nextPayment.discount.amount - Discount amount (e.g. 20 for 20% percent offer, or 2 for $2 fixed offer)
- * @param {string} currentPeriodEnd - Subscription current period end (ISO 8601 date string)
  *
  * @returns {string}
  */
-function getOfferLabel({nextPayment, currentPeriodEnd}) {
+function getOfferLabel({nextPayment}) {
     if (!nextPayment) {
         return '';
     }
@@ -231,15 +227,9 @@ function getOfferLabel({nextPayment, currentPeriodEnd}) {
         return '';
     }
 
-    let durationLabel = '';
-    if (discount.duration === 'forever') {
-        durationLabel = t('Forever');
-    } else if (discount.duration === 'repeating' && discount.end) {
-        durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(discount.end)});
-    } else if (discount.duration === 'once' && currentPeriodEnd) {
-        // By design, "once" offers don't have a discount end in Stripe. They expire at the end of the current billing period.
-        durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(currentPeriodEnd)});
-    }
+    const durationLabel = discount.end
+        ? t('Ends {offerEndDate}', {offerEndDate: getDateString(discount.end)})
+        : t('Forever');
 
     const formattedPrice = Intl.NumberFormat('en', {currency: nextPayment.currency, style: 'currency'}).format(nextPayment.amount / 100);
 

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -339,7 +339,7 @@ describe('PaidAccountActions', () => {
         test('displays discounted price with "Ends {date}" for once offers', () => {
             const products = getProductsData({numOfProducts: 1});
             const site = getSiteData({products, portalProducts: products.map(p => p.id)});
-            const currentPeriodEnd = new Date('2099-03-01T12:00:00.000Z');
+            const discountEnd = new Date('2099-03-01T12:00:00.000Z');
 
             const member = getMemberData({
                 paid: true,
@@ -354,8 +354,6 @@ describe('PaidAccountActions', () => {
                             amount: 20,
                             duration: 'once'
                         },
-                        currentPeriodEnd: currentPeriodEnd.toISOString(),
-
                         nextPayment: getNextPaymentData({
                             originalAmount: 500,
                             amount: 400,
@@ -365,7 +363,7 @@ describe('PaidAccountActions', () => {
                                 duration: 'once',
                                 type: 'percent',
                                 amount: 20,
-                                end: null
+                                end: discountEnd.toISOString()
                             })
                         })
                     })
@@ -378,7 +376,7 @@ describe('PaidAccountActions', () => {
             expect(queryByText('$5.00/month')).toBeInTheDocument();
             // Should have the offer label
             expect(queryByTestId('offer-label')).toBeInTheDocument();
-            // Should show the discounted price with end date from current period end
+            // Should show the discounted price with end date from next_payment.discount.end
             expect(queryByText('$4.00/month — Ends 1 Mar 2099')).toBeInTheDocument();
         });
 

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -505,8 +505,9 @@ describe('Unit: Util: subscription-data', function () {
             },
             {
                 name: 'retention + percent + once',
-                offer: {redemption_type: 'retention', type: 'percent', amount: 50, duration: 'once'},
-                expected: {label: 'Retention offer', detail: '50% off'}
+                offer: {id: 'offer_once_1', redemption_type: 'retention', type: 'percent', amount: 50, duration: 'once'},
+                sub: {next_payment: {discount: {offer_id: 'offer_once_1', end: '2026-02-17T00:00:00.000Z'}}},
+                expected: {label: 'Retention offer', detail: '50% off until Feb 2026'}
             },
             {
                 name: 'retention + percent + repeating (no discount end)',

--- a/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
+++ b/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
@@ -7,10 +7,10 @@ const getDiscountWindow = require('../utils/get-discount-window');
 /**
  * @typedef {object} SubscriptionDiscount
  * @prop {string} offer_id
- * @prop {string} start
- * @prop {string|null} end
+ * @prop {string} start - ISO string for active discounts
+ * @prop {string|null} end - ISO string for active once/repeating discounts, null for forever discounts
  * @prop {'once'|'repeating'|'forever'} duration
- * @prop {number|null} duration_in_months
+ * @prop {number|null} duration_in_months - Duration in months for repeating discounts, null for other types of discounts
  * @prop {'percent'|'fixed'} type
  * @prop {number} amount
  */
@@ -103,14 +103,6 @@ class NextPaymentCalculator {
      * @returns {ActiveDiscount|null}
      */
     _getActiveDiscount(subscription, offer) {
-        // Skip if there's no Stripe discount data and the offer isn't eligible for legacy backport:
-        // - signup offers are backported for legacy data without discount_start
-        // - retention offers are excluded because they were introduced after discount_start
-        //   was available, so missing discount_start means there's no active discount
-        if (!subscription.discount_start && offer.redemption_type !== 'signup') {
-            return null;
-        }
-
         return getDiscountWindow(subscription, offer);
     }
 

--- a/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
+++ b/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
@@ -1,3 +1,21 @@
+/**
+ * @typedef {import('../../../offers/application/offer-mapper').OfferDTO} OfferDTO
+ */
+
+/**
+ * @typedef {object} SubscriptionMinimal
+ * @prop {Date|null} discount_start
+ * @prop {Date|null} discount_end
+ * @prop {Date} start_date
+ * @prop {Date} current_period_end
+ */
+
+/**
+ * @typedef {object} DiscountWindow
+ * @prop {Date} start
+ * @prop {Date|null} end
+ */
+
 function getLastDayOfMonth(year, month) {
     return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
 }
@@ -46,16 +64,15 @@ function getLastDiscountedPayment(nextBillingDate, discountEnd) {
  * 1. Stripe coupon discounts (post-6.16) - uses discount_start / discount_end
  * 2. Legacy fallback - computes from offer duration and start_date
  *
- * @param {object} subscription - plain object with: discount_start, discount_end, start_date, current_period_end, plan.interval, plan_interval
- * @param {object|null} offer - offer data with: duration, duration_in_months.
- *   Pass null to skip offer-dependent checks.
- * @returns {{start: *, end: *}|null}
+ * @param {SubscriptionMinimal} subscription
+ * @param {OfferDTO} offer
+ * @returns {DiscountWindow|null}
  */
 
 module.exports = function getDiscountWindow(subscription, offer) {
     // Stripe coupon discount (post-6.16 data)
     if (subscription.discount_start) {
-        if (subscription.discount_end && offer?.duration === 'repeating') {
+        if (offer.duration === 'repeating') {
             const discountEnd = new Date(subscription.discount_end);
             const currentPeriodEnd = new Date(subscription.current_period_end);
 
@@ -75,14 +92,22 @@ module.exports = function getDiscountWindow(subscription, offer) {
             };
         }
 
+        if (offer.duration === 'once') {
+            return {
+                start: subscription.discount_start,
+                end: subscription.current_period_end
+            };
+        }
+
         return {
             start: subscription.discount_start,
             end: subscription.discount_end || null
         };
     }
 
-    // Legacy fallback: compute window from offer duration
-    if (!offer) {
+    // Legacy fallback for subscriptions without discount start / end dates
+    // This applies to signup offers only, as retention offers have been added after the introduction of discount start / end dates
+    if (offer.redemption_type !== 'signup') {
         return null;
     }
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -240,7 +240,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.66"
+        "version": "2.67"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -259,6 +259,7 @@ describe('Members API - Member Offers', function () {
             const stripePrice = subscription.related('stripePrice');
             const stripeProduct = stripePrice.related('stripeProduct');
             const product = stripeProduct.related('product');
+            const originalCurrentPeriodEnd = subscription.get('current_period_end');
 
             const tierId = product.id;
             const cadence = stripePrice.get('interval');
@@ -299,10 +300,12 @@ describe('Members API - Member Offers', function () {
             const now = new Date();
             const discountStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000); // 7 days ago
             const discountEnd = new Date(now.getTime() + 23 * 24 * 60 * 60 * 1000); // 23 days from now
+            const currentPeriodEnd = new Date(discountEnd);
             await subscription.save({
                 offer_id: signupOffer.id,
                 discount_start: discountStart,
-                discount_end: discountEnd
+                discount_end: discountEnd,
+                current_period_end: currentPeriodEnd
             }, {patch: true});
 
             try {
@@ -317,7 +320,12 @@ describe('Members API - Member Offers', function () {
                 assert.deepEqual(body, {offers: []});
             } finally {
                 // Clean up
-                await subscription.save({offer_id: null, discount_start: null, discount_end: null}, {patch: true});
+                await subscription.save({
+                    offer_id: null,
+                    discount_start: null,
+                    discount_end: null,
+                    current_period_end: originalCurrentPeriodEnd
+                }, {patch: true});
                 await models.Offer.destroy({id: offer.id});
                 await models.Offer.destroy({id: signupOffer.id});
             }
@@ -573,6 +581,7 @@ describe('Members API - Member Offers', function () {
             const stripePrice = subscription.related('stripePrice');
             const stripeProduct = stripePrice.related('stripeProduct');
             const product = stripeProduct.related('product');
+            const originalCurrentPeriodEnd = subscription.get('current_period_end');
 
             const stripeSubscriptionId = subscription.get('subscription_id');
             const tierId = product.id;
@@ -614,10 +623,12 @@ describe('Members API - Member Offers', function () {
             const now = new Date();
             const discountStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
             const discountEnd = new Date(now.getTime() + 23 * 24 * 60 * 60 * 1000);
+            const currentPeriodEnd = new Date(discountEnd);
             await subscription.save({
                 offer_id: existingOffer.id,
                 discount_start: discountStart,
-                discount_end: discountEnd
+                discount_end: discountEnd,
+                current_period_end: currentPeriodEnd
             }, {patch: true});
 
             try {
@@ -628,7 +639,12 @@ describe('Members API - Member Offers', function () {
                     .body({identity: token, offer_id: retentionOffer.id})
                     .expectStatus(400);
             } finally {
-                await subscription.save({offer_id: null, discount_start: null, discount_end: null}, {patch: true});
+                await subscription.save({
+                    offer_id: null,
+                    discount_start: null,
+                    discount_end: null,
+                    current_period_end: originalCurrentPeriodEnd
+                }, {patch: true});
                 await models.Offer.destroy({id: retentionOffer.id});
                 await models.Offer.destroy({id: existingOffer.id});
             }

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -465,6 +465,10 @@ describe('MemberBreadService', function () {
                     id: 'sub_123',
                     subscription_id: 'sub_123',
                     status: 'active',
+                    discount_start: null,
+                    discount_end: null,
+                    start_date: new Date('2025-01-01T00:00:00.000Z'),
+                    current_period_end: new Date('2025-06-15T00:00:00.000Z'),
                     plan: {
                         amount: 500,
                         interval: 'month',
@@ -514,6 +518,7 @@ describe('MemberBreadService', function () {
             const offerId = 'offer_abc123';
             const discountStart = new Date('2020-01-01T00:00:00.000Z');
             const discountEnd = new Date('2099-12-31T00:00:00.000Z');
+            const lastDiscountedBillingDate = new Date('2099-12-15T00:00:00.000Z');
 
             const subscriptionsJSON = [
                 {
@@ -532,6 +537,7 @@ describe('MemberBreadService', function () {
                     },
                     discount_start: discountStart,
                     discount_end: discountEnd,
+                    start_date: new Date('2020-01-01T00:00:00.000Z'),
                     current_period_end: new Date('2099-06-15T00:00:00.000Z')
                 }
             ];
@@ -591,6 +597,8 @@ describe('MemberBreadService', function () {
             assert.equal(nextPayment.discount.amount, 20);
             assert.equal(nextPayment.discount.duration, 'repeating');
             assert.equal(nextPayment.discount.duration_in_months, 12);
+            assert.equal(nextPayment.discount.start, discountStart.toISOString());
+            assert.equal(nextPayment.discount.end, lastDiscountedBillingDate.toISOString());
         });
 
         it('attaches offer_redemptions to subscriptions', async function () {
@@ -602,6 +610,10 @@ describe('MemberBreadService', function () {
                     id: 'sub_123',
                     subscription_id: 'sub_123',
                     status: 'active',
+                    discount_start: null,
+                    discount_end: null,
+                    start_date: new Date('2025-01-01T00:00:00.000Z'),
+                    current_period_end: new Date('2025-06-15T00:00:00.000Z'),
                     plan: {
                         amount: 500,
                         interval: 'month',
@@ -640,7 +652,8 @@ describe('MemberBreadService', function () {
                 name: 'Signup Offer',
                 type: 'percent',
                 amount: 10,
-                duration: 'once'
+                duration: 'once',
+                redemption_type: 'signup'
             };
             const offerDTO2 = {
                 id: offerId2,
@@ -648,7 +661,8 @@ describe('MemberBreadService', function () {
                 type: 'percent',
                 amount: 20,
                 duration: 'repeating',
-                duration_in_months: 3
+                duration_in_months: 3,
+                redemption_type: 'retention'
             };
 
             const offersAPIStub = {

--- a/ghost/core/test/unit/server/services/members/members-api/services/next-payment-calculator.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/next-payment-calculator.test.js
@@ -199,7 +199,7 @@ describe('NextPaymentCalculator', function () {
             const offer = createOffer({type: 'percent', amount: 50, duration: 'once', redemption_type: 'retention'});
             const subscription = createSubscription({
                 discount_start: new Date('2025-01-01T00:00:00.000Z'),
-                discount_end: null // Once discounts don't have a discount_end (based on Stripe)
+                discount_end: null // Once discounts don't have a discount_end in Stripe
             }, offer);
 
             const result = nextPaymentCalculator.calculate(subscription);
@@ -208,7 +208,7 @@ describe('NextPaymentCalculator', function () {
             assert.equal(result.amount, 250); // 500 - 50% = 250
             assert.equal(result.discount.duration, 'once');
             assert.equal(result.discount.start, '2025-01-01T00:00:00.000Z');
-            assert.equal(result.discount.end, null);
+            assert.equal(result.discount.end, '2025-06-15T00:00:00.000Z'); // In the next payment object, we assign discount.end = current billing period end for once offers
             assert.equal(result.discount.amount, 50);
             assert.equal(result.discount.type, 'percent');
             assert.equal(result.discount.offer_id, 'offer_123');

--- a/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
@@ -2,6 +2,10 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const getDiscountWindow = require('../../../../../../../core/server/services/members/members-api/utils/get-discount-window');
 
+/**
+ * @typedef {import('../../../../../../../core/server/services/offers/application/offer-mapper').OfferDTO} OfferDTO
+ */
+
 describe('getDiscountWindow', function () {
     beforeEach(function () {
         sinon.useFakeTimers(new Date('2025-05-15T00:00:00.000Z'));
@@ -24,10 +28,52 @@ describe('getDiscountWindow', function () {
         };
     }
 
+    /**
+     * @param {Partial<OfferDTO>} [overrides]
+     * @returns {OfferDTO}
+     */
     function createOffer(overrides = {}) {
-        return {
+        /** @type {OfferDTO} */
+        const defaults = {
+            id: 'offer_123',
+            name: 'Test Offer',
+            code: 'test-offer',
+            display_title: 'Test Offer Title',
+            display_description: 'Test offer description',
+            type: 'percent',
+            cadence: 'month',
+            amount: 20,
+            currency_restriction: false,
+            currency: null,
             duration: 'once',
             duration_in_months: null,
+            status: 'active',
+            redemption_count: 0,
+            redemption_type: 'signup',
+            tier: {
+                id: 'tier_123',
+                name: 'Default Tier'
+            },
+            created_at: '2025-01-01T00:00:00.000Z',
+            last_redeemed: null
+        };
+
+        if (overrides.type === 'fixed') {
+            defaults.currency_restriction = true;
+            defaults.currency = 'USD';
+        }
+
+        if (overrides.type === 'trial') {
+            defaults.duration = 'trial';
+            defaults.duration_in_months = null;
+        }
+
+        if (overrides.duration === 'repeating' && overrides.duration_in_months === undefined) {
+            defaults.duration_in_months = 6;
+        }
+
+        return {
+            ...defaults,
             ...overrides
         };
     }
@@ -97,6 +143,23 @@ describe('getDiscountWindow', function () {
             assert.deepEqual(result, {start: discountStart, end: null});
         });
 
+        it('returns current period end for once discounts', function () {
+            const discountStart = new Date('2025-05-01T00:00:00.000Z');
+            const currentPeriodEnd = new Date('2025-06-15T00:00:00.000Z');
+            const subscription = createSubscription({
+                discount_start: discountStart,
+                discount_end: null,
+                current_period_end: currentPeriodEnd
+            });
+
+            const result = getDiscountWindow(subscription, createOffer({duration: 'once'}));
+
+            assert.deepEqual(result, {
+                start: discountStart,
+                end: currentPeriodEnd
+            });
+        });
+
         it('returns null when discount_end expires before the next billing date', function () {
             const discountStart = new Date('2025-05-01T00:00:00.000Z');
             const discountEnd = new Date('2025-06-01T00:00:00.000Z');
@@ -127,32 +190,41 @@ describe('getDiscountWindow', function () {
 
         it('discount_start takes precedence over legacy offer data', function () {
             const discountStart = new Date('2025-05-01T00:00:00.000Z');
+            const currentPeriodEnd = new Date('2025-06-15T00:00:00.000Z');
             const subscription = createSubscription({
                 discount_start: discountStart,
-                discount_end: null
+                discount_end: null,
+                current_period_end: currentPeriodEnd
             });
 
-            const result = getDiscountWindow(subscription, {duration: 'once'});
+            const result = getDiscountWindow(subscription, createOffer({duration: 'once'}));
 
-            assert.deepEqual(result, {start: discountStart, end: null});
+            assert.deepEqual(result, {start: discountStart, end: currentPeriodEnd});
         });
     });
 
     // Legacy fallback (no discount_start, uses offer duration)
 
     describe('legacy fallback', function () {
-        it('returns null when no offer is provided', function () {
+        it('returns null for once duration', function () {
             const subscription = createSubscription();
 
-            const result = getDiscountWindow(subscription, null);
+            const result = getDiscountWindow(subscription, createOffer({duration: 'once'}));
 
             assert.equal(result, null);
         });
 
-        it('returns null for once duration', function () {
-            const subscription = createSubscription();
+        it('returns null for retention offers without a discount start (no legacy fallback)', function () {
+            const subscription = createSubscription({
+                start_date: new Date('2025-04-01T00:00:00.000Z'),
+                current_period_end: new Date('2025-06-01T00:00:00.000Z')
+            });
 
-            const result = getDiscountWindow(subscription, {duration: 'once'});
+            const result = getDiscountWindow(subscription, createOffer({
+                duration: 'repeating',
+                duration_in_months: 3,
+                redemption_type: 'retention'
+            }));
 
             assert.equal(result, null);
         });
@@ -161,7 +233,7 @@ describe('getDiscountWindow', function () {
             const startDate = new Date('2025-01-01T00:00:00.000Z');
             const subscription = createSubscription({start_date: startDate});
 
-            const result = getDiscountWindow(subscription, {duration: 'forever'});
+            const result = getDiscountWindow(subscription, createOffer({duration: 'forever'}));
 
             assert.deepEqual(result, {start: startDate, end: null});
         });
@@ -173,7 +245,7 @@ describe('getDiscountWindow', function () {
                 current_period_end: new Date('2025-06-01T00:00:00.000Z')
             });
 
-            const result = getDiscountWindow(subscription, {duration: 'repeating', duration_in_months: 3});
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 3}));
 
             assert.deepEqual(result, {
                 start: startDate,
@@ -185,7 +257,7 @@ describe('getDiscountWindow', function () {
             const startDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000); // 3 months ago
             const subscription = createSubscription({start_date: startDate});
 
-            const result = getDiscountWindow(subscription, {duration: 'repeating', duration_in_months: 6});
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 6}));
 
             assert.notEqual(result, null);
             assert.deepEqual(result.start, startDate);
@@ -197,7 +269,7 @@ describe('getDiscountWindow', function () {
             const startDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000); // 1 year ago
             const subscription = createSubscription({start_date: startDate});
 
-            const result = getDiscountWindow(subscription, {duration: 'repeating', duration_in_months: 6});
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 6}));
 
             assert.equal(result, null);
         });
@@ -205,7 +277,15 @@ describe('getDiscountWindow', function () {
         it('returns null for repeating offer with zero duration_in_months', function () {
             const subscription = createSubscription();
 
-            const result = getDiscountWindow(subscription, {duration: 'repeating', duration_in_months: 0});
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 0}));
+
+            assert.equal(result, null);
+        });
+
+        it('returns null for non-signup offers without synced discount dates', function () {
+            const subscription = createSubscription();
+
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 3, redemption_type: 'retention'}));
 
             assert.equal(result, null);
         });
@@ -213,7 +293,7 @@ describe('getDiscountWindow', function () {
         it('returns null for unknown duration', function () {
             const subscription = createSubscription();
 
-            const result = getDiscountWindow(subscription, {duration: 'unknown'});
+            const result = getDiscountWindow(subscription, createOffer({duration: 'unknown'}));
 
             assert.equal(result, null);
         });

--- a/ghost/core/test/unit/server/services/members/members-api/utils/has-active-offer.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/has-active-offer.test.js
@@ -41,6 +41,15 @@ describe('hasActiveOffer', function () {
         };
     }
 
+    function createOffer(overrides = {}) {
+        return {
+            duration: 'once',
+            duration_in_months: null,
+            redemption_type: 'signup',
+            ...overrides
+        };
+    }
+
     it('returns false when there is no trial and no offer', async function () {
         const model = createSubscriptionModel();
 
@@ -74,7 +83,7 @@ describe('hasActiveOffer', function () {
             offerId: 'offer_123',
             discountStart: new Date('2025-05-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'forever'});
+        const offersAPI = createOffersAPI(createOffer({duration: 'forever'}));
 
         const result = await hasActiveOffer(model, offersAPI);
 
@@ -88,7 +97,7 @@ describe('hasActiveOffer', function () {
             discountEnd: new Date('2025-08-01T00:00:00.000Z'),
             currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 3});
+        const offersAPI = createOffersAPI(createOffer({duration: 'repeating', duration_in_months: 3}));
 
         const result = await hasActiveOffer(model, offersAPI);
 
@@ -102,7 +111,7 @@ describe('hasActiveOffer', function () {
             discountEnd: new Date('2025-05-31T00:00:00.000Z'),
             currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 2});
+        const offersAPI = createOffersAPI(createOffer({duration: 'repeating', duration_in_months: 2}));
 
         const result = await hasActiveOffer(model, offersAPI);
 
@@ -117,11 +126,25 @@ describe('hasActiveOffer', function () {
             discountEnd: new Date('2025-06-01T00:00:00.000Z'),
             currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 1});
+        const offersAPI = createOffersAPI(createOffer({duration: 'repeating', duration_in_months: 1}));
 
         const result = await hasActiveOffer(model, offersAPI);
 
         assert.equal(result, false);
+    });
+
+    it('returns true for a synced once offer before the current billing date', async function () {
+        const model = createSubscriptionModel({
+            offerId: 'offer_123',
+            discountStart: new Date('2025-05-01T00:00:00.000Z'),
+            discountEnd: null,
+            currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
+        });
+        const offersAPI = createOffersAPI(createOffer({duration: 'once'}));
+
+        const result = await hasActiveOffer(model, offersAPI);
+
+        assert.equal(result, true);
     });
 
     it('returns true for a legacy forever offer', async function () {
@@ -129,7 +152,7 @@ describe('hasActiveOffer', function () {
             offerId: 'offer_123',
             startDate: new Date('2025-01-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'forever'});
+        const offersAPI = createOffersAPI(createOffer({duration: 'forever'}));
 
         const result = await hasActiveOffer(model, offersAPI);
 
@@ -138,7 +161,7 @@ describe('hasActiveOffer', function () {
 
     it('returns false for a legacy once offer', async function () {
         const model = createSubscriptionModel({offerId: 'offer_123'});
-        const offersAPI = createOffersAPI({duration: 'once'});
+        const offersAPI = createOffersAPI(createOffer({duration: 'once'}));
 
         const result = await hasActiveOffer(model, offersAPI);
 
@@ -151,7 +174,7 @@ describe('hasActiveOffer', function () {
             startDate: new Date('2025-04-01T00:00:00.000Z'),
             currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 3});
+        const offersAPI = createOffersAPI(createOffer({duration: 'repeating', duration_in_months: 3}));
 
         const result = await hasActiveOffer(model, offersAPI);
 
@@ -164,7 +187,20 @@ describe('hasActiveOffer', function () {
             startDate: new Date('2025-01-01T00:00:00.000Z'),
             currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 3});
+        const offersAPI = createOffersAPI(createOffer({duration: 'repeating', duration_in_months: 3}));
+
+        const result = await hasActiveOffer(model, offersAPI);
+
+        assert.equal(result, false);
+    });
+
+    it('returns false for retention offers without discount dates (no legacy support)', async function () {
+        const model = createSubscriptionModel({
+            offerId: 'offer_123',
+            startDate: new Date('2025-04-01T00:00:00.000Z'),
+            currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
+        });
+        const offersAPI = createOffersAPI(createOffer({duration: 'repeating', duration_in_months: 3, redemption_type: 'retention'}));
 
         const result = await hasActiveOffer(model, offersAPI);
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3466

- Stripe does not return a discount end date for once offers
- As a result, the next payment object was returning a null discount end date for once offers
- As a result, clients (Portal, themes) had to differentiate between types of offers (once offers expire at the end of the current billing period, repeating offers at discount end, forever offers never)
- We want to abstract away this business logic, so that Portal and themes don’t have to know nor worry about the differences between types of offers. Instead, if the next payment object exposes an end date, then it’s a limited-time offer with an end date (once, repeating). If not, it’s an offer without time limit (forever offer)


### Code sample for themes

Before:
```
 {{#if next_payment.discount}}
    <!-- {{next_payment.discount.duration}} -->
    <s>{{price plan}}/{{plan.interval}}</s>
    <p>
    {{price next_payment}}/{{next_payment.interval}}
    {{#match next_payment.discount.duration "=" "forever"}}
        — Forever
    {{/match}}
    {{#match next_payment.discount.duration "=" "repeating"}}
        — Ends {{date next_payment.discount.end format="D MMM YYYY"}}
    {{/match}}
    {{#match next_payment.discount.duration "=" "once"}}
        — Ends {{date current_period_end format="D MMM YYYY"}}
    {{/match}}
    </p>
{{else}}
    <p>{{price plan}}/{{plan.interval}}</p>
{{/if}}
```

After:
```
{{#if next_payment.discount}}
      <s>{{price plan}}/{{plan.interval}}</s>
      <p>
          {{price next_payment}}/{{next_payment.interval}}
          {{#if (next_payment.discount.end)}}
              — Ends {{date next_payment.discount.end format="D MMM YYYY"}}
          {{else}}
              — Forever
          {{/if}}
      </p>
  {{else}}
      <p>{{price plan}}/{{plan.interval}}</p>
  {{/if}}
```

### Code sample for Portal

Before: 

```
    if (discount.duration === 'forever') {
        durationLabel = t('Forever');
    } else if (discount.duration === 'repeating' && discount.end) {
        durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(discount.end)});
    } else if (discount.duration === 'once' && currentPeriodEnd) {
        // By design, "once" offers don't have a discount end in Stripe. They expire at the end of the current billing period.
        durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(currentPeriodEnd)});
    }
```

After:

```
    const durationLabel = discount.end
        ? t('Ends {offerEndDate}', {offerEndDate: getDateString(discount.end)})
        : t('Forever');
```
