### PR TITLE
Fixed white surface-elevated variale

### DIFF
--- a/apps/shade/src/components/ui/toggle-group.tsx
+++ b/apps/shade/src/components/ui/toggle-group.tsx
@@ -19,7 +19,7 @@ const ToggleGroup = React.forwardRef<
 >(({className, variant, size, children, ...props}, ref) => (
     <ToggleGroupPrimitive.Root
         ref={ref}
-        className={cn('inline-flex items-center justify-center gap-0.5 bg-surface-elevated p-0.5 rounded-md', className)}
+        className={cn('inline-flex items-center justify-center gap-0.5 bg-muted p-0.5 rounded-md', className)}
         {...props}
     >
         <ToggleGroupContext.Provider value={{variant, size}}>

--- a/apps/shade/theme-variables.css
+++ b/apps/shade/theme-variables.css
@@ -22,7 +22,7 @@
     --surface-page: var(--background);
     --surface-panel: var(--card);
     --surface-panel-foreground: var(--card-foreground);
-    --surface-elevated: hsl(200 12% 96%);
+    --surface-elevated: hsl(0 0% 100%);
     --surface-elevated-foreground: var(--card-foreground);
     --surface-overlay: var(--popover);
     --surface-overlay-foreground: var(--popover-foreground);

--- a/apps/shade/theme-variables.css
+++ b/apps/shade/theme-variables.css
@@ -22,7 +22,7 @@
     --surface-page: var(--background);
     --surface-panel: var(--card);
     --surface-panel-foreground: var(--card-foreground);
-    --surface-elevated: hsl(0 0% 100%);
+    --surface-elevated: hsl(200 12% 96%);
     --surface-elevated-foreground: var(--card-foreground);
     --surface-overlay: var(--popover);
     --surface-overlay-foreground: var(--popover-foreground);


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1339/tags-page-has-broken-togglegroup

When the new tokens were added, surface-elevated was set to white which meant it wasn't indistinguishable from a white page/card/panel background. This tweaks adjusts its value to improve contrast. 

| Before | After |
|--------|--------|
| <img width="448" height="131" alt="Screenshot 2026-04-07 at 14 06 14" src="https://github.com/user-attachments/assets/54d878e7-29a5-4629-b088-bb00a2b51b43" /> | <img width="452" height="129" alt="Screenshot 2026-04-07 at 14 05 56" src="https://github.com/user-attachments/assets/ac85d433-ef73-4771-a035-cbcab41279e4" /> | 