### PR TITLE
Improved member list query performance

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "6.36.1-rc.0",
+  "version": "6.37.0-rc.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",

--- a/ghost/core/core/server/data/migrations/versions/6.37/2026-05-04-07-51-14-add-members-created-at-id-index.js
+++ b/ghost/core/core/server/data/migrations/versions/6.37/2026-05-04-07-51-14-add-members-created-at-id-index.js
@@ -1,0 +1,63 @@
+const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
+const {createNonTransactionalMigration} = require('../../utils');
+
+const INDEX_NAME = 'members_created_at_id_index';
+
+async function hasIndex(knex) {
+    if (DatabaseInfo.isSQLite(knex)) {
+        const result = await knex.raw(`select * from sqlite_master where type = 'index' and tbl_name = 'members' and name = '${INDEX_NAME}'`);
+        return result.length !== 0;
+    }
+
+    const result = await knex.raw(`show index from members where Key_name = '${INDEX_NAME}'`);
+    return result[0].length !== 0;
+}
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        if (await hasIndex(knex)) {
+            logging.info(`Skipping creation of index ${INDEX_NAME} on members for created_at, id - already exists`);
+            return;
+        }
+
+        logging.info(`Creating index ${INDEX_NAME} on members for created_at, id`);
+
+        if (DatabaseInfo.isMySQL(knex)) {
+            await knex.raw(`
+                ALTER TABLE members
+                ADD INDEX ${INDEX_NAME} (created_at, id),
+                ALGORITHM=INPLACE,
+                LOCK=NONE
+            `);
+            return;
+        }
+
+        await knex.schema.table('members', (table) => {
+            table.index(['created_at', 'id']);
+        });
+    },
+
+    async function down(knex) {
+        if (!(await hasIndex(knex))) {
+            logging.info(`Skipping drop of index ${INDEX_NAME} on members for created_at, id - does not exist`);
+            return;
+        }
+
+        logging.info(`Dropping index ${INDEX_NAME} on members for created_at, id`);
+
+        if (DatabaseInfo.isMySQL(knex)) {
+            await knex.raw(`
+                ALTER TABLE members
+                DROP INDEX ${INDEX_NAME},
+                ALGORITHM=INPLACE,
+                LOCK=NONE
+            `);
+            return;
+        }
+
+        await knex.schema.table('members', (table) => {
+            table.dropIndex(['created_at', 'id']);
+        });
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -441,7 +441,8 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         '@@INDEXES@@': [
-            ['email_disabled']
+            ['email_disabled'],
+            ['created_at', 'id']
         ]
     },
     // NOTE: this is the tiers table

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.36.1-rc.0",
+  "version": "6.37.0-rc.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '20b3032b2ec14edfdac13d1485391f19';
+    const currentSchemaHash = 'f6eb178fe153ce8cf8e9df09f3a34fe9';
     const currentFixturesHash = 'b76d01321e02fb99b11e7a29f91859f7';
     const currentSettingsHash = '857b77a8e1c7072d9eb639152c78a49e';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3471/fix-default-members-list-query-performance-with-a-composite-index

This PR adds a composite index for the default members list query. The default members browse path orders by `created_at DESC, id DESC`. Without a matching composite index, large member tables fall back to a full scan plus filesort. This change keeps the schema aligned with that query shape by adding `members(created_at, id)` to the members schema definition and shipping a non-transactional migration that creates the index with online DDL on MySQL.

### Performance impact:

With 2m members cold queries went from ~7s to ~0.1s and hot queries from ~0.8s to ~0.03s.

### Verification:

- Ran `yarn knex-migrator migrate`, `yarn knex-migrator rollback --force`, and `yarn knex-migrator migrate` against MySQL
- Confirmed the `members_created_at_id_index` index exists after re-migrating and that the default members query uses it again
- Verified the migration's `up`/`down` and idempotent paths against SQLite with an isolated direct migration check
- Ran `mocha test/unit/server/data/schema/schema.test.js`
