### PR TITLE
Restrict Renovate runs to automerge-adjacent windows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,23 @@
     // as otherwise renovate wont follow our schedule
     "platformAutomerge": false,
     "timezone": "Etc/UTC",
+    // Restrict Renovate runs to the automerge windows so branch updates
+    // (rebasing, force-pushes) happen around the same times automerge
+    // can actually complete, not during the working day when CI is busy.
+    // Each block starts one hour earlier than the matching automerge
+    // window so Renovate has time to rebase and open/refresh PRs before
+    // automerge is eligible to run.
+    "schedule": [
+        // Run all weekend
+        "* * * * 0,6",
+        // Run on Monday morning (Sun 23:00 is already covered by weekend)
+        "* 0-12 * * 1",
+        // Run on weekday evenings, starting 1 hour earlier than automerge
+        "* 21-23 * * 1-5",
+        // Run on early weekday mornings (previous day 23:00 is already
+        // covered by the evening block above)
+        "* 0-4 * * 2-6"
+    ],
     "automergeSchedule": [
         // Allow automerge all weekend
         "* * * * 0,6",


### PR DESCRIPTION
## Summary
- add a Renovate `schedule` matching the existing `automergeSchedule`, with each block starting one hour earlier
- keep rebase churn and force-pushes out of the working day so long-running CI jobs (e.g. Playwright E2E) are not cancelled mid-run by Renovate rebasing
- give Renovate a 1-hour warmup window before each automerge window so branches are rebased and ready when automerge becomes eligible

## Why this change
`rebaseWhen: "automerging"` tells Renovate to rebase automerge-enabled branches whenever they fall behind `main`. With no `schedule` set, those rebases (and force-pushes) happen on every run throughout the day, which repeatedly cancelled in-progress CI runs as new merges landed on `main`.

Restricting `schedule` to the same weekend, Monday morning, weekday evening and early morning windows as `automergeSchedule` keeps Renovate from touching branches during normal working hours. Starting each schedule block one hour earlier than the matching automerge block gives Renovate time to rebase branches and refresh PRs so they are ready when the automerge window opens.

## Testing
- `npx --yes -p renovate renovate-config-validator .github/renovate.json5` -> `Config validated successfully`
