### PR TITLE
Updated dependency `got` to v13.0.0

### DIFF
--- a/ghost/core/core/server/lib/request-external.js
+++ b/ghost/core/core/server/lib/request-external.js
@@ -3,7 +3,7 @@
  * @typedef {import('got').ExtendOptions} ExtendOptions
  */
 
-const got = /** @type {Got} */ (/** @type {unknown} */ (require('got')));
+const got = /** @type {Got} */ (/** @type {unknown} */ (require('got').default));
 const dns = require('dns');
 const net = require('net');
 const dnsPromises = require('dns').promises;
@@ -208,7 +208,9 @@ async function disableRetries(options) {
         limit: 0,
         calculateDelay: () => 0
     };
-    options.timeout = 5000;
+    options.timeout = {
+        request: 5000
+    };
 }
 
 /**
@@ -275,7 +277,9 @@ const gotOpts = {
     headers: {
         'user-agent': 'Ghost(https://github.com/TryGhost/Ghost)'
     },
-    timeout: 10000, // default is no timeout
+    timeout: {
+        request: 10000
+    }, // default is no timeout
     hooks: {
         init: process.env.NODE_ENV?.startsWith('test') ? [disableRetries] : [],
         beforeRequest: [errorIfInvalidUrl, errorIfHostnameResolvesToPrivateIp, installSafeDnsLookup],

--- a/ghost/core/core/server/services/auth/session/session-service.js
+++ b/ghost/core/core/server/services/auth/session/session-service.js
@@ -5,7 +5,7 @@ const errors = require('@tryghost/errors');
 const crypto = require('crypto');
 const emailTemplate = require('./emails/signin');
 const UAParser = require('ua-parser-js');
-const got = require('got');
+const got = require('got').default;
 const otp = require('../otp');
 const IPV4_REGEX = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 const IPV6_REGEX = /^(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$/i;
@@ -310,11 +310,15 @@ module.exports = function createSessionService({
         }
 
         const gotOpts = {
-            timeout: 500
+            timeout: {
+                request: 500
+            }
         };
 
         if (process.env.NODE_ENV?.startsWith('test')) {
-            gotOpts.retry = 0;
+            gotOpts.retry = {
+                limit: 0
+            };
         }
 
         const geojsUrl = `https://get.geojs.io/v1/ip/geo/${encodeURIComponent(ip)}.json`;

--- a/ghost/core/core/server/services/members/members-api/services/geolocation-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/geolocation-service.js
@@ -1,4 +1,4 @@
-const got = require('got');
+const got = require('got').default;
 const IPV4_REGEX = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 const IPV6_REGEX = /^(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$/i;
 
@@ -9,11 +9,15 @@ module.exports = class GeolocationService {
         }
 
         const gotOpts = {
-            timeout: 500
+            timeout: {
+                request: 500
+            }
         };
 
         if (process.env.NODE_ENV?.startsWith('test')) {
-            gotOpts.retry = 0;
+            gotOpts.retry = {
+                limit: 0
+            };
         }
 
         const geojsUrl = `https://get.geojs.io/v1/ip/geo/${encodeURIComponent(ipAddress)}.json`;

--- a/ghost/core/core/server/services/mentions/mention-discovery-service.js
+++ b/ghost/core/core/server/services/mentions/mention-discovery-service.js
@@ -18,7 +18,9 @@ module.exports = class MentionDiscoveryService {
                 throwHttpErrors: true,
                 followRedirect: true,
                 maxRedirects: 10,
-                timeout: 15000,
+                timeout: {
+                    request: 15000
+                },
                 retry: {
                     // Only retry on network issues, or specific HTTP status codes
                     limit: 3

--- a/ghost/core/core/server/services/mentions/mention-sending-service.js
+++ b/ghost/core/core/server/services/mentions/mention-sending-service.js
@@ -97,7 +97,9 @@ module.exports = class MentionSendingService {
             throwHttpErrors: false,
             maxRedirects: 10,
             followRedirect: true,
-            timeout: 15000,
+            timeout: {
+                request: 15000
+            },
             retry: {
                 // Only retry on network issues, or specific HTTP status codes
                 limit: 3

--- a/ghost/core/core/server/services/mentions/webmention-metadata.js
+++ b/ghost/core/core/server/services/mentions/webmention-metadata.js
@@ -35,7 +35,9 @@ module.exports = class WebmentionMetadata {
     async fetch(url) {
         const mappedUrl = this.#getMappedUrl(url);
         const data = await oembedService.fetchOembedDataFromUrl(mappedUrl.href, 'mention', {
-            timeout: 15000,
+            timeout: {
+                request: 15000
+            },
             retry: {
                 // Only retry on network issues, or specific HTTP status codes
                 limit: 3
@@ -57,7 +59,9 @@ module.exports = class WebmentionMetadata {
             // Still need to fetch body and contentType separately now
             // For verification
             const {body, contentType} = await oembedService.fetchPageHtml(url, {
-                timeout: 15000,
+                timeout: {
+                    request: 15000
+                },
                 retry: {
                     // Only retry on network issues, or specific HTTP status codes
                     limit: 3

--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -186,7 +186,9 @@ class OEmbedService {
                 headers: {
                     'user-agent': USER_AGENT
                 },
-                timeout: 2000,
+                timeout: {
+                    request: 2000
+                },
                 followRedirect: true,
                 ...options
             });
@@ -273,15 +275,22 @@ class OEmbedService {
      * }>}
      */
     async fetchBookmarkData(url, html, type) {
-        const got = require('got');
-        const gotOpts = got.mergeOptions(this.externalRequest.defaults?.options || {}, {
+        const requestOptions = this.externalRequest.defaults?.options || {};
+        const gotOpts = {
+            hooks: requestOptions.hooks,
+            retry: requestOptions.retry,
+            timeout: requestOptions.timeout,
+            ...requestOptions,
             headers: {
+                ...(requestOptions.headers || {}),
                 'User-Agent': USER_AGENT
             }
-        });
+        };
 
         if (process.env.NODE_ENV?.startsWith('test')) {
-            gotOpts.retry = 0;
+            gotOpts.retry = {
+                limit: 0
+            };
         }
 
         const pickFn = (sizes, pickDefault) => {

--- a/ghost/core/core/server/services/recommendations/service/recommendation-metadata-service.ts
+++ b/ghost/core/core/server/services/recommendations/service/recommendation-metadata-service.ts
@@ -17,7 +17,7 @@ type OembedMetadata<Type extends string> = {
 }
 
 type OEmbedService = {
-    fetchOembedDataFromUrl<Type extends string>(url: string, type: Type, options?: {timeout?: number}): Promise<OembedMetadata<Type>>
+    fetchOembedDataFromUrl<Type extends string>(url: string, type: Type, options?: {timeout?: number | {request: number}}): Promise<OembedMetadata<Type>>
 }
 
 type ExternalRequest = {
@@ -41,21 +41,26 @@ export class RecommendationMetadataService {
         this.#externalRequest = dependencies.externalRequest;
     }
 
-    async #fetchJSON(url: URL, options?: {timeout?: number}) {
+    async #fetchJSON(url: URL, options?: {timeout?: number | {request: number}}) {
         // Even though we have throwHttpErrors: false, we still need to catch DNS errors
         // that can arise from externalRequest, otherwise we'll return a HTTP 500 to the user
         try {
+            const timeout = typeof options?.timeout === 'number' ? {request: options.timeout} : options?.timeout;
+
             // default content type is application/x-www-form-encoded which is what we need for the webmentions spec
             const response = await this.#externalRequest.get(url.toString(), {
                 throwHttpErrors: false,
                 maxRedirects: 10,
                 followRedirect: true,
-                timeout: 15000,
+                timeout: {
+                    request: 15000
+                },
                 retry: {
                     // Only retry on network issues, or specific HTTP status codes
                     limit: 3
                 },
-                ...options
+                ...options,
+                ...(timeout ? {timeout} : {})
             });
 
             if (response.statusCode >= 200 && response.statusCode < 300) {
@@ -81,7 +86,7 @@ export class RecommendationMetadataService {
         }
     }
 
-    async fetch(url: URL, options: {timeout: number} = {timeout: 5000}): Promise<RecommendationMetadata> {
+    async fetch(url: URL, options: {timeout: number | {request: number}} = {timeout: {request: 5000}}): Promise<RecommendationMetadata> {
         // Make sure url path ends with a slash (urls should be resolved relative to the path)
         if (!url.pathname.endsWith('/')) {
             url.pathname += '/';

--- a/ghost/core/core/server/services/slack-notifications/slack-notifications.js
+++ b/ghost/core/core/server/services/slack-notifications/slack-notifications.js
@@ -1,4 +1,4 @@
-const got = require('got');
+const got = require('got').default;
 const validator = require('@tryghost/validator');
 const errors = require('@tryghost/errors');
 const ghostVersion = require('@tryghost/version');
@@ -173,7 +173,9 @@ class SlackNotifications {
         };
 
         if (process.env.NODE_ENV?.startsWith('test')) {
-            requestOptions.retry = 0;
+            requestOptions.retry = {
+                limit: 0
+            };
         }
 
         return await got.post(url, requestOptions);

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -163,7 +163,7 @@
     "fs-extra": "11.3.0",
     "ghost-storage-base": "1.0.0",
     "glob": "8.1.0",
-    "got": "11.8.6",
+    "got": "13.0.0",
     "gscan": "5.4.0",
     "handlebars": "4.7.8",
     "heic-convert": "2.1.0",

--- a/ghost/core/test/unit/server/lib/request-external.test.js
+++ b/ghost/core/test/unit/server/lib/request-external.test.js
@@ -477,8 +477,7 @@ describe('External Request', function () {
                 throw new Error('Request should have rejected with invalid url message');
             }, (err) => {
                 assertExists(err);
-                // got v11+ throws an error instead of the external requests lib
-                assert.equal(err.message, 'No URL protocol specified');
+                assert.equal(err.message, 'Invalid URL');
             });
         });
 
@@ -509,7 +508,9 @@ describe('External Request', function () {
                 headers: {
                     'User-Agent': 'Mozilla/5.0'
                 },
-                retry: 0
+                retry: {
+                    limit: 0
+                }
             };
 
             const requestMock = nock('http://nofilehere.com')

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert/strict');
 const nock = require('nock');
-const got = require('got');
+const got = require('got').default;
 const sinon = require('sinon');
 
 const OembedService = require('../../../../../core/server/services/oembed/oembed-service');
@@ -369,7 +369,9 @@ describe('oembed-service', function () {
 
             const externalRequest = got.extend({
                 retry: {limit: 0, calculateDelay: () => 0},
-                timeout: 5000,
+                timeout: {
+                    request: 5000
+                },
                 hooks: {
                     init: [],
                     beforeRequest: [beforeRequestHook],

--- a/ghost/core/test/unit/server/services/recommendations/service/recommendation-metadata-service.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/recommendation-metadata-service.test.ts
@@ -1,8 +1,9 @@
 import assert from 'assert/strict';
-import got from 'got';
 import nock from 'nock';
 import {RecommendationMetadataService} from '../../../../../../core/server/services/recommendations/service';
 import sinon from 'sinon';
+
+const got = require('got').default;
 
 describe('RecommendationMetadataService', function () {
     let service: RecommendationMetadataService;

--- a/ghost/core/test/unit/server/services/slack-notifications/slack-notifications.test.js
+++ b/ghost/core/test/unit/server/services/slack-notifications/slack-notifications.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const SlackNotifications = require('../../../../../core/server/services/slack-notifications/slack-notifications');
 const nock = require('nock');
 const ObjectId = require('bson-objectid').default;
-const got = require('got');
+const got = require('got').default;
 const ghostVersion = require('@tryghost/version');
 
 describe('SlackNotifications', function () {
@@ -290,7 +290,9 @@ describe('SlackNotifications', function () {
                 {
                     body: '{"data":"test"}',
                     headers: {'user-agent': 'Ghost/5.0.0 (https://github.com/TryGhost/Ghost)'},
-                    retry: 0
+                    retry: {
+                        limit: 0
+                    }
                 }
             ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21769,23 +21769,6 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-got@11.8.6, got@~11.8.0:
-  version "11.8.6"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
-  integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
-  dependencies:
-    "@sindresorhus/is" "^4.0.0"
-    "@szmarczak/http-timer" "^4.0.5"
-    "@types/cacheable-request" "^6.0.1"
-    "@types/responselike" "^1.0.0"
-    cacheable-lookup "^5.0.3"
-    cacheable-request "^7.0.2"
-    decompress-response "^6.0.0"
-    http2-wrapper "^1.0.0-beta.5.2"
-    lowercase-keys "^2.0.0"
-    p-cancelable "^2.0.0"
-    responselike "^2.0.0"
-
 got@13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/got/-/got-13.0.0.tgz#a2402862cef27a5d0d1b07c0fb25d12b58175422"
@@ -21802,6 +21785,23 @@ got@13.0.0:
     lowercase-keys "^3.0.0"
     p-cancelable "^3.0.0"
     responselike "^3.0.0"
+
+got@~11.8.0:
+  version "11.8.6"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
+  integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.2"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.8, graceful-fs@^4.2.9:
   version "4.2.11"


### PR DESCRIPTION
no issue

- `@tryghost/request` uses v13.0.0 but Ghost's direct usage of `got` was on an earlier v11.x
- updated dependency to match versions and modified all call sites to account for breaking changes in options shape