### PR TITLE
Enabled Friday release cron schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 run-name: "Release — ${{ inputs.bump-type || 'auto' }} from ${{ inputs.branch || 'main' }}${{ inputs.dry-run && ' (dry run)' || '' }}"
 
 on:
-  # schedule:
-  #   - cron: '0 15 * * 5' # Friday 3pm UTC — disabled until cutover from Ghost-Release (BER-3313)
+  schedule:
+    - cron: '0 15 * * 5' # Friday 3pm UTC
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
## Summary
Uncomments the Friday 3pm UTC cron schedule in `release.yml`, enabling automated weekly releases from this repo.

## Context
Part of [BER-3313](https://linear.app/ghost/issue/BER-3313) — consolidating Ghost-Release into the Ghost monorepo. The release workflow has been tested manually (v6.25.1 released successfully). This enables the scheduled trigger.

**Merge together with:** TryGhost/Ghost-Release PR that removes the cron from Ghost-Release, so both repos don't fire on the same Friday.