### PR TITLE
Tightened fork guard on Pro CD trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1547,7 +1547,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       always()
-      && github.repository_owner == 'TryGhost'
+      && github.repository == 'TryGhost/Ghost'
       && needs.job_setup.result == 'success'
       && needs.job_docker_build_production.result == 'success'
       && needs.job_docker_build_production.outputs.use-artifact != 'true'


### PR DESCRIPTION
## Summary
- Changed `trigger_cd` job condition from `github.repository_owner == 'TryGhost'` to `github.repository == 'TryGhost/Ghost'`
- Prevents TryGhost-org forks (e.g. Ghost-Security) from attempting to trigger the Ghost(Pro) CD pipeline in Ghost-Moya
- Previously these runs would fail noisily with `Parameter token or opts.auth is required` because the fork lacks the `CANARY_DOCKER_BUILD` secret — this skips the job cleanly instead

## Test plan
- [ ] Verify CI passes on this PR (the `trigger_cd` job should be skipped since this is a PR, not main)
- [ ] Confirm Ghost-Security CI no longer errors on the `trigger_cd` step after merge