### PR TITLE
Refactored gift repository to have dedicated update method

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -1,3 +1,4 @@
+import errors from '@tryghost/errors';
 import {Gift, type GiftCadence, type GiftStatus} from './gift';
 import type {GiftRepository, RepositoryTransactionOptions} from './gift-repository';
 
@@ -53,10 +54,6 @@ export class GiftBookshelfRepository implements GiftRepository {
         return !!existing;
     }
 
-    async create(gift: Gift, options: RepositoryTransactionOptions = {}) {
-        await this.model.add(this.toRow(gift), options);
-    }
-
     async getByToken(token: string, options: RepositoryTransactionOptions = {}): Promise<Gift | null> {
         const model = await this.model.findOne({
             token
@@ -73,13 +70,17 @@ export class GiftBookshelfRepository implements GiftRepository {
         return this.toGift(model);
     }
 
-    async save(gift: Gift, options: RepositoryTransactionOptions = {}) {
+    async create(gift: Gift, options: RepositoryTransactionOptions = {}) {
+        await this.model.add(this.toRow(gift), options);
+    }
+
+    async update(gift: Gift, options: RepositoryTransactionOptions = {}) {
         const existing = await this.model.findOne({
             token: gift.token
         }, {require: false, ...options});
 
         if (!existing) {
-            return this.create(gift, options);
+            throw new errors.InternalServerError({message: `Gift not found: ${gift.token}`});
         }
 
         await existing.save(this.toRow(gift), {

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -7,9 +7,9 @@ export interface RepositoryTransactionOptions {
 
 export interface GiftRepository {
     existsByCheckoutSessionId(checkoutSessionId: string): Promise<boolean>;
-    create(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     getByToken(token: string, options?: RepositoryTransactionOptions): Promise<Gift | null>;
     getByPaymentIntentId(paymentIntentId: string): Promise<Gift | null>;
-    save(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
+    create(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
+    update(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;
 }

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -246,7 +246,7 @@ export class GiftService {
                 status: 'gift'
             }, {id: memberId, transacting});
 
-            await this.deps.giftRepository.save(redeemed, {transacting});
+            await this.deps.giftRepository.update(redeemed, {transacting});
 
             return redeemed;
         });
@@ -266,7 +266,7 @@ export class GiftService {
         }
 
         await this.deps.giftRepository.transaction(async (transacting) => {
-            await this.deps.giftRepository.save(refunded, {transacting});
+            await this.deps.giftRepository.update(refunded, {transacting});
 
             if (gift.redeemerMemberId) {
                 await this.deps.memberRepository.update({

--- a/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
@@ -80,7 +80,7 @@ describe('GiftBookshelfRepository', function () {
         assert.equal(gift, null);
     });
 
-    it('updates an existing gift when saving', async function () {
+    it('updates an existing gift', async function () {
         const existing = {
             save: sinon.stub().resolves(undefined),
             set: sinon.stub(),
@@ -136,7 +136,7 @@ describe('GiftBookshelfRepository', function () {
             refundedAt: null
         });
 
-        await repository.save(gift, {transacting: 'trx'});
+        await repository.update(gift, {transacting: 'trx'});
 
         sinon.assert.calledOnceWithExactly(GiftModel.findOne, {
             token: 'gift-token'
@@ -149,9 +149,9 @@ describe('GiftBookshelfRepository', function () {
         assert.equal(existing.save.firstCall.args[1].patch, true);
     });
 
-    it('creates a new gift when saving and no row exists', async function () {
+    it('throws InternalServerError when updating a gift that does not exist', async function () {
         const GiftModel = {
-            add: sinon.stub().resolves(undefined),
+            add: sinon.stub(),
             transaction: sinon.stub(),
             findOne: sinon.stub().resolves(null)
         };
@@ -178,14 +178,14 @@ describe('GiftBookshelfRepository', function () {
             refundedAt: null
         });
 
-        await repository.save(gift, {transacting: 'trx'});
-
-        sinon.assert.calledOnceWithExactly(GiftModel.findOne, {
-            token: 'gift-token'
-        }, {require: false, transacting: 'trx'});
-        sinon.assert.calledOnce(GiftModel.add);
-        assert.equal(GiftModel.add.firstCall.args[0].status, 'purchased');
-        assert.equal(GiftModel.add.firstCall.args[1].transacting, 'trx');
+        await assert.rejects(
+            () => repository.update(gift, {transacting: 'trx'}),
+            (err: any) => {
+                assert.equal(err.errorType, 'InternalServerError');
+                assert.equal(err.message, 'Gift not found: gift-token');
+                return true;
+            }
+        );
     });
 
     it('delegates transaction callbacks to the model', async function () {

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -8,11 +8,11 @@ import {buildGift} from './utils';
 
 describe('GiftService', function () {
     type GiftRepositoryStub = {
-        create: sinon.SinonStub;
         existsByCheckoutSessionId: sinon.SinonStub<[string], Promise<boolean>>;
         getByToken: sinon.SinonStub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>;
         getByPaymentIntentId: sinon.SinonStub<[string], Promise<Gift | null>>;
-        save: sinon.SinonStub;
+        create: sinon.SinonStub;
+        update: sinon.SinonStub;
         transaction: sinon.SinonStub<Parameters<GiftRepository['transaction']>, Promise<unknown>>;
     };
 
@@ -47,11 +47,11 @@ describe('GiftService', function () {
 
     beforeEach(function () {
         giftRepository = {
-            create: sinon.stub(),
             existsByCheckoutSessionId: sinon.stub<[string], Promise<boolean>>().resolves(false),
             getByToken: sinon.stub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>().resolves(null),
             getByPaymentIntentId: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
-            save: sinon.stub(),
+            create: sinon.stub(),
+            update: sinon.stub(),
             transaction: sinon.stub<Parameters<GiftRepository['transaction']>, Promise<unknown>>().callsFake(async (callback) => {
                 return await callback('trx');
             })
@@ -449,7 +449,7 @@ describe('GiftService', function () {
                 id: 'member_1',
                 transacting: 'trx'
             });
-            sinon.assert.calledOnceWithExactly(giftRepository.save, redeemed, {transacting: 'trx'});
+            sinon.assert.calledOnceWithExactly(giftRepository.update, redeemed, {transacting: 'trx'});
             assert.equal(redeemed.status, 'redeemed');
             assert.equal(redeemed.redeemerMemberId, 'member_1');
             assert.notEqual(redeemed.consumesAt, null);
@@ -472,7 +472,7 @@ describe('GiftService', function () {
             );
 
             sinon.assert.notCalled(memberRepository.update);
-            sinon.assert.notCalled(giftRepository.save);
+            sinon.assert.notCalled(giftRepository.update);
         });
 
         it('throws NotFoundError when the gift token does not exist', async function () {
@@ -492,7 +492,7 @@ describe('GiftService', function () {
             );
 
             sinon.assert.notCalled(memberRepository.update);
-            sinon.assert.notCalled(giftRepository.save);
+            sinon.assert.notCalled(giftRepository.update);
         });
 
         it('throws BadRequestError when the member is not eligible', async function () {
@@ -516,7 +516,7 @@ describe('GiftService', function () {
             );
 
             sinon.assert.notCalled(memberRepository.update);
-            sinon.assert.notCalled(giftRepository.save);
+            sinon.assert.notCalled(giftRepository.update);
         });
     });
 
@@ -530,9 +530,9 @@ describe('GiftService', function () {
             const result = await service.refund('pi_456');
 
             assert.equal(result, true);
-            sinon.assert.calledOnce(giftRepository.save);
+            sinon.assert.calledOnce(giftRepository.update);
 
-            const [saved, options] = giftRepository.save.getCall(0).args;
+            const [saved, options] = giftRepository.update.getCall(0).args;
 
             assert.equal(saved.status, 'refunded');
             assert.ok(saved.refundedAt);
@@ -547,7 +547,7 @@ describe('GiftService', function () {
             const result = await service.refund('pi_unknown');
 
             assert.equal(result, false);
-            sinon.assert.notCalled(giftRepository.save);
+            sinon.assert.notCalled(giftRepository.update);
         });
 
         it('downgrades the redeemer to free when the gift was redeemed', async function () {
@@ -564,7 +564,7 @@ describe('GiftService', function () {
             const result = await service.refund('pi_456');
 
             assert.equal(result, true);
-            sinon.assert.calledOnce(giftRepository.save);
+            sinon.assert.calledOnce(giftRepository.update);
             sinon.assert.calledOnce(giftRepository.transaction);
             sinon.assert.calledOnceWithExactly(memberRepository.update, {
                 products: [],
@@ -615,7 +615,7 @@ describe('GiftService', function () {
             const result = await service.refund('pi_456');
 
             assert.equal(result, true);
-            sinon.assert.notCalled(giftRepository.save);
+            sinon.assert.notCalled(giftRepository.update);
         });
     });
 });


### PR DESCRIPTION
no ref

In the gift repository we decided to have a dedicated `update` method instead of a generic `save` method that also fell back to creating
