### PR TITLE
Hardened release workflow and script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1628,13 +1628,21 @@ jobs:
           CURRENT_TAG="${GITHUB_REF_NAME}"
           # Find the tag immediately before this one (excluding pre-releases)
           PREV_TAG=$(git tag --list 'v[0-9]*' --sort=-version:refname | grep -v '-' | grep -v "^${CURRENT_TAG}$" | head -n 1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "::warning::No previous stable tag found — release notes will use fallback message"
+          fi
           echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Previous tag: ${PREV_TAG}"
+          echo "Previous tag: ${PREV_TAG:-<none>}"
 
       - name: Generate release notes
         id: notes
         run: |
-          node scripts/lib/release-notes.js "${{ steps.prev_tag.outputs.tag }}" "${GITHUB_REF_NAME}" > /tmp/release-notes.md
+          PREV_TAG="${{ steps.prev_tag.outputs.tag }}"
+          if [ -n "$PREV_TAG" ]; then
+            node scripts/lib/release-notes.js "$PREV_TAG" "${GITHUB_REF_NAME}" > /tmp/release-notes.md
+          else
+            echo "This release contains fixes for minor bugs and issues reported by Ghost users." > /tmp/release-notes.md
+          fi
           cat /tmp/release-notes.md
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - run: yarn --ignore-scripts
+
       - name: Set up Git
         run: |
           git config user.name "Ghost CI"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -24,8 +24,7 @@ function parseArgs() {
         bumpType: 'auto',
         branch: 'main',
         dryRun: false,
-        skipChecks: false,
-        waitForChecks: false
+        skipChecks: false
     };
 
     for (const arg of args) {
@@ -37,8 +36,6 @@ function parseArgs() {
             opts.dryRun = true;
         } else if (arg === '--skip-checks') {
             opts.skipChecks = true;
-        } else if (arg === '--wait-for-checks') {
-            opts.waitForChecks = true;
         } else {
             console.error(`Unknown argument: ${arg}`);
             process.exit(1);
@@ -281,10 +278,10 @@ async function main() {
     log(`Tag v${newVersion} does not exist on remote`);
 
     // 5. Wait for CI checks
-    if (opts.waitForChecks && !opts.skipChecks) {
+    if (!opts.skipChecks) {
         const headSha = run('git rev-parse HEAD');
         await waitForChecks(headSha);
-    } else if (opts.skipChecks) {
+    } else {
         log('Skipping CI checks');
     }
 
@@ -315,7 +312,8 @@ async function main() {
         log(`Would push branch ${opts.branch} and tag v${newVersion}`);
     } else {
         logStep('Pushing');
-        run(`git push origin HEAD --follow-tags`);
+        run('git push origin HEAD');
+        run(`git push origin v${newVersion}`);
         log('Pushed branch and tag');
     }
 


### PR DESCRIPTION
## Summary
- Added `yarn --ignore-scripts` to install dependencies before running release script (fixes `Cannot find module 'semver'`)
- Changed CI check polling to run by default instead of opt-in (`--wait-for-checks` removed, checks run unless `--skip-checks` is passed)
- Replaced `git push origin HEAD --follow-tags` with explicit `git push origin HEAD` + `git push origin v{version}` to prevent accidental tag pushes
- Added graceful handling for missing previous tag in `create_github_release` job (uses fallback release notes instead of failing)

## Context
Dry run of release.yml failed — see [run #23846573012](https://github.com/TryGhost/Ghost/actions/runs/23846573012/job/69515277901). Review uncovered additional issues beyond the missing install step.

ref https://linear.app/ghost/issue/BER-3313