### PR TITLE
🌐 Added ESLint rule to detect adjacent t() calls in JSX

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -5,6 +5,11 @@ const FLAT_CONFIG_WORKSPACES = [
     'apps/admin'
 ];
 
+// Workspaces that use legacy eslintrc but need extra flags (e.g. --rulesdir)
+const LEGACY_SCOPED_WORKSPACES = [
+    {path: 'apps/comments-ui', extraFlags: ['--rulesdir', path.join(__dirname, 'ghost/i18n/eslint-rules')]}
+];
+
 function normalize(file) {
     return file.split(path.sep).join('/');
 }
@@ -33,6 +38,16 @@ function buildScopedEslintCommand(workspace, files) {
     return `yarn --cwd ${shellQuote(workspace)} eslint --cache ${relativeFiles}`;
 }
 
+function buildLegacyScopedEslintCommand(workspace, files) {
+    if (files.length === 0) {
+        return null;
+    }
+
+    const quotedFiles = files.map(file => shellQuote(normalize(file))).join(' ');
+    const flags = workspace.extraFlags.map(shellQuote).join(' ');
+    return `eslint --cache ${flags} ${quotedFiles}`;
+}
+
 function buildRootEslintCommand(files) {
     if (files.length === 0) {
         return null;
@@ -45,13 +60,17 @@ function buildRootEslintCommand(files) {
 module.exports = {
     '*.{js,ts,tsx,jsx,cjs}': (files) => {
         const workspaceGroups = new Map(FLAT_CONFIG_WORKSPACES.map(workspace => [workspace, []]));
+        const legacyGroups = new Map(LEGACY_SCOPED_WORKSPACES.map(ws => [ws.path, []]));
         const rootFiles = [];
 
         for (const file of files) {
-            const workspace = FLAT_CONFIG_WORKSPACES.find(candidate => isInWorkspace(file, candidate));
+            const flatWorkspace = FLAT_CONFIG_WORKSPACES.find(candidate => isInWorkspace(file, candidate));
+            const legacyWorkspace = LEGACY_SCOPED_WORKSPACES.find(ws => isInWorkspace(file, ws.path));
 
-            if (workspace) {
-                workspaceGroups.get(workspace).push(file);
+            if (flatWorkspace) {
+                workspaceGroups.get(flatWorkspace).push(file);
+            } else if (legacyWorkspace) {
+                legacyGroups.get(legacyWorkspace.path).push(file);
             } else {
                 rootFiles.push(file);
             }
@@ -60,6 +79,9 @@ module.exports = {
         return [
             ...FLAT_CONFIG_WORKSPACES
                 .map(workspace => buildScopedEslintCommand(workspace, workspaceGroups.get(workspace)))
+                .filter(Boolean),
+            ...LEGACY_SCOPED_WORKSPACES
+                .map(ws => buildLegacyScopedEslintCommand(ws, legacyGroups.get(ws.path)))
                 .filter(Boolean),
             buildRootEslintCommand(rootFiles)
         ].filter(Boolean);

--- a/apps/comments-ui/.eslintrc.js
+++ b/apps/comments-ui/.eslintrc.js
@@ -54,6 +54,10 @@ module.exports = {
         'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}],
 
         // This rule doesn't work correctly with TypeScript, and TypeScript has its own better version
-        'no-undef': 'off'
+        'no-undef': 'off',
+
+        // Flag potential split-sentence translation keys that break i18n.
+        // Warning-only: some adjacent t() calls are independent UI elements, not split sentences.
+        'no-adjacent-t-calls': 'warn'
     }
 };

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -25,7 +25,7 @@
     "test:e2e": "NODE_OPTIONS='--experimental-specifier-resolution=node --no-warnings' VITE_TEST=true playwright test",
     "test:slowmo": "TIMEOUT=100000 PLAYWRIGHT_SLOWMO=1000 yarn test:e2e --headed",
     "test:e2e:full": "ALL_BROWSERS=1 yarn test:e2e",
-    "lint": "eslint src --ext .js,.ts,.jsx,.tsx --cache",
+    "lint": "eslint src --ext .js,.ts,.jsx,.tsx --cache --rulesdir ../../ghost/i18n/eslint-rules",
     "preship": "yarn lint",
     "ship": "node ../../.github/scripts/release-apps.js",
     "prepublishOnly": "yarn build"

--- a/ghost/i18n/eslint-rules/no-adjacent-t-calls.js
+++ b/ghost/i18n/eslint-rules/no-adjacent-t-calls.js
@@ -1,0 +1,90 @@
+/**
+ * ESLint rule: no-adjacent-t-calls
+ *
+ * Detects adjacent t() calls in JSX that likely form a single sentence.
+ * Split sentences prevent translators from reordering words for different
+ * languages. Use @doist/react-interpolate with a single t() call instead.
+ *
+ * Bad:  {t('Could not sign in.')} <a>{t('Click here')}</a>
+ * Good: <Interpolate string={t('Could not sign in. <a>Click here</a>')} mapping={{a: <a />}} />
+ */
+
+function isTCall(node) {
+    return (
+        node.type === 'JSXExpressionContainer' &&
+        node.expression.type === 'CallExpression' &&
+        node.expression.callee.type === 'Identifier' &&
+        node.expression.callee.name === 't'
+    );
+}
+
+function containsTCall(node) {
+    if (!node) {
+        return false;
+    }
+    if (isTCall(node)) {
+        return true;
+    }
+    // Check JSX elements that have t() in their children
+    if (node.type === 'JSXElement') {
+        return node.children && node.children.some(child => containsTCall(child));
+    }
+    return false;
+}
+
+module.exports = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description:
+                'Disallow adjacent t() calls in JSX that form a single sentence. Use @doist/react-interpolate instead.'
+        },
+        messages: {
+            adjacentTCalls:
+                'Adjacent t() calls detected — this splits a sentence across multiple translation keys, preventing translators from reordering words. Use @doist/react-interpolate with a single t() call instead.'
+        }
+    },
+    create(context) {
+        return {
+            JSXElement(node) {
+                const children = node.children;
+                if (!children || children.length < 2) {
+                    return;
+                }
+
+                // Look for patterns where two t() calls (or elements wrapping t() calls)
+                // are siblings, possibly separated only by whitespace, <br/>, or inline elements
+                const significantChildren = children.filter((child) => {
+                    // Skip whitespace-only text
+                    if (child.type === 'JSXText' && child.value.trim() === '') {
+                        return false;
+                    }
+                    // Skip <br /> elements
+                    if (
+                        child.type === 'JSXElement' &&
+                        child.openingElement.name.type === 'JSXIdentifier' &&
+                        child.openingElement.name.name === 'br'
+                    ) {
+                        return false;
+                    }
+                    return true;
+                });
+
+                for (let i = 0; i < significantChildren.length - 1; i++) {
+                    const current = significantChildren[i];
+                    const next = significantChildren[i + 1];
+
+                    const currentHasT = containsTCall(current);
+                    const nextHasT = containsTCall(next);
+
+                    if (currentHasT && nextHasT) {
+                        context.report({
+                            node: next,
+                            messageId: 'adjacentTCalls'
+                        });
+                    }
+                }
+            }
+        };
+    }
+};


### PR DESCRIPTION
## Summary

- Added a custom ESLint rule `no-adjacent-t-calls` that detects adjacent `t()` calls in JSX — a pattern that splits sentences across multiple translation keys, preventing translators from reordering words for different languages
- Rule placed in shared location (`ghost/i18n/eslint-rules/`) so it can be reused across apps
- Enabled as a **warning** in `comments-ui` (not an error, since some adjacent `t()` calls are independent UI elements rather than split sentences)
- Updated lint-staged config so the `--rulesdir` flag is passed correctly during pre-commit

### How it works

The rule flags sibling JSX children that both contain `t()` calls, e.g.:

```jsx
// ⚠️ Flagged: split sentence
<p>{t('Could not sign in.')} <a>{t('Click here')}</a></p>

// ✅ Good: single translation key with interpolation
<p><Interpolate string={t('Could not sign in. <a>Click here</a>')} mapping={{a: <a />}} /></p>
```

### Why warn instead of error

Some adjacent `t()` calls are genuinely independent UI elements (e.g., a label next to a button), not split sentences. The rule is warning-only to surface potential issues without blocking CI. Future work could refine the heuristics or add `eslint-disable` comments for known false positives.

## Test plan

- [x] `yarn workspace @tryghost/comments-ui lint` passes (0 errors, warnings only)
- [x] Rule correctly flags known split-sentence patterns
- [x] Rule does not produce errors that would block CI