### PR TITLE
Added `verificationFlow` labs feature flag

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -29,6 +29,7 @@ Object {
       "tagsX": true,
       "themeTranslation": true,
       "transistor": true,
+      "verificationFlow": true,
       "urlCache": true,
       "verificationFlow": true,
       "welcomeEmailsDesignCustomization": true,


### PR DESCRIPTION
ref [GVA-732](https://linear.app/ghost/issue/GVA-732/roll-out-to-ga-and-remove-old-logic-in-ghost)

This base PR adds the `verificationFlow` labs flag that the follow-up prep and GA rollout branches stack on. It is the prerequisite branch for the flag-aware test prep PR and the later GA removal PR.