### PR TITLE
Improved welcome email color pickers with semantic swatches

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
@@ -1,18 +1,25 @@
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 import {ColorPicker} from '@tryghost/shade/patterns';
 import {Popover, PopoverContent, PopoverTrigger} from '@tryghost/shade/components';
 
-interface ColorPickerFieldProps {
+export interface ColorPickerFieldSwatch {
     title: string;
-    value: string;
-    onChange: (color: string) => void;
-    accentColor?: string;
+    value: string | null;
+    hex: string;
 }
 
-const VALID_HEX = /^#(?:[0-9a-f]{3}){1,2}$/i;
+interface ColorPickerFieldProps {
+    title: string;
+    value: string | null;
+    onChange: (color: string | null) => void;
+    accentColor?: string;
+    swatches?: ColorPickerFieldSwatch[];
+}
 
-const normalizeColorValue = (value: string, accentColor?: string): string => {
-    if (VALID_HEX.test(value)) {
+const VALID_HEX = /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+const normalizeColorValue = (value: string | null, accentColor?: string, swatches: ColorPickerFieldSwatch[] = []): string => {
+    if (value && VALID_HEX.test(value)) {
         return value;
     }
 
@@ -20,45 +27,124 @@ const normalizeColorValue = (value: string, accentColor?: string): string => {
     case 'accent':
         return accentColor && VALID_HEX.test(accentColor) ? accentColor : '#ffffff';
     case 'light':
+        return '#ffffff';
     case 'transparent':
-        return '#ffffff';
+        return '#00000000';
     default:
-        return '#ffffff';
+        break;
     }
+
+    const selectedSwatch = swatches.find(swatch => swatch.value === value);
+    if (selectedSwatch) {
+        return selectedSwatch.hex;
+    }
+
+    return '#ffffff';
 };
 
-const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChange, accentColor}) => {
+const isTransparent = (hex: string) => {
+    const normalized = hex.toLowerCase();
+
+    return (normalized.length === 5 && normalized[4] === '0') || (normalized.length === 9 && normalized.slice(7) === '00');
+};
+
+const TransparentIndicator = () => (
+    <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-full" data-testid="transparent-indicator" aria-hidden>
+        <span className="absolute top-1/2 left-[-30%] block h-px w-[160%] -translate-y-1/2 -rotate-45 bg-red" />
+    </span>
+);
+
+const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChange, accentColor, swatches = []}) => {
     const [open, setOpen] = useState(false);
-    const normalizedValue = normalizeColorValue(value, accentColor);
+    const normalizedValue = normalizeColorValue(value, accentColor, swatches);
+    const allowPickerChanges = useRef(false);
+    const suppressPickerChanges = useRef(false);
+    const selectedSwatch = swatches.find((swatch) => {
+        return swatch.value === value || (value && swatch.hex.toLowerCase() === value.toLowerCase());
+    });
 
     return (
-        <div className="flex items-center justify-between">
-            <span>{title}</span>
-            <Popover open={open} onOpenChange={setOpen}>
-                <PopoverTrigger asChild>
-                    <button
-                        aria-label={title}
-                        className="aspect-square size-7 rounded-full p-1"
-                        style={{background: 'conic-gradient(from 0deg, hsl(0, 100%, 50%), hsl(60, 100%, 50%), hsl(120, 100%, 50%), hsl(180, 100%, 50%), hsl(240, 100%, 50%), hsl(300, 100%, 50%), hsl(360, 100%, 50%))'}}
-                        title={title}
-                        type="button"
-                    >
-                        <span
-                            className="block size-full rounded-full border-2 border-white"
-                            style={{background: normalizedValue}}
-                        />
-                    </button>
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-auto p-4">
+        <Popover
+            open={open}
+            onOpenChange={(nextOpen) => {
+                allowPickerChanges.current = false;
+                suppressPickerChanges.current = false;
+                setOpen(nextOpen);
+            }}
+        >
+            <PopoverTrigger asChild>
+                <div className="flex w-full cursor-pointer items-start justify-between">
+                    <span className="mt-px flex-1">{title}</span>
+                    <div className="flex shrink-0 gap-1">
+                        {open && swatches.length > 0 && (
+                            <div className="flex items-center gap-1">
+                                {swatches.map((swatch) => {
+                                    const swatchValue = swatch.value === undefined ? swatch.hex : swatch.value;
+                                    const isSelected = selectedSwatch?.title === swatch.title;
+
+                                    return (
+                                        <button
+                                            key={swatch.title}
+                                            aria-label={swatch.title}
+                                            className={`relative flex h-5 w-5 shrink-0 cursor-pointer items-center overflow-hidden rounded-full border border-grey-300 dark:border-grey-800 ${isSelected ? 'outline-2 outline-green' : ''}`}
+                                            style={{backgroundColor: swatch.hex}}
+                                            title={swatch.title}
+                                            type="button"
+                                            onClick={() => {
+                                                allowPickerChanges.current = false;
+                                                suppressPickerChanges.current = true;
+                                                onChange(swatchValue);
+                                                setOpen(false);
+                                            }}
+                                        >
+                                            {isTransparent(swatch.hex) && <TransparentIndicator />}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        )}
+                        <button
+                            aria-label="Pick color"
+                            className="relative size-6 cursor-pointer rounded-full border border-grey-250 dark:border-grey-800"
+                            type="button"
+                        >
+                            <div className="absolute inset-0 rounded-full bg-[conic-gradient(hsl(360,100%,50%),hsl(315,100%,50%),hsl(270,100%,50%),hsl(225,100%,50%),hsl(180,100%,50%),hsl(135,100%,50%),hsl(90,100%,50%),hsl(45,100%,50%),hsl(0,100%,50%))]" />
+                            <div className="absolute inset-[3px] overflow-hidden rounded-full border border-white dark:border-grey-950" style={{backgroundColor: normalizedValue}} />
+                        </button>
+                    </div>
+                </div>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-auto p-4">
+                <div
+                    onInputCapture={() => {
+                        allowPickerChanges.current = true;
+                    }}
+                    onKeyDownCapture={() => {
+                        allowPickerChanges.current = true;
+                    }}
+                    onMouseDownCapture={() => {
+                        allowPickerChanges.current = true;
+                    }}
+                    onPointerDownCapture={() => {
+                        allowPickerChanges.current = true;
+                    }}
+                    onTouchStartCapture={() => {
+                        allowPickerChanges.current = true;
+                    }}
+                >
                     <ColorPicker
                         value={normalizedValue}
                         onChange={(hex: string) => {
+                            if (suppressPickerChanges.current || !allowPickerChanges.current) {
+                                return;
+                            }
+
                             onChange(hex);
                         }}
                     />
-                </PopoverContent>
-            </Popover>
-        </div>
+                </div>
+            </PopoverContent>
+        </Popover>
     );
 };
 

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/background-color-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/background-color-field.tsx
@@ -5,9 +5,16 @@ export const BackgroundColorField = () => {
     const {settings, onSettingsChange} = useEmailDesign();
     return (
         <ColorPickerField
+            swatches={[
+                {
+                    title: 'White',
+                    value: 'light',
+                    hex: '#ffffff'
+                }
+            ]}
             title="Background color"
             value={settings.background_color}
-            onChange={color => onSettingsChange({background_color: color})}
+            onChange={color => color && onSettingsChange({background_color: color})}
         />
     );
 };

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/button-color-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/button-color-field.tsx
@@ -1,13 +1,28 @@
 import ColorPickerField from '../color-picker-field';
+import {getAutoSwatchHex} from './color-swatch-helpers';
 import {useEmailDesign} from '../email-design-context';
 
 export const ButtonColorField = () => {
     const {settings, onSettingsChange, accentColor} = useEmailDesign();
+    const autoSwatchHex = getAutoSwatchHex(settings.background_color);
+
     return (
         <ColorPickerField
             accentColor={accentColor}
+            swatches={[
+                {
+                    title: 'Accent',
+                    value: 'accent',
+                    hex: accentColor
+                },
+                {
+                    title: 'Auto',
+                    value: null,
+                    hex: autoSwatchHex
+                }
+            ]}
             title="Button color"
-            value={settings.button_color || accentColor}
+            value={settings.button_color}
             onChange={color => onSettingsChange({button_color: color})}
         />
     );

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/color-swatch-helpers.ts
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/color-swatch-helpers.ts
@@ -1,0 +1,19 @@
+import {textColorForBackgroundColor} from '@tryghost/color-utils';
+
+const VALID_HEX = /^#(?:[0-9a-f]{3}){1,2}$/i;
+
+const normalizeBackgroundColor = (value: string): string => {
+    if (value === 'light') {
+        return '#ffffff';
+    }
+
+    if (VALID_HEX.test(value)) {
+        return value;
+    }
+
+    return '#ffffff';
+};
+
+export const getAutoSwatchHex = (backgroundColor: string): string => {
+    return textColorForBackgroundColor(normalizeBackgroundColor(backgroundColor)).hex();
+};

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/divider-color-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/divider-color-field.tsx
@@ -2,11 +2,25 @@ import ColorPickerField from '../color-picker-field';
 import {useEmailDesign} from '../email-design-context';
 
 export const DividerColorField = () => {
-    const {settings, onSettingsChange} = useEmailDesign();
+    const {settings, onSettingsChange, accentColor} = useEmailDesign();
+
     return (
         <ColorPickerField
+            accentColor={accentColor}
+            swatches={[
+                {
+                    title: 'Light',
+                    value: null,
+                    hex: '#e0e7eb'
+                },
+                {
+                    title: 'Accent',
+                    value: 'accent',
+                    hex: accentColor
+                }
+            ]}
             title="Divider color"
-            value={settings.divider_color || '#e0e7eb'}
+            value={settings.divider_color}
             onChange={color => onSettingsChange({divider_color: color})}
         />
     );

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/header-background-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/header-background-field.tsx
@@ -5,9 +5,16 @@ export const HeaderBackgroundField = () => {
     const {settings, onSettingsChange} = useEmailDesign();
     return (
         <ColorPickerField
+            swatches={[
+                {
+                    title: 'Transparent',
+                    value: 'transparent',
+                    hex: '#00000000'
+                }
+            ]}
             title="Header background color"
             value={settings.header_background_color}
-            onChange={color => onSettingsChange({header_background_color: color})}
+            onChange={color => color && onSettingsChange({header_background_color: color})}
         />
     );
 };

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/link-color-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/link-color-field.tsx
@@ -1,13 +1,28 @@
 import ColorPickerField from '../color-picker-field';
+import {getAutoSwatchHex} from './color-swatch-helpers';
 import {useEmailDesign} from '../email-design-context';
 
 export const LinkColorField = () => {
     const {settings, onSettingsChange, accentColor} = useEmailDesign();
+    const autoSwatchHex = getAutoSwatchHex(settings.background_color);
+
     return (
         <ColorPickerField
             accentColor={accentColor}
+            swatches={[
+                {
+                    title: 'Accent',
+                    value: 'accent',
+                    hex: accentColor
+                },
+                {
+                    title: 'Auto',
+                    value: null,
+                    hex: autoSwatchHex
+                }
+            ]}
             title="Link color"
-            value={settings.link_color || accentColor}
+            value={settings.link_color}
             onChange={color => onSettingsChange({link_color: color})}
         />
     );

--- a/apps/admin-x-settings/src/components/settings/email-design/design-fields/section-title-color-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-fields/section-title-color-field.tsx
@@ -1,12 +1,28 @@
 import ColorPickerField from '../color-picker-field';
+import {getAutoSwatchHex} from './color-swatch-helpers';
 import {useEmailDesign} from '../email-design-context';
 
 export const SectionTitleColorField = () => {
-    const {settings, onSettingsChange} = useEmailDesign();
+    const {settings, onSettingsChange, accentColor} = useEmailDesign();
+    const autoSwatchHex = getAutoSwatchHex(settings.background_color);
+
     return (
         <ColorPickerField
+            accentColor={accentColor}
+            swatches={[
+                {
+                    title: 'Auto',
+                    value: null,
+                    hex: autoSwatchHex
+                },
+                {
+                    title: 'Accent',
+                    value: 'accent',
+                    hex: accentColor
+                }
+            ]}
             title="Section title color"
-            value={settings.section_title_color || '#000000'}
+            value={settings.section_title_color}
             onChange={color => onSettingsChange({section_title_color: color})}
         />
     );

--- a/apps/admin-x-settings/test/unit/email-design/color-fields.test.tsx
+++ b/apps/admin-x-settings/test/unit/email-design/color-fields.test.tsx
@@ -1,44 +1,204 @@
 import assert from 'node:assert/strict';
+import {BackgroundColorField} from '@src/components/settings/email-design/design-fields/background-color-field';
 import {ButtonColorField} from '@src/components/settings/email-design/design-fields/button-color-field';
 import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
+import {DividerColorField} from '@src/components/settings/email-design/design-fields/divider-color-field';
 import {EmailDesignProvider} from '@src/components/settings/email-design/email-design-context';
+import {HeaderBackgroundField} from '@src/components/settings/email-design/design-fields/header-background-field';
 import {LinkColorField} from '@src/components/settings/email-design/design-fields/link-color-field';
-import {render, screen} from '@testing-library/react';
+import {type ReactNode} from 'react';
+import {SectionTitleColorField} from '@src/components/settings/email-design/design-fields/section-title-color-field';
+import {act, fireEvent, render, screen} from '@testing-library/react';
+
+type EmailDesignUpdate = Partial<typeof DEFAULT_EMAIL_DESIGN>;
+type OnSettingsChange = (update: EmailDesignUpdate) => void;
+
+const renderField = (field: ReactNode, settings = DEFAULT_EMAIL_DESIGN, accentColor = '#ff0088', onSettingsChange: OnSettingsChange = () => {}) => {
+    return render(
+        <EmailDesignProvider
+            accentColor={accentColor}
+            settings={settings}
+            onSettingsChange={onSettingsChange}
+        >
+            {field}
+        </EmailDesignProvider>
+    );
+};
+
+const openPicker = (label: string) => {
+    fireEvent.click(screen.getByText(label));
+};
 
 describe('Email design color fields', function () {
     it('renders accent-backed button colors using the resolved accent color', function () {
-        render(
-            <EmailDesignProvider
-                accentColor="#ff0088"
-                settings={{...DEFAULT_EMAIL_DESIGN, button_color: 'accent'}}
-                onSettingsChange={() => {}}
-            >
-                <ButtonColorField />
-            </EmailDesignProvider>
-        );
+        renderField(<ButtonColorField />, {...DEFAULT_EMAIL_DESIGN, button_color: 'accent'});
 
-        const trigger = screen.getByRole('button', {name: 'Button color'});
-        const swatch = trigger.querySelector('span');
+        const trigger = screen.getByRole('button', {name: 'Pick color'});
+        const swatch = trigger.querySelector(String.raw`.inset-\[3px\]`);
 
         assert.ok(swatch);
-        assert.equal(swatch.style.background, 'rgb(255, 0, 136)');
+        assert.equal(swatch.getAttribute('style')?.includes('rgb(255, 0, 136)'), true);
     });
 
     it('renders accent-backed link colors using the resolved accent color', function () {
-        render(
-            <EmailDesignProvider
-                accentColor="#00aaee"
-                settings={{...DEFAULT_EMAIL_DESIGN, link_color: 'accent'}}
-                onSettingsChange={() => {}}
-            >
-                <LinkColorField />
-            </EmailDesignProvider>
-        );
+        renderField(<LinkColorField />, {...DEFAULT_EMAIL_DESIGN, link_color: 'accent'}, '#00aaee');
 
-        const trigger = screen.getByRole('button', {name: 'Link color'});
-        const swatch = trigger.querySelector('span');
+        const trigger = screen.getByRole('button', {name: 'Pick color'});
+        const swatch = trigger.querySelector(String.raw`.inset-\[3px\]`);
 
         assert.ok(swatch);
-        assert.equal(swatch.style.background, 'rgb(0, 170, 238)');
+        assert.equal(swatch.getAttribute('style')?.includes('rgb(0, 170, 238)'), true);
+    });
+
+    it('shows semantic swatches for each configured welcome-email color field', function () {
+        const background = renderField(<BackgroundColorField />);
+        openPicker('Background color');
+        assert.ok(screen.getByRole('button', {name: 'White'}));
+        background.unmount();
+
+        const header = renderField(<HeaderBackgroundField />);
+        openPicker('Header background color');
+        const transparentSwatch = screen.getByRole('button', {name: 'Transparent'});
+        const pickerTrigger = screen.getByRole('button', {name: 'Pick color'});
+        assert.ok(transparentSwatch);
+        assert.ok(transparentSwatch.querySelector('[data-testid="transparent-indicator"]'));
+        assert.equal(pickerTrigger.querySelector('[data-testid="transparent-indicator"]'), null);
+        header.unmount();
+
+        const sectionTitle = renderField(<SectionTitleColorField />);
+        openPicker('Section title color');
+        assert.ok(screen.getByRole('button', {name: 'Auto'}));
+        assert.ok(screen.getByRole('button', {name: 'Accent'}));
+        sectionTitle.unmount();
+
+        const button = renderField(<ButtonColorField />);
+        openPicker('Button color');
+        assert.ok(screen.getByRole('button', {name: 'Auto'}));
+        assert.ok(screen.getByRole('button', {name: 'Accent'}));
+        button.unmount();
+
+        const link = renderField(<LinkColorField />);
+        openPicker('Link color');
+        assert.ok(screen.getByRole('button', {name: 'Auto'}));
+        assert.ok(screen.getByRole('button', {name: 'Accent'}));
+        link.unmount();
+
+        const divider = renderField(<DividerColorField />);
+        openPicker('Divider color');
+        assert.ok(screen.getByRole('button', {name: 'Light'}));
+        assert.ok(screen.getByRole('button', {name: 'Accent'}));
+        divider.unmount();
+    });
+
+    it('stores semantic values when selecting accent and auto swatches', function () {
+        const updates: Array<{button_color?: string | null}> = [];
+        renderField(
+            <ButtonColorField />,
+            {...DEFAULT_EMAIL_DESIGN, background_color: '#ffffff', button_color: '#123456'},
+            '#ff0088',
+            update => updates.push(update)
+        );
+
+        openPicker('Button color');
+        updates.length = 0;
+        fireEvent.click(screen.getByRole('button', {name: 'Accent'}));
+        assert.equal(updates.at(-1)?.button_color, 'accent');
+
+        openPicker('Button color');
+        updates.length = 0;
+        fireEvent.click(screen.getByRole('button', {name: 'Auto'}));
+        assert.equal(updates.at(-1)?.button_color, null);
+    });
+
+    it('stores semantic values for light and transparent swatches', function () {
+        const updates: Array<{background_color?: string; header_background_color?: string}> = [];
+        renderField(
+            <>
+                <BackgroundColorField />
+                <HeaderBackgroundField />
+            </>,
+            {...DEFAULT_EMAIL_DESIGN, background_color: '#121212', header_background_color: '#ff0000'},
+            '#ff0088',
+            update => updates.push(update)
+        );
+
+        openPicker('Background color');
+        updates.length = 0;
+        fireEvent.click(screen.getByRole('button', {name: 'White'}));
+        assert.equal(updates.at(-1)?.background_color, 'light');
+
+        openPicker('Header background color');
+        updates.length = 0;
+        fireEvent.click(screen.getByRole('button', {name: 'Transparent'}));
+        assert.equal(updates.at(-1)?.header_background_color, 'transparent');
+    });
+
+    it('stores null when selecting divider Light swatch', function () {
+        const updates: Array<{divider_color?: string | null}> = [];
+        renderField(
+            <DividerColorField />,
+            {...DEFAULT_EMAIL_DESIGN, divider_color: '#333333'},
+            '#ff0088',
+            update => updates.push(update)
+        );
+
+        openPicker('Divider color');
+        updates.length = 0;
+        fireEvent.click(screen.getByRole('button', {name: 'Light'}));
+
+        assert.equal(updates.at(-1)?.divider_color, null);
+    });
+
+    it('uses background contrast to render Auto swatch color', function () {
+        renderField(
+            <SectionTitleColorField />,
+            {...DEFAULT_EMAIL_DESIGN, background_color: '#111111', section_title_color: null}
+        );
+
+        openPicker('Section title color');
+        const autoSwatch = screen.getByRole('button', {name: 'Auto'});
+
+        assert.equal(autoSwatch.getAttribute('style')?.includes('rgb(255, 255, 255)'), true);
+    });
+
+    it('stores hex values when choosing a custom color in the picker', function () {
+        const updates: Array<{button_color?: string | null}> = [];
+        renderField(
+            <ButtonColorField />,
+            {...DEFAULT_EMAIL_DESIGN, button_color: 'accent'},
+            '#ff0088',
+            update => updates.push(update)
+        );
+
+        openPicker('Button color');
+        updates.length = 0;
+        const hexInput = screen.getByRole('textbox');
+        fireEvent.pointerDown(hexInput);
+        fireEvent.input(hexInput, {target: {value: '#123456'}});
+        fireEvent.change(hexInput, {target: {value: '#123456'}});
+
+        assert.equal(updates.some(update => update.button_color?.toLowerCase() === '#123456'), true);
+    });
+
+    it('does not mutate transparent header background when opening the picker', async function () {
+        const updates: Array<{header_background_color?: string}> = [];
+        renderField(
+            <HeaderBackgroundField />,
+            {...DEFAULT_EMAIL_DESIGN, header_background_color: 'transparent'},
+            '#ff0088',
+            update => updates.push(update)
+        );
+
+        await act(async () => {
+            openPicker('Header background color');
+            await Promise.resolve();
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+        });
+
+        const hexInput = screen.getByRole('textbox');
+        assert.equal(updates.length, 0);
+        assert.equal(hexInput.getAttribute('value')?.toLowerCase(), '#000000');
     });
 });


### PR DESCRIPTION
closes [NY-1202](https://linear.app/ghost/issue/NY-1202/add-accent-and-auto-swatches-to-color-pickers-in-customize-modal)

This PR updates welcome-email design color pickers to use semantic swatch chips while keeping persistence semantic-first and preserving manual hex edits.

## What changed
- Local welcome-email `ColorPickerField` was refactored (no Shade changes):
  - Swatches render as circular chips with selected outline.
  - Transparent swatch has a diagonal slash indicator.
  - Swatches are shown when picker is open.
  - Swatch click stores semantic value when defined, otherwise hex.
  - Picker initialization callbacks are gated so opening the picker does not mutate values.
- Field behavior:
  - Background: `White` → `light`
  - Header background: `Transparent` → `transparent`
  - Section title: `Auto` → `null`, `Accent` → `accent`
  - Button: `Auto` → `null`, `Accent` → `accent`
  - Link: `Auto` → `null`, `Accent` → `accent`
  - Divider: `Light` → `null`, `Accent` → `accent`
- Auto swatch preview (for Section title/Button/Link) is computed from background contrast.

## Manual testing
1. Open Welcome emails → Design and verify swatches are circular chips.
2. For each field, select swatches and confirm mappings above.
3. Set Header background to Transparent, reopen picker, confirm value does not change on open.
4. Enter a custom hex and confirm hex is stored.
5. Change background light/dark and verify Auto swatch preview updates.
6. Send test emails in these states:
   - Transparent header on light and dark backgrounds
   - Accent button/link
   - Auto button/link/title on light and dark backgrounds

This was one of two possible approaches, see also https://github.com/TryGhost/Ghost/pull/27241