### PR TITLE
Updated pnpm scripts/docs

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -4,5 +4,5 @@ name = "Ghost"
 
 [setup]
 script = '''
-pnpm setup
+pnpm run setup
 '''

--- a/.github/scripts/enforce-package-manager.js
+++ b/.github/scripts/enforce-package-manager.js
@@ -16,7 +16,7 @@ Use one of these instead:
   pnpm install
 
 Common command replacements:
-  yarn setup   -> pnpm setup
+  yarn setup   -> pnpm run setup
   yarn dev     -> pnpm dev
   yarn test    -> pnpm test
   yarn lint    -> pnpm lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Two categories of apps:
 ### Development
 ```bash
 pnpm                           # Install dependencies
-pnpm setup                     # First-time setup (installs deps + submodules)
+pnpm run setup                 # First-time setup (installs deps + submodules)
 pnpm dev                       # Start development (Docker backend + host frontend dev servers)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Two categories of apps:
 
 ### Development
 ```bash
-pnpm                           # Install dependencies
+corepack enable pnpm           # Enable corepack to use the correct pnpm version
 pnpm run setup                 # First-time setup (installs deps + submodules)
 pnpm dev                       # Start development (Docker backend + host frontend dev servers)
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ git remote add origin git@github.com:<YourUsername>/Ghost.git
 
 ```bash
 # Install dependencies and initialize submodules
-pnpm setup
+pnpm run setup
 ```
 
 #### 3. Start Ghost

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ git remote add origin git@github.com:<YourUsername>/Ghost.git
 
 ```bash
 # Install dependencies and initialize submodules
+corepack enable pnpm
 pnpm run setup
 ```
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,7 +6,7 @@ This test suite runs automated browser tests against a running Ghost instance to
 
 ### Prerequisites
 - Docker and Docker Compose installed
-- Node.js and pnpm installed
+- Node.js installed (pnpm is managed via corepack — run `corepack enable pnpm` first)
 
 ### Running Tests
 To run the test, within this `e2e` folder run:


### PR DESCRIPTION
no ref

`setup` is a pnpm command, so we need to use the run command to identify the setup script.
`corepack enable` is needed before setup (as it is invoked by `pnpm`).