### PR TITLE
Grouped staff user email notification toggles into sections

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/users/email-notifications-tab.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/email-notifications-tab.tsx
@@ -11,87 +11,110 @@ const EmailNotificationsInputs: React.FC<{ user: User; setUserData: (user: User)
 
     return (
         <SettingGroupContent>
-            <Toggle
-                checked={user.comment_notifications}
-                direction='rtl'
-                hint='Every time a member comments on one of your posts'
-                label='Comments'
-                onChange={(e) => {
-                    setUserData?.({...user, comment_notifications: e.target.checked});
-                }}
-            />
-            {hasAdminAccess(user) && <>
-                <Toggle
-                    checked={user.recommendation_notifications}
-                    direction='rtl'
-                    hint='Every time another publisher recommends you to their audience'
-                    label='Recommendations'
-                    onChange={(e) => {
-                        setUserData?.({...user, recommendation_notifications: e.target.checked});
-                    }}
-                />
-                <Toggle
-                    checked={user.free_member_signup_notification}
-                    direction='rtl'
-                    hint='Every time a new free member signs up'
-                    label='New signups'
-                    onChange={(e) => {
-                        setUserData?.({...user, free_member_signup_notification: e.target.checked});
-                    }}
-                />
-                {hasStripeEnabled &&
-                <>
+            <div>
+                <span className='text-xs font-medium tracking-wide text-grey-700 uppercase'>Engagement</span>
+                <div className='mt-3 flex flex-col gap-4'>
                     <Toggle
-                        checked={user.paid_subscription_started_notification}
+                        align='center'
+                        checked={user.comment_notifications}
                         direction='rtl'
-                        hint='Every time a member starts a new paid subscription'
-                        label='New paid members'
+                        hint='Every time a member comments on one of your posts'
+                        label='Comments'
                         onChange={(e) => {
-                            setUserData?.({...user, paid_subscription_started_notification: e.target.checked});
+                            setUserData?.({...user, comment_notifications: e.target.checked});
                         }}
                     />
-                    <Toggle
-                        checked={user.paid_subscription_canceled_notification}
-                        direction='rtl'
-                        hint='Every time a member cancels their paid subscription'
-                        label='Paid member cancellations'
-                        onChange={(e) => {
-                            setUserData?.({...user, paid_subscription_canceled_notification: e.target.checked});
-                        }}
-                    />
-                </>
-                }
-                <Toggle
-                    checked={user.milestone_notifications}
-                    direction='rtl'
-                    hint={hasStripeEnabled ?
-                        'Occasional summaries of your audience & revenue growth'
-                        :
-                        'Occasional summaries of your audience growth'
+                    {hasAdminAccess(user) &&
+                        <Toggle
+                            align='center'
+                            checked={user.recommendation_notifications}
+                            direction='rtl'
+                            hint='Every time another publisher recommends you to their audience'
+                            label='Recommendations'
+                            onChange={(e) => {
+                                setUserData?.({...user, recommendation_notifications: e.target.checked});
+                            }}
+                        />
                     }
-                    label='Milestones'
-                    onChange={(e) => {
-                        setUserData?.({...user, milestone_notifications: e.target.checked});
-                    }}
-                />
-                {hasStripeEnabled && <Toggle
-                    checked={user.donation_notifications}
-                    direction='rtl'
-                    hint='Every time you receive a one-time payment'
-                    label='Tips & donations'
-                    onChange={(e) => {
-                        setUserData?.({...user, donation_notifications: e.target.checked});
-                    }}
-                />}
-                {hasStripeEnabled && hasGiftSubscriptions && <Toggle
-                    checked={user.gift_subscription_purchase_notification}
-                    direction='rtl'
-                    hint='Every time someone purchases a gift subscription'
-                    label='Gift subscription purchases'
-                    onChange={(e) => {
-                        setUserData?.({...user, gift_subscription_purchase_notification: e.target.checked});
-                    }}
-                />}
+                </div>
+            </div>
+            {hasAdminAccess(user) && <>
+                <div>
+                    <span className='text-xs font-medium tracking-wide text-grey-700 uppercase'>Members</span>
+                    <div className='mt-3 flex flex-col gap-4'>
+                        <Toggle
+                            align='center'
+                            checked={user.free_member_signup_notification}
+                            direction='rtl'
+                            hint='Every time a new free member signs up'
+                            label='New signups'
+                            onChange={(e) => {
+                                setUserData?.({...user, free_member_signup_notification: e.target.checked});
+                            }}
+                        />
+                        {hasStripeEnabled && <>
+                            <Toggle
+                                align='center'
+                                checked={user.paid_subscription_started_notification}
+                                direction='rtl'
+                                hint='Every time a member starts a new paid subscription'
+                                label='New paid members'
+                                onChange={(e) => {
+                                    setUserData?.({...user, paid_subscription_started_notification: e.target.checked});
+                                }}
+                            />
+                            <Toggle
+                                align='center'
+                                checked={user.paid_subscription_canceled_notification}
+                                direction='rtl'
+                                hint='Every time a member cancels their paid subscription'
+                                label='Paid member cancellations'
+                                onChange={(e) => {
+                                    setUserData?.({...user, paid_subscription_canceled_notification: e.target.checked});
+                                }}
+                            />
+                        </>}
+                    </div>
+                </div>
+                <div>
+                    <span className='text-xs font-medium tracking-wide text-grey-700 uppercase'>Revenue</span>
+                    <div className='mt-3 flex flex-col gap-4'>
+                        <Toggle
+                            align='center'
+                            checked={user.milestone_notifications}
+                            direction='rtl'
+                            hint={hasStripeEnabled ?
+                                'Occasional summaries of your audience & revenue growth'
+                                :
+                                'Occasional summaries of your audience growth'
+                            }
+                            label='Milestones'
+                            onChange={(e) => {
+                                setUserData?.({...user, milestone_notifications: e.target.checked});
+                            }}
+                        />
+                        {hasStripeEnabled && <Toggle
+                            align='center'
+                            checked={user.donation_notifications}
+                            direction='rtl'
+                            hint='Every time you receive a one-time payment'
+                            label='Tips & donations'
+                            onChange={(e) => {
+                                setUserData?.({...user, donation_notifications: e.target.checked});
+                            }}
+                        />}
+                        {hasStripeEnabled && hasGiftSubscriptions && <Toggle
+                            align='center'
+                            checked={user.gift_subscription_purchase_notification}
+                            direction='rtl'
+                            hint='Every time someone purchases a gift subscription'
+                            label='Gift subscription purchases'
+                            onChange={(e) => {
+                                setUserData?.({...user, gift_subscription_purchase_notification: e.target.checked});
+                            }}
+                        />}
+                    </div>
+                </div>
             </>}
         </SettingGroupContent>
     );


### PR DESCRIPTION
no issues

Reorganized the Email Notifications tab in the staff user settings modal from a flat list of toggles into three labeled sections for better visual hierarchy:                                                      
                  
  - **Engagement** — Comments, Recommendations                                                                                                                                                                       
  - **Members** — New signups, New paid members, Paid member cancellations
  - **Revenue** — Milestones, Tips & donations, Gift subscription purchases