### PR TITLE
Fixed filter input triggering password autofill suggestions

### DIFF
--- a/apps/shade/src/components/ui/filters.tsx
+++ b/apps/shade/src/components/ui/filters.tsx
@@ -605,8 +605,12 @@ function FilterInput<T = unknown>({
                 <input
                     aria-describedby={!isValid && validationMessage ? `${field?.key || 'input'}-error` : undefined}
                     aria-invalid={!isValid}
+                    autoComplete="off"
                     className="w-full bg-transparent outline-hidden dark:!bg-transparent"
+                    data-form-type="other"
+                    data-lpignore="true"
                     data-slot="filters-input"
+                    data-1p-ignore
                     onBlur={handleBlur}
                     onChange={handleChange}
                     onKeyDown={handleKeyDown}


### PR DESCRIPTION
The email filter input in the members list was being detected by browser password managers as a login field, causing autofill suggestions to appear over the filter UI. This happens because browsers and password manager extensions use heuristics to identify input fields that might be part of login forms, and the filter input was matching those heuristics.

This fix adds `autoComplete="off"` to the `FilterInput` component along with vendor-specific attributes that tell 1Password (`data-1p-ignore`), LastPass (`data-lpignore`), and browser form detection heuristics (`data-form-type="other"`) to ignore the field. Together these attributes prevent all major password managers from interfering with the filter input.

ref BER-3495