### PR TITLE
Allow tinybird-local Docker updates to automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -196,6 +196,16 @@
             "automerge": true,
             "automergeType": "pr"
         },
+        {
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "tinybirdco/tinybird-local"
+            ],
+            "automerge": true,
+            "automergeType": "pr"
+        },
 
         // Ignore all ember-related packages in admin
         // Our ember codebase is being replaced with react and

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -184,24 +184,19 @@
             "automerge": true
         },
 
-        // Allow patch updates to the internal traffic analytics image to
-        // automerge once CI has gone green.
+        // Allow internal Docker digest pins to automerge once the relevant
+        // CI checks have gone green.
         {
+            "description": "Automerge internal Docker digest updates after CI passes",
             "matchDatasources": [
                 "docker"
             ],
             "matchPackageNames": [
-                "ghost/traffic-analytics"
-            ],
-            "automerge": true,
-            "automergeType": "pr"
-        },
-        {
-            "matchDatasources": [
-                "docker"
-            ],
-            "matchPackageNames": [
+                "ghost/traffic-analytics",
                 "tinybirdco/tinybird-local"
+            ],
+            "matchUpdateTypes": [
+                "digest"
             ],
             "automerge": true,
             "automergeType": "pr"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
               - *shared
               - 'apps/sodo-search/**'
             tinybird:
+              - '.github/workflows/ci.yml'
+              - 'compose.dev.analytics.yaml'
               - 'ghost/core/core/server/data/tinybird/**'
               - '!ghost/core/core/server/data/tinybird/**/*.md'
             any-code:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
               - 'compose.dev.analytics.yaml'
               - 'ghost/core/core/server/data/tinybird/**'
               - '!ghost/core/core/server/data/tinybird/**/*.md'
+            tinybird-deploy:
+              - 'ghost/core/core/server/data/tinybird/**'
+              - '!ghost/core/core/server/data/tinybird/**/*.md'
             any-code:
               - '!**/*.md'
 
@@ -200,6 +203,7 @@ jobs:
       changed_signup_form: ${{ steps.changed.outputs.signup-form }}
       changed_sodo_search: ${{ steps.changed.outputs.sodo-search }}
       changed_tinybird: ${{ steps.changed.outputs.tinybird }}
+      changed_tinybird_deploy: ${{ steps.changed.outputs.tinybird-deploy }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
       changed_new_package: ${{ steps.added.outputs.new-package }}
       base_commit: ${{ env.BASE_COMMIT }}
@@ -1598,7 +1602,7 @@ jobs:
       job_setup,
       job_tinybird-tests
     ]
-    if: always() && github.repository == 'TryGhost/Ghost' && github.event_name == 'push' && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && github.repository == 'TryGhost/Ghost' && github.event_name == 'push' && needs.job_setup.outputs.changed_tinybird_deploy == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - uses: actions/checkout@v6
       - name: Trigger and watch traffic analytics infra Tinybird workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
               - 'compose.dev.analytics.yaml'
               - 'ghost/core/core/server/data/tinybird/**'
               - '!ghost/core/core/server/data/tinybird/**/*.md'
-            tinybird-deploy:
+            tinybird-datafiles:
               - 'ghost/core/core/server/data/tinybird/**'
               - '!ghost/core/core/server/data/tinybird/**/*.md'
             any-code:
@@ -203,7 +203,7 @@ jobs:
       changed_signup_form: ${{ steps.changed.outputs.signup-form }}
       changed_sodo_search: ${{ steps.changed.outputs.sodo-search }}
       changed_tinybird: ${{ steps.changed.outputs.tinybird }}
-      changed_tinybird_deploy: ${{ steps.changed.outputs.tinybird-deploy }}
+      changed_tinybird_datafiles: ${{ steps.changed.outputs.tinybird-datafiles }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
       changed_new_package: ${{ steps.added.outputs.new-package }}
       base_commit: ${{ env.BASE_COMMIT }}
@@ -1602,7 +1602,7 @@ jobs:
       job_setup,
       job_tinybird-tests
     ]
-    if: always() && github.repository == 'TryGhost/Ghost' && github.event_name == 'push' && needs.job_setup.outputs.changed_tinybird_deploy == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && github.repository == 'TryGhost/Ghost' && github.event_name == 'push' && needs.job_setup.outputs.changed_tinybird_datafiles == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - uses: actions/checkout@v6
       - name: Trigger and watch traffic analytics infra Tinybird workflow


### PR DESCRIPTION
## Summary
- add a narrow Renovate package rule for the `tinybirdco/tinybird-local` Docker image
- allow those Docker digest PRs to use PR automerge once CI has passed
- keep the rule scoped to this single image rather than enabling Docker automerge broadly

## Why this change
The `tinybirdco/tinybird-local` digest PR in #27228 updates Ghost's local analytics service image in CI and compose files. Like `ghost/traffic-analytics`, it is an internal operational image update that can safely use PR automerge once CI has passed.
