### PR TITLE
Added dormant welcome email models

### DIFF
--- a/ghost/core/core/server/models/welcome-email-automated-email.js
+++ b/ghost/core/core/server/models/welcome-email-automated-email.js
@@ -1,0 +1,50 @@
+const ghostBookshelf = require('./base');
+const urlUtils = require('../../shared/url-utils');
+const lexicalLib = require('../lib/lexical');
+
+const WelcomeEmailAutomatedEmail = ghostBookshelf.Model.extend({
+    tableName: 'welcome_email_automated_emails',
+
+    /**
+     * @returns {import('bookshelf').Model}
+     */
+    emailDesignSetting() {
+        return this.belongsTo('EmailDesignSetting', 'email_design_setting_id', 'id');
+    },
+
+    welcomeEmailAutomation() {
+        return this.belongsTo('WelcomeEmailAutomation', 'welcome_email_automation_id', 'id');
+    },
+
+    nextWelcomeEmailAutomatedEmail() {
+        return this.belongsTo('WelcomeEmailAutomatedEmail', 'next_welcome_email_automated_email_id', 'id');
+    },
+
+    parse() {
+        const attrs = ghostBookshelf.Model.prototype.parse.apply(this, arguments);
+
+        // transform URLs from __GHOST_URL__ to absolute
+        if (attrs.lexical) {
+            attrs.lexical = urlUtils.transformReadyToAbsolute(attrs.lexical);
+        }
+
+        return attrs;
+    },
+
+    // Alternative to Bookshelf's .format() that is only called when writing to db
+    formatOnWrite(attrs) {
+        // Ensure lexical URLs are stored as transform-ready with __GHOST_URL__ representing config.url
+        if (attrs.lexical) {
+            attrs.lexical = urlUtils.lexicalToTransformReady(attrs.lexical, {
+                nodes: lexicalLib.nodes,
+                transformMap: lexicalLib.urlTransformMap
+            });
+        }
+
+        return attrs;
+    }
+});
+
+module.exports = {
+    WelcomeEmailAutomatedEmail: ghostBookshelf.model('WelcomeEmailAutomatedEmail', WelcomeEmailAutomatedEmail)
+};

--- a/ghost/core/core/server/models/welcome-email-automation.js
+++ b/ghost/core/core/server/models/welcome-email-automation.js
@@ -1,0 +1,19 @@
+const ghostBookshelf = require('./base');
+
+const WelcomeEmailAutomation = ghostBookshelf.Model.extend({
+    tableName: 'welcome_email_automations',
+
+    defaults() {
+        return {
+            status: 'inactive'
+        };
+    },
+
+    welcomeEmailAutomatedEmails() {
+        return this.hasMany('WelcomeEmailAutomatedEmail', 'welcome_email_automation_id');
+    }
+});
+
+module.exports = {
+    WelcomeEmailAutomation: ghostBookshelf.model('WelcomeEmailAutomation', WelcomeEmailAutomation)
+};

--- a/ghost/core/test/unit/server/models/welcome-email-automated-email.test.js
+++ b/ghost/core/test/unit/server/models/welcome-email-automated-email.test.js
@@ -1,0 +1,110 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const models = require('../../../../core/server/models');
+const config = require('../../../../core/shared/config');
+
+describe('Unit: models/welcome-email-automated-email', function () {
+    before(function () {
+        models.init();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('parse', function () {
+        it('transforms __GHOST_URL__ to absolute URL in lexical field', function () {
+            const model = models.WelcomeEmailAutomatedEmail.forge();
+
+            const result = model.parse({
+                id: '123',
+                lexical: '{"root":{"children":[{"type":"paragraph","children":[{"type":"link","url":"__GHOST_URL__/test"}]}]}}'
+            });
+
+            assert.ok(result.lexical.includes(`${config.get('url')}/test`));
+            assert.ok(!result.lexical.includes('__GHOST_URL__'));
+        });
+
+        it('handles null lexical field', function () {
+            const model = models.WelcomeEmailAutomatedEmail.forge();
+
+            const result = model.parse({
+                id: '123',
+                lexical: null
+            });
+
+            assert.equal(result.lexical, null);
+        });
+
+        it('handles undefined lexical field', function () {
+            const model = models.WelcomeEmailAutomatedEmail.forge();
+
+            const result = model.parse({
+                id: '123'
+            });
+
+            assert.equal(result.lexical, undefined);
+        });
+
+        it('preserves other fields', function () {
+            const model = models.WelcomeEmailAutomatedEmail.forge();
+
+            const result = model.parse({
+                id: '123',
+                subject: 'Welcome!',
+                lexical: '{"root":{"children":[]}}'
+            });
+
+            assert.equal(result.id, '123');
+            assert.equal(result.subject, 'Welcome!');
+        });
+    });
+
+    describe('formatOnWrite', function () {
+        it('transforms absolute URLs to __GHOST_URL__ in lexical field', function () {
+            const model = models.WelcomeEmailAutomatedEmail.forge();
+
+            const siteUrl = config.get('url');
+            const result = model.formatOnWrite({
+                lexical: `{"root":{"children":[{"type":"paragraph","children":[{"type":"link","url":"${siteUrl}/test"}]}]}}`
+            });
+
+            assert.ok(result.lexical.includes('__GHOST_URL__/test'));
+            assert.ok(!result.lexical.includes(siteUrl));
+        });
+
+        it('handles null lexical field', function () {
+            const model = models.WelcomeEmailAutomatedEmail.forge();
+
+            const result = model.formatOnWrite({
+                lexical: null
+            });
+
+            assert.equal(result.lexical, null);
+        });
+
+        it('handles undefined lexical field', function () {
+            const model = models.WelcomeEmailAutomatedEmail.forge();
+
+            const result = model.formatOnWrite({
+                subject: 'Welcome!'
+            });
+
+            assert.equal(result.lexical, undefined);
+            assert.equal(result.subject, 'Welcome!');
+        });
+
+        it('preserves other fields', function () {
+            const model = models.WelcomeEmailAutomatedEmail.forge();
+
+            const result = model.formatOnWrite({
+                id: '123',
+                subject: 'Welcome!',
+                lexical: '{"root":{"children":[]}}'
+            });
+
+            assert.equal(result.id, '123');
+            assert.equal(result.subject, 'Welcome!');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/models/welcome-email-automation.test.js
+++ b/ghost/core/test/unit/server/models/welcome-email-automation.test.js
@@ -1,0 +1,31 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const models = require('../../../../core/server/models');
+
+describe('Unit: models/welcome-email-automation', function () {
+    before(function () {
+        models.init();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('defaults', function () {
+        it('sets default status to inactive', function () {
+            const model = new models.WelcomeEmailAutomation();
+            const defaults = model.defaults();
+
+            assert.equal(defaults.status, 'inactive');
+        });
+
+        it('returns expected default values', function () {
+            const model = new models.WelcomeEmailAutomation();
+            const defaults = model.defaults();
+
+            assert.ok(defaults);
+            assert.equal(Object.keys(defaults).length, 1);
+            assert.equal(defaults.status, 'inactive');
+        });
+    });
+});


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1188
ref https://github.com/TryGhost/Ghost/pull/27183

We just added two new tables: `welcome_email_automations` and `welcome_email_automated_emails`. This adds dormant models for those, which are based on the existing `AutomatedEmail` model.

**You may wish to review a diff of these with their associated `AutomatedEmail` counterpart, which will make these changes look much smaller.** For example, I ran these commands as part of self-review:

```sh
vimdiff ghost/core/core/server/models/{automated-email,welcome-email-automation}.js
vimdiff ghost/core/core/server/models/{automated-email,welcome-email-automated-email}.js
vimdiff ghost/core/test/unit/server/models/{automated-email,welcome-email-automation}.test.js
vimdiff ghost/core/test/unit/server/models/{automated-email,welcome-email-automated-email}.test.js
```
