### PR TITLE
Fixed Nx cache outputs for parse-email-address package

### DIFF
--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -34,5 +34,12 @@
   },
   "dependencies": {
     "parse-email-address": "0.0.2"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{projectRoot}/build"]
+      }
+    }
   }
 }


### PR DESCRIPTION
no ref

The build target compiled to `build/` but Nx's default cache outputs only tracked `dist`, `es`, `types`, and `umd`, causing the directory to be missing after cache hits.
