### PR TITLE
Shortened gift token from UUID to 8-char base64url for cleaner URLs

### DIFF
--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -174,7 +174,7 @@ class PaymentsService {
         const amount = tier.getPrice(cadence);
         const currency = tier.currency.toLowerCase();
 
-        const token = crypto.randomUUID();
+        const token = crypto.randomBytes(6).toString('base64url');
 
         const successUrlObj = new URL(successUrl);
         successUrlObj.searchParams.set('stripe', 'gift-purchase-success');

--- a/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
@@ -362,7 +362,7 @@ describe('PaymentsService', function () {
             assert.equal(args.metadata.duration, '1');
             assert.equal(args.metadata.buyer_email, 'buyer@example.com');
             assert.equal(args.metadata.requestSrc, 'portal');
-            assert.match(args.metadata.gift_token, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+            assert.match(args.metadata.gift_token, /^[A-Za-z0-9_-]{8}$/);
         });
 
         it('appends gift token to success URL', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3484

Uses `crypto.randomBytes(6).toString('base64url')` which gives 48 bits of entropy encoded into 8 URL-safe characters

