### PR TITLE
Updated Handlebars to v4.7.9

### DIFF
--- a/ghost/core/core/frontend/helpers/match.js
+++ b/ghost/core/core/frontend/helpers/match.js
@@ -1,3 +1,5 @@
+// Use the shared frontend Handlebars runtime so SafeString instanceof checks
+// keep working even when multiple handlebars copies are installed.
 const {SafeString} = require('../services/handlebars');
 
 const logging = require('@tryghost/logging');

--- a/ghost/core/core/frontend/helpers/split.js
+++ b/ghost/core/core/frontend/helpers/split.js
@@ -1,4 +1,6 @@
-const {SafeString} = require('handlebars');
+// Use the shared frontend Handlebars runtime so SafeString values stay
+// compatible with helpers that check them with instanceof.
+const {SafeString} = require('../services/handlebars');
 
 function renderResult(result, options, data) {
     if (options && typeof options.fn === 'function') {

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -165,7 +165,7 @@
     "glob": "8.1.0",
     "got": "11.8.6",
     "gscan": "5.4.0",
-    "handlebars": "4.7.8",
+    "handlebars": "4.7.9",
     "heic-convert": "2.1.0",
     "html-to-text": "5.1.1",
     "html5parser": "2.0.2",

--- a/ghost/core/test/unit/frontend/helpers/split.test.js
+++ b/ghost/core/test/unit/frontend/helpers/split.test.js
@@ -1,5 +1,5 @@
 const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');
-const {SafeString} = require('handlebars');
+const {SafeString} = require('../../../../core/frontend/services/handlebars');
 
 describe('{{split}} helper in block mode', function () {
     before(function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21864,10 +21864,10 @@ gulp-sort@^2.0.0:
   dependencies:
     through2 "^2.0.1"
 
-handlebars@4.7.8, handlebars@^4.0.13, handlebars@^4.0.4, handlebars@^4.3.1, handlebars@^4.4.2, handlebars@^4.7.3, handlebars@^4.7.6, handlebars@^4.7.7, handlebars@^4.7.8:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+handlebars@4.7.9, handlebars@^4.0.13, handlebars@^4.0.4, handlebars@^4.3.1, handlebars@^4.4.2, handlebars@^4.7.3, handlebars@^4.7.6, handlebars@^4.7.7, handlebars@^4.7.8:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"


### PR DESCRIPTION
## What
- bump `ghost/core`'s explicit `handlebars` dependency from `4.7.8` to `4.7.9`
- update the `split` helper and its unit test to use Ghost's frontend Handlebars runtime consistently when multiple `handlebars` copies are present

## Why
Ghost core frontend helpers rely on `SafeString` constructor identity. If one helper creates `SafeString` values from a different `handlebars` module instance than another helper checks with `instanceof`, those values stop matching even though they look identical. Using the shared frontend Handlebars runtime keeps helper behavior consistent across dependency layouts.