### PR TITLE
Wired up gift redemption rendering

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.0",
+  "version": "2.68.1",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -569,7 +569,7 @@ export default class App extends React.Component {
                 page: 'giftRedemption',
                 pageData: {
                     token,
-                    gift: response?.gift || null
+                    gift: response?.gifts?.[0] || null
                 }
             };
         } catch (error) {

--- a/apps/portal/src/components/pages/gift-redemption-page.js
+++ b/apps/portal/src/components/pages/gift-redemption-page.js
@@ -294,12 +294,21 @@ const GiftRedemptionPage = () => {
 
                     {gift.tier.benefits.length > 0 && (
                         <div className='gh-gift-redemption-benefits'>
-                            {gift.tier.benefits.map((benefit, index) => (
-                                <div className='gh-gift-redemption-benefit' key={benefit?.id || `gift-benefit-${index}`}>
-                                    <CheckmarkIcon />
-                                    <span>{benefit.name}</span>
-                                </div>
-                            ))}
+                            {gift.tier.benefits.map((benefit, index) => {
+                                const benefitName = typeof benefit === 'string' ? benefit : benefit?.name;
+                                const benefitKey = typeof benefit === 'string' ? benefit : benefit?.id || `gift-benefit-${index}`;
+
+                                if (!benefitName) {
+                                    return null;
+                                }
+
+                                return (
+                                    <div className='gh-gift-redemption-benefit' key={benefitKey}>
+                                        <CheckmarkIcon />
+                                        <span>{benefitName}</span>
+                                    </div>
+                                );
+                            })}
                         </div>
                     )}
 

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -169,63 +169,26 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
 
     api.gift = {
         async fetchRedemptionData({token}) {
-            // Temporary: Mocked API response
-            return {
-                gift: {
-                    token,
-                    cadence: 'year',
-                    duration: 1,
-                    currency: 'EUR',
-                    amount: 4000,
-                    expires_at: '2027-04-06T10:09:30.000Z',
-                    tier: {
-                        id: '00000000703e0fb16598bca1',
-                        name: 'Ultra',
-                        description: 'Everything in Premium, but fancier',
-                        benefits: [
-                            {
-                                id: '69d39d43acb2b803745058a1',
-                                name: 'Weekly round-up on Sunday'
-                            },
-                            {
-                                id: '69d39d43acb2b803745058a2',
-                                name: 'Access to all podcasts and videos'
-                            },
-                            {
-                                id: '69d39d43acb2b803745058a3',
-                                name: 'Five new stories per week'
-                            }
-                        ]
-                    }
-                }
-            };
+            const url = endpointFor({type: 'members', resource: `gifts/${encodeURIComponent(token)}/redeem`});
+            const res = await makeRequest({
+                url,
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                credentials: 'same-origin'
+            });
 
-            // Test out error cases:
-            // throw new HumanReadableError('This gift has already been redeemed.');
-            // throw new HumanReadableError('This gift has expired.');
-            // throw new HumanReadableError('This gift link is not valid.');
+            if (res.ok) {
+                return res.json();
+            }
 
-            // TODO: Restore actual API code when ready to integrate
-            // const url = endpointFor({type: 'members', resource: `gifts/${encodeURIComponent(token)}`});
-            // const res = await makeRequest({
-            //     url,
-            //     method: 'GET',
-            //     headers: {
-            //         'Content-Type': 'application/json'
-            //     },
-            //     credentials: 'same-origin'
-            // });
+            const humanError = await HumanReadableError.fromApiResponse(res);
+            if (humanError) {
+                throw humanError;
+            }
 
-            // if (res.ok) {
-            //     return res.json();
-            // }
-
-            // const humanError = await HumanReadableError.fromApiResponse(res);
-            // if (humanError) {
-            //     throw humanError;
-            // }
-
-            // throw new Error('Failed to load gift data');
+            throw new Error('Failed to load gift data');
         }
     };
 

--- a/apps/portal/src/utils/errors.js
+++ b/apps/portal/src/utils/errors.js
@@ -19,6 +19,23 @@ export class HumanReadableError extends Error {
                 return undefined;
             }
         }
+        if (res.status === 404) {
+            const contentType = (res.headers.get('content-type') || '').toLowerCase();
+
+            if (!contentType.includes('application/json')) {
+                return undefined;
+            }
+
+            try {
+                const json = await res.json();
+                if (json.errors && Array.isArray(json.errors) && json.errors.length > 0 && json.errors[0].message) {
+                    return new HumanReadableError(json.errors[0].message);
+                }
+            } catch (e) {
+                // Failed to decode: ignore
+                return undefined;
+            }
+        }
         if (res.status === 500) {
             return new HumanReadableError('A server error occurred');
         }

--- a/apps/portal/test/api.test.js
+++ b/apps/portal/test/api.test.js
@@ -1,0 +1,70 @@
+import setupGhostApi from '../src/utils/api';
+import {HumanReadableError} from '../src/utils/errors';
+import {vi} from 'vitest';
+
+describe('Portal API gift redemption', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('returns the gifts api payload for redeemable gift tokens', async () => {
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+
+        vi.spyOn(window, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+            gifts: [{
+                token: 'gift-token-123'
+            }]
+        }), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }));
+
+        const response = await ghostApi.gift.fetchRedemptionData({token: 'gift-token-123'});
+
+        expect(response.gifts[0].token).toBe('gift-token-123');
+        expect(window.fetch).toHaveBeenCalledWith('https://example.com/members/api/gifts/gift-token-123/redeem/', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            credentials: 'same-origin',
+            body: undefined
+        });
+    });
+
+    test('throws a human-readable error for 400 members api gift responses', async () => {
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+
+        vi.spyOn(window, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+            errors: [{
+                message: 'This gift has expired.'
+            }]
+        }), {
+            status: 400,
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }));
+
+        await expect(ghostApi.gift.fetchRedemptionData({token: 'gift-token-123'})).rejects.toEqual(new HumanReadableError('This gift has expired.'));
+    });
+
+    test('preserves the api error message for 404 members api gift responses', async () => {
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+
+        vi.spyOn(window, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+            errors: [{
+                message: 'Gift not found.'
+            }]
+        }), {
+            status: 404,
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }));
+
+        await expect(ghostApi.gift.fetchRedemptionData({token: 'gift-token-123'})).rejects.toEqual(new HumanReadableError('Gift not found.'));
+    });
+});

--- a/apps/portal/test/errors.test.js
+++ b/apps/portal/test/errors.test.js
@@ -52,6 +52,17 @@ describe('error messages are set correctly', () => {
         expect(chooseBestErrorMessage(humanReadableError, null)).toEqual('translated A server error occurred');
     });
 
+    test('handles a 404 json api error', async () => {
+        const error = new Response('{"errors":[{"message":"Gift not found."}]}', {
+            status: 404,
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+        const humanReadableError = await HumanReadableError.fromApiResponse(error);
+        expect(chooseBestErrorMessage(humanReadableError, null)).toEqual('translated Gift not found.');
+    });
+
     test('gets the magic link error message correctly', async () => {
         const error = new Response('{"errors":[{"message":"Failed to send magic link email"}]}', {status: 400});
         const humanReadableError = await HumanReadableError.fromApiResponse(error);

--- a/apps/portal/test/portal-links.test.js
+++ b/apps/portal/test/portal-links.test.js
@@ -4,19 +4,21 @@ import {appRender, fireEvent, waitFor, within} from './utils/test-utils';
 import setupGhostApi from '../src/utils/api';
 
 const defaultGiftResponse = {
-    gift: {
-        token: 'gift-token-123',
-        cadence: 'year',
-        duration: 1,
-        tier: {
-            id: 'tier-gift',
-            name: 'Bronze',
-            benefits: [
-                {id: 'benefit-1', name: 'Five great stories to read every day'},
-                {id: 'benefit-2', name: 'Videos and podcasts to charm and delight you'}
-            ]
+    gifts: [
+        {
+            token: 'gift-token-123',
+            cadence: 'year',
+            duration: 1,
+            tier: {
+                id: 'tier-gift',
+                name: 'Bronze',
+                benefits: [
+                    'Five great stories to read every day',
+                    'Videos and podcasts to charm and delight you'
+                ]
+            }
         }
-    }
+    ]
 };
 
 const setup = async ({site, member = null, showPopup = true, giftResponse = defaultGiftResponse, giftError = null}) => {
@@ -476,6 +478,22 @@ describe('Portal Data links:', () => {
             await expectGiftRedemptionErrorToast({
                 utils,
                 subtitle: /This gift has already been redeemed\./i
+            });
+        });
+
+        test('renders a toast error when logged-in member already has an active subscription', async () => {
+            let {
+                ghostApi, triggerButtonFrame, ...utils
+            } = await setupGiftRedemption({
+                giftError: new Error('You already have an active subscription.')
+            });
+
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(ghostApi.gift.fetchRedemptionData).toHaveBeenCalledWith({token: 'gift-token-123'});
+
+            await expectGiftRedemptionErrorToast({
+                utils,
+                subtitle: /You already have an active subscription\./i
             });
         });
 

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -375,11 +375,14 @@ async function initServices() {
         slackNotifications.init(),
         mediaInliner.init(),
         donationService.init(),
-        giftService.init(),
         recommendationsService.init(),
         statsService.init(),
         explorePingService.init()
     ]);
+
+    // Gift service depends on members, tiers, and staff services
+    await giftService.init();
+
     debug('End: Services');
 
     debug('End: initServices');

--- a/ghost/core/core/server/api/endpoints/gifts-members.js
+++ b/ghost/core/core/server/api/endpoints/gifts-members.js
@@ -1,0 +1,30 @@
+const giftService = require('../../services/gifts');
+
+/** @type {import('@tryghost/api-framework').Controller} */
+module.exports = {
+    docName: 'gifts',
+
+    isRedeemable: {
+        headers: {
+            cacheInvalidate: false
+        },
+        data: [
+            'token'
+        ],
+        validation: {
+            data: {
+                token: {
+                    type: 'string',
+                    required: true
+                }
+            }
+        },
+        permissions: false,
+        query(frame) {
+            return giftService.service.getRedeemableGiftByToken({
+                token: frame.data.token,
+                currentMember: frame.options.context.member
+            });
+        }
+    }
+};

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -289,6 +289,10 @@ module.exports = {
         return apiFramework.pipeline(require('./feedback-members'), localUtils, 'members');
     },
 
+    get giftsMembers() {
+        return apiFramework.pipeline(require('./gifts-members'), localUtils, 'members');
+    },
+
     get recommendationsPublic() {
         return apiFramework.pipeline(require('./recommendations-public'), localUtils, 'content');
     },

--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -1,12 +1,38 @@
-import type {Gift} from './gift';
+import {Gift} from './gift';
 import type {GiftRepository} from './gift-repository';
+
+type BookshelfDocument<T> = {
+    toJSON(): T;
+};
 
 type BookshelfModel<T> = {
     add(data: Partial<T>, unfilteredOptions?: unknown): Promise<T>;
-    findOne(data: Record<string, unknown>, unfilteredOptions?: unknown): Promise<T | null>;
+    findOne(data: Record<string, unknown>, unfilteredOptions?: unknown): Promise<BookshelfDocument<T> | null>;
 };
 
-type GiftBookshelfModel = BookshelfModel<Record<string, unknown>>;
+type GiftRow = {
+    token: string;
+    buyer_email: string;
+    buyer_member_id: string | null;
+    redeemer_member_id: string | null;
+    tier_id: string;
+    cadence: 'month' | 'year';
+    duration: number;
+    currency: string;
+    amount: number;
+    stripe_checkout_session_id: string;
+    stripe_payment_intent_id: string;
+    consumes_at: Date | null;
+    expires_at: Date | null;
+    status: 'purchased' | 'redeemed' | 'consumed' | 'expired' | 'refunded';
+    purchased_at: Date;
+    redeemed_at: Date | null;
+    consumed_at: Date | null;
+    expired_at: Date | null;
+    refunded_at: Date | null;
+};
+
+type GiftBookshelfModel = BookshelfModel<GiftRow>;
 
 export class GiftBookshelfRepository implements GiftRepository {
     private readonly model: GiftBookshelfModel;
@@ -44,6 +70,40 @@ export class GiftBookshelfRepository implements GiftRepository {
             consumed_at: gift.consumedAt,
             expired_at: gift.expiredAt,
             refunded_at: gift.refundedAt
+        });
+    }
+
+    async getByToken(token: string): Promise<Gift | null> {
+        const model = await this.model.findOne({
+            token
+        }, {require: false});
+
+        if (!model) {
+            return null;
+        }
+
+        const json = model.toJSON();
+
+        return new Gift({
+            token: json.token,
+            buyerEmail: json.buyer_email,
+            buyerMemberId: json.buyer_member_id,
+            redeemerMemberId: json.redeemer_member_id,
+            tierId: json.tier_id,
+            cadence: json.cadence,
+            duration: json.duration,
+            currency: json.currency,
+            amount: json.amount,
+            stripeCheckoutSessionId: json.stripe_checkout_session_id,
+            stripePaymentIntentId: json.stripe_payment_intent_id,
+            consumesAt: json.consumes_at,
+            expiresAt: json.expires_at,
+            status: json.status,
+            purchasedAt: json.purchased_at,
+            redeemedAt: json.redeemed_at,
+            consumedAt: json.consumed_at,
+            expiredAt: json.expired_at,
+            refundedAt: json.refunded_at
         });
     }
 }

--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -1,4 +1,4 @@
-import {Gift} from './gift';
+import {Gift, type GiftCadence, type GiftStatus} from './gift';
 import type {GiftRepository} from './gift-repository';
 
 type BookshelfDocument<T> = {
@@ -16,7 +16,7 @@ type GiftRow = {
     buyer_member_id: string | null;
     redeemer_member_id: string | null;
     tier_id: string;
-    cadence: 'month' | 'year';
+    cadence: GiftCadence;
     duration: number;
     currency: string;
     amount: number;
@@ -24,7 +24,7 @@ type GiftRow = {
     stripe_payment_intent_id: string;
     consumes_at: Date | null;
     expires_at: Date | null;
-    status: 'purchased' | 'redeemed' | 'consumed' | 'expired' | 'refunded';
+    status: GiftStatus;
     purchased_at: Date;
     redeemed_at: Date | null;
     consumed_at: Date | null;

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -3,4 +3,5 @@ import type {Gift} from './gift';
 export interface GiftRepository {
     existsByCheckoutSessionId(checkoutSessionId: string): Promise<boolean>;
     create(gift: Gift): Promise<void>;
+    getByToken(token: string): Promise<Gift | null>;
 }

--- a/ghost/core/core/server/services/gifts/gift-service-wrapper.js
+++ b/ghost/core/core/server/services/gifts/gift-service-wrapper.js
@@ -11,8 +11,9 @@ class GiftServiceWrapper {
         const {GiftService} = require('./gift-service');
         const {GiftEmailService} = require('./gift-email-service');
         const membersService = require('../members');
-        const tiersService = require('../tiers/service');
+        const tiersService = require('../tiers');
         const staffService = require('../staff');
+        const labsService = require('../../../shared/labs');
 
         const {GhostMailer} = require('../mail');
         const settingsCache = require('../../../shared/settings-cache');
@@ -42,7 +43,8 @@ class GiftServiceWrapper {
             giftEmailService,
             get staffServiceEmails() {
                 return staffService.api.emails;
-            }
+            },
+            labsService
         });
     }
 }

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -72,7 +72,9 @@ const messages = {
     giftSubscriptionsNotEnabled: 'Gift subscriptions are not enabled on this site.',
     giftNotFound: 'Gift not found.',
     giftAlreadyRedeemed: 'This gift has already been redeemed.',
+    giftConsumed: 'This gift has already been consumed.',
     giftExpired: 'This gift has expired.',
+    giftRefunded: 'This gift has been refunded.',
     memberAlreadySubscribed: 'You already have an active subscription.'
 };
 
@@ -178,18 +180,31 @@ export class GiftService {
             });
         }
 
-        if (gift.redeemedAt !== null) {
-            throw new errors.BadRequestError({
-                message: tpl(messages.giftAlreadyRedeemed)
-            });
-        }
+        const isRedeemable = gift.isRedeemable();
 
-        const now = new Date();
+        if (!isRedeemable) {
+            const redeemFailureReason = gift.getRedeemFailureReason();
 
-        if (gift.expiredAt !== null || (gift.expiresAt !== null && gift.expiresAt <= now)) {
-            throw new errors.BadRequestError({
-                message: tpl(messages.giftExpired)
-            });
+            switch (redeemFailureReason) {
+            case 'redeemed':
+                throw new errors.BadRequestError({
+                    message: tpl(messages.giftAlreadyRedeemed)
+                });
+            case 'consumed':
+                throw new errors.BadRequestError({
+                    message: tpl(messages.giftConsumed)
+                });
+            case 'expired':
+                throw new errors.BadRequestError({
+                    message: tpl(messages.giftExpired)
+                });
+            case 'refunded':
+                throw new errors.BadRequestError({
+                    message: tpl(messages.giftRefunded)
+                });
+            default:
+                break;
+            }
         }
 
         if (currentMember && currentMember.status !== 'free') {

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -1,15 +1,30 @@
 import errors from '@tryghost/errors';
 import logging from '@tryghost/logging';
+import tpl from '@tryghost/tpl';
 import {Gift} from './gift';
 import type {GiftRepository} from './gift-repository';
+import ObjectID from 'bson-objectid';
 
 interface MemberRepository {
     get(filter: Record<string, unknown>): Promise<{id: string; get(key: string): string | null} | null>;
 }
 
+type Tier = {
+    id: ObjectID;
+    name: string;
+    description: string | null;
+    benefits: string[] | null;
+    toJSON?: () => {
+        id: string;
+        name: string;
+        description: string | null;
+        benefits: string[] | null;
+    };
+};
+
 interface TiersService {
     api: {
-        read(idString: string): Promise<{name: string} | null>;
+        read(idString: string): Promise<Tier | null>;
     };
 }
 
@@ -36,6 +51,10 @@ interface StaffServiceEmails {
     }): Promise<void>;
 }
 
+interface LabsService {
+    isSet(key: string): boolean;
+}
+
 export interface GiftPurchaseData {
     token: string;
     buyerEmail: string;
@@ -49,19 +68,29 @@ export interface GiftPurchaseData {
     stripePaymentIntentId: string;
 }
 
+const messages = {
+    giftSubscriptionsNotEnabled: 'Gift subscriptions are not enabled on this site.',
+    giftNotFound: 'Gift not found.',
+    giftAlreadyRedeemed: 'This gift has already been redeemed.',
+    giftExpired: 'This gift has expired.',
+    memberAlreadySubscribed: 'You already have an active subscription.'
+};
+
 export class GiftService {
     private readonly giftRepository: GiftRepository;
     private readonly memberRepository: MemberRepository;
     private readonly tiersService: TiersService;
     private readonly giftEmailService: GiftEmailService;
     private readonly staffServiceEmails: StaffServiceEmails;
+    private readonly labsService: LabsService;
 
-    constructor({giftRepository, memberRepository, tiersService, giftEmailService, staffServiceEmails}: {giftRepository: GiftRepository; memberRepository: MemberRepository; tiersService: TiersService; giftEmailService: GiftEmailService; staffServiceEmails: StaffServiceEmails}) {
+    constructor({giftRepository, memberRepository, tiersService, giftEmailService, staffServiceEmails, labsService}: {giftRepository: GiftRepository; memberRepository: MemberRepository; tiersService: TiersService; giftEmailService: GiftEmailService; staffServiceEmails: StaffServiceEmails; labsService: LabsService}) {
         this.giftRepository = giftRepository;
         this.memberRepository = memberRepository;
         this.tiersService = tiersService;
         this.giftEmailService = giftEmailService;
         this.staffServiceEmails = staffServiceEmails;
+        this.labsService = labsService;
     }
 
     async recordPurchase(data: GiftPurchaseData): Promise<boolean> {
@@ -132,5 +161,66 @@ export class GiftService {
         }
 
         return true;
+    }
+
+    async getRedeemableGiftByToken({token, currentMember}: {token: string; currentMember?: {status: string} | null}) {
+        if (!this.labsService.isSet('giftSubscriptions')) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.giftSubscriptionsNotEnabled)
+            });
+        }
+
+        const gift = await this.giftRepository.getByToken(token);
+
+        if (!gift) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.giftNotFound)
+            });
+        }
+
+        if (gift.redeemedAt !== null) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.giftAlreadyRedeemed)
+            });
+        }
+
+        const now = new Date();
+
+        if (gift.expiredAt !== null || (gift.expiresAt !== null && gift.expiresAt <= now)) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.giftExpired)
+            });
+        }
+
+        if (currentMember && currentMember.status !== 'free') {
+            throw new errors.BadRequestError({
+                message: tpl(messages.memberAlreadySubscribed)
+            });
+        }
+
+        const tier = await this.tiersService.api.read(gift.tierId);
+
+        if (!tier) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.giftNotFound)
+            });
+        }
+
+        const tierJSON = tier.toJSON ? tier.toJSON() : tier;
+
+        return {
+            token: gift.token,
+            cadence: gift.cadence,
+            duration: gift.duration,
+            currency: gift.currency,
+            amount: gift.amount,
+            expires_at: gift.expiresAt,
+            tier: {
+                id: tierJSON.id,
+                name: tierJSON.name,
+                description: tierJSON.description ?? null,
+                benefits: Array.isArray(tierJSON.benefits) ? tierJSON.benefits : []
+            }
+        };
     }
 }

--- a/ghost/core/core/server/services/gifts/gift.ts
+++ b/ghost/core/core/server/services/gifts/gift.ts
@@ -1,7 +1,7 @@
 import {GIFT_EXPIRY_DAYS} from './constants';
 
-type GiftStatus = 'purchased' | 'redeemed' | 'consumed' | 'expired' | 'refunded';
-type GiftCadence = 'month' | 'year';
+export type GiftStatus = 'purchased' | 'redeemed' | 'consumed' | 'expired' | 'refunded';
+export type GiftCadence = 'month' | 'year';
 
 interface GiftData {
     token: string;
@@ -99,5 +99,45 @@ export class Gift {
             expiredAt: null,
             refundedAt: null
         });
+    }
+
+    isRedeemed() {
+        return this.redeemedAt !== null;
+    }
+
+    isExpired() {
+        return this.expiredAt !== null;
+    }
+
+    isRefunded() {
+        return this.refundedAt !== null;
+    }
+
+    isConsumed() {
+        return this.consumedAt !== null;
+    }
+
+    getRedeemFailureReason(): 'redeemed' | 'consumed' | 'expired' | 'refunded' | null {
+        if (this.isRedeemed()) {
+            return 'redeemed';
+        }
+
+        if (this.isConsumed()) {
+            return 'consumed';
+        }
+
+        if (this.isExpired()) {
+            return 'expired';
+        }
+
+        if (this.isRefunded()) {
+            return 'refunded';
+        }
+
+        return null;
+    }
+
+    isRedeemable() {
+        return this.getRedeemFailureReason() === null;
     }
 }

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -73,7 +73,7 @@ module.exports = function setupMembersApp() {
     // Manage session
     membersApp.get('/api/session', middleware.getIdentityToken);
     membersApp.delete('/api/session', bodyParser.json({limit: '5mb'}), middleware.deleteSession);
-    
+
     membersApp.get('/api/entitlements', middleware.getEntitlementToken);
     membersApp.get('/api/integrity-token', middleware.createIntegrityToken);
 
@@ -127,6 +127,13 @@ module.exports = function setupMembersApp() {
         middleware.loadMemberSession,
         middleware.authMemberByUuid,
         http(api.feedbackMembers.add)
+    );
+
+    // Gifts
+    membersApp.get(
+        '/api/gifts/:token/redeem',
+        middleware.loadMemberSession,
+        http(api.giftsMembers.isRedeemable)
     );
 
     // Announcement

--- a/ghost/core/test/e2e-api/members/gifts.test.js
+++ b/ghost/core/test/e2e-api/members/gifts.test.js
@@ -8,7 +8,9 @@ describe('Members Gifts', function () {
     let giftSequence = 0;
 
     const alreadyRedeemedMessage = 'This gift has already been redeemed.';
+    const alreadyConsumedMessage = 'This gift has already been consumed.';
     const expiredMessage = 'This gift has expired.';
+    const refundedMessage = 'This gift has been refunded.';
     const activeSubscriptionMessage = 'You already have an active subscription.';
     const notFoundMessage = 'Gift not found.';
 
@@ -160,6 +162,20 @@ describe('Members Gifts', function () {
         assert.equal(body.errors[0].message, alreadyRedeemedMessage);
     });
 
+    it('returns 400 when the gift has already been consumed', async function () {
+        const consumedAt = new Date('2026-04-07T11:00:00.000Z');
+        const gift = await createGift({
+            status: 'consumed',
+            consumed_at: consumedAt
+        });
+
+        const {body} = await membersAgent
+            .get(`/api/gifts/${gift.get('token')}/redeem/`)
+            .expectStatus(400);
+
+        assert.equal(body.errors[0].message, alreadyConsumedMessage);
+    });
+
     it('returns 400 when the gift has expired', async function () {
         const expiredAt = new Date('2026-04-07T11:00:00.000Z');
         const gift = await createGift({
@@ -172,6 +188,20 @@ describe('Members Gifts', function () {
             .expectStatus(400);
 
         assert.equal(body.errors[0].message, expiredMessage);
+    });
+
+    it('returns 400 when the gift has been refunded', async function () {
+        const refundedAt = new Date('2026-04-07T11:00:00.000Z');
+        const gift = await createGift({
+            status: 'refunded',
+            refunded_at: refundedAt
+        });
+
+        const {body} = await membersAgent
+            .get(`/api/gifts/${gift.get('token')}/redeem/`)
+            .expectStatus(400);
+
+        assert.equal(body.errors[0].message, refundedMessage);
     });
 
     it('returns 404 when the gift token does not exist', async function () {

--- a/ghost/core/test/e2e-api/members/gifts.test.js
+++ b/ghost/core/test/e2e-api/members/gifts.test.js
@@ -1,0 +1,184 @@
+const assert = require('node:assert/strict');
+const {agentProvider, fixtureManager, mockManager, configUtils} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+
+describe('Members Gifts', function () {
+    let membersAgent;
+    let paidProduct;
+    let giftSequence = 0;
+
+    const alreadyRedeemedMessage = 'This gift has already been redeemed.';
+    const expiredMessage = 'This gift has expired.';
+    const activeSubscriptionMessage = 'You already have an active subscription.';
+    const notFoundMessage = 'Gift not found.';
+
+    before(async function () {
+        membersAgent = await agentProvider.getMembersAPIAgent();
+
+        await fixtureManager.init('members');
+
+        paidProduct = await models.Product.findOne({
+            type: 'paid'
+        }, {
+            require: true,
+            withRelated: ['benefits']
+        });
+    });
+
+    beforeEach(function () {
+        mockManager.mockLabsEnabled('giftSubscriptions');
+    });
+
+    afterEach(async function () {
+        await configUtils.restore();
+        mockManager.restore();
+    });
+
+    async function createGift(overrides = {}) {
+        giftSequence += 1;
+
+        const sequence = giftSequence;
+        const now = new Date('2026-04-07T10:00:00.000Z');
+        const expiresAt = new Date('2030-01-01T00:00:00.000Z');
+
+        return await models.Gift.add({
+            token: `gift-token-${sequence}`,
+            buyer_email: `gift-buyer-${sequence}@example.com`,
+            buyer_member_id: null,
+            redeemer_member_id: null,
+            tier_id: paidProduct.id,
+            cadence: 'year',
+            duration: 1,
+            currency: 'usd',
+            amount: 5000,
+            stripe_checkout_session_id: `cs_gift_${sequence}`,
+            stripe_payment_intent_id: `pi_gift_${sequence}`,
+            consumes_at: null,
+            expires_at: expiresAt,
+            status: 'purchased',
+            purchased_at: now,
+            redeemed_at: null,
+            consumed_at: null,
+            expired_at: null,
+            refunded_at: null,
+            ...overrides
+        });
+    }
+
+    async function createCompedMemberAgent() {
+        const agent = membersAgent.duplicate();
+        const email = `gift-comped-${giftSequence + 1}@example.com`;
+
+        await agent.loginAs(email);
+
+        const member = await models.Member.findOne({email}, {require: true});
+
+        await models.Member.edit({
+            status: 'comped',
+            products: [{
+                id: paidProduct.id
+            }]
+        }, {
+            id: member.id
+        });
+
+        return agent;
+    }
+
+    it('returns gift details for an anonymous visitor when the token is redeemable', async function () {
+        const gift = await createGift();
+
+        const {body} = await membersAgent
+            .get(`/api/gifts/${gift.get('token')}/redeem/`)
+            .expectStatus(200);
+
+        assert.equal(body.gifts.length, 1);
+        assert.equal(body.gifts[0].token, gift.get('token'));
+        assert.equal(body.gifts[0].cadence, 'year');
+        assert.equal(body.gifts[0].duration, 1);
+        assert.equal(body.gifts[0].currency, 'usd');
+        assert.equal(body.gifts[0].amount, 5000);
+        assert.equal(body.gifts[0].expires_at, '2030-01-01T00:00:00.000Z');
+        assert.deepEqual(body.gifts[0].tier, {
+            id: paidProduct.id,
+            name: paidProduct.get('name'),
+            description: paidProduct.get('description'),
+            benefits: paidProduct.related('benefits').toJSON().map(item => item.name)
+        });
+        assert.equal(body.gifts[0].buyer_email, undefined);
+        assert.equal(body.gifts[0].redeemed_at, undefined);
+    });
+
+    it('returns gift details for a logged-in free member when the token is redeemable', async function () {
+        const agent = membersAgent.duplicate();
+        const gift = await createGift();
+
+        await agent.loginAs(`gift-free-${giftSequence + 1}@example.com`);
+
+        const {body} = await agent
+            .get(`/api/gifts/${gift.get('token')}/redeem/`)
+            .expectStatus(200);
+
+        assert.equal(body.gifts[0].token, gift.get('token'));
+    });
+
+    it('returns 400 when the logged-in member already has a paid subscription', async function () {
+        const agent = membersAgent.duplicate();
+        const gift = await createGift();
+
+        await agent.loginAs('paid@test.com');
+
+        const {body} = await agent
+            .get(`/api/gifts/${gift.get('token')}/redeem/`)
+            .expectStatus(400);
+
+        assert.equal(body.errors[0].message, activeSubscriptionMessage);
+    });
+
+    it('returns 400 when the logged-in member already has a comped subscription', async function () {
+        const agent = await createCompedMemberAgent();
+        const gift = await createGift();
+
+        const {body} = await agent
+            .get(`/api/gifts/${gift.get('token')}/redeem/`)
+            .expectStatus(400);
+
+        assert.equal(body.errors[0].message, activeSubscriptionMessage);
+    });
+
+    it('returns 400 when the gift has already been redeemed', async function () {
+        const redeemedAt = new Date('2026-04-07T11:00:00.000Z');
+        const gift = await createGift({
+            status: 'redeemed',
+            redeemed_at: redeemedAt
+        });
+
+        const {body} = await membersAgent
+            .get(`/api/gifts/${gift.get('token')}/redeem/`)
+            .expectStatus(400);
+
+        assert.equal(body.errors[0].message, alreadyRedeemedMessage);
+    });
+
+    it('returns 400 when the gift has expired', async function () {
+        const expiredAt = new Date('2026-04-07T11:00:00.000Z');
+        const gift = await createGift({
+            status: 'expired',
+            expired_at: expiredAt
+        });
+
+        const {body} = await membersAgent
+            .get(`/api/gifts/${gift.get('token')}/redeem/`)
+            .expectStatus(400);
+
+        assert.equal(body.errors[0].message, expiredMessage);
+    });
+
+    it('returns 404 when the gift token does not exist', async function () {
+        const {body} = await membersAgent
+            .get('/api/gifts/nonexistent-token/redeem/')
+            .expectStatus(404);
+
+        assert.equal(body.errors[0].message, notFoundMessage);
+    });
+});

--- a/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import {GiftBookshelfRepository} from '../../../../../core/server/services/gifts/gift-bookshelf-repository';
+import {Gift} from '../../../../../core/server/services/gifts/gift';
+
+describe('GiftBookshelfRepository', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('returns a Gift when a token matches', async function () {
+        const GiftModel = {
+            add: sinon.stub(),
+            findOne: sinon.stub().resolves({
+                toJSON() {
+                    return {
+                        token: 'gift-token',
+                        buyer_email: 'buyer@example.com',
+                        buyer_member_id: 'buyer_member_1',
+                        redeemer_member_id: null,
+                        tier_id: 'tier_1',
+                        cadence: 'year',
+                        duration: 1,
+                        currency: 'usd',
+                        amount: 5000,
+                        stripe_checkout_session_id: 'cs_123',
+                        stripe_payment_intent_id: 'pi_456',
+                        consumes_at: null,
+                        expires_at: new Date('2030-01-01T00:00:00.000Z'),
+                        status: 'purchased',
+                        purchased_at: new Date('2026-01-01T00:00:00.000Z'),
+                        redeemed_at: null,
+                        consumed_at: null,
+                        expired_at: null,
+                        refunded_at: null
+                    };
+                }
+            })
+        };
+        const repository = new GiftBookshelfRepository({GiftModel});
+
+        const gift = await repository.getByToken('gift-token');
+
+        sinon.assert.calledOnceWithExactly(GiftModel.findOne, {
+            token: 'gift-token'
+        }, {require: false});
+        assert.ok(gift instanceof Gift);
+        assert.equal(gift?.token, 'gift-token');
+        assert.equal(gift?.tierId, 'tier_1');
+    });
+
+    it('returns null when no gift matches the token', async function () {
+        const GiftModel = {
+            add: sinon.stub(),
+            findOne: sinon.stub().resolves(null)
+        };
+        const repository = new GiftBookshelfRepository({GiftModel});
+
+        const gift = await repository.getByToken('missing-token');
+
+        assert.equal(gift, null);
+    });
+});

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -353,6 +353,25 @@ describe('GiftService', function () {
             );
         });
 
+        it('throws BadRequestError when the gift has already been consumed', async function () {
+            giftRepository.getByToken.resolves(buildGift({
+                consumedAt: new Date('2026-02-01T00:00:00.000Z')
+            }));
+
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({token: 'gift-token'}),
+                (err: any) => {
+                    assert.equal(err.errorType, 'BadRequestError');
+                    assert.equal(err.message, 'This gift has already been consumed.');
+                    return true;
+                }
+            );
+
+            sinon.assert.notCalled(tiersService.api.read);
+        });
+
         it('throws BadRequestError when the gift has expired', async function () {
             giftRepository.getByToken.resolves(buildGift({
                 expiredAt: new Date('2026-02-01T00:00:00.000Z')
@@ -370,10 +389,9 @@ describe('GiftService', function () {
             );
         });
 
-        it('throws BadRequestError when the gift expiry timestamp is in the past but not yet swept', async function () {
+        it('throws BadRequestError when the gift has been refunded', async function () {
             giftRepository.getByToken.resolves(buildGift({
-                expiresAt: new Date('2026-01-15T00:00:00.000Z'),
-                expiredAt: null
+                refundedAt: new Date('2026-02-01T00:00:00.000Z')
             }));
 
             const service = createService();
@@ -382,10 +400,12 @@ describe('GiftService', function () {
                 () => service.getRedeemableGiftByToken({token: 'gift-token'}),
                 (err: any) => {
                     assert.equal(err.errorType, 'BadRequestError');
-                    assert.equal(err.message, 'This gift has expired.');
+                    assert.equal(err.message, 'This gift has been refunded.');
                     return true;
                 }
             );
+
+            sinon.assert.notCalled(tiersService.api.read);
         });
 
         it('throws BadRequestError for a logged-in paid member', async function () {

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -16,7 +16,12 @@ describe('GiftService', function () {
         sendPurchaseConfirmation: sinon.SinonStub;
     };
     let tiersService: {
-        api: {read: sinon.SinonStub};
+        api: {
+            read: sinon.SinonStub;
+        };
+    };
+    let labsService: {
+        isSet: sinon.SinonStub;
     };
     const purchaseData: GiftPurchaseData = {
         token: 'abc-123',
@@ -33,8 +38,9 @@ describe('GiftService', function () {
 
     beforeEach(function () {
         giftRepository = {
-            create: sinon.stub<[Gift], Promise<void>>(),
-            existsByCheckoutSessionId: sinon.stub<[string], Promise<boolean>>().resolves(false)
+            create: sinon.stub(),
+            existsByCheckoutSessionId: sinon.stub<[string], Promise<boolean>>().resolves(false),
+            getByToken: sinon.stub<[string], Promise<Gift | null>>().resolves(null)
         };
         memberRepository = {
             get: sinon.stub().resolves({id: 'member_1', get: sinon.stub().returns(null)})
@@ -46,7 +52,17 @@ describe('GiftService', function () {
             sendPurchaseConfirmation: sinon.stub()
         };
         tiersService = {
-            api: {read: sinon.stub().resolves({name: 'Gold'})}
+            api: {
+                read: sinon.stub().resolves({
+                    id: 'tier_1',
+                    name: 'Bronze',
+                    description: 'Tier description',
+                    benefits: ['Benefit 1', 'Benefit 2']
+                })
+            }
+        };
+        labsService = {
+            isSet: sinon.stub().returns(true)
         };
     });
 
@@ -55,7 +71,39 @@ describe('GiftService', function () {
     });
 
     function createService() {
-        return new GiftService({giftRepository, memberRepository, tiersService, giftEmailService, staffServiceEmails});
+        return new GiftService({
+            giftRepository: giftRepository as any,
+            memberRepository,
+            tiersService,
+            giftEmailService,
+            staffServiceEmails,
+            labsService
+        });
+    }
+
+    function buildGift(overrides: Partial<ConstructorParameters<typeof Gift>[0]> = {}) {
+        return new Gift({
+            token: 'gift-token',
+            buyerEmail: 'buyer@example.com',
+            buyerMemberId: 'buyer_member_1',
+            redeemerMemberId: null,
+            tierId: 'tier_1',
+            cadence: 'year',
+            duration: 1,
+            currency: 'usd',
+            amount: 5000,
+            stripeCheckoutSessionId: 'cs_123',
+            stripePaymentIntentId: 'pi_456',
+            consumesAt: null,
+            expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+            status: 'purchased',
+            purchasedAt: new Date('2026-01-01T00:00:00.000Z'),
+            redeemedAt: null,
+            consumedAt: null,
+            expiredAt: null,
+            refundedAt: null,
+            ...overrides
+        });
     }
 
     describe('recordPurchase', function () {
@@ -207,7 +255,7 @@ describe('GiftService', function () {
             assert.equal(emailData.amount, 5000);
             assert.equal(emailData.currency, 'usd');
             assert.equal(emailData.token, 'abc-123');
-            assert.equal(emailData.tierName, 'Gold');
+            assert.equal(emailData.tierName, 'Bronze');
             assert.equal(emailData.cadence, 'year');
             assert.equal(emailData.duration, 1);
             assert.ok(emailData.expiresAt instanceof Date);
@@ -233,6 +281,184 @@ describe('GiftService', function () {
 
             assert.equal(result, true);
             sinon.assert.calledOnce(giftRepository.create);
+        });
+    });
+
+    describe('getRedeemableGiftByToken', function () {
+        it('returns gift details for an anonymous visitor', async function () {
+            giftRepository.getByToken.resolves(buildGift());
+
+            const service = createService();
+            const gift = await service.getRedeemableGiftByToken({token: 'gift-token'});
+
+            sinon.assert.calledOnceWithExactly(giftRepository.getByToken, 'gift-token');
+            sinon.assert.calledOnceWithExactly(tiersService.api.read, 'tier_1');
+            assert.deepEqual(gift, {
+                token: 'gift-token',
+                cadence: 'year',
+                duration: 1,
+                currency: 'usd',
+                amount: 5000,
+                expires_at: new Date('2030-01-01T00:00:00.000Z'),
+                tier: {
+                    id: 'tier_1',
+                    name: 'Bronze',
+                    description: 'Tier description',
+                    benefits: ['Benefit 1', 'Benefit 2']
+                }
+            });
+        });
+
+        it('returns gift details for a logged-in free member', async function () {
+            giftRepository.getByToken.resolves(buildGift());
+
+            const service = createService();
+            const gift = await service.getRedeemableGiftByToken({
+                token: 'gift-token',
+                currentMember: {
+                    status: 'free'
+                }
+            });
+
+            assert.equal(gift.token, 'gift-token');
+        });
+
+        it('throws NotFoundError when the token does not exist', async function () {
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({token: 'missing-token'}),
+                (err: any) => {
+                    assert.equal(err.errorType, 'NotFoundError');
+                    assert.equal(err.message, 'Gift not found.');
+                    return true;
+                }
+            );
+        });
+
+        it('throws BadRequestError when the gift has already been redeemed', async function () {
+            giftRepository.getByToken.resolves(buildGift({
+                redeemedAt: new Date('2026-02-01T00:00:00.000Z')
+            }));
+
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({token: 'gift-token'}),
+                (err: any) => {
+                    assert.equal(err.errorType, 'BadRequestError');
+                    assert.equal(err.message, 'This gift has already been redeemed.');
+                    return true;
+                }
+            );
+        });
+
+        it('throws BadRequestError when the gift has expired', async function () {
+            giftRepository.getByToken.resolves(buildGift({
+                expiredAt: new Date('2026-02-01T00:00:00.000Z')
+            }));
+
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({token: 'gift-token'}),
+                (err: any) => {
+                    assert.equal(err.errorType, 'BadRequestError');
+                    assert.equal(err.message, 'This gift has expired.');
+                    return true;
+                }
+            );
+        });
+
+        it('throws BadRequestError when the gift expiry timestamp is in the past but not yet swept', async function () {
+            giftRepository.getByToken.resolves(buildGift({
+                expiresAt: new Date('2026-01-15T00:00:00.000Z'),
+                expiredAt: null
+            }));
+
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({token: 'gift-token'}),
+                (err: any) => {
+                    assert.equal(err.errorType, 'BadRequestError');
+                    assert.equal(err.message, 'This gift has expired.');
+                    return true;
+                }
+            );
+        });
+
+        it('throws BadRequestError for a logged-in paid member', async function () {
+            giftRepository.getByToken.resolves(buildGift());
+
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({
+                    token: 'gift-token',
+                    currentMember: {
+                        status: 'paid'
+                    }
+                }),
+                (err: any) => {
+                    assert.equal(err.errorType, 'BadRequestError');
+                    assert.equal(err.message, 'You already have an active subscription.');
+                    return true;
+                }
+            );
+        });
+
+        it('throws BadRequestError for a logged-in comped member', async function () {
+            giftRepository.getByToken.resolves(buildGift());
+
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({
+                    token: 'gift-token',
+                    currentMember: {
+                        status: 'comped'
+                    }
+                }),
+                (err: any) => {
+                    assert.equal(err.errorType, 'BadRequestError');
+                    assert.equal(err.message, 'You already have an active subscription.');
+                    return true;
+                }
+            );
+        });
+
+        it('throws BadRequestError when the labs flag is disabled', async function () {
+            labsService.isSet.returns(false);
+
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({token: 'gift-token'}),
+                (err: any) => {
+                    assert.equal(err.errorType, 'BadRequestError');
+                    assert.equal(err.message, 'Gift subscriptions are not enabled on this site.');
+                    return true;
+                }
+            );
+
+            sinon.assert.notCalled(giftRepository.getByToken);
+        });
+
+        it('throws NotFoundError when the tier cannot be loaded', async function () {
+            giftRepository.getByToken.resolves(buildGift());
+            tiersService.api.read.resolves(null);
+
+            const service = createService();
+
+            await assert.rejects(
+                () => service.getRedeemableGiftByToken({token: 'gift-token'}),
+                (err: any) => {
+                    assert.equal(err.errorType, 'NotFoundError');
+                    assert.equal(err.message, 'Gift not found.');
+                    return true;
+                }
+            );
         });
     });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift.test.ts
@@ -67,4 +67,74 @@ describe('Gift', function () {
             assert.equal(gift.stripePaymentIntentId, 'pi_456');
         });
     });
+
+    describe('redeemability', function () {
+        function buildGift(overrides: Partial<ConstructorParameters<typeof Gift>[0]> = {}) {
+            return new Gift({
+                token: 'gift-token',
+                buyerEmail: 'buyer@example.com',
+                buyerMemberId: 'buyer_member_1',
+                redeemerMemberId: null,
+                tierId: 'tier_1',
+                cadence: 'year',
+                duration: 1,
+                currency: 'usd',
+                amount: 5000,
+                stripeCheckoutSessionId: 'cs_123',
+                stripePaymentIntentId: 'pi_456',
+                consumesAt: null,
+                expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+                status: 'purchased',
+                purchasedAt: new Date('2026-01-01T00:00:00.000Z'),
+                redeemedAt: null,
+                consumedAt: null,
+                expiredAt: null,
+                refundedAt: null,
+                ...overrides
+            });
+        }
+
+        it('is redeemable when it has not been redeemed, consumed, expired, or refunded', function () {
+            const gift = buildGift();
+
+            assert.equal(gift.isRedeemable(), true);
+            assert.equal(gift.getRedeemFailureReason(), null);
+        });
+
+        it('is not redeemable when it has already been redeemed', function () {
+            const gift = buildGift({
+                redeemedAt: new Date('2026-02-01T00:00:00.000Z')
+            });
+
+            assert.equal(gift.isRedeemable(), false);
+            assert.equal(gift.getRedeemFailureReason(), 'redeemed');
+        });
+
+        it('is not redeemable when it has already been consumed', function () {
+            const gift = buildGift({
+                consumedAt: new Date('2026-02-01T00:00:00.000Z')
+            });
+
+            assert.equal(gift.isRedeemable(), false);
+            assert.equal(gift.getRedeemFailureReason(), 'consumed');
+        });
+
+        it('is not redeemable when it has already been expired', function () {
+            const gift = buildGift({
+                expiredAt: new Date('2026-02-01T00:00:00.000Z')
+            });
+
+            assert.equal(gift.isRedeemable(), false);
+            assert.equal(gift.getRedeemFailureReason(), 'expired');
+        });
+
+        it('is not redeemable when it has been refunded', function () {
+            const gift = buildGift({
+                refundedAt: new Date('2026-02-01T00:00:00.000Z')
+            });
+
+            assert.equal(gift.isRedeemable(), false);
+            assert.equal(gift.getRedeemFailureReason(), 'refunded');
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3476

## Summary

This PR adds a gift redemption preflight endpoint for Portal:

`GET /members/api/gifts/:token/redeem/`

The endpoint is read-only and answers one question before any redemption write happens: can this token be redeemed right now by the current visitor?

It supports both anonymous visitors and logged-in members. If the token is redeemable, it returns the gift details Portal needs to render the redemption screen. If not, it returns a standard members API error response with a user-facing message.

The endpoint validates gift redeemability in this order:

1. Gift subscriptions labs flag is enabled
2. A gift exists for the token
3. The gift has not already been redeemed
4. The gift has not expired
5. If a member is logged in, they do not already have active access
6. If all checks pass, the gift is considered redeemable and the endpoint returns the gift details.

## API contract

`GET /members/api/gifts/:token/redeem/`

Success response:

```
{
  "gifts": [
    {
      "token": "gift-token-123",
      "cadence": "year",
      "duration": 1,
      "currency": "usd",
      "amount": 5000,
      "expires_at": "2030-01-01T00:00:00.000Z",
      "tier": {
        "id": "tier_123",
        "name": "Bronze",
        "description": "Tier description",
        "benefits": [
          "Benefit 1",
          "Benefit 2"
        ]
      }
    }
  ]
}
```

Error response:

```
{
  "errors": [
    {
      "message": "This gift has expired.",
      "type": "BadRequestError"
    }
  ]
}
```

Expected error messages include:

- `"Gift not found."`
- `"This gift has already been redeemed."`
- `"This gift has expired."`
- `"You already have an active subscription."`
- `"Gift subscriptions are not enabled on this site."`

## Portal Flow

- A visitor opens `#/portal/gift/redeem/:token`
- Portal calls `GET /members/api/gifts/:token/redeem/`
- The gift service validates the token and current member eligibility
- If valid, the endpoint returns the gift payload in the standard members API envelope
- Portal reads response and renders the redemption UI
- If invalid, Portal surfaces the API error message through the existing notification flow
