### PR TITLE
🐛 Fixed @site.admin_url missing /ghost/ when admin URL is configured

### DIFF
--- a/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
+++ b/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
@@ -11,7 +11,7 @@ function updateLocalTemplateOptions(req, res, next) {
     // adjust @site.url for http/https based on the incoming request
     const siteData = {
         url: urlUtils.urlFor('home', {trailingSlash: false}, true),
-        admin_url: urlUtils.getAdminUrl() || urlUtils.urlFor('admin', true)
+        admin_url: urlUtils.urlFor('admin', true)
     };
 
     // @TODO: it would be nicer if this was proper middleware somehow...

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -9,6 +9,7 @@ const settingsCache = require('../../../../../core/shared/settings-cache');
 const customThemeSettingsCache = require('../../../../../core/shared/custom-theme-settings-cache');
 const config = require('../../../../../core/shared/config');
 const labs = require('../../../../../core/shared/labs');
+const urlUtils = require('../../../../../core/shared/url-utils');
 
 const sandbox = sinon.createSandbox();
 
@@ -212,7 +213,7 @@ describe('Themes middleware', function () {
     });
 
     describe('updateLocalTemplateOptions', function () {
-        it('includes admin_url in site data', function (done) {
+        it('includes admin_url ending with /ghost/ in site data', function (done) {
             executeMiddleware(middleware, req, res, function next(err) {
                 try {
                     assert.equal(err, undefined);
@@ -223,6 +224,30 @@ describe('Themes middleware', function () {
 
                     assert(data.site.admin_url, 'admin_url should be set in site data');
                     assert.equal(typeof data.site.admin_url, 'string');
+                    assert.ok(data.site.admin_url.endsWith('/ghost/'),
+                        `admin_url should end with /ghost/ but got: ${data.site.admin_url}`);
+
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            });
+        });
+
+        it('includes admin_url ending with /ghost/ when admin is on a separate domain', function (done) {
+            sandbox.stub(urlUtils, 'getAdminUrl').returns('https://admin.example.com/');
+
+            executeMiddleware(middleware, req, res, function next(err) {
+                try {
+                    assert.equal(err, undefined);
+
+                    sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
+                    const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
+                    const data = templateOptions.data;
+
+                    assert.ok(data.site.admin_url.endsWith('/ghost/'),
+                        `admin_url should end with /ghost/ but got: ${data.site.admin_url}`);
+                    assert.equal(data.site.admin_url, 'https://admin.example.com/ghost/');
 
                     done();
                 } catch (error) {


### PR DESCRIPTION
## Problem

`@site.admin_url` was using `getAdminUrl()` which returns the base admin domain (e.g. `https://admin.example.com/`) **without** `/ghost/`. This means the "Site owner login" link on the private page pointed to the domain root instead of the admin panel for any site with a separate admin URL configured (including all Ghost(Pro) sites).

## Fix

Changed `update-local-template-options.js` to use `urlFor('admin', true)` which correctly appends `/ghost/` to the admin URL.

## Test

Added a test that stubs `getAdminUrl()` with a separate domain (`https://admin.example.com/`) and asserts the resulting `admin_url` ends with `/ghost/`. This test fails on main and passes with the fix.