### PR TITLE
Added yarn dev:sqlite command for SQLite development

### DIFF
--- a/compose.dev.sqlite.yaml
+++ b/compose.dev.sqlite.yaml
@@ -1,0 +1,16 @@
+services:
+  mysql:
+    # Prevents mysql container from starting up
+    profiles:
+      - mysql
+
+  ghost-dev:
+    volumes:
+      # Override the named volume so the SQLite DB is accessible on the host.
+      - ./ghost/core/content/data:/home/ghost/ghost/core/content/data
+    environment:
+      database__client: sqlite3
+      database__connection__filename: content/data/ghost-dev.db
+    depends_on:
+      mysql:
+        required: false

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:clean": "nx reset && rimraf -g 'ghost/*/build' && rimraf -g 'ghost/*/tsconfig.tsbuildinfo'",
     "clean:hard": "node ./.github/scripts/clean.js",
     "dev": "nx run ghost-monorepo:docker:dev",
+    "dev:sqlite": "DEV_COMPOSE_FILES='-f compose.dev.sqlite.yaml' nx run ghost-monorepo:docker:dev",
     "dev:mailgun": "DEV_COMPOSE_FILES='-f compose.dev.mailgun.yaml' nx run ghost-monorepo:docker:dev",
     "dev:lexical": "EDITOR_URL=http://localhost:2368/ghost/assets/koenig-lexical/ yarn dev",
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' nx run ghost-monorepo:docker:dev",


### PR DESCRIPTION
no refs

## Summary

- Added `compose.dev.sqlite.yaml` Docker Compose override that disables the MySQL container and configures Ghost to use SQLite
- Added `yarn dev:sqlite` script to `package.json` for running the dev environment with SQLite instead of MySQL
- Mounts the SQLite database directory to the host for easy access
- Mostly this is useful when testing migrations on sqlite