### PR TITLE
Skipped E2E tests on CI-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,12 @@ jobs:
               - '!ghost/core/core/server/data/tinybird/**/*.md'
             any-code:
               - '!**/*.md'
+            app-code:
+              - 'ghost/**'
+              - 'apps/**'
+              - 'e2e/**'
+              - 'package.json'
+              - 'yarn.lock'
 
       - name: Compute lockfile hash
         run: echo "hash=lockfile-${{ hashFiles('yarn.lock') }}" >> "$GITHUB_ENV"
@@ -212,6 +218,7 @@ jobs:
       changed_sodo_search: ${{ steps.changed.outputs.sodo-search }}
       changed_tinybird: ${{ steps.changed.outputs.tinybird }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
+      changed_app_code: ${{ steps.changed.outputs.app-code }}
       changed_new_package: ${{ steps.added.outputs.new-package }}
       base_commit: ${{ env.BASE_COMMIT }}
       is_main: ${{ env.IS_MAIN }}
@@ -1083,7 +1090,7 @@ jobs:
     name: E2E Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     needs: [job_build_artifacts, job_setup]
-    if: needs.job_setup.outputs.is_tag != 'true'
+    if: needs.job_setup.outputs.is_tag != 'true' && needs.job_setup.outputs.changed_app_code == 'true'
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
## Problem

E2E tests run on every push regardless of what changed. A workflow-only or docs-only PR waits ~40 minutes for 8 E2E shards that can't possibly find regressions because no application code changed. This wastes CI minutes and slows down merges for infrastructure work.

## Proposal

Add a new `app-code` path filter to `job_setup` that matches actual application code:
- `ghost/**`, `apps/**`, `e2e/**`, `package.json`, `yarn.lock`

Gate `job_e2e_tests` on this filter. When no app code changes, e2e tests are skipped. The required check gate (`All required tests passed or skipped`) already handles skipped jobs — it only fails on `failure` or `cancelled`, not `skipped`.

## Not Doing

- Skipping other test jobs (unit, integration, lint) — those are already path-filtered via `shared` + package-specific filters.
- Skipping `job_build_artifacts` — that always runs (needed for Docker image builds on main).
- Changing the `shared` anchor that includes `.github/**` — other test jobs correctly re-run when workflows change since those changes could affect how tests execute.

## Trade-offs

- If a workflow change somehow breaks e2e tests (e.g., changing the e2e job's Docker image, environment variables, or sharding), it won't be caught until a subsequent PR that touches app code. This is a narrow window — the next app code PR will catch it.
- The `app-code` filter is deliberately broad (`ghost/**`, `apps/**`). A tighter filter could skip more, but the risk of missing real regressions increases.

## Rollback

- **Easy:** Revert the one-line `if:` condition change on `job_e2e_tests`. No data migration, no downstream impact.

## Blast Radius

- CI only. No production impact.
- PRs that only touch `.github/`, `docs/`, `scripts/`, or other non-app paths will merge faster.
- PRs that touch any file under `ghost/`, `apps/`, `e2e/`, or dependency files (`package.json`, `yarn.lock`) are unaffected — e2e runs as before.