### PR TITLE
Moved default recipients test from e2e-browser to Ember acceptance

### DIFF
--- a/ghost/admin/tests/acceptance/editor/publish-flow-test.js
+++ b/ghost/admin/tests/acceptance/editor/publish-flow-test.js
@@ -633,5 +633,37 @@ describe('Acceptance: Publish flow', function () {
 
         it('handles server error when confirming');
         it('handles email sending error');
+
+        it('defaults to publish-only when default recipients is "Usually nobody"', async function () {
+            // Set default recipients to "Usually nobody" (filter with null filter)
+            this.server.db.settings.update({key: 'editor_default_email_recipients'}, {value: 'filter'});
+            this.server.db.settings.update({key: 'editor_default_email_recipients_filter'}, {value: null});
+
+            await loginAsRole('Administrator', this.server);
+            const post = this.server.create('post', {status: 'draft'});
+            await visit(`/editor/post/${post.id}`);
+            await click('[data-test-button="publish-flow"]');
+
+            // defaults to "Publish" (not "Publish and email")
+            expect(
+                find('[data-test-setting="publish-type"] [data-test-setting-title]'), 'publish type title'
+            ).to.have.trimmed.rendered.text('Publish');
+
+            // shows "Not sent as newsletter"
+            expect(
+                find('[data-test-setting="email-recipients"] [data-test-setting-title]'), 'email recipients title'
+            ).to.have.trimmed.rendered.text('Not sent as newsletter');
+
+            // email options are still available when switching
+            await click('[data-test-setting="publish-type"] [data-test-setting-title]');
+            expect(find('[data-test-publish-type="publish+send"]')).to.not.have.attribute('disabled');
+            expect(find('[data-test-publish-type="send"]')).to.not.have.attribute('disabled');
+
+            // switching to publish+send shows subscriber count
+            await click('[data-test-publish-type="publish+send"] + label');
+            expect(
+                find('[data-test-setting="email-recipients"] [data-test-setting-title]').textContent
+            ).to.match(/\d+\s*subscriber/);
+        });
     });
 });

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -1,6 +1,6 @@
 const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
-const {createMember, createPostDraft} = require('../utils');
+const {createPostDraft} = require('../utils');
 
 /**
  * @param {import('@playwright/test').Page} page
@@ -132,42 +132,7 @@ test.describe('Updating post access', () => {
         await expect(page.locator('[data-test-date-time-picker-date-input]')).toHaveValue(/-15$/);
     });
 
-    test('default recipient settings - usually nobody', async ({page}) => {
-        // switch to "usually nobody" setting
-        await page.goto('/ghost/settings/newsletters');
-        await page.getByTestId('default-recipients-select').click();
-        await page.locator('[data-testid="select-option"]', {hasText: /Usually nobody/}).click();
-        await page.getByTestId('default-recipients').getByRole('button', {name: 'Save'}).click();
-
-        await expect(page.getByTestId('default-recipients')).toContainText('Usually nobody');
-
-        await page.goto('/ghost');
-
-        await createMember(page, {
-            name: 'Test Member Recipient',
-            email: 'test@recipient.com'
-        });
-
-        // go to publish a post
-        await createPostDraft(page, {title: 'Published in timezones', body: 'Published in timezones'});
-        await page.locator('[data-test-button="publish-flow"]').first().click();
-
-        await expect(page.locator('[data-test-setting="publish-type"] [data-test-setting-title]')).toContainText('Publish');
-
-        await expect(page.locator('[data-test-setting="email-recipients"] [data-test-setting-title]')).toContainText('Not sent as newsletter');
-
-        await page.locator('[data-test-setting="publish-type"] [data-test-setting-title]').click();
-
-        // email-related options are enabled
-        await expect(page.locator('[data-test-publish-type="publish+send"]')).not.toBeDisabled();
-        await expect(page.locator('[data-test-publish-type="send"]')).not.toBeDisabled();
-
-        await page.locator('label[for="publish-type-publish+send"]').click();
-
-        await expect(
-            page.locator('[data-test-setting="email-recipients"] [data-test-setting-title]')
-        ).toContainText(/\d+\s* subscriber/m);
-    });
+    // Default recipient settings test moved to ghost/admin/tests/acceptance/editor/publish-flow-test.js
 });
 
 // Delete post tests moved to e2e/tests/admin/posts/publishing.test.ts


### PR DESCRIPTION
## Summary
- Moved the "default recipient settings - usually nobody" test from `ghost/core/test/e2e-browser/admin/publishing.spec.js` to `ghost/admin/tests/acceptance/editor/publish-flow-test.js`
- The test verifies that the publish flow defaults to "Publish" (not "Publish and email") when newsletter defaults are set to "Usually nobody" — this is a client-side setting read that Mirage can mock directly
- Removed the test and unused `createMember` import from the legacy spec

## Test plan
- [x] New Ember acceptance test passes: `npx ember test --filter "defaults to publish-only when default recipients"`
- [ ] Existing browser tests still pass
- [ ] Lint passes