### PR TITLE
Fixed flaky timezone unit test that spawned a subprocess

### DIFF
--- a/ghost/core/test/unit/server/data/seeders/data-generator.test.js
+++ b/ghost/core/test/unit/server/data/seeders/data-generator.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const {spawnSync} = require('node:child_process');
 
 const knex = require('knex').default;
 
@@ -256,20 +255,18 @@ describe('Importer', function () {
 
 describe('Events Generator', function () {
     it('Parses database timestamps as UTC in non-UTC timezones', function () {
-        const script = `
-            const dateToDatabaseString = require(${JSON.stringify(require.resolve('../../../../../core/server/data/seeders/utils/database-date'))});
-            process.stdout.write(dateToDatabaseString.parse('2026-03-26 11:50:00.000').toISOString());
-        `;
-        const result = spawnSync(process.execPath, ['-e', script], {
-            env: {
-                ...process.env,
-                TZ: 'America/New_York'
-            },
-            encoding: 'utf8'
-        });
-
-        assert.equal(result.status, 0);
-        assert.equal(result.stdout, '2026-03-26T11:50:00.000Z');
+        const originalTZ = process.env.TZ;
+        try {
+            process.env.TZ = 'America/New_York';
+            const result = dateToDatabaseString.parse('2026-03-26 11:50:00.000');
+            assert.equal(result.toISOString(), '2026-03-26T11:50:00.000Z');
+        } finally {
+            if (originalTZ === undefined) {
+                delete process.env.TZ;
+            } else {
+                process.env.TZ = originalTZ;
+            }
+        }
     });
 
     it('Returns the start date when a range is inverted', function () {


### PR DESCRIPTION
## Summary
- The "Parses database timestamps as UTC in non-UTC timezones" test in `data-generator.test.js` used `spawnSync` to launch a child Node process with `TZ=America/New_York`, which intermittently timed out on CI (2s default mocha timeout)
- Since modern Node.js picks up `process.env.TZ` changes mid-process, we can set the timezone in-process instead — same test coverage, no subprocess, no flaky timeout
- This is the test causing the unit test failure on #27132 (and likely other PRs intermittently)

## Test plan
- [x] Lint passes (verified by pre-commit hook)
- [ ] CI unit tests pass without the timeout flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)