### PR TITLE
Improved create-database-migration skill with view support, Knex bindings guidance, and test DB init documentation

### DIFF
--- a/.agents/skills/create-database-migration/SKILL.md
+++ b/.agents/skills/create-database-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Create database migration
-description: Create a database migration to add a table, add columns to an existing table, add a setting, or otherwise change the schema of Ghost's MySQL database. Use this skill whenever the task involves modifying Ghost's database schema — including adding, removing, or renaming columns or tables, adding new settings, creating indexes, updating data, or any change that requires a migration file in ghost/core. Also use when the user references schema.js, knex-migrator, the migrations directory, or asks to "add a field" or "add a column" to any Ghost model/table. Even if the user frames it as a feature or Linear issue, if the implementation requires a schema change, this skill applies.
+description: Create a database migration to add a table, add columns to an existing table, add a setting, create or modify a database view, or otherwise change the schema of Ghost's database. Use this skill whenever the task involves modifying Ghost's database schema — including adding, removing, or renaming columns, tables, or views, adding new settings, creating indexes, updating data, or any change that requires a migration file in ghost/core. Also use when the user references schema.js, views.js, knex-migrator, the migrations directory, or asks to "add a field", "add a column", or "create a view" on any Ghost model/table. Even if the user frames it as a feature or Linear issue, if the implementation requires a schema change, this skill applies.
 ---
 
 # Create Database Migration
@@ -16,6 +16,22 @@ description: Create a database migration to add a table, add columns to an exist
 7. If adding or dropping a table, also add or remove the table name from the expected tables list in `ghost/core/test/integration/exporter/exporter.test.js`. This test has a hardcoded alphabetically-sorted array of all database tables — it runs in CI integration tests (not unit tests) and will fail if the new table is missing.
 8. Run the schema integrity test, and update the hash: `yarn test:single test/unit/server/data/schema/integrity.test.js`
 9. Run unit tests in Ghost core, and iterate until they pass: `cd ghost/core && yarn test:unit`
+
+## Database views
+
+Database views are defined in `ghost/core/core/server/data/schema/views.js` and created during database initialization in `ghost/core/core/server/data/migrations/init/1-create-tables.js`. When adding or modifying a view:
+
+1. Define or update the view in `ghost/core/core/server/data/schema/views.js` — this is the single source of truth for all view definitions.
+2. Create a version migration that references the view definition from `views.js` (see examples).
+3. Views do NOT need entries in `schema.js`, `table-lists.js`, or the exporter test — they are not tables.
+4. The init step (`1-create-tables.js`) automatically creates all views defined in `views.js` after creating tables, so tests and fresh installations will have the view without running version migrations.
+
+## Test database initialization
+
+Understanding the test DB init path is important:
+- `testUtils.setup('roles')` calls `knexMigrator.init({skip: 2})` — this only runs `1-create-tables.js` (which creates tables and views). **Version migrations are NOT executed.**
+- This means any schema object that only exists in a version migration will be missing in tests. Tables are covered because they're defined in `schema.js`. Views are covered because they're defined in `views.js` and created by `1-create-tables.js`.
+- If your migration adds a new table or view, you must ensure it's also defined in the appropriate schema file (`schema.js` for tables, `views.js` for views).
 
 ## Examples
 See [examples.md](examples.md) for example migrations.

--- a/.agents/skills/create-database-migration/examples.md
+++ b/.agents/skills/create-database-migration/examples.md
@@ -14,3 +14,30 @@ See [add member track source setting](../../../ghost/core/core/server/data/migra
 
 ## Manipulate data
 See [update newsletter subscriptions](../../../ghost/core/core/server/data/migrations/versions/5.31/2022-12-05-09-56-update-newsletter-subscriptions.js).
+
+## Create or modify a database view
+
+View definitions live in `ghost/core/core/server/data/schema/views.js`. The version migration references the shared definition:
+
+```javascript
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+const VIEW_NAME = 'my_view_name';
+const views = require('../../../schema/views');
+const viewDef = views.find(v => v.name === VIEW_NAME);
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info(`Creating view: ${VIEW_NAME}`);
+        await knex.raw('DROP VIEW IF EXISTS ??', [VIEW_NAME]);
+        await knex.raw('CREATE VIEW ?? AS ' + viewDef.body, [VIEW_NAME]);
+    },
+    async function down(knex) {
+        logging.info(`Dropping view: ${VIEW_NAME}`);
+        await knex.raw('DROP VIEW IF EXISTS ??', [VIEW_NAME]);
+    }
+);
+```
+
+See [add members effective subscriptions view](../../../ghost/core/core/server/data/migrations/versions/6.27/2026-04-08-10-56-56-add-members-effective-subscriptions-view.js) for a real example.

--- a/.agents/skills/create-database-migration/rules.md
+++ b/.agents/skills/create-database-migration/rules.md
@@ -31,3 +31,15 @@ Protect against missing data. If a migration crashes, Ghost cannot boot.
 ## Migrations should log every code path
 
 If we have to debug a migration, we need to know what it actually did. Without logging, that's impossible, so ensure all code paths and early returns contain logging. Note: when using the utility functions, logging is typically handled in the utility function itself, so no additional logging statements are necessary.
+
+## Use Knex bindings in raw queries
+
+When writing `knex.raw()` queries, always use parameter bindings instead of string interpolation:
+- `?` for value bindings: `knex.raw('UPDATE t SET col = ? WHERE id = ?', [value, id])`
+- `??` for identifier bindings (table/column names): `knex.raw('DROP VIEW IF EXISTS ??', [viewName])`
+
+This ensures proper quoting across both MySQL and SQLite (used in tests).
+
+## Migrations must work on both MySQL and SQLite
+
+Ghost uses MySQL in production and SQLite in tests. Migrations must be compatible with both. Avoid MySQL-specific syntax (e.g. backtick-quoting identifiers directly). Using Knex's `??` binding handles cross-database identifier quoting automatically.


### PR DESCRIPTION
The create-database-migration skill was missing guidance for several patterns that come up regularly when working with Ghost's database layer. This PR fills those gaps.

The most significant addition is documentation for database views. Views are defined in `views.js` and created during init in `1-create-tables.js`, but this workflow wasn't documented in the skill. The new "Database views" section in SKILL.md explains the full lifecycle — where to define views, how to write version migrations that reference the shared definition, and the important distinction that views don't need entries in `schema.js` or `table-lists.js`. A corresponding example migration template was added to examples.md showing the correct pattern of importing from `views.js` and using `knex.raw` with identifier bindings.

A section on test database initialization was also added. Understanding that `testUtils.setup('roles')` only runs `1-create-tables.js` (skipping version migrations) is critical for knowing why schema objects must be registered in `schema.js` or `views.js` — otherwise they won't exist in the test database.

Finally, two new rules were added to rules.md: always use Knex parameter bindings (`?` for values, `??` for identifiers) instead of string interpolation in raw queries, and ensure migrations are compatible with both MySQL and SQLite since Ghost uses MySQL in production but SQLite in tests.