### PR TITLE
Fixed inconsistent spacing in editor buttons

### DIFF
--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -1022,7 +1022,6 @@ body[data-user-is-dragging] .gh-editor-feature-image-dropzone {
     line-height: 34px;
     background: var(--white);
     border-radius: var(--border-radius);
-    margin-left: 8px;
 }
 
 @media (max-width: 500px) {
@@ -1078,6 +1077,7 @@ body[data-user-is-dragging] .gh-editor-feature-image-dropzone {
 .gh-editor-publish-buttons {
     display: flex;
     align-items: center;
+    gap: 8px;
     height: 100%;
     pointer-events: auto;
 }
@@ -1098,15 +1098,7 @@ body[data-user-is-dragging] .gh-editor-feature-image-dropzone {
     border-radius: var(--border-radius);
 }
 
-.gh-editor-save-trigger {
-    margin-right: 8px;
-}
 
-@media (max-width: 500px) {
-    .gh-editor-save-trigger {
-        margin-right: 0;
-    }
-}
 
 .gh-editor-preview-trigger {
     height: 34px;

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -16,7 +16,7 @@
                     @saveTask={{this.saveTask}}
                     as |publishManagement|
                 >
-                    <div class="flex items-center pe-auto h-100">
+                    <div class="flex items-center pe-auto h-100 gap-2">
                         {{#if this.ui.isFullScreen}}
                             {{#if this.fromAnalytics}}
                                 <a href="#{{this.fromAnalytics}}" class="gh-btn-editor gh-editor-back-button" data-test-breadcrumb>


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1337/right-side-buttons-have-inconsistent-spacing

The left and right side button groups in posts used inconsistent spacing between the buttons.

| Before | After |
|--------|--------|
| <img width="298" height="192" alt="Screenshot 2026-04-06 at 15 29 55" src="https://github.com/user-attachments/assets/8f595ccf-7439-4fe6-9790-1e9b6b231528" /> | <img width="300" height="198" alt="Screenshot 2026-04-06 at 15 29 20" src="https://github.com/user-attachments/assets/baa96bbb-d9f4-4c69-8f05-199a19ea4c94" />
