### PR TITLE
Fixed release Slack notification formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1658,10 +1658,11 @@ jobs:
           RELEASE_URL="https://github.com/TryGhost/Ghost/releases/tag/${VERSION}"
           CHANGELOG=$(cat /tmp/release-notes.md | head -c 3000)
 
-          # Build Slack payload
+          # Build Slack payload — use --rawfile so newlines in release notes are preserved
           PAYLOAD=$(jq -n \
-            --arg text "👻 *Ghost ${VERSION} is loose!* — <${RELEASE_URL}|Release Notes>\n\n${CHANGELOG}" \
-            '{text: $text}')
+            --arg header ":ghost: Ghost ${VERSION} is loose! - ${RELEASE_URL}" \
+            --rawfile notes /tmp/release-notes.md \
+            '{text: ($header + "\n\n" + $notes)}')
 
           curl -sf -X POST \
             -H 'Content-type: application/json' \


### PR DESCRIPTION
## Summary
- Fixed escaped `\n` characters appearing literally in Slack release notifications
- Matched the old notification format: `:ghost: Ghost v6.25.1 is loose! - <url>`
- Used `jq --rawfile` instead of `--arg` to preserve newlines in the changelog body

The previous approach used `jq --arg` which escapes newlines to literal `\n`. `--rawfile` reads the file contents with newlines intact.