### PR TITLE
Fixed pipe spacing in share modal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.7",
+  "version": "2.68.8",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/share/share-modal.js
+++ b/apps/portal/src/components/pages/share/share-modal.js
@@ -98,9 +98,12 @@ const ShareModal = () => {
                             )}
                             <div className='gh-portal-share-preview-meta'>
                                 {shareSiteName && <span className='gh-portal-share-preview-site'>{shareSiteName}</span>}
+                                {shareSiteName && shareAuthor && (
+                                    <span className='gh-portal-share-preview-separator' aria-hidden='true'>|</span>
+                                )}
                                 {shareAuthor && (
                                     <span className='gh-portal-share-preview-author'>
-                                        {shareSiteName ? `| ${shareAuthor}` : shareAuthor}
+                                        {shareAuthor}
                                     </span>
                                 )}
                             </div>

--- a/apps/portal/src/components/pages/share/share-modal.styles.js
+++ b/apps/portal/src/components/pages/share/share-modal.styles.js
@@ -86,6 +86,7 @@ export const ShareModalStyles = `
     .gh-portal-share-preview-meta {
         display: flex;
         align-items: center;
+        gap: 4px;
         min-width: 0;
         color: var(--grey3);
         font-size: 1.35rem;
@@ -97,8 +98,13 @@ export const ShareModalStyles = `
 
     .gh-portal-share-preview-site,
     .gh-portal-share-preview-author {
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    .gh-portal-share-preview-separator {
+        flex: 0 0 auto;
     }
 
     .gh-portal-share-preview-site {

--- a/apps/portal/test/unit/components/pages/share-modal.test.js
+++ b/apps/portal/test/unit/components/pages/share-modal.test.js
@@ -90,7 +90,9 @@ describe('ShareModal', () => {
         expect(getByTestId('share-preview-image')).toHaveAttribute('src', 'https://example.com/post.jpg');
         expect(getByTestId('share-preview-favicon')).toHaveAttribute('src', 'https://example.com/favicon.png');
         expect(getByText('Example site')).toBeInTheDocument();
-        expect(getByText('| Jane Doe')).toBeInTheDocument();
+        expect(getByText('|')).toBeInTheDocument();
+        expect(getByText('Jane Doe')).toBeInTheDocument();
+        expect(container.querySelector('.gh-portal-share-preview-meta')).not.toHaveTextContent('Example site| Jane Doe');
 
         const actions = Array.from(container.querySelector('.gh-portal-share-actions').children);
         expect(actions[0]).toHaveClass('gh-portal-share-action', 'copy');


### PR DESCRIPTION
no ref

- fixes spacing in the share modal between the site name, pipe, and post author

before:
<img width="300" height="1256" alt="image" src="https://github.com/user-attachments/assets/c92a4c9e-e024-4ba8-bf2f-78bb60eb17ce" />


after:
<img width="300" height="592" alt="Screenshot 2026-04-14 at 9 25 54 AM" src="https://github.com/user-attachments/assets/004b4fee-648a-40c7-b043-f0583a01c596" />

