### PR TITLE
Changed webhook trigger default request behavior

### DIFF
--- a/ghost/core/core/server/services/webhooks/webhook-trigger.js
+++ b/ghost/core/core/server/services/webhooks/webhook-trigger.js
@@ -1,6 +1,7 @@
 const debug = require('@tryghost/debug')('services:webhooks:trigger');
 const logging = require('@tryghost/logging');
 const ghostVersion = require('@tryghost/version');
+const config = require('../../../shared/config');
 const crypto = require('crypto');
 
 class WebhookTrigger {
@@ -16,7 +17,13 @@ class WebhookTrigger {
         this.models = models;
         this.payload = payload;
 
-        this.request = request ?? require('@tryghost/request');
+        if (request) {
+            this.request = request;
+        } else if (config.get('security:allowWebhookInternalIPs')) {
+            this.request = require('@tryghost/request');
+        } else {
+            this.request = require('../../lib/request-external');
+        }
         this.limitService = limitService;
     }
 
@@ -124,6 +131,7 @@ class WebhookTrigger {
             }
 
             const opts = {
+                method: 'POST',
                 body: reqPayload,
                 headers,
                 timeout: {

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -14,6 +14,7 @@
     },
     "privacy": false,
     "security": {
+        "allowWebhookInternalIPs": false,
         "staffDeviceVerification": true
     },
     "useMinFiles": true,

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -19,7 +19,8 @@
         "level": "error"
     },
     "security": {
-        "staffDeviceVerification": false
+        "staffDeviceVerification": false,
+        "allowWebhookInternalIPs": true
     },
     "spam": {
         "user_login": {

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -15,7 +15,8 @@
         "level": "error"
     },
     "security": {
-        "staffDeviceVerification": false
+        "staffDeviceVerification": false,
+        "allowWebhookInternalIPs": true
     },
     "spam": {
         "user_login": {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -36,6 +36,7 @@ Object {
     "mail": "",
     "mailgunIsConfigured": false,
     "security": Object {
+      "allowWebhookInternalIPs": true,
       "staffDeviceVerification": false,
     },
     "signupForm": Object {

--- a/ghost/core/test/integration/services/webhook-request.test.js
+++ b/ghost/core/test/integration/services/webhook-request.test.js
@@ -1,0 +1,99 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const nock = require('nock');
+const LimitService = require('@tryghost/limit-service');
+
+const WebhookTrigger = require('../../../core/server/services/webhooks/webhook-trigger');
+const configUtils = require('../../utils/config-utils');
+
+// for dns stub needed by request-external
+const dnsPromises = require('dns').promises;
+
+const WEBHOOK_EVENT = 'post.added';
+const WEBHOOK_TARGET = 'https://test-webhook-receiver.com';
+const WEBHOOK_PATH = '/webhook-delivery/';
+
+describe('Webhook delivery', function () {
+    let models, payload, limitService;
+
+    beforeEach(function () {
+        models = {
+            Webhook: {
+                edit: sinon.stub().resolves(null),
+                destroy: sinon.stub().resolves(null),
+                findAllByEvent: sinon.stub()
+            }
+        };
+
+        payload = sinon.stub().resolves({post: {current: {id: 1, title: 'Test'}, previous: {}}});
+
+        const realLimitService = new LimitService();
+        limitService = sinon.stub(realLimitService);
+        limitService.isLimited.withArgs('customIntegrations').returns(false);
+
+        // Stub DNS so request-external doesn't fail on fake domains
+        if (!dnsPromises.lookup.restore) {
+            sinon.stub(dnsPromises, 'lookup').resolves({address: '123.123.123.123', family: 4});
+        }
+
+        nock.disableNetConnect();
+    });
+
+    afterEach(async function () {
+        nock.cleanAll();
+        nock.enableNetConnect();
+        await configUtils.restore();
+        sinon.restore();
+    });
+
+    function setupWebhookModel(secret = '') {
+        const webhookModel = {
+            id: 'webhook-test-id',
+            get: sinon.stub()
+        };
+        webhookModel.get.withArgs('event').returns(WEBHOOK_EVENT);
+        webhookModel.get.withArgs('target_url').returns(WEBHOOK_TARGET + WEBHOOK_PATH);
+        webhookModel.get.withArgs('secret').returns(secret);
+
+        models.Webhook.findAllByEvent
+            .withArgs(WEBHOOK_EVENT, {context: {internal: true}})
+            .resolves({models: [webhookModel]});
+
+        return webhookModel;
+    }
+
+    describe('using @tryghost/request (allowWebhookInternalIPs: true)', function () {
+        it('delivers webhook payload via POST', async function () {
+            configUtils.set('security:allowWebhookInternalIPs', true);
+            setupWebhookModel();
+
+            const scope = nock(WEBHOOK_TARGET)
+                .post(WEBHOOK_PATH)
+                .reply(200, {status: 'OK'});
+
+            const trigger = new WebhookTrigger({models, payload, limitService});
+
+            await trigger.trigger(WEBHOOK_EVENT, {});
+
+            assert.ok(scope.isDone(), 'Expected webhook to be delivered as a POST request via @tryghost/request');
+        });
+    });
+
+    describe('using request-external (allowWebhookInternalIPs: false)', function () {
+        it('delivers webhook payload via POST', async function () {
+            configUtils.set('security:allowWebhookInternalIPs', false);
+            configUtils.set('env', 'development'); // bypass IP validation in request-external
+            setupWebhookModel();
+
+            const scope = nock(WEBHOOK_TARGET)
+                .post(WEBHOOK_PATH)
+                .reply(200, {status: 'OK'});
+
+            const trigger = new WebhookTrigger({models, payload, limitService});
+
+            await trigger.trigger(WEBHOOK_EVENT, {});
+
+            assert.ok(scope.isDone(), 'Expected webhook to be delivered as a POST request via request-external');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/webhooks/trigger.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/trigger.test.js
@@ -5,6 +5,7 @@ const logging = require('@tryghost/logging');
 const LimitService = require('@tryghost/limit-service');
 
 const WebhookTrigger = require('../../../../../core/server/services/webhooks/webhook-trigger');
+const configUtils = require('../../../../utils/config-utils');
 
 const SIGNATURE_HEADER = 'X-Ghost-Signature';
 const SIGNATURE_REGEX = /^sha256=[a-z0-9]+, t=\d+$/;
@@ -47,64 +48,25 @@ describe('Webhook Service', function () {
         sinon.stub(webhookTrigger, 'onError').callsFake(() => Promise.resolve());
     });
 
-    describe('onError', function () {
-        let loggingStub;
-        let errorTrigger;
+    afterEach(async function () {
+        await configUtils.restore();
+    });
 
-        beforeEach(function () {
-            loggingStub = sinon.stub(logging, 'error');
-            errorTrigger = new WebhookTrigger({models, payload, request, limitService});
+    describe('constructor', function () {
+        it('uses the external request library when internal IPs disabled in config', function () {
+            configUtils.set('security:allowWebhookInternalIPs', false);
+
+            const constructedWebhookTrigger = new WebhookTrigger({models, payload, limitService});
+
+            assert.equal(constructedWebhookTrigger.request, require('../../../../../core/server/lib/request-external'));
         });
 
-        afterEach(function () {
-            loggingStub.restore();
-        });
+        it('uses base request library when internal IPs enabled in config', function () {
+            configUtils.set('security:allowWebhookInternalIPs', true);
 
-        it('logs a structured error for failed webhook deliveries', function () {
-            const webhookModel = {
-                id: 'abc123',
-                get: sinon.stub()
-            };
-            webhookModel.get
-                .withArgs('event').returns('post.added')
-                .withArgs('target_url').returns('https://example.com/hook');
+            const constructedWebhookTrigger = new WebhookTrigger({models, payload, limitService});
 
-            const err = new Error('URL resolves to a non-permitted private IP block');
-            err.statusCode = 500;
-            err.code = 'URL_PRIVATE_INVALID';
-
-            errorTrigger.onError(webhookModel)(err);
-
-            sinon.assert.calledOnce(loggingStub);
-
-            // Example output:
-            // [WEBHOOK_DELIVERY_FAILURE] url=https://example.com/hook status=500 error_code=URL_PRIVATE_INVALID message=URL resolves to a non-permitted private IP block
-            const logLine = loggingStub.args[0][0];
-            assert.ok(logLine.startsWith('[WEBHOOK_DELIVERY_FAILURE]'), 'Log line must start with [WEBHOOK_DELIVERY_FAILURE] prefix');
-            assert.ok(logLine.includes('url=https://example.com/hook'));
-            assert.ok(logLine.includes('status=500'));
-            assert.ok(logLine.includes('error_code=URL_PRIVATE_INVALID'));
-            assert.ok(logLine.includes('message=URL resolves to a non-permitted private IP block'));
-            assert.equal(loggingStub.args[0][1], err, 'Error object must be passed as second argument for stack/metadata');
-        });
-
-        it('logs with fallback values when error properties are missing', function () {
-            const webhookModel = {
-                id: 'abc123',
-                get: sinon.stub()
-            };
-            webhookModel.get
-                .withArgs('event').returns('post.added')
-                .withArgs('target_url').returns(null);
-
-            const err = new Error();
-
-            errorTrigger.onError(webhookModel)(err);
-
-            const logLine = loggingStub.args[0][0];
-            assert.ok(logLine.includes('url=unknown'));
-            assert.ok(logLine.includes('status=none'));
-            assert.ok(logLine.includes('error_code=unknown'));
+            assert.equal(constructedWebhookTrigger.request, require('@tryghost/request'));
         });
     });
 
@@ -245,6 +207,67 @@ describe('Webhook Service', function () {
             assert.equal(expectedHeader, header);
 
             clock.restore();
+        });
+    });
+
+    describe('onError', function () {
+        let loggingStub;
+        let errorTrigger;
+
+        beforeEach(function () {
+            loggingStub = sinon.stub(logging, 'error');
+            errorTrigger = new WebhookTrigger({models, payload, request, limitService});
+        });
+
+        afterEach(function () {
+            loggingStub.restore();
+        });
+
+        it('logs a structured error for failed webhook deliveries', function () {
+            const webhookModel = {
+                id: 'abc123',
+                get: sinon.stub()
+            };
+            webhookModel.get
+                .withArgs('event').returns('post.added')
+                .withArgs('target_url').returns('https://example.com/hook');
+
+            const err = new Error('URL resolves to a non-permitted private IP block');
+            err.statusCode = 500;
+            err.code = 'URL_PRIVATE_INVALID';
+
+            errorTrigger.onError(webhookModel)(err);
+
+            sinon.assert.calledOnce(loggingStub);
+
+            // Example output:
+            // [WEBHOOK_DELIVERY_FAILURE] url=https://example.com/hook status=500 error_code=URL_PRIVATE_INVALID message=URL resolves to a non-permitted private IP block
+            const logLine = loggingStub.args[0][0];
+            assert.ok(logLine.startsWith('[WEBHOOK_DELIVERY_FAILURE]'), 'Log line must start with [WEBHOOK_DELIVERY_FAILURE] prefix');
+            assert.ok(logLine.includes('url=https://example.com/hook'));
+            assert.ok(logLine.includes('status=500'));
+            assert.ok(logLine.includes('error_code=URL_PRIVATE_INVALID'));
+            assert.ok(logLine.includes('message=URL resolves to a non-permitted private IP block'));
+            assert.equal(loggingStub.args[0][1], err, 'Error object must be passed as second argument for stack/metadata');
+        });
+
+        it('logs with fallback values when error properties are missing', function () {
+            const webhookModel = {
+                id: 'abc123',
+                get: sinon.stub()
+            };
+            webhookModel.get
+                .withArgs('event').returns('post.added')
+                .withArgs('target_url').returns(null);
+
+            const err = new Error();
+
+            errorTrigger.onError(webhookModel)(err);
+
+            const logLine = loggingStub.args[0][0];
+            assert.ok(logLine.includes('url=unknown'));
+            assert.ok(logLine.includes('status=none'));
+            assert.ok(logLine.includes('error_code=unknown'));
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1597/

- Webhook triggers now use `request-external` by default instead of `@tryghost/request`
- Internal IP destinations can still be enabled with `security.allowWebhookInternalIPs` for self-hosted setups

To allow webhooks to reach internal IP destinations, add to your Ghost config:

```
{
  "security": {
    "allowWebhookInternalIPs": true
  }
}
```