### PR TITLE
Fixed Podcast link in Portal Account Settings

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.67.8",
+  "version": "2.67.9",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/transistor-podcasts-action.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/transistor-podcasts-action.js
@@ -51,6 +51,7 @@ const TransistorPodcastsAction = ({hasPodcasts, memberUuid, settings = {}}) => {
                 href={transistorUrl}
                 rel='noopener noreferrer'
                 className='gh-portal-btn gh-portal-btn-list'
+                target="_parent"
             >
                 {buttonText}
             </a>

--- a/apps/portal/test/unit/components/pages/AccountHomePage/transistor-podcasts-action.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/transistor-podcasts-action.test.js
@@ -36,4 +36,11 @@ describe('TransistorPodcastsAction', () => {
         const link = getByText('Manage');
         expect(link.getAttribute('href')).toBe(`https://partner.transistor.fm/ghost/${TEST_UUID}`);
     });
+
+    test('Manage link opens in the parent browsing context', () => {
+        const {getByText} = setup({hasPodcasts: true, memberUuid: TEST_UUID});
+        const link = getByText('Manage');
+        expect(link.getAttribute('target')).toBe('_parent');
+        expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    });
 });


### PR DESCRIPTION
ref 35cbbbf7f3b3393a94e59d3d3abf14cc63377075

This was previously updated to remove the `target="_blank"` so that it opens in the same tab, however because Portal is in an iframe it needs to use the parent context in order to move navigation appropriately. 