### PR TITLE
Disabled transistor.fm integration when limited by host

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations.tsx
@@ -23,6 +23,16 @@ interface IntegrationItemProps {
     custom?: boolean;
 }
 
+interface BuiltInIntegrationItem {
+    active?: boolean;
+    detail: string;
+    disabled?: boolean;
+    icon: React.ReactNode;
+    modal: string;
+    testId: string;
+    title: string;
+}
+
 const IntegrationItem: React.FC<IntegrationItemProps> = ({
     icon,
     title,
@@ -80,7 +90,7 @@ const BuiltInIntegrations: React.FC = () => {
         updateRoute(modal);
     };
 
-    const zapierDisabled = config.hostSettings?.limits?.customIntegrations?.disabled;
+    const builtInApiIntegrationsDisabled = config.hostSettings?.limits?.customIntegrations?.disabled;
     const transistorFeatureEnabled = useFeatureFlag('transistor');
 
     const pinturaEditor = usePinturaEditor();
@@ -94,79 +104,86 @@ const BuiltInIntegrations: React.FC = () => {
         'transistor'
     ]);
 
+    const items: BuiltInIntegrationItem[] = [
+        {
+            detail: 'Automation for your apps',
+            disabled: builtInApiIntegrationsDisabled,
+            icon: <Icon name='zapier' size={32} />,
+            modal: 'integrations/zapier',
+            testId: 'zapier-integration',
+            title: 'Zapier'
+        },
+        {
+            active: !!(slackUrl && slackUsername),
+            detail: 'A messaging app for teams',
+            icon: <Icon name='slack' size={32} />,
+            modal: 'integrations/slack',
+            testId: 'slack-integration',
+            title: 'Slack'
+        },
+        {
+            active: !!unsplashEnabled,
+            detail: 'Beautiful, free photos',
+            icon: <Icon name='unsplash' size={32} />,
+            modal: 'integrations/unsplash',
+            testId: 'unsplash-integration',
+            title: 'Unsplash'
+        },
+        {
+            active: !!firstPromoterEnabled,
+            detail: 'Launch your member referral program',
+            icon: <Icon name='firstpromoter' size={32} />,
+            modal: 'integrations/firstpromoter',
+            testId: 'firstpromoter-integration',
+            title: 'FirstPromoter'
+        },
+        {
+            active: pinturaEditor.isEnabled,
+            detail: 'Advanced image editing',
+            icon: <Icon name='pintura' size={32} />,
+            modal: 'integrations/pintura',
+            testId: 'pintura-integration',
+            title: 'Pintura'
+        },
+        ...(transistorFeatureEnabled ? [{
+            active: !!transistorEnabled,
+            detail: 'Give your members access to private podcasts',
+            disabled: builtInApiIntegrationsDisabled,
+            icon: <Icon name='transistor' size={32} />,
+            modal: 'integrations/transistor',
+            testId: 'transistor-integration',
+            title: 'Transistor.fm'
+        }] : []),
+        {
+            detail: 'Access your content programmatically',
+            icon: <Icon name='angle-brackets' size={32} />,
+            modal: 'integrations/contentapi',
+            testId: 'content-api-integration',
+            title: 'Content API'
+        }
+    ];
+
+    const sortedItems = [
+        ...items.filter(item => !item.disabled),
+        ...items.filter(item => item.disabled)
+    ];
+
     return (
         <List titleSeparator={false}>
-            <IntegrationItem
-                action={() => {
-                    openModal('integrations/zapier');
-                }}
-                detail='Automation for your apps'
-                disabled={zapierDisabled}
-                icon={<Icon name='zapier' size={32} />}
-                testId='zapier-integration'
-                title='Zapier' />
-
-            <IntegrationItem
-                action={() => {
-                    openModal('integrations/slack');
-                }}
-                active={slackUrl && slackUsername}
-                detail='A messaging app for teams'
-                icon={<Icon name='slack' size={32} />}
-                testId='slack-integration'
-                title='Slack' />
-
-            <IntegrationItem
-                action={() => {
-                    openModal('integrations/unsplash');
-                }}
-                active={unsplashEnabled}
-                detail='Beautiful, free photos'
-                icon={<Icon name='unsplash' size={32} />}
-                testId='unsplash-integration'
-                title='Unsplash' />
-
-            <IntegrationItem
-                action={() => {
-                    openModal('integrations/firstpromoter');
-                }}
-                active={firstPromoterEnabled}
-                detail='Launch your member referral program'
-                icon={<Icon name='firstpromoter' size={32} />}
-                testId='firstpromoter-integration'
-                title='FirstPromoter' />
-
-            <IntegrationItem
-                action={() => {
-                    openModal('integrations/pintura');
-                }}
-                active={pinturaEditor.isEnabled}
-                detail='Advanced image editing'
-                icon={<Icon name='pintura' size={32} />}
-                testId='pintura-integration'
-                title='Pintura' />
-
-            {transistorFeatureEnabled && (
+            {sortedItems.map(item => (
                 <IntegrationItem
+                    key={item.testId}
                     action={() => {
-                        openModal('integrations/transistor');
+                        openModal(item.modal);
                     }}
-                    active={transistorEnabled}
-                    detail='Give your members access to private podcasts'
-                    icon={<Icon name='transistor' size={32} />}
-                    testId='transistor-integration'
-                    title='Transistor.fm' />
-            )}
-
-            <IntegrationItem
-                action={() => {
-                    openModal('integrations/contentapi');
-                }}
-                detail='Access your content programmatically'
-                icon={<Icon name='angle-brackets' size={32} />}
-                testId='content-api-integration'
-                title='Content API' />
-
+                    active={item.active}
+                    detail={item.detail}
+                    disabled={item.disabled}
+                    icon={item.icon}
+                    testId={item.testId}
+                    title={item.title}
+                />
+            ))}
         </List>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/transistor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/transistor-modal.tsx
@@ -14,7 +14,7 @@ import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 const TransistorModal = NiceModal.create(() => {
     const {updateRoute} = useRouting();
-    const {settings} = useGlobalData();
+    const {config, settings} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();
     const {data: {integrations} = {integrations: []}} = useBrowseIntegrations();
 
@@ -22,6 +22,7 @@ const TransistorModal = NiceModal.create(() => {
     const handleError = useHandleError();
     const [regenerated, setRegenerated] = useState(false);
 
+    const builtInApiIntegrationsDisabled = config.hostSettings?.limits?.customIntegrations?.disabled;
     const [transistorEnabled] = getSettingValues<boolean>(settings, ['transistor']);
     const [enabled, setEnabled] = useState<boolean>(!!transistorEnabled);
     const [okLabel, setOkLabel] = useState('Save');
@@ -29,6 +30,12 @@ const TransistorModal = NiceModal.create(() => {
     useEffect(() => {
         setEnabled(transistorEnabled || false);
     }, [transistorEnabled]);
+
+    useEffect(() => {
+        if (builtInApiIntegrationsDisabled) {
+            updateRoute('integrations');
+        }
+    }, [builtInApiIntegrationsDisabled, updateRoute]);
 
     const integration = integrations.find(({slug}) => slug === 'transistor');
     const adminApiKey = integration?.api_keys?.find(key => key.type === 'admin');

--- a/apps/admin-x-settings/test/acceptance/advanced/integrations/transistor.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/integrations/transistor.test.ts
@@ -1,0 +1,78 @@
+import {expect, test} from '@playwright/test';
+import {globalDataRequests, mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
+
+test.describe('Transistor integration settings', async () => {
+    test('Disabled by configured limitations', async ({page}) => {
+        await mockApi({page, requests: {...globalDataRequests, browseConfig: {
+            ...globalDataRequests.browseConfig,
+            response: {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        ...responseFixtures.config.config.labs,
+                        transistor: true
+                    },
+                    hostSettings: {
+                        limits: {
+                            customIntegrations: {
+                                disabled: true
+                            }
+                        }
+                    }
+                }
+            }
+        }}});
+
+        await page.goto('/');
+
+        const integrationsSection = page.getByTestId('integrations');
+
+        await integrationsSection.getByTestId('transistor-integration').hover();
+        await expect(integrationsSection.getByTestId('transistor-integration').getByRole('button', {name: 'Upgrade'})).toHaveCount(1);
+    });
+
+    test('Disabled integrations sort to the bottom while keeping their relative order', async ({page}) => {
+        await mockApi({page, requests: {...globalDataRequests, browseConfig: {
+            ...globalDataRequests.browseConfig,
+            response: {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        ...responseFixtures.config.config.labs,
+                        transistor: true
+                    },
+                    hostSettings: {
+                        limits: {
+                            customIntegrations: {
+                                disabled: true
+                            }
+                        }
+                    }
+                }
+            }
+        }}});
+
+        await page.goto('/');
+
+        const integrationsSection = page.getByTestId('integrations');
+        const integrationOrder = await integrationsSection.locator([
+            '[data-testid="zapier-integration"]',
+            '[data-testid="slack-integration"]',
+            '[data-testid="unsplash-integration"]',
+            '[data-testid="firstpromoter-integration"]',
+            '[data-testid="pintura-integration"]',
+            '[data-testid="transistor-integration"]',
+            '[data-testid="content-api-integration"]'
+        ].join(', ')).evaluateAll(elements => elements.map(element => element.getAttribute('data-testid')));
+
+        expect(integrationOrder).toEqual([
+            'slack-integration',
+            'unsplash-integration',
+            'firstpromoter-integration',
+            'pintura-integration',
+            'content-api-integration',
+            'zapier-integration',
+            'transistor-integration'
+        ]);
+    });
+});

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -72,6 +72,8 @@ export interface GhostConfig {
     hostSettings__billing__enabled?: string;
     hostSettings__billing__url?: string;
     hostSettings__forceUpgrade?: string;
+    hostSettings__limits__customIntegrations__disabled?: string;
+    hostSettings__limits__customIntegrations__error?: string;
 }
 
 export interface GhostInstanceFixture {

--- a/e2e/tests/admin/settings/integrations-host-settings.test.ts
+++ b/e2e/tests/admin/settings/integrations-host-settings.test.ts
@@ -1,0 +1,54 @@
+import {SettingsPage} from '@/admin-pages';
+import {SettingsResponse, SettingsService} from '@/helpers/services/settings/settings-service';
+import {expect, test} from '@/helpers/playwright';
+
+test.describe('Ghost Admin - Integration Host Settings', () => {
+    test.use({
+        config: {
+            hostSettings__limits__customIntegrations__disabled: 'true',
+            hostSettings__limits__customIntegrations__error: 'Custom limit error message'
+        },
+        labs: {
+            transistor: true
+        }
+    });
+
+    test('Zapier shows upgrade when custom integrations are limited', async ({page}) => {
+        const settingsPage = new SettingsPage(page);
+
+        await settingsPage.integrationsSection.goto();
+
+        const zapierIntegration = page.getByTestId('zapier-integration');
+
+        await expect(zapierIntegration).toBeVisible();
+        await expect(zapierIntegration.getByRole('button', {name: 'Upgrade'})).toBeVisible();
+        await expect(zapierIntegration.getByRole('button', {name: 'Configure'})).toHaveCount(0);
+    });
+
+    test('Transistor shows upgrade when custom integrations are limited', async ({page}) => {
+        const settingsPage = new SettingsPage(page);
+
+        await settingsPage.integrationsSection.goto();
+
+        const transistorIntegration = page.getByTestId('transistor-integration');
+
+        await expect(transistorIntegration).toBeVisible();
+        await expect(transistorIntegration.getByRole('button', {name: 'Upgrade'})).toBeVisible();
+        await expect(transistorIntegration.getByRole('button', {name: 'Configure'})).toHaveCount(0);
+    });
+
+    test('Transistor reads as disabled in admin settings when custom integrations are limited', async ({page}) => {
+        const settingsService = new SettingsService(page.request);
+
+        await settingsService.updateSettings([{key: 'transistor', value: true}]);
+
+        const response = await page.request.get('/ghost/api/admin/settings/');
+        expect(response.ok()).toBe(true);
+
+        const data = await response.json() as SettingsResponse;
+        const transistorSetting = data.settings.find(s => s.key === 'transistor');
+
+        expect(transistorSetting).toBeDefined();
+        expect(transistorSetting?.value).toBe(false);
+    });
+});

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -23,6 +23,18 @@ const MAGIC_LINK_TOKEN_VALIDITY = 24 * 60 * 60 * 1000;
 const MAGIC_LINK_TOKEN_VALIDITY_AFTER_USAGE = 10 * 60 * 1000;
 const MAGIC_LINK_TOKEN_MAX_USAGE_COUNT = 7;
 
+const getSettingsOverrides = () => {
+    const settingsOverrides = config.get('hostSettings:settingsOverrides') || {};
+    const limitOverrides = {};
+
+    // Transistor.fm's Ghost-based features should be treated as off if the webhooks functionality is limited by the host
+    if (config.get('hostSettings:limits:customIntegrations:disabled') === true) {
+        limitOverrides.transistor = false;
+    }
+
+    return Object.assign({}, settingsOverrides, limitOverrides);
+};
+
 /**
  * @returns {SettingsBREADService} instance of the PostsService
  */
@@ -74,7 +86,7 @@ module.exports = {
     async init() {
         const cacheStore = adapterManager.getAdapter('cache:settings');
         const settingsCollection = await models.Settings.populateDefaults();
-        const settingsOverrides = config.get('hostSettings:settingsOverrides') || {};
+        const settingsOverrides = getSettingsOverrides();
         SettingsCache.init(events, settingsCollection, this.getCalculatedFields(), cacheStore, settingsOverrides);
 
         // Validate site_uuid matches config

--- a/ghost/core/test/unit/server/services/settings/settings-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-service.test.js
@@ -3,6 +3,8 @@ const assert = require('node:assert/strict');
 const configUtils = require('../../../../utils/config-utils');
 const settingsCache = require('../../../../../core/shared/settings-cache');
 const logging = require('@tryghost/logging');
+const models = require('../../../../../core/server/models');
+const adapterManager = require('../../../../../core/server/services/adapter-manager');
 
 describe('UNIT: Settings Service', function () {
     let settingsService;
@@ -13,6 +15,7 @@ describe('UNIT: Settings Service', function () {
 
     beforeEach(async function () {
         await configUtils.restore();
+        models.init();
         settingsCacheStub = sinon.stub();
         settingsCache.get = settingsCacheStub;
         loggingStub = sinon.stub();
@@ -85,6 +88,53 @@ describe('UNIT: Settings Service', function () {
                 assert.equal(error.constructor.name, 'IncorrectUsageError');
                 assert.equal(error.message, 'Site UUID configuration does not match database value');
             }
+        });
+    });
+
+    describe('init', function () {
+        it('merges host settings overrides with transistor disabled when custom integrations are limited', async function () {
+            const settingsCollection = {};
+            const cacheStore = {};
+
+            configUtils.set('hostSettings:settingsOverrides', {
+                title: 'Custom title',
+                transistor: true
+            });
+            configUtils.set('hostSettings:limits:customIntegrations:disabled', true);
+
+            sinon.stub(adapterManager, 'getAdapter').withArgs('cache:settings').returns(cacheStore);
+            sinon.stub(models.Settings, 'populateDefaults').resolves(settingsCollection);
+            const initStub = sinon.stub(settingsCache, 'init');
+
+            await settingsService.init();
+
+            sinon.assert.calledOnce(initStub);
+            assert.deepEqual(initStub.firstCall.args[4], {
+                title: 'Custom title',
+                transistor: false
+            });
+        });
+
+        it('keeps configured settings overrides unchanged when custom integrations are not limited', async function () {
+            const settingsCollection = {};
+            const cacheStore = {};
+
+            configUtils.set('hostSettings:settingsOverrides', {
+                title: 'Custom title',
+                transistor: true
+            });
+
+            sinon.stub(adapterManager, 'getAdapter').withArgs('cache:settings').returns(cacheStore);
+            sinon.stub(models.Settings, 'populateDefaults').resolves(settingsCollection);
+            const initStub = sinon.stub(settingsCache, 'init');
+
+            await settingsService.init();
+
+            sinon.assert.calledOnce(initStub);
+            assert.deepEqual(initStub.firstCall.args[4], {
+                title: 'Custom title',
+                transistor: true
+            });
         });
     });
 });

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -170,6 +170,19 @@ describe('UNIT: settings cache', function () {
         assert.deepEqual(cache.getPublic(), values);
     });
 
+    it('.getPublic() respects a transistor override when computing portal visibility', function () {
+        cache = createCacheManager({
+            transistor: false
+        });
+        cache.set('transistor', {value: true});
+        cache.set('transistor_portal_enabled', {value: true});
+
+        let values = _.zipObject(_.keys(publicSettings), _.fill(Array(_.size(publicSettings)), null));
+        values.transistor_portal_enabled = false;
+
+        assert.deepEqual(cache.getPublic(), values);
+    });
+
     it('.reset() and .init() do not double up events', function () {
         const setSpy = sinon.spy(cache, 'set');
 


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C0A0YQ2S53R/p1774572762467409
- marked transistor integration as locked/disabled when limited by host; overrode related backend settings
- updated sort behavior of integrations (disabled sorts to bottom)

Host plans may limit custom integrations via blocking webhooks. This currently happens for Zapier and was not extended to Transistor, which needs different handling given it has both externally set up webhooks + native Ghost functionality.

We now disable the Ghost-related functionality based on the host settings which is consistent with the webhook behavior.