### PR TITLE
Fixed update banner triggered by Ember ajax requests

### DIFF
--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -242,14 +242,6 @@ class ajaxService extends AjaxService {
             'App-Pragma': 'no-cache'
         };
 
-        // Omit the version header when running in forward admin to avoid issues
-        // with the server triggering a version mismatch error. We can expect
-        // the admin and backend will be on different versions from time to time
-        // due to different release cadences.
-        if (!this.feature.inAdminForward) {
-            headers['X-Ghost-Version'] = config.APP.version;
-        }
-
         return headers;
     }
 


### PR DESCRIPTION
no issue

- the `feature.inAdminForward` getter was removed in cleanup but the `ajax` service check was left in place causing a regression with the banner display in development and continuous-delivery environments
- Admin is now always in "adminForward" so the check in the ajax service to add the `X-Ghost-Version` header when not in "adminForward" no longer makes sense
