### PR TITLE
✨ Added active subscription count filter for members

### DIFF
--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -41,7 +41,8 @@ describe('memberFields', () => {
             'opened_emails.post_id',
             'clicked_links.post_id',
             'newsletter_feedback',
-            'offer_redemptions'
+            'offer_redemptions',
+            'subscription_count'
         ]);
     });
 
@@ -51,6 +52,11 @@ describe('memberFields', () => {
         expect(memberFields['newsletters.:slug'].operators).toEqual(['is']);
         expect(memberFields.newsletter_feedback.operators).toEqual(['1', '0']);
         expect(memberFields.email_count.operators).toEqual([
+            'is',
+            'is-greater',
+            'is-less'
+        ]);
+        expect(memberFields.subscription_count.operators).toEqual([
             'is',
             'is-greater',
             'is-less'

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -483,5 +483,17 @@ export const memberFields = defineFields({
             }
         },
         codec: setCodec({quoteStrings: true, serializeSingletonAsScalar: true})
+    },
+    subscription_count: {
+        operators: NUMBER_OPERATORS,
+        ui: {
+            label: 'Active subscriptions',
+            type: 'number',
+            defaultOperator: 'is-greater',
+            defaultValue: 1,
+            min: 1,
+            className: 'w-24'
+        },
+        codec: numberCodec()
     }
 });

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -102,6 +102,8 @@ function getFieldIcon(key: string) {
         return React.createElement(LucideIcon.MessageSquare, {className: 'size-4'});
     case 'offer_redemptions':
         return React.createElement(LucideIcon.Ticket, {className: 'size-4'});
+    case 'subscription_count':
+        return React.createElement(LucideIcon.Hash, {className: 'size-4'});
     default:
         if (key.startsWith('newsletters.')) {
             return React.createElement(LucideIcon.Newspaper, {className: 'size-4'});
@@ -395,6 +397,10 @@ export function useMemberFilterFields({
                     postValueSource
                 )));
             }
+
+            subscriptionFields.push(
+                createFieldConfig('subscription_count', {}, NUMBER_OPERATOR_LABELS)
+            );
 
             if (offers.length > 0) {
                 subscriptionFields.push(createFieldConfig('offer_redemptions', {

--- a/ghost/core/core/server/data/migrations/init/1-create-tables.js
+++ b/ghost/core/core/server/data/migrations/init/1-create-tables.js
@@ -1,5 +1,6 @@
 const commands = require('../../schema').commands;
 const schema = require('../../schema').tables;
+const views = require('../../schema').views;
 const logging = require('@tryghost/logging');
 const schemaTables = Object.keys(schema);
 const {sequence} = require('@tryghost/promise');
@@ -14,6 +15,13 @@ module.exports.up = async (options) => {
         logging.info('Creating table: ' + table);
         await commands.createTable(table, connection);
     }));
+
+    // Create database views after all tables exist
+    for (const view of views) {
+        logging.info('Creating view: ' + view.name);
+        await connection.raw('DROP VIEW IF EXISTS ??', [view.name]);
+        await connection.raw('CREATE VIEW ?? AS ' + view.body, [view.name]);
+    }
 };
 
 /**

--- a/ghost/core/core/server/data/migrations/versions/6.28/2026-04-09-12-37-33-add-members-subscription-counts-view.js
+++ b/ghost/core/core/server/data/migrations/versions/6.28/2026-04-09-12-37-33-add-members-subscription-counts-view.js
@@ -1,0 +1,18 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+const VIEW_NAME = 'members_subscription_counts';
+const views = require('../../../schema/views');
+const viewDef = views.find(v => v.name === VIEW_NAME);
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info(`Creating view: ${VIEW_NAME}`);
+        await knex.raw('DROP VIEW IF EXISTS ??', [VIEW_NAME]);
+        await knex.raw('CREATE VIEW ?? AS ' + viewDef.body, [VIEW_NAME]);
+    },
+    async function down(knex) {
+        logging.info(`Dropping view: ${VIEW_NAME}`);
+        await knex.raw('DROP VIEW IF EXISTS ??', [VIEW_NAME]);
+    }
+);

--- a/ghost/core/core/server/data/schema/index.js
+++ b/ghost/core/core/server/data/schema/index.js
@@ -2,3 +2,4 @@ module.exports.tables = require('./schema');
 module.exports.commands = require('./commands');
 module.exports.defaultSettings = require('./default-settings');
 module.exports.validate = require('./validator');
+module.exports.views = require('./views');

--- a/ghost/core/core/server/data/schema/views.js
+++ b/ghost/core/core/server/data/schema/views.js
@@ -1,0 +1,13 @@
+module.exports = [
+    {
+        name: 'members_subscription_counts',
+        body: `SELECT
+            msc.member_id,
+            COUNT(mscs.id) as subscription_count
+        FROM members_stripe_customers msc
+        INNER JOIN members_stripe_customers_subscriptions mscs
+            ON mscs.customer_id = msc.customer_id
+        WHERE mscs.status IN ('active', 'trialing', 'past_due', 'unpaid')
+        GROUP BY msc.member_id`
+    }
+];

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -96,6 +96,9 @@ const Member = ghostBookshelf.Model.extend({
         }, {
             key: 'offer_redemptions',
             replacement: 'offer_redemptions.offer_id'
+        }, {
+            key: 'subscription_count',
+            replacement: 'subscription_counts.subscription_count'
         }];
     },
 
@@ -167,6 +170,12 @@ const Member = ghostBookshelf.Model.extend({
             },
             offer_redemptions: {
                 tableName: 'offer_redemptions',
+                type: 'oneToOne',
+                joinFrom: 'member_id'
+            },
+            subscription_counts: {
+                tableName: 'members_subscription_counts',
+                tableNameAs: 'subscription_counts',
                 type: 'oneToOne',
                 joinFrom: 'member_id'
             }

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -3,12 +3,18 @@ const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const configUtils = require('../../../utils/config-utils');
 const labs = require('../../../../core/shared/labs');
+const knex = require('../../../../core/server/data/db').knex;
 
 const config = configUtils.config;
 
 describe('Unit: models/member', function () {
+    const mockDb = require('mock-knex');
+    let tracker;
+
     before(function () {
         models.init();
+        mockDb.mock(knex);
+        tracker = mockDb.getTracker();
     });
 
     beforeEach(function () {
@@ -18,6 +24,10 @@ describe('Unit: models/member', function () {
     afterEach(async function () {
         await configUtils.restore();
         sinon.restore();
+    });
+
+    after(function () {
+        mockDb.unmock(knex);
     });
 
     describe('toJSON', function () {
@@ -84,6 +94,47 @@ describe('Unit: models/member', function () {
             }]);
 
             sinon.assert.calledWith(updatePivot, {expiry_at: null}, {query: {where: {product_id: '1'}}});
+        });
+    });
+
+    describe('filter', function () {
+        it('generates correct query for subscription_count filter', function () {
+            const queries = [];
+            tracker.install();
+
+            tracker.on('query', (query) => {
+                queries.push(query);
+                query.response([]);
+            });
+
+            return models.Member.findPage({
+                filter: 'subscription_count:>1'
+            }).then(() => {
+                assert.equal(queries.length, 2);
+
+                // The count query must alias the VIEW as subscription_counts so the
+                // WHERE clause references the same name used in the LEFT JOIN.
+                assert.ok(
+                    queries[0].sql.includes('left join `members_subscription_counts` as `subscription_counts`'),
+                    `Expected aliased JOIN in count query, got: ${queries[0].sql}`
+                );
+                assert.ok(
+                    queries[0].sql.includes('`subscription_counts`.`subscription_count` > ?'),
+                    `Expected WHERE to reference alias in count query, got: ${queries[0].sql}`
+                );
+
+                // The data query must also use the alias consistently.
+                assert.ok(
+                    queries[1].sql.includes('left join `members_subscription_counts` as `subscription_counts`'),
+                    `Expected aliased JOIN in data query, got: ${queries[1].sql}`
+                );
+                assert.ok(
+                    queries[1].sql.includes('`subscription_counts`.`subscription_count` > ?'),
+                    `Expected WHERE to reference alias in data query, got: ${queries[1].sql}`
+                );
+            }).finally(() => {
+                tracker.uninstall();
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary
- Added an "Active subscriptions" number filter so admins can find members with multiple concurrent Stripe subscriptions (e.g. `> 1`)
- Created a database VIEW (`members_subscription_counts`) that counts only current subscriptions per member — filtered to statuses `active`, `trialing`, `past_due`, `unpaid`
- Historical/terminal subscriptions (canceled, incomplete_expired) are excluded from the count, so a member who cancelled and re-subscribed shows count 1, not 2
- Added a `oneToOne` filterRelation + filterExpansion in the Member model so mongo-knex generates the correct LEFT JOIN + WHERE clause
- Added the filter field to the frontend with number operators (is, greater than, less than)
- Added a unit test using mock-knex to verify the SQL uses correct table aliasing (`tableNameAs`)

ref https://linear.app/tryghost/issue/BER-3345