### PR TITLE
Revert "Bumped version to 6.30.0-rc.0"

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "6.30.0-rc.0",
+  "version": "6.29.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.30.0-rc.0",
+  "version": "6.29.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/27376

This reverts commit 60ba2126a3232af35eb49cea0affcabf4e03f433.

The `v6.29.0` release failed after creating the tag. This reverts the version in package.json back to `v6.29.0` so that we can release `v6.29.1`.