### PR TITLE
Fixed welcome email body font after enabling design customization

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
+++ b/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
@@ -3,7 +3,7 @@
                 <td class="wrapper">
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr class="post-content-row">
-                      <td class="post-content">
+                      <td class="{{classes.content}}">
                         {{{content}}}
                       </td>
                     </tr>

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -16,6 +16,7 @@ const UNMATCHED_TOKEN_REGEX = /%%\{.*?\}%%/g;
 // TODO: remove this constant after removing the labs flag, as we won't need these defaults anymore
 const DEFAULT_DESIGN_SETTINGS = {
     background_color: '#ffffff',
+    body_font_category: 'sans_serif',
     button_color: 'accent',
     button_corners: null,
     button_style: null,
@@ -203,6 +204,7 @@ class MemberWelcomeEmailRenderer {
         const headerImage = useDesignCustomization ? (designSettings.header_image || null) : null;
         const showHeaderTitle = useDesignCustomization ? designSettings.show_header_title !== false : false;
         const showBadge = useDesignCustomization ? designSettings.show_badge !== false : false;
+        const bodyFontCategory = designSettings.body_font_category === 'serif' ? 'serif' : 'sans_serif';
 
         const html = this.#wrapperTemplate({
             content: contentWithAbsoluteLinks,
@@ -235,7 +237,8 @@ class MemberWelcomeEmailRenderer {
             ],
             ...design,
             classes: {
-                container: 'container'
+                container: 'container',
+                content: useDesignCustomization && bodyFontCategory !== 'serif' ? 'post-content-sans-serif' : 'post-content'
             }
         });
 

--- a/ghost/core/test/integration/services/__snapshots__/member-welcome-emails-snapshot.test.js.snap
+++ b/ghost/core/test/integration/services/__snapshots__/member-welcome-emails-snapshot.test.js.snap
@@ -618,7 +618,7 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
-                                                  <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                     <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Welcome to our site!</p>
                                                   </td>
                                                 </tr>
@@ -1387,7 +1387,7 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
-                                                  <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                     <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Hello friend, welcome!</p>
                                                   </td>
                                                 </tr>
@@ -2156,7 +2156,7 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
-                                                  <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                     <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Hello Jamie, welcome to Test Site! Your email is jamie@example.com.</p>
                                                   </td>
                                                 </tr>
@@ -2926,7 +2926,7 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
-                                                  <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                     <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Welcome!</p>
                                                   </td>
                                                 </tr>

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -577,7 +577,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 assert(result.html.includes('https://ghost.org/?via=pbg-newsletter'));
             });
 
-            it('uses the newsletter content-shell class when design customization is enabled', async function () {
+            it('uses the sans-serif content-shell class by default when design customization is enabled', async function () {
                 lexicalRenderStub.resolves('<p>Content</p>');
                 const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
@@ -589,7 +589,26 @@ describe('MemberWelcomeEmailRenderer', function () {
                 });
 
                 assert.match(result.html, /<tr class="post-content-row">/);
+                assert(result.html.includes('class="post-content-sans-serif"'));
+                assert(result.html.includes('font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;'));
+            });
+
+            it('uses the serif content-shell class when a serif body font is explicitly configured', async function () {
+                lexicalRenderStub.resolves('<p>Content</p>');
+                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+
+                const result = await renderer.render({
+                    lexical: '{}',
+                    subject: 'Test Subject',
+                    designSettings: {
+                        body_font_category: 'serif'
+                    },
+                    member: {name: 'John', email: 'john@example.com'},
+                    siteSettings: defaultSiteSettings
+                });
+
                 assert(result.html.includes('class="post-content"'));
+                assert(result.html.includes('font-family: Georgia, serif;'));
             });
 
             it('applies custom link colors when design customization is enabled', async function () {
@@ -606,7 +625,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                     siteSettings: defaultSiteSettings
                 });
 
-                assert(result.html.includes('class="post-content"'));
+                assert(result.html.includes('class="post-content-sans-serif"'));
                 assert(result.html.includes('color: #000000'));
             });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1209/font-changes-for-existing-welcome-emails-when-customization-is-enabled

Enabling the `welcomeEmailsDesignCustomization` labs flag switched welcome emails onto the new template path, but the renderer always used the serif content class instead of honoring the stored body font setting. This keeps existing welcome emails on the default sans-serif styling until someone explicitly chooses a different body font in the customize flow.