### PR TITLE
Disabled welcome email customization labs flag in tests

### DIFF
--- a/ghost/core/test/integration/services/member-welcome-emails-snapshot.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails-snapshot.test.js
@@ -2,16 +2,27 @@ const sinon = require('sinon');
 const i18nLib = require('@tryghost/i18n');
 const testUtils = require('../../utils');
 const {assertMatchSnapshot} = require('../../utils/assertions');
+const labs = require('../../../core/shared/labs');
 const MemberWelcomeEmailRenderer = require('../../../core/server/services/member-welcome-emails/member-welcome-email-renderer');
 
 describe('Member Welcome Email Renderer Snapshots', function () {
     let renderer;
+    let originalLabsIsSet;
 
     before(async function () {
         await testUtils.setup('default')();
     });
 
     beforeEach(function () {
+        originalLabsIsSet = labs.isSet;
+        sinon.stub(labs, 'isSet').callsFake((flag) => {
+            if (flag === 'welcomeEmailsDesignCustomization') {
+                return false;
+            }
+
+            return originalLabsIsSet(flag);
+        });
+
         const i18n = i18nLib('en', 'ghost');
         renderer = new MemberWelcomeEmailRenderer({t: i18n.t});
 

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -8,11 +8,13 @@ const db = require('../../../core/server/data/db');
 const mailService = require('../../../core/server/services/mail');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../core/server/services/member-welcome-emails/constants');
 const processOutbox = require('../../../core/server/services/outbox/jobs/lib/process-outbox');
+const labs = require('../../../core/shared/labs');
 
 describe('Member Welcome Emails Integration', function () {
     let membersService;
     let defaultNewsletterSenderState = null;
     let defaultEmailDesignSettingId;
+    let originalLabsIsSet;
 
     before(async function () {
         await testUtils.setup('default')();
@@ -25,6 +27,15 @@ describe('Member Welcome Emails Integration', function () {
     });
 
     beforeEach(async function () {
+        originalLabsIsSet = labs.isSet;
+        sinon.stub(labs, 'isSet').callsFake((flag) => {
+            if (flag === 'welcomeEmailsDesignCustomization') {
+                return false;
+            }
+
+            return originalLabsIsSet(flag);
+        });
+
         const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
         if (defaultNewsletter) {
             defaultNewsletterSenderState = {
@@ -78,6 +89,8 @@ describe('Member Welcome Emails Integration', function () {
     });
 
     afterEach(async function () {
+        sinon.restore();
+
         if (defaultNewsletterSenderState) {
             await db.knex('newsletters')
                 .where('id', defaultNewsletterSenderState.id)

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -2,10 +2,12 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const errors = require('@tryghost/errors');
+const labs = require('../../../../../core/shared/labs');
 
 describe('MemberWelcomeEmailRenderer', function () {
     let MemberWelcomeEmailRenderer;
     let lexicalRenderStub;
+    let originalLabsIsSet;
 
     const defaultSiteSettings = {
         title: 'Test Site',
@@ -14,6 +16,15 @@ describe('MemberWelcomeEmailRenderer', function () {
     };
 
     beforeEach(function () {
+        originalLabsIsSet = labs.isSet;
+        sinon.stub(labs, 'isSet').callsFake((flag) => {
+            if (flag === 'welcomeEmailsDesignCustomization') {
+                return false;
+            }
+
+            return originalLabsIsSet(flag);
+        });
+
         lexicalRenderStub = sinon.stub().resolves('<p>Hello World</p>');
 
         MemberWelcomeEmailRenderer = rewire('../../../../../core/server/services/member-welcome-emails/member-welcome-email-renderer');


### PR DESCRIPTION
refs https://linear.app/ghost/issue/NY-1197/use-design-settings-from-the-database-when-rendering-welcome-emails

This is a test-only change; there should be no user-facing impact from this.

## Summary

- labs flags default to "on" in these test suites, so these tests are currently running with the `welcomeEmailsDesignCustomization` flag enabled
- this change forces the existing welcome email integration and renderer tests to run with `welcomeEmailsDesignCustomization` disabled
- keep the legacy snapshot coverage unchanged, including existing snapshot names
- add the minimal sinon cleanup needed for the integration suite's shared labs stub

## Motivation

Getting ready to add substantial rendering changes with this labs flag _on_, and I want to ensure this upcoming change doesn't introduce any change in rendering behavior with the labs flag _off_.