### PR TITLE
Fixed pre-commit hook when no submodules changed

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -22,7 +22,7 @@ red='\033[0;31m'
 
 ROOT_DIR=$(git rev-parse --show-cdup)
 SUBMODULES=$(grep path ${ROOT_DIR}.gitmodules | sed 's/^.*path = //')
-MOD_SUBMODULES=$(git diff --cached --name-only --ignore-submodules=none | grep -F "$SUBMODULES")
+MOD_SUBMODULES=$(git diff --cached --name-only --ignore-submodules=none | grep -F "$SUBMODULES" || true)
 
 echo -e "Checking submodules ${grey}(pre-commit hook)${no_color} "
 


### PR DESCRIPTION
no ref

I ran into an issue where the pre-commit hook was failing. This was because:

1. [Husky runs the hook script with `sh -e .github/hooks/pre-commit`.][0] [The `-e` flag][e] tells the script to exit immediately if something goes wrong (like most programming languages).
1. `grep` failed because there were no results, causing the script to crash.

I don't know why this problem didn't surface earlier, but I reckon it's due to our recent upgrade of Husky.

[0]: https://github.com/typicode/husky/blob/3f0023dc10d7003d70f2e31aa56300eab80e76d6/husky#L17
[e]: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#:~:text=%2De
