### PR TITLE
Updated welcome email rendering to prepare for custom options

### DIFF
--- a/ghost/core/core/server/services/email-rendering/email-design.js
+++ b/ghost/core/core/server/services/email-rendering/email-design.js
@@ -69,54 +69,14 @@ const isDark = color => textColorForBackgroundColor(color).hex().toLowerCase() =
  * @returns {EmailDesign}
  */
 exports.getEmailDesign = (settings) => {
-    // TEMPORARY: To make this change easier to review, I've copy-pasted the
-    // original version where applicable. I will remove this in a followup
-    // commit.
-
-    // ORIGINALLY:
-    // #getAccentColor() {
-    //     let accentColor = this.#settingsCache?.get('accent_color') || DEFAULT_ACCENT_COLOR;
-    //
-    //     if (!VALID_HEX_REGEX.test(accentColor)) {
-    //         accentColor = DEFAULT_ACCENT_COLOR;
-    //     }
-    //
-    //     return accentColor;
-    // }
     const accentColor = getHexColor(settings.accentColor, DEFAULT_ACCENT_COLOR);
 
-    // ORIGINALLY:
-    // #getAccentContrastColor() {
-    //     const accentColor = this.#getAccentColor();
-    //     return textColorForBackgroundColor(accentColor).hex();
-    // }
     const accentContrastColor = textColorForBackgroundColor(accentColor).hex();
 
-    // ORIGINALLY:
-    // #getBackgroundColor(newsletter) {
-    //     /** @type {'light' | string | null} */
-    //     const value = newsletter?.get('background_color');
-    //
-    //     if (VALID_HEX_REGEX.test(value)) {
-    //         return value;
-    //     }
-    //
-    //     // value === null, value is not valid hex
-    //     return '#ffffff';
-    // }
     const backgroundColor = getHexColor(settings.backgroundColor, '#ffffff');
 
-    // ORIGINALLY:
-    // buttonCorners: newsletter?.get('button_corners'),
     const buttonCorners = typeof settings.buttonCorners === 'string' ? settings.buttonCorners : null;
 
-    // ORIGINALLY:
-    // let buttonBorderRadius = '6px';
-    // if (newsletter.get('button_corners') === 'square') {
-    //     buttonBorderRadius = '0';
-    // } else if (newsletter.get('button_corners') === 'pill') {
-    //     buttonBorderRadius = '9999px';
-    // }
     let buttonBorderRadius;
     switch (buttonCorners) {
     case 'square':
@@ -130,26 +90,6 @@ exports.getEmailDesign = (settings) => {
         break;
     }
 
-    // ORIGINALLY:
-    // #getButtonColor(newsletter, accentColor) {
-    //     /** @type {'accent' | string | null} */
-    //     const buttonColor = newsletter?.get('button_color');
-    //
-    //     if (buttonColor === 'accent') {
-    //         return accentColor;
-    //     }
-    //
-    //     if (buttonColor === null) {
-    //         const backgroundColor = this.#getBackgroundColor(newsletter);
-    //         return textColorForBackgroundColor(backgroundColor).hex();
-    //     }
-    //
-    //     if (VALID_HEX_REGEX.test(buttonColor)) {
-    //         return buttonColor;
-    //     }
-    //
-    //     return accentColor; // default to accent color
-    // }
     let buttonColor;
     switch (settings.buttonColor) {
     case 'accent':
@@ -163,19 +103,6 @@ exports.getEmailDesign = (settings) => {
         break;
     }
 
-    // ORIGINALLY:
-    // #getDividerColor(newsletter) {
-    //     const value = newsletter?.get('divider_color');
-    //
-    //     if (value === 'accent') {
-    //         return this.#getAccentColor();
-    //     } else if (VALID_HEX_REGEX.test(value)) {
-    //         return value;
-    //     } else {
-    //         // value === 'light'/missing/invalid
-    //         return '#e0e7eb';
-    //     }
-    // }
     let dividerColor;
     if (settings.dividerColor === 'accent') {
         dividerColor = accentColor;
@@ -183,24 +110,6 @@ exports.getEmailDesign = (settings) => {
         dividerColor = getHexColor(settings.dividerColor, DEFAULT_DIVIDER_COLOR);
     }
 
-    // ORIGINALLY:
-    // #getHeaderBackgroundColor(newsletter, accentColor) {
-    //     const value = newsletter?.get('header_background_color');
-    //
-    //     if (value === 'transparent') {
-    //         return null;
-    //     }
-    //
-    //     if (value === 'accent') {
-    //         return accentColor;
-    //     }
-    //
-    //     if (VALID_HEX_REGEX.test(value)) {
-    //         return value;
-    //     }
-    //
-    //     return null;
-    // }
     let headerBackgroundColor;
     if (settings.headerBackgroundColor === 'accent') {
         headerBackgroundColor = accentColor;
@@ -210,28 +119,8 @@ exports.getEmailDesign = (settings) => {
         headerBackgroundColor = null;
     }
 
-    // ORIGINALLY:
-    // imageCorners: newsletter?.get('image_corners')
     const imageCorners = typeof settings.imageCorners === 'string' ? settings.imageCorners : null;
 
-    // ORIGINALLY:
-    // #getLinkColor(newsletter, accentColor) {
-    //     const value = newsletter.get('link_color');
-    //
-    //     if (value === 'accent') {
-    //         return accentColor;
-    //     }
-    //
-    //     if (value === null) {
-    //         return textColorForBackgroundColor(this.#getBackgroundColor(newsletter)).hex();
-    //     }
-    //
-    //     if (VALID_HEX_REGEX.test(value)) {
-    //         return value;
-    //     }
-    //
-    //     return accentColor; // default to accent color
-    // }
     let linkColor;
     switch (settings.linkColor) {
     case 'accent':
@@ -245,23 +134,6 @@ exports.getEmailDesign = (settings) => {
         break;
     }
 
-    // ORIGINALLY:
-    // #getPostTitleColor(newsletter, accentColor) {
-    //     /** @type {'accent' | string | null} */
-    //     const value = newsletter?.get('post_title_color');
-    //
-    //     if (VALID_HEX_REGEX.test(value)) {
-    //         return value;
-    //     }
-    //
-    //     if (value === 'accent') {
-    //         return accentColor;
-    //     }
-    //
-    //     // value === null, value is not valid hex
-    //     const backgroundColor = this.#getHeaderBackgroundColor(newsletter, accentColor) || this.#getBackgroundColor(newsletter);
-    //     return textColorForBackgroundColor(backgroundColor).hex();
-    // }
     let postTitleColor;
     if (settings.postTitleColor === 'accent') {
         postTitleColor = accentColor;
@@ -272,21 +144,6 @@ exports.getEmailDesign = (settings) => {
         postTitleColor = textColorForBackgroundColor(postTitleBackgroundColor).hex();
     }
 
-    // ORIGINALLY:
-    // #getSectionTitleColor(newsletter, accentColor) {
-    //     /** @type {'accent' | string | null} */
-    //     const value = newsletter.get('section_title_color');
-    //
-    //     if (VALID_HEX_REGEX.test(value)) {
-    //         return value;
-    //     }
-    //
-    //     if (value === 'accent') {
-    //         return accentColor;
-    //     }
-    //
-    //     return null;
-    // }
     let sectionTitleColor;
     if (settings.sectionTitleColor === 'accent') {
         sectionTitleColor = accentColor;
@@ -296,20 +153,6 @@ exports.getEmailDesign = (settings) => {
         sectionTitleColor = null;
     }
 
-    // ORIGINALLY:
-    // #getTitleWeight(newsletter) {
-    //     const weights = {
-    //         normal: '400',
-    //         medium: '500',
-    //         semibold: '600',
-    //         bold: '700'
-    //     };
-    //
-    //     /** @type {'normal' | 'medium' | 'semibold' | 'bold' | string | null} */
-    //     const settingValue = newsletter.get('title_font_weight');
-    //
-    //     return weights[settingValue] || weights.bold;
-    // }
     let titleWeight;
     switch (settings.titleFontWeight) {
     case 'normal':
@@ -330,73 +173,25 @@ exports.getEmailDesign = (settings) => {
         accentColor,
         accentContrastColor,
         backgroundColor,
-        // ORIGINALLY:
-        // #checkIfBackgroundIsDark(newsletter) {
-        //     const backgroundColor = this.#getBackgroundColor(newsletter);
-        //     return textColorForBackgroundColor(backgroundColor).hex().toLowerCase() === '#ffffff';
-        // }
         backgroundIsDark: isDark(backgroundColor),
         buttonBorderRadius,
         buttonColor,
         buttonCorners,
-        // ORIGINALLY:
-        // buttonStyle: newsletter?.get('button_style'),
         buttonStyle: typeof settings.buttonStyle === 'string' ? settings.buttonStyle : null,
-        // ORIGINALLY:
-        // // white/black for dark/light button colors
-        // // outline buttons use button color as text color but that's handled in styles
-        // #getButtonTextColor(newsletter, accentColor) {
-        //     const buttonColor = this.#getButtonColor(newsletter, accentColor);
-        //     return textColorForBackgroundColor(buttonColor).hex();
-        // }
         buttonTextColor: textColorForBackgroundColor(buttonColor).hex(),
         dividerColor,
-        // ORIGINALLY:
-        // const hasOutlineButtons = newsletter.get('button_style') === 'outline';
         hasOutlineButtons: settings.buttonStyle === 'outline',
-        // ORIGINALLY:
-        // #getImageCorners(newsletter) {
-        //     const value = newsletter.get('image_corners');
-        //     if (value === 'rounded') {
-        //         return true;
-        //     }
-        //     return false;
-        // }
         hasRoundedImageCorners: imageCorners === 'rounded',
         headerBackgroundColor,
-        // ORIGINALLY:
-        // const headerBackgroundIsDark = textColorForBackgroundColor(headerBackgroundColor || backgroundColor).hex().toLowerCase() === '#ffffff';
         headerBackgroundIsDark: isDark(headerBackgroundColor || backgroundColor),
         imageCorners,
         linkColor,
-        // ORIGINALLY:
-        // const linkStyle = newsletter.get('link_style') || 'underline';
         linkStyle: typeof settings.linkStyle === 'string' ? settings.linkStyle : 'underline',
         postTitleColor,
         sectionTitleColor,
-        // ORIGINALLY:
-        // const textColor = textColorForBackgroundColor(backgroundColor).hex(); // this is used by the header background color so keeping it separate from the content text color
         textColor: textColorForBackgroundColor(backgroundColor).hex(),
         // Some consumers want the weight as is (`titleFontWeight`) where others want it as a stringified number (`titleWeight`).
-        // ORIGINALLY:
-        // titleFontWeight: newsletter?.get('title_font_weight'),
         titleFontWeight: typeof settings.titleFontWeight === 'string' ? settings.titleFontWeight : null,
-        // ORIGINALLY:
-        // #getTitleStrongWeight(titleWeight) {
-        //     const numericWeight = parseInt(titleWeight, 10);
-        //
-        //     if (isNaN(numericWeight)) {
-        //         return '800';
-        //     }
-        //
-        //     // when titleWeight has been set to less than bold,
-        //     // reduce boldness of strong to match our other strong text
-        //     if (numericWeight < 700) {
-        //         return '700';
-        //     } else {
-        //         return '800';
-        //     }
-        // }
         titleStrongWeight: String(titleWeight < 700 ? 700 : 800),
         titleWeight: String(titleWeight)
     };

--- a/ghost/core/core/server/services/email-rendering/email-design.js
+++ b/ghost/core/core/server/services/email-rendering/email-design.js
@@ -1,0 +1,403 @@
+// @ts-check
+const {textColorForBackgroundColor} = require('@tryghost/color-utils');
+
+const DEFAULT_ACCENT_COLOR = '#15212A';
+const DEFAULT_DIVIDER_COLOR = '#e0e7eb';
+const VALID_HEX_REGEX = /^#([0-9a-f]{3}){1,2}$/i;
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+const isValidHexColor = value => (typeof value === 'string') && VALID_HEX_REGEX.test(value);
+
+/**
+ * @param {unknown} value
+ * @param {string} fallback
+ * @returns {string}
+ */
+const getHexColor = (value, fallback) => (isValidHexColor(value) ? value : fallback);
+
+/**
+ * @param {string} color
+ * @returns {boolean}
+ */
+const isDark = color => textColorForBackgroundColor(color).hex().toLowerCase() === '#ffffff';
+
+/**
+ * @typedef {object} EmailDesign
+ * @prop {string} accentColor
+ * @prop {string} accentContrastColor
+ * @prop {string} backgroundColor
+ * @prop {boolean} backgroundIsDark
+ * @prop {string} buttonBorderRadius
+ * @prop {string} buttonColor
+ * @prop {string} buttonTextColor
+ * @prop {string} dividerColor
+ * @prop {boolean} hasOutlineButtons
+ * @prop {null | string} buttonCorners
+ * @prop {null | string} buttonStyle
+ * @prop {null | string} imageCorners
+ * @prop {boolean} hasRoundedImageCorners
+ * @prop {null | string} headerBackgroundColor
+ * @prop {boolean} headerBackgroundIsDark
+ * @prop {string} linkColor
+ * @prop {string} linkStyle
+ * @prop {string} postTitleColor
+ * @prop {null | string} sectionTitleColor
+ * @prop {string} textColor
+ * @prop {string} titleFontWeight
+ * @prop {string} titleStrongWeight
+ * @prop {string} titleWeight
+ */
+
+/**
+ * @param {object} settings
+ * @param {unknown} settings.accentColor
+ * @param {unknown} settings.backgroundColor
+ * @param {unknown} settings.buttonColor
+ * @param {unknown} settings.buttonCorners
+ * @param {unknown} settings.buttonStyle
+ * @param {unknown} settings.dividerColor
+ * @param {unknown} settings.headerBackgroundColor
+ * @param {unknown} settings.imageCorners
+ * @param {unknown} settings.linkColor
+ * @param {unknown} settings.linkStyle
+ * @param {unknown} settings.postTitleColor
+ * @param {unknown} settings.sectionTitleColor
+ * @param {unknown} settings.titleFontWeight
+ * @returns {EmailDesign}
+ */
+exports.getEmailDesign = (settings) => {
+    // TEMPORARY: To make this change easier to review, I've copy-pasted the
+    // original version where applicable. I will remove this in a followup
+    // commit.
+
+    // ORIGINALLY:
+    // #getAccentColor() {
+    //     let accentColor = this.#settingsCache?.get('accent_color') || DEFAULT_ACCENT_COLOR;
+    //
+    //     if (!VALID_HEX_REGEX.test(accentColor)) {
+    //         accentColor = DEFAULT_ACCENT_COLOR;
+    //     }
+    //
+    //     return accentColor;
+    // }
+    const accentColor = getHexColor(settings.accentColor, DEFAULT_ACCENT_COLOR);
+
+    // ORIGINALLY:
+    // #getAccentContrastColor() {
+    //     const accentColor = this.#getAccentColor();
+    //     return textColorForBackgroundColor(accentColor).hex();
+    // }
+    const accentContrastColor = textColorForBackgroundColor(accentColor).hex();
+
+    // ORIGINALLY:
+    // #getBackgroundColor(newsletter) {
+    //     /** @type {'light' | string | null} */
+    //     const value = newsletter?.get('background_color');
+    //
+    //     if (VALID_HEX_REGEX.test(value)) {
+    //         return value;
+    //     }
+    //
+    //     // value === null, value is not valid hex
+    //     return '#ffffff';
+    // }
+    const backgroundColor = getHexColor(settings.backgroundColor, '#ffffff');
+
+    // ORIGINALLY:
+    // buttonCorners: newsletter?.get('button_corners'),
+    const buttonCorners = typeof settings.buttonCorners === 'string' ? settings.buttonCorners : null;
+
+    // ORIGINALLY:
+    // let buttonBorderRadius = '6px';
+    // if (newsletter.get('button_corners') === 'square') {
+    //     buttonBorderRadius = '0';
+    // } else if (newsletter.get('button_corners') === 'pill') {
+    //     buttonBorderRadius = '9999px';
+    // }
+    let buttonBorderRadius;
+    switch (buttonCorners) {
+    case 'square':
+        buttonBorderRadius = '0';
+        break;
+    case 'pill':
+        buttonBorderRadius = '9999px';
+        break;
+    default:
+        buttonBorderRadius = '6px';
+        break;
+    }
+
+    // ORIGINALLY:
+    // #getButtonColor(newsletter, accentColor) {
+    //     /** @type {'accent' | string | null} */
+    //     const buttonColor = newsletter?.get('button_color');
+    //
+    //     if (buttonColor === 'accent') {
+    //         return accentColor;
+    //     }
+    //
+    //     if (buttonColor === null) {
+    //         const backgroundColor = this.#getBackgroundColor(newsletter);
+    //         return textColorForBackgroundColor(backgroundColor).hex();
+    //     }
+    //
+    //     if (VALID_HEX_REGEX.test(buttonColor)) {
+    //         return buttonColor;
+    //     }
+    //
+    //     return accentColor; // default to accent color
+    // }
+    let buttonColor;
+    switch (settings.buttonColor) {
+    case 'accent':
+        buttonColor = accentColor;
+        break;
+    case null:
+        buttonColor = textColorForBackgroundColor(backgroundColor).hex();
+        break;
+    default:
+        buttonColor = getHexColor(settings.buttonColor, accentColor);
+        break;
+    }
+
+    // ORIGINALLY:
+    // #getDividerColor(newsletter) {
+    //     const value = newsletter?.get('divider_color');
+    //
+    //     if (value === 'accent') {
+    //         return this.#getAccentColor();
+    //     } else if (VALID_HEX_REGEX.test(value)) {
+    //         return value;
+    //     } else {
+    //         // value === 'light'/missing/invalid
+    //         return '#e0e7eb';
+    //     }
+    // }
+    let dividerColor;
+    if (settings.dividerColor === 'accent') {
+        dividerColor = accentColor;
+    } else {
+        dividerColor = getHexColor(settings.dividerColor, DEFAULT_DIVIDER_COLOR);
+    }
+
+    // ORIGINALLY:
+    // #getHeaderBackgroundColor(newsletter, accentColor) {
+    //     const value = newsletter?.get('header_background_color');
+    //
+    //     if (value === 'transparent') {
+    //         return null;
+    //     }
+    //
+    //     if (value === 'accent') {
+    //         return accentColor;
+    //     }
+    //
+    //     if (VALID_HEX_REGEX.test(value)) {
+    //         return value;
+    //     }
+    //
+    //     return null;
+    // }
+    let headerBackgroundColor;
+    if (settings.headerBackgroundColor === 'accent') {
+        headerBackgroundColor = accentColor;
+    } else if (isValidHexColor(settings.headerBackgroundColor)) {
+        headerBackgroundColor = settings.headerBackgroundColor;
+    } else {
+        headerBackgroundColor = null;
+    }
+
+    // ORIGINALLY:
+    // imageCorners: newsletter?.get('image_corners')
+    const imageCorners = typeof settings.imageCorners === 'string' ? settings.imageCorners : null;
+
+    // ORIGINALLY:
+    // #getLinkColor(newsletter, accentColor) {
+    //     const value = newsletter.get('link_color');
+    //
+    //     if (value === 'accent') {
+    //         return accentColor;
+    //     }
+    //
+    //     if (value === null) {
+    //         return textColorForBackgroundColor(this.#getBackgroundColor(newsletter)).hex();
+    //     }
+    //
+    //     if (VALID_HEX_REGEX.test(value)) {
+    //         return value;
+    //     }
+    //
+    //     return accentColor; // default to accent color
+    // }
+    let linkColor;
+    switch (settings.linkColor) {
+    case 'accent':
+        linkColor = accentColor;
+        break;
+    case null:
+        linkColor = textColorForBackgroundColor(backgroundColor).hex();
+        break;
+    default:
+        linkColor = getHexColor(settings.linkColor, accentColor);
+        break;
+    }
+
+    // ORIGINALLY:
+    // #getPostTitleColor(newsletter, accentColor) {
+    //     /** @type {'accent' | string | null} */
+    //     const value = newsletter?.get('post_title_color');
+    //
+    //     if (VALID_HEX_REGEX.test(value)) {
+    //         return value;
+    //     }
+    //
+    //     if (value === 'accent') {
+    //         return accentColor;
+    //     }
+    //
+    //     // value === null, value is not valid hex
+    //     const backgroundColor = this.#getHeaderBackgroundColor(newsletter, accentColor) || this.#getBackgroundColor(newsletter);
+    //     return textColorForBackgroundColor(backgroundColor).hex();
+    // }
+    let postTitleColor;
+    if (settings.postTitleColor === 'accent') {
+        postTitleColor = accentColor;
+    } else if (isValidHexColor(settings.postTitleColor)) {
+        postTitleColor = settings.postTitleColor;
+    } else {
+        const postTitleBackgroundColor = headerBackgroundColor || backgroundColor;
+        postTitleColor = textColorForBackgroundColor(postTitleBackgroundColor).hex();
+    }
+
+    // ORIGINALLY:
+    // #getSectionTitleColor(newsletter, accentColor) {
+    //     /** @type {'accent' | string | null} */
+    //     const value = newsletter.get('section_title_color');
+    //
+    //     if (VALID_HEX_REGEX.test(value)) {
+    //         return value;
+    //     }
+    //
+    //     if (value === 'accent') {
+    //         return accentColor;
+    //     }
+    //
+    //     return null;
+    // }
+    let sectionTitleColor;
+    if (settings.sectionTitleColor === 'accent') {
+        sectionTitleColor = accentColor;
+    } else if (isValidHexColor(settings.sectionTitleColor)) {
+        sectionTitleColor = settings.sectionTitleColor;
+    } else {
+        sectionTitleColor = null;
+    }
+
+    // ORIGINALLY:
+    // #getTitleWeight(newsletter) {
+    //     const weights = {
+    //         normal: '400',
+    //         medium: '500',
+    //         semibold: '600',
+    //         bold: '700'
+    //     };
+    //
+    //     /** @type {'normal' | 'medium' | 'semibold' | 'bold' | string | null} */
+    //     const settingValue = newsletter.get('title_font_weight');
+    //
+    //     return weights[settingValue] || weights.bold;
+    // }
+    let titleWeight;
+    switch (settings.titleFontWeight) {
+    case 'normal':
+        titleWeight = 400;
+        break;
+    case 'medium':
+        titleWeight = 500;
+        break;
+    case 'semibold':
+        titleWeight = 600;
+        break;
+    default:
+        titleWeight = 700;
+        break;
+    }
+
+    return {
+        accentColor,
+        accentContrastColor,
+        backgroundColor,
+        // ORIGINALLY:
+        // #checkIfBackgroundIsDark(newsletter) {
+        //     const backgroundColor = this.#getBackgroundColor(newsletter);
+        //     return textColorForBackgroundColor(backgroundColor).hex().toLowerCase() === '#ffffff';
+        // }
+        backgroundIsDark: isDark(backgroundColor),
+        buttonBorderRadius,
+        buttonColor,
+        buttonCorners,
+        // ORIGINALLY:
+        // buttonStyle: newsletter?.get('button_style'),
+        buttonStyle: typeof settings.buttonStyle === 'string' ? settings.buttonStyle : null,
+        // ORIGINALLY:
+        // // white/black for dark/light button colors
+        // // outline buttons use button color as text color but that's handled in styles
+        // #getButtonTextColor(newsletter, accentColor) {
+        //     const buttonColor = this.#getButtonColor(newsletter, accentColor);
+        //     return textColorForBackgroundColor(buttonColor).hex();
+        // }
+        buttonTextColor: textColorForBackgroundColor(buttonColor).hex(),
+        dividerColor,
+        // ORIGINALLY:
+        // const hasOutlineButtons = newsletter.get('button_style') === 'outline';
+        hasOutlineButtons: settings.buttonStyle === 'outline',
+        // ORIGINALLY:
+        // #getImageCorners(newsletter) {
+        //     const value = newsletter.get('image_corners');
+        //     if (value === 'rounded') {
+        //         return true;
+        //     }
+        //     return false;
+        // }
+        hasRoundedImageCorners: imageCorners === 'rounded',
+        headerBackgroundColor,
+        // ORIGINALLY:
+        // const headerBackgroundIsDark = textColorForBackgroundColor(headerBackgroundColor || backgroundColor).hex().toLowerCase() === '#ffffff';
+        headerBackgroundIsDark: isDark(headerBackgroundColor || backgroundColor),
+        imageCorners,
+        linkColor,
+        // ORIGINALLY:
+        // const linkStyle = newsletter.get('link_style') || 'underline';
+        linkStyle: typeof settings.linkStyle === 'string' ? settings.linkStyle : 'underline',
+        postTitleColor,
+        sectionTitleColor,
+        // ORIGINALLY:
+        // const textColor = textColorForBackgroundColor(backgroundColor).hex(); // this is used by the header background color so keeping it separate from the content text color
+        textColor: textColorForBackgroundColor(backgroundColor).hex(),
+        // Some consumers want the weight as is (`titleFontWeight`) where others want it as a stringified number (`titleWeight`).
+        // ORIGINALLY:
+        // titleFontWeight: newsletter?.get('title_font_weight'),
+        titleFontWeight: typeof settings.titleFontWeight === 'string' ? settings.titleFontWeight : null,
+        // ORIGINALLY:
+        // #getTitleStrongWeight(titleWeight) {
+        //     const numericWeight = parseInt(titleWeight, 10);
+        //
+        //     if (isNaN(numericWeight)) {
+        //         return '800';
+        //     }
+        //
+        //     // when titleWeight has been set to less than bold,
+        //     // reduce boldness of strong to match our other strong text
+        //     if (numericWeight < 700) {
+        //         return '700';
+        //     } else {
+        //         return '800';
+        //     }
+        // }
+        titleStrongWeight: String(titleWeight < 700 ? 700 : 800),
+        titleWeight: String(titleWeight)
+    };
+};

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -7,16 +7,14 @@ const clsx = require('clsx');
 function isUnsplashImage(url) {
     return /images\.unsplash\.com/.test(url);
 }
-const {textColorForBackgroundColor} = require('@tryghost/color-utils');
 const {DateTime} = require('luxon');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const EmailAddressParser = require('../email-address/email-address-parser');
+const {getEmailDesign} = require('../email-rendering/email-design');
 const {registerHelpers} = require('./helpers/register-helpers');
 const crypto = require('crypto');
 
 const DEFAULT_LOCALE = 'en-gb';
-const DEFAULT_ACCENT_COLOR = '#15212A';
-const VALID_HEX_REGEX = /^#([0-9a-f]{3}){1,2}$/i;
 const CONTENT_IMAGES_PATH_WITHOUT_SIZE_REGEX = /\/content\/images\/(?!size\/)/;
 
 // Wrapper function so that i18next-parser can find these strings
@@ -325,43 +323,16 @@ class EmailRenderer {
     async renderPostBaseHtml(post, newsletter) {
         const postUrl = this.#getPostUrl(post);
 
-        const renderOptions = {
-            target: 'email',
-            postUrl
-        };
-
-        const accentColor = this.#getAccentColor();
-        const accentContrastColor = this.#getAccentContrastColor();
-
-        renderOptions.design = {
-            accentColor,
-            accentContrastColor,
-            backgroundColor: newsletter?.get('background_color'),
-            backgroundIsDark: this.#checkIfBackgroundIsDark(newsletter),
-            headerBackgroundColor: this.#getHeaderBackgroundColor(newsletter, accentColor),
-            buttonCorners: newsletter?.get('button_corners'),
-            buttonStyle: newsletter?.get('button_style'),
-            titleFontWeight: newsletter?.get('title_font_weight'),
-            linkStyle: newsletter?.get('link_style'),
-            imageCorners: newsletter?.get('image_corners'),
-            postTitleColor: this.#getPostTitleColor(newsletter, accentColor),
-            sectionTitleColor: newsletter?.get('section_title_color'),
-            linkColor: newsletter?.get('link_color'),
-            // TODO:
-            // if the other options above have default or calculated values we
-            // should follow the same pattern as the options below to avoid
-            //duplicating magic values or logic in renderers
-            dividerColor: this.#getDividerColor(newsletter),
-            buttonColor: this.#getButtonColor(newsletter, accentColor),
-            buttonTextColor: this.#getButtonTextColor(newsletter, accentColor)
-        };
-
         let html;
         if (post.get('lexical')) {
             // only lexical's renderer is async
             html = await this.#renderers.lexical.render(
                 post.get('lexical'),
-                renderOptions
+                {
+                    target: 'email',
+                    postUrl,
+                    design: this.#getEmailDesign(newsletter)
+                }
             );
         } else {
             html = this.#renderers.mobiledoc.render(
@@ -887,6 +858,28 @@ class EmailRenderer {
     }
 
     /**
+     * @param {Newsletter} newsletter
+     * @returns {ReturnType<typeof getEmailDesign>}
+     */
+    #getEmailDesign(newsletter) {
+        return getEmailDesign({
+            accentColor: this.#settingsCache?.get('accent_color'),
+            backgroundColor: newsletter?.get('background_color'),
+            buttonColor: newsletter?.get('button_color'),
+            buttonCorners: newsletter?.get('button_corners'),
+            buttonStyle: newsletter?.get('button_style'),
+            dividerColor: newsletter?.get('divider_color'),
+            headerBackgroundColor: newsletter?.get('header_background_color'),
+            imageCorners: newsletter?.get('image_corners'),
+            linkColor: newsletter?.get('link_color'),
+            linkStyle: newsletter?.get('link_style'),
+            postTitleColor: newsletter?.get('post_title_color'),
+            sectionTitleColor: newsletter?.get('section_title_color'),
+            titleFontWeight: newsletter?.get('title_font_weight')
+        });
+    }
+
+    /**
      * Get email preheader text from post model
      * @param {object} postModel
      * @returns
@@ -945,215 +938,11 @@ class EmailRenderer {
         }
     }
 
-    #getAccentColor() {
-        let accentColor = this.#settingsCache?.get('accent_color') || DEFAULT_ACCENT_COLOR;
-
-        if (!VALID_HEX_REGEX.test(accentColor)) {
-            accentColor = DEFAULT_ACCENT_COLOR;
-        }
-
-        return accentColor;
-    }
-
-    #getAccentContrastColor() {
-        const accentColor = this.#getAccentColor();
-        return textColorForBackgroundColor(accentColor).hex();
-    }
-
-    #getBackgroundColor(newsletter) {
-        /** @type {'light' | string | null} */
-        const value = newsletter?.get('background_color');
-
-        if (VALID_HEX_REGEX.test(value)) {
-            return value;
-        }
-
-        // value === null, value is not valid hex
-        return '#ffffff';
-    }
-
-    #getPostTitleColor(newsletter, accentColor) {
-        /** @type {'accent' | string | null} */
-        const value = newsletter?.get('post_title_color');
-
-        if (VALID_HEX_REGEX.test(value)) {
-            return value;
-        }
-
-        if (value === 'accent') {
-            return accentColor;
-        }
-
-        // value === null, value is not valid hex
-        const backgroundColor = this.#getHeaderBackgroundColor(newsletter, accentColor) || this.#getBackgroundColor(newsletter);
-        return textColorForBackgroundColor(backgroundColor).hex();
-    }
-
-    #getSectionTitleColor(newsletter, accentColor) {
-        /** @type {'accent' | string | null} */
-        const value = newsletter.get('section_title_color');
-
-        if (VALID_HEX_REGEX.test(value)) {
-            return value;
-        }
-
-        if (value === 'accent') {
-            return accentColor;
-        }
-
-        return null;
-    }
-
-    #getTitleWeight(newsletter) {
-        const weights = {
-            normal: '400',
-            medium: '500',
-            semibold: '600',
-            bold: '700'
-        };
-
-        /** @type {'normal' | 'medium' | 'semibold' | 'bold' | string | null} */
-        const settingValue = newsletter.get('title_font_weight');
-
-        return weights[settingValue] || weights.bold;
-    }
-
-    #getTitleStrongWeight(titleWeight) {
-        const numericWeight = parseInt(titleWeight, 10);
-
-        if (isNaN(numericWeight)) {
-            return '800';
-        }
-
-        // when titleWeight has been set to less than bold,
-        // reduce boldness of strong to match our other strong text
-        if (numericWeight < 700) {
-            return '700';
-        } else {
-            return '800';
-        }
-    }
-
-    #getImageCorners(newsletter) {
-        const value = newsletter.get('image_corners');
-        if (value === 'rounded') {
-            return true;
-        }
-        return false;
-    }
-
-    #getDividerColor(newsletter) {
-        const value = newsletter?.get('divider_color');
-
-        if (value === 'accent') {
-            return this.#getAccentColor();
-        } else if (VALID_HEX_REGEX.test(value)) {
-            return value;
-        } else {
-            // value === 'light'/missing/invalid
-            return '#e0e7eb';
-        }
-    }
-
-    #getLinkColor(newsletter, accentColor) {
-        const value = newsletter.get('link_color');
-
-        if (value === 'accent') {
-            return accentColor;
-        }
-
-        if (value === null) {
-            return textColorForBackgroundColor(this.#getBackgroundColor(newsletter)).hex();
-        }
-
-        if (VALID_HEX_REGEX.test(value)) {
-            return value;
-        }
-
-        return accentColor; // default to accent color
-    }
-
-    #getButtonColor(newsletter, accentColor) {
-        /** @type {'accent' | string | null} */
-        const buttonColor = newsletter?.get('button_color');
-
-        if (buttonColor === 'accent') {
-            return accentColor;
-        }
-
-        if (buttonColor === null) {
-            const backgroundColor = this.#getBackgroundColor(newsletter);
-            return textColorForBackgroundColor(backgroundColor).hex();
-        }
-
-        if (VALID_HEX_REGEX.test(buttonColor)) {
-            return buttonColor;
-        }
-
-        return accentColor; // default to accent color
-    }
-
-    // white/black for dark/light button colors
-    // outline buttons use button color as text color but that's handled in styles
-    #getButtonTextColor(newsletter, accentColor) {
-        const buttonColor = this.#getButtonColor(newsletter, accentColor);
-        return textColorForBackgroundColor(buttonColor).hex();
-    }
-
-    #checkIfBackgroundIsDark(newsletter) {
-        const backgroundColor = this.#getBackgroundColor(newsletter);
-        return textColorForBackgroundColor(backgroundColor).hex().toLowerCase() === '#ffffff';
-    }
-
-    #getHeaderBackgroundColor(newsletter, accentColor) {
-        const value = newsletter?.get('header_background_color');
-
-        if (value === 'transparent') {
-            return null;
-        }
-
-        if (value === 'accent') {
-            return accentColor;
-        }
-
-        if (VALID_HEX_REGEX.test(value)) {
-            return value;
-        }
-
-        return null;
-    }
-
     /**
      * @private
      */
     async getTemplateData({post, newsletter, html, addPaywall, segment}) {
-        const accentColor = this.#getAccentColor();
-        const accentContrastColor = this.#getAccentContrastColor();
-
-        // TODO: remove passthrough of accent color to getters
-        const backgroundColor = this.#getBackgroundColor(newsletter);
-        const backgroundIsDark = this.#checkIfBackgroundIsDark(newsletter);
-        const postTitleColor = this.#getPostTitleColor(newsletter, accentColor);
-        const titleWeight = this.#getTitleWeight(newsletter);
-        const titleStrongWeight = this.#getTitleStrongWeight(titleWeight);
-        const textColor = textColorForBackgroundColor(backgroundColor).hex(); // this is used by the header background color so keeping it separate from the content text color
-        const linkColor = this.#getLinkColor(newsletter, accentColor);
-        const hasRoundedImageCorners = this.#getImageCorners(newsletter);
-        const sectionTitleColor = this.#getSectionTitleColor(newsletter, accentColor);
-        const dividerColor = this.#getDividerColor(newsletter);
-        const buttonColor = this.#getButtonColor(newsletter, accentColor);
-        const buttonTextColor = this.#getButtonTextColor(newsletter, accentColor);
-        const headerBackgroundColor = this.#getHeaderBackgroundColor(newsletter, accentColor);
-        const headerBackgroundIsDark = textColorForBackgroundColor(headerBackgroundColor || backgroundColor).hex().toLowerCase() === '#ffffff';
-
-        let buttonBorderRadius = '6px';
-        if (newsletter.get('button_corners') === 'square') {
-            buttonBorderRadius = '0';
-        } else if (newsletter.get('button_corners') === 'pill') {
-            buttonBorderRadius = '9999px';
-        }
-
-        const hasOutlineButtons = newsletter.get('button_style') === 'outline';
+        const emailDesign = this.#getEmailDesign(newsletter);
 
         const {href: headerImage, width: headerImageWidth} = await this.limitImageWidth(newsletter.get('header_image'));
         const {href: postFeatureImage, width: postFeatureImageWidth, height: postFeatureImageHeight} = await this.limitImageWidth(post.get('feature_image'));
@@ -1243,8 +1032,6 @@ class EmailRenderer {
         const titleAlignment = newsletter.get('title_alignment');
         const showFeatureImage = newsletter.get('show_feature_image') && !!postFeatureImage;
 
-        const linkStyle = newsletter.get('link_style') || 'underline';
-
         const data = {
             emailTitle: post.get('title'),
             site: {
@@ -1294,35 +1081,17 @@ class EmailRenderer {
             latestPostsHasImages,
 
             //CSS
-            accentColor, // default to #15212A
-            accentContrastColor,
+            ...emailDesign,
             showBadge: newsletter.get('show_badge'),
-            backgroundColor,
-            backgroundIsDark,
-            postTitleColor,
-            titleWeight,
-            titleStrongWeight,
-            textColor,
-            linkColor,
-            hasRoundedImageCorners,
-            buttonBorderRadius,
-            sectionTitleColor,
             headerImage,
             headerImageWidth,
             showHeaderIcon: newsletter.get('show_header_icon') && this.#settingsCache.get('icon'),
-            dividerColor,
-            buttonColor,
-            buttonTextColor,
-            headerBackgroundColor,
-            headerBackgroundIsDark,
 
             // TODO: consider moving these to newsletter property
             showHeaderTitle: newsletter.get('show_header_title'),
             showHeaderName: newsletter.get('show_header_name'),
             showFeatureImage: showFeatureImage,
             footerContent: newsletter.get('footer_content'),
-            linkStyle,
-            hasOutlineButtons,
 
             // useful data
             ctaBgColors: [

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -3,10 +3,10 @@ const path = require('path');
 const lexicalLib = require('../../lib/lexical');
 const {finalize} = require('../email-rendering/finalize');
 const errors = require('@tryghost/errors');
-const {textColorForBackgroundColor} = require('@tryghost/color-utils');
 const {MESSAGES} = require('./constants');
 const {wrapReplacementStrings} = require('../koenig/render-utils/replacement-strings');
 const linkReplacer = require('../lib/link-replacer');
+const {getEmailDesign} = require('../email-rendering/email-design');
 
 const REPLACEMENT_REGEX = /%%\{(\w+?)(?:,? *"(.*?)")?\}%%/g;
 const UNMATCHED_TOKEN_REGEX = /%%\{.*?\}%%/g;
@@ -113,9 +113,25 @@ class MemberWelcomeEmailRenderer {
      * @returns {Promise<{html: string, text: string, subject: string}>}
      */
     async render({lexical, subject, member, siteSettings}) {
+        const design = getEmailDesign({
+            accentColor: siteSettings.accentColor,
+            backgroundColor: '#ffffff',
+            buttonColor: 'accent',
+            buttonCorners: null,
+            buttonStyle: null,
+            dividerColor: null,
+            headerBackgroundColor: null,
+            imageCorners: null,
+            linkColor: 'accent',
+            linkStyle: null,
+            postTitleColor: null,
+            sectionTitleColor: null,
+            titleFontWeight: 'bold'
+        });
+
         let content;
         try {
-            content = await lexicalLib.render(lexical, {target: 'email', design: {accentColor: siteSettings.accentColor}});
+            content = await lexicalLib.render(lexical, {target: 'email', design});
         } catch (err) {
             throw new errors.IncorrectUsageError({
                 message: MESSAGES.INVALID_LEXICAL_STRUCTURE,
@@ -142,8 +158,6 @@ class MemberWelcomeEmailRenderer {
 
         const managePreferencesUrl = new URL('#/portal/account/newsletters', siteSettings.url).href;
         const year = new Date().getFullYear();
-        const accentColor = siteSettings.accentColor || '#15212A';
-        const accentContrastColor = textColorForBackgroundColor(accentColor).hex();
 
         const html = this.#wrapperTemplate({
             content: contentWithAbsoluteLinks,
@@ -151,22 +165,9 @@ class MemberWelcomeEmailRenderer {
             subject: subjectWithReplacements,
             siteTitle: siteSettings.title,
             siteUrl: siteSettings.url,
-            accentColor,
-            accentContrastColor,
-            backgroundColor: '#ffffff',
-            dividerColor: '#e0e7eb',
-            backgroundIsDark: false,
-            hasRoundedImageCorners: false,
-            sectionTitleColor: null,
-            titleWeight: '700',
-            titleStrongWeight: '800',
-            linkColor: accentColor,
-            hasOutlineButtons: false,
-            buttonColor: accentColor,
-            buttonTextColor: accentContrastColor,
-            buttonBorderRadius: '6px',
             managePreferencesUrl,
             year,
+            ...design,
             classes: {
                 container: 'container'
             }

--- a/ghost/core/test/unit/server/services/email-rendering/email-design.test.js
+++ b/ghost/core/test/unit/server/services/email-rendering/email-design.test.js
@@ -1,0 +1,557 @@
+// @ts-check
+const assert = require('node:assert/strict');
+const {getEmailDesign} = require('../../../../../core/server/services/email-rendering/email-design');
+
+const VALID_HEX_COLORS = [
+    '#f00',
+    '#F00',
+    '#ab9801',
+    '#AB9801'
+];
+const INVALID_HEX_COLORS = [
+    null,
+    undefined,
+    0xabcdef,
+    ['#ff9900'],
+    '',
+    'invalid',
+    'accent',
+    'light',
+    'dark',
+    '#',
+    '#F',
+    '#F0',
+    '#F00A',
+    '#F00AB',
+    '#AB9801F',
+    '#AB9801FF',
+    'f00',
+    'ab9801',
+    'foo#AB9801',
+    '#AB9801qux',
+    'foo#AB9801qux'
+];
+
+/**
+ * @param {string} actual
+ * @param {string} expected
+ */
+const assertColorsEqual = (actual, expected) => {
+    assert.equal(
+        actual.toUpperCase(),
+        expected.toUpperCase(),
+        `Expected ${actual} to be the same color as ${expected}`
+    );
+};
+
+describe('getEmailDesign', function () {
+    /** @type {Parameters<typeof getEmailDesign>[0]} */
+    const baseSettings = {
+        accentColor: null,
+        backgroundColor: null,
+        buttonColor: null,
+        buttonCorners: null,
+        buttonStyle: null,
+        dividerColor: null,
+        headerBackgroundColor: null,
+        imageCorners: 'square',
+        linkColor: null,
+        linkStyle: null,
+        postTitleColor: null,
+        sectionTitleColor: null,
+        titleFontWeight: 'bold'
+    };
+
+    describe('accentColor', function () {
+        it('returns the provided accent color when input is valid', function () {
+            for (const accentColor of VALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, accentColor});
+                assertColorsEqual(result.accentColor, accentColor);
+            }
+        });
+
+        it('returns the default accent color when input is invalid', function () {
+            for (const accentColor of INVALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, accentColor});
+                assertColorsEqual(result.accentColor, '#15212a');
+            }
+        });
+    });
+
+    describe('accentContrastColor', function () {
+        it('returns white for a dark accent color', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#333'});
+            assertColorsEqual(result.accentContrastColor, '#ffffff');
+        });
+
+        it('returns black for a light accent color', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#ddd'});
+            assertColorsEqual(result.accentContrastColor, '#000000');
+        });
+
+        it('returns white for invalid accent colors', function () {
+            for (const accentColor of INVALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, accentColor});
+                assertColorsEqual(result.accentContrastColor, '#ffffff');
+            }
+        });
+    });
+
+    describe('backgroundColor', function () {
+        it('returns the provided background color when input is valid', function () {
+            for (const backgroundColor of VALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, backgroundColor});
+                assertColorsEqual(result.backgroundColor, backgroundColor);
+            }
+        });
+
+        it('returns the default background color when input is invalid', function () {
+            for (const backgroundColor of INVALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, backgroundColor});
+                assertColorsEqual(result.backgroundColor, '#ffffff');
+            }
+        });
+    });
+
+    describe('backgroundIsDark', function () {
+        it('returns true for dark background colors', function () {
+            for (const backgroundColor of ['#000', '#333']) {
+                const result = getEmailDesign({...baseSettings, backgroundColor});
+                assert(result.backgroundIsDark);
+            }
+        });
+
+        it('returns false for light background colors', function () {
+            for (const backgroundColor of ['#fff', '#ddd']) {
+                const result = getEmailDesign({...baseSettings, backgroundColor});
+                assert(!result.backgroundIsDark);
+            }
+        });
+
+        it('returns false for invalid background colors', function () {
+            for (const backgroundColor of INVALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, backgroundColor});
+                assert(!result.backgroundIsDark);
+            }
+        });
+    });
+
+    describe('buttonBorderRadius', function () {
+        it('returns 0 when button corners are square', function () {
+            const result = getEmailDesign({...baseSettings, buttonCorners: 'square'});
+            assert.equal(result.buttonBorderRadius, '0');
+        });
+
+        it('returns 9999px when button corners are pill', function () {
+            const result = getEmailDesign({...baseSettings, buttonCorners: 'pill'});
+            assert.equal(result.buttonBorderRadius, '9999px');
+        });
+
+        it('returns 6px for any other value', function () {
+            for (const buttonCorners of ['rounded', null, undefined, '', 'foo', 123]) {
+                const result = getEmailDesign({...baseSettings, buttonCorners});
+                assert.equal(result.buttonBorderRadius, '6px');
+            }
+        });
+    });
+
+    describe('buttonColor', function () {
+        it('returns the accent color when button color is set to "accent"', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#f00', buttonColor: 'accent'});
+            assertColorsEqual(result.buttonColor, '#f00');
+        });
+
+        it('returns the default accent color when the button color is set to "accent" but the accent color is invalid', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: 'invalid', buttonColor: 'accent'});
+            assertColorsEqual(result.buttonColor, '#15212a');
+        });
+
+        it('returns the background contrast color when button color is null', function () {
+            assertColorsEqual(
+                getEmailDesign({...baseSettings, backgroundColor: '#333', buttonColor: null}).buttonColor,
+                '#ffffff'
+            );
+            assertColorsEqual(
+                getEmailDesign({...baseSettings, backgroundColor: '#ddd', buttonColor: null}).buttonColor,
+                '#000000'
+            );
+        });
+
+        it('returns the provided button color when input is valid', function () {
+            for (const buttonColor of VALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, buttonColor});
+                assertColorsEqual(result.buttonColor, buttonColor);
+            }
+        });
+
+        it('returns the accent color when input is invalid', function () {
+            for (const buttonColor of INVALID_HEX_COLORS.filter(color => color !== 'accent' && color !== null)) {
+                const result = getEmailDesign({...baseSettings, accentColor: '#f00', buttonColor});
+                assertColorsEqual(result.buttonColor, '#f00');
+            }
+        });
+    });
+
+    describe('buttonCorners', function () {
+        it('returns the provided button corners when input is a string', function () {
+            for (const buttonCorners of ['square', 'rounded', 'pill', 'foo']) {
+                const result = getEmailDesign({...baseSettings, buttonCorners});
+                assert.equal(result.buttonCorners, buttonCorners);
+            }
+        });
+
+        it('returns null when input is not a string', function () {
+            for (const buttonCorners of [null, undefined, 0, ['pill']]) {
+                const result = getEmailDesign({...baseSettings, buttonCorners});
+                assert.equal(result.buttonCorners, null);
+            }
+        });
+    });
+
+    describe('buttonStyle', function () {
+        it('returns the provided button style when input is a string', function () {
+            for (const buttonStyle of ['solid', 'outline', 'foo']) {
+                const result = getEmailDesign({...baseSettings, buttonStyle});
+                assert.equal(result.buttonStyle, buttonStyle);
+            }
+        });
+
+        it('returns null when input is not a string', function () {
+            for (const buttonStyle of [null, undefined, 0, ['outline']]) {
+                const result = getEmailDesign({...baseSettings, buttonStyle});
+                assert.equal(result.buttonStyle, null);
+            }
+        });
+    });
+
+    describe('buttonTextColor', function () {
+        it('returns white for a dark button color', function () {
+            const result = getEmailDesign({...baseSettings, buttonColor: '#333'});
+            assertColorsEqual(result.buttonTextColor, '#ffffff');
+        });
+
+        it('returns black for a light button color', function () {
+            const result = getEmailDesign({...baseSettings, buttonColor: '#ddd'});
+            assertColorsEqual(result.buttonTextColor, '#000000');
+        });
+
+        it('returns white when the button color falls back to a dark accent color', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#333', buttonColor: 'invalid'});
+            assertColorsEqual(result.buttonTextColor, '#ffffff');
+        });
+
+        it('returns black when the button color falls back to a light accent color', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#ddd', buttonColor: 'invalid'});
+            assertColorsEqual(result.buttonTextColor, '#000000');
+        });
+    });
+
+    describe('dividerColor', function () {
+        it('returns the accent color when divider color is set to "accent"', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#f00', dividerColor: 'accent'});
+            assertColorsEqual(result.dividerColor, '#f00');
+        });
+
+        it('returns the default accent color when the divider color is set to "accent" but the accent color is invalid', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: 'invalid', dividerColor: 'accent'});
+            assertColorsEqual(result.dividerColor, '#15212a');
+        });
+
+        it('returns the provided divider color when input is valid', function () {
+            for (const dividerColor of VALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, dividerColor});
+                assertColorsEqual(result.dividerColor, dividerColor);
+            }
+        });
+
+        it('returns the default divider color when input is invalid', function () {
+            for (const dividerColor of INVALID_HEX_COLORS.filter(color => color !== 'accent')) {
+                const result = getEmailDesign({...baseSettings, dividerColor});
+                assertColorsEqual(result.dividerColor, '#e0e7eb');
+            }
+        });
+    });
+
+    describe('hasOutlineButtons', function () {
+        it('is true when button style is outline', function () {
+            const result = getEmailDesign({...baseSettings, buttonStyle: 'outline'});
+            assert(result.hasOutlineButtons);
+        });
+
+        it('is false for any other value', function () {
+            for (const buttonStyle of ['solid', null, undefined, '', 'foo', 123]) {
+                const result = getEmailDesign({...baseSettings, buttonStyle});
+                assert(!result.hasOutlineButtons);
+            }
+        });
+    });
+
+    describe('hasRoundedImageCorners', function () {
+        it('is true if corners are set to rounded', function () {
+            const result = getEmailDesign({...baseSettings, imageCorners: 'rounded'});
+            assert(result.hasRoundedImageCorners);
+        });
+
+        it('is false for any other value', function () {
+            for (const imageCorners of ['square', null, undefined, '', 'foo']) {
+                const result = getEmailDesign({...baseSettings, imageCorners});
+                assert(!result.hasRoundedImageCorners);
+            }
+        });
+    });
+
+    describe('headerBackgroundColor', function () {
+        it('returns the accent color when header background color is set to "accent"', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#f00', headerBackgroundColor: 'accent'});
+            assertColorsEqual(result.headerBackgroundColor, '#f00');
+        });
+
+        it('returns the default accent color when the header background color is set to "accent" but the accent color is invalid', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: 'invalid', headerBackgroundColor: 'accent'});
+            assertColorsEqual(result.headerBackgroundColor, '#15212a');
+        });
+
+        it('returns the provided header background color when input is valid', function () {
+            for (const headerBackgroundColor of VALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, headerBackgroundColor});
+                assertColorsEqual(result.headerBackgroundColor, headerBackgroundColor);
+            }
+        });
+
+        it('returns null when input is invalid', function () {
+            for (const headerBackgroundColor of INVALID_HEX_COLORS.filter(color => color !== 'accent')) {
+                const result = getEmailDesign({...baseSettings, headerBackgroundColor});
+                assert.equal(result.headerBackgroundColor, null);
+            }
+        });
+    });
+
+    describe('headerBackgroundIsDark', function () {
+        it('returns true for dark header background colors', function () {
+            const result = getEmailDesign({...baseSettings, headerBackgroundColor: '#333'});
+            assert(result.headerBackgroundIsDark);
+        });
+
+        it('returns false for light header background colors', function () {
+            const result = getEmailDesign({...baseSettings, headerBackgroundColor: '#ddd'});
+            assert(!result.headerBackgroundIsDark);
+        });
+
+        it('falls back to the background color when header background color is invalid', function () {
+            assert(
+                getEmailDesign({...baseSettings, backgroundColor: '#333', headerBackgroundColor: 'invalid'}).headerBackgroundIsDark
+            );
+            assert(
+                !getEmailDesign({...baseSettings, backgroundColor: '#ddd', headerBackgroundColor: 'invalid'}).headerBackgroundIsDark
+            );
+        });
+    });
+
+    describe('imageCorners', function () {
+        it('returns the provided image corners when input is a string', function () {
+            for (const imageCorners of ['square', 'rounded', 'foo']) {
+                const result = getEmailDesign({...baseSettings, imageCorners});
+                assert.equal(result.imageCorners, imageCorners);
+            }
+        });
+
+        it('returns null when input is not a string', function () {
+            for (const imageCorners of [null, undefined, 0, ['rounded']]) {
+                const result = getEmailDesign({...baseSettings, imageCorners});
+                assert.equal(result.imageCorners, null);
+            }
+        });
+    });
+
+    describe('linkColor', function () {
+        it('returns the accent color when link color is set to "accent"', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#f00', linkColor: 'accent'});
+            assertColorsEqual(result.linkColor, '#f00');
+        });
+
+        it('returns the default accent color when the link color is set to "accent" but the accent color is invalid', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: 'invalid', linkColor: 'accent'});
+            assertColorsEqual(result.linkColor, '#15212a');
+        });
+
+        it('returns the background contrast color when link color is null', function () {
+            assertColorsEqual(
+                getEmailDesign({...baseSettings, backgroundColor: '#333', linkColor: null}).linkColor,
+                '#ffffff'
+            );
+            assertColorsEqual(
+                getEmailDesign({...baseSettings, backgroundColor: '#ddd', linkColor: null}).linkColor,
+                '#000000'
+            );
+        });
+
+        it('returns the provided link color when input is valid', function () {
+            for (const linkColor of VALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, linkColor});
+                assertColorsEqual(result.linkColor, linkColor);
+            }
+        });
+
+        it('returns the accent color when input is invalid', function () {
+            for (const linkColor of INVALID_HEX_COLORS.filter(color => color !== 'accent' && color !== null)) {
+                const result = getEmailDesign({...baseSettings, accentColor: '#f00', linkColor});
+                assertColorsEqual(result.linkColor, '#f00');
+            }
+        });
+    });
+
+    describe('linkStyle', function () {
+        it('returns the provided link style when input is a string', function () {
+            for (const linkStyle of ['underline', 'plain', 'foo']) {
+                const result = getEmailDesign({...baseSettings, linkStyle});
+                assert.equal(result.linkStyle, linkStyle);
+            }
+        });
+
+        it('returns underline when input is not a string', function () {
+            for (const linkStyle of [null, undefined, 0, ['underline']]) {
+                const result = getEmailDesign({...baseSettings, linkStyle});
+                assert.equal(result.linkStyle, 'underline');
+            }
+        });
+    });
+
+    describe('postTitleColor', function () {
+        it('returns the accent color when post title color is set to "accent"', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#f00', postTitleColor: 'accent'});
+            assertColorsEqual(result.postTitleColor, '#f00');
+        });
+
+        it('returns the default accent color when the post title color is set to "accent" but the accent color is invalid', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: 'invalid', postTitleColor: 'accent'});
+            assertColorsEqual(result.postTitleColor, '#15212a');
+        });
+
+        it('returns the provided post title color when input is valid', function () {
+            for (const postTitleColor of VALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, postTitleColor});
+                assertColorsEqual(result.postTitleColor, postTitleColor);
+            }
+        });
+
+        it('returns the header background contrast color when input is invalid and the header background color is set', function () {
+            assertColorsEqual(
+                getEmailDesign({...baseSettings, headerBackgroundColor: '#333', postTitleColor: 'invalid'}).postTitleColor,
+                '#ffffff'
+            );
+            assertColorsEqual(
+                getEmailDesign({...baseSettings, headerBackgroundColor: '#ddd', postTitleColor: 'invalid'}).postTitleColor,
+                '#000000'
+            );
+        });
+
+        it('returns the background contrast color when input is invalid and the header background color is not set', function () {
+            assertColorsEqual(
+                getEmailDesign({...baseSettings, backgroundColor: '#333', postTitleColor: 'invalid'}).postTitleColor,
+                '#ffffff'
+            );
+            assertColorsEqual(
+                getEmailDesign({...baseSettings, backgroundColor: '#ddd', postTitleColor: 'invalid'}).postTitleColor,
+                '#000000'
+            );
+        });
+    });
+
+    describe('sectionTitleColor', function () {
+        it('returns the accent color when section title color is set to "accent"', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: '#f00', sectionTitleColor: 'accent'});
+            assertColorsEqual(result.sectionTitleColor, '#f00');
+        });
+
+        it('returns the default accent color when the section title color is set to "accent" but the accent color is invalid', function () {
+            const result = getEmailDesign({...baseSettings, accentColor: 'invalid', sectionTitleColor: 'accent'});
+            assertColorsEqual(result.sectionTitleColor, '#15212a');
+        });
+
+        it('returns the provided section title color when input is valid', function () {
+            for (const sectionTitleColor of VALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, sectionTitleColor});
+                assertColorsEqual(result.sectionTitleColor, sectionTitleColor);
+            }
+        });
+
+        it('returns null when input is invalid', function () {
+            for (const sectionTitleColor of INVALID_HEX_COLORS.filter(color => color !== 'accent')) {
+                const result = getEmailDesign({...baseSettings, sectionTitleColor});
+                assert.equal(result.sectionTitleColor, null);
+            }
+        });
+    });
+
+    describe('textColor', function () {
+        it('returns white for dark background colors', function () {
+            const result = getEmailDesign({...baseSettings, backgroundColor: '#333'});
+            assertColorsEqual(result.textColor, '#ffffff');
+        });
+
+        it('returns black for light or invalid background colors', function () {
+            const result = getEmailDesign({...baseSettings, backgroundColor: '#ddd'});
+            assertColorsEqual(result.textColor, '#000000');
+        });
+
+        it('returns black for invalid background colors', function () {
+            for (const backgroundColor of INVALID_HEX_COLORS) {
+                const result = getEmailDesign({...baseSettings, backgroundColor});
+                assertColorsEqual(result.textColor, '#000000');
+            }
+        });
+    });
+
+    describe('titleFontWeight', function () {
+        it('returns the provided title font weight when input is a string', function () {
+            for (const titleFontWeight of ['normal', 'medium', 'semibold', 'bold', 'foo']) {
+                const result = getEmailDesign({...baseSettings, titleFontWeight});
+                assert.equal(result.titleFontWeight, titleFontWeight);
+            }
+        });
+
+        it('returns null when input is not a string', function () {
+            for (const titleFontWeight of [null, undefined, 400, ['bold']]) {
+                const result = getEmailDesign({...baseSettings, titleFontWeight});
+                assert.equal(result.titleFontWeight, null);
+            }
+        });
+    });
+
+    describe('titleStrongWeight', function () {
+        it('returns 700 when title weight is less than that', function () {
+            for (const titleFontWeight of ['normal', 'medium', 'semibold']) {
+                const result = getEmailDesign({...baseSettings, titleFontWeight});
+                assert.equal(result.titleStrongWeight, '700');
+            }
+        });
+
+        it('returns 800 when title weight is bold', function () {
+            const result = getEmailDesign({...baseSettings, titleFontWeight: 'bold'});
+            assert.equal(result.titleStrongWeight, '800');
+        });
+
+        it('returns 800 when title weight is invalid', function () {
+            for (const titleFontWeight of [null, undefined, 400, '', 'foo', 'hasOwnProperty']) {
+                const result = getEmailDesign({...baseSettings, titleFontWeight});
+                assert.equal(result.titleStrongWeight, '800');
+            }
+        });
+    });
+
+    describe('titleWeight', function () {
+        it('maps title font weight settings to numeric CSS values', function () {
+            assert.equal(getEmailDesign({...baseSettings, titleFontWeight: 'normal'}).titleWeight, '400');
+            assert.equal(getEmailDesign({...baseSettings, titleFontWeight: 'medium'}).titleWeight, '500');
+            assert.equal(getEmailDesign({...baseSettings, titleFontWeight: 'semibold'}).titleWeight, '600');
+            assert.equal(getEmailDesign({...baseSettings, titleFontWeight: 'bold'}).titleWeight, '700');
+        });
+
+        it('returns bold when no mapping exists', function () {
+            for (const titleFontWeight of [null, undefined, 400, '', 'foo', 'hasOwnProperty']) {
+                const result = getEmailDesign({...baseSettings, titleFontWeight});
+                assert.equal(result.titleWeight, '700');
+            }
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -39,7 +39,31 @@ describe('MemberWelcomeEmailRenderer', function () {
             });
 
             sinon.assert.calledOnce(lexicalRenderStub);
-            sinon.assert.calledWith(lexicalRenderStub, lexicalJson, {target: 'email', design: {accentColor: '#ff0000'}});
+            sinon.assert.calledWith(lexicalRenderStub, lexicalJson, {target: 'email', design: {
+                accentColor: '#ff0000',
+                accentContrastColor: '#FFFFFF',
+                backgroundColor: '#ffffff',
+                backgroundIsDark: false,
+                buttonBorderRadius: '6px',
+                buttonColor: '#ff0000',
+                buttonCorners: null,
+                buttonStyle: null,
+                buttonTextColor: '#FFFFFF',
+                dividerColor: '#e0e7eb',
+                hasOutlineButtons: false,
+                hasRoundedImageCorners: false,
+                headerBackgroundColor: null,
+                headerBackgroundIsDark: false,
+                imageCorners: null,
+                linkColor: '#ff0000',
+                linkStyle: 'underline',
+                postTitleColor: '#000000',
+                sectionTitleColor: null,
+                textColor: '#000000',
+                titleFontWeight: 'bold',
+                titleStrongWeight: '800',
+                titleWeight: '700'
+            }});
         });
 
         it('substitutes member template variables', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1163

_I recommend reviewing this [commit-by-commit](https://github.com/TryGhost/Ghost/pull/26966/commits) rather than all at once._

_This change should have no user impact._

This lets the welcome email renderer match the newsletter email renderer's design settings. For example, it now fetches the background color the same way.

It's currently hard-coded, but it should be easy to add real values on top of this.

In addition to automated tests, I manually verified that welcome emails' HTML was unchanged.