### PR TITLE
Disabled the deploy-to-staging label workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1561,15 +1561,11 @@ jobs:
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 
-            DEPLOY_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-to-staging') }}"
-            IS_ORG_MEMBER="${{ needs.job_setup.outputs.member_is_in_org }}"
-            IS_RENOVATE="${{ github.event.pull_request.user.login == 'renovate[bot]' }}"
-
-            if [ "$DEPLOY_LABEL" = "true" ] && ([ "$IS_ORG_MEMBER" = "true" ] || [ "$IS_RENOVATE" = "true" ]); then
-              echo "deploy=true" >> $GITHUB_OUTPUT
-            else
-              echo "deploy=" >> $GITHUB_OUTPUT
-            fi
+            # DISABLED: deploy-to-staging label detection is disabled.
+            # The label workflow has fundamental problems — admin deploys are global
+            # (not per-site) and main merges overwrite the deployment immediately.
+            # See deploy-to-staging.yml for details.
+            echo "deploy=" >> $GITHUB_OUTPUT
           else
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,5 +1,14 @@
 name: Deploy to Staging
 
+# DISABLED: The deploy-to-staging label workflow is currently broken and disabled.
+# Problems:
+#   1. Admin is global — deploying a PR's admin overwrites admin-forward/ for ALL staging
+#      sites, not just demo.ghost.is. Per-site admin versioning is needed first.
+#   2. Main merges overwrite — any merge to main triggers a full staging rollout that
+#      overwrites both the server version on demo.ghost.is and admin-forward/ globally.
+# The deployment lasts only until the next merge to main, making it unreliable.
+# See: https://www.notion.so/ghost/Proposal-Per-site-admin-versioning-31951439c03081daa133eb0215642202
+
 on:
   pull_request_target:
     types: [labeled]
@@ -10,7 +19,8 @@ jobs:
     # Runs when the "deploy-to-staging" label is added — requires collaborator write access.
     # Fork PRs are rejected because they don't have GHCR images (CI uses artifact transfer).
     if: >-
-      github.event.label.name == 'deploy-to-staging'
+      false
+      && github.event.label.name == 'deploy-to-staging'
       && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The deploy-to-staging label workflow lets you add a label to a PR to deploy it to demo.ghost.is for testing. In practice, it has two fundamental problems that make it unreliable.

First, admin deploys are global per-environment, not per-site. When the workflow deploys a PR's admin assets, it overwrites `admin-forward/` for every staging site, not just demo.ghost.is. This means labelling a PR silently breaks admin for all other staging blogs until the next main merge restores it.

Second, any merge to main triggers a full staging rollout that immediately overwrites both the server version on demo.ghost.is and the global admin-forward/ assets. So even if a deploy succeeds, the PR's deployment only survives until the next merge to main — which on a busy day could be minutes.

This change hardcodes `deploy=""` in CI's label detection step and sets the workflow's `if:` condition to `false` so the job never runs. Both files include comments explaining why the workflow is disabled and linking to the per-site admin versioning proposal that would need to land before this can work reliably.