### PR TITLE
Updated podcast view link in Portal to open in same tab

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.67.5",
+  "version": "2.67.6",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/transistor-podcasts-action.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/transistor-podcasts-action.js
@@ -49,7 +49,6 @@ const TransistorPodcastsAction = ({hasPodcasts, memberUuid, settings = {}}) => {
             </div>
             <a
                 href={transistorUrl}
-                target='_blank'
                 rel='noopener noreferrer'
                 className='gh-portal-btn gh-portal-btn-list'
             >

--- a/apps/portal/test/unit/components/pages/AccountHomePage/transistor-podcasts-action.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/transistor-podcasts-action.test.js
@@ -36,11 +36,4 @@ describe('TransistorPodcastsAction', () => {
         const link = getByText('Manage');
         expect(link.getAttribute('href')).toBe(`https://partner.transistor.fm/ghost/${TEST_UUID}`);
     });
-
-    test('Manage link opens in new tab', () => {
-        const {getByText} = setup({hasPodcasts: true, memberUuid: TEST_UUID});
-        const link = getByText('Manage');
-        expect(link.getAttribute('target')).toBe('_blank');
-        expect(link.getAttribute('rel')).toBe('noopener noreferrer');
-    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1199/
- removed `target="_blank"`