### PR TITLE
Fixed Escape key closing both AlertDialog and Dialog in EmailDesignModal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email-design/dirty-confirm-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/dirty-confirm-modal.tsx
@@ -18,6 +18,7 @@ const DirtyConfirmModal: React.FC<DirtyConfirmModalProps> = ({
 }) => {
     const modal = useModal();
     const prevVisibleRef = useRef(modal.visible);
+    const shouldLeaveRef = useRef(false);
 
     useEffect(() => {
         if (prevVisibleRef.current && !modal.visible) {
@@ -28,17 +29,14 @@ const DirtyConfirmModal: React.FC<DirtyConfirmModalProps> = ({
         prevVisibleRef.current = modal.visible;
     }, [modal]);
 
-    const close = (shouldLeave: boolean) => {
-        modal.resolve(shouldLeave);
-        modal.hide();
-    };
-
     return (
         <AlertDialog
             open={modal.visible}
             onOpenChange={(isOpen) => {
                 if (!isOpen) {
-                    close(false);
+                    modal.resolve(shouldLeaveRef.current);
+                    shouldLeaveRef.current = false;
+                    modal.hide();
                 }
             }}
         >
@@ -56,10 +54,17 @@ const DirtyConfirmModal: React.FC<DirtyConfirmModalProps> = ({
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                     <AlertDialogCancel asChild>
-                        <Button variant="outline" onClick={() => close(false)}>Stay</Button>
+                        <Button variant="outline">Stay</Button>
                     </AlertDialogCancel>
                     <AlertDialogAction asChild>
-                        <Button variant="destructive" onClick={() => close(true)}>Leave</Button>
+                        <Button
+                            variant="destructive"
+                            onClick={() => {
+                                shouldLeaveRef.current = true;
+                            }}
+                        >
+                            Leave
+                        </Button>
                     </AlertDialogAction>
                 </AlertDialogFooter>
             </AlertDialogContent>

--- a/apps/admin-x-settings/src/components/settings/email-design/dirty-confirm-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/dirty-confirm-modal.tsx
@@ -1,0 +1,70 @@
+import NiceModal, {useModal} from '@ebay/nice-modal-react';
+import React, {useEffect, useRef} from 'react';
+import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button} from '@tryghost/shade/components';
+
+interface DirtyConfirmModalProps {
+    title?: string;
+    description?: React.ReactNode;
+}
+
+const DirtyConfirmModal: React.FC<DirtyConfirmModalProps> = ({
+    title = 'Are you sure you want to leave this page?',
+    description = (
+        <div className="space-y-2">
+            <p>{`Hey there! It looks like you didn't save the changes you made.`}</p>
+            <p>Save before you go!</p>
+        </div>
+    )
+}) => {
+    const modal = useModal();
+    const prevVisibleRef = useRef(modal.visible);
+
+    useEffect(() => {
+        if (prevVisibleRef.current && !modal.visible) {
+            modal.resolveHide();
+            modal.remove();
+        }
+
+        prevVisibleRef.current = modal.visible;
+    }, [modal]);
+
+    const close = (shouldLeave: boolean) => {
+        modal.resolve(shouldLeave);
+        void modal.hide();
+    };
+
+    return (
+        <AlertDialog
+            open={modal.visible}
+            onOpenChange={(isOpen) => {
+                if (!isOpen) {
+                    close(false);
+                }
+            }}
+        >
+            <AlertDialogContent
+                data-testid="welcome-email-dirty-confirm-modal"
+                onEscapeKeyDown={(event) => {
+                    event.stopPropagation();
+                }}
+            >
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{title}</AlertDialogTitle>
+                    <AlertDialogDescription asChild>
+                        {description}
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel asChild>
+                        <Button variant="outline" onClick={() => close(false)}>Stay</Button>
+                    </AlertDialogCancel>
+                    <AlertDialogAction asChild>
+                        <Button variant="destructive" onClick={() => close(true)}>Leave</Button>
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};
+
+export default NiceModal.create(DirtyConfirmModal);

--- a/apps/admin-x-settings/src/components/settings/email-design/dirty-confirm-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/dirty-confirm-modal.tsx
@@ -4,7 +4,7 @@ import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, A
 
 interface DirtyConfirmModalProps {
     title?: string;
-    description?: React.ReactNode;
+    description?: React.ReactElement;
 }
 
 const DirtyConfirmModal: React.FC<DirtyConfirmModalProps> = ({

--- a/apps/admin-x-settings/src/components/settings/email-design/dirty-confirm-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/dirty-confirm-modal.tsx
@@ -30,7 +30,7 @@ const DirtyConfirmModal: React.FC<DirtyConfirmModalProps> = ({
 
     const close = (shouldLeave: boolean) => {
         modal.resolve(shouldLeave);
-        void modal.hide();
+        modal.hide();
     };
 
     return (

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
@@ -1,5 +1,7 @@
-import React, {useEffect, useRef, useState} from 'react';
-import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, Dialog, DialogContent, DialogTitle} from '@tryghost/shade/components';
+import DirtyConfirmModal from './dirty-confirm-modal';
+import NiceModal from '@ebay/nice-modal-react';
+import React, {useEffect, useRef} from 'react';
+import {Button, Dialog, DialogContent, DialogTitle} from '@tryghost/shade/components';
 import {type OkProps} from '@tryghost/admin-x-framework/hooks';
 import {cn} from '@tryghost/shade/utils';
 
@@ -32,7 +34,7 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
 }) => {
     const onSaveRef = useRef(onSave);
     const prevOpenRef = useRef(open);
-    const [showDirtyConfirm, setShowDirtyConfirm] = useState(false);
+
     useEffect(() => {
         onSaveRef.current = onSave;
     }, [onSave]);
@@ -56,86 +58,65 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
 
-    const handleClose = () => {
+    const handleClose = async () => {
         if (!dirty) {
             onClose();
             return;
         }
 
-        setShowDirtyConfirm(true);
+        const shouldLeave = await NiceModal.show(DirtyConfirmModal) as boolean;
+        if (shouldLeave) {
+            onClose();
+        }
     };
 
     return (
-        <>
-            <Dialog open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
-                <DialogContent
-                    className={cn(
-                        'top-[50%] left-[50%] h-[calc(100vh-8vmin)] w-[calc(100vw-8vmin)] max-w-none translate-x-[-50%] translate-y-[-50%] gap-0 overflow-hidden p-0'
-                    )}
-                    data-testid={testId}
-                    onEscapeKeyDown={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        handleClose();
-                    }}
-                >
-                    <div className="flex h-full min-h-0">
-                        {/* Left: Preview */}
-                        <div className="hidden min-h-0 flex-1 flex-col bg-gray-50 dark:bg-black [@media(min-width:801px)]:flex">
-                            <div className="flex min-h-0 flex-1 items-center justify-center p-8">
-                                {preview}
-                            </div>
-                        </div>
-
-                        {/* Right: Sidebar */}
-                        <div className="flex min-h-0 w-full flex-col border-l border-gray-200 dark:border-gray-900 [@media(min-width:801px)]:w-[400px] [@media(min-width:801px)]:shrink-0">
-                            <div className="flex items-center justify-between px-6 py-5">
-                                <DialogTitle>{title}</DialogTitle>
-                                <div className="flex items-center gap-2">
-                                    <Button variant="outline" onClick={handleClose}>Close</Button>
-                                    <Button
-                                        className={okProps?.color === 'green' ? 'bg-green text-white hover:bg-green/90' : undefined}
-                                        disabled={isLoading || okProps?.disabled}
-                                        variant={okProps?.color === 'red' ? 'destructive' : 'default'}
-                                        onClick={onSave}
-                                    >
-                                        {okProps?.label || 'Save'}
-                                    </Button>
-                                </div>
-                            </div>
-                            {sidebar}
+        <Dialog
+            open={open}
+            onOpenChange={(isOpen) => {
+                if (!isOpen) {
+                    void handleClose();
+                }
+            }}
+        >
+            <DialogContent
+                className={cn(
+                    'top-[50%] left-[50%] h-[calc(100vh-8vmin)] w-[calc(100vw-8vmin)] max-w-none translate-x-[-50%] translate-y-[-50%] gap-0 overflow-hidden p-0'
+                )}
+                data-testid={testId}
+                onEscapeKeyDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    void handleClose();
+                }}
+            >
+                <div className="flex h-full min-h-0">
+                    <div className="hidden min-h-0 flex-1 flex-col bg-gray-50 dark:bg-black [@media(min-width:801px)]:flex">
+                        <div className="flex min-h-0 flex-1 items-center justify-center p-8">
+                            {preview}
                         </div>
                     </div>
-                </DialogContent>
-            </Dialog>
-            <AlertDialog open={showDirtyConfirm} onOpenChange={setShowDirtyConfirm}>
-                <AlertDialogContent
-                    onEscapeKeyDown={(event) => {
-                        event.stopPropagation();
-                    }}
-                >
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>Are you sure you want to leave this page?</AlertDialogTitle>
-                        <AlertDialogDescription asChild>
-                            <div className="space-y-2">
-                                <p>{`Hey there! It looks like you didn't save the changes you made.`}</p>
-                                <p>Save before you go!</p>
+
+                    <div className="flex min-h-0 w-full flex-col border-l border-gray-200 dark:border-gray-900 [@media(min-width:801px)]:w-[400px] [@media(min-width:801px)]:shrink-0">
+                        <div className="flex items-center justify-between px-6 py-5">
+                            <DialogTitle>{title}</DialogTitle>
+                            <div className="flex items-center gap-2">
+                                <Button variant="outline" onClick={() => void handleClose()}>Close</Button>
+                                <Button
+                                    className={okProps?.color === 'green' ? 'bg-green text-white hover:bg-green/90' : undefined}
+                                    disabled={isLoading || okProps?.disabled}
+                                    variant={okProps?.color === 'red' ? 'destructive' : 'default'}
+                                    onClick={onSave}
+                                >
+                                    {okProps?.label || 'Save'}
+                                </Button>
                             </div>
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel asChild>
-                            <Button variant="outline">Stay</Button>
-                        </AlertDialogCancel>
-                        <AlertDialogAction asChild>
-                            <Button className="bg-destructive text-destructive-foreground hover:bg-destructive/90" onClick={onClose}>
-                                Leave
-                            </Button>
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
-        </>
+                        </div>
+                        {sidebar}
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
     );
 };
 

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
@@ -75,7 +75,7 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
             open={open}
             onOpenChange={(isOpen) => {
                 if (!isOpen) {
-                    void handleClose();
+                    handleClose();
                 }
             }}
         >
@@ -87,7 +87,7 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
                 onEscapeKeyDown={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    void handleClose();
+                    handleClose();
                 }}
             >
                 <div className="flex h-full min-h-0">
@@ -101,7 +101,7 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
                         <div className="flex items-center justify-between px-6 py-5">
                             <DialogTitle>{title}</DialogTitle>
                             <div className="flex items-center gap-2">
-                                <Button variant="outline" onClick={() => void handleClose()}>Close</Button>
+                                <Button variant="outline" onClick={() => handleClose()}>Close</Button>
                                 <Button
                                     className={okProps?.color === 'green' ? 'bg-green text-white hover:bg-green/90' : undefined}
                                     disabled={isLoading || okProps?.disabled}

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -253,9 +253,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await expect(page).toHaveURL(/\/ghost\/#\/settings\/memberemails$/);
     });
 
-    // Skipped: Escape event from AlertDialog propagates to parent Dialog, closing both.
-    // Fix needed in EmailDesignModal to prevent Dialog from reacting when AlertDialog is open.
-    test.skip('Escape closes welcome email customization confirmation without closing the customize modal', async ({page}) => {
+    test('Escape closes welcome email customization confirmation without closing the customize modal', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();
@@ -273,9 +271,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await expect(page).toHaveURL(/\/ghost\/#\/settings\/memberemails$/);
     });
 
-    // Skipped: Escape event from AlertDialog propagates to parent Dialog, closing both.
-    // Fix needed in EmailDesignModal to prevent Dialog from reacting when AlertDialog is open.
-    test.skip('Escape closes welcome email color picker without bypassing unsaved changes confirmation', async ({page}) => {
+    test('Escape closes welcome email color picker without bypassing unsaved changes confirmation', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();
@@ -303,9 +299,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await expect(page).toHaveURL(/\/ghost\/#\/settings\/memberemails$/);
     });
 
-    // Skipped: Escape event from AlertDialog propagates to parent Dialog, closing both.
-    // Fix needed in EmailDesignModal to prevent Dialog from reacting when AlertDialog is open.
-    test.skip('Escape closes welcome email font select without bypassing unsaved changes confirmation', async ({page}) => {
+    test('Escape closes welcome email font select without bypassing unsaved changes confirmation', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();


### PR DESCRIPTION
refs 71d78022c6340472d9a68166109864bd37e0b855

## Summary

This fixes a bug in the welcome email customization flow where pressing `Escape` on the unsaved changes confirmation could close both the confirmation dialog and the parent customize modal.

The issue was caused by nesting two independent dialog flows around the same interaction. Once the unsaved changes confirmation was open, `Escape` could still be handled in a way that allowed the parent modal's close path to run again, which made the behavior flaky and caused the customize modal to close when it should have stayed open.

The fix moves the unsaved changes confirmation into its own `NiceModal` flow and gives it a single close/resolve path. That keeps the confirmation dialog responsible for deciding whether the user is staying or leaving, and prevents duplicate close handling from the parent modal. As part of that cleanup, the confirmation modal's `description` prop was also tightened to `React.ReactElement` so it matches the `asChild` usage in `AlertDialogDescription` and can't be passed an unsafe node type.

## Behavior

- pressing `Escape` with unsaved changes now opens the confirmation dialog
- pressing `Escape` again closes only the confirmation dialog and keeps the customize modal open
- dismissing nested controls like the color picker or font select with `Escape` still works without bypassing the unsaved changes confirmation

## Testing

- `yarn workspace @tryghost/e2e test e2e/tests/admin/settings/member-welcome-emails.test.ts`