### PR TITLE
Included CI-relevant paths in nx.json named inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,15 @@
 {
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
     "namedInputs": {
-        "default": ["{projectRoot}/**/*", "{workspaceRoot}/ghost/tsconfig.json"]
+        "default": [
+            "{projectRoot}/**/*",
+            "{workspaceRoot}/package.json",
+            "{workspaceRoot}/ghost/tsconfig.json",
+            "{workspaceRoot}/.github/workflows/**/*",
+            "{workspaceRoot}/.github/actions/**/*",
+            "{workspaceRoot}/.github/scripts/**/*",
+            "{workspaceRoot}/.npmrc"
+        ]
     },
     "parallel": 4,
     "targetDefaults": {


### PR DESCRIPTION
## Summary

Adds filepaths for shared ci/other flows to default nx named inputs. This allows us to remove the dependency on the 'shared' filepath detection in the ci paths-filter and exclusively leverage nx affected to determine if builds should run

## Why

Relates to #27348 - once we start to use `nx affected` to conditionally skip/trigger jobs, we will need some way to dictate to `nx` that changes to the `.github/` folder should trigger reruns of packages in the workspace. Instead of looking at changes in _all_ `.github` files however, I borrowed the list of relevant files from #27311 so things are a bit cleaner.

## Potential Drawbacks

Because nx.json affects local development as well as CI runs, anytime the Github CI-related files are changed, it will also invalidate the local nx build cache.
