### PR TITLE
Updated gift purchase flow to attribute buyer by email

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -14,7 +14,6 @@ interface StaffServiceEmails {
 interface GiftPurchaseData {
     token: string;
     buyerEmail: string;
-    stripeCustomerId: string | null;
     tierId: string;
     cadence: 'month' | 'year';
     duration: string;
@@ -46,9 +45,7 @@ export class GiftService {
             return false;
         }
 
-        const member = data.stripeCustomerId
-            ? await this.#memberRepository.get({customer_id: data.stripeCustomerId})
-            : null;
+        const member = await this.#memberRepository.get({email: data.buyerEmail});
 
         const gift = Gift.fromPurchase({
             token: data.token,

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -67,7 +67,6 @@ module.exports = class CheckoutSessionEventService {
         await this.deps.giftService.recordPurchase({
             token: session.metadata?.gift_token,
             buyerEmail: session.metadata?.purchaser_email,
-            stripeCustomerId: session.customer ?? null,
             tierId: session.metadata?.tier_id,
             cadence: session.metadata?.cadence,
             duration: session.metadata?.duration,

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -17,7 +17,6 @@ describe('GiftService', function () {
     const purchaseData = {
         token: 'abc-123',
         buyerEmail: 'buyer@example.com',
-        stripeCustomerId: 'cust_123',
         tierId: 'tier_1',
         cadence: 'year' as const,
         duration: '1',
@@ -33,7 +32,7 @@ describe('GiftService', function () {
             existsByCheckoutSessionId: sinon.stub().resolves(false)
         };
         memberRepository = {
-            get: sinon.stub().resolves({id: 'member_1', get: sinon.stub().returns(null)})
+            get: sinon.stub()
         };
         staffServiceEmails = {
             notifyGiftReceived: sinon.stub()
@@ -75,39 +74,22 @@ describe('GiftService', function () {
             sinon.assert.notCalled(giftRepository.create);
         });
 
-        it('resolves member by stripeCustomerId', async function () {
-            const memberGet = sinon.stub();
-
-            memberGet.withArgs('name').returns('Member Name');
-            memberGet.withArgs('email').returns('member@example.com');
-
-            memberRepository.get.resolves({id: 'member_1', get: memberGet});
+        it('resolves member by buyerEmail', async function () {
+            memberRepository.get.withArgs({email: 'buyer@example.com'}).resolves({id: 'member_1', get: sinon.stub().returns(null)});
 
             const service = createService();
 
             await service.recordPurchase(purchaseData);
 
-            sinon.assert.calledWith(memberRepository.get, {customer_id: 'cust_123'});
+            sinon.assert.calledWith(memberRepository.get, {email: 'buyer@example.com'});
 
             const gift = giftRepository.create.getCall(0).args[0];
 
             assert.equal(gift.buyerMemberId, 'member_1');
         });
 
-        it('sets buyerMemberId to null when stripeCustomerId is null', async function () {
-            const service = createService();
-
-            await service.recordPurchase({...purchaseData, stripeCustomerId: null});
-
-            sinon.assert.notCalled(memberRepository.get);
-
-            const gift = giftRepository.create.getCall(0).args[0];
-
-            assert.equal(gift.buyerMemberId, null);
-        });
-
         it('sets buyerMemberId to null when member not found', async function () {
-            memberRepository.get.resolves(null);
+            memberRepository.get.withArgs({email: 'buyer@example.com'}).resolves(null);
 
             const service = createService();
 
@@ -148,10 +130,10 @@ describe('GiftService', function () {
         it('sends staff notification email after recording purchase', async function () {
             const memberGet = sinon.stub();
 
-            memberGet.withArgs('name').returns('Member Name');
-            memberGet.withArgs('email').returns('member@example.com');
+            memberGet.withArgs('name').returns('Alice');
+            memberGet.withArgs('email').returns('buyer@example.com');
 
-            memberRepository.get.resolves({id: 'member_1', get: memberGet});
+            memberRepository.get.withArgs({email: 'buyer@example.com'}).resolves({id: 'member_1', get: memberGet});
 
             const service = createService();
 
@@ -161,17 +143,19 @@ describe('GiftService', function () {
 
             const emailData = staffServiceEmails.notifyGiftReceived.getCall(0).args[0];
 
-            assert.equal(emailData.name, 'Member Name');
-            assert.equal(emailData.email, 'member@example.com');
+            assert.equal(emailData.name, 'Alice');
+            assert.equal(emailData.email, 'buyer@example.com');
             assert.equal(emailData.memberId, 'member_1');
             assert.equal(emailData.amount, 5000);
             assert.equal(emailData.currency, 'usd');
         });
 
         it('uses buyerEmail and null name when purchaser is not a member', async function () {
+            memberRepository.get.withArgs({email: 'buyer@example.com'}).resolves(null);
+
             const service = createService();
 
-            await service.recordPurchase({...purchaseData, stripeCustomerId: null});
+            await service.recordPurchase(purchaseData);
 
             sinon.assert.calledOnce(staffServiceEmails.notifyGiftReceived);
 

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -592,7 +592,6 @@ describe('CheckoutSessionEventService', function () {
 
             assert.equal(purchaseData.token, 'abc-123-token');
             assert.equal(purchaseData.buyerEmail, 'buyer@example.com');
-            assert.equal(purchaseData.stripeCustomerId, 'cust_123');
             assert.equal(purchaseData.tierId, 'tier_456');
             assert.equal(purchaseData.cadence, 'year');
             assert.equal(purchaseData.duration, '1');
@@ -600,32 +599,6 @@ describe('CheckoutSessionEventService', function () {
             assert.equal(purchaseData.amount, 5000);
             assert.equal(purchaseData.stripeCheckoutSessionId, 'cs_test_123');
             assert.equal(purchaseData.stripePaymentIntentId, 'pi_test_456');
-        });
-
-        it('passes null stripeCustomerId for unauthenticated purchasers', async function () {
-            const service = createService();
-            const session = {
-                id: 'cs_test_123',
-                mode: 'payment',
-                amount_total: 3000,
-                currency: 'gbp',
-                customer: null,
-                payment_intent: 'pi_test_789',
-                metadata: {
-                    ghost_gift: 'true',
-                    gift_token: 'def-456-token',
-                    tier_id: 'tier_111',
-                    cadence: 'month',
-                    duration: '1',
-                    purchaser_email: 'guest@example.com'
-                }
-            };
-
-            await service.handleGiftEvent(session);
-
-            const purchaseData = giftService.recordPurchase.getCall(0).args[0];
-
-            assert.equal(purchaseData.stripeCustomerId, null);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3484

- previously, we'd attribute a gift to existing members based on stripe_customer_id
- however, this limits the attribution to paid members only, and misses existing free members
- we now attribute the gift based on the buyer email


