### PR TITLE
Fixed redundant CI runs on main branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ env:
   DISABLE_V8_COMPILE_CACHE: 1
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Changed CI concurrency group from `github.run_id` to `github.ref` for push events, so consecutive main branch pushes cancel earlier in-progress runs instead of all running simultaneously
- PR concurrency is unaffected (`github.head_ref` takes precedence for PRs)
- Observed 5 full CI runs triggered within 60 seconds on main today, each consuming ~147 runner-minutes — this change would cancel all but the latest

## Context

The concurrency group `${{ github.head_ref || github.run_id }}` works well for PRs (groups by branch name, cancels stale runs). But for push events `github.head_ref` is empty, so it fell back to `github.run_id` — a unique value per run, meaning no cancellation ever happened on main.

During merge bursts (e.g. merging multiple Renovate PRs), this caused 4-5 full CI pipelines to compete for runners simultaneously, starving PR CI runs and causing 15+ minute queue times.

## Test plan

- [ ] Verify PR CI still cancels in-progress runs when a new commit is pushed to the same branch
- [ ] Verify consecutive main pushes cancel earlier runs (observable on next merge burst)


🤖 Generated with [Claude Code](https://claude.com/claude-code)