### PR TITLE
Added gift subscription URL to editor link autocomplete

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -300,9 +300,20 @@ export default class KoenigLexicalEditor extends Component {
                 return [];
             };
 
+            const giftLink = () => {
+                if (this.feature.giftSubscriptions) {
+                    return [{
+                        label: 'Gift subscription',
+                        value: '#/portal/gift'
+                    }];
+                }
+
+                return [];
+            };
+
             const offersLinks = await offerUrls.call(this);
 
-            return [...defaults, ...memberLinks(), ...donationLink(), ...recommendationLink(), ...offersLinks];
+            return [...defaults, ...memberLinks(), ...donationLink(), ...recommendationLink(), ...giftLink(), ...offersLinks];
         };
 
         const fetchLabels = async () => {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -68,6 +68,7 @@ export default class FeatureService extends Service {
     @feature('tagsX') tagsX;
     @feature('membersForward') membersForward;
     @feature('commentModeration') commentModeration;
+    @feature('giftSubscriptions') giftSubscriptions;
     _user = null;
 
     @computed('settings.labs')


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3489/ghost-admin-add-gifting-url-to-the-button-card-in-the-editor
ref https://linear.app/ghost/issue/BER-3488/ghost-admin-add-gifting-url-to-the-cta-card-in-the-editor

- lets publishers promote the new gift subscription flow from posts and emails via Button or CTA cards
- adds #/portal/gift to the link autocomplete alongside the other portal links
- picked up automatically by all cards using the shared InputUrlSetting (Button, CTA, Email CTA, Header, Product)
- gated behind the giftSubscriptions lab flag
