### PR TITLE
Added `/email-design-settings/` Admin API endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -16,12 +16,20 @@ const controller = {
             cacheInvalidate: false
         },
         options: [
+            'include',
             'filter',
             'fields',
             'limit',
             'order',
             'page'
         ],
+        validation: {
+            options: {
+                include: {
+                    values: ['email_design_setting']
+                }
+            }
+        },
         permissions: true,
         query(frame) {
             return models.AutomatedEmail.findPage(frame.options);
@@ -33,12 +41,20 @@ const controller = {
             cacheInvalidate: false
         },
         options: [
+            'include',
             'filter',
             'fields'
         ],
         data: [
             'id'
         ],
+        validation: {
+            options: {
+                include: {
+                    values: ['email_design_setting']
+                }
+            }
+        },
         permissions: true,
         async query(frame) {
             const model = await models.AutomatedEmail.findOne(frame.data, frame.options);

--- a/ghost/core/core/server/api/endpoints/email-design-settings.js
+++ b/ghost/core/core/server/api/endpoints/email-design-settings.js
@@ -1,0 +1,83 @@
+const tpl = require('@tryghost/tpl');
+const errors = require('@tryghost/errors');
+const models = require('../../models');
+
+const messages = {
+    emailDesignSettingNotFound: 'Email design setting not found.'
+};
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'email_design_settings',
+
+    browse: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'filter',
+            'fields',
+            'limit',
+            'order',
+            'page'
+        ],
+        permissions: true,
+        query(frame) {
+            return models.EmailDesignSetting.findPage(frame.options);
+        }
+    },
+
+    read: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'filter',
+            'fields'
+        ],
+        data: [
+            'id'
+        ],
+        permissions: true,
+        async query(frame) {
+            const model = await models.EmailDesignSetting.findOne(frame.data, frame.options);
+            if (!model) {
+                throw new errors.NotFoundError({
+                    message: tpl(messages.emailDesignSettingNotFound)
+                });
+            }
+
+            return model;
+        }
+    },
+
+    edit: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        async query(frame) {
+            const data = frame.data.email_design_settings[0];
+            const model = await models.EmailDesignSetting.edit(data, frame.options);
+            if (!model) {
+                throw new errors.NotFoundError({
+                    message: tpl(messages.emailDesignSettingNotFound)
+                });
+            }
+
+            return model;
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -85,6 +85,10 @@ module.exports = {
         return apiFramework.pipeline(require('./automated-emails'), localUtils);
     },
 
+    get emailDesignSettings() {
+        return apiFramework.pipeline(require('./email-design-settings'), localUtils);
+    },
+
     get membersStripeConnect() {
         return apiFramework.pipeline(require('./members-stripe-connect'), localUtils);
     },

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/email_design_settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/email_design_settings.js
@@ -1,0 +1,92 @@
+// Filename must match the docName specified in ../../../email-design-settings.js
+/* eslint-disable ghost/filenames/match-regex */
+
+const {ValidationError} = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+const ALLOWED_BUTTON_CORNERS = ['square', 'rounded', 'pill'];
+const ALLOWED_BUTTON_STYLES = ['fill', 'outline'];
+const ALLOWED_LINK_STYLES = ['underline', 'regular', 'bold'];
+const ALLOWED_FONT_CATEGORIES = ['serif', 'sans_serif'];
+const ALLOWED_TITLE_FONT_WEIGHTS = ['normal', 'medium', 'semibold', 'bold'];
+const ALLOWED_IMAGE_CORNERS = ['square', 'rounded'];
+
+const messages = {
+    invalidButtonCorners: `button_corners must be one of: ${ALLOWED_BUTTON_CORNERS.join(', ')}`,
+    invalidButtonStyle: `button_style must be one of: ${ALLOWED_BUTTON_STYLES.join(', ')}`,
+    invalidLinkStyle: `link_style must be one of: ${ALLOWED_LINK_STYLES.join(', ')}`,
+    invalidBodyFontCategory: `body_font_category must be one of: ${ALLOWED_FONT_CATEGORIES.join(', ')}`,
+    invalidTitleFontCategory: `title_font_category must be one of: ${ALLOWED_FONT_CATEGORIES.join(', ')}`,
+    invalidTitleFontWeight: `title_font_weight must be one of: ${ALLOWED_TITLE_FONT_WEIGHTS.join(', ')}`,
+    invalidImageCorners: `image_corners must be one of: ${ALLOWED_IMAGE_CORNERS.join(', ')}`
+};
+
+/**
+ * Validates enum fields on email design settings data.
+ * @param {object} frame - The API frame containing the request data
+ * @returns {Promise<void>}
+ */
+const validateEmailDesignSetting = async function (frame) {
+    if (!frame.data.email_design_settings || !frame.data.email_design_settings[0]) {
+        return Promise.resolve();
+    }
+
+    const data = frame.data.email_design_settings[0];
+
+    if (data.button_corners !== undefined && !ALLOWED_BUTTON_CORNERS.includes(data.button_corners)) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.invalidButtonCorners),
+            property: 'button_corners'
+        }));
+    }
+
+    if (data.button_style !== undefined && !ALLOWED_BUTTON_STYLES.includes(data.button_style)) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.invalidButtonStyle),
+            property: 'button_style'
+        }));
+    }
+
+    if (data.link_style !== undefined && !ALLOWED_LINK_STYLES.includes(data.link_style)) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.invalidLinkStyle),
+            property: 'link_style'
+        }));
+    }
+
+    if (data.body_font_category !== undefined && !ALLOWED_FONT_CATEGORIES.includes(data.body_font_category)) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.invalidBodyFontCategory),
+            property: 'body_font_category'
+        }));
+    }
+
+    if (data.title_font_category !== undefined && !ALLOWED_FONT_CATEGORIES.includes(data.title_font_category)) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.invalidTitleFontCategory),
+            property: 'title_font_category'
+        }));
+    }
+
+    if (data.title_font_weight !== undefined && !ALLOWED_TITLE_FONT_WEIGHTS.includes(data.title_font_weight)) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.invalidTitleFontWeight),
+            property: 'title_font_weight'
+        }));
+    }
+
+    if (data.image_corners !== undefined && !ALLOWED_IMAGE_CORNERS.includes(data.image_corners)) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.invalidImageCorners),
+            property: 'image_corners'
+        }));
+    }
+
+    return Promise.resolve();
+};
+
+module.exports = {
+    async edit(apiConfig, frame) {
+        await validateEmailDesignSetting(frame);
+    }
+};

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/email_design_settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/email_design_settings.js
@@ -12,6 +12,7 @@ const ALLOWED_TITLE_FONT_WEIGHTS = ['normal', 'medium', 'semibold', 'bold'];
 const ALLOWED_IMAGE_CORNERS = ['square', 'rounded'];
 
 const messages = {
+    immutableSlug: 'slug cannot be edited',
     invalidButtonCorners: `button_corners must be one of: ${ALLOWED_BUTTON_CORNERS.join(', ')}`,
     invalidButtonStyle: `button_style must be one of: ${ALLOWED_BUTTON_STYLES.join(', ')}`,
     invalidLinkStyle: `link_style must be one of: ${ALLOWED_LINK_STYLES.join(', ')}`,
@@ -32,6 +33,13 @@ const validateEmailDesignSetting = async function (frame) {
     }
 
     const data = frame.data.email_design_settings[0];
+
+    if (data.slug !== undefined) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.immutableSlug),
+            property: 'slug'
+        }));
+    }
 
     if (data.button_corners !== undefined && !ALLOWED_BUTTON_CORNERS.includes(data.button_corners)) {
         return Promise.reject(new ValidationError({

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/index.js
@@ -9,6 +9,10 @@ module.exports = {
         return require('./automated_emails');
     },
 
+    get email_design_settings() {
+        return require('./email_design_settings');
+    },
+
     get password_reset() {
         return require('./password_reset');
     },

--- a/ghost/core/core/server/models/automated-email.js
+++ b/ghost/core/core/server/models/automated-email.js
@@ -20,7 +20,7 @@ const AutomatedEmail = ghostBookshelf.Model.extend({
     /**
      * @returns {import('bookshelf').Model}
      */
-    emailDesignSetting() {
+    email_design_setting: function emailDesignSetting() {
         return this.belongsTo('EmailDesignSetting', 'email_design_setting_id', 'id');
     },
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -185,6 +185,11 @@ module.exports = function apiRoutes() {
     router.put('/labels/:id', mw.authAdminApi, http(api.labels.edit));
     router.del('/labels/:id', mw.authAdminApi, http(api.labels.destroy));
 
+    // ## Email Design Settings
+    router.get('/email_design_settings', mw.authAdminApi, http(api.emailDesignSettings.browse));
+    router.get('/email_design_settings/:id', mw.authAdminApi, http(api.emailDesignSettings.read));
+    router.put('/email_design_settings/:id', mw.authAdminApi, http(api.emailDesignSettings.edit));
+
     // ## Automated Emails
     router.get('/automated_emails', mw.authAdminApi, http(api.automatedEmails.browse));
     router.get('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.read));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
@@ -172,6 +172,73 @@ Object {
 }
 `;
 
+exports[`Automated Emails API Browse Can browse automated emails with email_design_setting included 1: [body] 1`] = `
+Object {
+  "automated_emails": Array [
+    Object {
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email_design_setting": Object {
+        "background_color": "light",
+        "body_font_category": "sans_serif",
+        "button_color": "accent",
+        "button_corners": "rounded",
+        "button_style": "fill",
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "divider_color": null,
+        "footer_content": null,
+        "header_background_color": "transparent",
+        "header_image": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "image_corners": "square",
+        "link_color": "accent",
+        "link_style": "underline",
+        "section_title_color": null,
+        "show_badge": true,
+        "show_header_title": true,
+        "slug": "default-automated-email",
+        "title_font_category": "sans_serif",
+        "title_font_weight": "bold",
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      },
+      "email_design_setting_id": "680000000000000000000001",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": "{\\"root\\":{\\"children\\":[]}}",
+      "name": "Welcome Email (Free)",
+      "sender_email": null,
+      "sender_name": null,
+      "sender_reply_to": null,
+      "slug": "member-welcome-email-free",
+      "status": "inactive",
+      "subject": "Welcome to the site!",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Automated Emails API Browse Can browse automated emails with email_design_setting included 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1109",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Automated Emails API Browse Can browse with no automated emails 1: [body] 1`] = `
 Object {
   "automated_emails": Array [],
@@ -520,6 +587,63 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "410",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API Read Can read an automated email with email_design_setting included 1: [body] 1`] = `
+Object {
+  "automated_emails": Array [
+    Object {
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email_design_setting": Object {
+        "background_color": "light",
+        "body_font_category": "sans_serif",
+        "button_color": "accent",
+        "button_corners": "rounded",
+        "button_style": "fill",
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "divider_color": null,
+        "footer_content": null,
+        "header_background_color": "transparent",
+        "header_image": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "image_corners": "square",
+        "link_color": "accent",
+        "link_style": "underline",
+        "section_title_color": null,
+        "show_badge": true,
+        "show_header_title": true,
+        "slug": "default-automated-email",
+        "title_font_category": "sans_serif",
+        "title_font_weight": "bold",
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      },
+      "email_design_setting_id": "680000000000000000000001",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": "{\\"root\\":{\\"children\\":[]}}",
+      "name": "Welcome Email (Free)",
+      "sender_email": null,
+      "sender_name": null,
+      "sender_reply_to": null,
+      "slug": "member-welcome-email-free",
+      "status": "inactive",
+      "subject": "Welcome to the site!",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API Read Can read an automated email with email_design_setting included 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1021",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/email-design-settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/email-design-settings.test.js.snap
@@ -1,0 +1,481 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Email Design Settings API Browse Can browse email design settings 1: [body] 1`] = `
+Object {
+  "email_design_settings": Array [
+    Object {
+      "background_color": "light",
+      "body_font_category": "sans_serif",
+      "button_color": "accent",
+      "button_corners": "rounded",
+      "button_style": "fill",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "divider_color": null,
+      "footer_content": null,
+      "header_background_color": "transparent",
+      "header_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "image_corners": "square",
+      "link_color": "accent",
+      "link_style": "underline",
+      "section_title_color": null,
+      "show_badge": true,
+      "show_header_title": true,
+      "slug": "default-automated-email",
+      "title_font_category": "sans_serif",
+      "title_font_weight": "bold",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Email Design Settings API Browse Can browse email design settings 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "703",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Edit Can edit an email design setting 1: [body] 1`] = `
+Object {
+  "email_design_settings": Array [
+    Object {
+      "background_color": "#ffffff",
+      "body_font_category": "serif",
+      "button_color": "accent",
+      "button_corners": "pill",
+      "button_style": "fill",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "divider_color": null,
+      "footer_content": null,
+      "header_background_color": "transparent",
+      "header_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "image_corners": "square",
+      "link_color": "accent",
+      "link_style": "underline",
+      "section_title_color": null,
+      "show_badge": true,
+      "show_header_title": true,
+      "slug": "default-automated-email",
+      "title_font_category": "sans_serif",
+      "title_font_weight": "bold",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Can edit an email design setting 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "609",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Edit Validates body_font_category on edit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "body_font_category must be one of: serif, sans_serif",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit email_design_setting.",
+      "property": "body_font_category",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Validates body_font_category on edit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "305",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Edit Validates button_corners on edit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "button_corners must be one of: square, rounded, pill",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit email_design_setting.",
+      "property": "button_corners",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Validates button_corners on edit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "301",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Edit Validates button_style on edit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "button_style must be one of: fill, outline",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit email_design_setting.",
+      "property": "button_style",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Validates button_style on edit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "289",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Edit Validates image_corners on edit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "image_corners must be one of: square, rounded",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit email_design_setting.",
+      "property": "image_corners",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Validates image_corners on edit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "293",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Edit Validates link_style on edit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "link_style must be one of: underline, regular, bold",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit email_design_setting.",
+      "property": "link_style",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Validates link_style on edit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "296",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Edit Validates title_font_category on edit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "title_font_category must be one of: serif, sans_serif",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit email_design_setting.",
+      "property": "title_font_category",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Validates title_font_category on edit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "307",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Edit Validates title_font_weight on edit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "title_font_weight must be one of: normal, medium, semibold, bold",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit email_design_setting.",
+      "property": "title_font_weight",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Validates title_font_weight on edit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "316",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Permissions Cannot access email design settings as author 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "You do not have permission to browse email_design_settings",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot list email_design_settings.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Permissions Cannot access email design settings as author 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "298",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Permissions Cannot access email design settings as contributor 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "You do not have permission to browse email_design_settings",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot list email_design_settings.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Permissions Cannot access email design settings as contributor 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "298",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Permissions Cannot access email design settings as editor 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "You do not have permission to browse email_design_settings",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot list email_design_settings.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Permissions Cannot access email design settings as editor 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "298",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Read Can read an email design setting by id 1: [body] 1`] = `
+Object {
+  "email_design_settings": Array [
+    Object {
+      "background_color": "light",
+      "body_font_category": "sans_serif",
+      "button_color": "accent",
+      "button_corners": "rounded",
+      "button_style": "fill",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "divider_color": null,
+      "footer_content": null,
+      "header_background_color": "transparent",
+      "header_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "image_corners": "square",
+      "link_color": "accent",
+      "link_style": "underline",
+      "section_title_color": null,
+      "show_badge": true,
+      "show_header_title": true,
+      "slug": "default-automated-email",
+      "title_font_category": "sans_serif",
+      "title_font_weight": "bold",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Read Can read an email design setting by id 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "615",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Email Design Settings API Read Cannot read a non-existent email design setting 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Email design setting not found.",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found error, cannot read email_design_setting.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Read Cannot read a non-existent email design setting 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "274",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/email-design-settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/email-design-settings.test.js.snap
@@ -96,6 +96,37 @@ Object {
 }
 `;
 
+exports[`Email Design Settings API Edit Rejects slug on edit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "slug cannot be edited",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit email_design_setting.",
+      "property": "slug",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Email Design Settings API Edit Rejects slug on edit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "260",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Email Design Settings API Edit Validates body_font_category on edit 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -10,6 +10,17 @@ const matchAutomatedEmail = {
     updated_at: anyISODateTime
 };
 
+const matchAutomatedEmailWithDesignSetting = {
+    id: anyObjectId,
+    created_at: anyISODateTime,
+    updated_at: anyISODateTime,
+    email_design_setting: {
+        id: anyObjectId,
+        created_at: anyISODateTime,
+        updated_at: anyISODateTime
+    }
+};
+
 describe('Automated Emails API', function () {
     let agent;
 
@@ -65,6 +76,21 @@ describe('Automated Emails API', function () {
                     etag: anyEtag
                 });
         });
+
+        it('Can browse automated emails with email_design_setting included', async function () {
+            await createAutomatedEmail();
+
+            await agent
+                .get('automated_emails?include=email_design_setting')
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    automated_emails: [matchAutomatedEmailWithDesignSetting]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
     });
 
     describe('Read', function () {
@@ -78,6 +104,23 @@ describe('Automated Emails API', function () {
                 .expectStatus(200)
                 .matchBodySnapshot({
                     automated_emails: [matchAutomatedEmail]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Can read an automated email with email_design_setting included', async function () {
+            const automatedEmail = await createAutomatedEmail();
+
+            const id = automatedEmail.id;
+
+            await agent
+                .get(`automated_emails/${id}?include=email_design_setting`)
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    automated_emails: [matchAutomatedEmailWithDesignSetting]
                 })
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,

--- a/ghost/core/test/e2e-api/admin/email-design-settings.test.js
+++ b/ghost/core/test/e2e-api/admin/email-design-settings.test.js
@@ -1,0 +1,316 @@
+const {agentProvider, fixtureManager, matchers, dbUtils} = require('../../utils/e2e-framework');
+const {anyContentVersion, anyObjectId, anyISODateTime, anyErrorId, anyEtag} = matchers;
+
+const matchEmailDesignSetting = {
+    id: anyObjectId,
+    created_at: anyISODateTime,
+    updated_at: anyISODateTime
+};
+
+describe('Email Design Settings API', function () {
+    let agent;
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+        await agent.loginAsOwner();
+    });
+
+    describe('Browse', function () {
+        it('Can browse email design settings', async function () {
+            await agent
+                .get('email_design_settings')
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    email_design_settings: [matchEmailDesignSetting]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+    });
+
+    describe('Read', function () {
+        it('Can read an email design setting by id', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .get(`email_design_settings/${id}`)
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    email_design_settings: [matchEmailDesignSetting]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Cannot read a non-existent email design setting', async function () {
+            await agent
+                .get('email_design_settings/abcd1234abcd1234abcd1234')
+                .expectStatus(404)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+    });
+
+    describe('Edit', function () {
+        it('Can edit an email design setting', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    background_color: '#ffffff',
+                    button_corners: 'pill',
+                    body_font_category: 'serif'
+                }]})
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    email_design_settings: [matchEmailDesignSetting]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Validates button_corners on edit', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    button_corners: 'invalid'
+                }]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Validates button_style on edit', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    button_style: 'invalid'
+                }]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Validates link_style on edit', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    link_style: 'invalid'
+                }]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Validates body_font_category on edit', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    body_font_category: 'invalid'
+                }]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Validates title_font_category on edit', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    title_font_category: 'invalid'
+                }]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Validates title_font_weight on edit', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    title_font_weight: 'invalid'
+                }]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Validates image_corners on edit', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    image_corners: 'invalid'
+                }]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+    });
+
+    describe('Permissions', function () {
+        it('Cannot access email design settings as editor', async function () {
+            await agent.loginAsEditor();
+
+            await agent
+                .get('email_design_settings')
+                .expectStatus(403)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Cannot access email design settings as author', async function () {
+            await agent.loginAsAuthor();
+
+            await agent
+                .get('email_design_settings')
+                .expectStatus(403)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Cannot access email design settings as contributor', async function () {
+            await agent.loginAsContributor();
+
+            await agent
+                .get('email_design_settings')
+                .expectStatus(403)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+    });
+});

--- a/ghost/core/test/e2e-api/admin/email-design-settings.test.js
+++ b/ghost/core/test/e2e-api/admin/email-design-settings.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, fixtureManager, matchers, dbUtils} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyObjectId, anyISODateTime, anyErrorId, anyEtag} = matchers;
 
 const matchEmailDesignSetting = {
@@ -247,6 +247,30 @@ describe('Email Design Settings API', function () {
                 .put(`email_design_settings/${id}`)
                 .body({email_design_settings: [{
                     image_corners: 'invalid'
+                }]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Rejects slug on edit', async function () {
+            const {body: browseBody} = await agent
+                .get('email_design_settings')
+                .expectStatus(200);
+
+            const id = browseBody.email_design_settings[0].id;
+
+            await agent
+                .put(`email_design_settings/${id}`)
+                .body({email_design_settings: [{
+                    slug: 'changed-slug'
                 }]})
                 .expectStatus(422)
                 .matchBodySnapshot({


### PR DESCRIPTION
closes NY-1138

Adds browse, read, and edit endpoints for email design settings with input validation for enum columns. Updates automated emails endpoint to support eager-loading the related email design setting via include.
