### PR TITLE
Moved post unschedule browser test to `e2e`

### DIFF
--- a/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
@@ -126,6 +126,8 @@ export class PostEditorPage extends AdminPage {
     readonly lexicalEditor: Locator;
     readonly secondaryEditor: Locator;
     readonly publishSaveButton: Locator;
+    readonly updateFlowButton: Locator;
+    readonly revertToDraftButton: Locator;
 
     readonly settingsMenu: SettingsMenu;
 
@@ -143,6 +145,8 @@ export class PostEditorPage extends AdminPage {
         this.lexicalEditor = page.locator('[data-kg="editor"]').first();
         this.secondaryEditor = page.locator('[data-secondary-instance="true"]');
         this.publishSaveButton = page.locator('[data-test-button="publish-save"]').first();
+        this.updateFlowButton = page.locator('[data-test-button="update-flow"]').first();
+        this.revertToDraftButton = page.locator('[data-test-button="revert-to-draft"]');
 
         this.settingsMenu = new SettingsMenu(page);
     }
@@ -184,6 +188,11 @@ export class PostEditorPage extends AdminPage {
     async appendToBody(text: string): Promise<void> {
         await this.lexicalEditor.click();
         await this.page.keyboard.type(text);
+    }
+
+    async revertToDraft(): Promise<void> {
+        await this.updateFlowButton.click();
+        await this.revertToDraftButton.click();
     }
 
     get previewModalDesktopFrame(): DesktopPreviewFrame {

--- a/e2e/tests/admin/posts/publishing.test.ts
+++ b/e2e/tests/admin/posts/publishing.test.ts
@@ -27,6 +27,15 @@ function formatFrontendDate(date: Date): string {
     }).format(date);
 }
 
+async function expectPostStatus(editor: PostEditorPage, status: string | RegExp, detail?: string | RegExp) {
+    await expect(editor.postStatus.first()).toContainText(status);
+
+    if (detail) {
+        await editor.postStatus.first().hover();
+        await expect(editor.postStatus.first()).toContainText(detail);
+    }
+}
+
 test.describe('Ghost Admin - Publishing', () => {
     test.use({mailgunEnabled: true});
 
@@ -103,6 +112,34 @@ test.describe('Ghost Admin - Publishing', () => {
         const slug = generateSlug(postData.title);
         const response = await page.goto(`/${slug}/`);
         expect(response?.status()).toBe(404);
+    });
+
+    test('unschedules a scheduled post', async ({page}) => {
+        const title = `unschedule-post-${Date.now()}`;
+        const body = 'This is my unscheduled post body.';
+        const slug = generateSlug(title);
+
+        const postsPage = new PostsPage(page);
+        await postsPage.goto();
+        await postsPage.newPostButton.click();
+
+        const editor = new PostEditorPage(page);
+        await editor.createDraft({title, body});
+
+        await editor.publishFlow.open();
+        await editor.publishFlow.schedule({date: '2050-01-01'});
+        await editor.publishFlow.confirm();
+        await editor.publishFlow.close();
+
+        await expectPostStatus(editor, 'Scheduled', /to be published\s+at .*2050/i);
+
+        const frontendPage = await page.context().newPage();
+        await expectFrontendStatus(frontendPage, slug, 404);
+
+        await postsPage.getPostByTitle(title).click();
+        await editor.revertToDraft();
+        await expect(editor.postStatus.first()).toContainText('Draft - Saved');
+        await expectFrontendStatus(frontendPage, slug, 404);
     });
 
     test('publish only - page is visible on frontend', async ({page}) => {

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -322,43 +322,6 @@ test.describe('Publishing', () => {
             // Stil not published yet (email only)
             await checkPostNotPublished(sharedPage, postData);
         });
-
-        // A previously scheduled post can be unscheduled, which resets it to a draft
-        test('A scheduled post should be able to be unscheduled', async ({sharedPage, context}) => {
-            const postData = {
-                title: 'Unschedule post test',
-                body: 'This is my unscheduled post body.'
-            };
-
-            await sharedPage.goto('/ghost');
-            await createPostDraft(sharedPage, postData);
-
-            const editorUrl = await sharedPage.url();
-
-            // Schedule far in the future
-            await publishPost(sharedPage, {date: '2050-01-01', time: '10:09'});
-            await closePublishFlow(sharedPage);
-
-            // Check status
-            await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published at 10:09 (UTC) on 01 Jan 2050');
-
-            // Check not published
-            const testsharedPage = await context.newPage();
-
-            // Check not published
-            await checkPostNotPublished(testsharedPage, postData);
-
-            // Now unschedule this post
-            await sharedPage.goto(editorUrl);
-            await sharedPage.locator('[data-test-button="update-flow"]').first().click();
-            await sharedPage.locator('[data-test-button="revert-to-draft"]').click();
-
-            // Check status
-            await checkPostStatus(sharedPage, 'Draft - Saved');
-
-            // Check not published
-            await checkPostNotPublished(testsharedPage, postData);
-        });
     });
 });
 


### PR DESCRIPTION
## What this does
- move the future scheduled post unschedule case into e2e/tests/admin/posts/publishing.test.ts
- add a revertToDraft helper to the post editor page object
- remove the migrated unschedule case from the legacy browser publishing spec

## What stays in core browser for now
- Scheduled Publish and Email
- Scheduled Publish only
- Scheduled Email only

Those ASAP scheduling cases still stay scheduled in local e2e dev mode instead of completing, so I left them in the legacy suite for a separate follow-up.

## Testing
- yarn workspace @tryghost/e2e test tests/admin/posts/publishing.test.ts
- yarn workspace @tryghost/e2e test:types
- yarn eslint ghost/core/test/e2e-browser/admin/publishing.spec.js