### PR TITLE
Bumped comments-ui default CDN version to 1.4

### DIFF
--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -253,7 +253,7 @@
     },
     "comments": {
         "url": "https://cdn.jsdelivr.net/ghost/comments-ui@~{version}/umd/comments-ui.min.js",
-        "version": "1.3"
+        "version": "1.4"
     },
     "signupForm": {
         "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",


### PR DESCRIPTION
The comments-ui default version in the shared config `defaults.json` was still pointing at `1.3`, which meant self-hosted instances pulling from the jsDelivr CDN would not pick up the latest `1.4` release. This bumps the pinned version so new installs and existing sites that rely on the default config serve the current comments-ui bundle.