### PR TITLE
Restore Renovate automerge rebasing

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,8 +2,6 @@
     "extends": [
         "github>tryghost/renovate-config"
     ],
-    // This reduces PR churn when managing lots of dependencies
-    "rebaseWhen": "never",
     // We have to disable platform based automerge (forcing renovate to do it manually)
     // as otherwise renovate wont follow our schedule
     "platformAutomerge": false,


### PR DESCRIPTION
## Summary
- remove Ghost's local `rebaseWhen: "never"` override so the shared TryGhost preset can apply `rebaseWhen: "automerging"`
- preserve the current Ghost automerge schedule and `platformAutomerge: false` behavior while testing the smallest config change that matches the logs
- document the timeline behind the change in the commit message: frequent self-merges through early October, sharp drop after the 2025-10-15 local config change, and recurring Mend logs showing `rebaseWhen=never so skipping branch update check` and `no-work`

## Why this change
Our investigation found that Ghost's shared Renovate preset expects rebasing during automerge, but the repo has locally overridden that to `never` since Oct 15 2025.

The recent Mend logs repeatedly show existing PRs being revisited without progressing to merge, with `rebaseWhen=never so skipping branch update check` followed by `no-work`. Restoring the preset's automerging rebase behavior is the smallest targeted change that may allow automergeable PRs to rebase and merge again without changing the current merge schedule.
