### PR TITLE
Fixed subscription status filter to support multi-select

### DIFF
--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -48,6 +48,7 @@ describe('memberFields', () => {
     it('keeps the expected operators for key member fields', () => {
         expect(memberFields.label.operators).toEqual(['is-any', 'is-not-any']);
         expect(memberFields.tier_id.operators).toEqual(['is-any', 'is-not-any']);
+        expect(memberFields['subscriptions.status'].operators).toEqual(['is-any', 'is-not-any']);
         expect(memberFields['newsletters.:slug'].operators).toEqual(['is']);
         expect(memberFields.newsletter_feedback.operators).toEqual(['1', '0']);
         expect(memberFields.email_count.operators).toEqual([

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -16,7 +16,7 @@ const DATE_OPERATORS = ['is-less', 'is-or-less', 'is-greater', 'is-or-greater'] 
 const NUMBER_OPERATORS = ['is', 'is-greater', 'is-less'] as const;
 const SCALAR_OPERATORS = ['is', 'is-not'] as const;
 const SET_OPERATORS = ['is-any', 'is-not-any'] as const;
-const SUBSCRIPTION_STATUS_OPTIONS: Array<{value: string; label: string}> = [
+export const SUBSCRIPTION_STATUS_OPTIONS: Array<{value: string; label: string}> = [
     {value: 'active', label: 'Active'},
     {value: 'trialing', label: 'Trialing'},
     {value: 'canceled', label: 'Canceled'},
@@ -323,11 +323,12 @@ export const memberFields = defineFields({
         codec: scalarCodec()
     },
     'subscriptions.status': {
-        operators: SCALAR_OPERATORS,
+        operators: SET_OPERATORS,
         ui: {
             label: 'Stripe subscription status',
-            type: 'select',
-            searchable: false
+            type: 'multiselect',
+            searchable: false,
+            defaultOperator: 'is-any'
         },
         options: SUBSCRIPTION_STATUS_OPTIONS,
         metadata: {
@@ -337,7 +338,7 @@ export const memberFields = defineFields({
                 include: 'subscriptions'
             }
         },
-        codec: scalarCodec()
+        codec: setCodec()
     },
     'subscriptions.start_date': {
         operators: DATE_OPERATORS,

--- a/apps/posts/src/views/members/member-query-params.test.ts
+++ b/apps/posts/src/views/members/member-query-params.test.ts
@@ -1,10 +1,12 @@
 import {
     buildMemberListSearchParams,
     buildMemberOperationParams,
+    getActiveColumnValue,
     getMemberActiveColumns
 } from './member-query-params';
 import {describe, expect, it} from 'vitest';
 import type {FilterPredicate} from '../filters/filter-types';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
 
 describe('member-query-params', () => {
     it('keeps search separate while deriving includes from active field metadata', () => {
@@ -88,5 +90,104 @@ describe('member-query-params', () => {
         })).toEqual({
             all: true
         });
+    });
+});
+
+describe('getActiveColumnValue', () => {
+    const baseMember: Member = {
+        id: '1',
+        transient_id: 't1',
+        uuid: 'u1',
+        status: 'paid',
+        subscribed: true,
+        last_seen_at: null,
+        last_commented_at: null,
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z'
+    };
+
+    const makeSub = (id: string, status: string) => ({
+        id,
+        status,
+        customer: {id: 'cust_1', name: null, email: 'test@test.com'},
+        plan: {id: 'plan_1', nickname: '', interval: 'month' as const, currency: 'usd', amount: 500},
+        start_date: '2024-01-01T00:00:00.000Z',
+        current_period_end: '2024-02-01T00:00:00.000Z',
+        cancel_at_period_end: false,
+        price: {id: 'price_1', price_id: 'price_1', nickname: '', amount: 500, currency: 'usd', type: 'recurring', interval: 'month' as const},
+        tier: {id: 'tier_1', name: 'Default', slug: 'default', active: true, type: 'paid' as const},
+        offer: null
+    });
+
+    const statusColumn = {key: 'subscriptions.status', label: 'Subscription status', include: 'subscriptions'};
+
+    it('shows all unique subscription statuses for a member', () => {
+        const member = {
+            ...baseMember,
+            subscriptions: [
+                makeSub('sub_1', 'active'),
+                makeSub('sub_2', 'canceled')
+            ]
+        };
+
+        expect(getActiveColumnValue(statusColumn, member, 'UTC')).toEqual({
+            text: 'Active, Canceled'
+        });
+    });
+
+    it('deduplicates subscription statuses', () => {
+        const member = {
+            ...baseMember,
+            subscriptions: [
+                makeSub('sub_1', 'canceled'),
+                makeSub('sub_2', 'canceled')
+            ]
+        };
+
+        expect(getActiveColumnValue(statusColumn, member, 'UTC')).toEqual({
+            text: 'Canceled'
+        });
+    });
+
+    it('formats multi-word statuses correctly', () => {
+        const member = {
+            ...baseMember,
+            subscriptions: [
+                makeSub('sub_1', 'past_due'),
+                makeSub('sub_2', 'incomplete_expired')
+            ]
+        };
+
+        expect(getActiveColumnValue(statusColumn, member, 'UTC')).toEqual({
+            text: 'Past Due, Incomplete - Expired'
+        });
+    });
+
+    it('sorts statuses by severity (active states first)', () => {
+        const member = {
+            ...baseMember,
+            subscriptions: [
+                makeSub('sub_1', 'canceled'),
+                makeSub('sub_2', 'active'),
+                makeSub('sub_3', 'past_due')
+            ]
+        };
+
+        expect(getActiveColumnValue(statusColumn, member, 'UTC')).toEqual({
+            text: 'Active, Past Due, Canceled'
+        });
+    });
+
+    it('returns null when member has no subscriptions', () => {
+        expect(getActiveColumnValue(statusColumn, baseMember, 'UTC')).toBeNull();
+    });
+
+    it('returns null when subscriptions have no id', () => {
+        const member = {
+            ...baseMember,
+            subscriptions: [{...makeSub('', 'active'), id: ''}]
+        };
+
+        expect(getActiveColumnValue(statusColumn, member, 'UTC')).toBeNull();
     });
 });

--- a/apps/posts/src/views/members/member-query-params.ts
+++ b/apps/posts/src/views/members/member-query-params.ts
@@ -1,5 +1,5 @@
 import moment from 'moment-timezone';
-import {memberFields} from './member-fields';
+import {SUBSCRIPTION_STATUS_OPTIONS, memberFields} from './member-fields';
 import {resolveField} from '../filters/resolve-field';
 import type {FilterPredicate} from '../filters/filter-types';
 import type {Member, MemberSubscription} from '@tryghost/admin-x-framework/api/members';
@@ -7,6 +7,20 @@ import type {Member, MemberSubscription} from '@tryghost/admin-x-framework/api/m
 const MAX_ACTIVE_COLUMNS = 2;
 
 const ACTIVE_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing', 'unpaid', 'past_due']);
+
+const SUBSCRIPTION_STATUS_LABELS = new Map(
+    SUBSCRIPTION_STATUS_OPTIONS.map(option => [option.value, option.label])
+);
+
+const SUBSCRIPTION_STATUS_ORDER: Record<string, number> = {
+    active: 0,
+    trialing: 1,
+    past_due: 2,
+    unpaid: 3,
+    canceled: 4,
+    incomplete: 5,
+    incomplete_expired: 6
+};
 
 export type ActiveColumn = {
     key: string;
@@ -167,15 +181,21 @@ export function getActiveColumnValue(
     }
 
     case 'subscriptions.status': {
-        const status = mostRelevantSubscription(member.subscriptions)?.status;
-        if (!status) {
+        if (!member.subscriptions?.length) {
+            return null;
+        }
+        const statuses = [...new Set(
+            member.subscriptions
+                .filter(s => s.id)
+                .map(s => s.status)
+        )].sort((a, b) => (SUBSCRIPTION_STATUS_ORDER[a] ?? 99) - (SUBSCRIPTION_STATUS_ORDER[b] ?? 99));
+        if (!statuses.length) {
             return null;
         }
         return {
-            text: status
-                .split('_')
-                .map(part => part.charAt(0).toUpperCase() + part.slice(1))
-                .join(' ')
+            text: statuses
+                .map(s => SUBSCRIPTION_STATUS_LABELS.get(s) ?? s.split('_').map(p => p.charAt(0).toUpperCase() + p.slice(1)).join(' '))
+                .join(', ')
         };
     }
 


### PR DESCRIPTION
## Summary
- Converted `subscriptions.status` filter from single-select (`is`/`is-not`) to multi-select (`is-any`/`is-not-any`), allowing users to filter members by multiple subscription statuses at once
- Updated the subscription status column in the members list to display all unique statuses per member (deduplicated and sorted by severity) instead of only showing the "most relevant" subscription's status
- Backend already supports `$in`/`$nin` for the manyToMany subscriptions relation, so no backend changes needed

ref https://linear.app/tryghost/issue/BER-3345