### PR TITLE
Moved post access browser tests to e2e

### DIFF
--- a/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-editor-page.ts
@@ -7,6 +7,10 @@ class SettingsMenu extends BasePage {
     readonly postUrlInput: Locator;
     readonly publishDateInput: Locator;
     readonly publishTimeInput: Locator;
+    readonly visibilitySelect: Locator;
+    readonly visibilitySegmentSelect: Locator;
+    readonly visibilitySegmentInput: Locator;
+    readonly visibilitySelectedTokens: Locator;
     readonly customExcerptInput: Locator;
     readonly deletePostButton: Locator;
     readonly deletePostConfirmButton: Locator;
@@ -17,9 +21,40 @@ class SettingsMenu extends BasePage {
         this.postUrlInput = page.getByRole('textbox', {name: 'Post URL'});
         this.publishDateInput = page.getByLabel('Date Picker');
         this.publishTimeInput = page.getByLabel('Time Picker');
+        this.visibilitySelect = page.locator('[data-test-select="post-visibility"]');
+        this.visibilitySegmentSelect = page.locator('[data-test-visibility-segment-select]');
+        this.visibilitySegmentInput = this.visibilitySegmentSelect.getByTestId('token-input-search');
+        this.visibilitySelectedTokens = this.visibilitySegmentSelect.locator('[data-test-selected-token]');
         this.customExcerptInput = page.locator('[data-test-field="custom-excerpt"]');
         this.deletePostButton = page.locator('[data-test-button="delete-post"]');
         this.deletePostConfirmButton = page.locator('[data-test-button="delete-post-confirm"]');
+    }
+
+    async setVisibility(visibility: 'public' | 'members' | 'paid' | 'tiers'): Promise<void> {
+        await this.visibilitySelect.selectOption(visibility);
+
+        if (visibility === 'tiers') {
+            await this.visibilitySegmentSelect.waitFor({state: 'visible'});
+        }
+    }
+
+    async clearVisibilityTiers(): Promise<void> {
+        await this.visibilitySegmentInput.click();
+
+        let selectedCount = await this.visibilitySelectedTokens.count();
+
+        while (selectedCount > 0) {
+            const token = this.visibilitySelectedTokens.nth(selectedCount - 1);
+            await this.page.keyboard.press('Backspace');
+            await token.waitFor({state: 'detached'});
+            selectedCount -= 1;
+        }
+    }
+
+    async selectVisibilityTier(name: string): Promise<void> {
+        await this.visibilitySegmentInput.click();
+        await this.page.keyboard.type(name);
+        await this.page.locator(`[data-test-visibility-segment-option="${name}"]`).click();
     }
 
     async deletePost(): Promise<void> {

--- a/e2e/helpers/pages/public/post-page.ts
+++ b/e2e/helpers/pages/public/post-page.ts
@@ -8,6 +8,8 @@ export class PostPage extends PublicPage {
     readonly articleTitle: Locator;
     readonly articleHeader: Locator;
     readonly articleBody: Locator;
+    readonly accessCtaContent: Locator;
+    readonly accessCtaHeading: Locator;
     readonly metaDescription: Locator;
     readonly commentsSection: CommentsSection;
     readonly transistorCard: Locator;
@@ -21,6 +23,8 @@ export class PostPage extends PublicPage {
         this.articleTitle = page.locator('.gh-article-title');
         this.articleHeader = page.locator('main > article > header');
         this.articleBody = page.locator('.gh-content.gh-canvas > p');
+        this.accessCtaContent = page.locator('.gh-post-upgrade-cta-content');
+        this.accessCtaHeading = this.accessCtaContent.locator('h2');
         this.metaDescription = page.locator('meta[name="description"]');
         this.commentsSection = new CommentsSection(page);
         this.transistorCard = page.locator('.kg-transistor-card');

--- a/e2e/tests/admin/posts/publishing.test.ts
+++ b/e2e/tests/admin/posts/publishing.test.ts
@@ -1,8 +1,9 @@
-import {APIRequestContext, Page} from '@playwright/test';
+import {APIRequestContext, Browser, BrowserContext, Page} from '@playwright/test';
+import {Member, createMemberFactory, createTierFactory, generateSlug} from '@/data-factory';
 import {PageEditorPage, PostEditorPage, PostsPage} from '@/admin-pages';
 import {PostPage} from '@/helpers/pages';
-import {createMemberFactory, generateSlug} from '@/data-factory';
 import {expect, test} from '@/helpers/playwright';
+import {signInAsMember} from '@/helpers/playwright/flows/sign-in';
 
 async function getNewsletters(request: APIRequestContext): Promise<string[]> {
     const response = await request.get('/ghost/api/admin/newsletters/?status=active&limit=all');
@@ -34,6 +35,53 @@ async function expectPostStatus(editor: PostEditorPage, status: string | RegExp,
         await editor.postStatus.first().hover();
         await expect(editor.postStatus.first()).toContainText(detail);
     }
+}
+
+async function publishPost(editor: PostEditorPage): Promise<Page> {
+    await editor.publishFlow.open();
+    await editor.publishFlow.confirm();
+    const frontendPage = await editor.publishFlow.openPublishedPost();
+    await editor.publishFlow.close();
+
+    return frontendPage;
+}
+
+async function createPostWithVisibility(page: Page, {
+    title,
+    body,
+    visibility
+}: {
+    title: string;
+    body: string;
+    visibility: 'public' | 'members' | 'paid';
+}): Promise<Page> {
+    const postsPage = new PostsPage(page);
+    await postsPage.goto();
+    await postsPage.newPostButton.click();
+
+    const editor = new PostEditorPage(page);
+    await editor.createDraft({title, body});
+    await editor.settingsToggleButton.click();
+    await editor.settingsMenu.setVisibility(visibility);
+
+    return await publishPost(editor);
+}
+
+async function createAuthenticatedPublicPage(browser: Browser, baseURL: string, member: Member): Promise<{context: BrowserContext; page: Page; postPage: PostPage}> {
+    const context = await browser.newContext({
+        baseURL,
+        extraHTTPHeaders: {
+            Origin: baseURL
+        }
+    });
+    const page = await context.newPage();
+    await signInAsMember(page, member);
+
+    return {
+        context,
+        page,
+        postPage: new PostPage(page)
+    };
 }
 
 test.describe('Ghost Admin - Publishing', () => {
@@ -163,6 +211,112 @@ test.describe('Ghost Admin - Publishing', () => {
         await publicPage.gotoPost(generateSlug(title));
         await expect(publicPage.articleTitle).toHaveText(title);
         await expect(publicPage.articleBody).toHaveText(body);
+    });
+
+    test('members-only post shows subscriber gate', async ({page}) => {
+        const title = `members-only-post-${Date.now()}`;
+        const body = 'This is my members-only post body.';
+        const frontendPage = await createPostWithVisibility(page, {title, body, visibility: 'members'});
+
+        const publicPage = new PostPage(frontendPage);
+        await expect(publicPage.accessCtaHeading).toHaveText('This post is for subscribers only');
+    });
+
+    test('paid-members-only post shows paid subscriber gate', async ({page}) => {
+        const title = `paid-members-only-post-${Date.now()}`;
+        const body = 'This is my paid-members-only post body.';
+        const frontendPage = await createPostWithVisibility(page, {title, body, visibility: 'paid'});
+
+        const publicPage = new PostPage(frontendPage);
+        await expect(publicPage.accessCtaHeading).toHaveText('This post is for paying subscribers only');
+    });
+
+    test('public visibility change keeps post visible on frontend', async ({page}) => {
+        const title = `public-visibility-post-${Date.now()}`;
+        const body = 'This is my public visibility post body.';
+        const frontendPage = await createPostWithVisibility(page, {title, body, visibility: 'public'});
+
+        const publicPage = new PostPage(frontendPage);
+        await expect(publicPage.articleTitle).toHaveText(title);
+        await expect(publicPage.articleBody).toHaveText(body);
+    });
+
+    test.describe('specific tier visibility', () => {
+        test.use({stripeEnabled: true});
+
+        test('only allows selected tier members', async ({page, browser}) => {
+            test.setTimeout(60000);
+
+            const timestamp = Date.now();
+            const title = `gold-tier-post-${timestamp}`;
+            const body = 'Only gold members can see this';
+            const silverTierName = `Silver ${timestamp}`;
+            const goldTierName = `Gold ${timestamp}`;
+            const slug = generateSlug(title);
+            const tierFactory = createTierFactory(page.request);
+            const memberFactory = createMemberFactory(page.request);
+            const silverTier = await tierFactory.create({
+                name: silverTierName,
+                currency: 'usd',
+                monthly_price: 500,
+                yearly_price: 5000
+            });
+            const goldTier = await tierFactory.create({
+                name: goldTierName,
+                currency: 'usd',
+                monthly_price: 1000,
+                yearly_price: 10000
+            });
+            const silverMember = await memberFactory.create({
+                email: `silver-tier-${timestamp}@example.com`,
+                name: 'Silver Member',
+                status: 'comped',
+                tiers: [{id: silverTier.id}]
+            });
+            const goldMember = await memberFactory.create({
+                email: `gold-tier-${timestamp}@example.com`,
+                name: 'Gold Member',
+                status: 'comped',
+                tiers: [{id: goldTier.id}]
+            });
+
+            const postsPage = new PostsPage(page);
+            await postsPage.goto();
+            await postsPage.newPostButton.click();
+
+            const editor = new PostEditorPage(page);
+            await editor.createDraft({title, body});
+            await expect(editor.postStatus.first()).toContainText('Draft');
+            await expect(editor.postStatus.first()).not.toContainText('Saving');
+            await editor.settingsToggleButton.click();
+            await editor.settingsMenu.setVisibility('tiers');
+            await editor.settingsMenu.clearVisibilityTiers();
+            await editor.settingsMenu.selectVisibilityTier(goldTier.name);
+
+            await editor.publishFlow.open();
+            await editor.publishFlow.confirm();
+
+            const anonymousPage = await page.context().newPage();
+            const anonymousPostPage = new PostPage(anonymousPage);
+            await anonymousPostPage.gotoPost(slug);
+            await expect(anonymousPostPage.accessCtaHeading).toContainText(`on the ${goldTier.name} tier only`);
+
+            const baseURL = new URL(page.url()).origin;
+            const silverSession = await createAuthenticatedPublicPage(browser, baseURL, silverMember);
+            const goldSession = await createAuthenticatedPublicPage(browser, baseURL, goldMember);
+
+            try {
+                await silverSession.postPage.gotoPost(slug);
+                await expect(silverSession.postPage.accessCtaHeading).toContainText(`on the ${goldTier.name} tier only`);
+
+                await goldSession.postPage.gotoPost(slug);
+                await expect(goldSession.postPage.accessCtaContent).toBeHidden();
+                await expect(goldSession.postPage.articleBody).toHaveText(body);
+            } finally {
+                await silverSession.context.close();
+                await goldSession.context.close();
+            }
+        });
     });
 
     test('updates a published post', async ({page}) => {

--- a/e2e/tests/admin/posts/publishing.test.ts
+++ b/e2e/tests/admin/posts/publishing.test.ts
@@ -37,11 +37,6 @@ async function expectPostStatus(editor: PostEditorPage, status: string | RegExp,
     }
 }
 
-async function waitForDraftEditorToSettle(editor: PostEditorPage): Promise<void> {
-    await expect(editor.postStatus.first()).toContainText('Draft');
-    await expect(editor.postStatus.first()).not.toContainText('Saving');
-}
-
 async function publishPost(editor: PostEditorPage): Promise<Page> {
     await editor.publishFlow.open();
     await editor.publishFlow.confirm();
@@ -89,42 +84,6 @@ async function createAuthenticatedPublicPage(browser: Browser, baseURL: string, 
     };
 }
 
-async function withAuthenticatedPublicPage<T>(browser: Browser, baseURL: string, member: Member, callback: (postPage: PostPage) => Promise<T>): Promise<T> {
-    const {context, postPage} = await createAuthenticatedPublicPage(browser, baseURL, member);
-
-    try {
-        return await callback(postPage);
-    } finally {
-        await context.close();
-    }
-}
-
-async function createPostWithTierVisibility(page: Page, {
-    title,
-    body,
-    tierName
-}: {
-    title: string;
-    body: string;
-    tierName: string;
-}): Promise<string> {
-    const postsPage = new PostsPage(page);
-    await postsPage.goto();
-    await postsPage.newPostButton.click();
-
-    const editor = new PostEditorPage(page);
-    await editor.createDraft({title, body});
-    await waitForDraftEditorToSettle(editor);
-    await editor.settingsToggleButton.click();
-    await editor.settingsMenu.setVisibility('tiers');
-    await editor.settingsMenu.clearVisibilityTiers();
-    await editor.settingsMenu.selectVisibilityTier(tierName);
-    await editor.publishFlow.open();
-    await editor.publishFlow.confirm();
-
-    return generateSlug(title);
-}
-
 async function createTierVisibilityFixture(request: APIRequestContext, timestamp: number): Promise<{
     allowedTierName: string;
     allowedMember: Member;
@@ -168,14 +127,6 @@ async function createTierVisibilityFixture(request: APIRequestContext, timestamp
         allowedMember,
         disallowedMember
     };
-}
-
-function tierAccessMessage(tierName: string): string {
-    return `on the ${tierName} tier only`;
-}
-
-async function expectTierGate(postPage: PostPage, tierName: string): Promise<void> {
-    await expect(postPage.accessCtaHeading).toContainText(tierAccessMessage(tierName));
 }
 
 test.describe('Ghost Admin - Publishing', () => {
@@ -339,34 +290,53 @@ test.describe('Ghost Admin - Publishing', () => {
         test.use({stripeEnabled: true});
 
         test('only allows selected tier members', async ({page, browser}) => {
-            test.setTimeout(60000);
-
             const timestamp = Date.now();
             const title = `gold-tier-post-${timestamp}`;
             const body = 'Only gold members can see this';
             const {allowedTierName, allowedMember, disallowedMember} = await createTierVisibilityFixture(page.request, timestamp);
-            const slug = await createPostWithTierVisibility(page, {title, body, tierName: allowedTierName});
+            const accessMessage = `on the ${allowedTierName} tier only`;
+
+            const postsPage = new PostsPage(page);
+            await postsPage.goto();
+            await postsPage.newPostButton.click();
+
+            const editor = new PostEditorPage(page);
+            await editor.createDraft({title, body});
+            await expect(editor.postStatus.first()).toContainText('Draft');
+            await expect(editor.postStatus.first()).not.toContainText('Saving');
+            await editor.settingsToggleButton.click();
+            await editor.settingsMenu.setVisibility('tiers');
+            await editor.settingsMenu.clearVisibilityTiers();
+            await editor.settingsMenu.selectVisibilityTier(allowedTierName);
+            await editor.publishFlow.open();
+            await editor.publishFlow.confirm();
+
+            const slug = generateSlug(title);
 
             const anonymousPage = await page.context().newPage();
             try {
                 const anonymousPostPage = new PostPage(anonymousPage);
                 await anonymousPostPage.gotoPost(slug);
-                await expectTierGate(anonymousPostPage, allowedTierName);
+                await expect(anonymousPostPage.accessCtaHeading).toContainText(accessMessage);
             } finally {
                 await anonymousPage.close();
             }
 
             const baseURL = new URL(page.url()).origin;
-            await withAuthenticatedPublicPage(browser, baseURL, disallowedMember, async (postPage) => {
-                await postPage.gotoPost(slug);
-                await expectTierGate(postPage, allowedTierName);
-            });
+            const disallowedSession = await createAuthenticatedPublicPage(browser, baseURL, disallowedMember);
+            const allowedSession = await createAuthenticatedPublicPage(browser, baseURL, allowedMember);
 
-            await withAuthenticatedPublicPage(browser, baseURL, allowedMember, async (postPage) => {
-                await postPage.gotoPost(slug);
-                await expect(postPage.accessCtaContent).toBeHidden();
-                await expect(postPage.articleBody).toHaveText(body);
-            });
+            try {
+                await disallowedSession.postPage.gotoPost(slug);
+                await expect(disallowedSession.postPage.accessCtaHeading).toContainText(accessMessage);
+
+                await allowedSession.postPage.gotoPost(slug);
+                await expect(allowedSession.postPage.accessCtaContent).toBeHidden();
+                await expect(allowedSession.postPage.articleBody).toHaveText(body);
+            } finally {
+                await disallowedSession.context.close();
+                await allowedSession.context.close();
+            }
         });
     });
 

--- a/e2e/tests/admin/posts/publishing.test.ts
+++ b/e2e/tests/admin/posts/publishing.test.ts
@@ -37,6 +37,11 @@ async function expectPostStatus(editor: PostEditorPage, status: string | RegExp,
     }
 }
 
+async function waitForDraftEditorToSettle(editor: PostEditorPage): Promise<void> {
+    await expect(editor.postStatus.first()).toContainText('Draft');
+    await expect(editor.postStatus.first()).not.toContainText('Saving');
+}
+
 async function publishPost(editor: PostEditorPage): Promise<Page> {
     await editor.publishFlow.open();
     await editor.publishFlow.confirm();
@@ -82,6 +87,95 @@ async function createAuthenticatedPublicPage(browser: Browser, baseURL: string, 
         page,
         postPage: new PostPage(page)
     };
+}
+
+async function withAuthenticatedPublicPage<T>(browser: Browser, baseURL: string, member: Member, callback: (postPage: PostPage) => Promise<T>): Promise<T> {
+    const {context, postPage} = await createAuthenticatedPublicPage(browser, baseURL, member);
+
+    try {
+        return await callback(postPage);
+    } finally {
+        await context.close();
+    }
+}
+
+async function createPostWithTierVisibility(page: Page, {
+    title,
+    body,
+    tierName
+}: {
+    title: string;
+    body: string;
+    tierName: string;
+}): Promise<string> {
+    const postsPage = new PostsPage(page);
+    await postsPage.goto();
+    await postsPage.newPostButton.click();
+
+    const editor = new PostEditorPage(page);
+    await editor.createDraft({title, body});
+    await waitForDraftEditorToSettle(editor);
+    await editor.settingsToggleButton.click();
+    await editor.settingsMenu.setVisibility('tiers');
+    await editor.settingsMenu.clearVisibilityTiers();
+    await editor.settingsMenu.selectVisibilityTier(tierName);
+    await editor.publishFlow.open();
+    await editor.publishFlow.confirm();
+
+    return generateSlug(title);
+}
+
+async function createTierVisibilityFixture(request: APIRequestContext, timestamp: number): Promise<{
+    allowedTierName: string;
+    allowedMember: Member;
+    disallowedMember: Member;
+}> {
+    const tierFactory = createTierFactory(request);
+    const memberFactory = createMemberFactory(request);
+
+    const [disallowedTier, allowedTier] = await Promise.all([
+        tierFactory.create({
+            name: `Silver ${timestamp}`,
+            currency: 'usd',
+            monthly_price: 500,
+            yearly_price: 5000
+        }),
+        tierFactory.create({
+            name: `Gold ${timestamp}`,
+            currency: 'usd',
+            monthly_price: 1000,
+            yearly_price: 10000
+        })
+    ]);
+
+    const [disallowedMember, allowedMember] = await Promise.all([
+        memberFactory.create({
+            email: `silver-tier-${timestamp}@example.com`,
+            name: 'Silver Member',
+            status: 'comped',
+            tiers: [{id: disallowedTier.id}]
+        }),
+        memberFactory.create({
+            email: `gold-tier-${timestamp}@example.com`,
+            name: 'Gold Member',
+            status: 'comped',
+            tiers: [{id: allowedTier.id}]
+        })
+    ]);
+
+    return {
+        allowedTierName: allowedTier.name,
+        allowedMember,
+        disallowedMember
+    };
+}
+
+function tierAccessMessage(tierName: string): string {
+    return `on the ${tierName} tier only`;
+}
+
+async function expectTierGate(postPage: PostPage, tierName: string): Promise<void> {
+    await expect(postPage.accessCtaHeading).toContainText(tierAccessMessage(tierName));
 }
 
 test.describe('Ghost Admin - Publishing', () => {
@@ -250,72 +344,29 @@ test.describe('Ghost Admin - Publishing', () => {
             const timestamp = Date.now();
             const title = `gold-tier-post-${timestamp}`;
             const body = 'Only gold members can see this';
-            const silverTierName = `Silver ${timestamp}`;
-            const goldTierName = `Gold ${timestamp}`;
-            const slug = generateSlug(title);
-            const tierFactory = createTierFactory(page.request);
-            const memberFactory = createMemberFactory(page.request);
-            const silverTier = await tierFactory.create({
-                name: silverTierName,
-                currency: 'usd',
-                monthly_price: 500,
-                yearly_price: 5000
-            });
-            const goldTier = await tierFactory.create({
-                name: goldTierName,
-                currency: 'usd',
-                monthly_price: 1000,
-                yearly_price: 10000
-            });
-            const silverMember = await memberFactory.create({
-                email: `silver-tier-${timestamp}@example.com`,
-                name: 'Silver Member',
-                status: 'comped',
-                tiers: [{id: silverTier.id}]
-            });
-            const goldMember = await memberFactory.create({
-                email: `gold-tier-${timestamp}@example.com`,
-                name: 'Gold Member',
-                status: 'comped',
-                tiers: [{id: goldTier.id}]
-            });
-
-            const postsPage = new PostsPage(page);
-            await postsPage.goto();
-            await postsPage.newPostButton.click();
-
-            const editor = new PostEditorPage(page);
-            await editor.createDraft({title, body});
-            await expect(editor.postStatus.first()).toContainText('Draft');
-            await expect(editor.postStatus.first()).not.toContainText('Saving');
-            await editor.settingsToggleButton.click();
-            await editor.settingsMenu.setVisibility('tiers');
-            await editor.settingsMenu.clearVisibilityTiers();
-            await editor.settingsMenu.selectVisibilityTier(goldTier.name);
-
-            await editor.publishFlow.open();
-            await editor.publishFlow.confirm();
+            const {allowedTierName, allowedMember, disallowedMember} = await createTierVisibilityFixture(page.request, timestamp);
+            const slug = await createPostWithTierVisibility(page, {title, body, tierName: allowedTierName});
 
             const anonymousPage = await page.context().newPage();
-            const anonymousPostPage = new PostPage(anonymousPage);
-            await anonymousPostPage.gotoPost(slug);
-            await expect(anonymousPostPage.accessCtaHeading).toContainText(`on the ${goldTier.name} tier only`);
+            try {
+                const anonymousPostPage = new PostPage(anonymousPage);
+                await anonymousPostPage.gotoPost(slug);
+                await expectTierGate(anonymousPostPage, allowedTierName);
+            } finally {
+                await anonymousPage.close();
+            }
 
             const baseURL = new URL(page.url()).origin;
-            const silverSession = await createAuthenticatedPublicPage(browser, baseURL, silverMember);
-            const goldSession = await createAuthenticatedPublicPage(browser, baseURL, goldMember);
+            await withAuthenticatedPublicPage(browser, baseURL, disallowedMember, async (postPage) => {
+                await postPage.gotoPost(slug);
+                await expectTierGate(postPage, allowedTierName);
+            });
 
-            try {
-                await silverSession.postPage.gotoPost(slug);
-                await expect(silverSession.postPage.accessCtaHeading).toContainText(`on the ${goldTier.name} tier only`);
-
-                await goldSession.postPage.gotoPost(slug);
-                await expect(goldSession.postPage.accessCtaContent).toBeHidden();
-                await expect(goldSession.postPage.articleBody).toHaveText(body);
-            } finally {
-                await silverSession.context.close();
-                await goldSession.context.close();
-            }
+            await withAuthenticatedPublicPage(browser, baseURL, allowedMember, async (postPage) => {
+                await postPage.gotoPost(slug);
+                await expect(postPage.accessCtaContent).toBeHidden();
+                await expect(postPage.articleBody).toHaveText(body);
+            });
         });
     });
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -2,7 +2,7 @@ const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 const {DateTime} = require('luxon');
 const {slugify} = require('@tryghost/string');
-const {createTier, createMember, createPostDraft, impersonateMember} = require('../utils');
+const {createMember, createPostDraft} = require('../utils');
 
 // Schedules a post to publish ASAP by setting yesterday + 00:00, which is always in the past.
 // Ghost auto-corrects past dates to 5 seconds from now. We use yesterday (not today) because
@@ -115,14 +115,6 @@ const openPostSettingsMenu = async (page) => {
 };
 
 /**
- * @param {import('@playwright/test').Page} page
- * @param {'public'|'members'|'paid'|'tiers'} visibility
- */
-const setPostVisibility = async (page, visibility) => {
-    await page.locator('[data-test-select="post-visibility"]').selectOption(visibility);
-};
-
-/**
  * @typedef {Object} PublishOptions
  * @property {'publish'|'publish+send'|'send'|null} [type]
  * @property {String} [recipientFilter]
@@ -183,21 +175,6 @@ const publishPost = async (page, {type = 'publish', time, date} = {}) => {
 
     // Wait for the publish flow to complete by checking the confirm button is no longer visible
     await page.locator('[data-test-modal="publish-flow"] [data-test-button="confirm-publish"]').waitFor({state: 'hidden'});
-};
-
-/**
- * When on the publish flow completed step, click the bookmark
- * @param {import('@playwright/test').Page} page
- * @returns {Promise<import('@playwright/test').Page>}
- */
-const openPublishedPostBookmark = async (page) => {
-    // open the published post in a new tab
-    const [frontendPage] = await Promise.all([
-        page.waitForEvent('popup'),
-        page.locator('[data-test-complete-bookmark]').click()
-    ]);
-
-    return frontendPage;
 };
 
 test.describe('Publishing', () => {
@@ -326,107 +303,6 @@ test.describe('Publishing', () => {
 });
 
 test.describe('Updating post access', () => {
-    test.describe('Change post visibility to members-only', () => {
-        test('Only logged-in members (free or paid) can see', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-
-            await createPostDraft(sharedPage);
-            await openPostSettingsMenu(sharedPage);
-            await setPostVisibility(sharedPage, 'members');
-
-            await publishPost(sharedPage);
-            const frontendPage = await openPublishedPostBookmark(sharedPage);
-
-            // Check if content gate for members is present on front-end
-            await expect(frontendPage.locator('.gh-post-upgrade-cta-content h2')).toHaveText('This post is for subscribers only');
-        });
-    });
-
-    test.describe('Change post visibility to paid-members-only', () => {
-        test('Only logged-in, paid members can see', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-
-            await createPostDraft(sharedPage);
-            await openPostSettingsMenu(sharedPage);
-            await setPostVisibility(sharedPage, 'paid');
-
-            await publishPost(sharedPage);
-            const frontendPage = await openPublishedPostBookmark(sharedPage);
-
-            // Check if content gate for paid members is present on front-end
-            await expect(frontendPage.locator('.gh-post-upgrade-cta-content h2')).toHaveText('This post is for paying subscribers only');
-        });
-    });
-
-    test.describe('Change post visibility to public', () => {
-        test('Everyone can see', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-
-            await createPostDraft(sharedPage);
-            await openPostSettingsMenu(sharedPage);
-            await setPostVisibility(sharedPage, 'public');
-
-            await publishPost(sharedPage);
-            const frontendPage = await openPublishedPostBookmark(sharedPage);
-
-            // Check if post content is publicly visible on front-end
-            await expect(frontendPage.locator('.gh-content.gh-canvas > p')).toHaveText('This is my post body.');
-        });
-    });
-
-    test('specific tiers', async ({sharedPage}) => {
-        await sharedPage.goto('/ghost');
-
-        // tiers and members are needed to test the access levels
-        await createTier(sharedPage, {name: 'Silver', monthlyPrice: 5, yearlyPrice: 50});
-        await createTier(sharedPage, {name: 'Gold', monthlyPrice: 10, yearlyPrice: 100});
-        await createMember(sharedPage, {email: 'silver@example.com', compedPlan: 'Silver'});
-        const silverMember = await sharedPage.url();
-        await createMember(sharedPage, {email: 'gold@example.com', compedPlan: 'Gold'});
-        const goldMember = await sharedPage.url();
-
-        await createPostDraft(sharedPage, {body: 'Only gold members can see this'});
-
-        await openPostSettingsMenu(sharedPage);
-        await setPostVisibility(sharedPage, 'tiers');
-
-        // backspace removes existing tiers
-        await expect(sharedPage.locator('[data-test-visibility-segment-select] [data-test-selected-token]')).toHaveCount(3);
-        await sharedPage.locator('[data-test-visibility-segment-select] input').click();
-        await sharedPage.keyboard.press('Backspace');
-        await sharedPage.waitForTimeout(50);
-        await sharedPage.keyboard.press('Backspace');
-        await sharedPage.waitForTimeout(50);
-        await sharedPage.keyboard.press('Backspace');
-        await expect(sharedPage.locator('[data-test-visibility-segment-select] [data-test-selected-token]')).toHaveCount(0);
-
-        // specific tier can be added back on
-        await sharedPage.keyboard.type('Go');
-        const goldOption = sharedPage.locator('[data-test-visibility-segment-option="Gold"]');
-        await goldOption.click();
-
-        // publish
-        await publishPost(sharedPage);
-        const frontendPage = await openPublishedPostBookmark(sharedPage);
-        await closePublishFlow(sharedPage);
-
-        // non-member doesn't have access
-        await expect(frontendPage.locator('.gh-post-upgrade-cta-content h2')).toContainText('on the Gold tier only');
-
-        // member on wrong tier doesn't have access
-        await sharedPage.goto(silverMember);
-        await impersonateMember(sharedPage);
-        await frontendPage.reload();
-        await expect(frontendPage.locator('.gh-post-upgrade-cta-content h2')).toContainText('on the Gold tier only');
-
-        // member on selected tier has access
-        await sharedPage.goto(goldMember);
-        await impersonateMember(sharedPage);
-        await frontendPage.reload();
-        await expect(frontendPage.locator('.gh-post-upgrade-cta-content')).not.toBeVisible();
-        await expect(frontendPage.locator('.gh-content.gh-canvas > p')).toHaveText('Only gold members can see this');
-    });
-
     test('publish time in timezone', async ({page}) => {
         await page.goto('/ghost');
 


### PR DESCRIPTION
## What this does
- moves the post access visibility coverage into the aggregated e2e publishing spec
- adds the editor/public page helpers needed for members, paid, public, and specific-tier visibility flows
- removes the migrated access tests from the legacy browser publishing spec

## Verification
- yarn workspace @tryghost/e2e test tests/admin/posts/publishing.test.ts
- yarn workspace @tryghost/e2e test:types
- yarn workspace @tryghost/e2e eslint helpers/pages/admin/posts/post/post-editor-page.ts helpers/pages/public/post-page.ts tests/admin/posts/publishing.test.ts
- yarn eslint ghost/core/test/e2e-browser/admin/publishing.spec.js

## Notes
- the existing playwright warning for click({force: true}) in post-editor-page.ts is unchanged