### PR TITLE
Removed unnecessary measureElement from virtual scroll

### DIFF
--- a/apps/posts/src/components/virtual-table/use-infinite-virtual-scroll.tsx
+++ b/apps/posts/src/components/virtual-table/use-infinite-virtual-scroll.tsx
@@ -45,7 +45,6 @@ export function useInfiniteVirtualScroll<T>({
         key: virtualItem.key,
         item: items[virtualItem.index],
         props: {
-            ref: virtualizer.measureElement,
             'data-index': virtualItem.index
         }
     }));


### PR DESCRIPTION
## Summary
- Removes `virtualizer.measureElement` ref from virtual scroll item props since all consumers use fixed-height rows (`estimateSize: () => 72` or default `() => 100`)
- Dynamic measurement forces synchronous layout/reflow on every row mount, which is unnecessary for fixed-height rows
- The `virtualizer` object is already returned from the hook, so any future consumer needing dynamic measurement can access `virtualizer.measureElement` directly

Built on top of #26952 which fixes the scroll container resolution.

## Test plan
- [x] `yarn workspace @tryghost/posts test:unit` passes (114 tests)
- [x] Verified members table renders correctly with 1,000 members (19 visible rows, 738 total DOM elements)
- [x] Scrolling and infinite loading work correctly