### PR TITLE
Split TryGhost package updates into smaller groups

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -120,7 +120,6 @@
                 "@tryghost/database-info",
                 "@tryghost/debug",
                 "@tryghost/domain-events",
-                "@tryghost/email-mock-receiver",
                 "@tryghost/errors",
                 "@tryghost/http-cache-utils",
                 "@tryghost/job-manager",
@@ -169,6 +168,7 @@
         {
             "groupName": "TryGhost test support packages",
             "matchPackageNames": [
+                "@tryghost/email-mock-receiver",
                 "@tryghost/express-test",
                 "@tryghost/webhook-mock-receiver"
             ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -107,6 +107,73 @@
             ]
         },
 
+        // Split the broad shared TryGhost group into smaller logical lanes so
+        // failures in one area (e.g. email rendering) don't block unrelated
+        // internal package updates from merging.
+        {
+            "groupName": "TryGhost runtime packages",
+            "matchPackageNames": [
+                "@tryghost/adapter-base-cache",
+                "@tryghost/admin-api-schema",
+                "@tryghost/api-framework",
+                "@tryghost/bookshelf-plugins",
+                "@tryghost/database-info",
+                "@tryghost/debug",
+                "@tryghost/domain-events",
+                "@tryghost/email-mock-receiver",
+                "@tryghost/errors",
+                "@tryghost/http-cache-utils",
+                "@tryghost/job-manager",
+                "@tryghost/logging",
+                "@tryghost/metrics",
+                "@tryghost/mw-error-handler",
+                "@tryghost/mw-vhost",
+                "@tryghost/pretty-cli",
+                "@tryghost/prometheus-metrics",
+                "@tryghost/promise",
+                "@tryghost/referrer-parser",
+                "@tryghost/root-utils",
+                "@tryghost/security",
+                "@tryghost/social-urls",
+                "@tryghost/tpl",
+                "@tryghost/validator",
+                "@tryghost/version",
+                "@tryghost/zip"
+            ]
+        },
+        {
+            "groupName": "TryGhost admin support packages",
+            "matchPackageNames": [
+                "@tryghost/color-utils",
+                "@tryghost/custom-fonts",
+                "@tryghost/limit-service",
+                "@tryghost/members-csv",
+                "@tryghost/timezone-data"
+            ]
+        },
+        {
+            "groupName": "TryGhost content and email packages",
+            "matchPackageNames": [
+                "@tryghost/config-url-helpers",
+                "@tryghost/content-api",
+                "@tryghost/helpers",
+                "@tryghost/html-to-mobiledoc",
+                "@tryghost/html-to-plaintext",
+                "@tryghost/nodemailer",
+                "@tryghost/parse-email-address",
+                "@tryghost/request",
+                "@tryghost/string",
+                "@tryghost/url-utils"
+            ]
+        },
+        {
+            "groupName": "TryGhost test support packages",
+            "matchPackageNames": [
+                "@tryghost/express-test",
+                "@tryghost/webhook-mock-receiver"
+            ]
+        },
+
         // Always automerge these packages:
         {
             "matchPackageNames": [


### PR DESCRIPTION
## Summary
- split the broad shared `@tryghost/*` update group into smaller non-overlapping groups in Ghost's local Renovate config
- separate runtime packages, admin support packages, content/email packages, and test support packages
- keep the existing NQL special-casing in place while making future `@tryghost/*` update PRs easier to diagnose and merge incrementally

## Why this change
The current shared `tryghost-packages` group is too broad to debug efficiently. Recent failures mixed together email rendering changes, admin-facing utility updates, runtime plumbing, and test support packages, so a failure in one area blocked all of the others.

Splitting the internal package updates into smaller logical lanes should let Ghost reopen and validate one subset at a time instead of carrying a single noisy grouped PR.
