### PR TITLE
Backported release tooling from main for 5.x releases

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -1,0 +1,106 @@
+name: Publish on Tag
+
+on:
+  push:
+    tags:
+      - 'v5.*'
+
+env:
+  FORCE_COLOR: 1
+  NODE_VERSION: '22'
+
+jobs:
+  publish_ghost:
+    name: Publish Ghost to npm
+    runs-on: ubuntu-latest
+    if: github.repository == 'TryGhost/Ghost'
+    environment: npm-release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Verify tag matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./ghost/core/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $TAG_VERSION"
+
+      - name: Create npm tarball
+        working-directory: ghost/core
+        run: npm pack
+
+      # TODO: Remove once Node v24 ships with npm >= 11
+      - name: Install npm v11 (required for OIDC publishing)
+        run: npm install -g npm@11
+
+      - name: Publish to npm
+        working-directory: ghost/core
+        run: npm publish ghost-*.tgz --access public
+
+      - uses: tryghost/actions/actions/slack-build@main
+        if: failure()
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  create_github_release:
+    needs: [publish_ghost]
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.CANARY_DOCKER_BUILD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve previous tag
+        id: prev_tag
+        run: |
+          CURRENT_TAG="${GITHUB_REF_NAME}"
+          PREV_TAG=$(git tag --list 'v5.*' --sort=-version:refname | grep -v '-' | grep -v "^${CURRENT_TAG}$" | head -n 1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "::warning::No previous stable tag found"
+          fi
+          echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${PREV_TAG:-<none>}"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          PREV_TAG="${{ steps.prev_tag.outputs.tag }}"
+          if [ -n "$PREV_TAG" ]; then
+            node scripts/lib/release-notes.js "$PREV_TAG" "${GITHUB_REF_NAME}" > /tmp/release-notes.md
+          else
+            echo "This release contains fixes for minor bugs and issues reported by Ghost users." > /tmp/release-notes.md
+          fi
+          cat /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file /tmp/release-notes.md
+
+      - uses: tryghost/actions/actions/slack-build@main
+        if: failure()
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -16,6 +16,10 @@
     "type": "git",
     "url": "git://github.com/TryGhost/Ghost.git"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "bugs": "https://github.com/TryGhost/Ghost/issues",
   "contributors": "https://github.com/TryGhost/Ghost/graphs/contributors",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "postinstall": "patch-package",
     "query:posts": "cd ghost/core/core/server/data/tinybird/scripts && ./query-posts.sh",
     "query:members": "cd ghost/core/core/server/data/tinybird/scripts && ./query-members.sh",
-    "generate:analytics": "cd ghost/core && node core/server/data/tinybird/scripts/analytics-generator.js"
+    "generate:analytics": "cd ghost/core && node core/server/data/tinybird/scripts/analytics-generator.js",
+    "release": "node scripts/release.js"
   },
   "resolutions": {
     "@tryghost/errors": "^1.3.7",
@@ -92,6 +93,7 @@
     "patch-package": "8.0.0",
     "postinstall-postinstall": "2.1.0",
     "rimraf": "5.0.10",
+    "semver": "7.7.2",
     "typescript": "5.8.3"
   }
 }

--- a/scripts/lib/release-notes.js
+++ b/scripts/lib/release-notes.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+'use strict';
+
+const {execSync} = require('node:child_process');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const REPO_URL = 'https://github.com/TryGhost/Ghost';
+
+// Emoji priority order (lowest index = lowest priority, sorted descending)
+const EMOJI_ORDER = ['💡', '🐛', '🎨', '💄', '✨', '🔒'];
+
+// User-facing emojis — only these are included in release notes
+const USER_FACING_EMOJIS = new Set(EMOJI_ORDER);
+
+function getCommitLog(fromTag, toTag) {
+    const range = `${fromTag}..${toTag}`;
+    const format = '* %s - %an';
+    const cmd = `git log --no-merges --pretty=tformat:'${format}' ${range}`;
+
+    let log;
+    try {
+        log = execSync(cmd, {cwd: ROOT, encoding: 'utf8'}).trim();
+    } catch {
+        return [];
+    }
+
+    if (!log) {
+        return [];
+    }
+
+    return log.split('\n').map(line => line.trim());
+}
+
+function extractLeadingEmoji(line) {
+    // Line format: * <message> - <author>
+    const match = line.match(/^\* (.)/u);
+    return match ? match[1] : '';
+}
+
+function filterAndSortByEmoji(lines) {
+    const emojiLines = lines.filter((line) => {
+        const emoji = extractLeadingEmoji(line);
+        return USER_FACING_EMOJIS.has(emoji);
+    });
+
+    emojiLines.sort((a, b) => {
+        const emojiA = extractLeadingEmoji(a);
+        const emojiB = extractLeadingEmoji(b);
+        const indexA = EMOJI_ORDER.indexOf(emojiA);
+        const indexB = EMOJI_ORDER.indexOf(emojiB);
+        return indexB - indexA;
+    });
+
+    return emojiLines;
+}
+
+function generateReleaseNotes(fromTag, toTag) {
+    const lines = getCommitLog(fromTag, toTag);
+    const filtered = filterAndSortByEmoji(lines);
+
+    let body;
+    if (filtered.length === 0) {
+        body = 'This release contains fixes for minor bugs and issues reported by Ghost users.';
+    } else {
+        // Deduplicate (preserving order)
+        body = [...new Set(filtered)].join('\n');
+    }
+
+    body += `\n\n---\n\nView the changelog for full details: ${REPO_URL}/compare/${fromTag}...${toTag}`;
+
+    return body;
+}
+
+// CLI: node release-notes.js <from-tag> <to-tag>
+if (require.main === module) {
+    const [fromTag, toTag] = process.argv.slice(2);
+
+    if (!fromTag || !toTag) {
+        console.error('Usage: node release-notes.js <from-tag> <to-tag>');
+        process.exit(1);
+    }
+
+    process.stdout.write(generateReleaseNotes(fromTag, toTag));
+}
+
+module.exports = {generateReleaseNotes};

--- a/scripts/lib/resolve-base-tag.js
+++ b/scripts/lib/resolve-base-tag.js
@@ -1,0 +1,31 @@
+const semver = require('semver');
+const {execSync} = require('node:child_process');
+
+/**
+ * Resolve the base git tag for diff/log comparisons during release preparation.
+ *
+ * For stable versions (e.g. "6.18.0"), returns "v6.18.0" — the tag for that version.
+ * For prerelease versions (e.g. "6.19.0-rc.0"), the tag "v6.19.0-rc.0" won't exist,
+ * so we find the most recent stable version tag in HEAD's ancestry using git describe.
+ *
+ * @param {string} version - The current Ghost version from package.json
+ * @param {string} repoDir - Path to the Ghost repo checkout
+ * @returns {{tag: string, isPrerelease: boolean}}
+ */
+function resolveBaseTag(version, repoDir) {
+    if (semver.prerelease(version)) {
+        const tag = execSync(
+            `git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude 'v*-*' HEAD`,
+            {cwd: repoDir, encoding: 'utf8'}
+        ).trim();
+
+        return {tag, isPrerelease: true};
+    }
+
+    return {
+        tag: `v${version}`,
+        isPrerelease: false
+    };
+}
+
+module.exports = {resolveBaseTag};

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs');
+const {execSync} = require('node:child_process');
+const semver = require('semver');
+const {resolveBaseTag} = require('./lib/resolve-base-tag');
+
+const ROOT = path.resolve(__dirname, '..');
+const GHOST_CORE_PKG = path.join(ROOT, 'ghost/core/package.json');
+const GHOST_ADMIN_PKG = path.join(ROOT, 'ghost/admin/package.json');
+const CASPER_DIR = path.join(ROOT, 'ghost/core/content/themes/casper');
+const SOURCE_DIR = path.join(ROOT, 'ghost/core/content/themes/source');
+
+const MAX_WAIT_MS = 30 * 60 * 1000; // 30 minutes
+const POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
+
+// --- Argument parsing ---
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const opts = {
+        bumpType: 'auto',
+        branch: 'main',
+        dryRun: false,
+        skipChecks: false
+    };
+
+    for (const arg of args) {
+        if (arg.startsWith('--bump-type=')) {
+            opts.bumpType = arg.split('=')[1];
+        } else if (arg.startsWith('--branch=')) {
+            opts.branch = arg.split('=')[1];
+        } else if (arg === '--dry-run') {
+            opts.dryRun = true;
+        } else if (arg === '--skip-checks') {
+            opts.skipChecks = true;
+        } else {
+            console.error(`Unknown argument: ${arg}`);
+            process.exit(1);
+        }
+    }
+
+    return opts;
+}
+
+// --- Helpers ---
+
+function run(cmd, opts = {}) {
+    const result = execSync(cmd, {cwd: ROOT, encoding: 'utf8', ...opts});
+    return result.trim();
+}
+
+function readPkgVersion(pkgPath) {
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+}
+
+function writePkgVersion(pkgPath, version) {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    pkg.version = version;
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+}
+
+function log(msg) {
+    console.log(`  ${msg}`);
+}
+
+function logStep(msg) {
+    console.log(`\n▸ ${msg}`);
+}
+
+// --- Version detection ---
+
+function detectBumpType(baseTag, bumpType) {
+    // Check for new migration files
+    const migrationsPath = 'ghost/core/core/server/data/migrations/versions/';
+    try {
+        const addedFiles = run(`git diff --diff-filter=A --name-only ${baseTag} HEAD -- ${migrationsPath}`);
+        if (addedFiles?.includes('core/')) {
+            log('New migrations detected');
+            if (bumpType === 'auto') {
+                log('Auto-detecting: bumping to minor');
+                bumpType = 'minor';
+            }
+        } else {
+            log('No new migrations detected');
+        }
+    } catch {
+        log('Warning: could not diff migrations');
+    }
+
+    // Check for feature commits (✨ or 🎉)
+    try {
+        const commits = run(`git log --oneline ${baseTag}..HEAD`);
+        if (commits) {
+            const featureCommits = commits.split('\n').filter(c => c.includes('✨') || c.includes('🎉') || c.includes(':sparkles:'));
+            if (featureCommits.length) {
+                log(`Feature commits detected (${featureCommits.length})`);
+                if (bumpType === 'auto') {
+                    log('Auto-detecting: bumping to minor');
+                    bumpType = 'minor';
+                }
+            } else {
+                log('No feature commits detected');
+            }
+        } else {
+            log('No commits since base tag');
+        }
+    } catch {
+        log('Warning: could not read commit log');
+    }
+
+    if (bumpType === 'auto') {
+        log('Defaulting to patch');
+        bumpType = 'patch';
+    }
+
+    return bumpType;
+}
+
+// --- CI check polling ---
+
+const REQUIRED_CHECK_NAME = 'All required tests passed or skipped';
+
+async function waitForChecks(commit) {
+    logStep(`Waiting for CI checks on ${commit.slice(0, 8)}...`);
+
+    const token = process.env.GITHUB_TOKEN || process.env.RELEASE_TOKEN;
+    if (!token) {
+        throw new Error('GITHUB_TOKEN or RELEASE_TOKEN required for check polling');
+    }
+
+    const startTime = Date.now();
+
+    while (true) { // eslint-disable-line no-constant-condition
+        const response = await fetch(`https://api.github.com/repos/TryGhost/Ghost/commits/${commit}/check-runs`, {
+            headers: {
+                Authorization: `token ${token}`,
+                Accept: 'application/vnd.github+json'
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+        }
+
+        const {check_runs: checkRuns} = await response.json();
+
+        // Find the required check — this is the CI gate that aggregates all mandatory checks
+        const requiredCheck = checkRuns.find(r => r.name === REQUIRED_CHECK_NAME);
+
+        if (requiredCheck) {
+            if (requiredCheck.status === 'completed' && requiredCheck.conclusion === 'success') {
+                log(`Required check "${REQUIRED_CHECK_NAME}" passed`);
+                return;
+            }
+            if (requiredCheck.status === 'completed' && requiredCheck.conclusion !== 'success') {
+                throw new Error(`Required check "${REQUIRED_CHECK_NAME}" failed (${requiredCheck.conclusion})`);
+            }
+            log(`Required check is ${requiredCheck.status}, waiting...`);
+        } else {
+            log('Required check not found yet, waiting...');
+        }
+
+        const elapsedMs = Date.now() - startTime;
+        const elapsed = Math.round(elapsedMs / 1000);
+
+        if (elapsedMs >= MAX_WAIT_MS) {
+            throw new Error(`Timed out waiting for "${REQUIRED_CHECK_NAME}" after ${elapsed}s`);
+        }
+
+        log(`(${elapsed}s elapsed), polling in 30s...`);
+        await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+}
+
+// --- Theme submodule updates ---
+
+function updateThemeSubmodule(themeDir, themeName) {
+    if (!fs.existsSync(themeDir)) {
+        log(`${themeName} not present, skipping`);
+        return false;
+    }
+
+    const currentPkg = JSON.parse(fs.readFileSync(path.join(themeDir, 'package.json'), 'utf8'));
+    const currentVersion = currentPkg.version;
+
+    // Checkout latest stable tag on main branch
+    try {
+        execSync(
+            `git checkout $(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1 --branches=main))`,
+            {cwd: themeDir, encoding: 'utf8', stdio: 'pipe'}
+        );
+    } catch (err) {
+        log(`Warning: failed to update ${themeName}: ${err.message}`);
+        return false;
+    }
+
+    const updatedPkg = JSON.parse(fs.readFileSync(path.join(themeDir, 'package.json'), 'utf8'));
+    const newVersion = updatedPkg.version;
+
+    if (semver.gt(newVersion, currentVersion)) {
+        log(`${themeName} updated: v${currentVersion} → v${newVersion}`);
+        run(`git add -f ${path.relative(ROOT, themeDir)}`);
+        run(`git commit -m "🎨 Updated ${themeName} to v${newVersion}"`);
+        return true;
+    }
+
+    log(`${themeName} already at latest (v${currentVersion})`);
+    return false;
+}
+
+// --- Main ---
+
+async function main() {
+    const opts = parseArgs();
+
+    console.log('Ghost Release Script');
+    console.log('====================');
+    log(`Branch: ${opts.branch}`);
+    log(`Bump type: ${opts.bumpType}`);
+    log(`Dry run: ${opts.dryRun}`);
+
+    // 1. Read current version
+    logStep('Reading current version');
+    const currentVersion = readPkgVersion(GHOST_CORE_PKG);
+    log(`Current version: ${currentVersion}`);
+
+    // 2. Resolve base tag
+    logStep('Resolving base tag');
+    const {tag: baseTag, isPrerelease} = resolveBaseTag(currentVersion, ROOT);
+    if (isPrerelease) {
+        log(`Prerelease detected (${currentVersion}), resolved base tag: ${baseTag}`);
+    } else {
+        log(`Base tag: ${baseTag}`);
+    }
+
+    // 3. Detect bump type
+    logStep('Detecting bump type');
+    const resolvedBumpType = detectBumpType(baseTag, opts.bumpType);
+    const newVersion = semver.inc(currentVersion, resolvedBumpType);
+    if (!newVersion) {
+        console.error(`Failed to calculate new version from ${currentVersion} with bump type ${resolvedBumpType}`);
+        process.exit(1);
+    }
+    log(`Bump type: ${resolvedBumpType}`);
+    log(`New version: ${newVersion}`);
+
+    // 4. Check tag doesn't exist
+    logStep('Checking remote tags');
+    try {
+        const tagCheck = run(`git ls-remote --tags origin refs/tags/v${newVersion}`);
+        if (tagCheck) {
+            console.error(`Tag v${newVersion} already exists on remote. Cannot release this version.`);
+            process.exit(1);
+        }
+    } catch {
+        // ls-remote returns non-zero if no match — that's what we want
+    }
+    log(`Tag v${newVersion} does not exist on remote`);
+
+    // 5. Wait for CI checks
+    if (!opts.skipChecks) {
+        const headSha = run('git rev-parse HEAD');
+        await waitForChecks(headSha);
+    } else {
+        log('Skipping CI checks');
+    }
+
+    // 6. Update theme submodules (main branch only)
+    if (opts.branch === 'main') {
+        logStep('Updating theme submodules');
+        run('git submodule update --init');
+        updateThemeSubmodule(CASPER_DIR, 'Casper');
+        updateThemeSubmodule(SOURCE_DIR, 'Source');
+    } else {
+        logStep('Skipping theme updates (not main branch)');
+    }
+
+    // 7. Bump versions
+    logStep(`Bumping version to ${newVersion}`);
+    writePkgVersion(GHOST_CORE_PKG, newVersion);
+    writePkgVersion(GHOST_ADMIN_PKG, newVersion);
+
+    // 8. Commit and tag
+    run(`git add ${path.relative(ROOT, GHOST_CORE_PKG)} ${path.relative(ROOT, GHOST_ADMIN_PKG)}`);
+    run(`git commit -m "v${newVersion}"`);
+    run(`git tag v${newVersion}`);
+    log(`Created tag v${newVersion}`);
+
+    // 9. Push
+    if (opts.dryRun) {
+        logStep('DRY RUN — skipping push');
+        log(`Would push branch ${opts.branch} and tag v${newVersion}`);
+    } else {
+        logStep('Pushing');
+        run('git push origin HEAD');
+        run(`git push origin v${newVersion}`);
+        log('Pushed branch and tag');
+    }
+
+    // 10. Advance to next RC
+    logStep('Advancing to next RC');
+    const nextMinor = semver.inc(newVersion, 'minor');
+    const nextRc = `${nextMinor}-rc.0`;
+    log(`Next RC: ${nextRc}`);
+    writePkgVersion(GHOST_CORE_PKG, nextRc);
+    writePkgVersion(GHOST_ADMIN_PKG, nextRc);
+    run(`git add ${path.relative(ROOT, GHOST_CORE_PKG)} ${path.relative(ROOT, GHOST_ADMIN_PKG)}`);
+    run(`git commit -m "Bumped version to ${nextRc}"`);
+
+    if (opts.dryRun) {
+        log('DRY RUN — skipping RC push');
+    } else {
+        run('git push origin HEAD');
+        log('Pushed RC version');
+    }
+
+    console.log(`\n✓ Release ${newVersion} complete`);
+}
+
+main().catch((err) => {
+    console.error(`\n✗ Release failed: ${err.message}`);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Backports the release script and publish workflow from `main` so that 5.x patch releases can be cut using Ghost's own Release workflow (`Actions > Release > branch: 5.x`), removing the dependency on Ghost-Release.

This enables archiving the Ghost-Release repository once 5.x is no longer supported (or immediately, since this PR provides the same capability).

### What's included

- **`scripts/release.js`** — release orchestration (version detection, bump type, tag, push, RC advancement). Theme submodule updates are gated to `main` only, so they're a no-op on 5.x.
- **`scripts/lib/resolve-base-tag.js`** — resolves the base git tag for prerelease versions
- **`scripts/lib/release-notes.js`** — generates changelog between tags for GitHub Releases
- **`.github/workflows/publish-on-tag.yml`** — standalone workflow triggered by `v5.*` tags that publishes to npm via OIDC and creates a GitHub Release
- **`ghost/core/package.json`** — added `publishConfig` for OIDC npm publishing
- **`package.json`** — added `semver` to root devDependencies, added `release` script

### How it works

1. Trigger the Release workflow on `main` with `branch: 5.x`
2. The release script bumps the version in `ghost/core/package.json` and `ghost/admin/package.json`, commits, tags `v5.x.y`, and pushes
3. The tag push triggers `publish-on-tag.yml` on the 5.x branch, which publishes to npm and creates the GitHub Release

### Prerequisites

- npm OIDC trusted publishing must be configured for the `ghost` package to accept publishes from the `5.x` branch (same `npm-release` environment as `main`)
- `CANARY_DOCKER_BUILD` and `SLACK_WEBHOOK_URL` secrets must be available (already configured)

refs BER-3313

## Test plan

- [ ] Verify `publish-on-tag.yml` triggers correctly on `v5.*` tags (can test with a dry-run tag on a test branch first)
- [ ] Confirm npm OIDC trusted publishing is configured to allow publishes from the 5.x branch
- [ ] Run a 5.x patch release using the new flow: `Actions > Release > branch: 5.x, bump-type: patch`