### PR TITLE
Removed top divider from welcome email customization preview

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email-design/welcome-email-preview-content.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/welcome-email-preview-content.tsx
@@ -33,12 +33,7 @@ const WelcomeEmailPreviewContent: React.FC = () => {
     );
 
     return (
-        <div className='mx-auto w-full max-w-[600px] px-10'>
-            {/* Divider */}
-            <div className="my-5 py-4">
-                <hr className="m-0 border-0 border-t" style={{borderColor: colors.dividerColor}} />
-            </div>
-
+        <div className='mx-auto w-full max-w-[600px] px-10 pt-16'>
             <h3
                 className={titleFontClasses}
                 style={{color: colors.sectionTitleColor}}
@@ -67,13 +62,14 @@ const WelcomeEmailPreviewContent: React.FC = () => {
                         resolveImageCorners(settings.image_corners)
                     )} src={CoverImage} />
                 </div>
-                <div className="mt-1 w-full max-w-[600px] pb-8 text-center text-[1.3rem]" style={{color: colors.secondaryTextColor}}>Image caption</div>
+                <div className="mt-1 w-full max-w-[600px] pb-8 text-center text-body-sm" style={{color: colors.secondaryTextColor}}>Image caption</div>
 
                 <p className="mt-0 mb-6">
                     Welcome emails set the tone for your relationship with new members. We’ve optimized this template to look great across devices and inboxes, so your first impression lands exactly how you want it.
                 </p>
             </div>
 
+            {/* Divider */}
             <div className="my-5 py-4">
                 <hr className="m-0 border-0 border-t" style={{borderColor: colors.dividerColor}} />
             </div>


### PR DESCRIPTION
closes [NY-1211](https://linear.app/ghost/issue/NY-1211/remove-separator-from-welcome-email-header)

- removes top divider from welcome email preview, because it was kind of confusing - it seemed like it was part of the header
- there are still other dividers in the preview to be able to see changes to divider color
- also cleans up a class that could be `text-body-sm` instead of `text-[1.3rem]`

before:
<img width="500" height="940" alt="Screenshot 2026-04-08 at 8 06 54 AM" src="https://github.com/user-attachments/assets/df98ba06-b61e-4c89-a0c9-37094ee7fc27" />

after
<img width="500" height="921" alt="Screenshot 2026-04-08 at 8 07 17 AM" src="https://github.com/user-attachments/assets/6dd1c059-d92d-4a3e-b7fc-348e93857ff5" />
