### PR TITLE
Cleaned up Portal offer tests in `/e2e/`

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.66.9",
+  "version": "2.66.10",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/offer-page.js
+++ b/apps/portal/src/components/pages/offer-page.js
@@ -445,7 +445,7 @@ export default class OfferPage extends React.Component {
 
         if (offer.type === 'fixed') {
             return (
-                <h5 className="gh-portal-discount-label">{t('{amount} off', {
+                <h5 className="gh-portal-discount-label" data-testid="offer-discount-label">{t('{amount} off', {
                     amount: `${getCurrencySymbol(offer.currency)}${offer.amount / 100}`
                 })}</h5>
             );
@@ -453,12 +453,12 @@ export default class OfferPage extends React.Component {
 
         if (offer.type === 'trial') {
             return (
-                <h5 className="gh-portal-discount-label">{t('{amount} days free', {amount: offer.amount})}</h5>
+                <h5 className="gh-portal-discount-label" data-testid="offer-discount-label">{t('{amount} days free', {amount: offer.amount})}</h5>
             );
         }
 
         return (
-            <h5 className="gh-portal-discount-label">{t('{amount} off', {amount: offer.amount + '%'})}</h5>
+            <h5 className="gh-portal-discount-label" data-testid="offer-discount-label">{t('{amount} off', {amount: offer.amount + '%'})}</h5>
         );
     }
 
@@ -544,7 +544,7 @@ export default class OfferPage extends React.Component {
         }
         if (discountDuration === 'trial') {
             return (
-                <p className="footnote">{t('Try free for {amount} days, then {originalPrice}.', {
+                <p className="footnote" data-testid="offer-message">{t('Try free for {amount} days, then {originalPrice}.', {
                     amount: offer.amount,
                     originalPrice: originalPrice,
                     interpolation: {escapeValue: false}
@@ -552,7 +552,7 @@ export default class OfferPage extends React.Component {
             );
         }
         return (
-            <p className="footnote">{offerLabel} {useRenewsLabel ? renewsLabel : ''}</p>
+            <p className="footnote" data-testid="offer-message">{offerLabel} {useRenewsLabel ? renewsLabel : ''}</p>
         );
     }
 
@@ -573,7 +573,7 @@ export default class OfferPage extends React.Component {
         if (offer.type === 'trial') {
             return (
                 <div className="gh-portal-product-card-pricecontainer offer-type-trial">
-                    <div className="gh-portal-product-price">
+                    <div className="gh-portal-product-price" data-testid="offer-updated-price">
                         <span className={'currency-sign ' + currencyClass}>{getCurrencySymbol(price.currency)}</span>
                         <span className="amount">{formatNumber(this.renderRoundedPrice(updatedPrice))}</span>
                     </div>
@@ -582,7 +582,7 @@ export default class OfferPage extends React.Component {
         }
         return (
             <div className="gh-portal-product-card-pricecontainer">
-                <div className="gh-portal-product-price">
+                <div className="gh-portal-product-price" data-testid="offer-updated-price">
                     <span className={'currency-sign ' + currencyClass}>{getCurrencySymbol(price.currency)}</span>
                     <span className="amount">{formatNumber(this.renderRoundedPrice(updatedPrice))}</span>
                 </div>
@@ -657,7 +657,7 @@ export default class OfferPage extends React.Component {
 
                     <div className="gh-portal-offer-bar">
                         <div className="gh-portal-offer-title">
-                            {(offer.display_title ? <h4>{offer.display_title}</h4> : <h4 className='placeholder'>{t('Black Friday')}</h4>)}
+                            {(offer.display_title ? <h4 data-testid="offer-title">{offer.display_title}</h4> : <h4 className='placeholder' data-testid="offer-title">{t('Black Friday')}</h4>)}
                             {this.renderOfferTag()}
                         </div>
                         {(offer.display_description ? <p>{offer.display_description}</p> : '')}

--- a/e2e/eslint.config.js
+++ b/e2e/eslint.config.js
@@ -203,7 +203,10 @@ export default tseslint.config([
     {
         files: ['tests/**/*.ts', 'helpers/playwright/**/*.ts', 'helpers/pages/**/*.ts'],
         rules: {
-            ...playwrightPlugin.configs.recommended.rules
+            ...playwrightPlugin.configs.recommended.rules,
+            'playwright/expect-expect': ['warn', {
+                assertFunctionPatterns: ['^expect[A-Z].*']
+            }]
         }
     },
 

--- a/e2e/helpers/pages/portal/offer-page.ts
+++ b/e2e/helpers/pages/portal/offer-page.ts
@@ -6,6 +6,10 @@ export class PortalOfferPage extends PortalPage {
     readonly emailInput: Locator;
     readonly submitButton: Locator;
     readonly continueButton: Locator;
+    readonly offerTitle: Locator;
+    readonly discountLabel: Locator;
+    readonly offerMessage: Locator;
+    readonly updatedPrice: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -14,14 +18,10 @@ export class PortalOfferPage extends PortalPage {
         this.emailInput = this.portalFrame.getByRole('textbox', {name: 'Email'});
         this.submitButton = this.portalFrame.getByRole('button', {name: /Continue|Start .* free trial|Retry/});
         this.continueButton = this.portalFrame.getByRole('button', {name: 'Continue'});
-    }
-
-    headingWithText(text: string): Locator {
-        return this.portalFrame.getByRole('heading', {name: text});
-    }
-
-    text(text: string | RegExp): Locator {
-        return this.portalFrame.getByText(text);
+        this.offerTitle = this.portalFrame.getByTestId('offer-title');
+        this.discountLabel = this.portalFrame.getByTestId('offer-discount-label');
+        this.offerMessage = this.portalFrame.getByTestId('offer-message');
+        this.updatedPrice = this.portalFrame.getByTestId('offer-updated-price');
     }
 
     async fillAndSubmit(email: string, name?: string): Promise<void> {
@@ -39,12 +39,9 @@ export class PortalOfferPage extends PortalPage {
         }
     }
 
-    async waitForOfferPage(title?: string): Promise<void> {
+    async waitForOfferPage(): Promise<void> {
         await this.waitForPortalToOpen();
         await this.emailInput.waitFor({state: 'visible'});
-
-        if (title) {
-            await this.headingWithText(title).waitFor({state: 'visible'});
-        }
+        await this.offerTitle.waitFor({state: 'visible'});
     }
 }

--- a/e2e/helpers/playwright/flows/tiers.ts
+++ b/e2e/helpers/playwright/flows/tiers.ts
@@ -2,10 +2,12 @@ import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {TiersService} from '@/helpers/services/tiers/tiers-service';
 import type {AdminTier, TierCreateInput} from '@/helpers/services/tiers/tiers-service';
 import type {HttpClient} from '@/data-factory';
+import type {StripeTestService} from '@/helpers/services/stripe';
 
 export async function createPaidPortalTier(
     request: HttpClient,
-    input: Omit<TierCreateInput, 'visibility'> & Partial<Pick<TierCreateInput, 'visibility'>>
+    input: Omit<TierCreateInput, 'visibility'> & Partial<Pick<TierCreateInput, 'visibility'>>,
+    opts?: {stripe?: StripeTestService}
 ): Promise<AdminTier> {
     const tiersService = new TiersService(request);
     const settingsService = new SettingsService(request);
@@ -17,5 +19,31 @@ export async function createPaidPortalTier(
 
     await settingsService.setPortalPlans(['free', 'monthly', 'yearly']);
 
-    return tier;
+    if (!opts?.stripe) {
+        return tier;
+    }
+
+    // Tier creation returns before Ghost's async Stripe sync has finished.
+    // Stripe-backed tests that immediately use paid signup links need to wait
+    // until the product and prices exist in the fake Stripe state.
+    const timeoutMs = 10000;
+    const intervalMs = 250;
+    const startTime = Date.now();
+
+    while ((Date.now() - startTime) < timeoutMs) {
+        const product = opts.stripe.getProducts().find(item => item.name === tier.name);
+        const syncedPrices = product
+            ? opts.stripe.getPrices().filter(item => item.product === product.id).length
+            : 0;
+
+        if (syncedPrices === 2) {
+            return tier;
+        }
+
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve, intervalMs);
+        });
+    }
+
+    throw new Error(`Timed out waiting for Stripe sync for tier ${tier.name}`);
 }

--- a/e2e/tests/public/portal-offers.test.ts
+++ b/e2e/tests/public/portal-offers.test.ts
@@ -13,8 +13,24 @@ type SignupOfferInput = Pick<OfferCreateInput, 'amount' | 'duration' | 'duration
     tierNamePrefix: string;
 };
 
-// TODO: Move this setup into an OfferFactory-backed helper that owns tier creation,
-// portal settings, and Stripe sync instead of keeping it local to the test file.
+type OfferLandingExpectation = {
+    title: string;
+    discountLabel: string | RegExp;
+    message: string | RegExp;
+    updatedPrice?: string | RegExp;
+};
+
+type RedeemedOfferResult = Awaited<ReturnType<typeof redeemOfferViaPortal>>;
+
+type DiscountOfferExpectation = {
+    duration: 'once' | 'repeating' | 'forever';
+    durationInMonths?: number | null;
+    priceLabel: string;
+    timingLabel: string;
+};
+
+// TODO: Move this setup into an OfferFactory-backed helper that owns portal-button
+// setup plus paid-tier creation instead of keeping it local to the test file.
 async function createSignupOffer(request: HttpClient, stripe: StripeTestService, input: SignupOfferInput): Promise<AdminOffer> {
     const offersService = new OffersService(request);
     const settingsService = new SettingsService(request);
@@ -28,8 +44,9 @@ async function createSignupOffer(request: HttpClient, stripe: StripeTestService,
         currency: 'usd',
         monthly_price: 600,
         yearly_price: 6000
+    }, {
+        stripe
     });
-    await waitForTierStripeSync(stripe, tierName);
 
     return await offersService.createOffer({
         name: 'Black Friday Special',
@@ -43,21 +60,48 @@ async function createSignupOffer(request: HttpClient, stripe: StripeTestService,
     });
 }
 
-async function waitForTierStripeSync(stripe: StripeTestService, tierName: string): Promise<void> {
-    await expect.poll(() => {
-        const product = stripe.getProducts().find(item => item.name === tierName);
-        if (!product) {
-            return 0;
-        }
+async function expectOfferLandingPage(offerPage: PortalOfferPage, expected: OfferLandingExpectation): Promise<void> {
+    await offerPage.waitForOfferPage();
+    await expect(offerPage.offerTitle).toHaveText(expected.title);
+    await expect(offerPage.discountLabel).toContainText(expected.discountLabel);
+    await expect(offerPage.offerMessage).toContainText(expected.message);
 
-        return stripe.getPrices().filter(item => item.product === product.id).length;
-    }, {timeout: 10000}).toBe(2);
+    if (expected.updatedPrice) {
+        await expect(offerPage.updatedPrice).toContainText(expected.updatedPrice);
+    }
+}
+
+function expectOfferMetadata(result: RedeemedOfferResult, offer: AdminOffer): void {
+    expect(result.subscription.offer?.id).toBe(offer.id);
+    expect(result.subscription.offer_redemptions?.some(item => item.id === offer.id)).toBe(true);
+}
+
+async function expectTrialOfferRedemption(result: RedeemedOfferResult, offer: AdminOffer): Promise<void> {
+    await expect(result.accountPage.freeTrialLabel).toBeVisible();
+    expectOfferMetadata(result, offer);
+    expect(result.subscription.status).toBe('trialing');
+}
+
+async function expectDiscountOfferRedemption(
+    result: RedeemedOfferResult,
+    offer: AdminOffer,
+    expected: DiscountOfferExpectation
+): Promise<void> {
+    await expect(result.accountPage.offerLabel).toContainText(expected.priceLabel);
+    await expect(result.accountPage.offerLabel).toContainText(expected.timingLabel);
+
+    expectOfferMetadata(result, offer);
+    expect(result.subscription.offer?.duration).toBe(expected.duration);
+
+    if (expected.durationInMonths !== undefined) {
+        expect(result.subscription.offer?.duration_in_months).toBe(expected.durationInMonths);
+    }
 }
 
 test.describe('Ghost Public - Portal Offers', () => {
     test.use({stripeEnabled: true});
 
-    test('archived offer link opens site - does not open portal offer flow', async ({page}) => {
+    test('archived offer link opens site - does not open portal offer flow', async ({page, stripe}) => {
         const publicPage = new PublicPage(page);
         const offersService = new OffersService(page.request);
         const tier = await createPaidPortalTier(page.request, {
@@ -65,6 +109,8 @@ test.describe('Ghost Public - Portal Offers', () => {
             currency: 'usd',
             monthly_price: 600,
             yearly_price: 6000
+        }, {
+            stripe: stripe!
         });
         const offer = await offersService.createOffer({
             name: 'Archived Offer',
@@ -119,16 +165,14 @@ test.describe('Ghost Public - Portal Offers', () => {
         await publicPage.gotoOfferCode(offer.code);
 
         const offerPage = new PortalOfferPage(page);
-        await offerPage.waitForOfferPage(offer.name);
-        await expect(offerPage.headingWithText(offer.name)).toBeVisible();
-        await expect(offerPage.text('14 days free')).toBeVisible();
-        await expect(offerPage.text('Try free for 14 days')).toBeVisible();
+        await expectOfferLandingPage(offerPage, {
+            title: offer.display_title ?? offer.name,
+            discountLabel: '14 days free',
+            message: 'Try free for 14 days'
+        });
 
-        const {accountPage, subscription} = await redeemOfferViaPortal(page, stripe!, {name: MEMBER_NAME});
-        await expect(accountPage.freeTrialLabel).toBeVisible();
-        expect(subscription.offer?.id).toBe(offer.id);
-        expect(subscription.offer_redemptions?.some(item => item.id === offer.id)).toBe(true);
-        expect(subscription.status).toBe('trialing');
+        const redemption = await redeemOfferViaPortal(page, stripe!, {name: MEMBER_NAME});
+        await expectTrialOfferRedemption(redemption, offer);
     });
 
     test('one-time discount offer opens in portal - redemption shows discounted plan label', async ({page, stripe}) => {
@@ -144,18 +188,19 @@ test.describe('Ghost Public - Portal Offers', () => {
         await publicPage.gotoOfferCode(offer.code);
 
         const offerPage = new PortalOfferPage(page);
-        await offerPage.waitForOfferPage(offer.name);
-        await expect(offerPage.headingWithText(offer.name)).toBeVisible();
-        await expect(offerPage.text(/^10% off$/)).toBeVisible();
-        await expect(offerPage.text(/\$5\.40/)).toBeVisible();
-        await expect(offerPage.text('10% off for first month')).toBeVisible();
+        await expectOfferLandingPage(offerPage, {
+            title: offer.display_title ?? offer.name,
+            discountLabel: '10% off',
+            message: '10% off for first month',
+            updatedPrice: /\$5\.40/
+        });
 
-        const {accountPage, subscription} = await redeemOfferViaPortal(page, stripe!, {name: MEMBER_NAME});
-        await expect(accountPage.offerLabel).toContainText('$5.40/month');
-        await expect(accountPage.offerLabel).toContainText('Ends');
-        expect(subscription.offer?.id).toBe(offer.id);
-        expect(subscription.offer_redemptions?.some(item => item.id === offer.id)).toBe(true);
-        expect(subscription.offer?.duration).toBe('once');
+        const redemption = await redeemOfferViaPortal(page, stripe!, {name: MEMBER_NAME});
+        await expectDiscountOfferRedemption(redemption, offer, {
+            duration: 'once',
+            priceLabel: '$5.40/month',
+            timingLabel: 'Ends'
+        });
     });
 
     test('repeating discount offer opens in portal - redemption shows discounted plan label', async ({page, stripe}) => {
@@ -172,19 +217,20 @@ test.describe('Ghost Public - Portal Offers', () => {
         await publicPage.gotoOfferCode(offer.code);
 
         const offerPage = new PortalOfferPage(page);
-        await offerPage.waitForOfferPage(offer.name);
-        await expect(offerPage.headingWithText(offer.name)).toBeVisible();
-        await expect(offerPage.text(/^10% off$/)).toBeVisible();
-        await expect(offerPage.text(/\$5\.40/)).toBeVisible();
-        await expect(offerPage.text('10% off for first 3 months')).toBeVisible();
+        await expectOfferLandingPage(offerPage, {
+            title: offer.display_title ?? offer.name,
+            discountLabel: '10% off',
+            message: '10% off for first 3 months',
+            updatedPrice: /\$5\.40/
+        });
 
-        const {accountPage, subscription} = await redeemOfferViaPortal(page, stripe!, {name: MEMBER_NAME});
-        await expect(accountPage.offerLabel).toContainText('$5.40/month');
-        await expect(accountPage.offerLabel).toContainText('Ends');
-        expect(subscription.offer?.id).toBe(offer.id);
-        expect(subscription.offer_redemptions?.some(item => item.id === offer.id)).toBe(true);
-        expect(subscription.offer?.duration).toBe('repeating');
-        expect(subscription.offer?.duration_in_months).toBe(3);
+        const redemption = await redeemOfferViaPortal(page, stripe!, {name: MEMBER_NAME});
+        await expectDiscountOfferRedemption(redemption, offer, {
+            duration: 'repeating',
+            durationInMonths: 3,
+            priceLabel: '$5.40/month',
+            timingLabel: 'Ends'
+        });
     });
 
     test('forever discount offer opens in portal - redemption shows discounted plan label', async ({page, stripe}) => {
@@ -200,17 +246,18 @@ test.describe('Ghost Public - Portal Offers', () => {
         await publicPage.gotoOfferCode(offer.code);
 
         const offerPage = new PortalOfferPage(page);
-        await offerPage.waitForOfferPage(offer.name);
-        await expect(offerPage.headingWithText(offer.name)).toBeVisible();
-        await expect(offerPage.text(/^10% off$/)).toBeVisible();
-        await expect(offerPage.text(/\$5\.40/)).toBeVisible();
-        await expect(offerPage.text('10% off forever')).toBeVisible();
+        await expectOfferLandingPage(offerPage, {
+            title: offer.display_title ?? offer.name,
+            discountLabel: '10% off',
+            message: '10% off forever',
+            updatedPrice: /\$5\.40/
+        });
 
-        const {accountPage, subscription} = await redeemOfferViaPortal(page, stripe!, {name: MEMBER_NAME});
-        await expect(accountPage.offerLabel).toContainText('$5.40/month');
-        await expect(accountPage.offerLabel).toContainText('Forever');
-        expect(subscription.offer?.id).toBe(offer.id);
-        expect(subscription.offer_redemptions?.some(item => item.id === offer.id)).toBe(true);
-        expect(subscription.offer?.duration).toBe('forever');
+        const redemption = await redeemOfferViaPortal(page, stripe!, {name: MEMBER_NAME});
+        await expectDiscountOfferRedemption(redemption, offer, {
+            duration: 'forever',
+            priceLabel: '$5.40/month',
+            timingLabel: 'Forever'
+        });
     });
 });


### PR DESCRIPTION
## What this does
- adds stable Portal offer-page test ids for title, discount label, message, and updated price
- simplifies the Portal offer page object to expose plain locators instead of text-specific helper methods
- hides paid-tier Stripe readiness behind createPaidPortalTier(..., {stripe})
- reduces repeated assertion blocks in portal-offers.test.ts with local expectation helpers
- teaches the e2e Playwright lint rule to recognize local expect... assertion helpers

## Verification
- ./node_modules/.bin/eslint apps/portal/src/components/pages/offer-page.js
- cd e2e && yarn eslint eslint.config.js helpers/pages/portal/offer-page.ts helpers/playwright/flows/tiers.ts tests/public/portal-offers.test.ts
- cd e2e && yarn test:types

## Notes
- the focused local portal-offers runtime check still hit a dev-environment issue after the selector refactor was in place; the staged code paths and static checks passed cleanly