### PR TITLE
Added publication icon toggle to welcome email customization

### DIFF
--- a/apps/admin-x-framework/src/api/automated-email-design.ts
+++ b/apps/admin-x-framework/src/api/automated-email-design.ts
@@ -6,6 +6,7 @@ export type AutomatedEmailDesign = {
     background_color: string;
     header_background_color: string;
     header_image: string | null;
+    show_header_icon: boolean;
     show_header_title: boolean;
     footer_content: string | null;
     button_color: string | null;

--- a/apps/admin-x-framework/test/unit/api/automated-email-design.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/automated-email-design.test.tsx
@@ -16,6 +16,7 @@ describe('automated-email-design api', () => {
                 background_color: 'light',
                 header_background_color: 'transparent',
                 header_image: null,
+                show_header_icon: true,
                 show_header_title: true,
                 footer_content: null,
                 button_color: null,

--- a/apps/admin-x-settings/src/components/settings/email-design/email-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-preview.tsx
@@ -15,6 +15,7 @@ interface EmailPreviewProps {
     showRecipientLine?: boolean;
     showSubjectLine?: boolean;
     headerImage?: string;
+    showPublicationIcon?: boolean;
     showPublicationTitle?: boolean;
     showBadge?: boolean;
     emailFooter?: string;
@@ -64,12 +65,14 @@ const EnvelopeHeader: React.FC<{
 };
 
 const PublicationHeader: React.FC<{
+    iconUrl?: string | null;
+    showIcon: boolean;
     showTitle: boolean;
     siteTitle?: string;
     backgroundColor?: string;
     textColor: string;
-}> = ({showTitle, siteTitle, backgroundColor, textColor}) => {
-    if (!showTitle || !siteTitle) {
+}> = ({iconUrl, showIcon, showTitle, siteTitle, backgroundColor, textColor}) => {
+    if (!showIcon && (!showTitle || !siteTitle)) {
         return null;
     }
 
@@ -78,12 +81,21 @@ const PublicationHeader: React.FC<{
             className="px-[7rem] py-3 text-center"
             style={{backgroundColor: backgroundColor === 'transparent' ? undefined : backgroundColor}}
         >
-            <h4
-                className="mb-1 text-[1.6rem] leading-tight font-bold tracking-tight uppercase"
-                style={{color: textColor}}
-            >
-                {siteTitle}
-            </h4>
+            {showIcon && iconUrl && (
+                <img
+                    alt={siteTitle || 'Publication icon'}
+                    className="mx-auto mb-3 h-12 w-12 rounded"
+                    src={iconUrl}
+                />
+            )}
+            {showTitle && siteTitle && (
+                <h4
+                    className="mb-1 text-[1.6rem] leading-tight font-bold tracking-tight uppercase"
+                    style={{color: textColor}}
+                >
+                    {siteTitle}
+                </h4>
+            )}
         </div>
     );
 };
@@ -115,9 +127,9 @@ const Footer: React.FC<{siteTitle?: string; footerLinkText?: string; emailFooter
 
 // --- Main component ---
 
-const EmailPreview: React.FC<EmailPreviewProps> = ({settings, senderName, senderEmail, replyToEmail, subject, showRecipientLine = true, showSubjectLine = true, headerImage, showPublicationTitle = true, showBadge = true, emailFooter, footerLinkText, children}) => {
+const EmailPreview: React.FC<EmailPreviewProps> = ({settings, senderName, senderEmail, replyToEmail, subject, showRecipientLine = true, showSubjectLine = true, headerImage, showPublicationIcon = false, showPublicationTitle = true, showBadge = true, emailFooter, footerLinkText, children}) => {
     const {settings: globalSettings, siteData} = useGlobalData();
-    const [siteTitle] = getSettingValues<string>(globalSettings, ['title']);
+    const [siteTitle, icon] = getSettingValues<string>(globalSettings, ['title', 'icon']);
     const accentColor = siteData.accent_color;
 
     const colors = resolveAllColors(settings, accentColor);
@@ -140,6 +152,8 @@ const EmailPreview: React.FC<EmailPreviewProps> = ({settings, senderName, sender
 
                     <PublicationHeader
                         backgroundColor="transparent"
+                        iconUrl={icon}
+                        showIcon={showPublicationIcon && Boolean(icon)}
                         showTitle={showPublicationTitle}
                         siteTitle={siteTitle}
                         textColor={colors.headerTextColor}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -38,6 +38,7 @@ interface GeneralSettings {
     senderEmail: string;
     replyToEmail: string;
     headerImage: string;
+    showPublicationIcon: boolean;
     showPublicationTitle: boolean;
     showBadge: boolean;
     emailFooter: string;
@@ -55,6 +56,7 @@ const NON_DESIGN_FIELDS = new Set([
     'created_at',
     'updated_at',
     'header_image',
+    'show_header_icon',
     'show_header_title',
     'show_badge',
     'footer_content'
@@ -67,6 +69,7 @@ const PREVIEW_ONLY_FIELDS = new Set([
 interface GeneralTabProps {
     generalSettings: GeneralSettings;
     onGeneralChange: (updates: Partial<GeneralSettings>) => void;
+    showPublicationIconToggle: boolean;
     senderNamePlaceholder: string;
     senderEmailPlaceholder: string;
     replyToEmailPlaceholder: string;
@@ -79,6 +82,7 @@ interface GeneralTabProps {
 const GeneralTab: React.FC<GeneralTabProps> = ({
     generalSettings,
     onGeneralChange,
+    showPublicationIconToggle,
     senderNamePlaceholder,
     senderEmailPlaceholder,
     replyToEmailPlaceholder,
@@ -135,6 +139,16 @@ const GeneralTab: React.FC<GeneralTabProps> = ({
                     value={generalSettings.headerImage}
                     onChange={url => onGeneralChange({headerImage: url})}
                 />
+                {showPublicationIconToggle && (
+                    <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium">Publication icon</span>
+                        <Switch
+                            checked={generalSettings.showPublicationIcon}
+                            size='sm'
+                            onCheckedChange={checked => onGeneralChange({showPublicationIcon: checked})}
+                        />
+                    </div>
+                )}
                 <div className="flex items-center justify-between">
                     <span className="text-sm font-medium">Publication title</span>
                     <Switch
@@ -204,6 +218,7 @@ export const DesignTab: React.FC = () => (
 interface SidebarProps {
     generalSettings: GeneralSettings;
     onGeneralChange: (updates: Partial<GeneralSettings>) => void;
+    showPublicationIconToggle: boolean;
     senderNamePlaceholder: string;
     senderEmailPlaceholder: string;
     replyToEmailPlaceholder: string;
@@ -218,6 +233,7 @@ interface SidebarProps {
 const Sidebar: React.FC<SidebarProps> = ({
     generalSettings,
     onGeneralChange,
+    showPublicationIconToggle,
     senderNamePlaceholder,
     senderEmailPlaceholder,
     replyToEmailPlaceholder,
@@ -252,6 +268,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                         senderEmailPlaceholder={senderEmailPlaceholder}
                         senderNameError={senderNameError}
                         senderNamePlaceholder={senderNamePlaceholder}
+                        showPublicationIconToggle={showPublicationIconToggle}
                         showSenderEmailInput={showSenderEmailInput}
                         onGeneralChange={onGeneralChange}
                     />
@@ -268,12 +285,12 @@ const Sidebar: React.FC<SidebarProps> = ({
  * Maps API response fields to the frontend GeneralSettings shape.
  * Note: senderName, senderEmail and replyToEmail are not part of the design endpoint.
  *
- * @param {Pick<AutomatedEmailDesign, 'header_image' | 'show_header_title' | 'show_badge' | 'footer_content'>} apiData - Subset of design fields used for general settings
+ * @param {Pick<AutomatedEmailDesign, 'header_image' | 'show_header_icon' | 'show_header_title' | 'show_badge' | 'footer_content'>} apiData - Subset of design fields used for general settings
  * @param {GeneralSettings} defaults - Carries forward sender fields, which are not part of the design API
  * @returns {GeneralSettings} General settings populated from the API response
  */
 function mapApiToGeneralSettings(
-    apiData: Pick<AutomatedEmailDesign, 'header_image' | 'show_header_title' | 'show_badge' | 'footer_content'>,
+    apiData: Pick<AutomatedEmailDesign, 'header_image' | 'show_header_icon' | 'show_header_title' | 'show_badge' | 'footer_content'>,
     defaults: GeneralSettings
 ): GeneralSettings {
     return {
@@ -281,6 +298,7 @@ function mapApiToGeneralSettings(
         senderEmail: defaults.senderEmail,
         replyToEmail: defaults.replyToEmail,
         headerImage: apiData.header_image || '',
+        showPublicationIcon: apiData.show_header_icon,
         showPublicationTitle: apiData.show_header_title,
         showBadge: apiData.show_badge,
         emailFooter: apiData.footer_content || ''
@@ -316,6 +334,7 @@ export function buildAutomatedEmailDesignPayload(state: WelcomeEmailCustomizeFor
     return {
         ...persistedDesign,
         header_image: state.generalSettings.headerImage || null,
+        show_header_icon: state.generalSettings.showPublicationIcon,
         show_header_title: state.generalSettings.showPublicationTitle,
         show_badge: state.generalSettings.showBadge,
         footer_content: state.generalSettings.emailFooter || null
@@ -336,7 +355,7 @@ const normalizeSenderValue = (value: string | null | undefined) => {
 const WelcomeEmailCustomizeModal = NiceModal.create(() => {
     const modal = useModal();
     const {siteData, settings: globalSettings} = useGlobalData();
-    const [siteTitle, defaultEmailAddress] = getSettingValues<string>(globalSettings, ['title', 'default_email_address']);
+    const [siteTitle, defaultEmailAddress, icon] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'icon']);
 
     const handleError = useHandleError();
     const {data: designData, isLoading, isError} = useReadAutomatedEmailDesign();
@@ -364,6 +383,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
         senderEmail: senderEmailInput,
         replyToEmail: replyToEmailInput,
         headerImage: '',
+        showPublicationIcon: true,
         showPublicationTitle: true,
         showBadge: true,
         emailFooter: ''
@@ -532,6 +552,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                         senderName={generalSettings.senderName || senderNamePlaceholder || siteTitle || 'Your site'}
                         settings={designSettings}
                         showBadge={generalSettings.showBadge}
+                        showPublicationIcon={generalSettings.showPublicationIcon && Boolean(icon)}
                         showPublicationTitle={generalSettings.showPublicationTitle}
                         showRecipientLine={false}
                         showSubjectLine={false}
@@ -551,6 +572,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                         senderEmailPlaceholder={senderEmailPlaceholder}
                         senderNameError={errors.senderName}
                         senderNamePlaceholder={senderNamePlaceholder}
+                        showPublicationIconToggle={Boolean(icon)}
                         showSenderEmailInput={showSenderEmailInput}
                         onGeneralChange={handleGeneralChange}
                     />

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -636,6 +636,22 @@ test.describe('Member emails settings', async () => {
 
     test.describe('Welcome email customize modal sender fields', async () => {
         test('shows publication icon toggle, updates preview, and saves show_header_icon when an icon exists', async ({page}) => {
+            const addPaidResponse = {
+                automated_emails: [{
+                    id: 'paid-welcome-email-id',
+                    status: 'inactive',
+                    name: 'Welcome Email (Paid)',
+                    slug: 'member-welcome-email-paid',
+                    subject: 'Welcome to your paid subscription',
+                    lexical: '{"root":{"children":[]}}',
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null,
+                    created_at: '2024-01-01T00:00:00.000Z',
+                    updated_at: null
+                }]
+            };
+
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
                 browseSettings: {...globalDataRequests.browseSettings, response: settingsWithPublicationIcon},
@@ -644,6 +660,7 @@ test.describe('Member emails settings', async () => {
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
                 readAutomatedEmailDesign: {method: 'GET', path: '/automated_emails/design/', response: automatedEmailDesignFixture},
                 editAutomatedEmailDesign: {method: 'PUT', path: '/automated_emails/design/', response: automatedEmailDesignFixture},
+                addAutomatedEmail: {method: 'POST', path: '/automated_emails/', response: addPaidResponse},
                 editAutomatedEmailSenders: {
                     method: 'PUT',
                     path: /^\/automated_emails\/senders\/?$/,

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/test';
-import {globalDataRequests, mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
+import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
 import type {Page} from '@playwright/test';
 
 /**
@@ -76,6 +76,7 @@ const automatedEmailDesignFixture = {
         background_color: 'light',
         header_background_color: 'transparent',
         header_image: null,
+        show_header_icon: true,
         show_header_title: true,
         footer_content: null,
         button_color: null,
@@ -94,6 +95,10 @@ const automatedEmailDesignFixture = {
         updated_at: null
     }]
 };
+
+const settingsWithPublicationIcon = updatedSettingsResponse([
+    {key: 'icon', value: 'https://example.com/content/images/icon.png'}
+]);
 
 const pasteText = async (page: Page, content: string) => {
     await page.evaluate((text: string) => {
@@ -630,6 +635,72 @@ test.describe('Member emails settings', async () => {
     });
 
     test.describe('Welcome email customize modal sender fields', async () => {
+        test('shows publication icon toggle, updates preview, and saves show_header_icon when an icon exists', async ({page}) => {
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseSettings: {...globalDataRequests.browseSettings, response: settingsWithPublicationIcon},
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: configWithWelcomeEmailCustomization},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                readAutomatedEmailDesign: {method: 'GET', path: '/automated_emails/design/', response: automatedEmailDesignFixture},
+                editAutomatedEmailDesign: {method: 'PUT', path: '/automated_emails/design/', response: automatedEmailDesignFixture},
+                editAutomatedEmailSenders: {
+                    method: 'PUT',
+                    path: /^\/automated_emails\/senders\/?$/,
+                    response: {automated_emails: automatedEmailsFixture.automated_emails}
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByRole('button', {name: 'Customize'}).click();
+
+            const modal = page.getByTestId('welcome-email-customize-modal');
+            await expect(modal).toBeVisible();
+
+            const publicationIconSwitch = modal.getByText('Publication icon').locator('..').getByRole('switch');
+            await expect(publicationIconSwitch).toBeVisible();
+            await expect(modal.locator('img[alt="Test Site"]').first()).toBeVisible();
+
+            await publicationIconSwitch.click();
+
+            await expect(modal.locator('img[alt="Test Site"]')).toHaveCount(0);
+
+            await modal.getByRole('button', {name: 'Save'}).click();
+
+            await expect.poll(() => lastApiRequests.editAutomatedEmailDesign?.body).toMatchObject({
+                automated_email_design: [{
+                    show_header_icon: false
+                }]
+            });
+        });
+
+        test('hides publication icon toggle when no publication icon is set', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: configWithWelcomeEmailCustomization},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                readAutomatedEmailDesign: {method: 'GET', path: '/automated_emails/design/', response: automatedEmailDesignFixture}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByRole('button', {name: 'Customize'}).click();
+
+            const modal = page.getByTestId('welcome-email-customize-modal');
+            await expect(modal).toBeVisible();
+
+            await expect(modal.getByText('Publication icon')).toHaveCount(0);
+            await expect(modal.locator('img[alt="Test Site"]')).toHaveCount(0);
+        });
+
         test('uses placeholders when no automated sender overrides exist', async ({page}) => {
             await mockApi({page, requests: {
                 ...globalDataRequests,

--- a/apps/admin-x-settings/test/unit/email-design/design-payload.test.ts
+++ b/apps/admin-x-settings/test/unit/email-design/design-payload.test.ts
@@ -10,6 +10,7 @@ describe('Welcome email design payload helpers', function () {
             created_at: '2026-04-02T00:00:00.000Z',
             updated_at: '2026-04-02T00:00:00.000Z',
             header_image: null,
+            show_header_icon: true,
             show_header_title: true,
             show_badge: true,
             footer_content: null,
@@ -23,6 +24,7 @@ describe('Welcome email design payload helpers', function () {
         assert.equal('created_at' in result, false);
         assert.equal('updated_at' in result, false);
         assert.equal('header_image' in result, false);
+        assert.equal('show_header_icon' in result, false);
         assert.equal('show_header_title' in result, false);
         assert.equal('show_badge' in result, false);
         assert.equal('footer_content' in result, false);
@@ -59,8 +61,10 @@ describe('Welcome email design payload helpers', function () {
             },
             generalSettings: {
                 senderName: 'Ghost',
+                senderEmail: 'hello@example.com',
                 replyToEmail: 'support@example.com',
                 headerImage: '',
+                showPublicationIcon: true,
                 showPublicationTitle: true,
                 showBadge: false,
                 emailFooter: ''
@@ -69,6 +73,7 @@ describe('Welcome email design payload helpers', function () {
 
         const payload = buildAutomatedEmailDesignPayload(state as never) as typeof state.designSettings & {
             header_image: string | null;
+            show_header_icon: boolean;
             show_header_title: boolean;
             show_badge: boolean;
             footer_content: string | null;
@@ -81,5 +86,6 @@ describe('Welcome email design payload helpers', function () {
         assert.equal('updated_at' in payload, false);
         assert.equal('post_title_color' in payload, false);
         assert.equal('title_alignment' in payload, false);
+        assert.equal(payload.show_header_icon, true);
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1215/add-publication-icon-to-the-customization-modal

Adds a publication icon toggle to the welcome email customize modal when a site icon is configured, and updates the preview and save payload to match.

Also fixes the related acceptance test to mock the missing paid welcome email row that gets created during save.