### PR TITLE
Fixed two instances of Ghost running with `pnpm run dev`

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -177,6 +177,9 @@
     "webpack": "5.105.4"
   },
   "nx": {
+    "implicitDependencies": [
+      "!ghost"
+    ],
     "targets": {
       "build:dev": {
         "dependsOn": [


### PR DESCRIPTION
## Summary

`pnpm dev` was silently running two Ghost core instances — one inside Docker (the real one, behind Caddy on :2368) and a second one on the host via `nodemon index.js`. The host instance received no traffic but still burned CPU and file watchers.

## Root cause

- [nx.json](nx.json) sets `dev: { dependsOn: ["^dev"] }` as a global target default, meaning `nx dev` on any project fans out to `dev` on all its workspace dependencies.
- `pnpm dev` → `ghost-monorepo:docker:dev` → `@tryghost/admin:dev` → `ghost-admin:dev`.
- `ghost-admin` inherits the `^dev` default and declares `"ghost": "workspace:*"` in its dependencies, so the fan-out reaches the `ghost` project.
- The `ghost` project has a `dev` script of `nodemon index.js`, which nx auto-infers as a target — and runs it, in parallel with the Docker container.

## Why the workspace dep exists

The `"ghost": "workspace:*"` entry in ghost-admin was added 4 days ago in f186b6adeb (the pnpm migration, #27017) to resolve a phantom-dep warning pnpm's stricter module resolution exposed. Under yarn v1 it worked implicitly via hoisting.

The dep is used in exactly one place — [ghost/admin/lib/asset-delivery/index.js:62](ghost/admin/lib/asset-delivery/index.js#L62):

```js
const assetsOut = path.join(path.dirname(require.resolve('ghost')), `core/built/admin`);
```

asset-delivery calls `require.resolve('ghost')` at Ember build time to locate ghost core's directory on disk so it can copy the built Ember admin into `ghost/core/core/built/admin`. It's a pure resolve-path dependency — ghost-admin doesn't need ghost to be *built* first, just *installed* so pnpm has linked it into node_modules. Nothing in ghost-admin imports, requires, tests, or lints any code from ghost.

## Fix

Declared `!ghost` in ghost-admin's `nx.implicitDependencies`. This tells nx that the package.json dep is only for pnpm module resolution and is not part of the task graph, so ghost-admin's `^dev` (and `^build`, `^test`, `^lint`) fan-outs no longer reach ghost.

Verified via `nx graph --focus=ghost-admin`: ghost-admin's only remaining dep is `@tryghost/admin-x-framework`.

Side benefits:

- `nx affected` now correctly ignores ghost-admin when only ghost core is touched, skipping unnecessary Ember lint/test runs in CI.
- Any other workspace package that fans out `dev` into ghost in the future would need its own fix — but there are currently none, and this one lives with the project whose dep graph was misleading nx.

`cd ghost/core && pnpm dev` still runs `nodemon index.js` directly via pnpm for host-only manual testing of the core server outside Docker (pnpm script execution never goes through nx).