### PR TITLE
Ignore Sonar tag-plus-digest Docker warnings

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,12 +7,9 @@
 # Renovate and is what `pinDigest` updates produce out of the box.
 #
 # SonarCloud's docker:S8431 rule flags that format as a maintainability
-# warning and, because Ghost has SonarCloud configured as a required
-# quality gate, it blocks Renovate's pin-dependencies PRs from merging.
-# We want to keep Renovate's immutable pinning behaviour rather than
-# fight it repo-side, so this ignore lets `tag@digest` Docker refs pass
-# SonarCloud analysis without having to strip the tag from every pinned
-# image.
+# warning. As it's pure maintainability, we want to prefer renovate's 
+# default behavour to keep automerging working, which is actually more 
+# maintainable for us.
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S8431
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/Dockerfile*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S8431
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/Dockerfile*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,18 @@
+# Ignore SonarCloud rule docker:S8431 ("Use either the version tag or the
+# digest for the image instead of both") for all Dockerfiles.
+#
+# Renovate's default behaviour when pinning Docker images is to keep the
+# human-readable tag and append the immutable digest, producing refs of
+# the form `image:tag@sha256:...`. This is the format documented by
+# Renovate and is what `pinDigest` updates produce out of the box.
+#
+# SonarCloud's docker:S8431 rule flags that format as a maintainability
+# warning and, because Ghost has SonarCloud configured as a required
+# quality gate, it blocks Renovate's pin-dependencies PRs from merging.
+# We want to keep Renovate's immutable pinning behaviour rather than
+# fight it repo-side, so this ignore lets `tag@digest` Docker refs pass
+# SonarCloud analysis without having to strip the tag from every pinned
+# image.
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S8431
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/Dockerfile*


### PR DESCRIPTION
## Summary
- add a Sonar analysis override for rule `docker:S8431`
- suppress that rule for Dockerfiles in this repo
- stop SonarCloud from blocking Renovate pin-digest PRs on Docker image refs of the form `tag@sha256:digest`

## Why this change
SonarCloud is currently blocking Renovate's `pin-dependencies` PRs on rule `docker:S8431` (`Use either the version tag or the digest for the image instead of both`). Renovate intentionally preserves the human-readable tag while pinning the immutable digest for Docker updates, so this warning is tooling disagreement rather than a real problem for Ghost.

This change takes the repo-side suppression approach so Renovate's default Docker pinning format can continue to work without repeatedly blocking dependency PRs.
