### PR TITLE
Allow traffic analytics Docker updates to automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -96,6 +96,19 @@
             "automerge": true
         },
 
+        // Allow patch updates to the internal traffic analytics image to
+        // automerge once CI has gone green.
+        {
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "ghost/traffic-analytics"
+            ],
+            "automerge": true,
+            "automergeType": "pr"
+        },
+
         // Ignore all ember-related packages in admin
         // Our ember codebase is being replaced with react and
         // Most of the dependencies have breaking changes and it's too hard to update


### PR DESCRIPTION
## Summary
- add a narrow Renovate package rule for the `ghost/traffic-analytics` Docker image
- allow those Docker tag PRs to use PR automerge once CI has passed
- keep the rule scoped to this single internal image rather than enabling Docker automerge broadly

## Why this change
The `ghost/traffic-analytics` Docker update PRs pass CI cleanly but are currently marked as manual because the shared Renovate preset only automerges npm, action, and uses-with dependency types. This adds a targeted Docker rule so future internal traffic analytics image updates can flow through the existing weekend/Monday automerge window without manual intervention.
