### PR TITLE
Removed unused "destroy automated email" endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -92,27 +92,6 @@ const controller = {
         }
     },
 
-    destroy: {
-        statusCode: 204,
-        headers: {
-            cacheInvalidate: false
-        },
-        options: [
-            'id'
-        ],
-        validation: {
-            options: {
-                id: {
-                    required: true
-                }
-            }
-        },
-        permissions: true,
-        query(frame) {
-            return models.AutomatedEmail.destroy({...frame.options, require: true});
-        }
-    },
-
     sendTestEmail: {
         statusCode: 204,
         headers: {

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -192,7 +192,6 @@ module.exports = function apiRoutes() {
     router.post('/automated_emails', mw.authAdminApi, http(api.automatedEmails.add));
     router.put('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.edit));
     router.put('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.edit));
-    router.del('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.destroy));
     router.post('/automated_emails/:id/test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automatedEmails.sendTestEmail));
 
     // ## Roles

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
@@ -201,48 +201,6 @@ Object {
 }
 `;
 
-exports[`Automated Emails API Destroy Can destroy an automated email 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Automated Emails API Destroy Cannot destroy non-existent automated email 1: [body] 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "code": null,
-      "context": "Resource could not be found.",
-      "details": null,
-      "ghostErrorCode": null,
-      "help": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "Resource not found error, cannot delete automated_email.",
-      "property": null,
-      "type": "NotFoundError",
-    },
-  ],
-}
-`;
-
-exports[`Automated Emails API Destroy Cannot destroy non-existent automated email 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "268",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
 exports[`Automated Emails API Edit Can edit an automated email 1: [body] 1`] = `
 Object {
   "automated_emails": Array [

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -411,38 +411,6 @@ describe('Automated Emails API', function () {
         });
     });
 
-    describe('Destroy', function () {
-        it('Can destroy an automated email', async function () {
-            const automatedEmail = await createAutomatedEmail();
-
-            const id = automatedEmail.id;
-
-            await agent
-                .delete(`automated_emails/${id}`)
-                .expectStatus(204)
-                .expectEmptyBody()
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag
-                });
-        });
-
-        it('Cannot destroy non-existent automated email', async function () {
-            await agent
-                .delete('automated_emails/abcd1234abcd1234abcd1234')
-                .expectStatus(404)
-                .matchBodySnapshot({
-                    errors: [{
-                        id: anyErrorId
-                    }]
-                })
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag
-                });
-        });
-    });
-
     describe('SendTestEmail', function () {
         let automatedEmailId;
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1201

We aren't using this endpoint today, and its existence makes a future change more difficult. Let's remove it.
