### PR TITLE
Expand Renovate automerge windows on weekdays

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,9 +15,13 @@
     "platformAutomerge": false,
     "timezone": "Etc/UTC",
     "automergeSchedule": [
-        // Allow automerge all weekend: Saturday, Sunday, and Monday morning
+        // Allow automerge all weekend
         "* * * * 0,6",
-        "* 0-12 * * 1"
+        // Allow automerge on Monday morning
+        "* 0-12 * * 1",
+        // Allow automerge overnight on weekday evenings (10pm-4:59am UTC)
+        "* 22-23 * * 1-5",
+        "* 0-4 * * 2-6"
     ],
     "ignoreDeps": [
         // https://github.com/TryGhost/Ghost/commit/2b9e494dfcb95c40f596ccf54ec3151c25d53601


### PR DESCRIPTION
## Summary
- extend the Renovate automerge schedule to include weekday overnight windows from 10pm to 4:59am UTC
- keep the existing weekend and Monday-morning windows intact
- allow green PRs to continue merging later in the week without opening daytime merge windows

## Why this change
Ghost's current weekend and Monday-only automerge schedule makes it slow to work through dependency updates and easy to miss merge opportunities when CI clears later in the week. Adding weekday overnight windows gives Renovate more chances to merge green PRs while still keeping automation out of normal working hours.
