### PR TITLE
Fixed number formatting on Ember Member dropdown

### DIFF
--- a/ghost/admin/app/templates/members.hbs
+++ b/ghost/admin/app/templates/members.hbs
@@ -77,12 +77,12 @@
                                         {{#if this.showingAll}}
                                             <span>Export all members</span>
                                         {{else}}
-                                            <span>Export selected members ({{this.members.length}})</span>
+                                            <span>Export selected members ({{format-number this.members.length}})</span>
                                         {{/if}}
                                     </button>
                                 {{else}}
                                     <button class="mr2" disabled="true" type="button" data-test-button="export-members" data-testid="export-members">
-                                        <span>Export selected members (0)</span>
+                                        <span>Export selected members ({{format-number 0}})</span>
                                     </button>
                                 {{/if}}
                             </li>
@@ -90,18 +90,18 @@
                                 <li class="divider"></li>
                                 <li>
                                     <button class="mr2" data-test-button="add-label-selected" data-testid="add-label-selected" type="button" {{on "click" this.bulkAddLabel}}>
-                                        <span>Add label for selected members ({{this.members.length}})</span>
+                                        <span>Add label for selected members ({{format-number this.members.length}})</span>
                                     </button>
                                 </li>
                                 <li>
                                     <button class="mr2" data-test-button="remove-label-selected" data-testid="remove-label-selected" type="button" {{on "click" this.bulkRemoveLabel}}>
-                                        <span>Remove label from selected members ({{this.members.length}})</span>
+                                        <span>Remove label from selected members ({{format-number this.members.length}})</span>
                                     </button>
                                 </li>
                                 {{#if (not-eq this.settings.membersSignupAccess "none")}}
                                     <li>
                                         <button class="mr2" data-test-button="unsubscribe-selected" type="button" {{on "click" this.bulkUnsubscribe}}>
-                                            <span>Unsubscribe selected members ({{this.members.length}})</span>
+                                            <span>Unsubscribe selected members ({{format-number this.members.length}})</span>
                                         </button>
                                     </li>
                                 {{/if}}
@@ -109,7 +109,7 @@
                                     <li class="divider"></li>
                                     <li>
                                         <button class="mr2" data-test-button="delete-selected" type="button" {{on "click" this.bulkDelete}}>
-                                            <span class="red">Delete selected members ({{this.members.length}})</span>
+                                            <span class="red">Delete selected members ({{format-number this.members.length}})</span>
                                         </button>
                                     </li>
                                 {{/if}}

--- a/ghost/admin/tests/acceptance/members-test.js
+++ b/ghost/admin/tests/acceptance/members-test.js
@@ -300,6 +300,18 @@ describe('Acceptance: Members Test', function () {
             expect(find('[data-test-modal="delete-members"]')).to.not.exist;
         });
 
+        it('formats counts in members actions menu for filtered lists', async function () {
+            this.server.createList('member', 1000, {status: 'free'});
+
+            await visit('/members?filter=status%3Afree');
+            await click('[data-test-button="members-actions"]');
+
+            expect(find('[data-test-button="export-members"]')).to.have.text('Export selected members (1,000)');
+            expect(find('[data-test-button="add-label-selected"]')).to.have.text('Add label for selected members (1,000)');
+            expect(find('[data-test-button="remove-label-selected"]')).to.have.text('Remove label from selected members (1,000)');
+            expect(find('[data-test-button="delete-selected"]')).to.have.text('Delete selected members (1,000)');
+        });
+
         it('can delete a member (via list)', async function () {
             const newsletter = this.server.create('newsletter');
             const label = this.server.create('label');

--- a/ghost/admin/tests/acceptance/members-test.js
+++ b/ghost/admin/tests/acceptance/members-test.js
@@ -306,10 +306,10 @@ describe('Acceptance: Members Test', function () {
             await visit('/members?filter=status%3Afree');
             await click('[data-test-button="members-actions"]');
 
-            expect(find('[data-test-button="export-members"]')).to.have.text('Export selected members (1,000)');
-            expect(find('[data-test-button="add-label-selected"]')).to.have.text('Add label for selected members (1,000)');
-            expect(find('[data-test-button="remove-label-selected"]')).to.have.text('Remove label from selected members (1,000)');
-            expect(find('[data-test-button="delete-selected"]')).to.have.text('Delete selected members (1,000)');
+            expect(find('[data-test-button="export-members"] span')).to.have.text('Export selected members (1,000)');
+            expect(find('[data-test-button="add-label-selected"] span')).to.have.text('Add label for selected members (1,000)');
+            expect(find('[data-test-button="remove-label-selected"] span')).to.have.text('Remove label from selected members (1,000)');
+            expect(find('[data-test-button="delete-selected"] span')).to.have.text('Delete selected members (1,000)');
         });
 
         it('can delete a member (via list)', async function () {


### PR DESCRIPTION
no refs.

- The thousands indicator was missing in the actions menu on the Ember member list screen when a filter was applied.
