### PR TITLE
Added fake Mailgun server for e2e newsletter testing

### DIFF
--- a/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
@@ -22,6 +22,8 @@ class PublishFlow extends BasePage {
     readonly publishTypeSetting: Locator;
     readonly publishTypeButton: Locator;
     readonly emailRecipientsSetting: Locator;
+    readonly continueButton: Locator;
+    readonly confirmButton: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -30,10 +32,23 @@ class PublishFlow extends BasePage {
         this.publishTypeSetting = page.locator('[data-test-setting="publish-type"]');
         this.publishTypeButton = this.publishTypeSetting.locator('> button');
         this.emailRecipientsSetting = page.locator('[data-test-setting="email-recipients"]');
+        this.continueButton = page.locator('[data-test-modal="publish-flow"] [data-test-button="continue"]');
+        this.confirmButton = page.locator('[data-test-modal="publish-flow"] [data-test-button="confirm-publish"]');
     }
 
     async open(): Promise<void> {
         await this.publishButton.click();
+    }
+
+    async selectPublishType(type: 'publish' | 'publish+send' | 'send'): Promise<void> {
+        await this.publishTypeButton.click();
+        await this.page.locator(`[data-test-publish-type="${type}"] + label`).click();
+    }
+
+    async confirm(): Promise<void> {
+        await this.continueButton.click();
+        await this.confirmButton.click({force: true});
+        await this.confirmButton.waitFor({state: 'hidden'});
     }
 }
 

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -1,6 +1,8 @@
 import baseDebug from '@tryghost/debug';
 import {AnalyticsOverviewPage} from '@/helpers/pages';
 import {Browser, BrowserContext, Page, TestInfo, test as base} from '@playwright/test';
+import {EmailClient, MailPit} from '@/helpers/services/email/mail-pit';
+import {FakeMailgunServer, MailgunTestService} from '@/helpers/services/mailgun';
 import {FakeStripeServer, StripeTestService, WebhookClient} from '@/helpers/services/stripe';
 import {GhostInstance, getEnvironmentManager} from '@/helpers/environment';
 import {SettingsService} from '@/helpers/services/settings/settings-service';
@@ -87,6 +89,10 @@ export interface GhostInstanceFixture {
     stripeEnabled?: boolean;
     stripeServer?: FakeStripeServer;
     stripe?: StripeTestService;
+    mailgunEnabled?: boolean;
+    mailgunServer?: FakeMailgunServer;
+    mailgun?: MailgunTestService;
+    emailClient: EmailClient;
     ghostAccountOwner: User;
     pageWithAuthenticatedUser: {
         page: Page;
@@ -197,7 +203,7 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
         auto: true
     }],
 
-    _testEnvironmentContext: async ({config, isolation, labs, stripeEnabled, stripeServer}, use, testInfo: TestInfo) => {
+    _testEnvironmentContext: async ({config, isolation, labs, stripeEnabled, stripeServer, mailgunEnabled, mailgunServer}, use, testInfo: TestInfo) => {
         const environmentManager = await getEnvironmentManager();
         const requestedIsolation = getResolvedIsolation(testInfo, isolation);
         // Stripe-enabled tests boot Ghost against a per-test fake Stripe server,
@@ -209,7 +215,12 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
             STRIPE_API_PORT: String(stripeServer.port),
             STRIPE_API_PROTOCOL: 'http'
         } : {};
-        const mergedConfig = {...(config || {}), ...stripeConfig};
+        const mailgunConfig = mailgunEnabled && mailgunServer ? {
+            bulkEmail__mailgun__apiKey: 'fake-mailgun-api-key',
+            bulkEmail__mailgun__domain: 'fake.mailgun.test',
+            bulkEmail__mailgun__baseUrl: `http://host.docker.internal:${mailgunServer.port}/v3`
+        } : {};
+        const mergedConfig = {...(config || {}), ...stripeConfig, ...mailgunConfig};
         const stripe = stripeServer ? {
             secretKey: STRIPE_SECRET_KEY,
             publishableKey: STRIPE_PUBLISHABLE_KEY
@@ -320,6 +331,7 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
     isolation: [undefined, {option: true}],
     labs: [undefined, {option: true}],
     stripeEnabled: [false, {option: true}],
+    mailgunEnabled: [false, {option: true}],
 
     stripeServer: async ({stripeEnabled}, use) => {
         if (!stripeEnabled) {
@@ -337,6 +349,36 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
         debug('Fake Stripe server stopped');
     },
     
+    mailgunServer: async ({mailgunEnabled}, use) => {
+        if (!mailgunEnabled) {
+            await use(undefined);
+            return;
+        }
+
+        const server = new FakeMailgunServer();
+        await server.start();
+        debug('Fake Mailgun server started on port', server.port);
+
+        await use(server);
+
+        await server.stop();
+        debug('Fake Mailgun server stopped');
+    },
+
+    mailgun: async ({mailgunEnabled, mailgunServer}, use) => {
+        if (!mailgunEnabled || !mailgunServer) {
+            await use(undefined);
+            return;
+        }
+
+        const service = new MailgunTestService(mailgunServer);
+        await use(service);
+    },
+
+    emailClient: async ({}, use) => {
+        await use(new MailPit());
+    },
+
     ghostInstance: async ({_testEnvironmentContext}, use, testInfo: TestInfo) => {
         debug('Using Ghost instance for test:', {
             testTitle: testInfo.title,

--- a/e2e/helpers/services/fake-server.ts
+++ b/e2e/helpers/services/fake-server.ts
@@ -1,0 +1,56 @@
+import baseDebug from '@tryghost/debug';
+import express from 'express';
+import http from 'http';
+
+export abstract class FakeServer {
+    private server: http.Server | null = null;
+    protected readonly app = express();
+    private _port: number;
+    protected readonly debug: (...args: unknown[]) => void;
+
+    constructor(options: {port?: number; debugNamespace: string}) {
+        this._port = options.port ?? 0;
+        this.debug = baseDebug(options.debugNamespace);
+        this.app.use((req, _res, next) => {
+            this.debug(`${req.method} ${req.originalUrl}`);
+            next();
+        });
+        this.setupRoutes();
+    }
+
+    get port(): number {
+        return this._port;
+    }
+
+    async start(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.server = this.app.listen(this._port, () => {
+                const address = this.server?.address();
+
+                if (!address || typeof address === 'string') {
+                    reject(new Error(`${this.constructor.name} did not expose a TCP port`));
+                    return;
+                }
+
+                this._port = address.port;
+                resolve();
+            });
+            this.server.on('error', reject);
+        });
+    }
+
+    async stop(): Promise<void> {
+        return new Promise((resolve) => {
+            if (!this.server) {
+                resolve();
+                return;
+            }
+            this.server.close(() => {
+                this.server = null;
+                resolve();
+            });
+        });
+    }
+
+    protected abstract setupRoutes(): void;
+}

--- a/e2e/helpers/services/mailgun/fake-mailgun-server.ts
+++ b/e2e/helpers/services/mailgun/fake-mailgun-server.ts
@@ -1,9 +1,6 @@
-import baseDebug from '@tryghost/debug';
 import busboy from 'busboy';
 import express from 'express';
-import http from 'http';
-
-const debug = baseDebug('e2e:fake-mailgun');
+import {FakeServer} from '@/helpers/services/fake-server';
 
 export interface SentMessage {
     id: string;
@@ -35,21 +32,13 @@ interface MailPitSendRequest {
     Headers?: Record<string, string>;
 }
 
-export class FakeMailgunServer {
-    private server: http.Server | null = null;
-    private readonly app = express();
-    private _port: number;
+export class FakeMailgunServer extends FakeServer {
     private readonly _messages: SentMessage[] = [];
     private readonly mailpitUrl: string;
 
     constructor(options: {port?: number; mailpitUrl?: string} = {}) {
-        this._port = options.port ?? 0;
+        super({port: options.port, debugNamespace: 'e2e:fake-mailgun'});
         this.mailpitUrl = options.mailpitUrl ?? 'http://localhost:8025';
-        this.setupRoutes();
-    }
-
-    get port(): number {
-        return this._port;
     }
 
     get messages(): SentMessage[] {
@@ -60,48 +49,13 @@ export class FakeMailgunServer {
         this._messages.length = 0;
     }
 
-    async start(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            this.server = this.app.listen(this._port, () => {
-                const address = this.server?.address();
-
-                if (!address || typeof address === 'string') {
-                    reject(new Error('Fake Mailgun server did not expose a TCP port'));
-                    return;
-                }
-
-                this._port = address.port;
-                resolve();
-            });
-            this.server.on('error', reject);
-        });
-    }
-
-    async stop(): Promise<void> {
-        return new Promise((resolve) => {
-            if (!this.server) {
-                resolve();
-                return;
-            }
-            this.server.close(() => {
-                this.server = null;
-                resolve();
-            });
-        });
-    }
-
-    private setupRoutes(): void {
-        this.app.use((req, _res, next) => {
-            debug(`${req.method} ${req.originalUrl}`);
-            next();
-        });
-
+    protected setupRoutes(): void {
         this.app.post('/v3/:domain/messages', (req, res) => {
             this.handleSendMessage(req, res);
         });
 
         this.app.delete('/v3/:domain/suppressions/:type/:email', (req, res) => {
-            debug(`Suppression removal: ${req.params.type}/${req.params.email}`);
+            this.debug(`Suppression removal: ${req.params.type}/${req.params.email}`);
             res.status(200).json({message: 'Suppression removed'});
         });
 
@@ -110,7 +64,7 @@ export class FakeMailgunServer {
         });
 
         this.app.use((req, res) => {
-            debug(`Unhandled route: ${req.method} ${req.originalUrl}`);
+            this.debug(`Unhandled route: ${req.method} ${req.originalUrl}`);
             res.status(200).json({message: 'OK'});
         });
     }
@@ -145,7 +99,7 @@ export class FakeMailgunServer {
                     recipientVariables = JSON.parse(rvField);
                 }
             } catch {
-                debug('Failed to parse recipient-variables');
+                this.debug('Failed to parse recipient-variables');
             }
 
             const headers: Record<string, string> = {};
@@ -181,10 +135,10 @@ export class FakeMailgunServer {
             };
 
             this._messages.push(message);
-            debug(`Stored message ${messageId} to ${toArray.length} recipient(s) in domain ${domain}`);
+            this.debug(`Stored message ${messageId} to ${toArray.length} recipient(s) in domain ${domain}`);
 
             this.forwardToMailPit(message).catch((err) => {
-                debug('Failed to forward to MailPit:', err);
+                this.debug('Failed to forward to MailPit:', err);
             });
 
             res.status(200).json({
@@ -194,7 +148,7 @@ export class FakeMailgunServer {
         });
 
         bb.on('error', (err: Error) => {
-            debug('Busboy parse error:', err);
+            this.debug('Busboy parse error:', err);
             res.status(400).json({message: 'Failed to parse request'});
         });
 
@@ -245,12 +199,12 @@ export class FakeMailgunServer {
 
                 if (!response.ok) {
                     const responseBody = await response.text();
-                    debug(`MailPit forward failed for ${recipientEmail}: ${response.status} ${responseBody}`);
+                    this.debug(`MailPit forward failed for ${recipientEmail}: ${response.status} ${responseBody}`);
                 } else {
-                    debug(`Forwarded email to MailPit for ${recipientEmail}`);
+                    this.debug(`Forwarded email to MailPit for ${recipientEmail}`);
                 }
             } catch (err) {
-                debug(`MailPit forward error for ${recipientEmail}:`, err);
+                this.debug(`MailPit forward error for ${recipientEmail}:`, err);
             }
         }
     }

--- a/e2e/helpers/services/mailgun/fake-mailgun-server.ts
+++ b/e2e/helpers/services/mailgun/fake-mailgun-server.ts
@@ -1,0 +1,285 @@
+import baseDebug from '@tryghost/debug';
+import busboy from 'busboy';
+import express from 'express';
+import http from 'http';
+
+const debug = baseDebug('e2e:fake-mailgun');
+
+export interface SentMessage {
+    id: string;
+    domain: string;
+    from: string;
+    to: string[];
+    subject: string;
+    html: string;
+    text: string;
+    recipientVariables: Record<string, Record<string, string>>;
+    headers: Record<string, string>;
+    options: Record<string, string>;
+    customVars: Record<string, string>;
+    timestamp: Date;
+}
+
+interface MailPitAddress {
+    Name: string;
+    Email: string;
+}
+
+interface MailPitSendRequest {
+    From: MailPitAddress;
+    To: MailPitAddress[];
+    Subject: string;
+    HTML: string;
+    Text: string;
+    ReplyTo?: MailPitAddress[];
+    Headers?: Record<string, string>;
+}
+
+export class FakeMailgunServer {
+    private server: http.Server | null = null;
+    private readonly app = express();
+    private _port: number;
+    private readonly _messages: SentMessage[] = [];
+    private readonly mailpitUrl: string;
+
+    constructor(options: {port?: number; mailpitUrl?: string} = {}) {
+        this._port = options.port ?? 0;
+        this.mailpitUrl = options.mailpitUrl ?? 'http://localhost:8025';
+        this.setupRoutes();
+    }
+
+    get port(): number {
+        return this._port;
+    }
+
+    get messages(): SentMessage[] {
+        return [...this._messages];
+    }
+
+    clearMessages(): void {
+        this._messages.length = 0;
+    }
+
+    async start(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.server = this.app.listen(this._port, () => {
+                const address = this.server?.address();
+
+                if (!address || typeof address === 'string') {
+                    reject(new Error('Fake Mailgun server did not expose a TCP port'));
+                    return;
+                }
+
+                this._port = address.port;
+                resolve();
+            });
+            this.server.on('error', reject);
+        });
+    }
+
+    async stop(): Promise<void> {
+        return new Promise((resolve) => {
+            if (!this.server) {
+                resolve();
+                return;
+            }
+            this.server.close(() => {
+                this.server = null;
+                resolve();
+            });
+        });
+    }
+
+    private setupRoutes(): void {
+        this.app.use((req, _res, next) => {
+            debug(`${req.method} ${req.originalUrl}`);
+            next();
+        });
+
+        this.app.post('/v3/:domain/messages', (req, res) => {
+            this.handleSendMessage(req, res);
+        });
+
+        this.app.delete('/v3/:domain/suppressions/:type/:email', (req, res) => {
+            debug(`Suppression removal: ${req.params.type}/${req.params.email}`);
+            res.status(200).json({message: 'Suppression removed'});
+        });
+
+        this.app.get('/v3/:domain/events', (_req, res) => {
+            res.status(200).json({items: [], paging: {}});
+        });
+
+        this.app.use((req, res) => {
+            debug(`Unhandled route: ${req.method} ${req.originalUrl}`);
+            res.status(200).json({message: 'OK'});
+        });
+    }
+
+    private handleSendMessage(req: express.Request, res: express.Response): void {
+        const domain = req.params.domain;
+        const fields: Record<string, string | string[]> = {};
+
+        const bb = busboy({headers: req.headers});
+
+        bb.on('field', (name: string, val: string) => {
+            if (name in fields) {
+                const existing = fields[name];
+                if (Array.isArray(existing)) {
+                    existing.push(val);
+                } else {
+                    fields[name] = [existing, val];
+                }
+            } else {
+                fields[name] = val;
+            }
+        });
+
+        bb.on('close', () => {
+            const toField = fields.to;
+            const toArray = Array.isArray(toField) ? toField : (typeof toField === 'string' ? toField.split(',').map(e => e.trim()) : []);
+
+            let recipientVariables: Record<string, Record<string, string>> = {};
+            try {
+                const rvField = fields['recipient-variables'];
+                if (typeof rvField === 'string' && rvField) {
+                    recipientVariables = JSON.parse(rvField);
+                }
+            } catch {
+                debug('Failed to parse recipient-variables');
+            }
+
+            const headers: Record<string, string> = {};
+            const options: Record<string, string> = {};
+            const customVars: Record<string, string> = {};
+
+            for (const [key, value] of Object.entries(fields)) {
+                const strValue = Array.isArray(value) ? value.join(', ') : value;
+                if (key.startsWith('h:')) {
+                    headers[key.slice(2)] = strValue;
+                } else if (key.startsWith('o:')) {
+                    options[key.slice(2)] = strValue;
+                } else if (key.startsWith('v:')) {
+                    customVars[key.slice(2)] = strValue;
+                }
+            }
+
+            const messageId = `<${Date.now()}.${Math.random().toString(36).slice(2)}@${domain}>`;
+
+            const message: SentMessage = {
+                id: messageId,
+                domain,
+                from: this.getStringField(fields, 'from'),
+                to: toArray,
+                subject: this.getStringField(fields, 'subject'),
+                html: this.getStringField(fields, 'html'),
+                text: this.getStringField(fields, 'text'),
+                recipientVariables,
+                headers,
+                options,
+                customVars,
+                timestamp: new Date()
+            };
+
+            this._messages.push(message);
+            debug(`Stored message ${messageId} to ${toArray.length} recipient(s) in domain ${domain}`);
+
+            this.forwardToMailPit(message).catch((err) => {
+                debug('Failed to forward to MailPit:', err);
+            });
+
+            res.status(200).json({
+                id: messageId,
+                message: 'Queued. Thank you.'
+            });
+        });
+
+        bb.on('error', (err: Error) => {
+            debug('Busboy parse error:', err);
+            res.status(400).json({message: 'Failed to parse request'});
+        });
+
+        req.pipe(bb);
+    }
+
+    private async forwardToMailPit(message: SentMessage): Promise<void> {
+        const fromParsed = this.parseEmailAddress(message.from);
+
+        for (const recipientEmail of message.to) {
+            const recipientVars = message.recipientVariables[recipientEmail] || {};
+            const personalizedHtml = this.resolveRecipientVariables(message.html, recipientVars);
+            const personalizedText = this.resolveRecipientVariables(message.text, recipientVars);
+            const personalizedSubject = this.resolveRecipientVariables(message.subject, recipientVars);
+
+            // MailPit rejects reserved headers (Reply-To, Sender, etc.) in the
+            // generic Headers map — extract them to dedicated fields instead.
+            const reservedHeaders = new Set(['Reply-To', 'Sender', 'From', 'To', 'Subject', 'Date']);
+            const filteredHeaders: Record<string, string> = {
+                'X-Mailgun-Message-Id': message.id
+            };
+            const replyToAddresses: MailPitAddress[] = [];
+
+            for (const [key, value] of Object.entries(message.headers)) {
+                if (key === 'Reply-To' && value) {
+                    replyToAddresses.push(this.parseEmailAddress(value));
+                } else if (!reservedHeaders.has(key)) {
+                    filteredHeaders[key] = value;
+                }
+            }
+
+            const mailpitPayload: MailPitSendRequest = {
+                From: fromParsed,
+                To: [{Name: recipientVars.name || '', Email: recipientEmail}],
+                Subject: personalizedSubject,
+                HTML: personalizedHtml,
+                Text: personalizedText,
+                ...(replyToAddresses.length > 0 ? {ReplyTo: replyToAddresses} : {}),
+                Headers: filteredHeaders
+            };
+
+            try {
+                const response = await fetch(`${this.mailpitUrl}/api/v1/send`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify(mailpitPayload)
+                });
+
+                if (!response.ok) {
+                    const responseBody = await response.text();
+                    debug(`MailPit forward failed for ${recipientEmail}: ${response.status} ${responseBody}`);
+                } else {
+                    debug(`Forwarded email to MailPit for ${recipientEmail}`);
+                }
+            } catch (err) {
+                debug(`MailPit forward error for ${recipientEmail}:`, err);
+            }
+        }
+    }
+
+    private resolveRecipientVariables(content: string, variables: Record<string, string>): string {
+        if (!content) {
+            return content;
+        }
+
+        return content.replace(/%recipient\.([^%]+)%/g, (_match, varName: string) => {
+            return variables[varName] ?? `%recipient.${varName}%`;
+        });
+    }
+
+    private parseEmailAddress(address: string): MailPitAddress {
+        const match = address.match(/^(.+?)\s*<(.+?)>$/);
+        if (match) {
+            return {Name: match[1].trim(), Email: match[2].trim()};
+        }
+
+        return {Name: '', Email: address.trim()};
+    }
+
+    private getStringField(fields: Record<string, string | string[]>, key: string): string {
+        const value = fields[key];
+        if (Array.isArray(value)) {
+            return value[0] || '';
+        }
+
+        return value || '';
+    }
+}

--- a/e2e/helpers/services/mailgun/fake-mailgun-server.ts
+++ b/e2e/helpers/services/mailgun/fake-mailgun-server.ts
@@ -117,7 +117,7 @@ export class FakeMailgunServer extends FakeServer {
                 }
             }
 
-            const messageId = `<${Date.now()}.${Math.random().toString(36).slice(2)}@${domain}>`;
+            const messageId = `<${Date.now()}.${crypto.randomUUID()}@${domain}>`;
 
             const message: SentMessage = {
                 id: messageId,
@@ -220,7 +220,7 @@ export class FakeMailgunServer extends FakeServer {
     }
 
     private parseEmailAddress(address: string): MailPitAddress {
-        const match = address.match(/^(.+?)\s*<(.+?)>$/);
+        const match = address.match(/^([^<]+)<([^>]+)>$/);
         if (match) {
             return {Name: match[1].trim(), Email: match[2].trim()};
         }

--- a/e2e/helpers/services/mailgun/index.ts
+++ b/e2e/helpers/services/mailgun/index.ts
@@ -1,0 +1,3 @@
+export {FakeMailgunServer} from './fake-mailgun-server';
+export type {SentMessage} from './fake-mailgun-server';
+export {MailgunTestService} from './mailgun-service';

--- a/e2e/helpers/services/mailgun/mailgun-service.ts
+++ b/e2e/helpers/services/mailgun/mailgun-service.ts
@@ -1,0 +1,46 @@
+import {type FakeMailgunServer, type SentMessage} from './fake-mailgun-server';
+
+export class MailgunTestService {
+    private readonly server: FakeMailgunServer;
+
+    constructor(server: FakeMailgunServer) {
+        this.server = server;
+    }
+
+    getMessages(): SentMessage[] {
+        return this.server.messages;
+    }
+
+    getLastMessage(): SentMessage | undefined {
+        const messages = this.server.messages;
+        return messages[messages.length - 1];
+    }
+
+    getMessageCount(): number {
+        return this.server.messages.length;
+    }
+
+    getMessagesForRecipient(email: string): SentMessage[] {
+        return this.server.messages.filter(m => m.to.includes(email));
+    }
+
+    async waitForMessages(count: number = 1, timeoutMs: number = 30000): Promise<SentMessage[]> {
+        const startTime = Date.now();
+
+        while (Date.now() - startTime < timeoutMs) {
+            const messages = this.getMessages();
+            if (messages.length >= count) {
+                return messages;
+            }
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 500);
+            });
+        }
+
+        throw new Error(`Timeout after ${timeoutMs}ms waiting for ${count} Mailgun message(s), got ${this.getMessageCount()}`);
+    }
+
+    clearMessages(): void {
+        this.server.clearMessages();
+    }
+}

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -1,6 +1,5 @@
-import baseDebug from '@tryghost/debug';
 import express from 'express';
-import http from 'http';
+import {FakeServer} from '@/helpers/services/fake-server';
 import {
     type RecordedStripeCheckoutSession,
     type StripeCoupon,
@@ -17,12 +16,7 @@ import {
 } from './builders';
 import {renderFakeCheckoutPage, renderFakeDonationCheckoutPage} from './fake-checkout-page-renderer';
 
-const debug = baseDebug('e2e:fake-stripe');
-
-export class FakeStripeServer {
-    private server: http.Server | null = null;
-    private readonly app = express();
-    private _port: number;
+export class FakeStripeServer extends FakeServer {
     private readonly products: Map<string, StripeProduct> = new Map();
     private readonly prices: Map<string, StripePrice> = new Map();
     private readonly coupons: Map<string, StripeCoupon> = new Map();
@@ -32,12 +26,7 @@ export class FakeStripeServer {
     private readonly checkoutSessions: Map<string, RecordedStripeCheckoutSession> = new Map();
 
     constructor(port = 0) {
-        this._port = port;
-        this.setupRoutes();
-    }
-
-    get port(): number {
-        return this._port;
+        super({port, debugNamespace: 'e2e:fake-stripe'});
     }
 
     upsertProduct(product: StripeProduct): void {
@@ -92,56 +81,21 @@ export class FakeStripeServer {
         return Array.from(this.checkoutSessions.values());
     }
 
-    async start(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            this.server = this.app.listen(this._port, () => {
-                const address = this.server?.address();
-
-                if (!address || typeof address === 'string') {
-                    reject(new Error('Fake Stripe server did not expose a TCP port'));
-                    return;
-                }
-
-                this._port = address.port;
-                resolve();
-            });
-            this.server.on('error', reject);
-        });
-    }
-
-    async stop(): Promise<void> {
-        return new Promise((resolve) => {
-            if (!this.server) {
-                resolve();
-                return;
-            }
-            this.server.close(() => {
-                this.server = null;
-                resolve();
-            });
-        });
-    }
-
-    private setupRoutes(): void {
+    protected setupRoutes(): void {
         this.app.use(express.json());
         this.app.use(express.urlencoded({extended: true}));
-
-        this.app.use((req, _res, next) => {
-            debug(`${req.method} ${req.originalUrl}`);
-            next();
-        });
 
         this.app.get('/v1/products/:id', (req, res) => {
             const productId = req.params.id;
             const product = this.products.get(productId);
 
             if (!product) {
-                debug(`Product not found: ${productId}`);
+                this.debug(`Product not found: ${productId}`);
                 res.status(404).json({error: {type: 'invalid_request_error', message: 'No such product'}});
                 return;
             }
 
-            debug(`Returning product: ${productId}`);
+            this.debug(`Returning product: ${productId}`);
             res.status(200).json(product);
         });
 
@@ -152,7 +106,7 @@ export class FakeStripeServer {
             });
 
             this.upsertProduct(product);
-            debug(`Created product: ${product.id} (${product.name})`);
+            this.debug(`Created product: ${product.id} (${product.name})`);
             res.status(200).json(product);
         });
 
@@ -161,12 +115,12 @@ export class FakeStripeServer {
             const price = this.prices.get(priceId);
 
             if (!price) {
-                debug(`Price not found: ${priceId}`);
+                this.debug(`Price not found: ${priceId}`);
                 res.status(404).json({error: {type: 'invalid_request_error', message: 'No such price'}});
                 return;
             }
 
-            debug(`Returning price: ${priceId}`);
+            this.debug(`Returning price: ${priceId}`);
             res.status(200).json(price);
         });
 
@@ -176,7 +130,7 @@ export class FakeStripeServer {
             const customUnitAmount = this.parseCustomUnitAmount(req.body.custom_unit_amount);
 
             if (requestedProductId && !this.products.has(requestedProductId)) {
-                debug(`Cannot create price for missing product: ${requestedProductId}`);
+                this.debug(`Cannot create price for missing product: ${requestedProductId}`);
                 res.status(400).json({error: {type: 'invalid_request_error', message: 'No such product'}});
                 return;
             }
@@ -200,7 +154,7 @@ export class FakeStripeServer {
             });
 
             this.upsertPrice(price);
-            debug(`Created price: ${price.id} (${price.nickname ?? 'unnamed'})`);
+            this.debug(`Created price: ${price.id} (${price.nickname ?? 'unnamed'})`);
             res.status(200).json(price);
         });
 
@@ -209,7 +163,7 @@ export class FakeStripeServer {
             const customer = this.customers.get(customerId);
 
             if (!customer) {
-                debug(`Customer not found: ${customerId}`);
+                this.debug(`Customer not found: ${customerId}`);
                 res.status(404).json({error: {type: 'invalid_request_error', message: 'No such customer'}});
                 return;
             }
@@ -231,7 +185,7 @@ export class FakeStripeServer {
                 }
             };
 
-            debug(`Returning customer: ${customerId} with ${customerSubscriptions.length} subscription(s)`);
+            this.debug(`Returning customer: ${customerId} with ${customerSubscriptions.length} subscription(s)`);
             res.status(200).json(response);
         });
 
@@ -242,7 +196,7 @@ export class FakeStripeServer {
             });
 
             this.upsertCustomer(customer);
-            debug(`Created customer: ${customer.id} (${customer.email})`);
+            this.debug(`Created customer: ${customer.id} (${customer.email})`);
             res.status(200).json(customer);
         });
 
@@ -323,7 +277,7 @@ export class FakeStripeServer {
             });
 
             this.upsertCoupon(coupon);
-            debug(`Created coupon: ${coupon.id}`);
+            this.debug(`Created coupon: ${coupon.id}`);
             res.status(200).json(coupon);
         });
 
@@ -332,7 +286,7 @@ export class FakeStripeServer {
             const subscription = this.subscriptions.get(subscriptionId);
 
             if (!subscription) {
-                debug(`Subscription not found: ${subscriptionId}`);
+                this.debug(`Subscription not found: ${subscriptionId}`);
                 res.status(404).json({error: {type: 'invalid_request_error', message: 'No such subscription'}});
                 return;
             }
@@ -350,7 +304,7 @@ export class FakeStripeServer {
                 }
             }
 
-            debug(`Returning subscription: ${subscriptionId} (expand: ${expand.join(', ') || 'none'})`);
+            this.debug(`Returning subscription: ${subscriptionId} (expand: ${expand.join(', ') || 'none'})`);
             res.status(200).json(response);
         });
 
@@ -359,7 +313,7 @@ export class FakeStripeServer {
             const subscription = this.subscriptions.get(subscriptionId);
 
             if (!subscription) {
-                debug(`Subscription not found for update: ${subscriptionId}`);
+                this.debug(`Subscription not found for update: ${subscriptionId}`);
                 res.status(404).json({error: {type: 'invalid_request_error', message: 'No such subscription'}});
                 return;
             }
@@ -379,7 +333,7 @@ export class FakeStripeServer {
 
             if (defaultPaymentMethod !== undefined) {
                 if (defaultPaymentMethod !== '' && !this.paymentMethods.has(defaultPaymentMethod)) {
-                    debug(`Cannot update subscription ${subscriptionId} with missing payment method: ${defaultPaymentMethod}`);
+                    this.debug(`Cannot update subscription ${subscriptionId} with missing payment method: ${defaultPaymentMethod}`);
                     res.status(400).json({error: {type: 'invalid_request_error', message: 'No such payment method'}});
                     return;
                 }
@@ -418,7 +372,7 @@ export class FakeStripeServer {
                 })?.price;
 
                 if (missingPriceId) {
-                    debug(`Cannot update subscription ${subscriptionId} with missing price: ${missingPriceId}`);
+                    this.debug(`Cannot update subscription ${subscriptionId} with missing price: ${missingPriceId}`);
                     res.status(400).json({error: {type: 'invalid_request_error', message: 'No such price'}});
                     return;
                 }
@@ -430,7 +384,7 @@ export class FakeStripeServer {
             }
 
             this.upsertSubscription(updatedSubscription);
-            debug(`Updated subscription: ${subscriptionId}`);
+            this.debug(`Updated subscription: ${subscriptionId}`);
             res.status(200).json(updatedSubscription);
         });
 
@@ -439,7 +393,7 @@ export class FakeStripeServer {
             const subscription = this.subscriptions.get(subscriptionId);
 
             if (!subscription) {
-                debug(`Subscription not found for delete: ${subscriptionId}`);
+                this.debug(`Subscription not found for delete: ${subscriptionId}`);
                 res.status(404).json({error: {type: 'invalid_request_error', message: 'No such subscription'}});
                 return;
             }
@@ -452,7 +406,7 @@ export class FakeStripeServer {
             };
 
             this.upsertSubscription(canceledSubscription);
-            debug(`Deleted subscription: ${subscriptionId}`);
+            this.debug(`Deleted subscription: ${subscriptionId}`);
             res.status(200).json(canceledSubscription);
         });
 
@@ -461,12 +415,12 @@ export class FakeStripeServer {
             const paymentMethod = this.paymentMethods.get(paymentMethodId);
 
             if (!paymentMethod) {
-                debug(`Payment method not found: ${paymentMethodId}`);
+                this.debug(`Payment method not found: ${paymentMethodId}`);
                 res.status(404).json({error: {type: 'invalid_request_error', message: 'No such payment method'}});
                 return;
             }
 
-            debug(`Returning payment method: ${paymentMethodId}`);
+            this.debug(`Returning payment method: ${paymentMethodId}`);
             res.status(200).json(paymentMethod);
         });
 
@@ -478,7 +432,7 @@ export class FakeStripeServer {
             })?.coupon;
 
             if (missingCouponId) {
-                debug(`Cannot create checkout session with missing coupon: ${missingCouponId}`);
+                this.debug(`Cannot create checkout session with missing coupon: ${missingCouponId}`);
                 res.status(400).json({error: {type: 'invalid_request_error', message: 'No such coupon'}});
                 return;
             }
@@ -502,9 +456,9 @@ export class FakeStripeServer {
                 }
             });
 
-            session.response.url = `http://localhost:${this._port}/checkout/sessions/${session.response.id}`;
+            session.response.url = `http://localhost:${this.port}/checkout/sessions/${session.response.id}`;
             this.upsertCheckoutSession(session);
-            debug(`Created checkout session: ${session.response.id} (${session.response.mode})`);
+            this.debug(`Created checkout session: ${session.response.id} (${session.response.mode})`);
             res.status(200).json(session.response);
         });
 
@@ -540,12 +494,12 @@ export class FakeStripeServer {
 
         this.app.post('/v1/billing_portal/configurations/:id?', (req, res) => {
             const id = req.params.id || 'bpc_fake';
-            debug(`Returning billing portal configuration: ${id}`);
+            this.debug(`Returning billing portal configuration: ${id}`);
             res.status(200).json({id, object: 'billing_portal.configuration'});
         });
 
         this.app.use((req, res) => {
-            debug(`Unhandled route: ${req.method} ${req.originalUrl} — returning fallback`);
+            this.debug(`Unhandled route: ${req.method} ${req.originalUrl} — returning fallback`);
             res.status(200).json({id: 'fake', object: 'unknown'});
         });
     }

--- a/e2e/tests/admin/posts/newsletter-send.test.ts
+++ b/e2e/tests/admin/posts/newsletter-send.test.ts
@@ -1,0 +1,49 @@
+import {APIRequestContext} from '@playwright/test';
+import {PostEditorPage, PostsPage} from '@/admin-pages';
+import {createMemberFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+usePerTestIsolation();
+
+async function getNewsletters(request: APIRequestContext): Promise<{id: string}[]> {
+    const response = await request.get('/ghost/api/admin/newsletters/?status=active&limit=all');
+    const data = await response.json();
+    return data.newsletters.map((n: {id: string}) => ({id: n.id}));
+}
+
+test.describe('Ghost Admin - Newsletter Send', () => {
+    test.use({mailgunEnabled: true});
+
+    test('publish and send newsletter - email is delivered to member', async ({page, emailClient}) => {
+        const memberFactory = createMemberFactory(page.request);
+        const newsletters = await getNewsletters(page.request);
+        const member = await memberFactory.create({
+            name: 'Newsletter Recipient',
+            email: 'newsletter-test@example.com',
+            newsletters: newsletters as never
+        });
+
+        const postsPage = new PostsPage(page);
+        await postsPage.goto();
+        await postsPage.newPostButton.click();
+
+        const editor = new PostEditorPage(page);
+        await editor.titleInput.fill('Test Newsletter Post');
+        await editor.titleInput.press('Enter');
+        await expect(editor.postStatus).toContainText('Draft - Saved');
+
+        await editor.publishFlow.open();
+        await editor.publishFlow.selectPublishType('publish+send');
+        await editor.publishFlow.confirm();
+
+        const delivered = await emailClient.search(
+            {to: member.email, subject: 'Test Newsletter Post'},
+            {timeoutMs: 30_000}
+        );
+        expect(delivered.length).toBeGreaterThanOrEqual(1);
+
+        const detail = await emailClient.getMessageDetailed(delivered[0]);
+        expect(detail.HTML).toContain('Test Newsletter Post');
+    });
+});

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -9,3 +9,36 @@ declare module '@tryghost/debug' {
     function debug(namespace: string): (...args: unknown[]) => void;
     export = debug;
 }
+
+declare module 'busboy' {
+    import {IncomingHttpHeaders} from 'http';
+    import {Writable} from 'stream';
+
+    interface BusboyConfig {
+        headers: IncomingHttpHeaders;
+        highWaterMark?: number;
+        fileHwm?: number;
+        defCharset?: string;
+        preservePath?: boolean;
+        limits?: {
+            fieldNameSize?: number;
+            fieldSize?: number;
+            fields?: number;
+            fileSize?: number;
+            files?: number;
+            parts?: number;
+            headerPairs?: number;
+        };
+    }
+
+    interface Busboy extends Writable {
+        on(event: 'field', listener: (name: string, val: string, info: {nameTruncated: boolean; valueTruncated: boolean; encoding: string; mimeType: string}) => void): this;
+        on(event: 'file', listener: (name: string, file: NodeJS.ReadableStream, info: {filename: string; encoding: string; mimeType: string}) => void): this;
+        on(event: 'close', listener: () => void): this;
+        on(event: 'error', listener: (err: Error) => void): this;
+        on(event: string, listener: (...args: unknown[]) => void): this;
+    }
+
+    function busboy(config: BusboyConfig): Busboy;
+    export = busboy;
+}


### PR DESCRIPTION
## Summary
- Adds a fake Mailgun HTTP server (following the fake Stripe server pattern) that accepts newsletter email batches from Ghost and forwards personalized emails to MailPit for test assertions
- Adds `mailgunEnabled` fixture to configure Ghost's `bulkEmail.mailgun.*` settings to point at the fake server
- Adds `emailClient` fixture providing a shared MailPit client to any test
- Extends `PublishFlow` page object with `selectPublishType()` and `confirm()` methods
- Includes a smoke test that publishes a newsletter post and verifies email delivery end-to-end via MailPit

## Context
Bulk newsletter sends go through the Mailgun API, bypassing SMTP/MailPit entirely. The root e2e framework runs Ghost in Docker containers where in-process mocking (`sinon.stub`) isn't possible. This fake server bridges that gap, enabling migration of the remaining `publishing.spec.js` browser tests.

## Test plan
- [x] `yarn test tests/admin/posts/newsletter-send.test.ts` passes
- [x] `yarn lint` clean (0 errors)
- [x] `yarn test:types` clean