### PR TITLE
Added `/#/portal/gift` route for gift subscription checkout

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.67.2",
+  "version": "2.67.3",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -14,7 +14,7 @@ import {transformPortalAnchorToRelative} from './utils/transform-portal-anchor-t
 import {getActivePage, isAccountPage, isOfferPage} from './pages';
 import ActionHandler from './actions';
 import './app.css';
-import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isRetentionOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
+import {hasRecommendations, hasGiftSubscriptions, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isRetentionOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {validateHexColor} from './utils/sanitize-html';
 import {handleDataAttributes} from './data-attributes';
 
@@ -167,6 +167,11 @@ export default class App extends React.Component {
             const pagePath = (target && target.dataset.portal);
             const {page, pageQuery, pageData} = this.getPageFromLinkPath(pagePath) || {};
             if (this.state.initStatus === 'success') {
+                if (page === 'gift' && !hasGiftSubscriptions({site: this.state.site})) {
+                    removePortalLinkFromUrl();
+
+                    return;
+                }
                 if (pageQuery && pageQuery !== 'free') {
                     this.handleSignupQuery({site: this.state.site, pageQuery});
                 } else {
@@ -577,6 +582,12 @@ export default class App extends React.Component {
                 };
             }
 
+            if (page === 'gift' && !hasGiftSubscriptions({site})) {
+                removePortalLinkFromUrl();
+
+                return {};
+            }
+
             const lastPage = ['accountPlan', 'accountProfile'].includes(page) ? 'accountHome' : null;
             const showPopup = (
                 ['monthly', 'yearly'].includes(pageQuery) ||
@@ -949,6 +960,10 @@ export default class App extends React.Component {
                 pageData: {
                     signup: false
                 }
+            };
+        } else if (path === 'gift') {
+            return {
+                page: 'gift'
             };
         } else if (path === 'account/newsletters/help') {
             return {

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -1,0 +1,29 @@
+import {useContext} from 'react';
+import AppContext from '../../app-context';
+import CloseButton from '../common/close-button';
+import LoadingPage from './loading-page';
+
+// TODO: wrap strings with t() once copy is finalised
+/* eslint-disable i18next/no-literal-string */
+
+const GiftPage = () => {
+    const {site} = useContext(AppContext);
+
+    if (!site) {
+        return <LoadingPage />;
+    }
+
+    return (
+        <div className='gh-portal-content gh-portal-gift'>
+            <CloseButton />
+            <header className='gh-portal-header'>
+                <h1 className='gh-portal-main-title'>Gift a subscription</h1>
+            </header>
+            <div className='gh-portal-section'>
+                <p>Give the gift of a subscription to <strong>{site.title || 'this site'}</strong>.</p>
+            </div>
+        </div>
+    );
+};
+
+export default GiftPage;

--- a/apps/portal/src/pages.js
+++ b/apps/portal/src/pages.js
@@ -17,6 +17,7 @@ import SupportPage from './components/pages/support-page';
 import SupportSuccess from './components/pages/support-success';
 import SupportError from './components/pages/support-error';
 import RecommendationsPage from './components/pages/recommendations-page';
+import GiftPage from './components/pages/gift-page';
 
 /** List of all available pages in Portal, mapped to their UI component
  * Any new page added to portal needs to be mapped here
@@ -40,7 +41,8 @@ const Pages = {
     support: SupportPage,
     supportSuccess: SupportSuccess,
     supportError: SupportError,
-    recommendations: RecommendationsPage
+    recommendations: RecommendationsPage,
+    gift: GiftPage
 };
 
 /** Return page if valid, fallback to signup */

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -252,6 +252,10 @@ export function hasRecommendations({site}) {
     return site?.recommendations_enabled === true;
 }
 
+export function hasGiftSubscriptions({site}) {
+    return site?.labs?.giftSubscriptions === true;
+}
+
 export function isSigninAllowed({site}) {
     return site?.members_signup_access !== 'none';
 }

--- a/apps/portal/test/portal-links.test.js
+++ b/apps/portal/test/portal-links.test.js
@@ -344,6 +344,41 @@ describe('Portal Data links:', () => {
         });
     });
 
+    describe('#/portal/gift', () => {
+        test('opens gift page when giftSubscriptions labs flag is enabled', async () => {
+            window.location.hash = '#/portal/gift';
+
+            let {
+                popupFrame, triggerButtonFrame, ...utils
+            } = await setup({
+                site: {...FixtureSite.singleTier.basic, labs: {giftSubscriptions: true}},
+                showPopup: false
+            });
+
+            expect(triggerButtonFrame).toBeInTheDocument();
+
+            popupFrame = await utils.findByTitle(/portal-popup/i);
+            expect(popupFrame).toBeInTheDocument();
+
+            const giftTitle = within(popupFrame.contentDocument).queryByText(/gift a subscription/i);
+            expect(giftTitle).toBeInTheDocument();
+        });
+
+        test('does not open when giftSubscriptions labs flag is disabled', async () => {
+            window.location.hash = '#/portal/gift';
+
+            let {
+                popupFrame, triggerButtonFrame
+            } = await setup({
+                site: {...FixtureSite.singleTier.basic, labs: {}},
+                showPopup: false
+            });
+
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(popupFrame).not.toBeInTheDocument();
+        });
+    });
+
     describe('unauthenticated account page access', () => {
         test.each([
             {path: 'account', label: 'account'},

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -1,4 +1,5 @@
 import {
+    hasGiftSubscriptions,
     hasAvailablePrices,
     getAllProductsForSite,
     getAvailableProducts,
@@ -817,6 +818,24 @@ describe('Helpers - ', () => {
         it('returns the original date when month count is not an integer', () => {
             const date = '2024-03-15T00:00:00.000Z';
             expect(addMonths(date, 1.5)).toEqual(new Date(date));
+        });
+    });
+
+    describe('hasGiftSubscriptions', () => {
+        test('returns true when labs flag is enabled', () => {
+            expect(hasGiftSubscriptions({site: {labs: {giftSubscriptions: true}}})).toBe(true);
+        });
+
+        test('returns false when labs flag is disabled', () => {
+            expect(hasGiftSubscriptions({site: {labs: {giftSubscriptions: false}}})).toBe(false);
+        });
+
+        test('returns false when labs flag is missing', () => {
+            expect(hasGiftSubscriptions({site: {labs: {}}})).toBe(false);
+        });
+
+        test('returns false when labs is undefined', () => {
+            expect(hasGiftSubscriptions({site: {}})).toBe(false);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3484

Scaffolds the Portal gift page behind the `giftSubscriptions` labs flag. When the flag is disabled, both hash links and `data-portal` attributes are blocked and the URL is cleaned up