### PR TITLE
Added gift purchase events to the member activity feed

### DIFF
--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -263,14 +263,10 @@ export default class ParseMemberEventHelper extends Helper {
             const symbol = getSymbol(event.data.currency);
             const formattedAmount = symbol + getNonDecimal(event.data.amount, event.data.currency);
             const tierName = event.data.tier_name;
-            const cadenceLabel = event.data.cadence === 'month' ? 'month' : 'year';
-            const duration = event.data.duration || 1;
+            const duration = event.data.duration;
+            const cadenceLabel = duration === 1 ? event.data.cadence : event.data.cadence + 's';
 
-            if (tierName) {
-                return `Purchased a gift subscription for ${formattedAmount} (${tierName}, ${duration} ${cadenceLabel})`;
-            }
-
-            return `Purchased a gift subscription (${formattedAmount})`;
+            return `Purchased a gift subscription for ${formattedAmount} (${tierName}, ${duration} ${cadenceLabel})`;
         }
     }
 

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -140,6 +140,10 @@ export default class ParseMemberEventHelper extends Helper {
             icon = 'subscriptions';
         }
 
+        if (event.type === 'gift_purchase_event') {
+            icon = 'subscriptions';
+        }
+
         if (event.type === 'email_change_event') {
             icon = 'email-changed';
         }
@@ -253,6 +257,20 @@ export default class ParseMemberEventHelper extends Helper {
 
         if (event.type === 'donation_event') {
             return 'Made a one-time payment';
+        }
+
+        if (event.type === 'gift_purchase_event') {
+            const symbol = getSymbol(event.data.currency);
+            const formattedAmount = symbol + getNonDecimal(event.data.amount, event.data.currency);
+            const tierName = event.data.tier_name;
+            const cadenceLabel = event.data.cadence === 'month' ? 'month' : 'year';
+            const duration = event.data.duration || 1;
+
+            if (tierName) {
+                return `Purchased a gift subscription for ${formattedAmount} (${tierName}, ${duration} ${cadenceLabel})`;
+            }
+
+            return `Purchased a gift subscription (${formattedAmount})`;
         }
     }
 

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -33,9 +33,11 @@ export function toggleEventType(eventType, eventTypes) {
         if (excludedEvents.has('payment_event')) {
             excludedEvents.delete('payment_event');
             excludedEvents.delete('donation_event');
+            excludedEvents.delete('gift_purchase_event');
         } else {
             excludedEvents.add('payment_event');
             excludedEvents.add('donation_event');
+            excludedEvents.add('gift_purchase_event');
         }
     } else {
         if (excludedEvents.has(eventType)) {

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -24,7 +24,7 @@ describe('Unit | Utility | event-type-utils', function () {
 
         const newExcludedEvents = toggleEventType('payment_event', eventTypes);
 
-        expect(newExcludedEvents).to.equal('payment_event,donation_event');
+        expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event');
     });
 
     it('should toggle both payment_event and donation_event off when toggling payment_event off', function () {

--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -242,7 +242,8 @@ function createApiInstance(config) {
             EmailSpamComplaintEvent: models.EmailSpamComplaintEvent,
             Outbox: models.Outbox,
             WelcomeEmailAutomation: models.WelcomeEmailAutomation,
-            AutomatedEmailRecipient: models.AutomatedEmailRecipient
+            AutomatedEmailRecipient: models.AutomatedEmailRecipient,
+            Gift: models.Gift
         },
         stripeAPIService: stripeService.api,
         tiersService: tiersService,

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -66,7 +66,8 @@ module.exports = function MembersAPI({
         MemberFeedback,
         Outbox,
         WelcomeEmailAutomation,
-        AutomatedEmailRecipient
+        AutomatedEmailRecipient,
+        Gift
     },
     tiersService,
     stripeAPIService,
@@ -134,7 +135,8 @@ module.exports = function MembersAPI({
         labsService,
         memberAttributionService,
         MemberEmailChangeEvent,
-        AutomatedEmailRecipient
+        AutomatedEmailRecipient,
+        Gift
     });
 
     const nextPaymentCalculator = new NextPaymentCalculator();

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -458,7 +458,7 @@ module.exports = class EventRepository {
                     id: json.id,
                     member: json.buyer || null,
                     member_id: json.buyer_member_id,
-                    tier_name: json.tier?.name || null,
+                    tier_name: json.tier?.name,
                     cadence: json.cadence,
                     duration: json.duration,
                     amount: json.amount,

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -34,7 +34,8 @@ module.exports = class EventRepository {
         labsService,
         memberAttributionService,
         MemberEmailChangeEvent,
-        AutomatedEmailRecipient
+        AutomatedEmailRecipient,
+        Gift
     }) {
         this._DonationPaymentEvent = DonationPaymentEvent;
         this._MemberSubscribeEvent = MemberSubscribeEvent;
@@ -53,6 +54,7 @@ module.exports = class EventRepository {
         this._memberAttributionService = memberAttributionService;
         this._MemberEmailChangeEvent = MemberEmailChangeEvent;
         this._AutomatedEmailRecipient = AutomatedEmailRecipient;
+        this._Gift = Gift;
     }
 
     async getEventTimeline(options = {}) {
@@ -82,7 +84,8 @@ module.exports = class EventRepository {
                 {type: 'newsletter_event', action: 'getNewsletterSubscriptionEvents'},
                 {type: 'login_event', action: 'getLoginEvents'},
                 {type: 'payment_event', action: 'getPaymentEvents'},
-                {type: 'email_change_event', action: 'getEmailChangeEvent'}
+                {type: 'email_change_event', action: 'getEmailChangeEvent'},
+                {type: 'gift_purchase_event', action: 'getGiftPurchaseEvents'}
             );
 
             if (this._AutomatedEmailRecipient) {
@@ -412,6 +415,55 @@ module.exports = class EventRepository {
                 data: {
                     ...json,
                     attribution: this._memberAttributionService.getEventAttribution(model)
+                }
+            };
+        });
+
+        return {
+            data,
+            meta
+        };
+    }
+
+    async getGiftPurchaseEvents(options = {}, filter) {
+        options = {
+            ...options,
+            withRelated: ['buyer', 'tier'],
+            filter: 'buyer_member_id:-null+custom:true',
+            useBasicCount: true,
+            mongoTransformer: chainTransformers(
+                // First set the filter manually
+                replaceCustomFilterTransformer(filter),
+
+                // Map the used keys in that filter
+                ...mapKeys({
+                    'data.created_at': 'purchased_at',
+                    'data.member_id': 'buyer_member_id'
+                })
+            )
+        };
+
+        if (options.order) {
+            options.order = options.order.replace(/created_at/g, 'purchased_at');
+        }
+
+        const {data: models, meta} = await this._Gift.findPage(options);
+
+        const data = models.map((model) => {
+            const json = model.toJSON(options);
+
+            return {
+                type: 'gift_purchase_event',
+                data: {
+                    id: json.id,
+                    member: json.buyer || null,
+                    member_id: json.buyer_member_id,
+                    tier_name: json.tier?.name || null,
+                    cadence: json.cadence,
+                    duration: json.duration,
+                    amount: json.amount,
+                    currency: json.currency,
+                    created_at: json.purchased_at
                 }
             };
         });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -412,4 +412,127 @@ describe('EventRepository', function () {
             });
         });
     });
+
+    describe('getGiftPurchaseEvents', function () {
+        let eventRepository;
+        let fake;
+
+        before(function () {
+            fake = sinon.fake.returns({data: [{
+                toJSON: () => ({
+                    id: 'gift123',
+                    buyer_member_id: 'member456',
+                    buyer: {id: 'member456', name: 'Test Buyer', email: 'buyer@example.com'},
+                    tier: {name: 'Silver'},
+                    amount: 5000,
+                    currency: 'usd',
+                    cadence: 'year',
+                    duration: 1,
+                    purchased_at: '2024-06-15T12:00:00.000Z',
+                    token: 'secret-token',
+                    stripe_checkout_session_id: 'cs_123',
+                    stripe_payment_intent_id: 'pi_123',
+                    status: 'purchased'
+                })
+            }]});
+            eventRepository = new EventRepository({
+                EmailRecipient: null,
+                MemberSubscribeEvent: null,
+                MemberPaymentEvent: null,
+                MemberStatusEvent: null,
+                MemberLoginEvent: null,
+                MemberPaidSubscriptionEvent: null,
+                labsService: null,
+                Gift: {
+                    findPage: fake
+                }
+            });
+        });
+
+        afterEach(function () {
+            fake.resetHistory();
+        });
+
+        it('queries with correct options', async function () {
+            await eventRepository.getGiftPurchaseEvents({
+                filter: 'not used',
+                order: 'created_at desc, id desc'
+            }, {
+                type: 'unused'
+            });
+
+            sinon.assert.calledOnceWithMatch(fake, {
+                withRelated: ['buyer', 'tier'],
+                filter: 'buyer_member_id:-null+custom:true',
+                order: 'purchased_at desc, id desc'
+            });
+        });
+
+        it('returns correctly formatted gift_event', async function () {
+            const result = await eventRepository.getGiftPurchaseEvents({
+                order: 'created_at desc, id desc'
+            }, {});
+
+            assert.equal(result.data.length, 1);
+
+            const event = result.data[0];
+
+            assert.equal(event.type, 'gift_purchase_event');
+            assert.equal(event.data.id, 'gift123');
+            assert.equal(event.data.amount, 5000);
+            assert.equal(event.data.currency, 'usd');
+            assert.equal(event.data.tier_name, 'Silver');
+            assert.equal(event.data.cadence, 'year');
+            assert.equal(event.data.duration, 1);
+            assert.equal(event.data.member_id, 'member456');
+            assert.equal(event.data.created_at, '2024-06-15T12:00:00.000Z');
+            assert.deepEqual(event.data.member, {
+                id: 'member456',
+                name: 'Test Buyer',
+                email: 'buyer@example.com'
+            });
+        });
+
+        it('excludes internal fields from event data', async function () {
+            const result = await eventRepository.getGiftPurchaseEvents({}, {});
+
+            const event = result.data[0];
+
+            assert.equal(event.data.token, undefined);
+            assert.equal(event.data.stripe_checkout_session_id, undefined);
+            assert.equal(event.data.stripe_payment_intent_id, undefined);
+            assert.equal(event.data.status, undefined);
+        });
+
+        it('sets member to null when buyer is not present', async function () {
+            const nullBuyerFake = sinon.fake.returns({data: [{
+                toJSON: () => ({
+                    id: 'gift789',
+                    buyer_member_id: null,
+                    buyer: null,
+                    amount: 3000,
+                    currency: 'eur',
+                    purchased_at: '2024-07-01T12:00:00.000Z'
+                })
+            }]});
+            const repo = new EventRepository({
+                EmailRecipient: null,
+                MemberSubscribeEvent: null,
+                MemberPaymentEvent: null,
+                MemberStatusEvent: null,
+                MemberLoginEvent: null,
+                MemberPaidSubscriptionEvent: null,
+                labsService: null,
+                Gift: {
+                    findPage: nullBuyerFake
+                }
+            });
+
+            const result = await repo.getGiftPurchaseEvents({}, {});
+            const event = result.data[0];
+
+            assert.equal(event.data.member, null);
+            assert.equal(event.data.member_id, null);
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3484

Shows "Purchased a gift subscription" with the payment amount in the admin activity feed by reading directly from the gifts table. The event type is named `gift_purchase_event` to allow `gift_redemption_event` later