### PR TITLE
Collapsed forEach test loops and removed unnecessary isolation

### DIFF
--- a/e2e/tests/admin/billing/force-upgrade.test.ts
+++ b/e2e/tests/admin/billing/force-upgrade.test.ts
@@ -52,79 +52,71 @@ test.describe('Ghost Admin - Force Upgrade Mode', () => {
         });
     });
 
-    test.describe('navigation blocked in force upgrade mode', () => {
-        NAV_ITEMS.forEach(({name}) => {
-            test(`${name} link - billing iframe blocks access`, async ({page}) => {
-                const sidebarPage = new SidebarPage(page);
-                const billingPage = new BillingPage(page);
-                await sidebarPage.goto();
+    test('sidebar navigation is blocked by billing iframe', async ({page}) => {
+        const sidebarPage = new SidebarPage(page);
+        const billingPage = new BillingPage(page);
+        await sidebarPage.goto();
 
-                const billingIframe = await billingPage.waitForBillingIframe();
-                await expect(billingIframe).toBeVisible();
+        const billingIframe = await billingPage.waitForBillingIframe();
+        await expect(billingIframe).toBeVisible();
 
-                await sidebarPage.getNavLink(name).click();
-
-                await expect(billingIframe).toBeVisible();
-            });
-        });
+        for (const {name} of NAV_ITEMS) {
+            await sidebarPage.getNavLink(name).click();
+            await expect(billingIframe).toBeVisible();
+        }
     });
 
-    test.describe('direct URL navigation blocked', () => {
-        NAV_ITEMS.forEach(({name, directUrl}) => {
-            test(`direct navigation to ${name} shows billing iframe`, async ({page}) => {
-                const sidebarPage = new SidebarPage(page);
-                const billingPage = new BillingPage(page);
-                await sidebarPage.goto(directUrl);
+    test('direct URL navigation is blocked by billing iframe', async ({page}) => {
+        const sidebarPage = new SidebarPage(page);
+        const billingPage = new BillingPage(page);
 
-                const billingIframe = await billingPage.waitForBillingIframe();
-                await expect(billingIframe).toBeVisible();
-            });
-        });
-    });
-
-    test.describe('allowed routes in force upgrade mode', () => {
-        test('Settings is accessible via sidebar', async ({page}) => {
-            const sidebarPage = new SidebarPage(page);
-            const billingPage = new BillingPage(page);
-            await sidebarPage.goto();
-
-            await billingPage.waitForBillingIframe();
-            await sidebarPage.getNavLink('Settings').click();
-
-            await expect(page).toHaveURL(/#\/settings/);
-            await expect(billingPage.billingIframe).toBeHidden();
-        });
-
-        test('Settings is accessible via direct URL', async ({page}) => {
-            const sidebarPage = new SidebarPage(page);
-            const billingPage = new BillingPage(page);
-            await sidebarPage.goto('/ghost/#/settings');
-
-            await expect(page).toHaveURL(/#\/settings/);
-            await expect(billingPage.billingIframe).toBeHidden();
-        });
-
-        test('Sign out is accessible', async ({page}) => {
-            const sidebarPage = new SidebarPage(page);
-            const billingPage = new BillingPage(page);
-            await sidebarPage.goto();
-
-            await billingPage.waitForBillingIframe();
-            await sidebarPage.userDropdownTrigger.click();
-            await sidebarPage.signOutLink.click();
-
-            await expect(page).toHaveURL(/signin/);
-        });
-    });
-
-    test.describe('Ember-handled routes in force upgrade mode', () => {
-        test('tag detail route shows billing iframe', async ({page}) => {
-            const sidebarPage = new SidebarPage(page);
-            const billingPage = new BillingPage(page);
-            await sidebarPage.goto('/ghost/#/tags/default-tag');
+        for (const {directUrl} of NAV_ITEMS) {
+            await sidebarPage.goto(directUrl);
 
             const billingIframe = await billingPage.waitForBillingIframe();
             await expect(billingIframe).toBeVisible();
-        });
+        }
+    });
+
+    test('Settings is accessible via sidebar', async ({page}) => {
+        const sidebarPage = new SidebarPage(page);
+        const billingPage = new BillingPage(page);
+        await sidebarPage.goto();
+
+        await billingPage.waitForBillingIframe();
+        await sidebarPage.getNavLink('Settings').click();
+
+        await expect(page).toHaveURL(/#\/settings/);
+        await expect(billingPage.billingIframe).toBeHidden();
+    });
+
+    test('Settings is accessible via direct URL', async ({page}) => {
+        const sidebarPage = new SidebarPage(page);
+        const billingPage = new BillingPage(page);
+        await sidebarPage.goto('/ghost/#/settings');
+
+        await expect(page).toHaveURL(/#\/settings/);
+        await expect(billingPage.billingIframe).toBeHidden();
+    });
+
+    test('Sign out is accessible', async ({page}) => {
+        const sidebarPage = new SidebarPage(page);
+        const billingPage = new BillingPage(page);
+        await sidebarPage.goto();
+
+        await billingPage.waitForBillingIframe();
+        await sidebarPage.userDropdownTrigger.click();
+        await sidebarPage.signOutLink.click();
+
+        await expect(page).toHaveURL(/signin/);
+    });
+
+    test('Ember-handled tag detail route shows billing iframe', async ({page}) => {
+        const sidebarPage = new SidebarPage(page);
+        const billingPage = new BillingPage(page);
+        await sidebarPage.goto('/ghost/#/tags/default-tag');
+
+        const billingIframe = await billingPage.waitForBillingIframe();
+        await expect(billingIframe).toBeVisible();
     });
 });

--- a/e2e/tests/admin/members/filter-actions.test.ts
+++ b/e2e/tests/admin/members/filter-actions.test.ts
@@ -1,10 +1,7 @@
 import {expect, test} from '@/helpers/playwright';
-import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 
 import {MemberFactory, createMemberFactory} from '@/data-factory';
 import {MembersPage} from '@/admin-pages';
-
-usePerTestIsolation();
 
 test.describe('Ghost Admin - Member Filter Actions', () => {
     let memberFactory: MemberFactory;

--- a/e2e/tests/admin/sidebar/navigation.test.ts
+++ b/e2e/tests/admin/sidebar/navigation.test.ts
@@ -15,17 +15,16 @@ async function mockNotificationCount(page: Page, count: number) {
 
 test.describe('Ghost Admin - Sidebar Navigation', () => {
     test.describe('main navigation', () => {
-        NAV_ITEMS.forEach(({name, path}) => {
-            test(`clicking ${name} - navigates and shows active state`, async ({page}) => {
-                const sidebar = new SidebarPage(page);
+        test('clicking each nav item navigates and shows active state', async ({page}) => {
+            const sidebar = new SidebarPage(page);
 
+            for (const {name, path} of NAV_ITEMS) {
                 await sidebar.goto('/ghost');
-
                 await sidebar.getNavLink(name).click();
 
                 await expect(page).toHaveURL(path);
                 await expect(sidebar.getNavLink(name)).toHaveAttribute('aria-current', 'page');
-            });
+            }
         });
     });
 


### PR DESCRIPTION
## Summary
**forEach collapse:**
- `force-upgrade.test.ts`: Two `NAV_ITEMS.forEach()` loops were generating 14 per-test-isolated tests, each spinning up its own Ghost instance to assert the billing iframe is visible. Collapsed into 2 flow tests that iterate nav items within a single instance each. Eliminates ~11 Ghost instance spinups per CI run.
- `navigation.test.ts`: `NAV_ITEMS.forEach()` generating 7 tests collapsed into 1 flow test that iterates all items in sequence.

**ISO removal:**
- `filter-actions.test.ts`: Removed `usePerTestIsolation()` — both tests create their own fixture data and operate on independent label operations with no shared state conflicts.

**No coverage removed.** Every assertion is preserved, just grouped into fewer tests with fewer Ghost instances.

**Net impact:** ~19 fewer `test()` calls, ~13 fewer Ghost instance spinups per CI run.

## Test plan

- [ ] CI e2e tests pass on all 8 shards