### PR TITLE
Moved WORKDIR to /var/lib/ghost and added community Docker target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -883,6 +883,11 @@ jobs:
       - name: Prepare Docker build context
         run: mv ghost/core/package/ /tmp/ghost-production/
 
+      - name: Add community Docker files to build context
+        run: |
+          cp docker/community/docker-entrypoint.sh /tmp/ghost-production/
+          cp docker/community/config.production.json /tmp/ghost-production/
+
       - name: Determine push strategy
         id: strategy
         run: |

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1-labs@sha256:7eca9451d94f9b8ad22e44988b92d595d3e4d65163794237949a8c3413fbed5d
 
 # Production Dockerfile for Ghost
-# Two targets:
-#   core — server + production deps, no admin (Ghost-Pro base)
-#   full — core + built admin (self-hosting)
+# Three targets:
+#   core      — server + production deps, no admin (Ghost-Pro base)
+#   full      — core + built admin (E2E, review environments)
+#   community — full + entrypoint + volume (future Docker Hub image)
 #
 # Build context: extracted `npm pack` output from ghost/core
 
@@ -23,7 +24,7 @@ RUN apt-get update && \
     usermod -u 1001 node && \
     adduser --disabled-password --gecos "" -u 1000 ghost
 
-WORKDIR /home/ghost
+WORKDIR /var/lib/ghost
 
 COPY --exclude=core/built/admin . .
 
@@ -37,13 +38,10 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
     apt-get purge -y build-essential python3 && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
-    mkdir -p default log && \
     cp -R content base_content && \
-    cp -R content/themes/casper default/casper && \
-    ([ -d content/themes/source ] && cp -R content/themes/source default/source || true) && \
-    chown ghost:ghost /home/ghost && \
-    chown -R nobody:nogroup /home/ghost/* && \
-    chown -R ghost:ghost /home/ghost/content /home/ghost/log
+    chown ghost:ghost /var/lib/ghost && \
+    chown -R nobody:nogroup /var/lib/ghost/* && \
+    chown -R ghost:ghost /var/lib/ghost/content
 
 USER ghost
 ENV LD_PRELOAD=libjemalloc.so.2
@@ -59,3 +57,21 @@ USER root
 COPY core/built/admin core/built/admin
 RUN chown -R nobody:nogroup core/built/admin
 USER ghost
+
+# ---- Community: full + entrypoint + volume (Docker Hub) ----
+FROM full AS community
+
+ENV GHOST_INSTALL=/var/lib/ghost \
+    GHOST_CONTENT=/var/lib/ghost/content
+
+USER root
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY config.production.json config.production.json
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
+    chown nobody:nogroup config.production.json
+USER ghost
+
+VOLUME /var/lib/ghost/content
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["node", "index.js"]

--- a/docker/community/config.production.json
+++ b/docker/community/config.production.json
@@ -1,0 +1,16 @@
+{
+    "url": "http://localhost:2368",
+    "server": {
+        "host": "0.0.0.0",
+        "port": 2368
+    },
+    "database": {
+        "client": "sqlite3",
+        "connection": {
+            "filename": "content/data/ghost.db"
+        }
+    },
+    "logging": {
+        "transports": ["stdout"]
+    }
+}

--- a/docker/community/docker-entrypoint.sh
+++ b/docker/community/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+baseDir="./base_content"
+targetDir="./content"
+
+# Seed top-level content subdirectories (data, settings, etc.)
+for src in "$baseDir"/*/; do
+    src="${src%/}"
+    [[ -e "$src" ]] || continue
+    target="$targetDir/$(basename "$src")"
+    if [[ ! -e "$target" ]]; then
+        mkdir -p "$(dirname "$target")"
+        tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+    fi
+done
+
+# Seed individual themes (casper, source, etc.)
+for src in "$baseDir"/themes/*/; do
+    src="${src%/}"
+    [[ -e "$src" ]] || continue
+    target="$targetDir/themes/$(basename "$src")"
+    if [[ ! -e "$target" ]]; then
+        mkdir -p "$targetDir/themes"
+        tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$targetDir/themes"
+    fi
+done
+
+exec "$@"

--- a/e2e/Dockerfile.e2e
+++ b/e2e/Dockerfile.e2e
@@ -12,11 +12,11 @@ ARG GHOST_IMAGE=ghost-monorepo:latest
 FROM $GHOST_IMAGE
 
 # Public app UMD bundles — Ghost serves these from /content/files/
-COPY apps/portal/umd /home/ghost/content/files/portal
-COPY apps/comments-ui/umd /home/ghost/content/files/comments-ui
-COPY apps/sodo-search/umd /home/ghost/content/files/sodo-search
-COPY apps/signup-form/umd /home/ghost/content/files/signup-form
-COPY apps/announcement-bar/umd /home/ghost/content/files/announcement-bar
+COPY apps/portal/umd content/files/portal
+COPY apps/comments-ui/umd content/files/comments-ui
+COPY apps/sodo-search/umd content/files/sodo-search
+COPY apps/signup-form/umd content/files/signup-form
+COPY apps/announcement-bar/umd content/files/announcement-bar
 
 ENV portal__url=/content/files/portal/portal.min.js
 ENV comments__url=/content/files/comments-ui/comments-ui.min.js


### PR DESCRIPTION
refs [BER-3398](https://linear.app/ghost/issue/BER-3398), [BER-3399](https://linear.app/ghost/issue/BER-3399)

The community Docker image (`docker-library/ghost`) is maintained by external contributors, and updates consistently lag behind Ghost releases because they depend on community PRs through `docker-library/official-images`. We want to publish our own `tryghost/ghost` image to Docker Hub that's a zero-change migration for the tens of thousands of self-hosters currently using the community image.

To make that work, our production Dockerfile needs to match the conventions the community image established — primarily `WORKDIR /var/lib/ghost` (so existing volume mounts and compose files just work) and content seeding on first boot (so a fresh named volume gets default themes and scaffolding). This PR makes those alignment changes and adds a `community` build target that layers the entrypoint, config, and VOLUME declaration on top of the existing `full` target.

The WORKDIR move from `/home/ghost` to `/var/lib/ghost` also cleaned up some dead code from the legacy Pro source-build era — unused `default/` directory creation and theme copies that nothing references. The `log/` directory creation was moved to `Dockerfile.pro` where it belongs since Ghost itself writes logs to `content/logs/`, not a top-level `log/` dir.

The community target is not built or published in CI yet — that comes with [BER-3400](https://linear.app/ghost/issue/BER-3400) when we're ready to push to Docker Hub. For now, it can be built locally with `docker build --target community`.

Merge [Ghost-Moya#210](https://github.com/TryGhost/Ghost-Moya/pull/210) after this lands to align the Pro container and PR preview tooling with the new WORKDIR.