### PR TITLE
Added hidden drip sequence UI scaffold to admin

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/drip-sequences.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/drip-sequences.tsx
@@ -1,0 +1,109 @@
+/**
+ * NOTE: This component is very simplistic and will be significantly rewritten. See NY-1196.
+ */
+
+import React, {useState} from 'react';
+import TopLevelGroup from '../../top-level-group';
+import {Button, Heading, TextField, withErrorBoundary} from '@tryghost/admin-x-design-system';
+
+interface DripEmail {
+    id: string;
+    delayDays: number;
+    subject: string;
+}
+
+let nextId = 0;
+const makeId = () => {
+    nextId += 1;
+    return `drip-email-${nextId}`;
+};
+
+const DripEmailRow: React.FC<{
+    email: DripEmail;
+    onChange: (updated: DripEmail) => void;
+    onRemove: () => void;
+}> = ({email, onChange, onRemove}) => (
+    <div className='flex items-center gap-2'>
+        <div className='w-24'>
+            <TextField
+                title='Delay (days)'
+                type='number'
+                value={`${email.delayDays}`}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    onChange({...email, delayDays: Number.parseInt(e.target.value) || 0});
+                }}
+            />
+        </div>
+        <div className='flex-1'>
+            <TextField
+                title='Subject'
+                value={email.subject}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    onChange({...email, subject: e.target.value});
+                }}
+            />
+        </div>
+        <Button color='red' label='Remove' link onClick={onRemove} />
+    </div>
+);
+
+const SequenceEditor: React.FC<{
+    title: string;
+    emails: DripEmail[];
+    onChange: (emails: DripEmail[]) => void;
+}> = ({title, emails, onChange}) => (
+    <div className='mb-6'>
+        <Heading level={6}>{title}</Heading>
+        <div className='mt-2 flex flex-col gap-4'>
+            {emails.map((email, idx) => (
+                <DripEmailRow
+                    key={email.id}
+                    email={email}
+                    onChange={(updated) => {
+                        const next = [...emails];
+                        next[idx] = updated;
+                        onChange(next);
+                    }}
+                    onRemove={() => {
+                        onChange(emails.filter((_, i) => i !== idx));
+                    }}
+                />
+            ))}
+            <div>
+                <Button
+                    color='green'
+                    label='Add email'
+                    link
+                    onClick={() => {
+                        onChange([...emails, {id: makeId(), delayDays: 1, subject: ''}]);
+                    }}
+                />
+            </div>
+        </div>
+    </div>
+);
+
+const DripSequences: React.FC<{keywords: string[]}> = ({keywords}) => {
+    const [freeEmails, setFreeEmails] = useState<DripEmail[]>([]);
+    const [paidEmails, setPaidEmails] = useState<DripEmail[]>([]);
+
+    const handleSave = () => {
+        // eslint-disable-next-line no-console
+        console.log('Saving drip sequences (mock)', {freeEmails, paidEmails});
+    };
+
+    return (
+        <TopLevelGroup
+            keywords={keywords}
+            navid='drip-sequences'
+            testId='drip-sequences'
+            title='Drip sequences'
+        >
+            <SequenceEditor emails={freeEmails} title='Free drip sequence' onChange={setFreeEmails} />
+            <SequenceEditor emails={paidEmails} title='Paid drip sequence' onChange={setPaidEmails} />
+            <Button color='black' label='Save' onClick={handleSave} />
+        </TopLevelGroup>
+    );
+};
+
+export default withErrorBoundary(DripSequences, 'Drip sequences');

--- a/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
@@ -1,4 +1,5 @@
 import Access from './access';
+import DripSequences from './drip-sequences';
 import MemberEmails from './member-emails';
 import Portal from './portal';
 import React from 'react';
@@ -6,6 +7,7 @@ import SearchableSection from '../../searchable-section';
 import SpamFilters from '../advanced/spam-filters';
 import Tiers from './tiers';
 import TipsAndDonations from '../growth/tips-and-donations';
+import useFeatureFlag from '../../../hooks/use-feature-flag';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
 
@@ -21,6 +23,7 @@ const MembershipSettings: React.FC = () => {
     const {config, settings} = useGlobalData();
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
+    const hasDripSequences = useFeatureFlag('dripSequences');
 
     return (
         <SearchableSection keywords={Object.values(searchKeywords).flat()} title='Membership'>
@@ -29,6 +32,7 @@ const MembershipSettings: React.FC = () => {
             <Tiers keywords={searchKeywords.tiers} />
             <Portal keywords={searchKeywords.portal} />
             <MemberEmails keywords={searchKeywords.memberEmails} />
+            {hasDripSequences && <DripSequences keywords={searchKeywords.memberEmails} />}
             {hasTipsAndDonations && hasStripeEnabled && <TipsAndDonations keywords={searchKeywords.tips} />}
         </SearchableSection>
     );

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -12,6 +12,7 @@ import {searchKeywords as growthSearchKeywords} from './settings/growth/growth-s
 import {searchKeywords as membershipSearchKeywords} from './settings/membership/membership-settings';
 import {searchKeywords as siteSearchKeywords} from './settings/site/site-settings';
 
+import useFeatureFlag from '../hooks/use-feature-flag';
 import {useGlobalData} from './providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 import {useScrollSectionContext, useScrollSectionNav} from '../hooks/use-scroll-section';
@@ -110,6 +111,7 @@ const Sidebar: React.FC = () => {
     const {settings, config} = useGlobalData();
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [string];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
+    const hasDripSequences = useFeatureFlag('dripSequences');
 
     const handleSectionClick = (e?: React.MouseEvent<HTMLAnchorElement>) => {
         if (e) {
@@ -192,6 +194,7 @@ const Sidebar: React.FC = () => {
                     <NavItem icon='bills' keywords={membershipSearchKeywords.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
                     <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
                     <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />
+                    {hasDripSequences && <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='drip-sequences' title="Drip sequences" onClick={handleSectionClick} />}
                     {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
                     <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />
                 </SettingNavSection>


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1196

<p><img src="https://github.com/user-attachments/assets/44bd5299-f689-469d-8beb-b556489c92e6" alt="Screenshot" width="60%"></p>

This adds a hidden UI for drip campaigns to the admin panel. The UI is ugly and simplistic, but should be good enough to start wiring things up to new API endpoints. (These endpoints don't exist yet!)