### PR TITLE
Added i18n guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,39 @@ yarn dev:all                   # Include all optional services
 - Single source: `ghost/i18n/locales/{locale}/{namespace}.json`
 - Namespaces: `ghost`, `portal`, `signup-form`, `comments`, `search`
 - 60+ supported locales
+- Context descriptions: `ghost/i18n/locales/context.json` — every key must have a non-empty description
+
+**Translation Workflow:**
+```bash
+yarn workspace @tryghost/i18n translate   # Extract keys from source, update all locale files + context.json
+yarn workspace @tryghost/i18n lint:translations  # Validate interpolation variables across locales
+```
+
+`yarn translate` is run as part of `yarn workspace @tryghost/i18n test`. In CI, it fails if translation keys or `context.json` are out of date (`failOnUpdate: process.env.CI`). Always run `yarn translate` after adding or changing `t()` calls.
+
+**Rules for Translation Keys:**
+1. **Never split sentences across multiple `t()` calls.** Translators cannot reorder words across separate keys. Instead, use `@doist/react-interpolate` to embed React elements (links, bold, etc.) within a single translatable string.
+2. **Always provide context descriptions.** When adding a new key, add a description in `context.json` explaining where the string appears and what it does. CI will reject empty descriptions.
+3. **Use interpolation for dynamic values.** Ghost uses `{variable}` syntax: `t('Welcome back, {name}!', {name: firstname})`
+4. **Use `<tag>` syntax for inline elements.** Combined with `@doist/react-interpolate`: `t('Click <a>here</a> to retry')` with `mapping={{ a: <a href="..." /> }}`
+
+**Correct pattern (using Interpolate):**
+```jsx
+import Interpolate from '@doist/react-interpolate';
+
+<Interpolate
+    mapping={{ a: <a href={link} /> }}
+    string={t('Could not sign in. <a>Click here to retry</a>')}
+/>
+```
+
+**Incorrect pattern (split sentences):**
+```jsx
+// BAD: translators cannot reorder "Click here to retry" relative to the first sentence
+{t('Could not sign in.')} <a href={link}>{t('Click here to retry')}</a>
+```
+
+See `apps/portal/src/components/pages/email-receiving-faq.js` for a canonical example of correct `Interpolate` usage.
 
 ### Build Dependencies (Nx)
 


### PR DESCRIPTION
## Summary
- Expanded the i18n Architecture section in AGENTS.md with practical rules for developers and AI agents
- Documents the translation workflow (`yarn translate`), CI enforcement, and key rules:
  - Never split sentences across multiple `t()` calls
  - Always provide context descriptions in `context.json`
  - Use `@doist/react-interpolate` for inline elements (`<a>`, `<strong>`, etc.)
  - Use `{variable}` interpolation for dynamic values
- Includes correct/incorrect code examples and a reference to the canonical example

### Why
Translation contributors flagged that split-sentence keys prevent proper localization. This documentation ensures developers and agents building new features know the rules without needing to discover them through trial and error.

## Test plan
- [ ] Review the added documentation for accuracy and completeness