### PR TITLE
Removed 5.x-specific CI logic (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,9 @@ jobs:
     env:
       IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
       IS_TAG: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      IS_DEVELOPMENT: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/5.x' || github.ref == 'refs/heads/6.x' }}
+      IS_DEVELOPMENT: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/6.x' }}
       IS_SIX: ${{ github.ref == 'refs/heads/6.x' }}
       IS_SIX_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == '6.x' }}
-      IS_FIVE: ${{ github.ref == 'refs/heads/5.x' }}
     permissions:
       contents: read
       pull-requests: read
@@ -219,7 +218,6 @@ jobs:
       is_development: ${{ env.IS_DEVELOPMENT }}
       is_six: ${{ env.IS_SIX }}
       is_six_pr: ${{ env.IS_SIX_PR }}
-      is_five: ${{ env.IS_FIVE }}
       member_is_in_org: ${{ steps.check_user_org_membership.outputs.is_member }}
       dependency_cache_key: ${{ env.cachekey }}
       node_version: ${{ env.NODE_VERSION }}
@@ -1491,7 +1489,7 @@ jobs:
     ]
     name: Publish ${{ matrix.package_name }}
     runs-on: ubuntu-latest
-    if: always() && github.repository == 'TryGhost/Ghost' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && (needs.job_setup.outputs.is_main == 'true' || needs.job_setup.outputs.is_five == 'true')
+    if: always() && github.repository == 'TryGhost/Ghost' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     permissions:
       id-token: write
     strategy:
@@ -1544,27 +1542,15 @@ jobs:
           CURRENT_MAJOR=$(cat package.json | jq -r .version | awk -F. '{print $1}')
           echo "current_major=$CURRENT_MAJOR" >> $GITHUB_OUTPUT
 
-          if [ "${{ needs.job_setup.outputs.is_five }}" = "true" ]; then
-            # For 5.x branch, check if this exact version exists on npm
-            if npm show ${{ matrix.package_name }}@$CURRENT_VERSION version > /dev/null 2>&1; then
-              echo "Version $CURRENT_VERSION already exists on npm."
-              echo "version_changed=false" >> $GITHUB_OUTPUT
-            else
-              echo "Version $CURRENT_VERSION does not exist on npm."
-              echo "version_changed=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            # For main branch, compare against latest
-            PUBLISHED_VERSION=$(npm show ${{ matrix.package_name }} version || echo "0.0.0")
-            echo "Published version (latest): $PUBLISHED_VERSION"
+          PUBLISHED_VERSION=$(npm show ${{ matrix.package_name }} version || echo "0.0.0")
+          echo "Published version (latest): $PUBLISHED_VERSION"
 
-            if [ "$CURRENT_VERSION" = "$PUBLISHED_VERSION" ]; then
-              echo "Version is unchanged."
-              echo "version_changed=false" >> $GITHUB_OUTPUT
-            else
-              echo "Version has changed."
-              echo "version_changed=true" >> $GITHUB_OUTPUT
-            fi
+          if [ "$CURRENT_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "Version is unchanged."
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version has changed."
+            echo "version_changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Build the package
@@ -1585,11 +1571,7 @@ jobs:
         if: steps.version_check.outputs.version_changed == 'true'
         working-directory: ${{ matrix.package_path }}
         run: |
-          if [ "${{ needs.job_setup.outputs.is_five }}" = "true" ]; then
-            npm publish --access public --tag ghost-5x
-          else
-            npm publish --access public
-          fi
+          npm publish --access public
 
       - name: Replace version placeholders in cdn-paths
         id: cdn_paths


### PR DESCRIPTION
## Summary

Ghost 5.x has reached end of life. This removes all 5.x-specific logic from `ci.yml`:

- **`IS_FIVE` env var and output** — deleted (was `github.ref == 'refs/heads/5.x'`)
- **`IS_DEVELOPMENT`** — removed `5.x` (now only `main` and `6.x`)
- **`publish_packages` job** — removed `is_five` from the job condition, the 5.x-specific version check (exact version lookup vs latest), and the `--tag ghost-5x` npm publish flag

### What stays unchanged

- **Push triggers** — already generic patterns (`'[0-9]+.x'`, `'v[0-9]+.*'`), so if someone pushes to 5.x, CI tests still run — packages just won't be published
- **5.x branch** — remains in the repo for reference
- **Published artifacts** — all existing npm packages (`ghost@5.x`, `@tryghost/*@ghost-5x`) and Docker images remain available

ref BER-3313

## Test plan

- [ ] Verify CI runs normally on main after merge (no regressions)
- [ ] Verify `publish_packages` still triggers on main pushes