### PR TITLE
[POC] 🎨 Added post editing presence prototype

### DIFF
--- a/ghost/admin/app/components/gh-editor-post-status.hbs
+++ b/ghost/admin/app/components/gh-editor-post-status.hbs
@@ -66,4 +66,6 @@
         Draft
         {{unless @hasDirtyAttributes "- Saved"}}
     {{/if}}
+
+    <GhPostEditingIndicator @post={{@post}} />
 </div>

--- a/ghost/admin/app/components/gh-member-avatar.hbs
+++ b/ghost/admin/app/components/gh-member-avatar.hbs
@@ -1,5 +1,5 @@
 <figure class="gh-member-gravatar {{@containerClass}}">
-    {{#if @member.email}}
+    {{#if (or @member.email @member.name @member.avatarImage @member.avatar_image @name)}}
         <div class="gh-member-initials flex items-center justify-center br-100 {{@containerClass}}" style={{this.backgroundStyle}}>
             <span class="gh-member-avatar-label {{or @sizeClass "gh-member-list-avatar"}}">{{this.initials}}</span>
         </div>

--- a/ghost/admin/app/components/gh-post-editing-indicator.hbs
+++ b/ghost/admin/app/components/gh-post-editing-indicator.hbs
@@ -1,0 +1,22 @@
+{{#if this.activeEditor}}
+    <span
+        class={{this.indicatorClass}}
+        data-test-active-editor
+        title="Last activity {{gh-format-post-time this.activeEditor.heartbeatAt absolute=true}}"
+    >
+        {{#if this.isListVariant}}
+            {{svg-jar "pen"}}
+            <span class="gh-post-editing-indicator-label">{{this.indicatorText}}</span>
+        {{else}}
+            {{#if this.indicatorPrefix}}
+                <span class="gh-post-editing-indicator-prefix">{{this.indicatorPrefix}}</span>
+            {{/if}}
+            <GhMemberAvatar
+                @member={{this.editingMember}}
+                @containerClass="gh-post-editing-indicator-avatar"
+                @sizeClass="gh-post-editing-indicator-avatar-label"
+            />
+            <span class="gh-post-editing-indicator-label">{{this.indicatorText}}</span>
+        {{/if}}
+    </span>
+{{/if}}

--- a/ghost/admin/app/components/gh-post-editing-indicator.js
+++ b/ghost/admin/app/components/gh-post-editing-indicator.js
@@ -1,0 +1,76 @@
+import Component from '@glimmer/component';
+import moment from 'moment-timezone';
+import {get} from '@ember/object';
+import {inject as service} from '@ember/service';
+
+const ACTIVE_EDITING_TTL_SECONDS = 120;
+
+export default class GhPostEditingIndicatorComponent extends Component {
+    @service clock;
+    @service session;
+
+    get activeEditor() {
+        // force a recompute while the lease is ticking down
+        get(this.clock, 'second');
+
+        const heartbeatAt = this.args.post?.editingHeartbeatAt;
+        const editingBy = this.args.post?.editingBy;
+        const editingName = this.args.post?.editingName;
+
+        if (!heartbeatAt || !editingBy || editingBy === this.session.user.id) {
+            return null;
+        }
+
+        if (moment.utc().diff(moment.utc(heartbeatAt), 'seconds') >= ACTIVE_EDITING_TTL_SECONDS) {
+            return null;
+        }
+
+        return {
+            name: editingName || 'Another staff user',
+            heartbeatAt: moment.utc(heartbeatAt).toISOString()
+        };
+    }
+
+    get isListVariant() {
+        return this.args.variant === 'list';
+    }
+
+    get indicatorClass() {
+        return `gh-post-editing-indicator gh-post-editing-indicator--${this.isListVariant ? 'list' : 'editor'}`;
+    }
+
+    get indicatorText() {
+        if (!this.activeEditor) {
+            return null;
+        }
+
+        if (this.isListVariant) {
+            return `Being edited by ${this.activeEditor.name}`;
+        }
+
+        return this.activeEditor.name;
+    }
+
+    get indicatorPrefix() {
+        if (!this.activeEditor) {
+            return null;
+        }
+
+        if (this.isListVariant) {
+            return null;
+        }
+
+        return 'Currently being edited by';
+    }
+
+    get editingMember() {
+        if (!this.activeEditor) {
+            return null;
+        }
+
+        return {
+            name: this.activeEditor.name,
+            avatarImage: this.args.post?.editingAvatar || null
+        };
+    }
+}

--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -53,6 +53,7 @@
                             {{/if}}
                         </span>
                     </p>
+                    <GhPostEditingIndicator @post={{@post}} @variant="list" />
                 {{/unless}}
             </div>
         </a>
@@ -160,6 +161,7 @@
                             </span>
                         {{/if}}
                     </p>
+                    <GhPostEditingIndicator @post={{@post}} @variant="list" />
                 {{/unless}}
             </div>
         </LinkTo>

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -40,10 +40,11 @@
                                 and sent to {{gh-pluralize @post.email.emailCount "member"}}
                             {{else}}
                                 and sent
+                                {{/if}}
                             {{/if}}
-                        {{/if}}
-                    </span>
+                        </span>
                 </p>
+                <GhPostEditingIndicator @post={{@post}} @variant="list" />
             {{/unless}}
         </a>
     {{else}}
@@ -137,10 +138,11 @@
                                 {{#if this.isHovered}}
                                     <span {{css-transition "anim-fade-in-scale"}}>to {{gh-pluralize @post.email.emailCount "member"}}</span>
                                 {{/if}}
-                            {{/if}}
-                        </span>
-                    {{/if}}
+                                {{/if}}
+                            </span>
+                        {{/if}}
                 </p>
+                <GhPostEditingIndicator @post={{@post}} @variant="list" />
             {{/unless}}
         </LinkTo>
     {{/if}}

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -38,6 +38,7 @@ const DUPLICATED_POST_TITLE_SUFFIX = '(Copy)';
 const AUTOSAVE_TIMEOUT = 3000;
 // time in ms to force a save if the user is continuously typing
 const TIMEDSAVE_TIMEOUT = 60000;
+const EDITING_LEASE_INTERVAL = 30000;
 
 const TK_REGEX = new RegExp(/(^|.)([^\p{L}\p{N}\s]*(TK)+[^\p{L}\p{N}\s]*)(.)?/u);
 const WORD_CHAR_REGEX = new RegExp(/\p{L}|\p{N}/u);
@@ -158,9 +159,11 @@ export default class LexicalEditorController extends Controller {
     @service search;
     @service session;
     @service settings;
+    @service store;
     @service ui;
     @service localRevisions;
     @service('unsaved-changes') unsavedChanges;
+    @service postEditing;
 
     @inject config;
 
@@ -186,6 +189,7 @@ export default class LexicalEditorController extends Controller {
     _leaveConfirmed = false;
     _saveOnLeavePerformed = false;
     _previousTagNames = null; // set by setPost and _postSaved, used in hasDirtyAttributes
+    editingSessionId = null;
 
     /* debug properties ------------------------------------------------------*/
 
@@ -914,6 +918,8 @@ export default class LexicalEditorController extends Controller {
         if (titlesMatch && bodiesMatch) {
             this.set('hasDirtyAttributes', false);
         }
+
+        this._startEditingLease(post);
     }
 
     @task
@@ -1072,6 +1078,7 @@ export default class LexicalEditorController extends Controller {
         // don't do anything else if we're setting the same post
         if (post === this.post) {
             this.set('shouldFocusTitle', post.get('isNew'));
+            this._startEditingLease(post);
             return;
         }
 
@@ -1091,6 +1098,7 @@ export default class LexicalEditorController extends Controller {
         // TODO: can these be `boundOneWay` on the model as per the other attrs?
         post.set('titleScratch', post.get('title'));
         post.set('lexicalScratch', post.get('lexical'));
+        this._startEditingLease(post);
 
         this._previousTagNames = this._tagNames;
 
@@ -1328,10 +1336,14 @@ export default class LexicalEditorController extends Controller {
     // called when the editor route is left or the post model is swapped
     reset() {
         let post = this.post;
+        const editingSessionId = this.editingSessionId;
+        const postId = post?.id;
+        const postType = post?.displayName;
 
         // make sure the save tasks aren't still running in the background
         // after leaving the edit route
         this.cancelAutosave();
+        this.editingLeaseTask.cancelAll();
 
         this._unregisterUnsavedChanges?.();
         this._unregisterUnsavedChanges = null;
@@ -1348,9 +1360,16 @@ export default class LexicalEditorController extends Controller {
             }
         }
 
+        if (postId && editingSessionId) {
+            this.postEditing.release({postId, postType, sessionId: editingSessionId}).catch(() => {
+                // ignore lease release failures and rely on TTL expiry
+            });
+        }
+
         this._previousTagNames = [];
         this._leaveConfirmed = false;
         this._saveOnLeavePerformed = false;
+        this.editingSessionId = null;
 
         this._setPostState = null;
         this._postStates = [];
@@ -1399,6 +1418,24 @@ export default class LexicalEditorController extends Controller {
     }).drop())
         _timedSaveTask;
 
+    @restartableTask
+    *editingLeaseTask(postId, postType, sessionId) {
+        while (this.post?.id === postId && this.editingSessionId === sessionId) {
+            try {
+                const lease = yield this.postEditing.touch({postId, postType, sessionId});
+                this._applyEditingLease(lease, postType);
+            } catch (error) {
+                // ignore presence errors, this is informational only
+            }
+
+            if (config.environment === 'test') {
+                return;
+            }
+
+            yield timeout(EDITING_LEASE_INTERVAL);
+        }
+    }
+
     /* Private methods -------------------------------------------------------*/
 
     _assignLexicalDiffToLeaveModalReason() {
@@ -1439,6 +1476,32 @@ export default class LexicalEditorController extends Controller {
             console.error(error); // eslint-disable-line
             Sentry.captureException(error);
         }
+    }
+
+    _applyEditingLease(lease, postType) {
+        if (!lease || !this.post || lease.id !== this.post.id) {
+            return;
+        }
+
+        this.store.pushPayload({
+            [this.postEditing._resourcePath(postType)]: [lease]
+        });
+    }
+
+    _startEditingLease(post = this.post) {
+        if (config.environment === 'test') {
+            return;
+        }
+
+        if (!post || post.isNew || !post.id) {
+            return;
+        }
+
+        if (!this.editingSessionId) {
+            this.editingSessionId = this.postEditing.generateSessionId();
+        }
+
+        this.editingLeaseTask.perform(post.id, post.displayName, this.editingSessionId);
     }
 
     _hasDirtyAttributes() {

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -120,6 +120,10 @@ export default Model.extend(Comparable, ValidationEngine, {
     featureImageAlt: attr('string'),
     featureImageCaption: attr('string'),
     showTitleAndFeatureImage: attr('boolean', {defaultValue: true}),
+    editingBy: attr('string'),
+    editingName: attr('string'),
+    editingAvatar: attr('string'),
+    editingHeartbeatAt: attr('moment-utc'),
 
     authors: hasMany('user', {embedded: 'always', async: false}),
     email: belongsTo('email', {async: false}),

--- a/ghost/admin/app/serializers/post.js
+++ b/ghost/admin/app/serializers/post.js
@@ -9,6 +9,10 @@ export default class PostSerializer extends ApplicationSerializer.extend(Embedde
         publishedAtUTC: {key: 'published_at'},
         createdAtUTC: {key: 'created_at'},
         updatedAtUTC: {key: 'updated_at'},
+        editingBy: {key: 'editing_by'},
+        editingName: {key: 'editing_name'},
+        editingAvatar: {key: 'editing_avatar'},
+        editingHeartbeatAt: {key: 'editing_heartbeat_at'},
         email: {embedded: 'always'},
         newsletter: {embedded: 'always'},
         postRevisions: {embedded: 'always'}
@@ -27,6 +31,10 @@ export default class PostSerializer extends ApplicationSerializer.extend(Embedde
         delete json.email;
         delete json.newsletter;
         delete json.post_revisions;
+        delete json.editing_by;
+        delete json.editing_name;
+        delete json.editing_avatar;
+        delete json.editing_heartbeat_at;
         // Deprecated property (replaced with data.authors)
         delete json.author;
         // Page-only properties

--- a/ghost/admin/app/services/post-editing.js
+++ b/ghost/admin/app/services/post-editing.js
@@ -1,0 +1,39 @@
+import Service from '@ember/service';
+import {inject as service} from '@ember/service';
+
+export default class PostEditingService extends Service {
+    @service ajax;
+    @service ghostPaths;
+
+    generateSessionId() {
+        if (window.crypto?.randomUUID) {
+            return window.crypto.randomUUID();
+        }
+
+        return `editing-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    }
+
+    async touch({postId, postType, sessionId}) {
+        const url = new URL(this.ghostPaths.url.api(this._resourcePath(postType), postId, 'editing'), window.location.href);
+        url.searchParams.set('session_id', sessionId);
+
+        const response = await this.ajax.request(url.href, {
+            method: 'POST'
+        });
+
+        return response[this._resourcePath(postType)]?.[0] || null;
+    }
+
+    async release({postId, postType, sessionId}) {
+        const url = new URL(this.ghostPaths.url.api(this._resourcePath(postType), postId, 'editing'), window.location.href);
+        url.searchParams.set('session_id', sessionId);
+
+        await this.ajax.request(url.href, {
+            method: 'DELETE'
+        });
+    }
+
+    _resourcePath(postType) {
+        return postType === 'page' ? 'pages' : 'posts';
+    }
+}

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -950,14 +950,14 @@
 }
 
 .gh-content-entry-status .draft {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     color: var(--pink);
     font-weight: 500;
 }
 
 .gh-content-entry-status .scheduled {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     color: var(--green);
     font-weight: 500;
@@ -983,6 +983,74 @@
 
 .gh-content-entry-status .error {
     color: var(--red);
+    font-weight: 500;
+}
+
+.gh-post-editing-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 8px;
+    padding: 4px 14px 4px 10px;
+    color: var(--darkgrey);
+    font-size: 1.25rem;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    vertical-align: middle;
+    background: color-mod(var(--yellow) a(6%));
+    border: 1px solid color-mod(var(--yellow) a(30%));
+    border-radius: 999px;
+}
+
+.gh-post-editing-indicator-prefix {
+    color: color-mod(var(--yellow) l(-26%));
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+.gh-post-editing-indicator-avatar {
+    width: 22px;
+    height: 22px;
+    min-width: 22px;
+    box-shadow: none;
+}
+
+.gh-post-editing-indicator-avatar-label {
+    font-size: 1rem;
+    letter-spacing: -0.4px;
+}
+
+.gh-post-editing-indicator-label {
+    color: var(--darkgrey);
+    font-weight: 700;
+}
+
+.gh-post-editing-indicator--list {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 4px 0 0;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    color: var(--midgrey-d1);
+    font-size: 1.25rem;
+    font-weight: 500;
+    line-height: 1.35;
+    white-space: normal;
+}
+
+.gh-post-editing-indicator--list svg {
+    width: 1.3rem;
+    height: 1.3rem;
+    min-width: 1.3rem;
+    fill: var(--midlightgrey-d1);
+}
+
+.gh-post-editing-indicator--list .gh-post-editing-indicator-label {
+    color: var(--midgrey-d1);
     font-weight: 500;
 }
 

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -1063,6 +1063,21 @@ body[data-user-is-dragging] .gh-editor-feature-image-dropzone {
     transform: translateY(-1px);
 }
 
+.gh-editor-post-status .gh-post-editing-indicator {
+    margin-left: 10px;
+    font-size: 1.2rem;
+}
+
+.gh-editor-post-status .gh-post-editing-indicator-prefix {
+    font-size: 1.05rem;
+}
+
+.gh-editor-post-status .gh-post-editing-indicator-avatar {
+    width: 22px;
+    height: 22px;
+    min-width: 22px;
+}
+
 @media (max-width: 720px) {
     .gh-editor-post-status .newsletter-failed {
         display: none;

--- a/ghost/admin/mirage/config/pages.js
+++ b/ghost/admin/mirage/config/pages.js
@@ -63,5 +63,15 @@ export default function mockPages(server) {
         return page.update(attrs);
     });
 
+    server.post('/pages/:id/editing/', function ({pages}, {params}) {
+        return {
+            pages: [pages.find(params.id)]
+        };
+    });
+
+    server.del('/pages/:id/editing/', function () {
+        return new Response(204);
+    });
+
     server.del('/pages/:id/');
 }

--- a/ghost/admin/mirage/config/posts.js
+++ b/ghost/admin/mirage/config/posts.js
@@ -131,6 +131,16 @@ export default function mockPosts(server) {
         return post.update(attrs);
     });
 
+    server.post('/posts/:id/editing/', function ({posts}, {params}) {
+        return {
+            posts: [posts.find(params.id)]
+        };
+    });
+
+    server.del('/posts/:id/editing/', function () {
+        return new Response(204);
+    });
+
     server.del('/posts/:id/');
 
     server.del('/posts/', function ({posts}, {queryParams}) {

--- a/ghost/core/core/server/api/endpoints/pages.js
+++ b/ghost/core/core/server/api/endpoints/pages.js
@@ -175,6 +175,76 @@ const controller = {
         }
     },
 
+    touchEditing: {
+        statusCode: 200,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id',
+            'session_id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                },
+                session_id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            method: 'edit',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return postsService.touchEditing({
+                id: frame.options.id,
+                type: 'page',
+                context: frame.options.context,
+                sessionId: frame.options.session_id
+            });
+        }
+    },
+
+    clearEditing: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id',
+            'session_id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                },
+                session_id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            method: 'edit',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        async query(frame) {
+            await postsService.clearEditing({
+                id: frame.options.id,
+                type: 'page',
+                context: frame.options.context,
+                sessionId: frame.options.session_id
+            });
+
+            return null;
+        }
+    },
+
     bulkEdit: {
         statusCode: 200,
         headers: {

--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -232,6 +232,74 @@ const controller = {
         }
     },
 
+    touchEditing: {
+        statusCode: 200,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id',
+            'session_id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                },
+                session_id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            method: 'edit',
+            unsafeAttrs: unsafeAttrs
+        },
+        query(frame) {
+            return postsService.touchEditing({
+                id: frame.options.id,
+                type: 'post',
+                context: frame.options.context,
+                sessionId: frame.options.session_id
+            });
+        }
+    },
+
+    clearEditing: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id',
+            'session_id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                },
+                session_id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            method: 'edit',
+            unsafeAttrs: unsafeAttrs
+        },
+        async query(frame) {
+            await postsService.clearEditing({
+                id: frame.options.id,
+                type: 'post',
+                context: frame.options.context,
+                sessionId: frame.options.session_id
+            });
+
+            return null;
+        }
+    },
+
     bulkEdit: {
         statusCode: 200,
         headers: {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
@@ -112,7 +112,14 @@ module.exports = async (model, frame, options = {}) => {
     }
 
     // Transforms post/page metadata to flat structure
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    const editingMetaAttrs = ['editing_by', 'editing_name', 'editing_avatar', 'editing_heartbeat_at'];
+    const omittedMetaAttrs = ['id', 'post_id', 'editing_session_id'];
+
+    if (utils.isContentAPI(frame) || !options.includeEditingPresence) {
+        omittedMetaAttrs.push(...editingMetaAttrs);
+    }
+
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, omittedMetaAttrs));
     _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
@@ -120,7 +127,13 @@ module.exports = async (model, frame, options = {}) => {
         //       The undefined value is possible because `posts_meta` table is lazily created only one of the
         //       values is assigned.
         const defaultValue = (attr === 'email_only') ? false : null;
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || defaultValue;
+        const value = _.get(jsonModel.posts_meta, attr) || defaultValue;
+
+        if (editingMetaAttrs.includes(attr) && value === null) {
+            return;
+        }
+
+        jsonModel[attr] = value;
     });
     delete jsonModel.posts_meta;
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/pages.js
@@ -35,9 +35,10 @@ module.exports = {
             };
         }) || [];
 
+        const includeEditingPresence = ['browse', 'read'].includes(apiConfig.method);
         if (models.meta) {
             for (let model of models.data) {
-                let page = await mappers.pages(model, frame, {tiers});
+                let page = await mappers.pages(model, frame, {tiers, includeEditingPresence});
                 pages.push(page);
             }
             frame.response = {
@@ -47,9 +48,15 @@ module.exports = {
 
             return;
         }
-        let page = await mappers.pages(models, frame, {tiers});
+        let page = await mappers.pages(models, frame, {tiers, includeEditingPresence});
         frame.response = {
             pages: [page]
+        };
+    },
+
+    touchEditing(editing, _apiConfig, frame) {
+        frame.response = {
+            pages: [editing]
         };
     },
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
@@ -35,9 +35,10 @@ module.exports = {
                 yearly_price_id: null
             };
         }) || [];
+        const includeEditingPresence = ['browse', 'read'].includes(apiConfig.method);
         if (models.meta) {
             for (let model of models.data) {
-                let post = await mappers.posts(model, frame, {tiers});
+                let post = await mappers.posts(model, frame, {tiers, includeEditingPresence});
                 posts.push(post);
             }
             frame.response = {
@@ -47,9 +48,15 @@ module.exports = {
 
             return;
         }
-        let post = await mappers.posts(models, frame, {tiers});
+        let post = await mappers.posts(models, frame, {tiers, includeEditingPresence});
         frame.response = {
             posts: [post]
+        };
+    },
+
+    touchEditing(editing, _apiConfig, frame) {
+        frame.response = {
+            posts: [editing]
         };
     },
 

--- a/ghost/core/core/server/data/migrations/versions/6.39/2026-03-27-12-00-00-add-post-editing-presence-columns.js
+++ b/ghost/core/core/server/data/migrations/versions/6.39/2026-03-27-12-00-00-add-post-editing-presence-columns.js
@@ -1,0 +1,28 @@
+const {combineNonTransactionalMigrations, createAddColumnMigration} = require('../../utils');
+
+module.exports = combineNonTransactionalMigrations(
+    createAddColumnMigration('posts_meta', 'editing_by', {
+        type: 'string',
+        maxlength: 24,
+        nullable: true
+    }),
+    createAddColumnMigration('posts_meta', 'editing_name', {
+        type: 'string',
+        maxlength: 191,
+        nullable: true
+    }),
+    createAddColumnMigration('posts_meta', 'editing_avatar', {
+        type: 'string',
+        maxlength: 2000,
+        nullable: true
+    }),
+    createAddColumnMigration('posts_meta', 'editing_session_id', {
+        type: 'string',
+        maxlength: 50,
+        nullable: true
+    }),
+    createAddColumnMigration('posts_meta', 'editing_heartbeat_at', {
+        type: 'dateTime',
+        nullable: true
+    })
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -119,7 +119,12 @@ module.exports = {
         frontmatter: {type: 'text', maxlength: 65535, nullable: true},
         feature_image_alt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 191}}},
         feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
-        email_only: {type: 'boolean', nullable: false, defaultTo: false}
+        email_only: {type: 'boolean', nullable: false, defaultTo: false},
+        editing_by: {type: 'string', maxlength: 24, nullable: true},
+        editing_name: {type: 'string', maxlength: 191, nullable: true},
+        editing_avatar: {type: 'string', maxlength: 2000, nullable: true},
+        editing_session_id: {type: 'string', maxlength: 50, nullable: true},
+        editing_heartbeat_at: {type: 'dateTime', nullable: true}
     },
     // NOTE: this is the staff table
     users: {

--- a/ghost/core/core/server/services/posts/posts-service.js
+++ b/ghost/core/core/server/services/posts/posts-service.js
@@ -70,6 +70,13 @@ class PostsService {
 
         await this.postEmailHandler.createOrRetryEmail(model);
 
+        try {
+            // Presence is informational and should not block a successful save.
+            await this.#refreshEditingLeaseAfterSave(model, frame.options?.context);
+        } catch {
+            // ignore presence refresh failures
+        }
+
         const dto = model.toJSON(frame.options);
 
         if (typeof options?.eventHandler === 'function') {
@@ -211,6 +218,48 @@ class PostsService {
         }
 
         return currentLease.editing_by === userId || postsMeta?.get('editing_session_id') === sessionId;
+    }
+
+    async #refreshEditingLeaseAfterSave(model, context) {
+        const userId = context?.user;
+        const postId = model?.get?.('id') || model?.id;
+        const postType = model?.get?.('type') || model?.attributes?.type;
+
+        if (!userId || !postId || !postType) {
+            return;
+        }
+
+        const user = await this.models.User.findOne({id: userId}, {require: false});
+
+        if (!user) {
+            return;
+        }
+
+        const post = await this.models.Post.findOne(
+            {id: postId, type: postType, status: 'all'},
+            {context, withRelated: ['posts_meta'], require: false}
+        );
+
+        if (!post) {
+            return;
+        }
+
+        const postsMeta = post.related('posts_meta');
+        const currentLease = this.#serializeEditingMeta(postsMeta, post.id);
+
+        if (currentLease.editing_heartbeat_at && currentLease.editing_by !== user.get('id')) {
+            return;
+        }
+
+        const shouldKeepSessionId = currentLease.editing_by === user.get('id');
+
+        await this.#upsertPostMeta(post.id, {
+            editing_by: user.get('id'),
+            editing_name: user.get('name'),
+            editing_avatar: user.get('profile_image'),
+            editing_session_id: shouldKeepSessionId ? (postsMeta?.get('editing_session_id') || null) : null,
+            editing_heartbeat_at: new Date()
+        });
     }
 
     async #upsertPostMeta(postId, data) {

--- a/ghost/core/core/server/services/posts/posts-service.js
+++ b/ghost/core/core/server/services/posts/posts-service.js
@@ -3,6 +3,7 @@ const {BadRequestError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const ObjectId = require('bson-objectid').default;
+const db = require('../../data/db');
 const pick = require('lodash/pick');
 const DomainEvents = require('@tryghost/domain-events');
 const PostEmailHandler = require('./post-email-handler');
@@ -15,6 +16,8 @@ const messages = {
     unsupportedBulkAction: 'Unsupported bulk action',
     postNotFound: 'Post not found.'
 };
+
+const EDITING_TTL_MS = 2 * 60 * 1000;
 
 class PostsService {
     constructor({urlUtils, models, isSet, stats, emailService, postsExporter}) {
@@ -76,6 +79,77 @@ class PostsService {
         return dto;
     }
 
+    async touchEditing({id, type, context, sessionId}) {
+        const post = await this.models.Post.findOne(
+            {id, type, status: 'all'},
+            {context, withRelated: ['posts_meta'], require: false}
+        );
+
+        if (!post) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.postNotFound)
+            });
+        }
+
+        const userId = context?.user;
+        const user = userId ? await this.models.User.findOne({id: userId}, {require: false}) : null;
+        const postsMeta = post.related('posts_meta');
+        const currentLease = this.#serializeEditingMeta(postsMeta, post.id);
+
+        if (!user) {
+            return currentLease;
+        }
+
+        if (this.#canClaimEditingLease(postsMeta, user.get('id'), sessionId)) {
+            const now = new Date();
+            const lease = {
+                editing_by: user.get('id'),
+                editing_name: user.get('name'),
+                editing_avatar: user.get('profile_image'),
+                editing_session_id: sessionId,
+                editing_heartbeat_at: now
+            };
+
+            await this.#upsertPostMeta(post.id, lease);
+
+            return this.#serializeEditingMeta({
+                get(key) {
+                    return lease[key];
+                }
+            }, post.id);
+        }
+
+        return currentLease;
+    }
+
+    async clearEditing({id, type, context, sessionId}) {
+        const post = await this.models.Post.findOne(
+            {id, type, status: 'all'},
+            {context, withRelated: ['posts_meta'], require: false}
+        );
+
+        if (!post) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.postNotFound)
+            });
+        }
+
+        const postsMeta = post.related('posts_meta');
+        const currentSessionId = postsMeta?.get('editing_session_id');
+
+        if (!currentSessionId || currentSessionId !== sessionId) {
+            return;
+        }
+
+        await this.#upsertPostMeta(post.id, {
+            editing_by: null,
+            editing_name: null,
+            editing_avatar: null,
+            editing_session_id: null,
+            editing_heartbeat_at: null
+        });
+    }
+
     /**
      * @param {any} model
      * @returns {EventString}
@@ -96,6 +170,58 @@ class PostsService {
         if (model.get('status') === 'scheduled' && model.wasChanged()) {
             return 'scheduled_updated';
         }
+    }
+
+    #isLeaseActive(heartbeatAt) {
+        if (!heartbeatAt) {
+            return false;
+        }
+
+        return (Date.now() - new Date(heartbeatAt).getTime()) < EDITING_TTL_MS;
+    }
+
+    #serializeEditingMeta(postsMeta, postId = null) {
+        const id = postId || postsMeta?.get?.('post_id') || null;
+        const heartbeatAt = postsMeta?.get?.('editing_heartbeat_at') || null;
+
+        if (!this.#isLeaseActive(heartbeatAt)) {
+            return {
+                id,
+                editing_by: null,
+                editing_name: null,
+                editing_avatar: null,
+                editing_heartbeat_at: null
+            };
+        }
+
+        return {
+            id,
+            editing_by: postsMeta.get('editing_by') || null,
+            editing_name: postsMeta.get('editing_name') || null,
+            editing_avatar: postsMeta.get('editing_avatar') || null,
+            editing_heartbeat_at: new Date(heartbeatAt).toISOString()
+        };
+    }
+
+    #canClaimEditingLease(postsMeta, userId, sessionId) {
+        const currentLease = this.#serializeEditingMeta(postsMeta);
+
+        if (!currentLease.editing_heartbeat_at) {
+            return true;
+        }
+
+        return currentLease.editing_by === userId || postsMeta?.get('editing_session_id') === sessionId;
+    }
+
+    async #upsertPostMeta(postId, data) {
+        await db.knex('posts_meta')
+            .insert({
+                id: this.models.Post.generateId(),
+                post_id: postId,
+                ...data
+            })
+            .onConflict('post_id')
+            .merge(data);
     }
 
     #mergeFilters(...filters) {

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -34,6 +34,8 @@ module.exports = function apiRoutes() {
     router.put('/posts/bulk', mw.authAdminApi, http(api.posts.bulkEdit));
     router.get('/posts/:id', mw.authAdminApi, http(api.posts.read));
     router.get('/posts/slug/:slug', mw.authAdminApi, http(api.posts.read));
+    router.post('/posts/:id/editing', mw.authAdminApi, http(api.posts.touchEditing));
+    router.delete('/posts/:id/editing', mw.authAdminApi, http(api.posts.clearEditing));
     router.put('/posts/:id', mw.authAdminApi, http(api.posts.edit));
     router.delete('/posts/:id', mw.authAdminApi, http(api.posts.destroy));
     router.post('/posts/:id/copy', mw.authAdminApi, http(api.posts.copy));
@@ -57,6 +59,8 @@ module.exports = function apiRoutes() {
     router.post('/pages', mw.authAdminApi, http(api.pages.add));
     router.get('/pages/:id', mw.authAdminApi, http(api.pages.read));
     router.get('/pages/slug/:slug', mw.authAdminApi, http(api.pages.read));
+    router.post('/pages/:id/editing', mw.authAdminApi, http(api.pages.touchEditing));
+    router.delete('/pages/:id/editing', mw.authAdminApi, http(api.pages.clearEditing));
     router.put('/pages/:id', mw.authAdminApi, http(api.pages.edit));
     router.delete('/pages/:id', mw.authAdminApi, http(api.pages.destroy));
     router.post('/pages/:id/copy', mw.authAdminApi, http(api.pages.copy));

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '28bf4f027ceb900645a650bfe0f00fb0';
+    const currentSchemaHash = 'c2c777ecd16b66d8e8791a92310c145a';
     const currentFixturesHash = 'b76d01321e02fb99b11e7a29f91859f7';
     const currentSettingsHash = '857b77a8e1c7072d9eb639152c78a49e';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/services/posts/posts-service.test.js
+++ b/ghost/core/test/unit/server/services/posts/posts-service.test.js
@@ -1,5 +1,6 @@
 const PostsService = require('../../../../../core/server/services/posts/posts-service');
 const assert = require('node:assert/strict');
+const db = require('../../../../../core/server/data/db');
 const sinon = require('sinon');
 
 describe('Posts Service', function () {
@@ -268,7 +269,11 @@ describe('Posts Service', function () {
             mockModels = {
                 Post: {
                     findOne: sinon.stub(),
-                    edit: sinon.stub()
+                    edit: sinon.stub(),
+                    generateId: sinon.stub().returns('meta-id')
+                },
+                User: {
+                    findOne: sinon.stub()
                 },
                 Member: {
                     findPage: sinon.stub()
@@ -360,6 +365,12 @@ describe('Posts Service', function () {
             const postData = {id: 'post-123', title: 'Test Post'};
             const model = {
                 get: sinon.stub().callsFake((key) => {
+                    if (key === 'id') {
+                        return 'post-123';
+                    }
+                    if (key === 'type') {
+                        return 'post';
+                    }
                     if (key === 'newsletter_id') {
                         return null;
                     }
@@ -383,6 +394,203 @@ describe('Posts Service', function () {
 
             assert.deepEqual(result, postData);
             sinon.assert.calledOnceWithExactly(eventHandler, 'published_updated', postData);
+        });
+
+        it('refreshes the editing lease on save when there is no active editor', async function () {
+            const now = new Date(Date.now() - (3 * 60 * 1000));
+            const postData = {id: 'post-123', title: 'Test Post'};
+            const model = {
+                get: sinon.stub().callsFake((key) => {
+                    if (key === 'id') {
+                        return 'post-123';
+                    }
+                    if (key === 'type') {
+                        return 'post';
+                    }
+                    if (key === 'status') {
+                        return 'draft';
+                    }
+                    return null;
+                }),
+                previous: sinon.stub().returns('draft'),
+                toJSON: sinon.stub().returns(postData),
+                wasChanged: sinon.stub().returns(true)
+            };
+            const postsMeta = {
+                get(key) {
+                    if (key === 'editing_by') {
+                        return 'old-user';
+                    }
+                    if (key === 'editing_name') {
+                        return 'Old User';
+                    }
+                    if (key === 'editing_avatar') {
+                        return '/content/images/old.png';
+                    }
+                    if (key === 'editing_session_id') {
+                        return 'old-session';
+                    }
+                    if (key === 'editing_heartbeat_at') {
+                        return now;
+                    }
+                    return null;
+                }
+            };
+            const savedPost = {
+                id: 'post-123',
+                related: sinon.stub().withArgs('posts_meta').returns(postsMeta)
+            };
+            const user = {
+                get: sinon.stub().callsFake((key) => {
+                    if (key === 'id') {
+                        return 'user-1';
+                    }
+                    if (key === 'name') {
+                        return 'New User';
+                    }
+                    if (key === 'profile_image') {
+                        return '/content/images/new.png';
+                    }
+                    return null;
+                })
+            };
+            const queryBuilder = {
+                insert: sinon.stub().returnsThis(),
+                onConflict: sinon.stub().returnsThis(),
+                merge: sinon.stub().resolves()
+            };
+            const fakeKnex = sinon.stub().returns(queryBuilder);
+
+            mockModels.Post.edit.resolves(model);
+            mockModels.Post.findOne.resolves(savedPost);
+            mockModels.User.findOne.resolves(user);
+            sinon.stub(db, 'knex').get(() => fakeKnex);
+
+            const frame = {
+                data: {posts: [{status: 'draft'}]},
+                options: {
+                    id: 'post-123',
+                    context: {
+                        user: 'user-1'
+                    }
+                }
+            };
+
+            await postsService.editPost(frame);
+
+            sinon.assert.calledOnceWithExactly(mockModels.Post.findOne, {
+                id: 'post-123',
+                type: 'post',
+                status: 'all'
+            }, {
+                context: frame.options.context,
+                withRelated: ['posts_meta'],
+                require: false
+            });
+            sinon.assert.calledOnceWithExactly(mockModels.User.findOne, {id: 'user-1'}, {require: false});
+            sinon.assert.calledOnceWithExactly(fakeKnex, 'posts_meta');
+            sinon.assert.calledOnce(queryBuilder.insert);
+            assert.equal(queryBuilder.insert.firstCall.args[0].id, 'meta-id');
+            assert.equal(queryBuilder.insert.firstCall.args[0].post_id, 'post-123');
+            assert.equal(queryBuilder.insert.firstCall.args[0].editing_by, 'user-1');
+            assert.equal(queryBuilder.insert.firstCall.args[0].editing_name, 'New User');
+            assert.equal(queryBuilder.insert.firstCall.args[0].editing_avatar, '/content/images/new.png');
+            assert.equal(queryBuilder.insert.firstCall.args[0].editing_session_id, null);
+            assert.ok(queryBuilder.insert.firstCall.args[0].editing_heartbeat_at instanceof Date);
+            sinon.assert.calledOnceWithExactly(queryBuilder.onConflict, 'post_id');
+            sinon.assert.calledOnce(queryBuilder.merge);
+            assert.equal(queryBuilder.merge.firstCall.args[0].editing_by, 'user-1');
+            assert.equal(queryBuilder.merge.firstCall.args[0].editing_name, 'New User');
+            assert.equal(queryBuilder.merge.firstCall.args[0].editing_avatar, '/content/images/new.png');
+            assert.equal(queryBuilder.merge.firstCall.args[0].editing_session_id, null);
+            assert.ok(queryBuilder.merge.firstCall.args[0].editing_heartbeat_at instanceof Date);
+        });
+
+        it('does not steal the editing lease from another active editor on save', async function () {
+            const postData = {id: 'post-123', title: 'Test Post'};
+            const model = {
+                get: sinon.stub().callsFake((key) => {
+                    if (key === 'id') {
+                        return 'post-123';
+                    }
+                    if (key === 'type') {
+                        return 'post';
+                    }
+                    if (key === 'status') {
+                        return 'draft';
+                    }
+                    return null;
+                }),
+                previous: sinon.stub().returns('draft'),
+                toJSON: sinon.stub().returns(postData),
+                wasChanged: sinon.stub().returns(true)
+            };
+            const postsMeta = {
+                get(key) {
+                    if (key === 'editing_by') {
+                        return 'user-2';
+                    }
+                    if (key === 'editing_name') {
+                        return 'Other User';
+                    }
+                    if (key === 'editing_avatar') {
+                        return '/content/images/other.png';
+                    }
+                    if (key === 'editing_session_id') {
+                        return 'other-session';
+                    }
+                    if (key === 'editing_heartbeat_at') {
+                        return new Date();
+                    }
+                    return null;
+                }
+            };
+            const savedPost = {
+                id: 'post-123',
+                related: sinon.stub().withArgs('posts_meta').returns(postsMeta)
+            };
+            const user = {
+                get: sinon.stub().callsFake((key) => {
+                    if (key === 'id') {
+                        return 'user-1';
+                    }
+                    if (key === 'name') {
+                        return 'New User';
+                    }
+                    if (key === 'profile_image') {
+                        return '/content/images/new.png';
+                    }
+                    return null;
+                })
+            };
+            const queryBuilder = {
+                insert: sinon.stub().returnsThis(),
+                onConflict: sinon.stub().returnsThis(),
+                merge: sinon.stub().resolves()
+            };
+            const fakeKnex = sinon.stub().returns(queryBuilder);
+
+            mockModels.Post.edit.resolves(model);
+            mockModels.Post.findOne.resolves(savedPost);
+            mockModels.User.findOne.resolves(user);
+            sinon.stub(db, 'knex').get(() => fakeKnex);
+
+            const frame = {
+                data: {posts: [{status: 'draft'}]},
+                options: {
+                    id: 'post-123',
+                    context: {
+                        user: 'user-1'
+                    }
+                }
+            };
+
+            await postsService.editPost(frame);
+
+            sinon.assert.notCalled(fakeKnex);
+            sinon.assert.notCalled(queryBuilder.insert);
+            sinon.assert.notCalled(queryBuilder.onConflict);
+            sinon.assert.notCalled(queryBuilder.merge);
         });
     });
 


### PR DESCRIPTION
## What this does

- adds a soft editing lease for posts and pages in posts_meta
- heartbeats from the editor every 30 seconds to surface an active editor
- expires the lease after 2 minutes without a heartbeat
- refreshes the lease on successful save when the current lease is unowned or expired
- does not steal the lease from another actively editing user
- shows presence in the editor header and the posts list
- keeps the normal save path untouched so presence does not update post timestamps or create revisions

## Notes

- this is intentionally a POC and not a final UX recommendation
- the editor treatment is clearer than the list treatment; the list UI still needs design input
- there is no independent polling on the posts list yet, so list presence updates when row data refreshes

## Testing

- yarn eslint on the touched admin and core files
- yarn test:single test/unit/server/services/posts/posts-service.test.js
- pre-commit lint-staged ran ember-template-lint and eslint on staged files

## Why draft

- the mechanics are working, but the list presentation should be reviewed by design before shipping