### PR TITLE
Prevent resizing of animated GIFs to preserve animation

### DIFF
--- a/ghost/core/core/frontend/web/middleware/handle-image-sizes.js
+++ b/ghost/core/core/frontend/web/middleware/handle-image-sizes.js
@@ -100,6 +100,12 @@ module.exports = function handleImageSizes(req, res, next) {
         return redirectToOriginal();
     }
 
+    // CASE: do not resize GIFs when not converting to a different format
+    // Resizing animated GIFs causes them to lose their animation (only first frame is kept)
+    if (!format && requestUrlFileExtension === '.gif') {
+        return redirectToOriginal();
+    }
+
     const storageInstance = storage.getStorage('images');
     // CASE: unsupported storage adapter
     if (typeof storageInstance.saveRaw !== 'function') {

--- a/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
@@ -457,6 +457,35 @@ describe('handleImageSizes middleware', function () {
             });
         });
 
+        it('skips GIF if not formatted to preserve animation', function (done) {
+            dummyStorage.exists = async function () {
+                return false;
+            };
+
+            const fakeReq = {
+                url: '/size/w1000/animated.gif',
+                originalUrl: '/blog/content/images/size/w1000/animated.gif'
+            };
+            const fakeRes = {
+                redirect(url) {
+                    try {
+                        url.should.equal('/blog/content/images/animated.gif');
+                    } catch (e) {
+                        return done(e);
+                    }
+                    done();
+                },
+                setHeader() {}
+            };
+
+            handleImageSizes(fakeReq, fakeRes, function next(err) {
+                if (err) {
+                    return done(err);
+                }
+                done(new Error('Should not have called next'));
+            });
+        });
+
         it('skips formatting to ico', function (done) {
             dummyStorage.exists = async function () {
                 return false;


### PR DESCRIPTION
## Why are you making it?

Resizing animated GIFs causes them to lose their animation, as only the first frame is kept in the resized output. This is a poor user experience when Ghost users upload animated GIFs expecting them to remain animated.

## What does it do?

This change adds a check in the `handleImageSizes` middleware to skip resizing when:
- The requested image is a GIF (`.gif` extension)
- No format conversion is being applied

When these conditions are met, the middleware redirects to the original unresized image instead of attempting to resize it, preserving the animation.

## Why is this something Ghost users or developers need?

Ghost users who upload animated GIFs expect them to remain animated when displayed on their blog. Without this fix, any attempt to resize a GIF results in a static image showing only the first frame, which is unexpected and frustrating. This change ensures animated GIFs are served in their original form when no format conversion is requested.

## Checklist

- [x] I've explained my change
- [x] I've written an automated test to prove my change works

The test case `skips GIF if not formatted to preserve animation` verifies that GIF files without format conversion are redirected to their original unresized versions.

https://claude.ai/code/session_016Q7ydcbY2Wy7FaC4KqNXod