### PR TITLE
Switched release workflow to deploy key auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Prepare & Push Release
     steps:
+      - uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
       - uses: actions/checkout@v6
         with:
-          # PAT is required so that the tag push triggers ci.yml
-          # (pushes made with GITHUB_TOKEN don't trigger downstream workflows)
-          token: ${{ secrets.CANARY_DOCKER_BUILD }}
+          # Deploy key (via ssh-agent) is used for git push — it bypasses
+          # branch protection and triggers downstream workflows (unlike GITHUB_TOKEN)
           ref: ${{ inputs.branch || 'main' }}
           fetch-depth: 0
-          submodules: true
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      # Fetch submodules separately via HTTPS — the deploy key is scoped to
+      # Ghost only and can't authenticate against Casper/Source over SSH
+      - run: git submodule update --init
 
       - uses: actions/setup-node@v4
         env:
@@ -92,7 +99,7 @@ jobs:
           fi
           node scripts/release.js $ARGS
         env:
-          GITHUB_TOKEN: ${{ secrets.CANARY_DOCKER_BUILD }}
+          GITHUB_TOKEN: ${{ secrets.CANARY_DOCKER_BUILD }}  # PAT for GitHub API (check polling)
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
## Summary
- Replaced PAT-based checkout with SSH deploy key via `webfactory/ssh-agent`
- Deploy key bypasses branch protection rules (PR requirement + status checks) while still triggering downstream workflows
- PAT (`CANARY_DOCKER_BUILD`) retained only for GitHub API calls (check polling)

## Context
The release script pushes version bump commits directly to `main`, which is blocked by branch protection rules. Ghost-Release solved this with a deploy key — deploy keys are listed as bypass actors in the repo's rulesets. This follows the same pattern.

Requires `DEPLOY_KEY` secret to be configured on the repo (SSH private key matching an existing deploy key with write access).