### PR TITLE
Fixed boot with fresh development container

### DIFF
--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -26,8 +26,9 @@ COPY ghost/parse-email-address/package.json ghost/parse-email-address/package.js
 # Install dependencies
 # Note: Dependencies are installed at build time, but source code is mounted at runtime.
 
-# Copy the install helper script (pnpm install wrapper with retry logic)
-COPY .github/scripts/install-deps.sh .github/scripts/install-deps.sh
+# Copy root lifecycle scripts/hooks needed by `pnpm install`
+COPY .github/scripts .github/scripts
+COPY .github/hooks .github/hooks
 
 # Enable corepack so it can read packageManager from package.json and provide pnpm
 RUN corepack enable

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -37,6 +37,7 @@
     "mocha": "11.7.5"
   },
   "dependencies": {
+    "@tryghost/debug": "0.1.40",
     "i18next": "23.16.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2592,6 +2592,9 @@ importers:
 
   ghost/i18n:
     dependencies:
+      '@tryghost/debug':
+        specifier: 0.1.40
+        version: 0.1.40
       i18next:
         specifier: 23.16.8
         version: 23.16.8


### PR DESCRIPTION
ref f186b6adeb58412915012ac49c078a5fc96797c2

This fixes two bugs when booting a fresh development container:

- Fixes `Cannot find module '/home/ghost/.github/scripts/enforce-package-manager.js'` by copying all of `.github/scripts`, not just the `install-deps.sh` script
- `ghost/i18n` required `@tryghost/debug` but did not declare it, which meant a fresh container couldn't start