### PR TITLE
Limit Renovate Node heap for pnpm runs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,13 @@
     // Keep manually-closed immortal/grouped PRs closed unless explicitly
     // reopened from the Dependency Dashboard.
     "recreateWhen": "never",
+    // pnpm lockfile generation has been hitting Mend's 3GB memory ceiling.
+    // Renovate maintainers suggested starting with toolSettings.nodeMaxMemory
+    // set to 1024MB to reduce pnpm's Node heap usage and keep the overall job
+    // under the hosted runner limit.
+    "toolSettings": {
+        "nodeMaxMemory": 1024
+    },
     // We have to disable platform based automerge (forcing renovate to do it manually)
     // as otherwise renovate wont follow our schedule
     "platformAutomerge": false,


### PR DESCRIPTION
## Summary
- add `toolSettings.nodeMaxMemory: 1024` to Ghost's Renovate config
- apply the first maintainer-recommended mitigation for Mend-hosted pnpm lockfile OOMs
- give pnpm a smaller Node heap so the overall Renovate process has more headroom within Mend's 3GB runner limit

## Why this change
Recent Mend Renovate runs on Ghost have been failing with `kernel-out-of-memory` shortly after the pnpm migration, using the full 3GB memory limit while regenerating `pnpm-lock.yaml`.

In the failing runs, Renovate gets as far as:
- `Generating pnpm-lock.yaml for .`
- `Spawning pnpm install to create pnpm-lock.yaml`

and then the job dies at `3.0GB (of 3.0GB limit)` before it can return to branch updates or automerge logic.

Renovate maintainers suggested starting with:

```json
{
  "toolSettings": {
    "nodeMaxMemory": 1024
  }
}
```

as the first mitigation for pnpm OOMs on Mend-hosted infrastructure. The goal is to keep pnpm's own Node heap smaller so the overall Renovate process stays under the hosted runner memory ceiling.

## Context
- discussion: https://github.com/renovatebot/renovate/discussions/41972
- maintainer guidance: https://github.com/renovatebot/renovate/discussions/40942#discussioncomment-16011497

## Notes
This does not solve every reason a given run may do no work — schedule and automerge eligibility still matter — but it should reduce the number of runs that fail before they even reach merge logic.
