### PR TITLE
Re-enable deploy-to-staging label workflow (Step 6/6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1678,11 +1678,8 @@ jobs:
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 
-            # DISABLED: deploy-to-staging label detection is disabled.
-            # The label workflow has fundamental problems — admin deploys are global
-            # (not per-site) and main merges overwrite the deployment immediately.
-            # See deploy-to-staging.yml for details.
-            echo "deploy=" >> $GITHUB_OUTPUT
+            DEPLOY=$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}' | jq -r 'if any(. == "deploy-to-staging") then "true" else "" end')
+            echo "deploy=$DEPLOY" >> $GITHUB_OUTPUT
           else
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,17 +1,8 @@
 name: Deploy to Staging
 
-# DISABLED: The deploy-to-staging label workflow is currently broken and disabled.
-# Problems:
-#   1. Admin is global — deploying a PR's admin overwrites admin-forward/ for ALL staging
-#      sites, not just demo.ghost.is. Per-site admin versioning is needed first.
-#   2. Main merges overwrite — any merge to main triggers a full staging rollout that
-#      overwrites both the server version on demo.ghost.is and admin-forward/ globally.
-# The deployment lasts only until the next merge to main, making it unreliable.
-# See: https://www.notion.so/ghost/Proposal-Per-site-admin-versioning-31951439c03081daa133eb0215642202
-
 on:
   pull_request_target:
-    types: [labeled]
+    types: [labeled, unlabeled, closed]
 
 jobs:
   deploy:
@@ -19,8 +10,7 @@ jobs:
     # Runs when the "deploy-to-staging" label is added — requires collaborator write access.
     # Fork PRs are rejected because they don't have GHCR images (CI uses artifact transfer).
     if: >-
-      false
-      && github.event.label.name == 'deploy-to-staging'
+      github.event.label.name == 'deploy-to-staging'
       && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     permissions:
@@ -124,4 +114,49 @@ jobs:
               "source_repo": "${{ github.repository }}",
               "pr_number": "${{ env.PR_NUMBER }}",
               "deploy": "true"
+            }
+
+  # Clear version pins when label is removed or PR is closed
+  cleanup:
+    name: Cleanup staging pins
+    if: >-
+      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-to-staging')
+      || (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy-to-staging'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Deactivate GitHub deployment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const environment = `staging-pr-${{ github.event.pull_request.number }}`;
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment
+            });
+            for (const d of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: d.id,
+                state: 'inactive'
+              });
+            }
+            if (deployments.length) {
+              console.log(`Deactivated ${deployments.length} deployment(s) for ${environment}`);
+            }
+
+      - name: Dispatch unpin to Ghost-Moya
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CANARY_DOCKER_BUILD }}
+          repository: TryGhost/Ghost-Moya
+          event-type: unpin-staging-sites
+          client-payload: >-
+            {
+              "site_ids": "303000",
+              "pr_number": "${{ github.event.pull_request.number }}"
             }


### PR DESCRIPTION
## Summary

Re-enables the `deploy-to-staging` label workflow that was disabled due to admin deploys being global and main merges overwriting targeted server deploys. Both problems are now solved by per-site version pinning (Steps 1-5).

### Changes

- **deploy-to-staging.yml**: removed `false &&` guard and disabled comments. Added `unlabeled` and `closed` event handlers that dispatch to Ghost-Moya to clear version pins and deactivate GitHub deployments.
- **ci.yml**: restored `deploy-to-staging` label detection in the `trigger_cd` job so PR CI dispatches include `deploy=true` when the label is present.

### How it works now

1. Add `deploy-to-staging` label → Ghost CI dispatches to Moya with `deploy=true`
2. Moya deploys server to demo.ghost.is and pins both admin + server versions
3. Subsequent merges to `main` skip demo.ghost.is (pinned)
4. Remove label or close PR → Ghost dispatches `unpin-staging-sites` to Moya → pins cleared

## Proposal

https://www.notion.so/ghost/31951439c03081daa133eb0215642202

## Merge order

This is **Step 6 of 6** — must be merged last, after all infrastructure is deployed to staging.

| # | Repo | PR | Deploy via |
|---|------|----|-----------|
| 1 | Daisy.js | TryGhost/Daisy.js#1993 | Shipit (Jenkins) |
| 2 | Zuul | TryGhost/Zuul#1036 | Shipit (Jenkins) |
| 3+5 | Ghost-Moya | TryGhost/Ghost-Moya#209 | GitHub Actions (merge) |
| 4 | BlackPearl | TryGhost/BlackPearl#1830 | SaltStack (manual) |
| — | Ghost-Rollout | TryGhost/Ghost-Rollout#98 | Docker image rebuild |
| **6** | **Ghost** | **this PR** | GitHub Actions (merge) |

---

ref: https://linear.app/ghost/issue/BER-3516/ghost-re-enable-deploy-to-staging-label-workflow