### PR TITLE
Refined visual design and copy of gift purchase confirmation email

### DIFF
--- a/ghost/core/core/server/services/gifts/email-templates/gift-purchase-confirmation.hbs
+++ b/ghost/core/core/server/services/gifts/email-templates/gift-purchase-confirmation.hbs
@@ -40,7 +40,7 @@
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
                         <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 12px;">Your gift is ready to&nbsp;share!</h1>
-                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #738A94; font-weight: normal; margin: 0; padding-bottom: 24px;">Share the link below with the recipient to let them redeem their gift membership.</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; padding-bottom: 24px;">Share the link below with the recipient to let them redeem their gift membership.</p>
                         <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background: #F4F5F6; border-radius: 8px;">
                           <tbody>
                             <tr>
@@ -49,24 +49,41 @@
                                   <tr>
                                     <td style="padding-right: 8px; background-color: #F4F5F6; text-align: left; vertical-align: middle;" valign="middle">
                                       <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Gift subscription</p>
-                                      <p class="large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{gift.tierName}} ({{gift.cadenceLabel}})</p>
+                                      <p class="large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{gift.tierName}} &bull; {{gift.cadenceLabel}}</p>
                                       <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Amount paid</p>
-                                      <p class="large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 0; color: #15171A; font-weight: 400;">{{gift.amount}}</p>
+                                      <p class="large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{gift.amount}}</p>
+                                      <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Redemption link</p>
+                                      <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 24px; color: #738A94; word-break: break-all;"><a href="{{gift.link}}" style="color: {{accentColor}}; text-decoration: none;">{{gift.link}}</a></p>
                                     </td>
                                   </tr>
+                                </table>
+                                <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
+                                  <tbody>
+                                    <tr>
+                                      <td align="left" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top;">
+                                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                          <tbody>
+                                            <tr>
+                                              <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; vertical-align: top; background-color: {{accentColor}}; border-radius: 8px; text-align: center;">
+                                                <a href="{{gift.mailtoUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 8px; padding: 10px 20px; text-decoration: none;">Send to recipient</a>
+                                              </td>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                      </td>
+                                    </tr>
+                                  </tbody>
                                 </table>
                               </td>
                             </tr>
                           </tbody>
                         </table>
 
-                        <!-- GIFT LINK -->
-                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 24px;">
+                        <!-- EXPIRY NOTE -->
+                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 16px;">
                           <tr>
                             <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
-                              <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Redemption link</p>
-                              <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 16px; color: #738A94; word-break: break-all;"><a href="{{gift.link}}" style="color: {{accentColor}}; text-decoration: none;">{{gift.link}}</a></p>
-                              <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 13px; margin: 0; padding-bottom: 0; color: #738A94;">This link can be redeemed once and expires on {{gift.expiresAt}}.</p>
+                              <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 13px; margin: 0; padding-bottom: 0; color: #738A94;">This link can be redeemed once and expires on {{gift.expiresAt}}. It's only available to free or new members.</p>
                             </td>
                           </tr>
                         </table>

--- a/ghost/core/core/server/services/gifts/email-templates/gift-purchase-confirmation.ts
+++ b/ghost/core/core/server/services/gifts/email-templates/gift-purchase-confirmation.ts
@@ -16,12 +16,12 @@ export function renderText(data: GiftPurchaseConfirmationData): string {
 
 Share the link below with the recipient to let them redeem their gift membership.
 
-Gift subscription: ${data.gift.tierName} (${data.gift.cadenceLabel})
+Gift subscription: ${data.gift.tierName} • ${data.gift.cadenceLabel}
 Amount paid: ${data.gift.amount}
 
 Redemption link: ${data.gift.link}
 
-This link can be redeemed once and expires on ${data.gift.expiresAt}.
+This link can be redeemed once and expires on ${data.gift.expiresAt}. It's only available to free or new members.
 
 ---
 

--- a/ghost/core/core/server/services/gifts/gift-email-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-email-service.ts
@@ -65,14 +65,22 @@ export class GiftEmailService {
         const formattedAmount = this.formatAmount({currency, amount: amount / 100});
         const siteDomain = this.siteDomain;
         const siteUrl = this.urlUtils.getSiteUrl();
+        const siteTitle = this.settingsCache.get('title') ?? siteDomain;
 
         const giftLink = `${siteUrl.replace(/\/$/, '')}/gift/${token}`;
 
         const unit = cadence === 'month' ? 'month' : 'year';
         const cadenceLabel = duration === 1 ? `1 ${unit}` : `${duration} ${unit}s`;
 
+        // Pre-build a mailto: URL the buyer can click to open their default mail
+        // client with a friendly draft already filled in. Recipient is left blank
+        // — that's the one thing only the buyer knows.
+        const mailtoSubject = `I got you a gift subscription to ${siteTitle}`;
+        const mailtoBody = `Hi,\n\nI bought you a subscription to ${siteTitle}. You can redeem it here:\n\n${giftLink}`;
+        const mailtoUrl = `mailto:?subject=${encodeURIComponent(mailtoSubject)}&body=${encodeURIComponent(mailtoBody)}`;
+
         const templateData = {
-            siteTitle: this.settingsCache.get('title') ?? siteDomain,
+            siteTitle,
             siteUrl,
             siteIconUrl: this.blogIcon.getIconUrl({absolute: true, fallbackToDefault: false}),
             siteDomain,
@@ -83,6 +91,7 @@ export class GiftEmailService {
                 tierName,
                 cadenceLabel,
                 link: giftLink,
+                mailtoUrl,
                 expiresAt: moment(expiresAt).format('D MMM YYYY')
             }
         };

--- a/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
+++ b/ghost/core/test/unit/server/services/gifts/gift-email-service.test.js
@@ -93,6 +93,24 @@ describe('GiftEmailService', function () {
         sinon.assert.calledWith(mailer.send, sinon.match.has('html', sinon.match('1 month')));
     });
 
+    it('includes a mailto link with prefilled subject and body in the HTML', async function () {
+        await service.sendPurchaseConfirmation(defaultData);
+
+        const msg = mailer.send.getCall(0).args[0];
+
+        // Handlebars HTML-escapes some characters (including `=` → `&#x3D;`) when
+        // interpolating into an attribute. The browser decodes these back when the
+        // user clicks the link, so we don't care about the encoding here — we just
+        // verify the link is a mailto and that the encoded subject and body are
+        // present in the rendered output.
+        const expectedSubject = encodeURIComponent('I got you a gift subscription to Test Site');
+        const expectedBody = encodeURIComponent('Hi,\n\nI bought you a subscription to Test Site. You can redeem it here:\n\nhttps://example.com/gift/abc-123');
+
+        sinon.assert.match(msg.html, sinon.match('mailto:'));
+        sinon.assert.match(msg.html, sinon.match(expectedSubject));
+        sinon.assert.match(msg.html, sinon.match(expectedBody));
+    });
+
     it('falls back to site domain when site title is undefined', async function () {
         const noTitleSettingsCache = {
             get: (key) => {


### PR DESCRIPTION
no issues 

- Moved the redemption link inside the gray data container so the gift                                                                                                                                             
    details and the link to share read as one block.                                                                                                                                                                 
- Added a "Send to recipient" button below the link that opens the                                                                                                                                                 
    buyer's default mail client with a friendly subject and body                                                                                                                                                     
    prefilled. The visible link above remains as a fallback.                                                                                                                                                         
- Appended eligibility info to the expiration footnote so buyers know                                                                                                                                              
    upfront that gifts can only be redeemed by free or new members.                                                                                                                                                  
- Updated the intro paragraph color from #738A94 (chrome) to #3A464C                                                                                                                                               
    (body) to match the convention used in other transactional emails                                                                                                                                                
    like new-comment.hbs.                                                                                                                                                                                            
- Switched the tier/cadence separator from parens to a bullet, matching                                                                                                                                            
    the rest of the email family. 