### PR TITLE
Modified `email_design_setting_id` column to be non-nullable on `automated_emails` table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.25/2026-03-31-20-31-19-drop-nullable-on-automated-emails-email-design-setting-id.js
+++ b/ghost/core/core/server/data/migrations/versions/6.25/2026-03-31-20-31-19-drop-nullable-on-automated-emails-email-design-setting-id.js
@@ -1,0 +1,3 @@
+const {createDropNullableMigration} = require('../../utils');
+
+module.exports = createDropNullableMigration('automated_emails', 'email_design_setting_id');

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1177,7 +1177,7 @@ module.exports = {
         sender_name: {type: 'string', maxlength: 191, nullable: true},
         sender_email: {type: 'string', maxlength: 191, nullable: true, validations: {isEmail: true}},
         sender_reply_to: {type: 'string', maxlength: 191, nullable: true, validations: {isEmail: true}},
-        email_design_setting_id: {type: 'string', maxlength: 24, nullable: true, references: 'email_design_settings.id'},
+        email_design_setting_id: {type: 'string', maxlength: 24, nullable: false, references: 'email_design_settings.id'},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         '@@INDEXES@@': [

--- a/ghost/core/test/integration/jobs/process-outbox.test.js
+++ b/ghost/core/test/integration/jobs/process-outbox.test.js
@@ -14,10 +14,15 @@ const processOutbox = require('../../../core/server/services/outbox/jobs/lib/pro
 
 describe('Process Outbox Job', function () {
     let jobService;
+    let defaultEmailDesignSettingId;
 
     before(async function () {
         await testUtils.startGhost();
         jobService = require('../../../core/server/services/jobs/job-service');
+        defaultEmailDesignSettingId = await db.knex('email_design_settings')
+            .where('slug', 'default-automated-email')
+            .first('id')
+            .then(row => row.id);
     });
 
     afterEach(async function () {
@@ -61,6 +66,7 @@ describe('Process Outbox Job', function () {
 
             await db.knex('automated_emails').insert({
                 id: ObjectId().toHexString(),
+                email_design_setting_id: defaultEmailDesignSettingId,
                 status: 'active',
                 name: 'Free Member Welcome Email',
                 slug: MEMBER_WELCOME_EMAIL_SLUGS.free,

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -12,11 +12,16 @@ const processOutbox = require('../../../core/server/services/outbox/jobs/lib/pro
 describe('Member Welcome Emails Integration', function () {
     let membersService;
     let defaultNewsletterSenderState = null;
+    let defaultEmailDesignSettingId;
 
     before(async function () {
         await testUtils.setup('default')();
         membersService = require('../../../core/server/services/members');
         membersService.init();
+        defaultEmailDesignSettingId = await db.knex('email_design_settings')
+            .where('slug', 'default-automated-email')
+            .first('id')
+            .then(row => row.id);
     });
 
     beforeEach(async function () {
@@ -51,6 +56,7 @@ describe('Member Welcome Emails Integration', function () {
 
         await db.knex('automated_emails').insert({
             id: ObjectId().toHexString(),
+            email_design_setting_id: defaultEmailDesignSettingId,
             status: 'active',
             name: 'Free Member Welcome Email',
             slug: MEMBER_WELCOME_EMAIL_SLUGS.free,
@@ -61,6 +67,7 @@ describe('Member Welcome Emails Integration', function () {
 
         await db.knex('automated_emails').insert({
             id: ObjectId().toHexString(),
+            email_design_setting_id: defaultEmailDesignSettingId,
             status: 'active',
             name: 'Paid Member Welcome Email',
             slug: MEMBER_WELCOME_EMAIL_SLUGS.paid,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'dda821448f20db2f4965d67c7f3d4051';
+    const currentSchemaHash = '3371efe39a471bf7c67cf23c29790c8b';
     const currentFixturesHash = '2f86ab1e3820e86465f9ad738dd0ee93';
     const currentSettingsHash = 'a102b80d2ab0cd92325ed007c94d7da6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1185/drop-nullable-on-the-email-design-setting-id-column-on-automated

## Summary
- Changed `email_design_setting_id` column on `automated_emails` table from nullable to non-nullable
- Added a database migration using `createDropNullableMigration` to alter the column constraint
- Updated schema definition and schema integrity hash

This is the final step after backfilling existing rows in #27022, completing the column constraint tightening.

## Test plan
- [x] Schema integrity test updated with new hash
- [x] Run `yarn test:unit` in `ghost/core` to verify schema integrity
- [x] Run migration against a database with existing `automated_emails` rows to confirm no errors

