### PR TITLE
Removed "Refresh required" banner

### DIFF
--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -3,8 +3,6 @@ import AjaxService from 'ember-ajax/services/ajax';
 import classic from 'ember-classic-decorator';
 import config from 'ghost-admin/config/environment';
 import moment from 'moment-timezone';
-import semverCoerce from 'semver/functions/coerce';
-import semverLt from 'semver/functions/lt';
 import {AjaxError, isAjaxError, isForbiddenError} from 'ember-ajax/errors';
 import {get} from '@ember/object';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -340,15 +338,6 @@ class ajaxService extends AjaxService {
         Sentry.setTag('ajax_status', status);
         Sentry.setTag('ajax_url', request.url.slice(0, 200)); // the max length of a tag value is 200 characters
         Sentry.setTag('ajax_method', request.method);
-
-        if (headers['content-version']) {
-            const contentVersion = semverCoerce(headers['content-version']);
-            const appVersion = semverCoerce(config.APP.version);
-
-            if (semverLt(appVersion, contentVersion) && !this.feature.inAdminForward) {
-                this.upgradeStatus.refreshRequired = true;
-            }
-        }
 
         if (this.isTwoFactorTokenRequiredError(status, headers, payload)) {
             return new TwoFactorTokenRequiredError(payload);

--- a/ghost/admin/app/services/upgrade-status.js
+++ b/ghost/admin/app/services/upgrade-status.js
@@ -2,13 +2,10 @@ import Service, {inject as service} from '@ember/service';
 import classic from 'ember-classic-decorator';
 import {get, set} from '@ember/object';
 import {htmlSafe} from '@ember/template';
-import {tracked} from '@glimmer/tracking';
 
 @classic
 export default class UpgradeStatusService extends Service {
     @service notifications;
-
-    @tracked refreshRequired = false;
 
     isRequired = false;
     message = '';

--- a/ghost/admin/app/templates/application.hbs
+++ b/ghost/admin/app/templates/application.hbs
@@ -2,13 +2,6 @@
     <GhSkipLink @anchor=".gh-main">Skip to main content</GhSkipLink>
 
     <RenderInWormhole @elementId="ember-alerts-wormhole">
-        {{#if this.upgradeStatus.refreshRequired}}
-            <div class="gh-update-banner">
-                {{!-- template-lint-disable no-invalid-link-text --}}
-                <span>Ghost has been updated! To get access to the latest features, refresh or <a href="javascript:window.location.reload(true)">click here</a>.</span>
-            </div>
-        {{/if}}
-
         {{#if (and this.session.user.isAdmin this.showUpdateBanner)}}
         <aside class="gh-update-banner">
             {{#if this.session.user.isOwnerOnly}}


### PR DESCRIPTION
no issue

- the banner trigger was removed when running under the React Admin shell but has re-surfaced unintentionally when related "dead" code was cleaned up
- removed all version check/refresh banner related code from the Ember Admin to prevent any further accidental triggers
