### PR TITLE
🌐 Added check for empty keys in context.json for i18n

### DIFF
--- a/ghost/i18n/generate-context.js
+++ b/ghost/i18n/generate-context.js
@@ -34,5 +34,24 @@ const CONTEXT_FILE = './locales/context.json';
         process.exit(1);
     }
 
+    const emptyKeys = Object.keys(orderedContext).filter((key) => {
+        const value = orderedContext[key] ?? '';
+        return value.trim() === '';
+    });
+
+    if (emptyKeys.length > 0) {
+        if (process.env.CI) {
+            const keyList = emptyKeys.map(k => '  - "' + k + '"').join('\n');
+            // eslint-disable-next-line no-console
+            console.error('Translation keys are missing context descriptions in context.json:\n' + keyList);
+            // eslint-disable-next-line no-console
+            console.error('\nAdd a description for each key in locales/context.json to help translators understand where and how the string is used.');
+            process.exit(1);
+        } else {
+            // eslint-disable-next-line no-console
+            console.warn(`Warning: ${emptyKeys.length} key(s) in context.json have empty descriptions. Please add context before committing.`);
+        }
+    }
+
     await fs.writeFile(CONTEXT_FILE, newContent);
 })();


### PR DESCRIPTION
no ref

- We have CI checks to make sure that new i18n keys are added to context.json when they're generated, but there's no requirement to add any actual explanation for the key
- This fixes that. When generate-context.js runs locally it will log a warning, but in CI it will error
- This will apply to any i18n strings added from here on out - existing empty strings will be backfilled in https://github.com/TryGhost/Ghost/pull/27170 (to land before this one)

### testing
  1. Add a new translatable string to any scanned source file, e.g. in apps/portal/src/: `t('Some test string')`                                                                              
  2. Run `yarn translate` in ghost/i18n -- should print:                                               
  `Warning: 1 key(s) in context.json have empty descriptions. Please add context before committing. `  
  3. Verify the new key was added to locales/context.json with an empty value                        
  4. Simulate CI: run `CI=true node generate-context.js` in ghost/i18n -- should exit with code 1 and list the key                                                                                       
  5. Add a description for the key in context.json                                                   
  6. Run `CI=true node generate-context.js` again -- should pass                                       
  7. Revert your test string and run yarn translate to clean up