### PR TITLE
fix: Use modern email validator to support new gTLDs (.rocks, .radio, .app)

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
@@ -73,7 +73,7 @@ module.exports = {
         const subject = frame.data.subject;
         const lexical = frame.data.lexical;
 
-        if (typeof email !== 'string' || !validator.isEmail(email)) {
+        if (typeof email !== 'string' || !validator.isEmail(email, {legacy: false})) {
             throw new ValidationError({
                 message: tpl(messages.invalidEmailReceived)
             });

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/invitations.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/invitations.js
@@ -39,7 +39,7 @@ module.exports = {
 
         const email = frame.data.email;
 
-        if (typeof email !== 'string' || !validator.isEmail(email)) {
+        if (typeof email !== 'string' || !validator.isEmail(email, {legacy: false})) {
             throw new errors.BadRequestError({
                 message: tpl(messages.invalidEmailReceived)
             });

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/password_reset.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/password_reset.js
@@ -30,7 +30,7 @@ module.exports = {
 
         const email = frame.data.password_reset?.[0]?.email;
 
-        if (typeof email !== 'string' || !validator.isEmail(email)) {
+        if (typeof email !== 'string' || !validator.isEmail(email, {legacy: false})) {
             throw new errors.BadRequestError({
                 message: tpl(messages.invalidEmailReceived)
             });

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/settings.js
@@ -55,7 +55,7 @@ module.exports = {
             if (emailTypeSettings.includes(setting.key)) {
                 const email = setting.value;
 
-                if (typeof email !== 'string' || (!validator.isEmail(email) && email !== 'noreply')) {
+                if (typeof email !== 'string' || (!validator.isEmail(email, {legacy: false}) && email !== 'noreply')) {
                     const typeError = new ValidationError({
                         message: tpl(messages.invalidEmailValueReceived),
                         property: setting.key

--- a/ghost/core/core/server/services/email-address/email-address-service-wrapper.js
+++ b/ghost/core/core/server/services/email-address/email-address-service-wrapper.js
@@ -37,7 +37,7 @@ class EmailAddressServiceWrapper {
                 return settingsHelpers.getMembersSupportAddress();
             },
             isValidEmailAddress: (emailAddress) => {
-                return validator.isEmail(emailAddress);
+                return validator.isEmail(emailAddress, {legacy: false});
             }
         });
     }

--- a/ghost/core/core/server/services/lib/magic-link/magic-link.js
+++ b/ghost/core/core/server/services/lib/magic-link/magic-link.js
@@ -72,7 +72,7 @@ class MagicLink {
     async sendMagicLink(options) {
         this.sentry?.captureMessage?.(`[Magic Link] Generating magic link`, {extra: options});
 
-        if (!isEmail(options.email)) {
+        if (!isEmail(options.email, {legacy: false})) {
             throw new BadRequestError({
                 message: tpl(messages.invalidEmail)
             });

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -703,7 +703,7 @@ module.exports = class RouterController {
             });
         }
 
-        if (!isEmail(email)) {
+        if (!isEmail(email, {legacy: false})) {
             throw new errors.BadRequestError({
                 message: tpl(messages.invalidEmail)
             });

--- a/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
+++ b/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
@@ -57,6 +57,24 @@ describe('MagicLink', function () {
             assert.rejects(service.sendMagicLink(args));
         });
 
+        it('Accepts email addresses with modern gTLDs', async function () {
+            const options = buildOptions();
+            const service = new MagicLink(options);
+
+            const args = {
+                email: 'test@example.rocks',
+                tokenData: {
+                    id: '420'
+                },
+                type: 'signin'
+            };
+
+            await service.sendMagicLink(args);
+
+            sinon.assert.calledOnce(options.transporter.sendMail);
+            assert.equal(options.transporter.sendMail.firstCall.args[0].to, args.email);
+        });
+
         it('Sends an email to the user with a link generated from getSigninURL(token, type)', async function () {
             const options = buildOptions();
             const service = new MagicLink(options);

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -1007,18 +1007,53 @@ describe('RouterController', function () {
                 await controller.sendMagicLink(req, res);
                 assert.equal(sendEmailWithMagicLinkStub.notCalled, true);
             });
+        });
+
+        describe('email validation', function () {
+            let req, res, sendEmailWithMagicLinkStub;
+
+            const createRouterController = (deps = {}) => {
+                return new RouterController({
+                    allowSelfSignup: sinon.stub().returns(true),
+                    memberAttributionService: {
+                        getAttribution: sinon.stub().resolves({})
+                    },
+                    sendEmailWithMagicLink: sendEmailWithMagicLinkStub,
+                    settingsCache,
+                    settingsHelpers,
+                    emailAddressService,
+                    ...deps
+                });
+            };
+
+            beforeEach(function () {
+                req = {
+                    body: {
+                        email: 'jamie@example.com',
+                        emailType: 'signup'
+                    },
+                    get: sinon.stub()
+                };
+                res = {
+                    writeHead: sinon.stub(),
+                    end: sinon.stub()
+                };
+                sendEmailWithMagicLinkStub = sinon.stub().resolves();
+            });
 
             it('Accepts email addresses with modern gTLDs', async function () {
                 const controller = createRouterController();
+                const email = 'jamie@example.rocks';
 
-                req.body.email = 'jamie@example.rocks';
-                req.body.honeypot = 'filled!';
+                req.body.email = email;
 
                 await controller.sendMagicLink(req, res);
 
                 sinon.assert.calledWith(res.writeHead, 201, {'Content-Type': 'application/json'});
                 assert.equal(res.end.calledOnceWith('{}'), true);
-                assert.equal(sendEmailWithMagicLinkStub.notCalled, true);
+                sinon.assert.calledOnce(sendEmailWithMagicLinkStub);
+                assert.equal(sendEmailWithMagicLinkStub.args[0][0].email, email);
+                assert.equal(sendEmailWithMagicLinkStub.args[0][0].requestedType, 'signup');
             });
         });
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -1007,6 +1007,19 @@ describe('RouterController', function () {
                 await controller.sendMagicLink(req, res);
                 assert.equal(sendEmailWithMagicLinkStub.notCalled, true);
             });
+
+            it('Accepts email addresses with modern gTLDs', async function () {
+                const controller = createRouterController();
+
+                req.body.email = 'jamie@example.rocks';
+                req.body.honeypot = 'filled!';
+
+                await controller.sendMagicLink(req, res);
+
+                sinon.assert.calledWith(res.writeHead, 201, {'Content-Type': 'application/json'});
+                assert.equal(res.end.calledOnceWith('{}'), true);
+                assert.equal(sendEmailWithMagicLinkStub.notCalled, true);
+            });
         });
 
         describe('OTC response handling', function () {


### PR DESCRIPTION
## Summary

Fixed email validation to support modern generic Top-Level Domains (gTLDs) like `.rocks`, `.radio`, `.app`, etc.

## Problem

Ghost's email validation was rejecting legitimate email addresses using newer gTLDs approved by ICANN after 2012. The legacy validator (validator@7.2.0 from 2017) predates many of these TLDs.

## Solution

Changed all `validator.isEmail()` calls to use `{legacy: false}` option, which enables the modern custom validator that properly handles all TLDs.

## Files Changed

- `email-address-service-wrapper.js`
- `automated_emails.js`
- `invitations.js`
- `password_reset.js`
- `settings.js`

## Testing

- Verified syntax of all changed files
- The modern validator is already used in member-repository.js and sending-service.js

Fixes #26197

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes email validation behavior across several auth/members-related endpoints (magic links, invitations, password reset, settings), which could affect who can trigger these flows. Risk is moderate because it broadens accepted input but doesn’t alter core authorization or token logic.
> 
> **Overview**
> Switches multiple server-side email validation call sites to use `validator.isEmail(..., {legacy: false})`, enabling support for modern gTLDs across automated email test sends, invitations, password reset token generation, member support address settings, managed email address validation, and magic-link sign-in/signup flows.
> 
> Adds unit coverage to ensure magic-link sending and the members `sendMagicLink` controller accept addresses like `example.rocks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ef92b74535d49e81bb502e9f0ca9c0c28fe9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->