### PR TITLE
Tightened validation for colors in email renderer

### DIFF
--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -16,7 +16,7 @@ const crypto = require('crypto');
 
 const DEFAULT_LOCALE = 'en-gb';
 const DEFAULT_ACCENT_COLOR = '#15212A';
-const VALID_HEX_REGEX = /#([0-9a-f]{3}){1,2}$/i;
+const VALID_HEX_REGEX = /^#([0-9a-f]{3}){1,2}$/i;
 const CONTENT_IMAGES_PATH_WITHOUT_SIZE_REGEX = /\/content\/images\/(?!size\/)/;
 
 // Wrapper function so that i18next-parser can find these strings


### PR DESCRIPTION
no ref

Before this change, `foo #ff9900` was considered a valid hex color. After this change, it is not.

I believe it's difficult to have bad data in the database, but if that happens, we want to check it properly.
