### PR TITLE
Moved updated email verification webhook flow to GA

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -48,10 +48,6 @@ const features: Feature[] = [{
     description: 'Display a Feedback menu item in the admin sidebar. Requires the new admin experience.',
     flag: 'featurebaseFeedback'
 }, {
-    title: 'Verification flow',
-    description: 'Enable new Email verification webhook-based flow',
-    flag: 'verificationFlow'
-}, {
     title: 'Members Forward',
     description: 'Use the new React-based members list instead of the Ember implementation',
     flag: 'membersForward'

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -45,26 +45,6 @@ const membersStats = new MembersStats({
 let membersApi;
 let verificationTrigger;
 
-const sendVerificationEmail = async ({subject, message, amountTriggered}) => {
-    const escalationAddress = config.get('hostSettings:emailVerification:escalationAddress');
-    const replyTo = config.get('user_email');
-    const fromAddress = settingsHelpers.getDefaultEmailAddress();
-
-    if (escalationAddress) {
-        await ghostMailer.send({
-            subject,
-            html: tpl(message, {
-                amountTriggered: amountTriggered,
-                siteUrl: urlUtils.getSiteUrl()
-            }),
-            forceTextContent: true,
-            from: fromAddress,
-            replyTo,
-            to: escalationAddress
-        });
-    }
-};
-
 const initMembersCSVImporter = ({stripeAPIService}) => {
     return makeMembersCSVImporter({
         storagePath: config.getContentPath('data'),
@@ -113,8 +93,6 @@ const initVerificationTrigger = () => {
         isVerified: () => config.get('hostSettings:emailVerification:verified') === true,
         isVerificationRequired: () => settingsCache.get('email_verification_required') === true,
         setVerificationRequired: value => settingsCache.set('email_verification_required', {value}),
-        isVerificationFlowEnabled: () => labsService.isSet('verificationFlow'),
-        sendVerificationEmail,
         sendVerificationWebhook: verificationWebhookService.sendVerificationWebhook.bind(verificationWebhookService),
         membersStats,
         Settings: models.Settings,

--- a/ghost/core/core/server/services/verification-trigger.js
+++ b/ghost/core/core/server/services/verification-trigger.js
@@ -3,17 +3,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const {MemberCreatedEvent} = require('../../shared/events');
 
 const messages = {
-    emailVerificationNeeded: `We're hard at work processing your import. To make sure you get great deliverability, we'll need to enable some extra features for your account. A member of our team will be in touch with you by email to review your account make sure everything is configured correctly so you're ready to go.`,
-    emailVerificationEmailSubject: `Email needs verification`,
-    emailVerificationEmailMessageImport: `Email verification needed for site: {siteUrl}, has imported: {amountTriggered} members in the last 30 days.`,
-    emailVerificationEmailMessageAdmin: `Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the Admin client in the last 30 days.`,
-    emailVerificationEmailMessageAPI: `Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the API in the last 30 days.`
-};
-
-const verificationMessageBySource = {
-    api: messages.emailVerificationEmailMessageAPI,
-    admin: messages.emailVerificationEmailMessageAdmin,
-    import: messages.emailVerificationEmailMessageImport
+    emailVerificationNeeded: `We're hard at work processing your import. To make sure you get great deliverability, we'll need to enable some extra features for your account. A member of our team will be in touch by email to review your account and make sure everything is configured correctly so you're ready to go.`
 };
 
 class VerificationTrigger {
@@ -26,8 +16,6 @@ class VerificationTrigger {
      * @param {() => boolean} deps.isVerified Check Ghost config to see if we are already verified
      * @param {() => boolean} deps.isVerificationRequired Check Ghost settings to see whether verification has been requested
      * @param {(value: boolean) => void} deps.setVerificationRequired Directly update the settings cache for email_verification_required
-     * @param {() => boolean} deps.isVerificationFlowEnabled Check whether webhook-based verification flow is enabled
-     * @param {(content: {subject: string, message: string, amountTriggered: number}) => Promise<void>} deps.sendVerificationEmail Sends an email to the escalation address to confirm that customer needs to be verified
      * @param {(content: {amountTriggered: number, threshold: number, method: string}) => Promise<boolean>} deps.sendVerificationWebhook Sends a webhook to the escalation service to confirm that customer needs to be verified
      * @param {any} deps.Settings Ghost Settings model
      * @param {any} deps.eventRepository For querying events
@@ -39,8 +27,6 @@ class VerificationTrigger {
         isVerified,
         isVerificationRequired,
         setVerificationRequired,
-        isVerificationFlowEnabled,
-        sendVerificationEmail,
         sendVerificationWebhook,
         Settings,
         eventRepository
@@ -51,9 +37,7 @@ class VerificationTrigger {
         this._isVerified = isVerified;
         this._isVerificationRequired = isVerificationRequired;
         this._setVerificationRequired = setVerificationRequired || (() => {});
-        this._isVerificationFlowEnabled = isVerificationFlowEnabled || (() => false);
-        this._sendVerificationEmail = sendVerificationEmail;
-        this._sendVerificationWebhook = sendVerificationWebhook;
+        this._sendVerificationWebhook = sendVerificationWebhook || (async () => false);
         this._Settings = Settings;
         this._eventRepository = eventRepository;
 
@@ -74,10 +58,6 @@ class VerificationTrigger {
 
     get _importTriggerThreshold() {
         return this._getImportTriggerThreshold();
-    }
-
-    _shouldUseWebhookFlow() {
-        return this._isVerificationFlowEnabled() && typeof this._sendVerificationWebhook === 'function';
     }
 
     /**
@@ -150,21 +130,6 @@ class VerificationTrigger {
         return {
             needsVerification: true
         };
-    }
-
-    async _startLegacyEmailVerificationProcess({amount, triggerSource, throwOnTrigger}) {
-        // GA removal point: delete this method once webhook delivery fully replaces email escalation.
-        const verificationMessage = verificationMessageBySource[triggerSource] || messages.emailVerificationEmailMessageImport;
-
-        await this._markVerificationRequired();
-
-        await this._sendVerificationEmail({
-            message: verificationMessage,
-            subject: messages.emailVerificationEmailSubject,
-            amountTriggered: amount
-        });
-
-        return this._finishTrigger(throwOnTrigger);
     }
 
     async getImportThreshold() {
@@ -260,36 +225,30 @@ class VerificationTrigger {
             return {needsVerification: false};
         }
 
-        // Only trigger flag change and escalation notification the first time
+        // Only trigger verification once.
         if (this._isVerificationRequired()) {
             return {needsVerification: false};
         }
 
-        const triggerSource = method ?? source ?? 'import';
+        let webhookWasSent = false;
 
-        if (this._shouldUseWebhookFlow()) {
-            try {
-                const webhookWasSent = await this._sendVerificationWebhook({
-                    amountTriggered: amount,
-                    threshold: threshold ?? amount,
-                    method: triggerSource
-                });
-
-                if (webhookWasSent) {
-                    await this._markVerificationRequired();
-                    return this._finishTrigger(throwOnTrigger);
-                }
-            } catch (error) {
-                // `sendVerificationWebhook` already logs delivery failures.
-            }
+        try {
+            webhookWasSent = await this._sendVerificationWebhook({
+                amountTriggered: amount,
+                threshold: threshold ?? amount,
+                method: method ?? source ?? 'import'
+            });
+        } catch (error) {
+            // `sendVerificationWebhook` already logs delivery failures.
+            return {needsVerification: false};
         }
 
-        // Default email flow — used unless the webhook flow is enabled and succeeds.
-        return await this._startLegacyEmailVerificationProcess({
-            amount,
-            triggerSource,
-            throwOnTrigger
-        });
+        if (!webhookWasSent) {
+            return {needsVerification: false};
+        }
+
+        await this._markVerificationRequired();
+        return this._finishTrigger(throwOnTrigger);
     }
 }
 

--- a/ghost/core/core/server/services/verification/verification-webhook-service.ts
+++ b/ghost/core/core/server/services/verification/verification-webhook-service.ts
@@ -78,12 +78,12 @@ export class VerificationWebhookService {
         const {webhookType, webhookUrl, webhookSecret, siteId} = this.#readWebhookConfig();
 
         if (typeof webhookUrl !== 'string' || webhookUrl.length === 0) {
-            this.#logging.warn('Verification webhook flow is enabled but webhookUrl is not configured.');
+            this.#logging.warn('Verification webhook is not configured because webhookUrl is missing.');
             return false;
         }
 
         if (typeof webhookType !== 'string' || webhookType.length === 0) {
-            this.#logging.warn('Verification webhook flow is enabled but webhookType is not configured.');
+            this.#logging.warn('Verification webhook is not configured because webhookType is missing.');
             return false;
         }
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -47,7 +47,6 @@ const PRIVATE_FEATURES = [
     'emailUniqueid',
     'themeTranslation',
     'indexnow',
-    'verificationFlow',
     'membersForward',
     'welcomeEmailsDesignCustomization',
     'pictureImageFormats',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -30,7 +30,6 @@ Object {
       "themeTranslation": true,
       "transistor": true,
       "urlCache": true,
-      "verificationFlow": true,
       "welcomeEmailsDesignCustomization": true,
     },
     "mail": "",

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -937,56 +937,11 @@ describe('Members API', function () {
 
         afterEach(async function () {
             await restoreEmailVerificationUtils();
-            mockManager.mockLabsDisabled('verificationFlow');
         });
 
-        it('Can add a member and trigger host email verification limits -- sends email', async function () {
-            mockManager.mockLabsDisabled('verificationFlow');
-
-            await setupEmailVerificationUtils({
-                adminThreshold: 1,
-                escalationAddress: 'test@example.com'
-            });
-
-            assert.equal(settingsCache.get('email_verification_required'), false, 'Before import: email verification should NOT be required');
-
-            const member = {
-                name: 'pass verification',
-                email: 'memberPassVerifivation@test.com'
-            };
-
-            const passVerificationMember = await createMemberThroughApi({member, agent, tiersCount: 0, newsletterCount: 2});
-
-            await DomainEvents.allSettled();
-
-            assert.equal(settingsCache.get('email_verification_required'), false, 'After one import: Email verification should NOT be required');
-
-            const memberFailLimit = {
-                name: 'fail verification',
-                email: 'memberFailVerifivation@test.com'
-            };
-
-            const triggerVerificationMember = await createMemberThroughApi({member: memberFailLimit, agent, tiersCount: 0, newsletterCount: 2});
-
-            await DomainEvents.allSettled();
-
-            assert.equal(settingsCache.get('email_verification_required'), true, 'After exceeding limit: Email verification should be required');
-
-            mockManager.assert.sentEmail({
-                subject: 'Email needs verification'
-            });
-
-            // state cleanup
-            await agent.delete(`/members/${passVerificationMember.id}`);
-            await agent.delete(`/members/${triggerVerificationMember.id}`);
-        });
-
-        it('Can add a member and trigger host email verification limits - sends webhook', async function () {
-            mockManager.mockLabsEnabled('verificationFlow');
-
+        it('Can add a member and trigger host email verification limits', async function () {
             const {webhookSecret, receivedWebhookRequests} = await setupEmailVerificationUtils({
-                adminThreshold: 1,
-                escalationAddress: 'test@example.com'
+                adminThreshold: 1
             });
 
             assert.equal(settingsCache.get('email_verification_required'), false, 'Before import: email verification should NOT be required');

--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -503,8 +503,6 @@ describe.skip('Batch sending tests', function () {
     });
 
     it('Cannot send an email if verification is required', async function () {
-        // Update this test to check the new flow instead.
-        mockManager.mockLabsEnabled('verificationFlow');
         // First enable import thresholds
         setupEmailVerificationUtils({
             apiThreshold: 100,

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -12,7 +12,6 @@ const {assertExists} = require('../../../utils/assertions');
 const {setupEmailVerificationUtils, restoreEmailVerificationUtils} = require('../../../utils/email-verification-utils');
 
 let request;
-let emailMockReceiver;
 
 describe('Members Importer API', function () {
     before(async function () {
@@ -22,8 +21,7 @@ describe('Members Importer API', function () {
     });
 
     beforeEach(function () {
-        emailMockReceiver = mockManager.mockMail();
-        mockManager.mockLabsDisabled('verificationFlow');
+        mockManager.mockMail();
     });
 
     afterEach(function () {
@@ -245,150 +243,106 @@ describe('Members Importer API', function () {
     });
 
     it('Can import members with host emailVerification limits', async function () {
-        // If this test fails, check if the total members that have been created with fixtures has increased a lot, and if required, increase the amount of imported members
-        await setupEmailVerificationUtils({
-            apiThreshold: 2,
-            adminThreshold: 2,
-            importThreshold: 1, // note: this one isn't really used because (totalMembers - members_created_in_last_30_days) is larger and used instead
-            escalationAddress: 'test@example.com'
-        });
+        try {
+            // If this test fails, check if the total members that have been created with fixtures has increased a lot, and if required, increase the amount of imported members
+            const {receivedWebhookRequests} = await setupEmailVerificationUtils({
+                apiThreshold: 2,
+                adminThreshold: 2,
+                importThreshold: 1, // note: this one isn't really used because (totalMembers - members_created_in_last_30_days) is larger and used instead
+                persist: true
+            });
 
-        const res = await request
-            .post(localUtils.API.getApiQuery(`members/upload/`))
-            .field('labels', ['new-global-label'])
-            .attach('membersfile', path.join(__dirname, '/../../../utils/fixtures/csv/valid-members-import-large.csv'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(201);
-        assert.equal(res.headers['x-cache-invalidate'], undefined);
-        const jsonResponse = res.body;
+            assert.equal(settingsCache.get('email_verification_required'), false, 'Email verification should not be required');
 
-        assertExists(jsonResponse);
-        assertExists(jsonResponse.meta);
-        assertExists(jsonResponse.meta.stats);
+            const awaitCompletion = jobManager.awaitCompletion('members-import');
 
-        assert.equal(jsonResponse.meta.stats.imported, 10);
-        assert.equal(jsonResponse.meta.stats.invalid.length, 0);
+            const res = await request
+                .post(localUtils.API.getApiQuery(`members/upload/`))
+                .field('labels', ['new-global-label'])
+                .attach('membersfile', path.join(__dirname, '/../../../utils/fixtures/csv/valid-members-import-large-501.csv'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(202);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
+            const jsonResponse = res.body;
 
-        assert.equal(settingsCache.get('email_verification_required'), true, 'Email verification should now be required');
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.meta);
 
-        mockManager.assert.sentEmail({
-            subject: 'Email needs verification'
-        });
+            // Wait for the job to finish
+            await awaitCompletion;
 
-        // Don't reset email verification required flag, as the following test
-        // relies on that value being true already.
-    });
+            assert.equal(settingsCache.get('email_verification_required'), true, 'Email verification should now be required');
 
-    it('Can still import members once email verification is required but does not send email', async function () {
-        assert.equal(settingsCache.get('email_verification_required'), true, 'Email verification is already required');
+            assert.equal(receivedWebhookRequests.length, 1, 'Expected to receive webhook requests');
 
-        const res = await request
-            .post(localUtils.API.getApiQuery(`members/upload/`))
-            .field('labels', ['new-global-label'])
-            .attach('membersfile', path.join(__dirname, '/../../../utils/fixtures/csv/valid-members-import-large.csv'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(201);
-        assert.equal(res.headers['x-cache-invalidate'], undefined);
-        const jsonResponse = res.body;
+            const secondImport = await request
+                .post(localUtils.API.getApiQuery(`members/upload/`))
+                .field('labels', ['new-global-label'])
+                .attach('membersfile', path.join(__dirname, '/../../../utils/fixtures/csv/valid-members-import-large.csv'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+            assert.equal(secondImport.headers['x-cache-invalidate'], undefined);
+            const secondJsonResponse = secondImport.body;
 
-        assertExists(jsonResponse);
-        assertExists(jsonResponse.meta);
-        assertExists(jsonResponse.meta.stats);
+            assertExists(secondJsonResponse);
+            assertExists(secondJsonResponse.meta);
+            assertExists(secondJsonResponse.meta.stats);
 
-        assert.equal(jsonResponse.meta.stats.imported, 10);
-        assert.equal(jsonResponse.meta.stats.invalid.length, 0);
+            assert.equal(secondJsonResponse.meta.stats.imported, 10);
+            assert.equal(secondJsonResponse.meta.stats.invalid.length, 0);
 
-        assert.equal(settingsCache.get('email_verification_required'), true, 'Email verification should still be required');
+            assert.equal(settingsCache.get('email_verification_required'), true, 'Email verification should still be required');
 
-        // Don't send another email
-        emailMockReceiver.assertSentEmailCount(0);
-
-        // reset email verification required flag for next test
-        await restoreEmailVerificationUtils();
+            // Don't send another email
+            assert.equal(receivedWebhookRequests.length, 1, 'Expected no further webhook requests after second import');
+        } finally {
+            await restoreEmailVerificationUtils();
+        }
     });
 
     it('Can import members with host emailVerification limits for large imports', async function () {
-        // If this test fails, check if the total members that have been created with fixtures has increased a lot, and if required, increase the amount of imported members
-        await setupEmailVerificationUtils({
-            apiThreshold: 2,
-            adminThreshold: 2,
-            importThreshold: 1, // note: this one isn't really used because (totalMembers - members_created_in_last_30_days) is larger and used instead
-            escalationAddress: 'test@example.com'
-        });
+        try {
+            // If this test fails, check if the total members that have been created with fixtures has increased a lot, and if required, increase the amount of imported members
+            const {receivedWebhookRequests} = await setupEmailVerificationUtils({
+                apiThreshold: 2,
+                adminThreshold: 2,
+                importThreshold: 1 // note: this one isn't really used because (totalMembers - members_created_in_last_30_days) is larger and used instead
+            });
 
-        assert.equal(settingsCache.get('email_verification_required'), false, 'Email verification should not be required');
+            assert.equal(settingsCache.get('email_verification_required'), false, 'Email verification should not be required');
 
-        const awaitCompletion = jobManager.awaitCompletion('members-import');
+            const awaitCompletion = jobManager.awaitCompletion('members-import');
 
-        const res = await request
-            .post(localUtils.API.getApiQuery(`members/upload/`))
-            .field('labels', ['new-global-label'])
-            .attach('membersfile', path.join(__dirname, '/../../../utils/fixtures/csv/valid-members-import-large-501.csv'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(202);
-        assert.equal(res.headers['x-cache-invalidate'], undefined);
-        const jsonResponse = res.body;
+            const res = await request
+                .post(localUtils.API.getApiQuery(`members/upload/`))
+                .field('labels', ['new-global-label'])
+                .attach('membersfile', path.join(__dirname, '/../../../utils/fixtures/csv/valid-members-import-large-501.csv'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(202);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
+            const jsonResponse = res.body;
 
-        assertExists(jsonResponse);
-        assertExists(jsonResponse.meta);
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.meta);
 
-        // Wait for the job to finish
-        await awaitCompletion;
+            // Wait for the job to finish
+            await awaitCompletion;
 
-        assert.equal(settingsCache.get('email_verification_required'), true, 'Email verification should now be required');
+            assert.equal(settingsCache.get('email_verification_required'), true, 'Email verification should now be required');
 
-        mockManager.assert.sentEmail({
-            subject: 'Your member import is complete'
-        });
+            mockManager.assert.sentEmail({
+                subject: 'Your member import is complete'
+            });
 
-        mockManager.assert.sentEmail({
-            subject: 'Email needs verification'
-        });
-
-        await restoreEmailVerificationUtils();
-    });
-
-    it('Can import members with host emailVerification limits for large imports - webhook flow', async function () {
-        mockManager.mockLabsEnabled('verificationFlow');
-
-        // If this test fails, check if the total members that have been created with fixtures has increased a lot, and if required, increase the amount of imported members
-        const {receivedWebhookRequests} = await setupEmailVerificationUtils({
-            apiThreshold: 2,
-            adminThreshold: 2,
-            importThreshold: 1 // note: this one isn't really used because (totalMembers - members_created_in_last_30_days) is larger and used instead
-        });
-
-        assert.equal(settingsCache.get('email_verification_required'), false, 'Email verification should not be required');
-
-        const awaitCompletion = jobManager.awaitCompletion('members-import');
-
-        const res = await request
-            .post(localUtils.API.getApiQuery(`members/upload/`))
-            .field('labels', ['new-global-label'])
-            .attach('membersfile', path.join(__dirname, '/../../../utils/fixtures/csv/valid-members-import-large-501.csv'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(202);
-        assert.equal(res.headers['x-cache-invalidate'], undefined);
-        const jsonResponse = res.body;
-
-        assertExists(jsonResponse);
-        assertExists(jsonResponse.meta);
-
-        // Wait for the job to finish
-        await awaitCompletion;
-
-        assert.equal(settingsCache.get('email_verification_required'), true, 'Email verification should now be required');
-
-        assert(receivedWebhookRequests.length > 0, 'Expected to receive webhook requests');
-
-        await restoreEmailVerificationUtils();
+            assert.equal(receivedWebhookRequests.length, 1, 'Expected to receive webhook requests');
+        } finally {
+            await restoreEmailVerificationUtils();
+        }
     });
 });

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -5,11 +5,6 @@ const DomainEvents = require('@tryghost/domain-events');
 const VerificationTrigger = require('../../../../core/server/services/verification-trigger');
 const {MemberCreatedEvent} = require('../../../../core/shared/events');
 
-const EMAIL_SUBJECT = 'Email needs verification';
-const IMPORT_MESSAGE = 'Email verification needed for site: {siteUrl}, has imported: {amountTriggered} members in the last 30 days.';
-const ADMIN_MESSAGE = 'Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the Admin client in the last 30 days.';
-const API_MESSAGE = 'Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the API in the last 30 days.';
-
 const createEventsPage = ({total, limit = total, dataLength = total}) => {
     return {
         data: Array.from({length: dataLength}, () => ({})),
@@ -51,8 +46,6 @@ const assertRecentSourceQuery = (call, source) => {
  * @property {() => number} [getImportTriggerThreshold]
  * @property {boolean | (() => boolean)} [isVerified]
  * @property {boolean | (() => boolean)} [isVerificationRequired]
- * @property {boolean | (() => boolean)} [isVerificationFlowEnabled]
- * @property {import('sinon').SinonStub} [emailStub]
  * @property {import('sinon').SinonStub} [webhookStub]
  * @property {import('sinon').SinonStub} [settingsStub]
  * @property {import('sinon').SinonStub} [setVerificationRequired]
@@ -62,8 +55,7 @@ const assertRecentSourceQuery = (call, source) => {
 /**
  * @typedef {object} CreateVerificationTriggerResult
  * @property {VerificationTrigger} trigger
- * @property {import('sinon').SinonStub} emailStub
- * @property {import('sinon').SinonStub | undefined} webhookStub
+ * @property {import('sinon').SinonStub} webhookStub
  * @property {import('sinon').SinonStub} settingsStub
  * @property {import('sinon').SinonStub} setVerificationRequired
  * @property {import('sinon').SinonStub} eventStub
@@ -79,9 +71,7 @@ const createVerificationTrigger = ({
     getImportTriggerThreshold,
     isVerified = false,
     isVerificationRequired = false,
-    isVerificationFlowEnabled = false,
-    emailStub = sinon.stub().resolves(null),
-    webhookStub,
+    webhookStub = sinon.stub().resolves(true),
     settingsStub = sinon.stub().resolves(null),
     setVerificationRequired = sinon.stub(),
     eventStub = sinon.stub()
@@ -93,8 +83,6 @@ const createVerificationTrigger = ({
         isVerified: typeof isVerified === 'function' ? isVerified : () => isVerified,
         isVerificationRequired: typeof isVerificationRequired === 'function' ? isVerificationRequired : () => isVerificationRequired,
         setVerificationRequired,
-        isVerificationFlowEnabled: typeof isVerificationFlowEnabled === 'function' ? isVerificationFlowEnabled : () => isVerificationFlowEnabled,
-        sendVerificationEmail: emailStub,
         sendVerificationWebhook: webhookStub,
         Settings: {
             edit: settingsStub
@@ -106,7 +94,6 @@ const createVerificationTrigger = ({
 
     return {
         trigger,
-        emailStub,
         webhookStub,
         settingsStub,
         setVerificationRequired,
@@ -180,7 +167,7 @@ describe('Email verification flow', function () {
     });
 
     it('Triggers verification process', async function () {
-        const {trigger, emailStub, settingsStub} = createVerificationTrigger();
+        const {trigger, webhookStub, settingsStub} = createVerificationTrigger();
 
         const result = await trigger._startVerificationProcess({
             amount: 10,
@@ -188,12 +175,12 @@ describe('Email verification flow', function () {
         });
 
         assert.equal(result.needsVerification, true);
-        sinon.assert.calledOnce(emailStub);
+        sinon.assert.calledOnce(webhookStub);
         sinon.assert.calledOnce(settingsStub);
     });
 
     it('Does not trigger verification when already verified', async function () {
-        const {trigger, emailStub, settingsStub} = createVerificationTrigger({
+        const {trigger, webhookStub, settingsStub} = createVerificationTrigger({
             isVerified: true
         });
 
@@ -203,12 +190,12 @@ describe('Email verification flow', function () {
         });
 
         assert.equal(result.needsVerification, false);
-        sinon.assert.notCalled(emailStub);
+        sinon.assert.notCalled(webhookStub);
         sinon.assert.notCalled(settingsStub);
     });
 
     it('Does not trigger verification when already in progress', async function () {
-        const {trigger, emailStub, settingsStub} = createVerificationTrigger({
+        const {trigger, webhookStub, settingsStub} = createVerificationTrigger({
             isVerificationRequired: true
         });
 
@@ -218,11 +205,11 @@ describe('Email verification flow', function () {
         });
 
         assert.equal(result.needsVerification, false);
-        sinon.assert.notCalled(emailStub);
+        sinon.assert.notCalled(webhookStub);
         sinon.assert.notCalled(settingsStub);
     });
 
-    it('Throws when `throwsOnTrigger` is true', async function () {
+    it('Throws a verification error when the request should be blocked', async function () {
         const {trigger} = createVerificationTrigger();
 
         await assert.rejects(
@@ -233,7 +220,7 @@ describe('Email verification flow', function () {
         );
     });
 
-    it('Uses default message when no custom message is provided', async function () {
+    it('Uses the standard verification error message when blocking the request', async function () {
         const {trigger} = createVerificationTrigger();
 
         try {
@@ -248,19 +235,49 @@ describe('Email verification flow', function () {
         }
     });
 
-    it('Sends a message containing the number of members imported', async function () {
-        const {trigger, emailStub} = createVerificationTrigger();
+    it('Assumes the import threshold and method when they are not provided', async function () {
+        const {trigger, webhookStub} = createVerificationTrigger();
 
         await trigger._startVerificationProcess({
             amount: 10,
             throwOnTrigger: false
         });
 
-        assert.deepEqual(emailStub.lastCall.firstArg, {
-            subject: EMAIL_SUBJECT,
-            message: IMPORT_MESSAGE,
-            amountTriggered: 10
+        assert.deepEqual(webhookStub.lastCall.firstArg, {
+            amountTriggered: 10,
+            threshold: 10,
+            method: 'import'
         });
+    });
+
+    it('Does not mark verification as required when the webhook is not sent', async function () {
+        const {trigger, webhookStub, settingsStub} = createVerificationTrigger({
+            webhookStub: sinon.stub().resolves(false)
+        });
+
+        const result = await trigger._startVerificationProcess({
+            amount: 10,
+            throwOnTrigger: false
+        });
+
+        assert.equal(result.needsVerification, false);
+        sinon.assert.calledOnce(webhookStub);
+        sinon.assert.notCalled(settingsStub);
+    });
+
+    it('Does not mark verification as required when the webhook throws', async function () {
+        const {trigger, webhookStub, settingsStub} = createVerificationTrigger({
+            webhookStub: sinon.stub().rejects(new Error('Webhook failed'))
+        });
+
+        const result = await trigger._startVerificationProcess({
+            amount: 10,
+            throwOnTrigger: false
+        });
+
+        assert.equal(result.needsVerification, false);
+        sinon.assert.calledOnce(webhookStub);
+        sinon.assert.notCalled(settingsStub);
     });
 
     it('Updates the settings key when verification is marked as required', async function () {
@@ -279,77 +296,10 @@ describe('Email verification flow', function () {
         sinon.assert.calledOnceWithExactly(setVerificationRequired, true);
     });
 
-    it('Sends a webhook instead of an email when verificationFlow is enabled', async function () {
-        const webhookStub = sinon.stub().resolves(true);
-        const {trigger, emailStub, settingsStub} = createVerificationTrigger({
-            isVerificationFlowEnabled: true,
-            webhookStub
-        });
-
-        await trigger._startVerificationProcess({
-            amount: 10,
-            threshold: 5,
-            method: 'import',
-            throwOnTrigger: false
-        });
-
-        sinon.assert.notCalled(emailStub);
-        sinon.assert.calledOnce(webhookStub);
-        sinon.assert.calledOnce(settingsStub);
-        sinon.assert.callOrder(webhookStub, settingsStub);
-        assert.deepEqual(webhookStub.lastCall.firstArg, {
-            amountTriggered: 10,
-            threshold: 5,
-            method: 'import'
-        });
-    });
-
-    it('Falls back to email when verificationFlow is enabled but webhook is unconfigured', async function () {
-        const webhookStub = sinon.stub().resolves(false);
-        const {trigger, emailStub, settingsStub} = createVerificationTrigger({
-            isVerificationFlowEnabled: true,
-            webhookStub
-        });
-
-        const result = await trigger._startVerificationProcess({
-            amount: 10,
-            threshold: 5,
-            method: 'import',
-            throwOnTrigger: false
-        });
-
-        assert.equal(result.needsVerification, true);
-        sinon.assert.calledOnce(webhookStub);
-        sinon.assert.calledOnce(emailStub);
-        sinon.assert.calledOnce(settingsStub);
-        sinon.assert.callOrder(webhookStub, settingsStub, emailStub);
-    });
-
-    it('Falls back to email when webhook delivery fails', async function () {
-        const webhookStub = sinon.stub().rejects(new Error('Webhook failed'));
-        const {trigger, emailStub, settingsStub} = createVerificationTrigger({
-            isVerificationFlowEnabled: true,
-            webhookStub
-        });
-
-        const result = await trigger._startVerificationProcess({
-            amount: 10,
-            threshold: 5,
-            method: 'import',
-            throwOnTrigger: false
-        });
-
-        assert.equal(result.needsVerification, true);
-        sinon.assert.calledOnce(webhookStub);
-        sinon.assert.calledOnce(settingsStub);
-        sinon.assert.calledOnce(emailStub);
-        sinon.assert.callOrder(webhookStub, settingsStub, emailStub);
-    });
-
-    it('Triggers when a number of API events are dispatched', async function () {
+    it('Queries recent API signup events when an API member is created', async function () {
         domainEventsStub.restore();
 
-        const {eventStub} = createVerificationTrigger({
+        const {eventStub, webhookStub} = createVerificationTrigger({
             getApiTriggerThreshold: () => 2,
             isVerified: false,
             eventStub: createEventRepositoryStub({
@@ -363,9 +313,12 @@ describe('Email verification flow', function () {
             source: 'api',
             batchId: 'batch-id'
         }, new Date()));
+        await DomainEvents.allSettled();
 
-        sinon.assert.calledOnce(eventStub);
+        sinon.assert.calledTwice(eventStub);
         assertRecentSourceQuery(eventStub.firstCall, 'api');
+        assert.equal(eventStub.secondCall.lastArg.source, 'member');
+        sinon.assert.notCalled(webhookStub);
     });
 
     it('Does not trigger when site is already verified', async function () {
@@ -381,12 +334,13 @@ describe('Email verification flow', function () {
             source: 'api',
             batchId: 'batch-id'
         }, new Date()));
+        await DomainEvents.allSettled();
 
         sinon.assert.notCalled(eventStub);
     });
 
-    it('Triggers when a number of members are imported', async function () {
-        const {trigger, eventStub, emailStub} = createVerificationTrigger({
+    it('Queries recent import and member counts when checking the import threshold', async function () {
+        const {trigger, eventStub} = createVerificationTrigger({
             getImportTriggerThreshold: () => 2,
             eventStub: createEventRepositoryStub({
                 memberTotal: 15,
@@ -398,20 +352,12 @@ describe('Email verification flow', function () {
 
         sinon.assert.calledTwice(eventStub);
         assertRecentSourceQuery(eventStub.firstCall, 'import');
-        sinon.assert.calledOnce(emailStub);
-        assert.deepEqual(emailStub.lastCall.firstArg, {
-            subject: EMAIL_SUBJECT,
-            message: IMPORT_MESSAGE,
-            amountTriggered: 10
-        });
+        assert.equal(eventStub.secondCall.lastArg.source, 'member');
     });
 
-    it('Includes threshold and method in webhook payload when import threshold triggers', async function () {
-        const webhookStub = sinon.stub().resolves(true);
-        const {trigger, emailStub} = createVerificationTrigger({
+    it('Triggers webhook with the calculated import threshold payload when import threshold is exceeded', async function () {
+        const {trigger, webhookStub} = createVerificationTrigger({
             getImportTriggerThreshold: () => 2,
-            isVerificationFlowEnabled: true,
-            webhookStub,
             eventStub: createEventRepositoryStub({
                 memberTotal: 15,
                 sourceTotal: 10
@@ -420,7 +366,6 @@ describe('Email verification flow', function () {
 
         await trigger.testImportThreshold();
 
-        sinon.assert.notCalled(emailStub);
         sinon.assert.calledOnce(webhookStub);
         assert.deepEqual(webhookStub.lastCall.firstArg, {
             amountTriggered: 10,
@@ -429,28 +374,40 @@ describe('Email verification flow', function () {
         });
     });
 
-    it('checkVerificationRequired also checks import', async function () {
-        let verificationRequired = false;
-        const isVerificationRequiredStub = sinon.stub().callsFake(() => verificationRequired);
-        const settingsStub = sinon.stub().callsFake(() => {
-            verificationRequired = true;
-            return Promise.resolve();
-        });
-        const {trigger, emailStub} = createVerificationTrigger({
+    it('Does not trigger webhook when import count equals the calculated threshold', async function () {
+        const {trigger, webhookStub} = createVerificationTrigger({
             getImportTriggerThreshold: () => 2,
-            isVerificationRequired: isVerificationRequiredStub,
-            settingsStub,
             eventStub: createEventRepositoryStub({
                 memberTotal: 15,
-                sourceTotal: 10
+                sourceTotal: 5
             })
         });
 
-        assert.equal(await trigger.checkVerificationRequired(), true);
-        sinon.assert.calledOnce(emailStub);
+        await trigger.testImportThreshold();
+
+        sinon.assert.notCalled(webhookStub);
     });
 
-    it('testImportThreshold does not calculate anything if already verified', async function () {
+    it('Checks pending imports before deciding whether verification is required', async function () {
+        const {trigger} = createVerificationTrigger();
+        const testImportThresholdStub = sinon.stub(trigger, 'testImportThreshold').resolves();
+
+        await trigger.checkVerificationRequired();
+
+        sinon.assert.calledOnce(testImportThresholdStub);
+    });
+
+    it('Returns true when verification is required for an unverified site', async function () {
+        const {trigger} = createVerificationTrigger({
+            isVerificationRequired: true,
+            isVerified: false
+        });
+        sinon.stub(trigger, 'testImportThreshold').resolves();
+
+        assert.equal(await trigger.checkVerificationRequired(), true);
+    });
+
+    it('Skips import threshold checks when the site is already verified', async function () {
         const {trigger} = createVerificationTrigger({
             getImportTriggerThreshold: () => 2,
             isVerified: true
@@ -459,7 +416,7 @@ describe('Email verification flow', function () {
         assert.equal(await trigger.testImportThreshold(), undefined);
     });
 
-    it('testImportThreshold does not calculate anything if already pending', async function () {
+    it('Skips import threshold checks when verification is already required', async function () {
         const {trigger} = createVerificationTrigger({
             getImportTriggerThreshold: () => 2,
             isVerified: false,
@@ -470,7 +427,7 @@ describe('Email verification flow', function () {
     });
 
     it('Triggers when a number of members are added from Admin', async function () {
-        const {trigger, eventStub, emailStub} = createVerificationTrigger({
+        const {trigger, eventStub, webhookStub} = createVerificationTrigger({
             getAdminTriggerThreshold: () => 2,
             eventStub: createEventRepositoryStub({
                 memberTotal: 0,
@@ -482,16 +439,16 @@ describe('Email verification flow', function () {
 
         sinon.assert.calledTwice(eventStub);
         assertRecentSourceQuery(eventStub.firstCall, 'admin');
-        sinon.assert.calledOnce(emailStub);
-        assert.deepEqual(emailStub.lastCall.firstArg, {
-            subject: EMAIL_SUBJECT,
-            message: ADMIN_MESSAGE,
-            amountTriggered: 10
+        sinon.assert.calledOnce(webhookStub);
+        assert.deepEqual(webhookStub.lastCall.firstArg, {
+            amountTriggered: 10,
+            threshold: 2,
+            method: 'admin'
         });
     });
 
     it('Triggers when a number of members are added from API', async function () {
-        const {trigger, eventStub, emailStub} = createVerificationTrigger({
+        const {trigger, eventStub, webhookStub} = createVerificationTrigger({
             getAdminTriggerThreshold: () => 2,
             getApiTriggerThreshold: () => 2,
             eventStub: createEventRepositoryStub({
@@ -504,17 +461,31 @@ describe('Email verification flow', function () {
 
         sinon.assert.calledTwice(eventStub);
         assertRecentSourceQuery(eventStub.firstCall, 'api');
-        sinon.assert.calledOnce(emailStub);
-        assert.deepEqual(emailStub.lastCall.firstArg, {
-            subject: EMAIL_SUBJECT,
-            message: API_MESSAGE,
-            amountTriggered: 10
+        sinon.assert.calledOnce(webhookStub);
+        assert.deepEqual(webhookStub.lastCall.firstArg, {
+            amountTriggered: 10,
+            threshold: 2,
+            method: 'api'
         });
+    });
+
+    it('Does not trigger webhook when API count equals the effective threshold', async function () {
+        const {trigger, webhookStub} = createVerificationTrigger({
+            getApiTriggerThreshold: () => 2,
+            eventStub: createEventRepositoryStub({
+                memberTotal: 0,
+                sourceTotal: 2
+            })
+        });
+
+        await trigger._handleMemberCreatedEvent(createMemberCreatedEvent('api'));
+
+        sinon.assert.notCalled(webhookStub);
     });
 
     // TODO: Fix off-by-one issue in event dispatch: https://linear.app/ghost/issue/BER-3507/off-by-one-errors-in-event-query-pagination
     it('Counts the in-flight event when API/Admin pagination metadata is one behind', async function () {
-        const {trigger, emailStub} = createVerificationTrigger({
+        const {trigger, webhookStub} = createVerificationTrigger({
             getAdminTriggerThreshold: () => 9,
             eventStub: createEventRepositoryStub({
                 memberTotal: 0,
@@ -526,16 +497,16 @@ describe('Email verification flow', function () {
 
         await trigger._handleMemberCreatedEvent(createMemberCreatedEvent('admin'));
 
-        sinon.assert.calledOnce(emailStub);
-        assert.deepEqual(emailStub.lastCall.firstArg, {
-            subject: EMAIL_SUBJECT,
-            message: ADMIN_MESSAGE,
-            amountTriggered: 10
+        sinon.assert.calledOnce(webhookStub);
+        assert.deepEqual(webhookStub.lastCall.firstArg, {
+            amountTriggered: 10,
+            threshold: 9,
+            method: 'admin'
         });
     });
 
     it('Does not overcount when the source events query is already page-limited', async function () {
-        const {trigger, emailStub} = createVerificationTrigger({
+        const {trigger, webhookStub} = createVerificationTrigger({
             getAdminTriggerThreshold: () => 10,
             eventStub: createEventRepositoryStub({
                 memberTotal: 0,
@@ -547,12 +518,12 @@ describe('Email verification flow', function () {
 
         await trigger._handleMemberCreatedEvent(createMemberCreatedEvent('admin'));
 
-        sinon.assert.notCalled(emailStub);
+        sinon.assert.notCalled(webhookStub);
     });
 
     it('Does not fetch events and trigger when threshold is Infinity', async function () {
         const eventStub = sinon.stub();
-        const {trigger, emailStub} = createVerificationTrigger({
+        const {trigger, webhookStub} = createVerificationTrigger({
             getImportTriggerThreshold: () => Infinity,
             eventStub
         });
@@ -560,6 +531,6 @@ describe('Email verification flow', function () {
         await trigger.testImportThreshold();
 
         sinon.assert.notCalled(eventStub);
-        sinon.assert.notCalled(emailStub);
+        sinon.assert.notCalled(webhookStub);
     });
 });

--- a/ghost/core/test/unit/server/services/verification/verification-webhook-service.test.ts
+++ b/ghost/core/test/unit/server/services/verification/verification-webhook-service.test.ts
@@ -35,7 +35,7 @@ describe('VerificationWebhookService', function () {
     };
 
     it('returns false when webhookType is missing', async function () {
-        let warnCalled = false;
+        let warnMessage: string | undefined;
         const service = createService({
             config: {
                 get: (key: string) => {
@@ -52,8 +52,8 @@ describe('VerificationWebhookService', function () {
             },
             logging: {
                 info: () => {},
-                warn: () => {
-                    warnCalled = true;
+                warn: (message: string) => {
+                    warnMessage = message;
                 },
                 error: () => {}
             }
@@ -66,7 +66,7 @@ describe('VerificationWebhookService', function () {
         });
 
         assert.equal(result, false);
-        assert.equal(warnCalled, true);
+        assert.equal(warnMessage, 'Verification webhook is not configured because webhookType is missing.');
     });
 
     it('sends a POST request with the signed webhook payload', async function () {

--- a/ghost/core/test/utils/email-verification-utils.ts
+++ b/ghost/core/test/utils/email-verification-utils.ts
@@ -16,7 +16,6 @@ type EmailVerificationUtilsOptions = {
     persist?: boolean;
     siteId?: string;
     verified?: boolean;
-    escalationAddress?: string;
 };
 
 const DEFAULT_WEBHOOK_URL = 'https://test-webhook-receiver.com/mock-verification-event-endpoint/';
@@ -33,7 +32,6 @@ export async function setupEmailVerificationUtils({
     adminThreshold = 1,
     importThreshold = 0,
     verified = false,
-    escalationAddress = 'test@example.com',
     persist = false,
     siteId = '1'
 }: EmailVerificationUtilsOptions = {}) {
@@ -53,7 +51,6 @@ export async function setupEmailVerificationUtils({
         adminThreshold,
         importThreshold,
         verified,
-        escalationAddress,
         webhookType: DEFAULT_WEBHOOK_TYPE,
         webhookUrl,
         webhookSecret


### PR DESCRIPTION
closes [GVA-732](https://linear.app/ghost/issue/GVA-732/roll-out-to-ga-and-remove-old-logic-in-ghost)

The webhook-based verification flow is now the default behavior, so the `verificationFlow` labs flag and the old escalation email fallback were removed from Ghost. This updates the members, importer, and unit test coverage to expect webhook delivery by default, aligns the webhook configuration warnings with the GA rollout, and leaves the verification trigger maintaining a single supported path going forward.
