### PR TITLE
Added E2E tests for members-forward list page

### DIFF
--- a/e2e/helpers/pages/admin/members/index.ts
+++ b/e2e/helpers/pages/admin/members/index.ts
@@ -1,3 +1,4 @@
 export * from './members-page';
+export * from './members-forward-page';
 export * from './member-details-page';
 export * from './members-import-modal';

--- a/e2e/helpers/pages/admin/members/members-forward-page.ts
+++ b/e2e/helpers/pages/admin/members/members-forward-page.ts
@@ -1,0 +1,80 @@
+import {AdminPage} from '@/admin-pages';
+import {Download, Locator, Page} from '@playwright/test';
+import {readFileSync} from 'node:fs';
+
+interface ExportedFile {
+    suggestedFilename: string;
+    content: string;
+}
+
+export class MembersForwardPage extends AdminPage {
+    readonly membersList: Locator;
+    readonly memberRows: Locator;
+    readonly searchInput: Locator;
+    readonly actionsButton: Locator;
+    readonly newMemberButton: Locator;
+    readonly filterButton: Locator;
+    readonly clearFiltersButton: Locator;
+    readonly emptyState: Locator;
+    readonly noResults: Locator;
+    readonly showAllButton: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.pageUrl = '/ghost/#/members-forward';
+
+        this.membersList = page.getByTestId('members-list');
+        this.memberRows = page.getByTestId('members-list-item');
+        this.searchInput = page.getByLabel('Search members');
+        this.actionsButton = page.getByTestId('members-actions');
+        this.newMemberButton = page.getByRole('link', {name: 'New member'});
+        this.filterButton = page.getByRole('button', {name: /^(Filter|Add filter)$/});
+        this.clearFiltersButton = page.getByRole('button', {name: 'Clear'});
+        this.emptyState = page.getByText('No members yet');
+        this.noResults = page.getByText('No matching members found.');
+        this.showAllButton = page.getByRole('button', {name: 'Show all members'});
+    }
+
+    getMemberByName(name: string): Locator {
+        return this.memberRows.filter({hasText: name});
+    }
+
+    async openActionsMenu(): Promise<void> {
+        await this.actionsButton.click();
+    }
+
+    getMenuItem(name: string | RegExp): Locator {
+        return this.page.getByRole('menuitem', {name});
+    }
+
+    async addFilter(fieldName: string, value: string): Promise<void> {
+        await this.filterButton.click();
+        await this.page.getByRole('option', {name: fieldName, exact: true}).click();
+
+        if (fieldName === 'Name' || fieldName === 'Email') {
+            const placeholder = fieldName === 'Name' ? 'Enter name...' : 'Enter email...';
+            await this.page.getByRole('textbox', {name: placeholder}).fill(value);
+        } else {
+            // For select-based filters (Label, Status, etc.)
+            await this.page.getByRole('option', {name: value, exact: true}).click();
+        }
+    }
+
+    async exportMembers(): Promise<ExportedFile> {
+        const download = await this.exportMembersData();
+        const suggestedFilename = download.suggestedFilename();
+        const downloadPath = await download.path();
+        const downloadContent = readFileSync(downloadPath as string, 'utf-8');
+
+        return {
+            suggestedFilename,
+            content: downloadContent
+        };
+    }
+
+    async exportMembersData(): Promise<Download> {
+        const downloadPromise = this.page.waitForEvent('download');
+        await this.getMenuItem(/Export/).click();
+        return await downloadPromise;
+    }
+}

--- a/e2e/tests/admin/members-forward/bulk-actions.test.ts
+++ b/e2e/tests/admin/members-forward/bulk-actions.test.ts
@@ -1,0 +1,119 @@
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {MembersForwardPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Members Forward Bulk Actions', () => {
+    test.use({labs: {membersForward: true}});
+
+    let memberFactory: MemberFactory;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+    });
+
+    test('adds a label to all members via bulk action', async ({page}) => {
+        await memberFactory.createMany([
+            {name: 'Bulk Label 1', email: 'bulk1@example.com', labels: ['existing']},
+            {name: 'Bulk Label 2', email: 'bulk2@example.com', labels: ['existing']}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await expect(membersPage.memberRows).toHaveCount(2);
+
+        await membersPage.openActionsMenu();
+        await membersPage.getMenuItem(/Add label/).click();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+
+        // Type in the label picker to find and select a label
+        await dialog.getByRole('combobox').click();
+        await dialog.getByPlaceholder('Search labels...').fill('existing');
+        await dialog.getByText('existing', {exact: true}).first().click();
+
+        // Close the dropdown by clicking the dialog heading (outside the picker)
+        await dialog.getByRole('heading').click();
+        await dialog.getByRole('button', {name: 'Add label'}).click();
+        await expect(dialog).toBeHidden();
+    });
+
+    test('removes a label from filtered members via bulk action', async ({page}) => {
+        await memberFactory.createMany([
+            {name: 'Has Label', email: 'haslabel1@example.com', labels: ['removable']},
+            {name: 'Has Label Too', email: 'haslabel2@example.com', labels: ['removable']},
+            {name: 'No Label', email: 'nolabel@example.com'}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+
+        await membersPage.addFilter('Label', 'removable');
+        await expect(membersPage.memberRows).toHaveCount(2);
+
+        await membersPage.openActionsMenu();
+        await membersPage.getMenuItem(/Remove label/).click();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+
+        // Select the label to remove then close the dropdown by clicking the heading
+        await dialog.getByRole('combobox').click();
+        await dialog.getByText('removable', {exact: true}).first().click();
+        await dialog.getByRole('heading').click();
+
+        await dialog.getByRole('button', {name: 'Remove label'}).click();
+        await expect(dialog).toBeHidden();
+    });
+
+    test('unsubscribes all members from newsletters', async ({page}) => {
+        await memberFactory.createMany([
+            {name: 'Sub Member 1', email: 'sub1@example.com'},
+            {name: 'Sub Member 2', email: 'sub2@example.com'}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await expect(membersPage.memberRows).toHaveCount(2);
+
+        await membersPage.openActionsMenu();
+        await membersPage.getMenuItem(/Unsubscribe/).click();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByText('Unsubscribe members')).toBeVisible();
+
+        await dialog.getByRole('button', {name: 'Unsubscribe'}).click();
+        await expect(dialog).toBeHidden();
+    });
+
+    test('deletes members with backup download', async ({page}) => {
+        await memberFactory.createMany([
+            {name: 'Delete Me 1', email: 'delete1@example.com'},
+            {name: 'Delete Me 2', email: 'delete2@example.com'}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await expect(membersPage.memberRows).toHaveCount(2);
+
+        await membersPage.openActionsMenu();
+        await membersPage.getMenuItem(/Delete/).click();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByText('Delete selected members?')).toBeVisible();
+        await expect(dialog.getByText(/2 members/)).toBeVisible();
+
+        // Confirm triggers backup download then deletion
+        const downloadPromise = page.waitForEvent('download');
+        await dialog.getByRole('button', {name: 'Download backup & delete members'}).click();
+        await downloadPromise;
+
+        await expect(dialog).toBeHidden();
+        await expect(membersPage.emptyState).toBeVisible();
+    });
+});

--- a/e2e/tests/admin/members-forward/export.test.ts
+++ b/e2e/tests/admin/members-forward/export.test.ts
@@ -1,0 +1,75 @@
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {MembersForwardPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+usePerTestIsolation();
+
+const EXPECTED_CSV_HEADER_FIELDS = [
+    'id,',
+    'email,',
+    'name,',
+    'note,',
+    'subscribed_to_emails,',
+    'complimentary_plan,',
+    'stripe_customer_id,',
+    'created_at,',
+    'deleted_at,',
+    'labels,',
+    'tiers'
+];
+
+test.describe('Ghost Admin - Members Forward Export', () => {
+    test.use({labs: {membersForward: true}});
+
+    let memberFactory: MemberFactory;
+
+    const membersFixture = [
+        {name: 'Export Member 1', email: 'export1@example.com', note: 'First export test', labels: ['alpha']},
+        {name: 'Export Member 2', email: 'export2@example.com', note: 'Second export test', labels: ['alpha']},
+        {name: 'Export Member 3', email: 'export3@example.com', note: 'Third export test', labels: ['beta']}
+    ];
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+    });
+
+    test('exports all members to a CSV with expected fields', async ({page}) => {
+        await memberFactory.createMany(membersFixture);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await membersPage.openActionsMenu();
+
+        const {suggestedFilename, content} = await membersPage.exportMembers();
+
+        expect(content).toMatch(new RegExp(EXPECTED_CSV_HEADER_FIELDS.join('')));
+
+        for (const member of membersFixture) {
+            expect(content).toContain(member.name);
+            expect(content).toContain(member.email);
+            expect(content).toContain(member.note);
+        }
+
+        expect(suggestedFilename).toMatch(/^members\.\d{4}-\d{2}-\d{2}\.csv$/);
+    });
+
+    test('exports only filtered members when a filter is active', async ({page}) => {
+        await memberFactory.createMany(membersFixture);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+
+        await membersPage.addFilter('Label', 'alpha');
+        await expect(membersPage.memberRows).toHaveCount(2);
+
+        await membersPage.openActionsMenu();
+        await expect(membersPage.getMenuItem(/Export 2 members/)).toBeVisible();
+
+        const {content} = await membersPage.exportMembers();
+
+        expect(content).toContain('export1@example.com');
+        expect(content).toContain('export2@example.com');
+        expect(content).not.toContain('export3@example.com');
+    });
+});

--- a/e2e/tests/admin/members-forward/list.test.ts
+++ b/e2e/tests/admin/members-forward/list.test.ts
@@ -1,0 +1,58 @@
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {MembersForwardPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Members Forward List', () => {
+    test.use({labs: {membersForward: true}});
+
+    let memberFactory: MemberFactory;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+    });
+
+    test('displays members with name, email, status, and created date', async ({page}) => {
+        await memberFactory.createMany([
+            {name: 'Alice Anderson', email: 'alice@example.com'},
+            {name: 'Bob Baker', email: 'bob@example.com'},
+            {name: 'Charlie Clark', email: 'charlie@example.com'}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+
+        await expect(membersPage.memberRows).toHaveCount(3);
+        await expect(membersPage.getMemberByName('Alice Anderson')).toBeVisible();
+        await expect(membersPage.getMemberByName('Bob Baker')).toBeVisible();
+        await expect(membersPage.getMemberByName('Charlie Clark')).toBeVisible();
+
+        // Each row shows the email and status
+        await expect(membersPage.getMemberByName('Alice Anderson')).toContainText('alice@example.com');
+        await expect(membersPage.getMemberByName('Alice Anderson')).toContainText('Free');
+    });
+
+    test('shows empty state when there are no members', async ({page}) => {
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+
+        await expect(membersPage.emptyState).toBeVisible();
+        await expect(membersPage.memberRows).toHaveCount(0);
+    });
+
+    test('navigates to member detail when clicking a row', async ({page}) => {
+        const member = await memberFactory.create({
+            name: 'Detail Test Member',
+            email: 'detail@example.com'
+        });
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+
+        await membersPage.getMemberByName('Detail Test Member').click();
+
+        await expect(page).toHaveURL(new RegExp(`/members/${member.id}`));
+    });
+});

--- a/e2e/tests/admin/members-forward/saved-views.test.ts
+++ b/e2e/tests/admin/members-forward/saved-views.test.ts
@@ -29,7 +29,7 @@ async function saveCurrentView(page: Page, name: string) {
     await dialog.waitFor({state: 'hidden'});
 }
 
-test.describe('Ghost Admin - Member Saved Views', () => {
+test.describe('Ghost Admin - Members Forward Saved Views', () => {
     test.use({labs: {membersForward: true}});
 
     let memberFactory: MemberFactory;

--- a/e2e/tests/admin/members-forward/search-and-filter.test.ts
+++ b/e2e/tests/admin/members-forward/search-and-filter.test.ts
@@ -1,0 +1,90 @@
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {MembersForwardPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Members Forward Search and Filter', () => {
+    test.use({labs: {membersForward: true}});
+
+    let memberFactory: MemberFactory;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+    });
+
+    test('filters members by searching for a name and clears search to restore all', async ({page}) => {
+        await memberFactory.createMany([
+            {name: 'Unique Searchable Name', email: 'unique@example.com'},
+            {name: 'Other Member', email: 'other@example.com'},
+            {name: 'Another Member', email: 'another@example.com'}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await expect(membersPage.memberRows).toHaveCount(3);
+
+        await membersPage.searchInput.fill('Unique Searchable');
+        await expect(membersPage.memberRows).toHaveCount(1);
+        await expect(membersPage.getMemberByName('Unique Searchable Name')).toBeVisible();
+
+        await membersPage.searchInput.clear();
+        await expect(membersPage.memberRows).toHaveCount(3);
+    });
+
+    test('filters members by label and updates the displayed count', async ({page}) => {
+        await memberFactory.createMany([
+            {name: 'Labelled One', email: 'labelled1@example.com', labels: ['VIP']},
+            {name: 'Labelled Two', email: 'labelled2@example.com', labels: ['VIP']},
+            {name: 'No Label', email: 'nolabel@example.com'}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await expect(membersPage.memberRows).toHaveCount(3);
+
+        await membersPage.addFilter('Label', 'VIP');
+        await expect(membersPage.memberRows).toHaveCount(2);
+        await expect(membersPage.getMemberByName('Labelled One')).toBeVisible();
+        await expect(membersPage.getMemberByName('Labelled Two')).toBeVisible();
+    });
+
+    test('combines multiple filters to narrow results and clears all at once', async ({page}) => {
+        await memberFactory.createMany([
+            {name: 'Alice Alpha', email: 'alice@alpha.com', labels: ['Premium']},
+            {name: 'Alice Beta', email: 'alice@beta.com'},
+            {name: 'Bob Alpha', email: 'bob@alpha.com', labels: ['Premium']},
+            {name: 'Charlie Gamma', email: 'charlie@gamma.com'}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await expect(membersPage.memberRows).toHaveCount(4);
+
+        await membersPage.addFilter('Name', 'Alice');
+        await expect(membersPage.memberRows).toHaveCount(2);
+
+        await membersPage.addFilter('Label', 'Premium');
+        await expect(membersPage.memberRows).toHaveCount(1);
+        await expect(membersPage.getMemberByName('Alice Alpha')).toBeVisible();
+
+        await membersPage.clearFiltersButton.click();
+        await expect(membersPage.memberRows).toHaveCount(4);
+    });
+
+    test('shows no results state when search matches nothing', async ({page}) => {
+        await memberFactory.create({name: 'Existing Member', email: 'exists@example.com'});
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await expect(membersPage.memberRows).toHaveCount(1);
+
+        await membersPage.searchInput.fill('nonexistentnamestring');
+        await expect(membersPage.noResults).toBeVisible();
+        await expect(membersPage.showAllButton).toBeVisible();
+
+        await membersPage.searchInput.clear();
+        await expect(membersPage.memberRows).toHaveCount(1);
+    });
+});


### PR DESCRIPTION
The members-forward list page (behind the `membersForward` labs flag) had no E2E coverage. This PR adds a comprehensive test suite covering the core interactions: rendering the list with member details, navigating to member detail pages, searching and filtering (by name, label, and combined filters), the empty and no-results states, CSV export (both full and filtered), bulk actions (add/remove label, unsubscribe, delete with backup), and saved custom views with sidebar navigation.

The existing `custom-views.test.ts` file that lived under `e2e/tests/admin/members/` was moved to `e2e/tests/admin/members-forward/saved-views.test.ts` to co-locate it with the rest of the members-forward tests. A new `MembersForwardPage` page object encapsulates the locators and helper methods shared across the test files, keeping the tests focused on assertions rather than DOM wiring.