### PR TITLE
Skipped CI build and E2E jobs for non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,9 @@ jobs:
         with:
           filters: |
             shared: &shared
-              - '.github/**'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/scripts/**'
               - 'package.json'
               - 'yarn.lock'
             core:
@@ -147,6 +149,27 @@ jobs:
               - '!ghost/core/core/server/data/tinybird/**/*.md'
             any-code:
               - '!**/*.md'
+              - '!.github/renovate.json5'
+              - '!.github/CODEOWNERS'
+              - '!.github/codecov.yml'
+              - '!.github/FUNDING.yml'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/hooks/**'
+              - '!.github/agents/**'
+              - '!.github/aw/**'
+              - '!.coderabbit.yaml'
+              - '!.editorconfig'
+              - '!.gitattributes'
+              - '!.vscode/**'
+              - '!.cursor/**'
+              - '!.codex/**'
+              - '!.claude/**'
+              - '!.agents/**'
+              - '!adr/**'
+              - '!ai/**'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!sonar-project.properties'
 
       - name: Compute lockfile hash
         run: echo "hash=lockfile-${{ hashFiles('yarn.lock') }}" >> "$GITHUB_ENV"
@@ -805,6 +828,7 @@ jobs:
   job_build_artifacts:
     name: Build & Publish Artifacts
     needs: [job_setup]
+    if: needs.job_setup.outputs.changed_any_code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1067,7 +1091,7 @@ jobs:
   job_build_e2e_public_apps:
     name: Build E2E Public App Assets
     needs: [job_setup]
-    if: needs.job_setup.outputs.is_tag != 'true'
+    if: needs.job_setup.outputs.changed_any_code == 'true' && needs.job_setup.outputs.is_tag != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -1107,7 +1131,7 @@ jobs:
   job_build_e2e_image:
     name: Build E2E Docker Image
     needs: [job_setup, job_build_e2e_public_apps, job_build_artifacts]
-    if: needs.job_setup.outputs.is_tag != 'true'
+    if: needs.job_setup.outputs.changed_any_code == 'true' && needs.job_setup.outputs.is_tag != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1215,7 +1239,7 @@ jobs:
     name: E2E Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     needs: [job_build_e2e_image, job_setup]
-    if: needs.job_setup.outputs.is_tag != 'true'
+    if: needs.job_setup.outputs.changed_any_code == 'true' && needs.job_setup.outputs.is_tag != 'true'
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
## Summary

- Narrowed the shared paths-filter anchor from .github/** to only CI-relevant paths (.github/workflows/**, .github/actions/**, .github/scripts/**), so changes to renovate config, CODEOWNERS, codecov.yml, issue templates, and other non-CI metadata no longer trigger all test suites
- Expanded the any-code filter to exclude docs, IDE config, AI agent config, and other non-code files
- Wired the changed_any_code gate into job_build_artifacts, job_build_e2e_public_apps, job_build_e2e_image, and job_e2e_tests - these previously ran unconditionally on every non-tag PR

### What this skips for non-code PRs

The entire Docker build + E2E chain (~90 runner-minutes across 8 shards + 3 build jobs), plus lint and unit tests. For a config-only PR, CI now runs just Setup and the gate job.

### What is safe

- job_required_tests uses if: always() and treats skipped dependencies as passing
- trigger_cd and publish_ghost already check needs.job_build_artifacts.result == success, so they skip when build is skipped
- Test files live inside ghost/, apps/, and e2e/, so they still trigger any-code and their respective package filters

## Test plan

- [ ] Verify this PRs own CI run passes (it touches .github/workflows/ci.yml so all suites should still trigger via shared)
- [ ] Verify a non-code PR (e.g. renovate.json5 change, docs update) skips build + E2E jobs
- [ ] Verify a code PR still runs the full pipeline including E2E