### PR TITLE
Removed package directory cleanup from `pack:tarball` script

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "archive": "pnpm pack:standalone && pnpm pack:tarball",
     "pack:standalone": "rm -rf package; find . -maxdepth 1 -name 'ghost-*.tgz' -delete; npm pack && tar xzf ghost-*.tgz && cp ../../pnpm-lock.yaml package/ && cp ../../.npmrc package/.npmrc && echo '\nfrozen-lockfile=false\nshamefully-hoist=true' >> package/.npmrc && rm ghost-*.tgz && rm -f pnpm-lock.yaml pnpm-workspace.yaml .npmrc",
-    "pack:tarball": "tar czf ghost-$(node -p \"require('./package.json').version\").tgz package && rm -rf package",
+    "pack:tarball": "tar czf ghost-$(node -p \"require('./package.json').version\").tgz package",
     "dev": "nodemon index.js",
     "build:assets": "pnpm build:assets:css && pnpm build:assets:js",
     "build:assets:js": "node bin/minify-assets.js",


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/24369399597/job/71170929638

The CI workflow is failing at the "Prepare docker build context" step on runs on tags because `ghost/core/package/` doesn't exist:

```mv: cannot stat 'ghost/core/package/': No such file or directory```

At this stage in the workflow, `ghost/core/package/` doesn't exist, because it was deleted by the `pack:tarball` script a few steps prior in the same workflow by the `&& rm -rf package` addition to the `pack:tarball` script. Prior to the pnpm migration, the `package` directory wasn't cleaned up at all. This commit returns to that state, so that `ghost/core/package/` should still exist once it gets to the "Prepare docker build context" step.