### PR TITLE
Improve performance of core acceptance/legacy CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,9 +438,6 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Build TS packages
-        run: yarn nx run-many -t build --exclude=ghost-admin
-
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
@@ -458,12 +455,10 @@ jobs:
           echo "database__connection__password=root" >> $GITHUB_ENV
 
       - name: E2E tests
-        working-directory: ghost/core
-        run: yarn test:ci:e2e
+        run: yarn nx run ghost:test:ci:e2e
 
       - name: Integration tests
-        working-directory: ghost/core
-        run: yarn test:ci:integration
+        run: yarn nx run ghost:test:ci:integration
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: matrix.node == env.NODE_VERSION && contains(matrix.env.DB, 'mysql')
@@ -528,9 +523,6 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Build TS packages
-        run: yarn nx run-many -t build --exclude=ghost-admin
-
       - name: Set env vars (SQLite)
         if: contains(matrix.env.DB, 'sqlite')
         run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
@@ -543,8 +535,7 @@ jobs:
           echo "database__connection__password=root" >> $GITHUB_ENV
 
       - name: Legacy tests
-        working-directory: ghost/core
-        run: yarn test:ci:legacy
+        run: yarn nx run ghost:test:ci:legacy
 
       - uses: tryghost/actions/actions/slack-build@0cbdcbeb9030f46b109d5e6e44c14933026d8ca5 # main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ env:
     ${{ github.workspace }}/ghost/*/node_modules
     ${{ github.workspace }}/e2e/node_modules
     ~/.cache/ms-playwright/
-  NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
   NODE_VERSION: 22.18.0
   # Disable v8-compile-cache to prevent intermittent V8 deserializer crashes
   # when multiple parallel Nx workers race to read/write shared bytecode cache
@@ -163,17 +162,6 @@ jobs:
           echo "dep-cache-${{ env.hash }}" >> "$GITHUB_ENV"
           echo "dep-cache" >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"
-
-      - name: Nx cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        id: cache_nx
-        with:
-          path: .nxcache
-          key: nx-Linux-${{ github.ref }}-${{ env.HEAD_COMMIT }}
-          restore-keys: |
-            nx-Linux-${{ github.ref }}-${{ env.HEAD_COMMIT }}
-            nx-Linux-${{ github.ref }}
-            nx-Linux
 
       - name: Check dependency cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -280,12 +280,7 @@
     "targets": {
       "build:tsc": {
         "dependsOn": [
-          {
-            "projects": [
-              "@tryghost/parse-email-address"
-            ],
-            "target": "build"
-          }
+          "^build"
         ]
       },
       "archive": {
@@ -307,12 +302,7 @@
       },
       "lint": {
         "dependsOn": [
-          {
-            "projects": [
-              "@tryghost/parse-email-address"
-            ],
-            "target": "build"
-          }
+          "^build"
         ]
       },
       "test:all": {
@@ -323,12 +313,22 @@
       "test:unit": {
         "dependsOn": [
           "build:assets",
-          {
-            "projects": [
-              "@tryghost/parse-email-address"
-            ],
-            "target": "build"
-          }
+          "^build"
+        ]
+      },
+      "test:ci:e2e": {
+        "dependsOn": [
+          "^build"
+        ]
+      },
+      "test:ci:legacy": {
+        "dependsOn": [
+          "^build"
+        ]
+      },
+      "test:ci:integration": {
+        "dependsOn": [
+          "^build"
         ]
       }
     }


### PR DESCRIPTION
## Summary

- remove nx cache step + unnecessary env var from setup job that hasn't done anything since the Nx v22 update
- remove explicit TS package build step in favor of nx automatic build tracking

## Why this change

As part of #27202, I was looking into ways to leverage the Nx build cache across jobs in a given CI run, since I noticed that certain packages (the frontend code in apps/* primarily) were being built multiple times throughout the various CI jobs. What I ultimately realized after a bit more investigation is that the Core Acceptance + Legacy tests jobs are building more of the repo than they need to, since the `--exclude=ghost-admin` doesn't actually prevent any work from being done (ghost-admin is a dependency of `@tryghost/admin` so it gets built anyways).

## What the fix does

By updating the nx config in ghost/core to dependent on the built target for the test:ci:* scripts (and switching the jobs themselves to use `yarn nx run ghost:test:ci:*`), Nx will automatically build the dependencies it needs to. Overall, this should shave an average of 3-4 minutes off of all of the Acceptance/Legacy test builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but could cause unexpected rebuilds or missing prereqs if Nx target dependencies are misconfigured, affecting test job reliability/timings.
> 
> **Overview**
> **CI pipeline is simplified to reduce unnecessary work.** The setup job drops the unused `NX_REJECT_UNKNOWN_LOCAL_CACHE` env var and removes the GitHub Actions `Nx cache` step.
> 
> **Acceptance and legacy test jobs now rely on Nx dependency tracking.** The explicit “build TS packages” step is removed, and Ghost core `test:ci:*` scripts are executed via `yarn nx run ghost:test:ci:*`, with `ghost/core/package.json` updated so `build:tsc`, `lint`, `test:unit`, and the `test:ci:*` targets depend on `^build` instead of a hardcoded `@tryghost/parse-email-address` build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130791d8797b9d04e26a7705275a4c9033e13835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->