### PR TITLE
Skipped Tinybird tests job on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -754,7 +754,7 @@ jobs:
       - name: Test project
         run: tb test run
       - name: Trigger and watch traffic analytics infra Tinybird workflow
-        if: github.repository == 'TryGhost/Ghost'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.TRAFFIC_ANALYTICS_GITHUB_TOKEN }}
         uses: ./.github/actions/dispatch-workflow


### PR DESCRIPTION
no ref

This task requires a secret that's not available on forks, and we should skip it like we do other jobs.