### PR TITLE
Fixed pre-commit lint hook for Tailwind v4 workspaces

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,8 +1,10 @@
 const path = require('path');
 
-const FLAT_CONFIG_WORKSPACES = [
+const SCOPED_WORKSPACES = [
     'e2e',
-    'apps/admin'
+    'apps/admin',
+    'apps/posts',
+    'apps/shade'
 ];
 
 function normalize(file) {
@@ -44,11 +46,11 @@ function buildRootEslintCommand(files) {
 
 module.exports = {
     '*.{js,ts,tsx,jsx,cjs}': (files) => {
-        const workspaceGroups = new Map(FLAT_CONFIG_WORKSPACES.map(workspace => [workspace, []]));
+        const workspaceGroups = new Map(SCOPED_WORKSPACES.map(workspace => [workspace, []]));
         const rootFiles = [];
 
         for (const file of files) {
-            const workspace = FLAT_CONFIG_WORKSPACES.find(candidate => isInWorkspace(file, candidate));
+            const workspace = SCOPED_WORKSPACES.find(candidate => isInWorkspace(file, candidate));
 
             if (workspace) {
                 workspaceGroups.get(workspace).push(file);
@@ -58,7 +60,7 @@ module.exports = {
         }
 
         return [
-            ...FLAT_CONFIG_WORKSPACES
+            ...SCOPED_WORKSPACES
                 .map(workspace => buildScopedEslintCommand(workspace, workspaceGroups.get(workspace)))
                 .filter(Boolean),
             buildRootEslintCommand(rootFiles)


### PR DESCRIPTION
no issue

Added `apps/posts` and `apps/shade` to scoped workspaces in `.lintstagedrc.cjs` so eslint runs from within each package directory. This fixes the pre-commit hook failing because `eslint-plugin-tailwindcss` (via `tailwind-api-utils`) tries to require `tailwindcss/dist/lib/setupContextUtils.js` which only exists in Tailwind v3.

Renamed the constant from `FLAT_CONFIG_WORKSPACES` to `SCOPED_WORKSPACES` since it now includes non-flat-config packages too.