### PR TITLE
🐛 Fixed publish build step and added build verification on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1515,19 +1515,7 @@ jobs:
     ]
     name: Publish ${{ matrix.package_name }}
     runs-on: ubuntu-latest
-    if: >-
-      always() && github.repository == 'TryGhost/Ghost'
-      && needs.job_setup.result == 'success'
-      && (
-        (needs.job_setup.outputs.is_main == 'true' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success')
-        || (github.event_name == 'pull_request'
-          && (needs.job_setup.outputs.changed_activitypub == 'true'
-          || needs.job_setup.outputs.changed_portal == 'true'
-          || needs.job_setup.outputs.changed_sodo_search == 'true'
-          || needs.job_setup.outputs.changed_comments_ui == 'true'
-          || needs.job_setup.outputs.changed_signup_form == 'true'
-          || needs.job_setup.outputs.changed_announcement_bar == 'true'))
-      )
+    if: always() && github.repository == 'TryGhost/Ghost' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success'
     permissions:
       id-token: write
     strategy:
@@ -1598,24 +1586,24 @@ jobs:
         run: pnpm nx build ${{ matrix.package_name }}
 
       - name: Configure .npmrc
-        if: steps.version_check.outputs.version_changed == 'true'
+        if: needs.job_setup.outputs.is_main == 'true' && steps.version_check.outputs.version_changed == 'true'
         run: |
           echo "@tryghost:registry=https://registry.npmjs.org/" >> ~/.npmrc
 
       # TODO: Check we can remove this once we update Node to v24
       - name: Install v11 of NPM # We need this to install packages via OIDC.
-        if: steps.version_check.outputs.version_changed == 'true'
+        if: needs.job_setup.outputs.is_main == 'true' && steps.version_check.outputs.version_changed == 'true'
         run: npm install -g npm@11
 
       - name: Publish to npm
-        if: steps.version_check.outputs.version_changed == 'true'
+        if: needs.job_setup.outputs.is_main == 'true' && steps.version_check.outputs.version_changed == 'true'
         working-directory: ${{ matrix.package_path }}
         run: |
           npm publish --access public
 
       - name: Replace version placeholders in cdn-paths
         id: cdn_paths
-        if: steps.version_check.outputs.version_changed == 'true'
+        if: needs.job_setup.outputs.is_main == 'true' && steps.version_check.outputs.version_changed == 'true'
         run: |
           cdn_paths="${{ matrix.cdn_paths }}"
           echo "cdn_paths<<EOF" >> $GITHUB_OUTPUT
@@ -1623,17 +1611,17 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Print cdn_paths
-        if: steps.version_check.outputs.version_changed == 'true'
+        if: needs.job_setup.outputs.is_main == 'true' && steps.version_check.outputs.version_changed == 'true'
         run: echo "${{ steps.cdn_paths.outputs.cdn_paths }}"
 
       - name: Wait before purging jsDelivr cache
-        if: steps.version_check.outputs.version_changed == 'true' && matrix.package_name == '@tryghost/activitypub'
+        if: needs.job_setup.outputs.is_main == 'true' && steps.version_check.outputs.version_changed == 'true' && matrix.package_name == '@tryghost/activitypub'
         run: |
           echo "Purging jsDelivr cache immediately after publishing a new version on NPM is unreliable. Waiting 1 minute before purging cache..."
           sleep 60
 
       - name: Purge jsDelivr cache
-        if: steps.version_check.outputs.version_changed == 'true'
+        if: needs.job_setup.outputs.is_main == 'true' && steps.version_check.outputs.version_changed == 'true'
         uses: gacts/purge-jsdelivr-cache@8d92aea944f1a3e8ad70505379e1a8ac72d56b73 # v1
         with:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1489,7 +1489,8 @@ jobs:
         job_tinybird-tests,
         job_build_e2e_public_apps,
         job_build_e2e_image,
-        job_e2e_tests
+        job_e2e_tests,
+        publish_packages_dry_run
       ]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1512,8 +1512,7 @@ jobs:
     name: Publish dry-run ${{ matrix.package_name }}
     runs-on: ubuntu-latest
     if: >-
-      needs.job_setup.outputs.is_main != 'true'
-      && needs.job_setup.outputs.is_tag != 'true'
+      github.event_name == 'pull_request'
       && (needs.job_setup.outputs.changed_activitypub == 'true'
       || needs.job_setup.outputs.changed_portal == 'true'
       || needs.job_setup.outputs.changed_sodo_search == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1490,7 +1490,7 @@ jobs:
         job_build_e2e_public_apps,
         job_build_e2e_image,
         job_e2e_tests,
-        publish_packages_dry_run
+        publish_packages
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -1507,45 +1507,6 @@ jobs:
         run: |
           echo "One of the dependent jobs have failed or been cancelled. You may need to re-run it." && exit 1
 
-  publish_packages_dry_run:
-    needs: [job_setup]
-    name: Publish dry-run ${{ matrix.package_name }}
-    runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request'
-      && (needs.job_setup.outputs.changed_activitypub == 'true'
-      || needs.job_setup.outputs.changed_portal == 'true'
-      || needs.job_setup.outputs.changed_sodo_search == 'true'
-      || needs.job_setup.outputs.changed_comments_ui == 'true'
-      || needs.job_setup.outputs.changed_signup_form == 'true'
-      || needs.job_setup.outputs.changed_announcement_bar == 'true')
-    strategy:
-      matrix:
-        include:
-          - package_name: '@tryghost/activitypub'
-          - package_name: '@tryghost/portal'
-          - package_name: '@tryghost/sodo-search'
-          - package_name: '@tryghost/comments-ui'
-          - package_name: '@tryghost/signup-form'
-          - package_name: '@tryghost/announcement-bar'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-      - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Restore caches
-        uses: ./.github/actions/restore-cache
-        env:
-          DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
-
-      - name: Build the package
-        run: pnpm nx build ${{ matrix.package_name }}
-
   publish_packages:
     needs: [
       job_setup,
@@ -1554,7 +1515,19 @@ jobs:
     ]
     name: Publish ${{ matrix.package_name }}
     runs-on: ubuntu-latest
-    if: always() && github.repository == 'TryGhost/Ghost' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: >-
+      always() && github.repository == 'TryGhost/Ghost'
+      && needs.job_setup.result == 'success'
+      && (
+        (needs.job_setup.outputs.is_main == 'true' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success')
+        || (github.event_name == 'pull_request'
+          && (needs.job_setup.outputs.changed_activitypub == 'true'
+          || needs.job_setup.outputs.changed_portal == 'true'
+          || needs.job_setup.outputs.changed_sodo_search == 'true'
+          || needs.job_setup.outputs.changed_comments_ui == 'true'
+          || needs.job_setup.outputs.changed_signup_form == 'true'
+          || needs.job_setup.outputs.changed_announcement_bar == 'true'))
+      )
     permissions:
       id-token: write
     strategy:
@@ -1596,6 +1569,7 @@ jobs:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
       - name: Check if version changed
+        if: needs.job_setup.outputs.is_main == 'true'
         id: version_check
         working-directory: ${{ matrix.package_path }}
         run: |
@@ -1620,7 +1594,7 @@ jobs:
           fi
 
       - name: Build the package
-        if: steps.version_check.outputs.version_changed == 'true'
+        if: steps.version_check.outputs.version_changed == 'true' || github.event_name == 'pull_request'
         run: pnpm nx build ${{ matrix.package_name }}
 
       - name: Configure .npmrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1510,7 +1510,15 @@ jobs:
     needs: [job_setup]
     name: Publish dry-run ${{ matrix.package_name }}
     runs-on: ubuntu-latest
-    if: needs.job_setup.outputs.is_main != 'true' && needs.job_setup.outputs.is_tag != 'true'
+    if: >-
+      needs.job_setup.outputs.is_main != 'true'
+      && needs.job_setup.outputs.is_tag != 'true'
+      && (needs.job_setup.outputs.changed_activitypub == 'true'
+      || needs.job_setup.outputs.changed_portal == 'true'
+      || needs.job_setup.outputs.changed_sodo_search == 'true'
+      || needs.job_setup.outputs.changed_comments_ui == 'true'
+      || needs.job_setup.outputs.changed_signup_form == 'true'
+      || needs.job_setup.outputs.changed_announcement_bar == 'true')
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1506,6 +1506,38 @@ jobs:
         run: |
           echo "One of the dependent jobs have failed or been cancelled. You may need to re-run it." && exit 1
 
+  publish_packages_dry_run:
+    needs: [job_setup]
+    name: Publish dry-run ${{ matrix.package_name }}
+    runs-on: ubuntu-latest
+    if: needs.job_setup.outputs.is_main != 'true' && needs.job_setup.outputs.is_tag != 'true'
+    strategy:
+      matrix:
+        include:
+          - package_name: '@tryghost/activitypub'
+          - package_name: '@tryghost/portal'
+          - package_name: '@tryghost/sodo-search'
+          - package_name: '@tryghost/comments-ui'
+          - package_name: '@tryghost/signup-form'
+          - package_name: '@tryghost/announcement-bar'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        env:
+          DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
+
+      - name: Build the package
+        run: pnpm nx build ${{ matrix.package_name }}
+
   publish_packages:
     needs: [
       job_setup,
@@ -1581,7 +1613,7 @@ jobs:
 
       - name: Build the package
         if: steps.version_check.outputs.version_changed == 'true'
-        run: pnpm run nx build ${{ matrix.package_name }}
+        run: pnpm nx build ${{ matrix.package_name }}
 
       - name: Configure .npmrc
         if: steps.version_check.outputs.version_changed == 'true'


### PR DESCRIPTION
## Summary
- Fixed `pnpm run nx build` → `pnpm nx build` in the publish workflow — `pnpm run nx` looks for a nonexistent `nx` script in package.json, while `pnpm nx` correctly invokes the binary from node_modules
- The `publish_packages` job now runs on PRs too — on PRs it builds each package to verify the publish pipeline works; on main it continues to do the full version check → build → publish → CDN purge flow
- Added `publish_packages` to the `job_required_tests` aggregator so build failures block merges
- announcement-bar (1.1.16) and signup-form (0.3.13) already have unpublished version bumps from the pnpm migration PR — they will auto-publish once this merges

## Test plan
- [ ] CI passes — the publish job should run on this PR and build all 6 packages
- [ ] Publish steps (Configure .npmrc, Publish to npm, CDN purge) are skipped on PR runs
- [ ] After merge, announcement-bar and signup-form publish successfully