### PR TITLE
Skipped nx shas step in CI for tag workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           echo "GITHUB_CONTEXT: ${{ toJson(github.event) }}"
 
       - name: Set SHAs for Nx Commands
+        if: env.IS_TAG != 'true'
         uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
@@ -86,6 +87,7 @@ jobs:
           fi
 
       - name: Determine added packages
+        if: env.IS_TAG != 'true'
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: added
         with:
@@ -95,6 +97,7 @@ jobs:
               - added: 'ghost/**/package.json'
 
       - name: Determine changed packages
+        if: env.IS_TAG != 'true'
         uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5.0.0
         id: changed
         with:
@@ -191,6 +194,7 @@ jobs:
         run: bash .github/scripts/install-deps.sh
 
       - name: Determine Affected Projects
+        if: env.IS_TAG != 'true'
         id: affected
         run: |
           AFFECTED_PROJECTS=$(pnpm -s nx show projects --affected --json | tr -d '\n')


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/actions/runs/24363396931/job/71148722202

## Summary

Skip Nx SHA and affected-project setup during tag-triggered CI runs.

## Problem

The `v6.29.0` release failed in `job_setup` on the tag-triggered `CI` workflow. After `#27297`, `job_setup` started using `nrwl/nx-set-shas` to derive `NX_BASE`, and then passed that value into `paths-filter` and Nx affected-project detection.

On a tag push, `github.ref_name` is the tag itself, so `nx-set-shas` tried to resolve workflow history for `v6.29.0` as though it were a branch. That failed, so it fell back to the empty-tree hash (`4b825dc...`). `dorny/paths-filter` then errored because that object is a tree, not a commit.

## Why this fix

Tag-triggered release runs do not need Nx base resolution, changed-file detection, or affected-project calculation:
- the downstream jobs that use those outputs are already skipped on tags
- the release path only needs `job_setup` to succeed so artifact build/publish jobs can proceed

Instead of trying to infer a “correct” comparison base for tags, this change skips the tag-incompatible diff logic entirely on tag runs while preserving the existing behavior for PRs and branch pushes.

**Changes**

- Skip `Set SHAs for Nx Commands` on tag runs
- Skip `Determine added packages` on tag runs
- Skip `Determine changed packages` on tag runs
- Skip `Determine Affected Projects` on tag runs

**Result**

Branch and PR CI continue to use Nx/affected diffing as before, while tag-triggered releases no longer fail in setup due to an invalid `NX_BASE`.
