### PR TITLE
Replace deep workspace imports with package exports

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -14,6 +14,13 @@
   ],
   "main": "./dist/activitypub.umd.cjs",
   "module": "./dist/activitypub.js",
+  "exports": {
+    ".": {
+      "import": "./dist/activitypub.js",
+      "require": "./dist/activitypub.umd.cjs"
+    },
+    "./api": "./src/index.tsx"
+  },
   "private": false,
   "scripts": {
     "dev": "vite build --watch",

--- a/apps/admin/src/layout/app-sidebar/nav-main.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-main.tsx
@@ -7,7 +7,7 @@ import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { useBrowseSettings } from "@tryghost/admin-x-framework/api/settings";
 import { getSettingValue } from "@tryghost/admin-x-framework/api/settings";
 import { hasAdminAccess } from "@tryghost/admin-x-framework/api/users";
-import { useNotificationsCountForUser } from "@tryghost/activitypub/src/index";
+import { useNotificationsCountForUser } from "@tryghost/activitypub/api";
 import NetworkIcon from "./icons/network-icon";
 import { NavMenuItem } from "./nav-menu-item";
 import { useIsActiveLink } from "./use-is-active-link";

--- a/apps/admin/src/layout/app-sidebar/shared-views.ts
+++ b/apps/admin/src/layout/app-sidebar/shared-views.ts
@@ -1,8 +1,8 @@
 import {useMemo} from 'react';
-import {parseAllSharedViewsJSON} from '@tryghost/posts/src/views/members/shared-views';
+import {parseAllSharedViewsJSON} from '@tryghost/posts/api';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 
-export type {SharedView} from '@tryghost/posts/src/views/members/shared-views';
+export type {SharedView} from '@tryghost/posts/api';
 
 export function getColorHex(color: string): string {
     const colorMap: Record<string, string> = {

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,15 +1,13 @@
 import {type RouteObject, Outlet, lazyComponent, redirect} from "@tryghost/admin-x-framework";
 
 // ActivityPub
-import { FeatureFlagsProvider, routes as activityPubRoutes } from "@tryghost/activitypub/src/index";
+import { FeatureFlagsProvider, routes as activityPubRoutes } from "@tryghost/activitypub/api";
 
 // Posts (aka tags and post analytics)
-import PostsAppContextProvider from "@tryghost/posts/src/providers/posts-app-context";
-import { routes as postRoutes } from "@tryghost/posts/src/routes";
+import { PostsAppContextProvider, routes as postRoutes } from "@tryghost/posts/api";
 
 // Stats (aka analytics)
-import GlobalDataProvider from "@tryghost/stats/src/providers/global-data-provider";
-import { routes as statsRoutes } from "@tryghost/stats/src/routes";
+import { GlobalDataProvider, routes as statsRoutes } from "@tryghost/stats/api";
 import MyProfileRedirect from "./my-profile-redirect";
 
 // Ember
@@ -63,11 +61,11 @@ const membersRoute: RouteObject = {
     children: [
         {
             index: true,
-            lazy: lazyComponent(() => import("@tryghost/posts/src/views/members/members"))
+            lazy: lazyComponent(() => import("@tryghost/posts/members"))
         },
         {
             path: "import",
-            lazy: lazyComponent(() => import("@tryghost/posts/src/views/members/members"))
+            lazy: lazyComponent(() => import("@tryghost/posts/members"))
         }
     ]
 };

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -14,6 +14,14 @@
     ],
     "main": "./dist/posts.umd.cjs",
     "module": "./dist/posts.js",
+    "exports": {
+        ".": {
+            "import": "./dist/posts.js",
+            "require": "./dist/posts.umd.cjs"
+        },
+        "./api": "./src/api.ts",
+        "./members": "./src/views/members/members.tsx"
+    },
     "private": true,
     "scripts": {
         "dev": "vite build --watch",

--- a/apps/posts/src/api.ts
+++ b/apps/posts/src/api.ts
@@ -1,0 +1,8 @@
+/**
+ * Public API for cross-package imports.
+ * Admin uses these exports instead of reaching into src/ directly.
+ */
+export {default as PostsAppContextProvider} from './providers/posts-app-context';
+export {routes} from './routes';
+export {parseAllSharedViewsJSON} from './views/members/shared-views';
+export type {SharedView, AllSharedViewsParseResult} from './views/members/shared-views';

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -14,6 +14,13 @@
     ],
     "main": "./dist/stats.umd.cjs",
     "module": "./dist/stats.js",
+    "exports": {
+        ".": {
+            "import": "./dist/stats.js",
+            "require": "./dist/stats.umd.cjs"
+        },
+        "./api": "./src/api.ts"
+    },
     "private": true,
     "scripts": {
         "dev": "vite build --watch",

--- a/apps/stats/src/api.ts
+++ b/apps/stats/src/api.ts
@@ -1,0 +1,6 @@
+/**
+ * Public API for cross-package imports.
+ * Admin uses these exports instead of reaching into src/ directly.
+ */
+export {default as GlobalDataProvider} from './providers/global-data-provider';
+export {routes} from './routes';


### PR DESCRIPTION
## Summary
- Add `exports` field to posts, stats, and activitypub package.json with subpath exports
- Create `src/api.ts` in posts and stats as the public cross-package API
- Update admin to import from `@tryghost/posts/api`, `@tryghost/stats/api`, `@tryghost/activitypub/api` instead of reaching into `src/`

## Why
Admin was importing directly into other workspace packages' `src/` directories (`@tryghost/posts/src/providers/...`). This is a cross-package boundary violation — it bypasses the package's public API and couples admin to internal file structure.

## Scope
This is prep work for `pnpm deploy` with `injectWorkspacePackages=true`. The subpath exports currently point at source files (`./src/api.ts`), which works for normal workspace resolution (pnpm symlinks to the full directory). When `injectWorkspacePackages` is enabled, the `files` field in each package will need to include `src/` (or the exports will need to point at built outputs in `dist/`). That change belongs in the pnpm deploy PR.

## What changed
**Posts** — new `src/api.ts` exports: `PostsAppContextProvider`, `routes`, `parseAllSharedViewsJSON`, `SharedView` type. New `./members` subpath export for lazy-loaded members view.

**Stats** — new `src/api.ts` exports: `GlobalDataProvider`, `routes`.

**ActivityPub** — new `./api` subpath export pointing to existing `src/index.tsx`.

**Admin** — all 8 deep `src/` imports replaced with subpath exports.

## Test plan
- [x] `pnpm build` passes locally (except pre-existing stats test type issue)
- [ ] CI passes
- [ ] `pnpm dev` works correctly