### PR TITLE
fix: [Activitypub] Implement retrieving object part of the spec

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
@@ -55,12 +55,17 @@ const forTag = (id, attrs, options) => {
         attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
     }
 
-    return attrs;
-};
-
-const forImage = (path) => {
     return urlUtils.urlFor('image', {image: path}, true);
 };
+
+const forActivityPub = (resource) => {
+    return urlUtils.urlFor('activitypub', resource, true);
+};
+
+module.exports.forPost = forPost;
+module.exports.forUser = forUser;
+module.exports.forTag = forTag;
+module.exports.forActivityPub = forActivityPub;
 
 module.exports.forPost = forPost;
 module.exports.forUser = forUser;


### PR DESCRIPTION
Addition of a new function `forActivityPub` that generates URLs for ActivityPub resources.

Closes #27097

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches shared URL serializer utilities and appears to regress existing exports/return values (`forTag` now returns an image URL using an undefined `path`, and `forImage` is still exported but no longer defined), which can break API responses at runtime.
> 
> **Overview**
> Adds a new `forActivityPub(resource)` URL serializer that generates absolute ActivityPub URLs via `urlUtils.urlFor('activitypub', ...)`.
> 
> However, the change also alters `forTag` to return an image URL (referencing an undefined `path`) and introduces inconsistent/duplicated `module.exports` entries, including exporting `forImage` without a corresponding function definition—suggesting an accidental regression in existing URL serialization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e217790a3ef30e31a7dc9d5e4aaff6456d90b573. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->