### PR TITLE
Updated Tinybird CI to trigger & follow infra workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -738,11 +738,6 @@ jobs:
         image: tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
-    env:
-      TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
-      TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
-      TINYBIRD_HOST_STAGING: ${{ secrets.TINYBIRD_HOST_STAGING }}
-      TINYBIRD_TOKEN_STAGING: ${{ secrets.TINYBIRD_TOKEN_STAGING }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Tinybird CLI
@@ -751,10 +746,51 @@ jobs:
         run: tb build
       - name: Test project
         run: tb test run
-      - name: Deployment check - Staging
-        run: tb --cloud --host ${{ env.TINYBIRD_HOST_STAGING }} --token ${{ env.TINYBIRD_TOKEN_STAGING }} deploy --check
-      - name: Deployment check - Production
-        run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deploy --check
+      - name: Trigger and watch traffic analytics infra Tinybird workflow
+        if: github.repository == 'TryGhost/Ghost'
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_ANALYTICS_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          REPO="TryGhost/traffic-analytics-infra"
+          WORKFLOW="tinybird.yml"
+          BRANCH="main"
+          DISPATCHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          gh workflow run "$WORKFLOW" \
+            --repo "$REPO" \
+            --ref "$BRANCH" \
+            -f ghost_ref='${{ github.ref }}' \
+            -f run_local_tests='false'
+
+          RUN_ID=""
+          RUN_URL=""
+
+          for attempt in {1..30}; do
+            RUN_ID=$(gh run list \
+              --repo "$REPO" \
+              --workflow "$WORKFLOW" \
+              --branch "$BRANCH" \
+              --event workflow_dispatch \
+              --json databaseId,createdAt,url \
+              --jq 'map(select(.createdAt >= "'"$DISPATCHED_AT"'")) | sort_by(.createdAt) | last | .databaseId // empty')
+
+            if [ -n "$RUN_ID" ]; then
+              RUN_URL=$(gh run view "$RUN_ID" --repo "$REPO" --json url --jq '.url')
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Unable to find the triggered workflow run in $REPO"
+            exit 1
+          fi
+
+          echo "Watching remote workflow run: $RUN_URL"
+          gh run watch "$RUN_ID" --repo "$REPO" --exit-status
 
   job_ghost-cli:
     name: Ghost-CLI tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,33 +756,25 @@ jobs:
           REPO="TryGhost/traffic-analytics-infra"
           WORKFLOW="tinybird.yml"
           BRANCH="main"
-          DISPATCHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          DISPATCH_RESPONSE=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/$REPO/actions/workflows/$WORKFLOW/dispatches" \
+            --input - <<EOF
+          {
+            "ref": "$BRANCH",
+            "return_run_details": true,
+            "inputs": {
+              "ghost_ref": "${{ github.sha }}",
+              "caller_run_id": "${{ github.run_id }}",
+              "run_local_tests": false
+            }
+          }
+          EOF
+          )
 
-          gh workflow run "$WORKFLOW" \
-            --repo "$REPO" \
-            --ref "$BRANCH" \
-            -f ghost_ref='${{ github.ref }}' \
-            -f run_local_tests='false'
-
-          RUN_ID=""
-          RUN_URL=""
-
-          for attempt in {1..30}; do
-            RUN_ID=$(gh run list \
-              --repo "$REPO" \
-              --workflow "$WORKFLOW" \
-              --branch "$BRANCH" \
-              --event workflow_dispatch \
-              --json databaseId,createdAt,url \
-              --jq 'map(select(.createdAt >= "'"$DISPATCHED_AT"'")) | sort_by(.createdAt) | last | .databaseId // empty')
-
-            if [ -n "$RUN_ID" ]; then
-              RUN_URL=$(gh run view "$RUN_ID" --repo "$REPO" --json url --jq '.url')
-              break
-            fi
-
-            sleep 5
-          done
+          RUN_ID=$(printf '%s' "$DISPATCH_RESPONSE" | jq -r '.workflow_run_id // empty')
+          RUN_URL=$(printf '%s' "$DISPATCH_RESPONSE" | jq -r '.html_url // .run_url // empty')
 
           if [ -z "$RUN_ID" ]; then
             echo "::error::Unable to find the triggered workflow run in $REPO"

--- a/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
@@ -1,4 +1,5 @@
 
+
 - name: Date range
   description: All fixture data
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07


### PR DESCRIPTION
Ghost CI now triggers & waits for the dispatched traffic analytics workflow and mirrors its final result.

This moves the Tinybird deploy check out of this repo, over to an internally managed repo.