### PR TITLE
Added `show_header_icon` column to email design settings table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.28/2026-04-08-21-40-32-add-show-header-icon-to-email-design-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/6.28/2026-04-08-21-40-32-add-show-header-icon-to-email-design-settings.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('email_design_settings', 'show_header_icon', {
+    type: 'boolean',
+    nullable: false,
+    defaultTo: true
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1149,6 +1149,7 @@ module.exports = {
         background_color: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'light'},
         header_background_color: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'transparent'},
         header_image: {type: 'string', maxlength: 2000, nullable: true},
+        show_header_icon: {type: 'boolean', nullable: false, defaultTo: true},
         show_header_title: {type: 'boolean', nullable: false, defaultTo: true},
         footer_content: {type: 'text', maxlength: 1000000000, nullable: true},
         button_color: {type: 'string', maxlength: 50, nullable: true, defaultTo: 'accent'},

--- a/ghost/core/core/server/models/email-design-setting.js
+++ b/ghost/core/core/server/models/email-design-setting.js
@@ -7,6 +7,7 @@ const EmailDesignSetting = ghostBookshelf.Model.extend({
         return {
             background_color: 'light',
             header_background_color: 'transparent',
+            show_header_icon: true,
             show_header_title: true,
             button_color: 'accent',
             button_corners: 'rounded',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automated-email-design.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automated-email-design.test.js.snap
@@ -20,6 +20,7 @@ Object {
       "link_style": "bold",
       "section_title_color": null,
       "show_badge": true,
+      "show_header_icon": false,
       "show_header_title": true,
       "slug": "default-automated-email",
       "title_font_category": "sans_serif",
@@ -34,7 +35,7 @@ exports[`Automated Email Design API Edit Can edit the automated email design 2: 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "607",
+  "content-length": "632",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -218,6 +219,7 @@ Object {
       "link_style": "underline",
       "section_title_color": null,
       "show_badge": true,
+      "show_header_icon": true,
       "show_header_title": true,
       "slug": "default-automated-email",
       "title_font_category": "sans_serif",
@@ -232,7 +234,7 @@ exports[`Automated Email Design API Read Can read the default automated email de
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "616",
+  "content-length": "640",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/automated-email-design.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-email-design.test.js
@@ -39,7 +39,8 @@ describe('Automated Email Design API', function () {
                 .body({automated_email_design: [{
                     background_color: 'dark',
                     button_corners: 'pill',
-                    link_style: 'bold'
+                    link_style: 'bold',
+                    show_header_icon: false
                 }]})
                 .expectStatus(200)
                 .matchBodySnapshot({

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '6186d5aa5b62b6689ee8786efd5daccc';
+    const currentSchemaHash = 'b7519928208d1bf8b84ad4bd3b4b3be0';
     const currentFixturesHash = '2f86ab1e3820e86465f9ad738dd0ee93';
     const currentSettingsHash = 'a102b80d2ab0cd92325ed007c94d7da6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes  https://linear.app/tryghost/issue/NY-1213/

This field was overlooked in the initial implementation, but we do want to include it as a customizable option for welcome emails. This PR is just the minimal change to add the column to the `email_design_settings` table; other changes to the frontend modal and the rendering are forthcoming.

If you'd rather listen to this PR: 

https://github.com/user-attachments/assets/ae6511a5-c61e-4361-ab62-d8384541858e