### PR TITLE
Limit Renovate concurrent branches to 20

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,11 @@
     "extends": [
         "github>tryghost/renovate-config"
     ],
+    // Limit concurrent branches to keep Renovate runs within the 30-minute
+    // Mend timeout and avoid overwhelming CI with dozens of queued jobs.
+    // The shared preset disables rate limiting, but Ghost's monorepo is
+    // large enough that unlimited branches cause timeouts during rebasing.
+    "branchConcurrentLimit": 20,
     // We have to disable platform based automerge (forcing renovate to do it manually)
     // as otherwise renovate wont follow our schedule
     "platformAutomerge": false,


### PR DESCRIPTION
## Summary
- Add `branchConcurrentLimit: 20` to Ghost's local Renovate config
- Overrides the shared preset's `:disableRateLimiting` which allows unlimited branches

## Why
After restoring `rebaseWhen=automerging` in #27096, Renovate started rebasing all stale branches on every run. With 150+ accumulated branches from 5 months of broken automerge, each run hit the 30-minute Mend timeout before completing. Capping at 20 branches keeps runs well within the time limit and lets Renovate work through updates incrementally as it merges existing ones.
