### PR TITLE
Disabled playwright test report server auto-opening on test failures

### DIFF
--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -25,7 +25,7 @@ const config = {
     maxFailures: process.argv.includes('--ui') ? 0 : 1,
     workers: parseInt(process.env.TEST_WORKERS_COUNT, 10) || getWorkerCount(),
     fullyParallel: false,
-    reporter: process.env.CI ? [['list', {printSteps: true}], ['blob']] : [['list', {printSteps: true}], ['html']],
+    reporter: process.env.CI ? [['list', {printSteps: true}], ['blob']] : [['list', {printSteps: true}], ['html', {open: 'never'}]],
     use: {
         // Base URL will be set dynamically per test via fixture
         baseURL: process.env.GHOST_BASE_URL || 'http://localhost:2368',


### PR DESCRIPTION
When running e2e tests locally, the test report server runs automatically if there were any failures instead of exiting cleanly. This is especially annoying when agents run the e2e tests themselves, as they will hang indefinitely on the command, not realizing that the tests have already run.

This disables this behavior, so the e2e tests will exit cleanly even if tests fail. The html report is still generated and can be opened manually.