### PR TITLE
Improved avatars in members list

### DIFF
--- a/apps/posts/src/components/member-avatar.tsx
+++ b/apps/posts/src/components/member-avatar.tsx
@@ -1,27 +1,40 @@
-import {LucideIcon, cn} from '@tryghost/shade';
+import {LucideIcon, cn, formatMemberName, getMemberInitials, stringToHslColor} from '@tryghost/shade';
 
 interface MemberAvatarProps {
     avatarImage?: string | null;
     memberId?: string | null;
+    memberName?: string | null;
+    memberEmail?: string | null;
     isHidden?: boolean;
     className?: string;
 }
 
-export function MemberAvatar({avatarImage, memberId, isHidden, className}: MemberAvatarProps) {
+export function MemberAvatar({avatarImage, memberId, memberName, memberEmail, isHidden, className}: MemberAvatarProps) {
+    const member = {name: memberName || undefined, email: memberEmail || undefined};
+    const hasIdentity = !!(memberName || memberEmail);
+    const initials = hasIdentity ? getMemberInitials(member) : null;
+    const bgColor = hasIdentity ? stringToHslColor(formatMemberName(member), '75', '55') : undefined;
+
     return (
-        <div className={cn(
-            'relative flex size-6 min-w-6 items-center justify-center overflow-hidden rounded-full bg-accent md:size-8 md:min-w-8',
-            isHidden && 'opacity-50',
-            className
-        )}>
+        <div
+            className={cn(
+                'relative flex size-6 min-w-6 items-center justify-center overflow-hidden rounded-full md:size-8 md:min-w-8',
+                !hasIdentity && 'bg-accent',
+                isHidden && 'opacity-50',
+                className
+            )}
+            style={hasIdentity ? {backgroundColor: bgColor} : undefined}
+        >
+            {initials ? (
+                <span className='text-xs font-semibold text-white md:text-sm'>{initials}</span>
+            ) : (
+                <LucideIcon.User className='size-3! text-muted-foreground md:size-4!' size={12} />
+            )}
             {memberId && avatarImage && (
                 <div className='absolute inset-0'>
                     <img alt="Member avatar" src={avatarImage} />
                 </div>
             )}
-            <div>
-                <LucideIcon.User className='size-3! text-muted-foreground md:size-4!' size={12} />
-            </div>
         </div>
     );
 }

--- a/apps/posts/src/views/members/components/members-list-item.tsx
+++ b/apps/posts/src/views/members/components/members-list-item.tsx
@@ -57,7 +57,9 @@ function MembersListItemName({item, onClick}: { item: Member; onClick?: (memberI
             <MemberAvatar
                 avatarImage={item.avatar_image}
                 className="size-10 min-w-10 md:size-10 md:min-w-10"
+                memberEmail={item.email}
                 memberId={item.id}
+                memberName={item.name}
             />
             <div className="min-w-0">
                 <a


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3501/improve-avatars

- Avatars in the members list were falling back to the default user icon instead of the initials with a colored background.