### PR TITLE
Updated Codex environment setup to build all dependencies

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -4,6 +4,7 @@ name = "Ghost"
 
 [setup]
 script = '''
-git submodule update --init --recursive
-yarn
+yarn setup
+(cd node_modules/sqlite3 && npm run install)
+(cd ghost/parse-email-address && yarn build)
 '''


### PR DESCRIPTION
no issue

Uses `yarn setup` instead of separate commands, and builds sqlite3 native bindings and `parse-email-address` so e2e tests can run without prompting agents to perform additional steps.