### PR TITLE
Improved webhook delivery failure logging

### DIFF
--- a/ghost/core/core/server/services/webhooks/webhook-trigger.js
+++ b/ghost/core/core/server/services/webhooks/webhook-trigger.js
@@ -91,7 +91,7 @@ class WebhookTrigger {
                 error: `Request failed: ${err.code || 'unknown'}`
             });
 
-            logging.warn(`Request to ${webhook.get('target_url') || null} failed because of: ${err.code || ''}.`);
+            logging.error(`[WEBHOOK_DELIVERY_FAILURE] url=${webhook.get('target_url') || 'unknown'} status=${err.statusCode || 'none'} error_code=${err.code || 'unknown'} message=${err.message || ''}`, err);
         };
     }
 

--- a/ghost/core/test/unit/server/services/webhooks/trigger.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/trigger.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const crypto = require('crypto');
 const sinon = require('sinon');
+const logging = require('@tryghost/logging');
 const LimitService = require('@tryghost/limit-service');
 
 const WebhookTrigger = require('../../../../../core/server/services/webhooks/webhook-trigger');
@@ -44,6 +45,67 @@ describe('Webhook Service', function () {
 
         sinon.stub(webhookTrigger, 'onSuccess').callsFake(() => Promise.resolve());
         sinon.stub(webhookTrigger, 'onError').callsFake(() => Promise.resolve());
+    });
+
+    describe('onError', function () {
+        let loggingStub;
+        let errorTrigger;
+
+        beforeEach(function () {
+            loggingStub = sinon.stub(logging, 'error');
+            errorTrigger = new WebhookTrigger({models, payload, request, limitService});
+        });
+
+        afterEach(function () {
+            loggingStub.restore();
+        });
+
+        it('logs a structured error for failed webhook deliveries', function () {
+            const webhookModel = {
+                id: 'abc123',
+                get: sinon.stub()
+            };
+            webhookModel.get
+                .withArgs('event').returns('post.added')
+                .withArgs('target_url').returns('https://example.com/hook');
+
+            const err = new Error('URL resolves to a non-permitted private IP block');
+            err.statusCode = 500;
+            err.code = 'URL_PRIVATE_INVALID';
+
+            errorTrigger.onError(webhookModel)(err);
+
+            sinon.assert.calledOnce(loggingStub);
+
+            // Example output:
+            // [WEBHOOK_DELIVERY_FAILURE] url=https://example.com/hook status=500 error_code=URL_PRIVATE_INVALID message=URL resolves to a non-permitted private IP block
+            const logLine = loggingStub.args[0][0];
+            assert.ok(logLine.startsWith('[WEBHOOK_DELIVERY_FAILURE]'), 'Log line must start with [WEBHOOK_DELIVERY_FAILURE] prefix');
+            assert.ok(logLine.includes('url=https://example.com/hook'));
+            assert.ok(logLine.includes('status=500'));
+            assert.ok(logLine.includes('error_code=URL_PRIVATE_INVALID'));
+            assert.ok(logLine.includes('message=URL resolves to a non-permitted private IP block'));
+            assert.equal(loggingStub.args[0][1], err, 'Error object must be passed as second argument for stack/metadata');
+        });
+
+        it('logs with fallback values when error properties are missing', function () {
+            const webhookModel = {
+                id: 'abc123',
+                get: sinon.stub()
+            };
+            webhookModel.get
+                .withArgs('event').returns('post.added')
+                .withArgs('target_url').returns(null);
+
+            const err = new Error();
+
+            errorTrigger.onError(webhookModel)(err);
+
+            const logLine = loggingStub.args[0][0];
+            assert.ok(logLine.includes('url=unknown'));
+            assert.ok(logLine.includes('status=none'));
+            assert.ok(logLine.includes('error_code=unknown'));
+        });
     });
 
     describe('trigger', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1609/

- Promoted webhook delivery failure logs from `warn` to `error` level so they surface in error-level monitoring
- Added structured `[WEBHOOK_DELIVERY_FAILURE]` prefix with `url`, `status`, `error_code`, and `message` fields for easy SLO alerting
- Added unit tests verifying the structured log output and fallback values