### PR TITLE
Fixed image edit and delete buttons being hidden on touch devices

### DIFF
--- a/apps/admin-x-design-system/src/global/form/image-upload.tsx
+++ b/apps/admin-x-design-system/src/global/form/image-upload.tsx
@@ -101,14 +101,14 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
 
         if (!deleteButtonUnstyled) {
             deleteButtonClassName = clsx(
-                'absolute top-4 right-4 flex size-8 cursor-pointer items-center justify-center rounded bg-[rgba(0,0,0,0.75)] text-white group-hover:visible! hover:bg-black md:invisible',
+                'absolute top-4 right-4 flex size-8 cursor-pointer items-center justify-center rounded bg-[rgba(0,0,0,0.75)] text-white group-hover:visible! hover:bg-black md:invisible [@media(hover:none)]:visible!',
                 deleteButtonClassName
             );
         }
 
         if (!editButtonUnstyled) {
             editButtonClassName = clsx(
-                'absolute top-4 right-16 flex size-8 cursor-pointer items-center justify-center rounded bg-[rgba(0,0,0,0.75)] text-white group-hover:visible! hover:bg-black md:invisible',
+                'absolute top-4 right-16 flex size-8 cursor-pointer items-center justify-center rounded bg-[rgba(0,0,0,0.75)] text-white group-hover:visible! hover:bg-black md:invisible [@media(hover:none)]:visible!',
                 editButtonClassName
             );
         }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1341/design-and-branding-ui-issues-on-ios

- the edit/delete buttons relied on hover to become visible, leaving them inaccessible on touch devices where hover doesn't exist
- added a `[@media(hover:none)]:visible!` variant so the buttons are always shown when the device has no hover capability

