### PR TITLE
Removed @actions/core dependency

### DIFF
--- a/.github/scripts/bump-version.js
+++ b/.github/scripts/bump-version.js
@@ -2,8 +2,22 @@ const fs = require('fs/promises');
 const exec = require('util').promisify(require('child_process').exec);
 const path = require('path');
 
-const core = require('@actions/core');
 const semver = require('semver');
+
+// Minimal replacement for @actions/core's setOutput, writing to $GITHUB_OUTPUT.
+// See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+function setOutput(name, value) {
+    const filePath = process.env.GITHUB_OUTPUT;
+    const stringValue = typeof value === 'string' ? value : JSON.stringify(value);
+    if (!filePath) {
+        // Fallback: print so it's visible in logs when run outside Actions.
+        console.log(`::set-output name=${name}::${stringValue}`);
+        return;
+    }
+    // Use a random delimiter to support multi-line values safely.
+    const delimiter = `ghadelimiter_${Math.random().toString(36).slice(2)}`;
+    require('fs').appendFileSync(filePath, `${name}<<${delimiter}\n${stringValue}\n${delimiter}\n`);
+}
 
 (async () => {
     const corePackageJsonPath = path.join(__dirname, '../../ghost/core/package.json');
@@ -39,6 +53,6 @@ const semver = require('semver');
 
     console.log('Version bumped to', newVersion);
 
-    core.setOutput('BUILD_VERSION', newVersion);
-    core.setOutput('GIT_COMMIT_HASH', buildString)
+    setOutput('BUILD_VERSION', newVersion);
+    setOutput('GIT_COMMIT_HASH', buildString);
 })();

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -226,7 +226,6 @@
     "sqlite3": "5.1.7"
   },
   "devDependencies": {
-    "@actions/core": "1.11.1",
     "@prettier/sync": "0.6.1",
     "@tryghost/express-test": "0.15.0",
     "@tryghost/webhook-mock-receiver": "0.2.17",

--- a/ghost/core/test/utils/mocha-retry-reporter.js
+++ b/ghost/core/test/utils/mocha-retry-reporter.js
@@ -1,6 +1,38 @@
 const _ = require('lodash');
-const core = require('@actions/core');
 const mocha = require('mocha');
+
+// Escape data/properties for GitHub Actions workflow commands.
+// See https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+function escapeData(s) {
+    return String(s ?? '')
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
+}
+function escapeProperty(s) {
+    return String(s ?? '')
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A')
+        .replace(/:/g, '%3A')
+        .replace(/,/g, '%2C');
+}
+function issueWarning(message, properties) {
+    const {file, startLine, startColumn} = properties || {};
+    const props = [];
+    if (file) {
+        props.push(`file=${escapeProperty(file)}`);
+    }
+    if (startLine !== undefined) {
+        props.push(`line=${escapeProperty(startLine)}`);
+    }
+    if (startColumn !== undefined) {
+        props.push(`col=${escapeProperty(startColumn)}`);
+    }
+    const propsStr = props.length ? ` ${props.join(',')}` : '';
+    // eslint-disable-next-line no-console
+    console.log(`::warning${propsStr}::${escapeData(message)}`);
+}
 
 // From https://github.com/findmypast-oss/mocha-json-streamier-reporter/blob/master/lib/parse-stack-trace.js
 function extractModuleLineAndColumn(stackTrace) {
@@ -56,7 +88,7 @@ module.exports = class RetryReporter extends mocha.reporters.Spec {
                         };
                     }), _.isEqual)
                     .forEach(({file, line, col, testName, err}) => {
-                        core.warning(`Retried '${testName}' due to '${err}'`, {
+                        issueWarning(`Retried '${testName}' due to '${err}'`, {
                             file,
                             startLine: line,
                             startColumn: col

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "nwsapi": "2.2.12"
   },
   "devDependencies": {
-    "@actions/core": "1.11.1",
     "chalk": "4.1.2",
     "chokidar": "3.6.0",
     "concurrently": "8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,33 +12,6 @@
   resolved "https://registry.yarnpkg.com/@acemir/cssom/-/cssom-0.9.31.tgz#bd5337d290fb8be2ac18391f37386bc53778b0bc"
   integrity sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==
 
-"@actions/core@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.11.1.tgz#ae683aac5112438021588030efb53b1adb86f172"
-  integrity sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==
-  dependencies:
-    "@actions/exec" "^1.1.1"
-    "@actions/http-client" "^2.0.1"
-
-"@actions/exec@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.1.1.tgz#2e43f28c54022537172819a7cf886c844221a611"
-  integrity sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==
-  dependencies:
-    "@actions/io" "^1.0.1"
-
-"@actions/http-client@^2.0.1":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-2.1.0.tgz#b6d8c3934727d6a50d10d19f00a711a964599a9f"
-  integrity sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==
-  dependencies:
-    tunnel "^0.0.6"
-
-"@actions/io@^1.0.1":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.1.3.tgz#4cdb6254da7962b07473ff5c335f3da485d94d71"
-  integrity sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==
-
 "@adobe/css-tools@^4.0.1", "@adobe/css-tools@^4.4.0":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.2.tgz#c836b1bd81e6d62cd6cdf3ee4948bcdce8ea79c8"
@@ -34518,11 +34491,6 @@ tunnel-agent@^0.6.0:
   integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
   dependencies:
     safe-buffer "^5.0.1"
-
-tunnel@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
-  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 tw-animate-css@1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Summary

- Removed the `@actions/core` devDependency from both `package.json` and `ghost/core/package.json`
- Replaced `core.setOutput` in `.github/scripts/bump-version.js` with a minimal helper that writes directly to `$GITHUB_OUTPUT`
- Replaced `core.warning` in `ghost/core/test/utils/mocha-retry-reporter.js` with a helper that prints the `::warning file=,line=,col=::message` workflow command (with proper escaping)

## Why

Renovate PR #27161 attempted to bump `@actions/core` to v3, which broke the Ghost-CLI CI job:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in
/home/runner/work/Ghost/Ghost/node_modules/@actions/core/package.json
```

v3 dropped the CJS entry point that our two usages rely on via `require()`. Since both usages are trivial — one `setOutput` call and one `warning` call — it's simpler to emit the workflow commands directly and drop the dependency entirely than to pin the version or migrate to ESM. This also closes #27161.

## Testing

- `node .github/scripts/bump-version.js canary` emits the expected `BUILD_VERSION`/`GIT_COMMIT_HASH` outputs
- `mocha-retry-reporter.js` loads cleanly
- `yarn install` runs clean and `@actions/core` is no longer present in `yarn.lock`
