### PR TITLE
Fixed save error in welcome emails customize modal

### DIFF
--- a/apps/admin-x-framework/src/api/automated-email-design.ts
+++ b/apps/admin-x-framework/src/api/automated-email-design.ts
@@ -42,5 +42,9 @@ export const useEditAutomatedEmailDesign = createMutation<AutomatedEmailDesignRe
     method: 'PUT',
     path: () => '/automated_emails/design/',
     body: design => ({automated_email_design: [design]}),
-    invalidateQueries: {dataType}
+    updateQueries: {
+        emberUpdateType: 'skip',
+        dataType,
+        update: newData => newData
+    }
 });

--- a/apps/admin-x-framework/test/unit/api/automated-email-design.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/automated-email-design.test.tsx
@@ -1,0 +1,71 @@
+import {act, waitFor} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import {renderHookWithProviders, createTestQueryClient} from '../../../src/test/test-utils';
+import {useEditAutomatedEmailDesign, type AutomatedEmailDesignResponseType} from '../../../src/api/automated-email-design';
+import {withMockFetch} from '../../utils/mock-fetch';
+
+describe('automated-email-design api', () => {
+    it('updates the React cache without invalidating Ember state', async () => {
+        const queryClient = createTestQueryClient();
+        const onInvalidate = vi.fn();
+
+        const initialData: AutomatedEmailDesignResponseType = {
+            automated_email_design: [{
+                id: 'default-automated-email-design',
+                slug: 'default-automated-email',
+                background_color: 'light',
+                header_background_color: 'transparent',
+                header_image: null,
+                show_header_title: true,
+                footer_content: null,
+                button_color: null,
+                button_corners: 'square',
+                button_style: 'fill',
+                link_color: null,
+                link_style: 'underline',
+                body_font_category: 'sans_serif',
+                title_font_category: 'sans_serif',
+                title_font_weight: 'bold',
+                image_corners: 'square',
+                divider_color: null,
+                section_title_color: null,
+                show_badge: true,
+                created_at: '2024-01-01T00:00:00.000Z',
+                updated_at: null
+            }]
+        };
+
+        const updatedData: AutomatedEmailDesignResponseType = {
+            automated_email_design: [{
+                ...initialData.automated_email_design[0],
+                body_font_category: 'serif',
+                updated_at: '2024-01-02T00:00:00.000Z'
+            }]
+        };
+
+        queryClient.setQueryData(
+            ['AutomatedEmailDesignResponseType', 'http://localhost:3000/ghost/api/admin/automated_emails/design/'],
+            initialData
+        );
+
+        await withMockFetch({json: updatedData}, async () => {
+            const {result} = renderHookWithProviders(() => useEditAutomatedEmailDesign(), {
+                frameworkProps: {onInvalidate},
+                queryClient
+            });
+
+            await act(async () => {
+                await result.current.mutateAsync({body_font_category: 'serif'});
+            });
+
+            await waitFor(() => {
+                expect(queryClient.getQueryData([
+                    'AutomatedEmailDesignResponseType',
+                    'http://localhost:3000/ghost/api/admin/automated_emails/design/'
+                ])).toEqual(updatedData);
+            });
+
+            expect(onInvalidate).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -25,6 +25,7 @@ export class MemberWelcomeEmailsSection extends BasePage {
     // Customize modal — Design tab locators
     readonly customizeModalButtonStyleFill: Locator;
     readonly customizeModalButtonStyleOutline: Locator;
+    readonly customizeModalBodyFontSelect: Locator;
 
     // Modal locators
     readonly welcomeEmailModal: Locator;
@@ -54,11 +55,12 @@ export class MemberWelcomeEmailsSection extends BasePage {
         this.customizeModalPublicationTitleToggle = this.customizeModal.getByText('Publication title').locator('..').getByRole('switch');
         this.customizeModalFooterTextarea = this.customizeModal.getByLabel('Email footer');
         this.customizeModalHeaderImageUpload = this.customizeModal.getByTestId('header-image-field');
-        this.customizeModalBadgeToggle = this.customizeModal.getByText('Show badge').locator('..').getByRole('switch');
+        this.customizeModalBadgeToggle = this.customizeModal.getByText('Promote independent publishing').locator('../..').getByRole('switch');
 
         // Customize modal — Design tab
         this.customizeModalButtonStyleFill = this.customizeModal.getByLabel('Fill');
         this.customizeModalButtonStyleOutline = this.customizeModal.getByLabel('Outline');
+        this.customizeModalBodyFontSelect = this.customizeModal.getByText('Body font').locator('..').getByRole('combobox');
 
         // Modal locators
         this.welcomeEmailModal = page.getByTestId('welcome-email-modal');
@@ -182,5 +184,10 @@ export class MemberWelcomeEmailsSection extends BasePage {
 
     async switchToGeneralTab(): Promise<void> {
         await this.customizeModalGeneralTab.click();
+    }
+
+    async chooseBodyFont(optionName: 'Elegant serif' | 'Clean sans-serif'): Promise<void> {
+        await this.customizeModalBodyFontSelect.click();
+        await this.page.getByRole('option', {name: optionName, exact: true}).click();
     }
 }

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -1,5 +1,10 @@
+import {EmailClient, MailPit} from '@/helpers/services/email/mail-pit';
+import {HomePage, PublicPage} from '@/public-pages';
 import {MemberWelcomeEmailsSection} from '@/admin-pages';
-import {expect, test} from '@/helpers/playwright';
+import {SignUpPage, SignUpSuccessPage} from '@/portal-pages';
+import {expect, test, withIsolatedPage} from '@/helpers/playwright';
+import {extractMagicLink} from '@/helpers/services/email/utils';
+import {faker} from '@faker-js/faker';
 import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 
 usePerTestIsolation();
@@ -41,6 +46,11 @@ interface AutomatedEmailDesign {
 
 interface AutomatedEmailDesignResponse {
     automated_email_design: AutomatedEmailDesign[];
+}
+
+async function retrieveLatestEmailMessage(emailClient: EmailClient, emailAddress: string, timeoutMs: number = 10000) {
+    const messages = await emailClient.searchByRecipient(emailAddress, {timeoutMs});
+    return await emailClient.getMessageDetailed(messages[0]);
 }
 
 test.describe('Ghost Admin - Member Welcome Emails', () => {
@@ -227,6 +237,54 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await welcomeEmailsSection.openCustomizeModal();
 
         await expect(welcomeEmailsSection.customizeModalFooterTextarea).toHaveValue('Persisted footer');
+    });
+
+    test('customized design is applied to the free member welcome email', async ({page, browser, baseURL}) => {
+        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
+        const emailClient = new MailPit();
+
+        await welcomeEmailsSection.goto();
+        await welcomeEmailsSection.enableFreeWelcomeEmail();
+        await welcomeEmailsSection.openCustomizeModal();
+
+        await welcomeEmailsSection.customizeModalFooterTextarea.fill('Custom footer text for welcome members');
+
+        await welcomeEmailsSection.switchToDesignTab();
+        await welcomeEmailsSection.chooseBodyFont('Elegant serif');
+        await welcomeEmailsSection.saveCustomizeModal();
+        await welcomeEmailsSection.closeCustomizeModal();
+
+        await withIsolatedPage(browser, {baseURL}, async ({page: signupPage}) => {
+            const homePage = new HomePage(signupPage);
+            await homePage.gotoPortalSignup();
+
+            const signUpPage = new SignUpPage(signupPage);
+            const emailAddress = `test${faker.string.uuid()}@ghost.org`;
+            const name = faker.person.fullName();
+            await signUpPage.waitForPortalToOpen();
+            await signUpPage.fillAndSubmit(emailAddress, name);
+
+            const successPage = new SignUpSuccessPage(signupPage);
+            await successPage.waitForSignUpSuccess();
+            await successPage.closePortal();
+
+            const signupEmail = await retrieveLatestEmailMessage(emailClient, emailAddress);
+            const magicLink = extractMagicLink(signupEmail.Text);
+
+            const publicPage = new PublicPage(signupPage);
+            await publicPage.goto(magicLink);
+            await homePage.waitUntilLoaded();
+
+            const welcomeMessages = await emailClient.search(
+                {to: emailAddress, subject: 'Welcome'},
+                {timeoutMs: 10000}
+            );
+            const welcomeEmail = await emailClient.getMessageDetailed(welcomeMessages[0]);
+
+            expect(welcomeEmail.Subject).toContain('Welcome to Test Blog');
+            expect(welcomeEmail.HTML).toContain('Custom footer text for welcome members');
+            expect(welcomeEmail.HTML).toContain('font-family: Georgia, serif;');
+        });
     });
 });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1217/save-error-in-customize-modal

## Summary

Previously, saving automated email design settings used query invalidation. For automatedEmailDesignResponseType, that data is React-only, so invalidation could lead to stale UI behavior and save errors in the customize modal. This change switches the mutation to update the cached query directly with the API response and skips Ember state updates.

## Changes

  - Update useEditAutomatedEmailDesign to use updateQueries instead of invalidateQueries
  - Skip Ember bridge updates for automated email design saves
  - Add a unit test covering the cache update behavior and verifying Ember invalidation is not called
  - Add E2E coverage for customizing the free member welcome email and verifying the saved footer/body font are reflected in the delivered email
  - Update the member welcome emails page object with selectors/helpers needed for the new design customization flow

## Why

  AutomatedEmailDesignResponseType is intentionally React-only. Invalidating it after save does not help Ember refresh anything, but it does make the modal depend on a refetch path unnecessarily. Updating the React Query cache directly keeps the modal in sync with the successful save response and avoids the
  erroneous save-state behavior.
