### PR TITLE
🐛 Fixed deep-linking to Admin screens whilst logged out

### DIFF
--- a/e2e/helpers/pages/admin/login-page.ts
+++ b/e2e/helpers/pages/admin/login-page.ts
@@ -33,6 +33,7 @@ export class LoginPage extends AdminPage {
 
     async logout() {
         await this.page.goto('/ghost/#/signout');
+        await this.signInButton.waitFor({state: 'visible'});
     }
 
     async waitForLoginPageAfterUserCreated(): Promise<void> {

--- a/e2e/helpers/pages/admin/posts/posts-page.ts
+++ b/e2e/helpers/pages/admin/posts/posts-page.ts
@@ -44,6 +44,11 @@ export class PostsPage extends AdminPage {
         return this.postsListItem.filter({has: this.page.getByRole('heading', {name: title, exact: true, level: 3})});
     }
 
+    async waitForPageToFullyLoad() {
+        await this.page.waitForURL(this.pageUrl);
+        await this.postsList.waitFor({state: 'visible'});
+    }
+
     async refreshData() {
         await this.page.reload();
     }

--- a/e2e/tests/admin/signin.test.ts
+++ b/e2e/tests/admin/signin.test.ts
@@ -1,0 +1,38 @@
+import {LoginPage, PostsPage, TagsPage} from '@/admin-pages';
+import {Page} from '@playwright/test';
+import {expect, test} from '@/helpers/playwright';
+
+test.describe('Ghost Admin - Signin Redirect', () => {
+    async function logout(page: Page) {
+        const loginPage = new LoginPage(page);
+        await loginPage.logout();
+    }
+
+    test('deep-linking to a React route while logged out redirects back after signin', async ({page, ghostAccountOwner}) => {
+        await logout(page);
+
+        const tagsPage = new TagsPage(page);
+        await tagsPage.goto();
+
+        const loginPage = new LoginPage(page);
+        await expect(loginPage.signInButton).toBeVisible();
+
+        await loginPage.signIn(ghostAccountOwner.email, ghostAccountOwner.password);
+
+        await tagsPage.waitForPageToFullyLoad();
+    });
+
+    test('deep-linking to an Ember route while logged out redirects back after signin', async ({page, ghostAccountOwner}) => {
+        await logout(page);
+
+        const postsPage = new PostsPage(page);
+        await postsPage.goto();
+
+        const loginPage = new LoginPage(page);
+        await expect(loginPage.signInButton).toBeVisible();
+
+        await loginPage.signIn(ghostAccountOwner.email, ghostAccountOwner.password);
+
+        await postsPage.waitForPageToFullyLoad();
+    });
+});

--- a/ghost/admin/app/routes/authenticated.js
+++ b/ghost/admin/app/routes/authenticated.js
@@ -7,6 +7,13 @@ export default class AuthenticatedRoute extends Route {
     @service session;
 
     async beforeModel(transition) {
+        if (!this.session.isAuthenticated) {
+            const url = transition.intent?.url;
+            if (url) {
+                window.sessionStorage.setItem('ghost-signin-redirect', url);
+            }
+        }
+
         this.session.requireAuthentication(transition, () => {
             windowProxy.replaceLocation(AuthConfiguration.rootURL);
         });

--- a/ghost/admin/app/routes/authenticated.js
+++ b/ghost/admin/app/routes/authenticated.js
@@ -12,6 +12,8 @@ export default class AuthenticatedRoute extends Route {
             if (url) {
                 window.sessionStorage.setItem('ghost-signin-redirect', url);
             }
+        } else {
+            window.sessionStorage.removeItem('ghost-signin-redirect');
         }
 
         this.session.requireAuthentication(transition, () => {

--- a/ghost/admin/app/routes/react-fallback.js
+++ b/ghost/admin/app/routes/react-fallback.js
@@ -1,0 +1,3 @@
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+
+export default class ReactFallbackRoute extends AuthenticatedRoute {}

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -89,8 +89,8 @@ export default class SessionService extends ESASessionService {
             }
 
             const redirectUrl = window.sessionStorage.getItem('ghost-signin-redirect');
-            if (redirectUrl) {
-                window.sessionStorage.removeItem('ghost-signin-redirect');
+            window.sessionStorage.removeItem('ghost-signin-redirect');
+            if (redirectUrl && !redirectUrl.startsWith('/signin') && !redirectUrl.startsWith('/signup') && !redirectUrl.startsWith('/setup')) {
                 this.router.transitionTo(redirectUrl);
                 return;
             }

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -88,6 +88,13 @@ export default class SessionService extends ESASessionService {
                 return;
             }
 
+            const redirectUrl = window.sessionStorage.getItem('ghost-signin-redirect');
+            if (redirectUrl) {
+                window.sessionStorage.removeItem('ghost-signin-redirect');
+                this.router.transitionTo(redirectUrl);
+                return;
+            }
+
             super.handleAuthentication('home');
         });
     }

--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -183,8 +183,8 @@ describe('Acceptance: Authentication', function () {
 
             await visit('/signin/invalidurl/');
 
-            expect(currentURL(), 'url after invalid url').to.equal('/signin/invalidurl/');
-            expect(currentRouteName(), 'path after invalid url').to.equal('react-fallback');
+            expect(currentURL(), 'url after invalid url').to.equal('/signin');
+            expect(currentRouteName(), 'path after invalid url').to.equal('signin');
             expect(findAll('nav.gh-nav').length, 'nav menu presence').to.equal(0);
         });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1623/

When deep-linking to an admin route (e.g. `/ghost/#/tags`) while logged out, the page rendered blank instead of showing the signin screen. This was caused by the `react-fallback` catch-all route lacking the authentication check that was previously on the now-removed Ember route files.

- Added `react-fallback` route extending `AuthenticatedRoute` to enforce signin for all React-rendered routes
- Persisted intended URL in `sessionStorage` before the auth redirect so the user is returned to their original destination after signing in (works for both React and Ember routes)
- Made `LoginPage.logout()` wait for the signin page to fully load before resolving to avoid race conditions with subsequent navigations in e2e tests
- Added e2e tests covering signin redirect for both React (`/tags`) and Ember (`/posts`) routes