### PR TITLE
Fixed E2E Docker build for fork/cross-repo PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1141,6 +1141,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          # Fork/cross-repo PRs use artifact transfer (no GHCR push). The default
+          # docker-container driver runs in an isolated BuildKit container that
+          # cannot see locally loaded images, so we fall back to the docker driver
+          # which shares the host daemon's image store.
+          driver: ${{ needs.job_build_artifacts.outputs.use-artifact == 'true' && 'docker' || '' }}
 
       - name: Load base Ghost image
         uses: ./.github/actions/load-docker-image
@@ -1196,7 +1202,7 @@ jobs:
           load: ${{ steps.strategy.outputs.use-artifact == 'true' }}
           tags: ${{ steps.meta-e2e.outputs.tags }}
           labels: ${{ steps.meta-e2e.outputs.labels }}
-          cache-from: type=registry,ref=${{ needs.job_build_artifacts.outputs.image-e2e-name }}:cache-main
+          cache-from: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref={0}:cache-main', needs.job_build_artifacts.outputs.image-e2e-name) || '' }}
           cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', needs.job_build_artifacts.outputs.image-e2e-name, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
 
       - name: Save E2E image as artifact


### PR DESCRIPTION
The E2E Docker image build introduced in #27050 fails on fork/cross-repo PRs. An example of this failure can be seen on [PR #27073](https://github.com/TryGhost/Ghost/pull/27073), where the "Build E2E Docker Image" job [fails](https://github.com/TryGhost/Ghost/actions/runs/23895238793/job/69681884850).

There are two problems. First, fork PRs use artifact transfer instead of pushing to GHCR, which means the base Ghost image is loaded locally via `docker load`. The default `docker-container` Buildx driver runs BuildKit in an isolated container that cannot see locally loaded images on the host daemon, so the subsequent `docker buildx build` cannot find the base image. This is fixed by conditionally falling back to the `docker` driver when the artifact path is in use, since the `docker` driver shares the host daemon's image store.

Second, the `cache-from` directive unconditionally references the GHCR registry cache, but fork PRs do not have permission to pull from GHCR. This causes a registry authentication error during the build. The fix conditionally omits `cache-from` when the workflow is not configured to push, matching the existing pattern already used for `cache-to`.