### PR TITLE
Added Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,3 +267,38 @@ yarn nx reset                  # Reset Nx cache
 ### Test Issues
 - **E2E failures:** Check `e2e/CLAUDE.md` for debugging tips
 - **Docker issues:** `yarn docker:clean && yarn docker:build`
+
+## Cursor Cloud specific instructions
+
+### Docker requirement
+`yarn dev` requires Docker. The update script pre-builds Docker images (`yarn docker:build`) so that `yarn dev` doesn't time out waiting for the initial image build.
+
+### Starting the dev environment
+Run `yarn dev` in a tmux session — it starts Docker services (MySQL, Redis, Mailpit, Ghost backend, Caddy gateway) **and** host-side frontend dev servers (admin, portal, comments-ui, etc.).
+
+### Admin Vite server race condition
+The `@tryghost/admin` Vite dev server (port 5174) probes the Ghost backend on startup (`resolveGhostSiteUrl`). On a cold start (first Docker build), the backend may not be ready in time, causing the admin dev server to fail. If this happens, restart it manually:
+```bash
+cd apps/admin && yarn dev
+```
+The Ember admin dev server on port 4200 is separate and usually starts fine.
+
+### Key ports
+| Service | Port |
+|---|---|
+| Ghost (via Caddy) | 2368 |
+| Admin Vite | 5174 |
+| Admin Ember | 4200 |
+| Portal | 4175 |
+| Comments UI | 7173 |
+| Signup Form | 6174 |
+| Sodo Search | 4178 |
+| Announcement Bar | 4177 |
+| Mailpit Web UI | 8025 |
+| MySQL | 3306 |
+| Redis | 6379 |
+
+### Running tests
+- See "Common Commands" section above for all test commands.
+- Ghost core unit tests use SQLite in-memory and don't require Docker.
+- Integration/E2E API tests (`ghost/core`) connect to the Docker MySQL instance.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development environment caveats discovered during Cloud Agent setup:

- **Docker requirement**: Documents that `yarn dev` requires Docker and that pre-building images prevents timeout issues
- **Admin Vite race condition**: The `@tryghost/admin` Vite dev server can fail on cold starts because it probes the Ghost backend before it's ready
- **Key ports table**: Quick reference for all dev server ports
- **Testing notes**: Clarifies which tests need Docker and which don't

## Why?

Future Cursor Cloud agents need to know about these gotchas to set up the development environment reliably without trial-and-error.

## Evidence of working environment

[ghost-dev-environment-demo.mp4](https://cursor.com/agents/bc-e7bd9801-db1a-45ae-83d2-b8fae753e44d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fghost-dev-environment-demo.mp4)

Ghost frontend, admin panel, and post creation all working end-to-end.

[Ghost homepage showing published post](https://cursor.com/agents/bc-e7bd9801-db1a-45ae-83d2-b8fae753e44d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F01-ghost-homepage.webp)
[Admin posts list](https://cursor.com/agents/bc-e7bd9801-db1a-45ae-83d2-b8fae753e44d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F04-admin-posts-list.webp)

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] N/A for automated tests (documentation-only change)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7bd9801-db1a-45ae-83d2-b8fae753e44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7bd9801-db1a-45ae-83d2-b8fae753e44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

