### PR TITLE
Removed email input from gift purchase form

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.6",
+  "version": "2.68.7",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -244,8 +244,8 @@ async function checkoutPlan({data, state, api}) {
 
 async function checkoutGift({data, state, api}) {
     try {
-        const {tierId, cadence, email} = data;
-        await api.member.checkoutGift({tierId, cadence, email});
+        const {tierId, cadence} = data;
+        await api.member.checkoutGift({tierId, cadence});
         return {
             action: 'checkoutGift:success'
         };

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -2,12 +2,10 @@ import {useContext, useState} from 'react';
 import AppContext from '../../app-context';
 import CloseButton from '../common/close-button';
 import SiteTitleBackButton from '../common/site-title-back-button';
-import InputForm from '../common/input-form';
 import ActionButton from '../common/action-button';
 import LoadingPage from './loading-page';
 import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
 import {getAvailableProducts, getCurrencySymbol, formatNumber, getStripeAmount, isCookiesDisabled, getActiveInterval} from '../../utils/helpers';
-import {ValidateInputForm} from '../../utils/form';
 import calculateDiscount from '../../utils/discount';
 
 // TODO: wrap strings with t() once copy is finalised
@@ -134,9 +132,7 @@ function GiftPriceSwitch({selectedInterval, setSelectedInterval, products}) {
 }
 
 const GiftPage = () => {
-    const {site, member, brandColor, action, doAction} = useContext(AppContext);
-    const [email, setEmail] = useState(member?.email || '');
-    const [emailError, setEmailError] = useState('');
+    const {site, brandColor, action, doAction} = useContext(AppContext);
     const [selectedInterval, setSelectedInterval] = useState(null);
     const [selectedProduct, setSelectedProduct] = useState(null);
 
@@ -182,35 +178,14 @@ const GiftPage = () => {
     const isPurchasing = action === 'checkoutGift:running';
     const isDisabled = isCookiesDisabled() || isPurchasing;
 
-    const emailField = [{
-        type: 'email',
-        value: email,
-        placeholder: 'jamie@example.com',
-        label: 'Your email',
-        name: 'email',
-        required: true,
-        tabIndex: 1,
-        autoFocus: true,
-        errorMessage: emailError
-    }];
-
     const handlePurchase = (e, product) => {
         e.preventDefault();
 
-        const errors = ValidateInputForm({fields: emailField});
-
-        if (errors.email) {
-            setEmailError(errors.email);
-            return;
-        }
-
-        setEmailError('');
         setSelectedProduct(product.id);
 
         doAction('checkoutGift', {
             tierId: product.id,
-            cadence: activeInterval,
-            email
+            cadence: activeInterval
         });
     };
 
@@ -231,18 +206,6 @@ const GiftPage = () => {
 
                 <section className="gh-portal-signup">
                     <div className='gh-portal-section'>
-                        <div className='gh-portal-logged-out-form-container'>
-                            <InputForm
-                                fields={emailField}
-                                onChange={(e) => {
-                                    setEmail(e.target.value);
-                                    if (emailError) {
-                                        setEmailError('');
-                                    }
-                                }}
-                            />
-                        </div>
-
                         <section className='gh-portal-products'>
                             <GiftPriceSwitch
                                 selectedInterval={activeInterval}

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -534,7 +534,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             });
         },
 
-        async checkoutGift({tierId, cadence, email: customerEmail} = {}) {
+        async checkoutGift({tierId, cadence} = {}) {
             const url = endpointFor({type: 'members', resource: 'create-stripe-checkout-session'});
 
             let identity = null;
@@ -551,8 +551,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 },
                 type: 'gift',
                 tierId,
-                cadence,
-                customerEmail
+                cadence
             };
 
             const response = await makeRequest({

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -407,15 +407,14 @@ describe('checkoutGift action', () => {
 
         const result = await ActionHandler({
             action: 'checkoutGift',
-            data: {tierId: 'tier_123', cadence: 'month', email: 'buyer@example.com'},
+            data: {tierId: 'tier_123', cadence: 'month'},
             state: {},
             api: mockApi
         });
 
         expect(mockApi.member.checkoutGift).toHaveBeenCalledWith({
             tierId: 'tier_123',
-            cadence: 'month',
-            email: 'buyer@example.com'
+            cadence: 'month'
         });
         expect(result.action).toBe('checkoutGift:success');
     });
@@ -429,7 +428,7 @@ describe('checkoutGift action', () => {
 
         const result = await ActionHandler({
             action: 'checkoutGift',
-            data: {tierId: 'tier_123', cadence: 'month', email: 'buyer@example.com'},
+            data: {tierId: 'tier_123', cadence: 'month'},
             state: {},
             api: mockApi
         });

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -729,13 +729,6 @@ module.exports = class RouterController {
                 });
             }
 
-            if (typeof req.body.customerEmail !== 'string' || !isEmail(req.body.customerEmail)) {
-                throw new BadRequestError({
-                    message: tpl(messages.badRequest),
-                    context: 'A valid email address is required to purchase a gift subscription'
-                });
-            }
-
             if (req.body.offerId) {
                 throw new BadRequestError({
                     message: tpl(messages.badRequest),

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -156,7 +156,6 @@ class PaymentsService {
      * @param {import('../../../tiers/tier')} params.tier
      * @param {'month'|'year'} params.cadence
      * @param {number} params.duration
-     * @param {string} params.email
      * @param {string} params.successUrl
      * @param {string} params.cancelUrl
      * @param {object} params.metadata
@@ -165,7 +164,7 @@ class PaymentsService {
      *
      * @returns {Promise<string>}
      */
-    async getGiftPaymentLink({tier, cadence, duration, email, metadata, successUrl, cancelUrl, member, isAuthenticated}) {
+    async getGiftPaymentLink({tier, cadence, duration, metadata, successUrl, cancelUrl, member, isAuthenticated}) {
         let customer = null;
         if (member && isAuthenticated) {
             customer = await this.getCustomerForMember(member);
@@ -192,13 +191,11 @@ class PaymentsService {
                 gift_token: token,
                 tier_id: tier.id.toHexString(),
                 cadence,
-                duration: String(duration),
-                buyer_email: email
+                duration: String(duration)
             },
             successUrl: successUrlObj.toString(),
             cancelUrl,
-            customer,
-            customerEmail: !customer ? email : null
+            customer
         };
 
         const session = await this.stripeAPIService.createGiftCheckoutSession(data);

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -66,7 +66,7 @@ module.exports = class CheckoutSessionEventService {
     async handleGiftEvent(session) {
         await this.deps.giftService.recordPurchase({
             token: session.metadata?.gift_token,
-            buyerEmail: session.metadata?.buyer_email,
+            buyerEmail: session.customer_details?.email,
             stripeCustomerId: session.customer ?? null,
             tierId: session.metadata?.tier_id,
             cadence: session.metadata?.cadence,

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -695,11 +695,10 @@ module.exports = class StripeAPI {
      * @param {string} options.successUrl
      * @param {string} options.cancelUrl
      * @param {ICustomer|null} options.customer
-     * @param {string|null} options.customerEmail
      *
      * @returns {Promise<ICheckoutSession>}
      */
-    async createGiftCheckoutSession({amount, currency, tierName, cadence, duration, metadata, successUrl, cancelUrl, customer, customerEmail}) {
+    async createGiftCheckoutSession({amount, currency, tierName, cadence, duration, metadata, successUrl, cancelUrl, customer}) {
         await this._rateLimitBucket.throttle();
 
         const cadenceLabel = duration === 1 ? `1 ${cadence}` : `${duration} ${cadence}s`;
@@ -713,7 +712,6 @@ module.exports = class StripeAPI {
             },
             metadata,
             customer: customer ? customer.id : undefined,
-            customer_email: !customer && customerEmail ? customerEmail : undefined,
             submit_type: 'pay',
             line_items: [{
                 price_data: {

--- a/ghost/core/test/e2e-api/members/__snapshots__/gift-subscriptions.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/gift-subscriptions.test.js.snap
@@ -47,21 +47,3 @@ Object {
   ],
 }
 `;
-
-exports[`Gift Subscriptions Rejects purchase without a valid email 1: [body] 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "code": null,
-      "context": "A valid email address is required to purchase a gift subscription",
-      "details": null,
-      "ghostErrorCode": null,
-      "help": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "Bad Request.",
-      "property": null,
-      "type": "BadRequestError",
-    },
-  ],
-}
-`;

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -56,7 +56,6 @@ describe('Gift Subscriptions', function () {
                 type: 'gift',
                 tierId: paidTier.id,
                 cadence: 'month',
-                customerEmail: 'gift-buyer@example.com',
                 metadata: {}
             })
             .expectStatus(200)
@@ -71,7 +70,6 @@ describe('Gift Subscriptions', function () {
         assert.equal(checkoutSession.metadata.tier_id, paidTier.id);
         assert.equal(checkoutSession.metadata.cadence, 'month');
         assert.equal(String(checkoutSession.metadata.duration), '1');
-        assert.equal(checkoutSession.metadata.buyer_email, 'gift-buyer@example.com');
         assert.ok(checkoutSession.metadata.gift_token, 'Should have a gift token');
 
         await stripeMocker.sendWebhook({
@@ -83,6 +81,7 @@ describe('Gift Subscriptions', function () {
                     amount_total: paidTier.monthly_price,
                     currency: paidTier.currency.toLowerCase(),
                     customer: checkoutSession.customer,
+                    customer_details: {email: 'gift-buyer@example.com'},
                     metadata: toWebhookMetadata(checkoutSession.metadata),
                     payment_intent: 'pi_gift_test_123'
                 }
@@ -138,7 +137,6 @@ describe('Gift Subscriptions', function () {
                 type: 'gift',
                 tierId: paidTier.id,
                 cadence: 'year',
-                customerEmail: email,
                 identity: token,
                 metadata: {}
             })
@@ -159,6 +157,7 @@ describe('Gift Subscriptions', function () {
                     amount_total: paidTier.yearly_price,
                     currency: paidTier.currency.toLowerCase(),
                     customer: checkoutSession.customer,
+                    customer_details: {email},
                     metadata: toWebhookMetadata(checkoutSession.metadata),
                     payment_intent: 'pi_gift_member_test_456'
                 }
@@ -187,7 +186,6 @@ describe('Gift Subscriptions', function () {
                 type: 'gift',
                 tierId: paidTier.id,
                 cadence: 'month',
-                customerEmail: 'idempotent-buyer@example.com',
                 metadata: {}
             })
             .expectStatus(200);
@@ -203,6 +201,7 @@ describe('Gift Subscriptions', function () {
                     amount_total: paidTier.monthly_price,
                     currency: paidTier.currency.toLowerCase(),
                     customer: checkoutSession.customer,
+                    customer_details: {email: 'idempotent-buyer@example.com'},
                     metadata: toWebhookMetadata(checkoutSession.metadata),
                     payment_intent: 'pi_idempotent_test'
                 }
@@ -231,7 +230,6 @@ describe('Gift Subscriptions', function () {
                 type: 'gift',
                 tierId: paidTier.id,
                 cadence: 'month',
-                customerEmail: 'test-buyer@example.com',
                 metadata: {},
                 ...bodyOverrides
             })
@@ -244,18 +242,13 @@ describe('Gift Subscriptions', function () {
     it('Rejects purchase when labs flag is disabled', async function () {
         mockManager.mockLabsDisabled('giftSubscriptions');
 
-        await expectGiftCheckoutError({customerEmail: 'rejected-buyer@example.com'});
+        await expectGiftCheckoutError();
     });
 
     it('Rejects purchase with an offer', async function () {
         await expectGiftCheckoutError({
-            customerEmail: 'offer-buyer@example.com',
             offerId: 'some-offer-id'
         });
-    });
-
-    it('Rejects purchase without a valid email', async function () {
-        await expectGiftCheckoutError({customerEmail: 'not-an-email'});
     });
 
     it('Includes gift token in the success URL', async function () {
@@ -266,7 +259,6 @@ describe('Gift Subscriptions', function () {
                 type: 'gift',
                 tierId: paidTier.id,
                 cadence: 'month',
-                customerEmail: 'url-test-buyer@example.com',
                 metadata: {}
             })
             .expectStatus(200);

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -724,14 +724,13 @@ describe('RouterController', function () {
                 const controller = createGiftController({tiersService: paidTierService()});
 
                 await controller.createCheckoutSession({
-                    body: {type: 'gift', tierId: 'tier_123', cadence: 'month', customerEmail: 'buyer@example.com', metadata: {}}
+                    body: {type: 'gift', tierId: 'tier_123', cadence: 'month', metadata: {}}
                 }, mockRes);
 
                 sinon.assert.calledOnce(getGiftLinkSpy);
                 sinon.assert.calledWith(getGiftLinkSpy, sinon.match({
                     successUrl: 'https://example.com/',
-                    cancelUrl: 'https://example.com/',
-                    email: 'buyer@example.com'
+                    cancelUrl: 'https://example.com/'
                 }));
             });
 
@@ -741,41 +740,12 @@ describe('RouterController', function () {
 
                 try {
                     await controller.createCheckoutSession({
-                        body: {type: 'gift', tierId: 'tier_123', cadence: 'month', customerEmail: 'buyer@example.com', metadata: {}}
-                    }, mockRes);
-
-                    assert.fail('Should have thrown');
-                } catch (error) {
-                    assert(error instanceof errors.BadRequestError);
-                }
-            });
-
-            it('rejects when customerEmail is not provided', async function () {
-                const controller = createGiftController({tiersService: paidTierService()});
-
-                try {
-                    await controller.createCheckoutSession({
                         body: {type: 'gift', tierId: 'tier_123', cadence: 'month', metadata: {}}
                     }, mockRes);
 
                     assert.fail('Should have thrown');
                 } catch (error) {
                     assert(error instanceof errors.BadRequestError);
-                    assert.equal(error.context, 'A valid email address is required to purchase a gift subscription');
-                }
-            });
-
-            it('rejects when customerEmail is invalid', async function () {
-                const controller = createGiftController({tiersService: paidTierService()});
-
-                try {
-                    await controller.createCheckoutSession({
-                        body: {type: 'gift', tierId: 'tier_123', cadence: 'month', customerEmail: 'not-an-email', metadata: {}}
-                    }, mockRes);
-                    assert.fail('Should have thrown');
-                } catch (error) {
-                    assert(error instanceof errors.BadRequestError);
-                    assert.equal(error.context, 'A valid email address is required to purchase a gift subscription');
                 }
             });
 
@@ -784,7 +754,7 @@ describe('RouterController', function () {
 
                 try {
                     await controller.createCheckoutSession({
-                        body: {type: 'gift', offerId: 'offer_123', customerEmail: 'buyer@example.com', metadata: {}}
+                        body: {type: 'gift', offerId: 'offer_123', metadata: {}}
                     }, mockRes);
                     assert.fail('Should have thrown');
                 } catch (error) {
@@ -811,7 +781,7 @@ describe('RouterController', function () {
                 });
 
                 await controller.createCheckoutSession({
-                    body: {type: 'gift', tierId: 'tier_123', cadence: 'month', customerEmail: 'buyer@example.com', identity: 'valid-token', metadata: {}}
+                    body: {type: 'gift', tierId: 'tier_123', cadence: 'month', identity: 'valid-token', metadata: {}}
                 }, mockRes);
 
                 sinon.assert.calledOnce(getGiftLinkSpy);

--- a/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
@@ -328,7 +328,6 @@ describe('PaymentsService', function () {
         const defaultGiftOptions = {
             successUrl: 'https://example.com/',
             cancelUrl: 'https://example.com/',
-            email: 'buyer@example.com',
             duration: 1,
             metadata: {}
         };
@@ -360,7 +359,7 @@ describe('PaymentsService', function () {
             assert.equal(args.metadata.tier_id, tier.id.toHexString());
             assert.equal(args.metadata.cadence, 'month');
             assert.equal(args.metadata.duration, '1');
-            assert.equal(args.metadata.buyer_email, 'buyer@example.com');
+            assert.equal(args.metadata.buyer_email, undefined, 'buyer_email should not be in metadata');
             assert.equal(args.metadata.requestSrc, 'portal');
             assert.match(args.metadata.gift_token, /^[A-Za-z0-9_-]{8}$/);
         });
@@ -411,41 +410,6 @@ describe('PaymentsService', function () {
             sinon.assert.calledOnce(service.getCustomerForMember);
             sinon.assert.calledWith(service.getCustomerForMember, mockMember);
             assert.equal(getStripeArgs().customer, mockCustomer);
-            assert.equal(getStripeArgs().customerEmail, null);
-        });
-
-        it('passes customerEmail when purchaser is not authenticated', async function () {
-            const tier = await createTier();
-
-            await service.getGiftPaymentLink({
-                ...defaultGiftOptions,
-                tier,
-                cadence: 'month',
-                email: 'guest@example.com',
-                isAuthenticated: false
-            });
-
-            assert.equal(getStripeArgs().customer, null);
-            assert.equal(getStripeArgs().customerEmail, 'guest@example.com');
-        });
-
-        it('does not set customerEmail when customer is present', async function () {
-            const mockCustomer = {id: 'cus_123', email: 'member@example.com'};
-            sinon.stub(service, 'getCustomerForMember').resolves(mockCustomer);
-
-            const tier = await createTier();
-
-            await service.getGiftPaymentLink({
-                ...defaultGiftOptions,
-                tier,
-                cadence: 'month',
-                email: 'should-be-ignored@example.com',
-                member: {id: 'member_123', get: sinon.stub().returns('member@example.com')},
-                isAuthenticated: true
-            });
-
-            assert.equal(getStripeArgs().customer, mockCustomer);
-            assert.equal(getStripeArgs().customerEmail, null);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -574,13 +574,15 @@ describe('CheckoutSessionEventService', function () {
                 currency: 'usd',
                 customer: 'cust_123',
                 payment_intent: 'pi_test_456',
+                customer_details: {
+                    email: 'buyer@example.com'
+                },
                 metadata: {
                     ghost_gift: 'true',
                     gift_token: 'abc-123-token',
                     tier_id: 'tier_456',
                     cadence: 'year',
-                    duration: '1',
-                    buyer_email: 'buyer@example.com'
+                    duration: '1'
                 }
             };
 
@@ -611,13 +613,15 @@ describe('CheckoutSessionEventService', function () {
                 currency: 'gbp',
                 customer: null,
                 payment_intent: 'pi_test_789',
+                customer_details: {
+                    email: 'guest@example.com'
+                },
                 metadata: {
                     ghost_gift: 'true',
                     gift_token: 'def-456-token',
                     tier_id: 'tier_111',
                     cadence: 'month',
-                    duration: '1',
-                    buyer_email: 'guest@example.com'
+                    duration: '1'
                 }
             };
 

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -748,8 +748,7 @@ describe('StripeAPI', function () {
                 ghost_gift: 'true',
                 gift_token: 'token-xyz',
                 tier_id: 'tier_123',
-                cadence: 'month',
-                buyer_email: 'buyer@example.com'
+                cadence: 'month'
             };
 
             await api.createGiftCheckoutSession({
@@ -784,26 +783,6 @@ describe('StripeAPI', function () {
             const args = mockStripe.checkout.sessions.create.firstCall.firstArg;
 
             assert.equal(args.customer, mockCustomerId);
-            assert.equal(args.customer_email, undefined);
-        });
-
-        it('passes customer_email when no customer is provided', async function () {
-            await api.createGiftCheckoutSession({
-                amount: 5000,
-                currency: 'usd',
-                tierName: 'Pro',
-                cadence: 'year',
-                duration: 1,
-                successUrl: '/gift-success',
-                cancelUrl: '/gift-cancel',
-                metadata: {},
-                customerEmail: mockCustomerEmail
-            });
-
-            const args = mockStripe.checkout.sessions.create.firstCall.firstArg;
-
-            assert.equal(args.customer, undefined);
-            assert.equal(args.customer_email, mockCustomerEmail);
         });
 
         it('does not include invoice_creation or custom_fields', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3530

Removed email input from gift purchase as it is redundant and the user can just use the email input on the Stripe checkout. If the user is an authenticated member, the email address associated with their account will be used on the Stripe checkout