### PR TITLE
Updated welcome email renderer to use custom design settings

### DIFF
--- a/apps/admin-x-framework/src/api/automated-email-design.ts
+++ b/apps/admin-x-framework/src/api/automated-email-design.ts
@@ -1,0 +1,44 @@
+import {Meta, createMutation, createQuery} from '../utils/api/hooks';
+
+export type AutomatedEmailDesign = {
+    id: string;
+    slug: string;
+    background_color: string;
+    header_background_color: string;
+    header_image: string | null;
+    show_header_title: boolean;
+    footer_content: string | null;
+    button_color: string | null;
+    button_corners: string;
+    button_style: string;
+    link_color: string | null;
+    link_style: string;
+    body_font_category: string;
+    title_font_category: string;
+    title_font_weight: string;
+    image_corners: string;
+    divider_color: string | null;
+    section_title_color: string | null;
+    show_badge: boolean;
+    created_at: string;
+    updated_at: string | null;
+}
+
+export interface AutomatedEmailDesignResponseType {
+    meta?: Meta;
+    automated_email_design: AutomatedEmailDesign[];
+}
+
+const dataType = 'AutomatedEmailDesignResponseType';
+
+export const useReadAutomatedEmailDesign = createQuery<AutomatedEmailDesignResponseType>({
+    dataType,
+    path: '/automated_emails/design/'
+});
+
+export const useEditAutomatedEmailDesign = createMutation<AutomatedEmailDesignResponseType, Partial<AutomatedEmailDesign> & {id: string}>({
+    method: 'PUT',
+    path: () => '/automated_emails/design/',
+    body: design => ({automated_email_design: [design]}),
+    invalidateQueries: {dataType}
+});

--- a/apps/admin-x-framework/src/api/automated-email-design.ts
+++ b/apps/admin-x-framework/src/api/automated-email-design.ts
@@ -29,6 +29,8 @@ export interface AutomatedEmailDesignResponseType {
     automated_email_design: AutomatedEmailDesign[];
 }
 
+export type EditAutomatedEmailDesign = Omit<Partial<AutomatedEmailDesign>, 'id'>;
+
 const dataType = 'AutomatedEmailDesignResponseType';
 
 export const useReadAutomatedEmailDesign = createQuery<AutomatedEmailDesignResponseType>({
@@ -36,7 +38,7 @@ export const useReadAutomatedEmailDesign = createQuery<AutomatedEmailDesignRespo
     path: '/automated_emails/design/'
 });
 
-export const useEditAutomatedEmailDesign = createMutation<AutomatedEmailDesignResponseType, Partial<AutomatedEmailDesign> & {id: string}>({
+export const useEditAutomatedEmailDesign = createMutation<AutomatedEmailDesignResponseType, EditAutomatedEmailDesign>({
     method: 'PUT',
     path: () => '/automated_emails/design/',
     body: design => ({automated_email_design: [design]}),

--- a/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
@@ -8,8 +8,25 @@ interface ColorPickerFieldProps {
     onChange: (color: string) => void;
 }
 
+const VALID_HEX = /^#(?:[0-9a-f]{3}){1,2}$/i;
+
+const normalizeColorValue = (value: string): string => {
+    if (VALID_HEX.test(value)) {
+        return value;
+    }
+
+    switch (value) {
+    case 'light':
+    case 'transparent':
+        return '#ffffff';
+    default:
+        return '#ffffff';
+    }
+};
+
 const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChange}) => {
     const [open, setOpen] = useState(false);
+    const normalizedValue = normalizeColorValue(value);
 
     return (
         <div className="flex items-center justify-between">
@@ -25,13 +42,13 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
                     >
                         <span
                             className="block size-full rounded-full border-2 border-white"
-                            style={{background: value || '#ffffff'}}
+                            style={{background: normalizedValue}}
                         />
                     </button>
                 </PopoverTrigger>
                 <PopoverContent align="end" className="w-auto p-4">
                     <ColorPicker
-                        value={value}
+                        value={normalizedValue}
                         onChange={(hex: string) => {
                             onChange(hex);
                         }}

--- a/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
@@ -6,16 +6,19 @@ interface ColorPickerFieldProps {
     title: string;
     value: string;
     onChange: (color: string) => void;
+    accentColor?: string;
 }
 
 const VALID_HEX = /^#(?:[0-9a-f]{3}){1,2}$/i;
 
-const normalizeColorValue = (value: string): string => {
+const normalizeColorValue = (value: string, accentColor?: string): string => {
     if (VALID_HEX.test(value)) {
         return value;
     }
 
     switch (value) {
+    case 'accent':
+        return accentColor && VALID_HEX.test(accentColor) ? accentColor : '#ffffff';
     case 'light':
     case 'transparent':
         return '#ffffff';
@@ -24,9 +27,9 @@ const normalizeColorValue = (value: string): string => {
     }
 };
 
-const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChange}) => {
+const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChange, accentColor}) => {
     const [open, setOpen] = useState(false);
-    const normalizedValue = normalizeColorValue(value);
+    const normalizedValue = normalizeColorValue(value, accentColor);
 
     return (
         <div className="flex items-center justify-between">

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/button-color-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/button-color-field.tsx
@@ -5,6 +5,7 @@ export const ButtonColorField = () => {
     const {settings, onSettingsChange, accentColor} = useEmailDesign();
     return (
         <ColorPickerField
+            accentColor={accentColor}
             title="Button color"
             value={settings.button_color || accentColor}
             onChange={color => onSettingsChange({button_color: color})}

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/link-color-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/link-color-field.tsx
@@ -5,6 +5,7 @@ export const LinkColorField = () => {
     const {settings, onSettingsChange, accentColor} = useEmailDesign();
     return (
         <ColorPickerField
+            accentColor={accentColor}
             title="Link color"
             value={settings.link_color || accentColor}
             onChange={color => onSettingsChange({link_color: color})}

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/link-style-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/link-style-field.tsx
@@ -1,4 +1,4 @@
-import {Bold, Italic, Underline} from 'lucide-react';
+import {Bold, Type, Underline} from 'lucide-react';
 import {ToggleGroup, ToggleGroupItem} from '@tryghost/shade/components';
 import {useEmailDesign} from '../email-design-context';
 
@@ -9,7 +9,7 @@ export const LinkStyleField = () => {
             <span>Link style</span>
             <ToggleGroup type="single" value={settings.link_style || 'underline'} onValueChange={(value: string) => value && onSettingsChange({link_style: value})}>
                 <ToggleGroupItem aria-label="Underline" value="underline"><Underline className="size-4" /></ToggleGroupItem>
-                <ToggleGroupItem aria-label="Italic" value="regular"><Italic className="size-4" /></ToggleGroupItem>
+                <ToggleGroupItem aria-label="Regular" value="regular"><Type className="size-4" /></ToggleGroupItem>
                 <ToggleGroupItem aria-label="Bold" value="bold"><Bold className="size-4" /></ToggleGroupItem>
             </ToggleGroup>
         </div>

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
@@ -1,6 +1,7 @@
-import React, {useEffect, useRef} from 'react';
-import {Button, Dialog, DialogContent, DialogTitle} from '@tryghost/shade/components';
+import React, {useEffect, useRef, useState} from 'react';
+import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, Dialog, DialogContent, DialogTitle} from '@tryghost/shade/components';
 import {cn} from '@tryghost/shade/utils';
+import {type OkProps} from '@tryghost/admin-x-framework/hooks';
 
 interface EmailDesignModalProps {
     open: boolean;
@@ -8,9 +9,8 @@ interface EmailDesignModalProps {
     preview: React.ReactNode;
     sidebar: React.ReactNode;
     dirty?: boolean;
-    saveLabel?: string;
     isLoading?: boolean;
-    isSaving?: boolean;
+    okProps?: Pick<OkProps, 'color' | 'disabled' | 'label'>;
     onSave: () => void;
     onClose: () => void;
     afterClose?: () => void;
@@ -23,9 +23,8 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
     preview,
     sidebar,
     dirty = false,
-    saveLabel = 'Save',
     isLoading = false,
-    isSaving = false,
+    okProps,
     onSave,
     onClose,
     afterClose,
@@ -33,6 +32,7 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
 }) => {
     const onSaveRef = useRef(onSave);
     const prevOpenRef = useRef(open);
+    const [showDirtyConfirm, setShowDirtyConfirm] = useState(false);
     useEffect(() => {
         onSaveRef.current = onSave;
     }, [onSave]);
@@ -57,45 +57,80 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
     }, []);
 
     const handleClose = () => {
-        if (dirty) {
-            if (confirm('You have unsaved changes. Are you sure you want to close?')) {
-                onClose();
-            }
-        } else {
+        if (!dirty) {
             onClose();
+            return;
         }
+
+        setShowDirtyConfirm(true);
     };
 
-    return (
-        <Dialog open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
-            <DialogContent
-                className={cn(
-                    'top-[50%] left-[50%] h-[calc(100vh-8vmin)] w-[calc(100vw-8vmin)] max-w-none translate-x-[-50%] translate-y-[-50%] gap-0 overflow-hidden p-0'
-                )}
-                data-testid={testId}
-            >
-                <div className="flex h-full min-h-0">
-                    {/* Left: Preview */}
-                    <div className="hidden min-h-0 flex-1 flex-col bg-gray-50 dark:bg-black [@media(min-width:801px)]:flex">
-                        <div className="flex min-h-0 flex-1 items-center justify-center p-8">
-                            {preview}
-                        </div>
-                    </div>
+    const saveColor = okProps?.color || 'black';
+    const saveDisabled = okProps?.disabled || false;
+    const saveLabel = okProps?.label || 'Save';
+    const saveButtonClassName = saveColor === 'green'
+        ? 'bg-green text-white hover:bg-green/90'
+        : saveColor === 'red'
+            ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+            : undefined;
 
-                    {/* Right: Sidebar */}
-                    <div className="flex min-h-0 w-full flex-col border-l border-gray-200 dark:border-gray-900 [@media(min-width:801px)]:w-[400px] [@media(min-width:801px)]:shrink-0">
-                        <div className="flex items-center justify-between px-6 py-5">
-                            <DialogTitle>{title}</DialogTitle>
-                            <div className="flex items-center gap-2">
-                                <Button variant="outline" onClick={handleClose}>Close</Button>
-                                <Button disabled={isLoading || isSaving} onClick={onSave}>{isSaving ? 'Saving...' : saveLabel}</Button>
+    return (
+        <>
+            <Dialog open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+                <DialogContent
+                    className={cn(
+                        'top-[50%] left-[50%] h-[calc(100vh-8vmin)] w-[calc(100vw-8vmin)] max-w-none translate-x-[-50%] translate-y-[-50%] gap-0 overflow-hidden p-0'
+                    )}
+                    data-testid={testId}
+                >
+                    <div className="flex h-full min-h-0">
+                        {/* Left: Preview */}
+                        <div className="hidden min-h-0 flex-1 flex-col bg-gray-50 dark:bg-black [@media(min-width:801px)]:flex">
+                            <div className="flex min-h-0 flex-1 items-center justify-center p-8">
+                                {preview}
                             </div>
                         </div>
-                        {sidebar}
+
+                        {/* Right: Sidebar */}
+                        <div className="flex min-h-0 w-full flex-col border-l border-gray-200 dark:border-gray-900 [@media(min-width:801px)]:w-[400px] [@media(min-width:801px)]:shrink-0">
+                            <div className="flex items-center justify-between px-6 py-5">
+                                <DialogTitle>{title}</DialogTitle>
+                                <div className="flex items-center gap-2">
+                                    <Button variant="outline" onClick={handleClose}>Close</Button>
+                                    <Button className={saveButtonClassName} disabled={isLoading || saveDisabled} onClick={onSave}>
+                                        {saveLabel}
+                                    </Button>
+                                </div>
+                            </div>
+                            {sidebar}
+                        </div>
                     </div>
-                </div>
-            </DialogContent>
-        </Dialog>
+                </DialogContent>
+            </Dialog>
+            <AlertDialog open={showDirtyConfirm} onOpenChange={setShowDirtyConfirm}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Are you sure you want to leave this page?</AlertDialogTitle>
+                        <AlertDialogDescription asChild>
+                            <div className="space-y-2">
+                                <p>{`Hey there! It looks like you didn't save the changes you made.`}</p>
+                                <p>Save before you go!</p>
+                            </div>
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel asChild>
+                            <Button variant="outline">Stay</Button>
+                        </AlertDialogCancel>
+                        <AlertDialogAction asChild>
+                            <Button className="bg-destructive text-destructive-foreground hover:bg-destructive/90" onClick={onClose}>
+                                Leave
+                            </Button>
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
     );
 };
 

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
@@ -65,15 +65,6 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
         setShowDirtyConfirm(true);
     };
 
-    const saveColor = okProps?.color || 'black';
-    const saveDisabled = okProps?.disabled || false;
-    const saveLabel = okProps?.label || 'Save';
-    const saveButtonClassName = saveColor === 'green'
-        ? 'bg-green text-white hover:bg-green/90'
-        : saveColor === 'red'
-            ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
-            : undefined;
-
     return (
         <>
             <Dialog open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
@@ -97,8 +88,13 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
                                 <DialogTitle>{title}</DialogTitle>
                                 <div className="flex items-center gap-2">
                                     <Button variant="outline" onClick={handleClose}>Close</Button>
-                                    <Button className={saveButtonClassName} disabled={isLoading || saveDisabled} onClick={onSave}>
-                                        {saveLabel}
+                                    <Button
+                                        className={okProps?.color === 'green' ? 'bg-green text-white hover:bg-green/90' : undefined}
+                                        disabled={isLoading || okProps?.disabled}
+                                        variant={okProps?.color === 'red' ? 'destructive' : 'default'}
+                                        onClick={onSave}
+                                    >
+                                        {okProps?.label || 'Save'}
                                     </Button>
                                 </div>
                             </div>

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, Dialog, DialogContent, DialogTitle} from '@tryghost/shade/components';
-import {cn} from '@tryghost/shade/utils';
 import {type OkProps} from '@tryghost/admin-x-framework/hooks';
+import {cn} from '@tryghost/shade/utils';
 
 interface EmailDesignModalProps {
     open: boolean;

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
@@ -3,30 +3,47 @@ import {Button, Dialog, DialogContent, DialogTitle} from '@tryghost/shade/compon
 import {cn} from '@tryghost/shade/utils';
 
 interface EmailDesignModalProps {
+    open: boolean;
     title: string;
     preview: React.ReactNode;
     sidebar: React.ReactNode;
     dirty?: boolean;
     saveLabel?: string;
+    isLoading?: boolean;
+    isSaving?: boolean;
     onSave: () => void;
     onClose: () => void;
+    afterClose?: () => void;
     testId?: string;
 }
 
 const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
+    open,
     title,
     preview,
     sidebar,
     dirty = false,
     saveLabel = 'Save',
+    isLoading = false,
+    isSaving = false,
     onSave,
     onClose,
+    afterClose,
     testId
 }) => {
     const onSaveRef = useRef(onSave);
+    const prevOpenRef = useRef(open);
     useEffect(() => {
         onSaveRef.current = onSave;
     }, [onSave]);
+
+    useEffect(() => {
+        if (prevOpenRef.current && !open) {
+            afterClose?.();
+        }
+
+        prevOpenRef.current = open;
+    }, [afterClose, open]);
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -50,7 +67,7 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
     };
 
     return (
-        <Dialog open onOpenChange={handleClose}>
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
             <DialogContent
                 className={cn(
                     'top-[50%] left-[50%] h-[calc(100vh-8vmin)] w-[calc(100vw-8vmin)] max-w-none translate-x-[-50%] translate-y-[-50%] gap-0 overflow-hidden p-0'
@@ -71,7 +88,7 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
                             <DialogTitle>{title}</DialogTitle>
                             <div className="flex items-center gap-2">
                                 <Button variant="outline" onClick={handleClose}>Close</Button>
-                                <Button onClick={onSave}>{saveLabel}</Button>
+                                <Button disabled={isLoading || isSaving} onClick={onSave}>{isSaving ? 'Saving...' : saveLabel}</Button>
                             </div>
                         </div>
                         {sidebar}

--- a/apps/admin-x-settings/src/components/settings/email-design/header-image-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/header-image-field.tsx
@@ -16,8 +16,8 @@ const HeaderImageField: React.FC<HeaderImageFieldProps> = ({value, onChange}) =>
     };
 
     return (
-        <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium">Header image</label>
+        <div className="flex flex-col gap-1.5" data-testid="header-image-field">
+            <label className="text-sm font-medium" htmlFor="welcome-email-header-image">Header image</label>
             {value ? (
                 <div className="relative overflow-hidden rounded-md border border-gray-200 dark:border-gray-800">
                     <img
@@ -38,6 +38,7 @@ const HeaderImageField: React.FC<HeaderImageFieldProps> = ({value, onChange}) =>
                     <Dropzone
                         accept={{'image/*': ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg']}}
                         className="flex h-24 items-center justify-center p-0 text-sm"
+                        id="welcome-email-header-image"
                         onDropAccepted={files => files[0] && handleUpload(files[0])}
                     >
                         <span className="text-gray-700">Upload header image</span>

--- a/apps/admin-x-settings/src/components/settings/email-design/types.ts
+++ b/apps/admin-x-settings/src/components/settings/email-design/types.ts
@@ -1,11 +1,9 @@
-export interface EmailDesignSettings {
+export interface PersistedEmailDesignSettings {
     background_color: string;
     title_font_category: string;
     title_font_weight: string;
     body_font_category: string;
     header_background_color: string;
-    post_title_color: string | null;
-    title_alignment: string;
     section_title_color: string | null;
     button_color: string | null;
     button_style: string;
@@ -16,20 +14,27 @@ export interface EmailDesignSettings {
     divider_color: string | null;
 }
 
+export interface EmailDesignPreviewSettings {
+    post_title_color: string | null;
+    title_alignment: string;
+}
+
+export type EmailDesignSettings = PersistedEmailDesignSettings & EmailDesignPreviewSettings;
+
 export const DEFAULT_EMAIL_DESIGN: EmailDesignSettings = {
-    background_color: '#ffffff',
+    background_color: 'light',
     title_font_category: 'sans_serif',
     title_font_weight: 'bold',
     body_font_category: 'sans_serif',
-    header_background_color: '#ffffff',
-    post_title_color: null,
-    title_alignment: 'center',
+    header_background_color: 'transparent',
     section_title_color: null,
-    button_color: null,
+    button_color: 'accent',
     button_style: 'fill',
     button_corners: 'rounded',
-    link_color: null,
+    link_color: 'accent',
     link_style: 'underline',
     image_corners: 'square',
-    divider_color: null
+    divider_color: null,
+    post_title_color: null,
+    title_alignment: 'center'
 };

--- a/apps/admin-x-settings/src/components/settings/email-design/welcome-email-preview-content.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/welcome-email-preview-content.tsx
@@ -15,7 +15,6 @@ const WelcomeEmailPreviewContent: React.FC = () => {
     const linkClasses = cn(
         'no-underline',
         settings.link_style === 'underline' && 'underline',
-        settings.link_style === 'regular' && 'italic',
         settings.link_style === 'bold' && 'font-bold'
     );
 

--- a/apps/admin-x-settings/src/components/settings/email-design/welcome-email-preview-content.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/welcome-email-preview-content.tsx
@@ -42,7 +42,7 @@ const WelcomeEmailPreviewContent: React.FC = () => {
 
             <h3
                 className={titleFontClasses}
-                style={{color: colors.textColor}}
+                style={{color: colors.sectionTitleColor}}
             >
                 Your welcome email
             </h3>
@@ -81,7 +81,7 @@ const WelcomeEmailPreviewContent: React.FC = () => {
 
             <h3
                 className={titleFontClasses}
-                style={{color: colors.textColor}}
+                style={{color: colors.sectionTitleColor}}
             >
                 Need inspiration?
             </h3>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -4,6 +4,7 @@ import HeaderImageField from '../../email-design/header-image-field';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import ShowBadgeField from '../../email-design/show-badge-field';
 import WelcomeEmailPreviewContent from '../../email-design/welcome-email-preview-content';
+import {type AutomatedEmailDesign, useEditAutomatedEmailDesign, useReadAutomatedEmailDesign} from '@tryghost/admin-x-framework/api/automated-email-design';
 import {
     BackgroundColorField,
     BodyFontField,
@@ -18,11 +19,12 @@ import {
     LinkColorField,
     LinkStyleField
 } from '../../email-design/design-fields';
-import {DEFAULT_EMAIL_DESIGN, type EmailDesignSettings} from '../../email-design/types';
+import {DEFAULT_EMAIL_DESIGN, type EmailDesignSettings, type PersistedEmailDesignSettings} from '../../email-design/types';
 import {EmailDesignProvider} from '../../email-design/email-design-context';
-import {Input, Separator, Switch, Tabs, TabsContent, TabsList, TabsTrigger, Textarea} from '@tryghost/shade/components';
+import {Input, LoadingIndicator, Separator, Switch, Tabs, TabsContent, TabsList, TabsTrigger, Textarea} from '@tryghost/shade/components';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
-import {useCallback, useState} from 'react';
+import {showToast} from '@tryghost/admin-x-design-system';
+import {useCallback, useEffect, useState} from 'react';
 import {useGlobalData} from '../../../providers/global-data-provider';
 
 interface GeneralSettings {
@@ -47,16 +49,18 @@ const GeneralTab: React.FC<GeneralTabProps> = ({generalSettings, onGeneralChange
             <h4 className="mb-4 font-semibold md:text-lg">Email info</h4>
             <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1.5">
-                    <label className="text-sm font-medium">Sender name</label>
+                    <label className="text-sm font-medium" htmlFor="welcome-email-sender-name">Sender name</label>
                     <Input
+                        id="welcome-email-sender-name"
                         placeholder={siteTitle || 'Your site name'}
                         value={generalSettings.senderName}
                         onChange={e => onGeneralChange({senderName: e.target.value})}
                     />
                 </div>
                 <div className="flex flex-col gap-1.5">
-                    <label className="text-sm font-medium">Reply-to email</label>
+                    <label className="text-sm font-medium" htmlFor="welcome-email-reply-to-email">Reply-to email</label>
                     <Input
+                        id="welcome-email-reply-to-email"
                         placeholder={`noreply@${emailDomain}`}
                         value={generalSettings.replyToEmail}
                         onChange={e => onGeneralChange({replyToEmail: e.target.value})}
@@ -83,8 +87,9 @@ const GeneralTab: React.FC<GeneralTabProps> = ({generalSettings, onGeneralChange
                     />
                 </div>
                 <div className="mt-2 flex flex-col gap-1.5">
-                    <label className="text-sm font-medium">Email footer</label>
+                    <label className="text-sm font-medium" htmlFor="welcome-email-footer">Email footer</label>
                     <Textarea
+                        id="welcome-email-footer"
                         placeholder="Any extra information or legal text"
                         rows={3}
                         value={generalSettings.emailFooter}
@@ -143,32 +148,94 @@ interface SidebarProps {
     onGeneralChange: (updates: Partial<GeneralSettings>) => void;
     siteTitle: string | undefined;
     emailDomain: string;
+    isLoading: boolean;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({generalSettings, onGeneralChange, siteTitle, emailDomain}) => (
+const Sidebar: React.FC<SidebarProps> = ({generalSettings, onGeneralChange, siteTitle, emailDomain, isLoading}) => (
     <Tabs className="flex min-h-0 flex-1 flex-col" defaultValue="general" variant="underline">
         <TabsList className='px-5'>
             <TabsTrigger value="general">General</TabsTrigger>
             <TabsTrigger value="design">Design</TabsTrigger>
         </TabsList>
-        <TabsContent className='min-h-0 flex-1 overflow-y-auto px-5 pb-5' value="general">
-            <GeneralTab
-                emailDomain={emailDomain}
-                generalSettings={generalSettings}
-                siteTitle={siteTitle}
-                onGeneralChange={onGeneralChange}
-            />
-        </TabsContent>
-        <TabsContent className='min-h-0 flex-1 overflow-y-auto px-5 pb-5' value="design">
-            <DesignTab />
-        </TabsContent>
+        {isLoading ? (
+            <div className="flex flex-1 items-center justify-center">
+                <LoadingIndicator size="md" />
+            </div>
+        ) : (
+            <>
+                <TabsContent className='min-h-0 flex-1 overflow-y-auto px-5 pb-5' value="general">
+                    <GeneralTab
+                        emailDomain={emailDomain}
+                        generalSettings={generalSettings}
+                        siteTitle={siteTitle}
+                        onGeneralChange={onGeneralChange}
+                    />
+                </TabsContent>
+                <TabsContent className='min-h-0 flex-1 overflow-y-auto px-5 pb-5' value="design">
+                    <DesignTab />
+                </TabsContent>
+            </>
+        )}
     </Tabs>
 );
+
+/**
+ * Maps API response fields to the frontend GeneralSettings shape.
+ *
+ * @param {import('@tryghost/admin-x-framework/api/automated-email-design').AutomatedEmailDesign} apiData - The design record from the API
+ * @param {GeneralSettings} defaults - Fallback values for sender fields not in the design endpoint
+ * @returns {GeneralSettings} General settings populated from the API response
+ */
+function mapApiToGeneralSettings(
+    apiData: Pick<AutomatedEmailDesign, 'header_image' | 'show_header_title' | 'show_badge' | 'footer_content'>,
+    defaults: GeneralSettings
+): GeneralSettings {
+    return {
+        senderName: defaults.senderName,
+        replyToEmail: defaults.replyToEmail,
+        headerImage: apiData.header_image || '',
+        showPublicationTitle: apiData.show_header_title,
+        showBadge: apiData.show_badge,
+        emailFooter: apiData.footer_content || ''
+    };
+}
+
+/**
+ * Maps API response fields to the frontend EmailDesignSettings shape.
+ *
+ * @param {import('@tryghost/admin-x-framework/api/automated-email-design').AutomatedEmailDesign} apiData - The design record from the API
+ * @returns {EmailDesignSettings} Design settings populated from the API response
+ */
+function mapApiToDesignSettings(
+    apiData: PersistedEmailDesignSettings
+): EmailDesignSettings {
+    return {
+        background_color: apiData.background_color,
+        header_background_color: apiData.header_background_color,
+        title_font_category: apiData.title_font_category,
+        title_font_weight: apiData.title_font_weight,
+        body_font_category: apiData.body_font_category,
+        button_color: apiData.button_color,
+        button_style: apiData.button_style,
+        button_corners: apiData.button_corners,
+        link_color: apiData.link_color,
+        link_style: apiData.link_style,
+        image_corners: apiData.image_corners,
+        divider_color: apiData.divider_color,
+        section_title_color: apiData.section_title_color,
+        // Local-only fields not stored in the backend
+        post_title_color: DEFAULT_EMAIL_DESIGN.post_title_color,
+        title_alignment: DEFAULT_EMAIL_DESIGN.title_alignment
+    };
+}
 
 const WelcomeEmailCustomizeModal = NiceModal.create(() => {
     const modal = useModal();
     const {siteData, settings: globalSettings, config} = useGlobalData();
     const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'support_email_address']);
+
+    const {data: designData, isLoading} = useReadAutomatedEmailDesign();
+    const {mutateAsync: editDesign, isLoading: isSaving} = useEditAutomatedEmailDesign();
 
     const [designSettings, setDesignSettings] = useState<EmailDesignSettings>({...DEFAULT_EMAIL_DESIGN});
     const [generalSettings, setGeneralSettings] = useState<GeneralSettings>({
@@ -179,6 +246,18 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
         showBadge: true,
         emailFooter: ''
     });
+    const [hydratedDesignVersion, setHydratedDesignVersion] = useState<string | null>(null);
+    const design = designData?.automated_email_design?.[0];
+    const designVersion = design ? `${design.id}:${design.updated_at ?? 'initial'}` : null;
+
+    // Populate state from API response once data is available
+    useEffect(() => {
+        if (design && designVersion !== hydratedDesignVersion) {
+            setDesignSettings(mapApiToDesignSettings(design));
+            setGeneralSettings(prev => mapApiToGeneralSettings(design, prev));
+            setHydratedDesignVersion(designVersion);
+        }
+    }, [design, designVersion, hydratedDesignVersion]);
 
     const handleDesignChange = useCallback((updates: Partial<EmailDesignSettings>) => {
         setDesignSettings(prev => ({...prev, ...updates}));
@@ -188,13 +267,41 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
         setGeneralSettings(prev => ({...prev, ...updates}));
     }, []);
 
-    const handleSave = useCallback(() => {
-        // TODO: persist to backend when design columns are added
-        modal.remove();
-    }, [modal]);
+    const handleSave = useCallback(async () => {
+        if (!design) {
+            showToast({type: 'error', title: 'Unable to load email design settings'});
+            return;
+        }
+
+        try {
+            await editDesign({
+                id: design.id,
+                background_color: designSettings.background_color,
+                header_background_color: designSettings.header_background_color,
+                title_font_category: designSettings.title_font_category,
+                title_font_weight: designSettings.title_font_weight,
+                body_font_category: designSettings.body_font_category,
+                button_color: designSettings.button_color,
+                button_style: designSettings.button_style,
+                button_corners: designSettings.button_corners,
+                link_color: designSettings.link_color,
+                link_style: designSettings.link_style,
+                image_corners: designSettings.image_corners,
+                divider_color: designSettings.divider_color,
+                section_title_color: designSettings.section_title_color,
+                header_image: generalSettings.headerImage || null,
+                show_header_title: generalSettings.showPublicationTitle,
+                show_badge: generalSettings.showBadge,
+                footer_content: generalSettings.emailFooter || null
+            });
+            await modal.hide();
+        } catch {
+            showToast({type: 'error', title: 'Failed to save email design settings'});
+        }
+    }, [design, designSettings, generalSettings, editDesign, modal]);
 
     const handleClose = useCallback(() => {
-        modal.remove();
+        void modal.hide();
     }, [modal]);
 
     const emailDomain = (config?.emailDomain as string) || defaultEmailAddress?.split('@')[1] || '';
@@ -202,6 +309,13 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
     return (
         <EmailDesignProvider accentColor={siteData.accent_color} settings={designSettings} onSettingsChange={handleDesignChange}>
             <EmailDesignModal
+                afterClose={() => {
+                    modal.resolveHide();
+                    modal.remove();
+                }}
+                isLoading={isLoading}
+                isSaving={isSaving}
+                open={modal.visible}
                 preview={
                     <EmailPreview
                         emailFooter={generalSettings.emailFooter}
@@ -221,6 +335,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                     <Sidebar
                         emailDomain={emailDomain}
                         generalSettings={generalSettings}
+                        isLoading={isLoading}
                         siteTitle={siteTitle}
                         onGeneralChange={handleGeneralChange}
                     />

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -4,7 +4,7 @@ import HeaderImageField from '../../email-design/header-image-field';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import ShowBadgeField from '../../email-design/show-badge-field';
 import WelcomeEmailPreviewContent from '../../email-design/welcome-email-preview-content';
-import {type AutomatedEmailDesign, useEditAutomatedEmailDesign, useReadAutomatedEmailDesign} from '@tryghost/admin-x-framework/api/automated-email-design';
+import {type AutomatedEmailDesign, type EditAutomatedEmailDesign, useEditAutomatedEmailDesign, useReadAutomatedEmailDesign} from '@tryghost/admin-x-framework/api/automated-email-design';
 import {
     BackgroundColorField,
     BodyFontField,
@@ -222,26 +222,28 @@ function mapApiToGeneralSettings(
  * @param {PersistedEmailDesignSettings} apiData - The persisted design fields from the API response
  * @returns {EmailDesignSettings} Design settings populated from the API response, with local-only preview fields set to defaults
  */
-function mapApiToDesignSettings(
+export function mapApiToDesignSettings(
     apiData: PersistedEmailDesignSettings
 ): EmailDesignSettings {
     return {
-        background_color: apiData.background_color,
-        header_background_color: apiData.header_background_color,
-        title_font_category: apiData.title_font_category,
-        title_font_weight: apiData.title_font_weight,
-        body_font_category: apiData.body_font_category,
-        button_color: apiData.button_color,
-        button_style: apiData.button_style,
-        button_corners: apiData.button_corners,
-        link_color: apiData.link_color,
-        link_style: apiData.link_style,
-        image_corners: apiData.image_corners,
-        divider_color: apiData.divider_color,
-        section_title_color: apiData.section_title_color,
+        ...apiData,
         // Local-only fields not stored in the backend
         post_title_color: DEFAULT_EMAIL_DESIGN.post_title_color,
         title_alignment: DEFAULT_EMAIL_DESIGN.title_alignment
+    };
+}
+
+export function buildAutomatedEmailDesignPayload(state: WelcomeEmailCustomizeFormState): EditAutomatedEmailDesign {
+    const persistedDesign = Object.fromEntries(
+        Object.entries(state.designSettings).filter(([key]) => !['post_title_color', 'title_alignment'].includes(key))
+    );
+
+    return {
+        ...persistedDesign,
+        header_image: state.generalSettings.headerImage || null,
+        show_header_title: state.generalSettings.showPublicationTitle,
+        show_badge: state.generalSettings.showBadge,
+        footer_content: state.generalSettings.emailFooter || null
     };
 }
 
@@ -284,25 +286,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                 throw new Error('Unable to load email design settings');
             }
 
-            await editDesign({
-                background_color: state.designSettings.background_color,
-                header_background_color: state.designSettings.header_background_color,
-                title_font_category: state.designSettings.title_font_category,
-                title_font_weight: state.designSettings.title_font_weight,
-                body_font_category: state.designSettings.body_font_category,
-                button_color: state.designSettings.button_color,
-                button_style: state.designSettings.button_style,
-                button_corners: state.designSettings.button_corners,
-                link_color: state.designSettings.link_color,
-                link_style: state.designSettings.link_style,
-                image_corners: state.designSettings.image_corners,
-                divider_color: state.designSettings.divider_color,
-                section_title_color: state.designSettings.section_title_color,
-                header_image: state.generalSettings.headerImage || null,
-                show_header_title: state.generalSettings.showPublicationTitle,
-                show_badge: state.generalSettings.showBadge,
-                footer_content: state.generalSettings.emailFooter || null
-            });
+            await editDesign(buildAutomatedEmailDesignPayload(state));
             setHasSaveError(false);
             toast.dismiss(SAVE_ERROR_TOAST_ID);
         },

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -23,8 +23,9 @@ import {DEFAULT_EMAIL_DESIGN, type EmailDesignSettings, type PersistedEmailDesig
 import {EmailDesignProvider} from '../../email-design/email-design-context';
 import {Input, LoadingIndicator, Separator, Switch, Tabs, TabsContent, TabsList, TabsTrigger, Textarea} from '@tryghost/shade/components';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
-import {showToast} from '@tryghost/admin-x-design-system';
-import {useCallback, useEffect, useState} from 'react';
+import {toast} from 'sonner';
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalData} from '../../../providers/global-data-provider';
 
 interface GeneralSettings {
@@ -35,6 +36,13 @@ interface GeneralSettings {
     showBadge: boolean;
     emailFooter: string;
 }
+
+interface WelcomeEmailCustomizeFormState {
+    designSettings: EmailDesignSettings;
+    generalSettings: GeneralSettings;
+}
+
+const SAVE_ERROR_TOAST_ID = 'welcome-email-design-save-error';
 
 interface GeneralTabProps {
     generalSettings: GeneralSettings;
@@ -149,9 +157,10 @@ interface SidebarProps {
     siteTitle: string | undefined;
     emailDomain: string;
     isLoading: boolean;
+    errorMessage?: string;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({generalSettings, onGeneralChange, siteTitle, emailDomain, isLoading}) => (
+const Sidebar: React.FC<SidebarProps> = ({generalSettings, onGeneralChange, siteTitle, emailDomain, isLoading, errorMessage}) => (
     <Tabs className="flex min-h-0 flex-1 flex-col" defaultValue="general" variant="underline">
         <TabsList className='px-5'>
             <TabsTrigger value="general">General</TabsTrigger>
@@ -160,6 +169,10 @@ const Sidebar: React.FC<SidebarProps> = ({generalSettings, onGeneralChange, site
         {isLoading ? (
             <div className="flex flex-1 items-center justify-center">
                 <LoadingIndicator size="md" />
+            </div>
+        ) : errorMessage ? (
+            <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-gray-700 dark:text-gray-300">
+                {errorMessage}
             </div>
         ) : (
             <>
@@ -181,9 +194,10 @@ const Sidebar: React.FC<SidebarProps> = ({generalSettings, onGeneralChange, site
 
 /**
  * Maps API response fields to the frontend GeneralSettings shape.
+ * Note: senderName and replyToEmail come from site-level settings, not the design endpoint.
  *
- * @param {import('@tryghost/admin-x-framework/api/automated-email-design').AutomatedEmailDesign} apiData - The design record from the API
- * @param {GeneralSettings} defaults - Fallback values for sender fields not in the design endpoint
+ * @param {Pick<AutomatedEmailDesign, 'header_image' | 'show_header_title' | 'show_badge' | 'footer_content'>} apiData - Subset of design fields used for general settings
+ * @param {GeneralSettings} defaults - Carries forward senderName and replyToEmail, which are not part of the design API
  * @returns {GeneralSettings} General settings populated from the API response
  */
 function mapApiToGeneralSettings(
@@ -203,8 +217,8 @@ function mapApiToGeneralSettings(
 /**
  * Maps API response fields to the frontend EmailDesignSettings shape.
  *
- * @param {import('@tryghost/admin-x-framework/api/automated-email-design').AutomatedEmailDesign} apiData - The design record from the API
- * @returns {EmailDesignSettings} Design settings populated from the API response
+ * @param {PersistedEmailDesignSettings} apiData - The persisted design fields from the API response
+ * @returns {EmailDesignSettings} Design settings populated from the API response, with local-only preview fields set to defaults
  */
 function mapApiToDesignSettings(
     apiData: PersistedEmailDesignSettings
@@ -229,82 +243,120 @@ function mapApiToDesignSettings(
     };
 }
 
+const ErrorState: React.FC<{message: string}> = ({message}) => (
+    <div className="flex h-full items-center justify-center px-6 text-center text-sm text-gray-700 dark:text-gray-300">
+        {message}
+    </div>
+);
+
 const WelcomeEmailCustomizeModal = NiceModal.create(() => {
     const modal = useModal();
     const {siteData, settings: globalSettings, config} = useGlobalData();
     const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'support_email_address']);
 
-    const {data: designData, isLoading} = useReadAutomatedEmailDesign();
-    const {mutateAsync: editDesign, isLoading: isSaving} = useEditAutomatedEmailDesign();
+    const handleError = useHandleError();
+    const {data: designData, isLoading, isError} = useReadAutomatedEmailDesign();
+    const {mutateAsync: editDesign} = useEditAutomatedEmailDesign();
+    const [hasSaveError, setHasSaveError] = useState(false);
 
-    const [designSettings, setDesignSettings] = useState<EmailDesignSettings>({...DEFAULT_EMAIL_DESIGN});
-    const [generalSettings, setGeneralSettings] = useState<GeneralSettings>({
+    const defaultGeneralSettings = useMemo<GeneralSettings>(() => ({
         senderName: siteTitle || '',
         replyToEmail: supportEmailAddress || defaultEmailAddress || '',
         headerImage: '',
         showPublicationTitle: true,
         showBadge: true,
         emailFooter: ''
+    }), [defaultEmailAddress, siteTitle, supportEmailAddress]);
+    const {formState, saveState, updateForm, setFormState, handleSave, okProps} = useForm<WelcomeEmailCustomizeFormState>({
+        initialState: {
+            designSettings: {...DEFAULT_EMAIL_DESIGN},
+            generalSettings: defaultGeneralSettings
+        },
+        savingDelay: 500,
+        onSave: async (state) => {
+            if (!design) {
+                toast.error('Unable to load email design settings. Please try again.', {
+                    id: SAVE_ERROR_TOAST_ID
+                });
+                setHasSaveError(true);
+                throw new Error('Unable to load email design settings');
+            }
+
+            await editDesign({
+                background_color: state.designSettings.background_color,
+                header_background_color: state.designSettings.header_background_color,
+                title_font_category: state.designSettings.title_font_category,
+                title_font_weight: state.designSettings.title_font_weight,
+                body_font_category: state.designSettings.body_font_category,
+                button_color: state.designSettings.button_color,
+                button_style: state.designSettings.button_style,
+                button_corners: state.designSettings.button_corners,
+                link_color: state.designSettings.link_color,
+                link_style: state.designSettings.link_style,
+                image_corners: state.designSettings.image_corners,
+                divider_color: state.designSettings.divider_color,
+                section_title_color: state.designSettings.section_title_color,
+                header_image: state.generalSettings.headerImage || null,
+                show_header_title: state.generalSettings.showPublicationTitle,
+                show_badge: state.generalSettings.showBadge,
+                footer_content: state.generalSettings.emailFooter || null
+            });
+            setHasSaveError(false);
+            toast.dismiss(SAVE_ERROR_TOAST_ID);
+        },
+        onSaveError: (error) => {
+            handleError(error, {withToast: false});
+            toast.error('Unable to save email design settings. Please try again.', {
+                id: SAVE_ERROR_TOAST_ID
+            });
+            setHasSaveError(true);
+        }
     });
     const [hydratedDesignVersion, setHydratedDesignVersion] = useState<string | null>(null);
     const design = designData?.automated_email_design?.[0];
     const designVersion = design ? `${design.id}:${design.updated_at ?? 'initial'}` : null;
+    const {designSettings, generalSettings} = formState;
 
-    // Populate state from API response once data is available
+    // Hydrate local state from API data on initial load only
     useEffect(() => {
-        if (design && designVersion !== hydratedDesignVersion) {
-            setDesignSettings(mapApiToDesignSettings(design));
-            setGeneralSettings(prev => mapApiToGeneralSettings(design, prev));
+        if (design && hydratedDesignVersion === null) {
+            setFormState(() => ({
+                designSettings: mapApiToDesignSettings(design),
+                generalSettings: mapApiToGeneralSettings(design, defaultGeneralSettings)
+            }));
             setHydratedDesignVersion(designVersion);
         }
-    }, [design, designVersion, hydratedDesignVersion]);
+    }, [defaultGeneralSettings, design, designVersion, hydratedDesignVersion, setFormState]);
 
     const handleDesignChange = useCallback((updates: Partial<EmailDesignSettings>) => {
-        setDesignSettings(prev => ({...prev, ...updates}));
-    }, []);
+        setHasSaveError(false);
+        toast.dismiss(SAVE_ERROR_TOAST_ID);
+        updateForm(state => ({
+            ...state,
+            designSettings: {...state.designSettings, ...updates}
+        }));
+    }, [updateForm]);
 
     const handleGeneralChange = useCallback((updates: Partial<GeneralSettings>) => {
-        setGeneralSettings(prev => ({...prev, ...updates}));
-    }, []);
-
-    const handleSave = useCallback(async () => {
-        if (!design) {
-            showToast({type: 'error', title: 'Unable to load email design settings'});
-            return;
-        }
-
-        try {
-            await editDesign({
-                id: design.id,
-                background_color: designSettings.background_color,
-                header_background_color: designSettings.header_background_color,
-                title_font_category: designSettings.title_font_category,
-                title_font_weight: designSettings.title_font_weight,
-                body_font_category: designSettings.body_font_category,
-                button_color: designSettings.button_color,
-                button_style: designSettings.button_style,
-                button_corners: designSettings.button_corners,
-                link_color: designSettings.link_color,
-                link_style: designSettings.link_style,
-                image_corners: designSettings.image_corners,
-                divider_color: designSettings.divider_color,
-                section_title_color: designSettings.section_title_color,
-                header_image: generalSettings.headerImage || null,
-                show_header_title: generalSettings.showPublicationTitle,
-                show_badge: generalSettings.showBadge,
-                footer_content: generalSettings.emailFooter || null
-            });
-            await modal.hide();
-        } catch {
-            showToast({type: 'error', title: 'Failed to save email design settings'});
-        }
-    }, [design, designSettings, generalSettings, editDesign, modal]);
+        setHasSaveError(false);
+        toast.dismiss(SAVE_ERROR_TOAST_ID);
+        updateForm(state => ({
+            ...state,
+            generalSettings: {...state.generalSettings, ...updates}
+        }));
+    }, [updateForm]);
 
     const handleClose = useCallback(() => {
         void modal.hide();
     }, [modal]);
 
     const emailDomain = (config?.emailDomain as string) || defaultEmailAddress?.split('@')[1] || '';
+    const fetchErrorMessage = 'Unable to load email design settings. Please try again.';
+    const modalOkProps = hasSaveError ? {
+        ...okProps,
+        color: 'red' as const,
+        label: 'Retry'
+    } : okProps;
 
     return (
         <EmailDesignProvider accentColor={siteData.accent_color} settings={designSettings} onSettingsChange={handleDesignChange}>
@@ -313,10 +365,13 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                     modal.resolveHide();
                     modal.remove();
                 }}
-                isLoading={isLoading}
-                isSaving={isSaving}
+                dirty={saveState === 'unsaved'}
+                isLoading={isLoading || isError}
+                okProps={modalOkProps}
                 open={modal.visible}
-                preview={
+                preview={isError ? (
+                    <ErrorState message={fetchErrorMessage} />
+                ) : (
                     <EmailPreview
                         emailFooter={generalSettings.emailFooter}
                         footerLinkText="Manage your preferences"
@@ -330,10 +385,11 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                     >
                         <WelcomeEmailPreviewContent />
                     </EmailPreview>
-                }
+                )}
                 sidebar={
                     <Sidebar
                         emailDomain={emailDomain}
+                        errorMessage={isError ? fetchErrorMessage : undefined}
                         generalSettings={generalSettings}
                         isLoading={isLoading}
                         siteTitle={siteTitle}
@@ -343,7 +399,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                 testId="welcome-email-customize-modal"
                 title="Welcome emails"
                 onClose={handleClose}
-                onSave={handleSave}
+                onSave={() => handleSave({fakeWhenUnchanged: true})}
             />
         </EmailDesignProvider>
     );

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -17,7 +17,8 @@ import {
     HeadingWeightField,
     ImageCornersField,
     LinkColorField,
-    LinkStyleField
+    LinkStyleField,
+    SectionTitleColorField
 } from '../../email-design/design-fields';
 import {DEFAULT_EMAIL_DESIGN, type EmailDesignSettings, type PersistedEmailDesignSettings} from '../../email-design/types';
 import {EmailDesignProvider} from '../../email-design/email-design-context';
@@ -113,7 +114,7 @@ const GeneralTab: React.FC<GeneralTabProps> = ({generalSettings, onGeneralChange
     </div>
 );
 
-const DesignTab: React.FC = () => (
+export const DesignTab: React.FC = () => (
     <div className="flex flex-col gap-6 pt-6">
         <section>
             <h4 className="mb-4 font-semibold md:text-lg">Global</h4>
@@ -139,6 +140,7 @@ const DesignTab: React.FC = () => (
         <section>
             <h4 className="mb-4 font-semibold md:text-lg">Body</h4>
             <div className="flex flex-col gap-4">
+                <SectionTitleColorField />
                 <ButtonColorField />
                 <ButtonStyleField />
                 <ButtonCornersField />

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -44,6 +44,20 @@ interface WelcomeEmailCustomizeFormState {
 }
 
 const SAVE_ERROR_TOAST_ID = 'welcome-email-design-save-error';
+const NON_DESIGN_FIELDS = new Set([
+    'id',
+    'slug',
+    'created_at',
+    'updated_at',
+    'header_image',
+    'show_header_title',
+    'show_badge',
+    'footer_content'
+]);
+const PREVIEW_ONLY_FIELDS = new Set([
+    'post_title_color',
+    'title_alignment'
+]);
 
 interface GeneralTabProps {
     generalSettings: GeneralSettings;
@@ -225,8 +239,12 @@ function mapApiToGeneralSettings(
 export function mapApiToDesignSettings(
     apiData: PersistedEmailDesignSettings
 ): EmailDesignSettings {
+    const persistedDesign = Object.fromEntries(
+        Object.entries(apiData).filter(([key]) => !NON_DESIGN_FIELDS.has(key))
+    ) as PersistedEmailDesignSettings;
+
     return {
-        ...apiData,
+        ...persistedDesign,
         // Local-only fields not stored in the backend
         post_title_color: DEFAULT_EMAIL_DESIGN.post_title_color,
         title_alignment: DEFAULT_EMAIL_DESIGN.title_alignment
@@ -235,7 +253,7 @@ export function mapApiToDesignSettings(
 
 export function buildAutomatedEmailDesignPayload(state: WelcomeEmailCustomizeFormState): EditAutomatedEmailDesign {
     const persistedDesign = Object.fromEntries(
-        Object.entries(state.designSettings).filter(([key]) => !['post_title_color', 'title_alignment'].includes(key))
+        Object.entries(state.designSettings).filter(([key]) => !PREVIEW_ONLY_FIELDS.has(key) && !NON_DESIGN_FIELDS.has(key))
     );
 
     return {

--- a/apps/admin-x-settings/test/unit/email-design/color-fields.test.tsx
+++ b/apps/admin-x-settings/test/unit/email-design/color-fields.test.tsx
@@ -1,5 +1,4 @@
 import * as assert from 'assert/strict';
-import React from 'react';
 import {ButtonColorField} from '@src/components/settings/email-design/design-fields/button-color-field';
 import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
 import {EmailDesignProvider} from '@src/components/settings/email-design/email-design-context';

--- a/apps/admin-x-settings/test/unit/email-design/color-fields.test.tsx
+++ b/apps/admin-x-settings/test/unit/email-design/color-fields.test.tsx
@@ -1,0 +1,45 @@
+import * as assert from 'assert/strict';
+import React from 'react';
+import {ButtonColorField} from '@src/components/settings/email-design/design-fields/button-color-field';
+import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
+import {EmailDesignProvider} from '@src/components/settings/email-design/email-design-context';
+import {LinkColorField} from '@src/components/settings/email-design/design-fields/link-color-field';
+import {render, screen} from '@testing-library/react';
+
+describe('Email design color fields', function () {
+    it('renders accent-backed button colors using the resolved accent color', function () {
+        render(
+            <EmailDesignProvider
+                accentColor="#ff0088"
+                settings={{...DEFAULT_EMAIL_DESIGN, button_color: 'accent'}}
+                onSettingsChange={() => {}}
+            >
+                <ButtonColorField />
+            </EmailDesignProvider>
+        );
+
+        const trigger = screen.getByRole('button', {name: 'Button color'});
+        const swatch = trigger.querySelector('span');
+
+        assert.ok(swatch);
+        assert.equal(swatch.style.background, 'rgb(255, 0, 136)');
+    });
+
+    it('renders accent-backed link colors using the resolved accent color', function () {
+        render(
+            <EmailDesignProvider
+                accentColor="#00aaee"
+                settings={{...DEFAULT_EMAIL_DESIGN, link_color: 'accent'}}
+                onSettingsChange={() => {}}
+            >
+                <LinkColorField />
+            </EmailDesignProvider>
+        );
+
+        const trigger = screen.getByRole('button', {name: 'Link color'});
+        const swatch = trigger.querySelector('span');
+
+        assert.ok(swatch);
+        assert.equal(swatch.style.background, 'rgb(0, 170, 238)');
+    });
+});

--- a/apps/admin-x-settings/test/unit/email-design/design-payload.test.ts
+++ b/apps/admin-x-settings/test/unit/email-design/design-payload.test.ts
@@ -1,0 +1,46 @@
+import * as assert from 'assert/strict';
+import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
+import {buildAutomatedEmailDesignPayload, mapApiToDesignSettings} from '@src/components/settings/membership/member-emails/welcome-email-customize-modal';
+
+describe('Welcome email design payload helpers', function () {
+    it('preserves unexpected persisted design fields when mapping api data', function () {
+        const apiData = {
+            ...DEFAULT_EMAIL_DESIGN,
+            post_title_color: undefined,
+            title_alignment: undefined,
+            custom_future_field: '#123456'
+        };
+
+        const result = mapApiToDesignSettings(apiData as never) as typeof apiData;
+
+        assert.equal(result.custom_future_field, '#123456');
+    });
+
+    it('preserves unexpected persisted design fields in the save payload while excluding preview-only fields', function () {
+        const state = {
+            designSettings: {
+                ...DEFAULT_EMAIL_DESIGN,
+                custom_future_field: '#abcdef'
+            },
+            generalSettings: {
+                senderName: 'Ghost',
+                replyToEmail: 'support@example.com',
+                headerImage: '',
+                showPublicationTitle: true,
+                showBadge: false,
+                emailFooter: ''
+            }
+        };
+
+        const payload = buildAutomatedEmailDesignPayload(state as never) as typeof state.designSettings & {
+            header_image: string | null;
+            show_header_title: boolean;
+            show_badge: boolean;
+            footer_content: string | null;
+        };
+
+        assert.equal(payload.custom_future_field, '#abcdef');
+        assert.equal('post_title_color' in payload, false);
+        assert.equal('title_alignment' in payload, false);
+    });
+});

--- a/apps/admin-x-settings/test/unit/email-design/design-payload.test.ts
+++ b/apps/admin-x-settings/test/unit/email-design/design-payload.test.ts
@@ -3,6 +3,31 @@ import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types'
 import {buildAutomatedEmailDesignPayload, mapApiToDesignSettings} from '@src/components/settings/membership/member-emails/welcome-email-customize-modal';
 
 describe('Welcome email design payload helpers', function () {
+    it('does not hydrate immutable api metadata into design settings', function () {
+        const apiData = {
+            id: '1',
+            slug: 'default-automated-email',
+            created_at: '2026-04-02T00:00:00.000Z',
+            updated_at: '2026-04-02T00:00:00.000Z',
+            header_image: null,
+            show_header_title: true,
+            show_badge: true,
+            footer_content: null,
+            ...DEFAULT_EMAIL_DESIGN
+        };
+
+        const result = mapApiToDesignSettings(apiData as never) as typeof apiData;
+
+        assert.equal('id' in result, false);
+        assert.equal('slug' in result, false);
+        assert.equal('created_at' in result, false);
+        assert.equal('updated_at' in result, false);
+        assert.equal('header_image' in result, false);
+        assert.equal('show_header_title' in result, false);
+        assert.equal('show_badge' in result, false);
+        assert.equal('footer_content' in result, false);
+    });
+
     it('preserves unexpected persisted design fields when mapping api data', function () {
         const apiData = {
             ...DEFAULT_EMAIL_DESIGN,
@@ -20,6 +45,10 @@ describe('Welcome email design payload helpers', function () {
         const state = {
             designSettings: {
                 ...DEFAULT_EMAIL_DESIGN,
+                id: '1',
+                slug: 'default-automated-email',
+                created_at: '2026-04-02T00:00:00.000Z',
+                updated_at: '2026-04-02T00:00:00.000Z',
                 custom_future_field: '#abcdef'
             },
             generalSettings: {
@@ -40,6 +69,10 @@ describe('Welcome email design payload helpers', function () {
         };
 
         assert.equal(payload.custom_future_field, '#abcdef');
+        assert.equal('id' in payload, false);
+        assert.equal('slug' in payload, false);
+        assert.equal('created_at' in payload, false);
+        assert.equal('updated_at' in payload, false);
         assert.equal('post_title_color' in payload, false);
         assert.equal('title_alignment' in payload, false);
     });

--- a/apps/admin-x-settings/test/unit/email-design/design-payload.test.ts
+++ b/apps/admin-x-settings/test/unit/email-design/design-payload.test.ts
@@ -16,7 +16,7 @@ describe('Welcome email design payload helpers', function () {
             ...DEFAULT_EMAIL_DESIGN
         };
 
-        const result = mapApiToDesignSettings(apiData as never) as typeof apiData;
+        const result = mapApiToDesignSettings(apiData as never) as unknown as typeof apiData;
 
         assert.equal('id' in result, false);
         assert.equal('slug' in result, false);
@@ -36,7 +36,7 @@ describe('Welcome email design payload helpers', function () {
             custom_future_field: '#123456'
         };
 
-        const result = mapApiToDesignSettings(apiData as never) as typeof apiData;
+        const result = mapApiToDesignSettings(apiData as never) as unknown as typeof apiData;
 
         assert.equal(result.custom_future_field, '#123456');
     });
@@ -50,6 +50,12 @@ describe('Welcome email design payload helpers', function () {
                 created_at: '2026-04-02T00:00:00.000Z',
                 updated_at: '2026-04-02T00:00:00.000Z',
                 custom_future_field: '#abcdef'
+            } as unknown as typeof DEFAULT_EMAIL_DESIGN & {
+                id: string;
+                slug: string;
+                created_at: string;
+                updated_at: string;
+                custom_future_field: string;
             },
             generalSettings: {
                 senderName: 'Ghost',

--- a/apps/admin-x-settings/test/unit/email-design/link-style.test.tsx
+++ b/apps/admin-x-settings/test/unit/email-design/link-style.test.tsx
@@ -1,0 +1,39 @@
+import * as assert from 'assert/strict';
+import React from 'react';
+import WelcomeEmailPreviewContent from '@src/components/settings/email-design/welcome-email-preview-content';
+import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
+import {EmailDesignProvider} from '@src/components/settings/email-design/email-design-context';
+import {LinkStyleField} from '@src/components/settings/email-design/design-fields/link-style-field';
+import {render, screen} from '@testing-library/react';
+
+describe('Welcome email link styles', function () {
+    it('labels the non-underlined non-bold link option as regular', function () {
+        render(
+            <EmailDesignProvider
+                accentColor="#ff0088"
+                settings={DEFAULT_EMAIL_DESIGN}
+                onSettingsChange={() => {}}
+            >
+                <LinkStyleField />
+            </EmailDesignProvider>
+        );
+
+        assert.ok(screen.getByRole('radio', {name: 'Regular'}));
+    });
+
+    it('does not italicize links when the regular style is selected', function () {
+        render(
+            <EmailDesignProvider
+                accentColor="#ff0088"
+                settings={{...DEFAULT_EMAIL_DESIGN, link_style: 'regular'}}
+                onSettingsChange={() => {}}
+            >
+                <WelcomeEmailPreviewContent />
+            </EmailDesignProvider>
+        );
+
+        const link = screen.getByRole('link', {name: 'quick guide'});
+
+        assert.equal(link.classList.contains('italic'), false);
+    });
+});

--- a/apps/admin-x-settings/test/unit/email-design/link-style.test.tsx
+++ b/apps/admin-x-settings/test/unit/email-design/link-style.test.tsx
@@ -1,5 +1,4 @@
 import * as assert from 'assert/strict';
-import React from 'react';
 import WelcomeEmailPreviewContent from '@src/components/settings/email-design/welcome-email-preview-content';
 import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
 import {EmailDesignProvider} from '@src/components/settings/email-design/email-design-context';

--- a/apps/admin-x-settings/test/unit/email-design/section-title-color.test.tsx
+++ b/apps/admin-x-settings/test/unit/email-design/section-title-color.test.tsx
@@ -1,0 +1,41 @@
+import * as assert from 'assert/strict';
+import React from 'react';
+import WelcomeEmailPreviewContent from '@src/components/settings/email-design/welcome-email-preview-content';
+import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
+import {DesignTab} from '@src/components/settings/membership/member-emails/welcome-email-customize-modal';
+import {EmailDesignProvider} from '@src/components/settings/email-design/email-design-context';
+import {render, screen} from '@testing-library/react';
+
+describe('Section title color', function () {
+    it('includes a section title color control in the design tab', function () {
+        render(
+            <EmailDesignProvider
+                accentColor="#ff0088"
+                settings={DEFAULT_EMAIL_DESIGN}
+                onSettingsChange={() => {}}
+            >
+                <DesignTab />
+            </EmailDesignProvider>
+        );
+
+        const label = screen.queryByText('Section title color');
+
+        assert.ok(label);
+    });
+
+    it('uses the configured section title color in preview headings', function () {
+        render(
+            <EmailDesignProvider
+                accentColor="#ff0088"
+                settings={{...DEFAULT_EMAIL_DESIGN, section_title_color: '#2255aa'}}
+                onSettingsChange={() => {}}
+            >
+                <WelcomeEmailPreviewContent />
+            </EmailDesignProvider>
+        );
+
+        const heading = screen.getByRole('heading', {name: 'Your welcome email'});
+
+        assert.equal(heading.style.color, 'rgb(34, 85, 170)');
+    });
+});

--- a/apps/admin-x-settings/test/unit/email-design/section-title-color.test.tsx
+++ b/apps/admin-x-settings/test/unit/email-design/section-title-color.test.tsx
@@ -1,5 +1,4 @@
 import * as assert from 'assert/strict';
-import React from 'react';
 import WelcomeEmailPreviewContent from '@src/components/settings/email-design/welcome-email-preview-content';
 import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
 import {DesignTab} from '@src/components/settings/membership/member-emails/welcome-email-customize-modal';

--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -167,14 +167,8 @@ export class MemberWelcomeEmailsSection extends BasePage {
         );
         await this.customizeModalSaveButton.click();
         await saveResponse;
-
-        try {
-            await this.customizeModal.waitFor({state: 'hidden', timeout: 2000});
-        } catch {
-            if (await this.customizeModal.isVisible()) {
-                await this.closeCustomizeModal();
-            }
-        }
+        await this.customizeModal.waitFor({state: 'visible'});
+        await this.customizeModalSaveButton.waitFor({state: 'visible'});
     }
 
     async closeCustomizeModal(): Promise<void> {

--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -11,6 +11,20 @@ export class MemberWelcomeEmailsSection extends BasePage {
     // Customize button and modal
     readonly customizeButton: Locator;
     readonly customizeModal: Locator;
+    readonly customizeModalSaveButton: Locator;
+    readonly customizeModalCloseButton: Locator;
+    readonly customizeModalGeneralTab: Locator;
+    readonly customizeModalDesignTab: Locator;
+
+    // Customize modal — General tab locators
+    readonly customizeModalHeaderImageUpload: Locator;
+    readonly customizeModalPublicationTitleToggle: Locator;
+    readonly customizeModalFooterTextarea: Locator;
+    readonly customizeModalBadgeToggle: Locator;
+
+    // Customize modal — Design tab locators
+    readonly customizeModalButtonStyleFill: Locator;
+    readonly customizeModalButtonStyleOutline: Locator;
 
     // Modal locators
     readonly welcomeEmailModal: Locator;
@@ -31,6 +45,20 @@ export class MemberWelcomeEmailsSection extends BasePage {
         // Customize button and modal
         this.customizeButton = this.section.getByRole('button', {name: 'Customize'});
         this.customizeModal = page.getByTestId('welcome-email-customize-modal');
+        this.customizeModalSaveButton = this.customizeModal.getByRole('button', {name: 'Save'});
+        this.customizeModalCloseButton = this.customizeModal.getByRole('button', {name: 'Close'});
+        this.customizeModalGeneralTab = this.customizeModal.getByRole('tab', {name: 'General'});
+        this.customizeModalDesignTab = this.customizeModal.getByRole('tab', {name: 'Design'});
+
+        // Customize modal — General tab
+        this.customizeModalPublicationTitleToggle = this.customizeModal.getByText('Publication title').locator('..').getByRole('switch');
+        this.customizeModalFooterTextarea = this.customizeModal.getByLabel('Email footer');
+        this.customizeModalHeaderImageUpload = this.customizeModal.getByTestId('header-image-field');
+        this.customizeModalBadgeToggle = this.customizeModal.getByText('Show badge').locator('..').getByRole('switch');
+
+        // Customize modal — Design tab
+        this.customizeModalButtonStyleFill = this.customizeModal.getByLabel('Fill');
+        this.customizeModalButtonStyleOutline = this.customizeModal.getByLabel('Outline');
 
         // Modal locators
         this.welcomeEmailModal = page.getByTestId('welcome-email-modal');
@@ -120,5 +148,45 @@ export class MemberWelcomeEmailsSection extends BasePage {
         await editButton.click();
         await this.welcomeEmailModal.waitFor({state: 'visible'});
         await this.waitForWelcomeEmailEditor();
+    }
+
+    async openCustomizeModal(): Promise<void> {
+        await this.customizeButton.waitFor({state: 'visible'});
+        await this.customizeButton.click();
+        await this.customizeModal.waitFor({state: 'visible'});
+        await this.waitForCustomizeModalLoaded();
+    }
+
+    private async waitForCustomizeModalLoaded(): Promise<void> {
+        await this.customizeModalPublicationTitleToggle.waitFor({state: 'visible'});
+    }
+
+    async saveCustomizeModal(): Promise<void> {
+        const saveResponse = this.page.waitForResponse(
+            resp => resp.url().includes('/automated_emails/design') && resp.request().method() === 'PUT'
+        );
+        await this.customizeModalSaveButton.click();
+        await saveResponse;
+
+        try {
+            await this.customizeModal.waitFor({state: 'hidden', timeout: 2000});
+        } catch {
+            if (await this.customizeModal.isVisible()) {
+                await this.closeCustomizeModal();
+            }
+        }
+    }
+
+    async closeCustomizeModal(): Promise<void> {
+        await this.customizeModalCloseButton.click();
+        await this.customizeModal.waitFor({state: 'hidden'});
+    }
+
+    async switchToDesignTab(): Promise<void> {
+        await this.customizeModalDesignTab.click();
+    }
+
+    async switchToGeneralTab(): Promise<void> {
+        await this.customizeModalGeneralTab.click();
     }
 }

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -1,5 +1,8 @@
 import {MemberWelcomeEmailsSection} from '@/admin-pages';
 import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+usePerTestIsolation();
 
 interface AutomatedEmail {
     slug: string;
@@ -12,6 +15,32 @@ interface AutomatedEmail {
 
 interface AutomatedEmailsResponse {
     automated_emails: AutomatedEmail[];
+}
+
+interface AutomatedEmailDesign {
+    id: string;
+    slug: string;
+    background_color: string;
+    header_background_color: string;
+    header_image: string | null;
+    show_header_title: boolean;
+    footer_content: string | null;
+    button_color: string | null;
+    button_corners: string;
+    button_style: string;
+    link_color: string | null;
+    link_style: string;
+    body_font_category: string;
+    title_font_category: string;
+    title_font_weight: string;
+    image_corners: string;
+    divider_color: string | null;
+    section_title_color: string | null;
+    show_badge: boolean;
+}
+
+interface AutomatedEmailDesignResponse {
+    automated_email_design: AutomatedEmailDesign[];
 }
 
 test.describe('Ghost Admin - Member Welcome Emails', () => {
@@ -139,6 +168,61 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await welcomeEmailsSection.customizeModal.getByRole('button', {name: 'Close'}).click();
 
         await expect(welcomeEmailsSection.customizeModal).toBeHidden();
+    });
+
+    test('saving design settings persists to the API', async ({page}) => {
+        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
+
+        await welcomeEmailsSection.goto();
+        await welcomeEmailsSection.openCustomizeModal();
+
+        await welcomeEmailsSection.switchToDesignTab();
+        await welcomeEmailsSection.customizeModalButtonStyleOutline.click();
+
+        await welcomeEmailsSection.saveCustomizeModal();
+
+        const response = await page.request.get('/ghost/api/admin/automated_emails/design/');
+        expect(response.ok()).toBe(true);
+
+        const data = await response.json() as AutomatedEmailDesignResponse;
+        const design = data.automated_email_design[0];
+        expect(design.button_style).toBe('outline');
+    });
+
+    test('saving general settings persists to the API', async ({page}) => {
+        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
+
+        await welcomeEmailsSection.goto();
+        await welcomeEmailsSection.openCustomizeModal();
+
+        await welcomeEmailsSection.customizeModalPublicationTitleToggle.click();
+        await welcomeEmailsSection.customizeModalFooterTextarea.fill('Custom footer text');
+
+        await welcomeEmailsSection.saveCustomizeModal();
+
+        const response = await page.request.get('/ghost/api/admin/automated_emails/design/');
+        expect(response.ok()).toBe(true);
+
+        const data = await response.json() as AutomatedEmailDesignResponse;
+        const design = data.automated_email_design[0];
+        expect(design.show_header_title).toBe(false);
+        expect(design.footer_content).toBe('Custom footer text');
+    });
+
+    test('saved design settings load when modal is reopened', async ({page}) => {
+        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
+
+        await welcomeEmailsSection.goto();
+        await welcomeEmailsSection.openCustomizeModal();
+        await welcomeEmailsSection.customizeModalFooterTextarea.fill('Persisted footer');
+        await welcomeEmailsSection.saveCustomizeModal();
+
+        await page.reload();
+        await welcomeEmailsSection.section.waitFor({state: 'visible'});
+
+        await welcomeEmailsSection.openCustomizeModal();
+
+        await expect(welcomeEmailsSection.customizeModalFooterTextarea).toHaveValue('Persisted footer');
     });
 });
 

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -180,6 +180,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await welcomeEmailsSection.customizeModalButtonStyleOutline.click();
 
         await welcomeEmailsSection.saveCustomizeModal();
+        await expect(welcomeEmailsSection.customizeModal).toBeVisible();
 
         const response = await page.request.get('/ghost/api/admin/automated_emails/design/');
         expect(response.ok()).toBe(true);
@@ -199,6 +200,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await welcomeEmailsSection.customizeModalFooterTextarea.fill('Custom footer text');
 
         await welcomeEmailsSection.saveCustomizeModal();
+        await expect(welcomeEmailsSection.customizeModal).toBeVisible();
 
         const response = await page.request.get('/ghost/api/admin/automated_emails/design/');
         expect(response.ok()).toBe(true);
@@ -216,6 +218,8 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await welcomeEmailsSection.openCustomizeModal();
         await welcomeEmailsSection.customizeModalFooterTextarea.fill('Persisted footer');
         await welcomeEmailsSection.saveCustomizeModal();
+        await expect(welcomeEmailsSection.customizeModal).toBeVisible();
+        await welcomeEmailsSection.closeCustomizeModal();
 
         await page.reload();
         await welcomeEmailsSection.section.waitFor({state: 'visible'});

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -170,7 +170,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await expect(welcomeEmailsSection.customizeModal).toBeHidden();
     });
 
-    test('saving design settings persists to the API', async ({page}) => {
+    test('save design settings - persists to api', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();
@@ -190,7 +190,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         expect(design.button_style).toBe('outline');
     });
 
-    test('saving general settings persists to the API', async ({page}) => {
+    test('save general settings - persists to api', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();
@@ -211,7 +211,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         expect(design.footer_content).toBe('Custom footer text');
     });
 
-    test('saved design settings load when modal is reopened', async ({page}) => {
+    test('saved design settings - loads when modal is reopened', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -6,6 +6,7 @@ import {inject} from 'ghost-admin/decorators/inject';
 import {run} from '@ember/runloop';
 
 const emberDataTypeMapping = {
+    AutomatedEmailDesignResponseType: null, // automated email design settings only exist in React admin
     AutomatedEmailsResponseType: null, // automated emails only exist in React admin
     CommentsResponseType: null, // comments only exist in React admin
     IntegrationsResponseType: {type: 'integration'},

--- a/ghost/admin/tests/unit/services/state-bridge-test.js
+++ b/ghost/admin/tests/unit/services/state-bridge-test.js
@@ -62,6 +62,16 @@ describe('Unit: Service: state-bridge', function () {
             expect(store.pushPayload.called).to.be.false;
         });
 
+        it('skips processing for automated email design data type', function () {
+            const response = {automated_email_design: [{id: '1'}]};
+
+            run(() => {
+                service.onUpdate('AutomatedEmailDesignResponseType', response);
+            });
+
+            expect(store.pushPayload.called).to.be.false;
+        });
+
         it('pushes data to store for regular data types', function () {
             const response = {integrations: [{id: '1', name: 'Test Integration'}]};
 
@@ -247,6 +257,14 @@ describe('Unit: Service: state-bridge', function () {
         it('skips processing for null-mapped data types', function () {
             run(() => {
                 service.onInvalidate('CustomThemeSettingsResponseType');
+            });
+
+            expect(store.unloadAll.called).to.be.false;
+        });
+
+        it('skips processing for automated email design data type', function () {
+            run(() => {
+                service.onInvalidate('AutomatedEmailDesignResponseType');
             });
 
             expect(store.unloadAll.called).to.be.false;

--- a/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
+++ b/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
@@ -13,11 +13,21 @@
               <tr>
                 <td class="wrapper" align="center">
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-top: 40px; padding-bottom: 30px;">
+                    {{#if footerContent}}
+                      <tr>
+                        <td class="footer">{{{footerContent}}}</td>
+                      </tr>
+                    {{/if}}
                     <tr>
                       <td class="footer">
                         {{siteTitle}} &copy; {{year}} &mdash; <a href="{{managePreferencesUrl}}">{{t "Manage your preferences"}}</a>
                       </td>
                     </tr>
+                    {{#if showBadge}}
+                      <tr>
+                        <td class="footer-powered"><a href="https://ghost.org/?via=pbg-newsletter"><img src="https://static.ghost.org/v4.0.0/images/powered.png" border="0" width="142" height="30" class="gh-powered" alt="Powered by Ghost"></a></td>
+                      </tr>
+                    {{/if}}
                   </table>
                 </td>
               </tr>

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -16,6 +16,9 @@ class MemberWelcomeEmailRenderer {
 
     constructor({t}) {
         this.Handlebars = require('handlebars').create();
+        this.Handlebars.registerHelper('or', (...args) => args.slice(0, -1).some(Boolean));
+        this.Handlebars.registerHelper('and', (...args) => args.slice(0, -1).every(Boolean));
+        this.Handlebars.registerHelper('not', value => !value);
         this.Handlebars.registerHelper('t', function (key, options) {
             let hash = options?.hash;
             return t(key, hash || options || {});
@@ -36,7 +39,7 @@ class MemberWelcomeEmailRenderer {
         this.Handlebars.registerPartial('contentStyles', contentStylesSource);
         this.Handlebars.registerPartial('cardStyles', cardStylesSource);
         this.Handlebars.registerPartial('styles',
-            '<style>\n{{>baseStyles}}\n{{>contentStyles}}\n{{>cardStyles}}\n</style>'
+            '<style>\n{{>baseStyles}}\n{{>contentStyles}}\n{{>cardStyles}}\n.header {\n    line-height: 1.4;\n    {{#if headerBackgroundColor}}\n    background-color: {{headerBackgroundColor}};\n    {{else}}\n    background-color: {{backgroundColor}};\n    {{/if}}\n}\n.header-image {\n    padding-top: 24px;\n    padding-bottom: 16px;\n}\n.site-info {\n    padding-top: 32px;\n}\n.site-url {\n    color: {{#if headerBackgroundIsDark}}#ffffff{{else}}#15212A{{/if}};\n    font-size: 16px;\n    letter-spacing: -0.1px;\n    font-weight: 700;\n    text-transform: uppercase;\n    text-align: center;\n}\n.site-url-bottom-padding {\n    padding-bottom: 12px;\n}\n.site-title {\n    color: {{#if headerBackgroundIsDark}}#ffffff{{else}}#15212A{{/if}};\n}\n.footer-powered {\n    text-align: center;\n    padding-top: 32px;\n    padding-bottom: 20px;\n}\n.gh-powered {\n    width: 142px;\n    height: 30px;\n}\n</style>'
         );
         const emailWrapperSource = fs.readFileSync(
             path.join(__dirname, '../email-rendering/partials/email-wrapper.hbs'),
@@ -109,24 +112,25 @@ class MemberWelcomeEmailRenderer {
      * @param {string} options.lexical - Lexical JSON string to render
      * @param {string} options.subject - Email subject (may contain template variables)
      * @param {Object} options.member - Member data (name, email)
+     * @param {Object} [options.designSettings] - Email design settings from the database
      * @param {Object} options.siteSettings - Site settings (title, url, accentColor)
      * @returns {Promise<{html: string, text: string, subject: string}>}
      */
-    async render({lexical, subject, member, siteSettings}) {
+    async render({lexical, subject, member, designSettings = {}, siteSettings}) {
         const design = getEmailDesign({
             accentColor: siteSettings.accentColor,
-            backgroundColor: '#ffffff',
-            buttonColor: 'accent',
-            buttonCorners: null,
-            buttonStyle: null,
-            dividerColor: null,
-            headerBackgroundColor: null,
-            imageCorners: null,
-            linkColor: 'accent',
-            linkStyle: null,
+            backgroundColor: designSettings.background_color,
+            buttonColor: designSettings.button_color,
+            buttonCorners: designSettings.button_corners,
+            buttonStyle: designSettings.button_style,
+            dividerColor: designSettings.divider_color,
+            headerBackgroundColor: designSettings.header_background_color,
+            imageCorners: designSettings.image_corners,
+            linkColor: designSettings.link_color,
+            linkStyle: designSettings.link_style,
             postTitleColor: null,
-            sectionTitleColor: null,
-            titleFontWeight: 'bold'
+            sectionTitleColor: designSettings.section_title_color,
+            titleFontWeight: designSettings.title_font_weight
         });
 
         let content;
@@ -162,6 +166,15 @@ class MemberWelcomeEmailRenderer {
         const html = this.#wrapperTemplate({
             content: contentWithAbsoluteLinks,
             emailTitle: subjectWithReplacements,
+            footerContent: designSettings.footer_content,
+            hasHeaderContent: Boolean(designSettings.header_image || designSettings.show_header_title),
+            headerImage: designSettings.header_image,
+            showBadge: designSettings.show_badge,
+            showHeaderTitle: designSettings.show_header_title,
+            site: {
+                title: siteSettings.title,
+                url: siteSettings.url
+            },
             subject: subjectWithReplacements,
             siteTitle: siteSettings.title,
             siteUrl: siteSettings.url,

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -7,7 +7,7 @@ const settingsHelpers = require('../settings-helpers');
 const EmailAddressParser = require('../email-address/email-address-parser');
 const mail = require('../mail');
 // @ts-expect-error type checker has trouble with the dynamic exporting in models
-const {AutomatedEmail, Newsletter} = require('../../models');
+const {AutomatedEmail, EmailDesignSetting, Newsletter} = require('../../models');
 const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
 const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_TAG, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
 
@@ -93,11 +93,20 @@ class MemberWelcomeEmailService {
         return this.#defaultNewsletterSenderOptions;
     }
 
+    async #getEmailDesignSettings(emailDesignSettingId) {
+        if (!emailDesignSettingId) {
+            return null;
+        }
+
+        const emailDesignSetting = await EmailDesignSetting.findOne({id: emailDesignSettingId});
+        return emailDesignSetting ? emailDesignSetting.toJSON() : null;
+    }
+
     async loadMemberWelcomeEmails() {
         this.#defaultNewsletterSenderOptions = await this.#getDefaultNewsletterSenderOptions();
 
         for (const [memberStatus, slug] of Object.entries(MEMBER_WELCOME_EMAIL_SLUGS)) {
-            const row = await AutomatedEmail.findOne({slug});
+            const row = await AutomatedEmail.findOne({slug}, {withRelated: ['emailDesignSetting']});
 
             if (!row || !row.get('lexical')) {
                 this.#memberWelcomeEmails[memberStatus] = null;
@@ -108,6 +117,8 @@ class MemberWelcomeEmailService {
                 lexical: row.get('lexical'),
                 subject: row.get('subject'),
                 status: row.get('status'),
+                emailDesignSettingId: row.get('email_design_setting_id'),
+                designSettings: row.related('emailDesignSetting')?.toJSON() || null,
                 senderName: row.get('sender_name'),
                 senderEmail: row.get('sender_email'),
                 senderReplyTo: row.get('sender_reply_to')
@@ -131,6 +142,7 @@ class MemberWelcomeEmailService {
         }, `${MEMBER_WELCOME_EMAIL_LOG_KEY} Sending welcome email to ${name}${member.email}`);
 
         const memberWelcomeEmail = this.#memberWelcomeEmails[memberStatus];
+        const designSettings = await this.#getEmailDesignSettings(memberWelcomeEmail?.emailDesignSettingId) || memberWelcomeEmail?.designSettings;
 
         if (!memberWelcomeEmail) {
             throw new errors.IncorrectUsageError({
@@ -152,6 +164,7 @@ class MemberWelcomeEmailService {
                 email: member.email,
                 uuid: member.uuid
             },
+            designSettings,
             siteSettings: this.#getSiteSettings()
         });
 
@@ -211,6 +224,7 @@ class MemberWelcomeEmailService {
             lexical,
             subject,
             member: testMember,
+            designSettings: await this.#getEmailDesignSettings(automatedEmail.get('email_design_setting_id')),
             siteSettings: this.#getSiteSettings()
         });
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -7451,6 +7451,158 @@ Object {
 }
 `;
 
+exports[`Members API Email verification trigger Can add a member and trigger host email verification limits 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": Object {
+        "id": null,
+        "referrer_medium": "Ghost Admin",
+        "referrer_source": "Created manually",
+        "referrer_url": null,
+        "title": null,
+        "type": null,
+        "url": null,
+      },
+      "avatar_image": null,
+      "can_comment": true,
+      "commenting": Object {
+        "disabled": false,
+        "disabled_reason": null,
+        "disabled_until": null,
+      },
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "memberPassWebhookVerification@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "pass webhook verification",
+      "newsletters": Array [
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Newsletter",
+          "status": "active",
+        },
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Weekly newsletter",
+          "status": "active",
+        },
+      ],
+      "note": null,
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "tiers": Array [],
+      "unsubscribe_url": Any<String>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Email verification trigger Can add a member and trigger host email verification limits 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1083",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Email verification trigger Can add a member and trigger host email verification limits 3: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": Object {
+        "id": null,
+        "referrer_medium": "Ghost Admin",
+        "referrer_source": "Created manually",
+        "referrer_url": null,
+        "title": null,
+        "type": null,
+        "url": null,
+      },
+      "avatar_image": null,
+      "can_comment": true,
+      "commenting": Object {
+        "disabled": false,
+        "disabled_reason": null,
+        "disabled_until": null,
+      },
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "memberFailWebhookVerification@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "fail webhook verification",
+      "newsletters": Array [
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Newsletter",
+          "status": "active",
+        },
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Weekly newsletter",
+          "status": "active",
+        },
+      ],
+      "note": null,
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "tiers": Array [],
+      "unsubscribe_url": Any<String>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Email verification trigger Can add a member and trigger host email verification limits 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1083",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Errors when fetching stats with unknown days param value 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -431,5 +431,75 @@ describe('Member Welcome Emails Integration', function () {
             assert(!sendCall.args[0].html.includes('{uuid}'));
             assert(!sendCall.args[0].html.includes('%7Buuid%7D'));
         });
+
+        it('uses the latest design settings when sending cached welcome emails', async function () {
+            const memberWelcomeEmailService = require('../../../core/server/services/member-welcome-emails/service');
+            memberWelcomeEmailService.init();
+            await memberWelcomeEmailService.api.loadMemberWelcomeEmails();
+
+            await db.knex('email_design_settings')
+                .where('id', defaultEmailDesignSettingId)
+                .update({
+                    footer_content: '<p>Updated footer</p>',
+                    show_badge: true
+                });
+
+            await memberWelcomeEmailService.api.send({
+                member: {
+                    name: 'Cached Design Member',
+                    email: 'cached-design@example.com',
+                    uuid: '77777777-7777-4777-8777-777777777777'
+                },
+                memberStatus: 'free'
+            });
+
+            sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
+            const sendCall = mailService.GhostMailer.prototype.send.firstCall;
+            assert.ok(sendCall.args[0].html.includes('Updated footer</p>'));
+            assert.ok(sendCall.args[0].html.includes('https://ghost.org/?via=pbg-newsletter'));
+        });
+
+        it('uses the latest design settings when sending test welcome emails', async function () {
+            const memberWelcomeEmailService = require('../../../core/server/services/member-welcome-emails/service');
+            memberWelcomeEmailService.init();
+
+            const automatedEmail = await db.knex('automated_emails')
+                .where('slug', MEMBER_WELCOME_EMAIL_SLUGS.free)
+                .first();
+
+            await db.knex('email_design_settings')
+                .where('id', defaultEmailDesignSettingId)
+                .update({
+                    footer_content: '<p>First footer</p>',
+                    show_badge: true
+                });
+
+            await memberWelcomeEmailService.api.sendTestEmail({
+                email: 'test-member@example.com',
+                subject: 'Welcome test',
+                lexical: automatedEmail.lexical,
+                automatedEmailId: automatedEmail.id
+            });
+
+            await db.knex('email_design_settings')
+                .where('id', defaultEmailDesignSettingId)
+                .update({
+                    footer_content: '<p>Second footer</p>',
+                    show_badge: false
+                });
+
+            await memberWelcomeEmailService.api.sendTestEmail({
+                email: 'test-member@example.com',
+                subject: 'Welcome test',
+                lexical: automatedEmail.lexical,
+                automatedEmailId: automatedEmail.id
+            });
+
+            sinon.assert.calledTwice(mailService.GhostMailer.prototype.send);
+            assert.ok(mailService.GhostMailer.prototype.send.firstCall.args[0].html.includes('First footer</p>'));
+            assert.ok(mailService.GhostMailer.prototype.send.firstCall.args[0].html.includes('https://ghost.org/?via=pbg-newsletter'));
+            assert.ok(mailService.GhostMailer.prototype.send.secondCall.args[0].html.includes('Second footer</p>'));
+            assert.ok(!mailService.GhostMailer.prototype.send.secondCall.args[0].html.includes('https://ghost.org/?via=pbg-newsletter'));
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -2,9 +2,11 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const errors = require('@tryghost/errors');
+const {getEmailDesign: getRealEmailDesign} = require('../../../../../core/server/services/email-rendering/email-design');
 
 describe('MemberWelcomeEmailRenderer', function () {
     let MemberWelcomeEmailRenderer;
+    let getEmailDesignStub;
     let lexicalRenderStub;
 
     const defaultSiteSettings = {
@@ -15,11 +17,14 @@ describe('MemberWelcomeEmailRenderer', function () {
 
     beforeEach(function () {
         lexicalRenderStub = sinon.stub().resolves('<p>Hello World</p>');
+        getEmailDesignStub = sinon.stub();
+        getEmailDesignStub.callsFake(getRealEmailDesign);
 
         MemberWelcomeEmailRenderer = rewire('../../../../../core/server/services/member-welcome-emails/member-welcome-email-renderer');
         MemberWelcomeEmailRenderer.__set__('lexicalLib', {
             render: lexicalRenderStub
         });
+        MemberWelcomeEmailRenderer.__set__('getEmailDesign', getEmailDesignStub);
     });
 
     afterEach(function () {
@@ -30,6 +35,32 @@ describe('MemberWelcomeEmailRenderer', function () {
         it('renders Lexical content to HTML via lexicalLib.render', async function () {
             const renderer = new MemberWelcomeEmailRenderer({t: key => key});
             const lexicalJson = '{"root":{"children":[]}}';
+
+            getEmailDesignStub.callsFake(() => ({
+                accentColor: '#ff0000',
+                accentContrastColor: '#FFFFFF',
+                backgroundColor: '#ffffff',
+                backgroundIsDark: false,
+                buttonBorderRadius: '6px',
+                buttonColor: '#ff0000',
+                buttonCorners: null,
+                buttonStyle: null,
+                buttonTextColor: '#FFFFFF',
+                dividerColor: '#e0e7eb',
+                hasOutlineButtons: false,
+                hasRoundedImageCorners: false,
+                headerBackgroundColor: null,
+                headerBackgroundIsDark: false,
+                imageCorners: null,
+                linkColor: '#ff0000',
+                linkStyle: 'underline',
+                postTitleColor: '#000000',
+                sectionTitleColor: null,
+                textColor: '#000000',
+                titleFontWeight: 'bold',
+                titleStrongWeight: '800',
+                titleWeight: '700'
+            }));
 
             await renderer.render({
                 lexical: lexicalJson,
@@ -64,6 +95,46 @@ describe('MemberWelcomeEmailRenderer', function () {
                 titleStrongWeight: '800',
                 titleWeight: '700'
             }});
+        });
+
+        it('passes database design settings to getEmailDesign', async function () {
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+
+            await renderer.render({
+                lexical: '{}',
+                subject: 'Welcome!',
+                member: {name: 'John', email: 'john@example.com'},
+                designSettings: {
+                    background_color: 'dark',
+                    button_color: '#112233',
+                    button_corners: 'pill',
+                    button_style: 'outline',
+                    divider_color: '#445566',
+                    header_background_color: '#000000',
+                    image_corners: 'rounded',
+                    link_color: '#778899',
+                    link_style: 'plain',
+                    section_title_color: '#abcdef',
+                    title_font_weight: 'medium'
+                },
+                siteSettings: defaultSiteSettings
+            });
+
+            sinon.assert.calledWithExactly(getEmailDesignStub, {
+                accentColor: '#ff0000',
+                backgroundColor: 'dark',
+                buttonColor: '#112233',
+                buttonCorners: 'pill',
+                buttonStyle: 'outline',
+                dividerColor: '#445566',
+                headerBackgroundColor: '#000000',
+                imageCorners: 'rounded',
+                linkColor: '#778899',
+                linkStyle: 'plain',
+                postTitleColor: null,
+                sectionTitleColor: '#abcdef',
+                titleFontWeight: 'medium'
+            });
         });
 
         it('substitutes member template variables', async function () {
@@ -254,6 +325,11 @@ describe('MemberWelcomeEmailRenderer', function () {
             const renderer = new MemberWelcomeEmailRenderer({t: key => key});
             const year = new Date().getFullYear();
 
+            getEmailDesignStub.callsFake(() => ({
+                backgroundColor: '#ffffff',
+                backgroundIsDark: false
+            }));
+
             const result = await renderer.render({
                 lexical: '{}',
                 subject: 'Test Subject',
@@ -268,6 +344,34 @@ describe('MemberWelcomeEmailRenderer', function () {
             assert(result.html.includes(`&copy; ${year}`));
             assert(result.html.includes('Manage your preferences'));
             assert(result.html.includes('https://example.com/#/portal/account'));
+        });
+
+        it('renders header and footer settings from the database', async function () {
+            lexicalRenderStub.resolves('<p>Content</p>');
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+
+            getEmailDesignStub.callsFake(() => ({
+                backgroundColor: '#ffffff',
+                backgroundIsDark: false
+            }));
+
+            const result = await renderer.render({
+                lexical: '{}',
+                subject: 'Test Subject',
+                member: {name: 'John', email: 'john@example.com'},
+                designSettings: {
+                    header_image: 'https://example.com/header.png',
+                    show_header_title: false,
+                    show_badge: true,
+                    footer_content: '<p>Custom footer</p>'
+                },
+                siteSettings: defaultSiteSettings
+            });
+
+            assert(result.html.includes('https://example.com/header.png'));
+            assert(!result.html.includes('class="site-title"'));
+            assert(result.html.includes('Custom footer</p>'));
+            assert(result.html.includes('https://ghost.org/?via=pbg-newsletter'));
         });
 
         it('resolves relative portal links to absolute URLs', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1197/use-design-settings-from-the-database-when-rendering-welcome-emails

