### PR TITLE
Added slug to members tier filter search

### DIFF
--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -96,7 +96,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const postValueSource = usePostResourceValueSource();
     const emailValueSource = useEmailPostValueSource();
     const labelValueSource = useLabelValueSource();
-    const tierValueSource = useTierValueSource(activePaidTiers.map(tier => ({value: tier.id, label: tier.name})));
+    const tierValueSource = useTierValueSource(activePaidTiers.map(tier => ({value: tier.id, label: tier.name, detail: tier.slug})));
 
     const filterFields = useMemberFilterFields({
         newsletters,

--- a/e2e/helpers/pages/admin/members/members-forward-page.ts
+++ b/e2e/helpers/pages/admin/members/members-forward-page.ts
@@ -60,6 +60,13 @@ export class MembersForwardPage extends AdminPage {
         }
     }
 
+    async addSearchableFilter(fieldName: string, searchText: string, optionName: string): Promise<void> {
+        await this.filterButton.click();
+        await this.page.getByRole('option', {name: fieldName, exact: true}).click();
+        await this.page.getByPlaceholder(`Search ${fieldName.toLowerCase()}...`).pressSequentially(searchText);
+        await this.page.getByRole('option', {name: optionName}).click();
+    }
+
     async exportMembers(): Promise<ExportedFile> {
         const download = await this.exportMembersData();
         const suggestedFilename = download.suggestedFilename();

--- a/e2e/tests/admin/members-forward/tier-filter-search.test.ts
+++ b/e2e/tests/admin/members-forward/tier-filter-search.test.ts
@@ -1,0 +1,42 @@
+import {MemberFactory, TierFactory, createMemberFactory, createTierFactory} from '@/data-factory';
+import {MembersForwardPage} from '@/admin-pages';
+import {SettingsService} from '@/helpers/services/settings/settings-service';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Members Forward Tier Filter Search', () => {
+    test.use({labs: {membersForward: true}});
+
+    let memberFactory: MemberFactory;
+    let tierFactory: TierFactory;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+        tierFactory = createTierFactory(page.request);
+    });
+
+    test('filters tier options by slug in the search dropdown', async ({page}) => {
+        const settingsService = new SettingsService(page.request);
+        await settingsService.setStripeConnected();
+
+        const firstTier = await tierFactory.getFirstPaidTier();
+        const secondTier = await tierFactory.create({name: 'Silver Tier'});
+
+        await memberFactory.createMany([
+            {name: 'Paid Member', email: 'paid@example.com', status: 'comped', tiers: [{id: firstTier.id}]},
+            {name: 'Silver Member', email: 'silver@example.com', status: 'comped', tiers: [{id: secondTier.id}]},
+            {name: 'Free Member', email: 'free@example.com'}
+        ]);
+
+        const membersPage = new MembersForwardPage(page);
+        await membersPage.goto();
+        await page.reload({waitUntil: 'load'});
+        await expect(membersPage.memberRows).toHaveCount(3);
+
+        await membersPage.addSearchableFilter('Membership tier', secondTier.slug, secondTier.name);
+        await expect(membersPage.memberRows).toHaveCount(1);
+        await expect(membersPage.getMemberByName('Silver Member')).toBeVisible();
+    });
+});


### PR DESCRIPTION
The members tier filter dropdown only matches against the tier name, which has tripped up customers and support when trying to search by the tier slug. This change passes the tier's slug as the `detail` field into the tier value source, so the search input now matches against both name and slug.

The implementation is a one-line change in `members-filters.tsx` that adds `detail: tier.slug` to the tier mapping passed to `useTierValueSource`. The `detail` field is already supported by the underlying filter search component for matching purposes, so no framework changes were needed.

An E2E test has been added that creates two tiers and verifies that searching by slug correctly filters the tier dropdown options. A reusable `addSearchableFilter` helper was added to the `MembersForwardPage` page object to support this and future searchable filter tests.

ref https://linear.app/ghost/issue/BER-3465/add-slug-to-members-tier-filter-search