### PR TITLE
Fixed type error in email renderer test

### DIFF
--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2175,9 +2175,7 @@ describe('Email renderer', function () {
             });
         });
 
-        const testLexicalRenderDesignOptions = async function ({expectedObject, labs}) {
-            labsEnabled = labs || false;
-
+        const testLexicalRenderDesignOptions = async function ({expectedObject}) {
             const post = createModel(basePost);
             const newsletter = createModel({
                 ...baseNewsletter,


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1163

This change should have no user impact. Just fixes a type error when this test function was used.
