### PR TITLE
Added gift subscription label in Admin member page

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -183,6 +183,8 @@
                                                     </li>
                                                 </GhDropdown>
                                             </span>
+                                        {{else if sub.isGift}}
+                                        {{! No action menu for gift subscriptions }}
                                         {{else}}
                                             <span class="action-menu">
                                                 <GhDropdownButton @dropdownName="subscription-menu-{{sub.id}}" @classNames="gh-btn gh-btn-outline gh-btn-icon fill gh-btn-subscription-action icon-only" @title="Actions">

--- a/ghost/admin/app/components/gh-member-settings-form.js
+++ b/ghost/admin/app/components/gh-member-settings-form.js
@@ -61,7 +61,7 @@ export default class extends Component {
             });
 
         let subsWithPrice = subscriptions.filter(sub => !!sub.price);
-        let subscriptionData = subsWithPrice.map(sub => getSubscriptionData(sub));
+        let subscriptionData = subsWithPrice.map(sub => getSubscriptionData(sub, this.member.get('status')));
 
         return tiers.map((tier) => {
             let tierSubscriptions = subscriptionData.filter((subscription) => {

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
 import {getNonDecimal, getSymbol} from 'ghost-admin/utils/currency';
 
-export function getSubscriptionData(sub) {
+export function getSubscriptionData(sub, memberStatus) {
     const data = {
         ...sub,
         attribution: {
@@ -19,8 +19,10 @@ export function getSubscriptionData(sub) {
             currencySymbol: getSymbol(sub.price.currency),
             nonDecimalAmount: getNonDecimal(sub.price.amount)
         },
-        isComplimentary: isComplimentary(sub),
-        compExpiry: compExpiry(sub),
+        isGift: isGiftSubscription(memberStatus),
+        isComplimentary: isComplimentary(sub, memberStatus),
+        compExpiry: compExpiry(sub, memberStatus),
+        giftExpiry: giftExpiry(sub, memberStatus),
         trialUntil: trialUntil(sub)
     };
 
@@ -56,8 +58,12 @@ export function isActive(sub) {
     return ['active', 'trialing', 'past_due', 'unpaid'].includes(sub.status);
 }
 
-export function isComplimentary(sub) {
-    return !sub.id;
+export function isComplimentary(sub, memberStatus) {
+    return memberStatus === 'comped' && !sub.id;
+}
+
+export function isGiftSubscription(memberStatus) {
+    return memberStatus === 'gift';
 }
 
 export function isCanceled(sub) {
@@ -68,8 +74,24 @@ export function isSetToCancel(sub) {
     return sub.cancel_at_period_end && isActive(sub);
 }
 
-export function compExpiry(sub) {
-    if (!sub.id && sub.tier && sub.tier.expiry_at) {
+export function compExpiry(sub, memberStatus) {
+    if (!isComplimentary(sub, memberStatus)) {
+        return undefined;
+    }
+
+    if (sub.tier && sub.tier.expiry_at) {
+        return moment(sub.tier.expiry_at).utc().format('D MMM YYYY');
+    }
+
+    return undefined;
+}
+
+export function giftExpiry(sub, memberStatus) {
+    if (!isGiftSubscription(memberStatus)) {
+        return undefined;
+    }
+
+    if (sub.tier && sub.tier.expiry_at) {
         return moment(sub.tier.expiry_at).utc().format('D MMM YYYY');
     }
 
@@ -91,6 +113,14 @@ export function trialUntil(sub) {
 export function validityDetails(data, separatorNeeded = false) {
     const separator = separatorNeeded ? ' – ' : '';
     const space = data.validUntil ? ' ' : '';
+
+    if (data.isGift) {
+        if (data.giftExpiry) {
+            return `${separator}Expires ${data.giftExpiry}`;
+        } else {
+            return '';
+        }
+    }
 
     if (data.isComplimentary) {
         if (data.compExpiry) {
@@ -118,6 +148,10 @@ export function validityDetails(data, separatorNeeded = false) {
 export function priceLabel(data) {
     if (data.trialUntil) {
         return 'Free trial';
+    }
+
+    if (data.isGift) {
+        return 'Gift subscription';
     }
 
     if (data.price.nickname && data.price.nickname.length > 0 && data.price.nickname !== 'Monthly' && data.price.nickname !== 'Yearly') {

--- a/ghost/admin/tests/acceptance/members/details-test.js
+++ b/ghost/admin/tests/acceptance/members/details-test.js
@@ -248,6 +248,122 @@ describe('Acceptance: Member details', function () {
         expect(amountElement.textContent.trim()).to.equal('5.90');
     });
 
+    it('renders "Gift subscription" label for gift subscriptions, with no action menu', async function () {
+        const expiryAt = '2026-05-14T13:21:31.000Z';
+        tier.update({expiry_at: expiryAt});
+
+        const member = this.server.create('member', {
+            status: 'gift',
+            subscriptions: [
+                this.server.create('subscription', {
+                    id: '',
+                    tier,
+                    customer: {
+                        id: '',
+                        name: 'Receiver',
+                        email: 'receiver@example.com'
+                    },
+                    plan: {
+                        id: '',
+                        nickname: 'Complimentary',
+                        amount: 0,
+                        interval: 'year',
+                        currency: 'USD'
+                    },
+                    status: 'active',
+                    start_date: '2026-04-14T13:21:31.000Z',
+                    default_payment_card_last4: '****',
+                    cancel_at_period_end: false,
+                    cancellation_reason: null,
+                    current_period_end: expiryAt,
+                    price: {
+                        id: '',
+                        price_id: '',
+                        nickname: 'Complimentary',
+                        amount: 0,
+                        interval: 'year',
+                        type: 'recurring',
+                        currency: 'USD',
+                        tier: {
+                            id: '',
+                            tier_id: tier.id
+                        }
+                    },
+                    offer: null
+                })
+            ],
+            tiers: [tier]
+        });
+
+        await visit(`/members/${member.id}`);
+
+        const subscriptionCard = find(`[data-test-tier="${tier.id}"]`);
+        expect(subscriptionCard.textContent).to.include('Gift subscription');
+        expect(subscriptionCard.textContent).to.include('Expires 14 May 2026');
+        expect(subscriptionCard.textContent).to.not.include('Complimentary');
+        expect(findAll(`[data-test-tier="${tier.id}"] [data-test-button="subscription-actions"]`).length).to.equal(0);
+    });
+
+    it('renders "Complimentary" label for comped subscriptions, with "Remove complimentary subscription" action', async function () {
+        const expiryAt = '2026-05-14T13:21:31.000Z';
+        tier.update({expiry_at: expiryAt});
+
+        const member = this.server.create('member', {
+            status: 'comped',
+            subscriptions: [
+                this.server.create('subscription', {
+                    id: '',
+                    tier,
+                    customer: {
+                        id: '',
+                        name: 'Comped member',
+                        email: 'comped@example.com'
+                    },
+                    plan: {
+                        id: '',
+                        nickname: 'Complimentary',
+                        amount: 0,
+                        interval: 'year',
+                        currency: 'USD'
+                    },
+                    status: 'active',
+                    start_date: '2026-04-14T13:21:31.000Z',
+                    default_payment_card_last4: '****',
+                    cancel_at_period_end: false,
+                    cancellation_reason: null,
+                    current_period_end: expiryAt,
+                    price: {
+                        id: '',
+                        price_id: '',
+                        nickname: 'Complimentary',
+                        amount: 0,
+                        interval: 'year',
+                        type: 'recurring',
+                        currency: 'USD',
+                        tier: {
+                            id: '',
+                            tier_id: tier.id
+                        }
+                    },
+                    offer: null
+                })
+            ],
+            tiers: [tier]
+        });
+
+        await visit(`/members/${member.id}`);
+
+        const subscriptionCard = find(`[data-test-tier="${tier.id}"]`);
+        expect(subscriptionCard.textContent).to.include('Complimentary');
+        expect(subscriptionCard.textContent).to.include('Expires 14 May 2026');
+        expect(subscriptionCard.textContent).to.not.include('Gift subscription');
+        expect(findAll(`[data-test-tier="${tier.id}"] [data-test-button="subscription-actions"]`).length).to.equal(1);
+
+        await click(`[data-test-tier="${tier.id}"] [data-test-button="subscription-actions"]`);
+
+        expect(find(`[data-test-tier="${tier.id}"] [data-test-button="remove-complimentary"]`)).to.exist;
+    });
+
     it('can add and remove complimentary subscription', async function () {
         const member = this.server.create('member', {name: 'Comp Member Test'});
 

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -1,5 +1,5 @@
 import moment from 'moment-timezone';
-import {compExpiry, getDiscountPrice, getOfferDisplayData, getSubscriptionData, isActive, isCanceled, isComplimentary, isSetToCancel, priceLabel, trialUntil, validUntil, validityDetails} from 'ghost-admin/utils/subscription-data';
+import {compExpiry, getDiscountPrice, getOfferDisplayData, getSubscriptionData, giftExpiry, isActive, isCanceled, isComplimentary, isSetToCancel, priceLabel, trialUntil, validUntil, validityDetails} from 'ghost-admin/utils/subscription-data';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 
@@ -108,12 +108,22 @@ describe('Unit: Util: subscription-data', function () {
     describe('isComplimentary', function () {
         it('returns true for complimentary subscriptions', function () {
             let sub = {id: null};
-            expect(isComplimentary(sub)).to.be.true;
+            expect(isComplimentary(sub, 'comped')).to.be.true;
         });
 
         it('returns false for paid subscriptions', function () {
             let sub = {id: 'sub_123'};
+            expect(isComplimentary(sub, 'comped')).to.be.false;
+        });
+
+        it('returns false when member status is missing', function () {
+            let sub = {id: null};
             expect(isComplimentary(sub)).to.be.false;
+        });
+
+        it('returns false for gift subscriptions', function () {
+            let sub = {id: null};
+            expect(isComplimentary(sub, 'gift')).to.be.false;
         });
     });
 
@@ -166,12 +176,34 @@ describe('Unit: Util: subscription-data', function () {
     describe('compExpiry', function () {
         it('returns the complimentary expiry date for complimentary subscriptions', function () {
             let sub = {id: null, tier: {expiry_at: moment.utc('2021-05-31').toISOString()}};
-            expect(compExpiry(sub)).to.equal('31 May 2021');
+            expect(compExpiry(sub, 'comped')).to.equal('31 May 2021');
         });
 
         it('returns undefined for paid subscriptions', function () {
             let sub = {id: 'sub_123'};
-            expect(compExpiry(sub)).to.be.undefined;
+            expect(compExpiry(sub, 'comped')).to.be.undefined;
+        });
+
+        it('returns undefined for gift subscriptions', function () {
+            let sub = {id: null, tier: {expiry_at: moment.utc('2021-05-31').toISOString()}};
+            expect(compExpiry(sub, 'gift')).to.be.undefined;
+        });
+    });
+
+    describe('giftExpiry', function () {
+        it('returns the gift expiry date from the tier expiry', function () {
+            let sub = {tier: {expiry_at: moment.utc('2021-05-31').toISOString()}};
+            expect(giftExpiry(sub, 'gift')).to.equal('31 May 2021');
+        });
+
+        it('returns undefined when the tier expiry is missing', function () {
+            let sub = {tier: {expiry_at: null}};
+            expect(giftExpiry(sub, 'gift')).to.be.undefined;
+        });
+
+        it('returns undefined for non-gift subscriptions', function () {
+            let sub = {tier: {expiry_at: moment.utc('2021-05-31').toISOString()}};
+            expect(giftExpiry(sub)).to.be.undefined;
         });
     });
 
@@ -179,6 +211,15 @@ describe('Unit: Util: subscription-data', function () {
         it('returns "Free trial" for trial subscriptions', function () {
             let data = {trialUntil: '31 May 2021'};
             expect(priceLabel(data)).to.equal('Free trial');
+        });
+
+        it('returns "Gift subscription" for gift subscriptions', function () {
+            let data = {
+                isGift: true,
+                price: {nickname: 'Complimentary'}
+            };
+
+            expect(priceLabel(data)).to.equal('Gift subscription');
         });
 
         it('returns nothing if the price nickname is the default "monthly" or "yearly"', function () {
@@ -210,6 +251,14 @@ describe('Unit: Util: subscription-data', function () {
                 compExpiry: undefined
             };
             expect(validityDetails(data)).to.equal('');
+        });
+
+        it('returns "Expires {giftExpiry}" for gift subscriptions', function () {
+            let data = {
+                isGift: true,
+                giftExpiry: '31 May 2021'
+            };
+            expect(validityDetails(data)).to.equal('Expires 31 May 2021');
         });
 
         it('returns "Ended {validUntil}" for canceled subscriptions', function () {
@@ -257,7 +306,7 @@ describe('Unit: Util: subscription-data', function () {
                     amount: 5000
                 }
             };
-            let data = getSubscriptionData(sub);
+            let data = getSubscriptionData(sub, 'comped');
 
             expect(data).to.include({
                 isComplimentary: false,
@@ -284,7 +333,7 @@ describe('Unit: Util: subscription-data', function () {
                     amount: 5000
                 }
             };
-            let data = getSubscriptionData(sub);
+            let data = getSubscriptionData(sub, 'comped');
 
             expect(data).to.include({
                 isComplimentary: false,
@@ -316,7 +365,7 @@ describe('Unit: Util: subscription-data', function () {
                     nickname: 'Free tier'
                 }
             };
-            let data = getSubscriptionData(sub);
+            let data = getSubscriptionData(sub, 'comped');
 
             expect(data).to.include({
                 isComplimentary: false,
@@ -343,7 +392,7 @@ describe('Unit: Util: subscription-data', function () {
                     amount: 5000
                 }
             };
-            let data = getSubscriptionData(sub);
+            let data = getSubscriptionData(sub, 'comped');
 
             expect(data).to.include({
                 isComplimentary: false,
@@ -370,7 +419,7 @@ describe('Unit: Util: subscription-data', function () {
                     amount: 5000
                 }
             };
-            let data = getSubscriptionData(sub);
+            let data = getSubscriptionData(sub, 'comped');
 
             expect(data).to.include({
                 isComplimentary: false,
@@ -400,11 +449,13 @@ describe('Unit: Util: subscription-data', function () {
                     nickname: 'Complimentary'
                 }
             };
-            let data = getSubscriptionData(sub);
+            let data = getSubscriptionData(sub, 'comped');
 
             expect(data).to.include({
+                isGift: false,
                 isComplimentary: true,
                 compExpiry: undefined,
+                giftExpiry: undefined,
                 hasEnded: false,
                 validUntil: '31 May 2021',
                 willEndSoon: false,
@@ -430,16 +481,50 @@ describe('Unit: Util: subscription-data', function () {
                     nickname: 'Complimentary'
                 }
             };
-            let data = getSubscriptionData(sub);
+            let data = getSubscriptionData(sub, 'comped');
 
             expect(data).to.include({
+                isGift: false,
                 isComplimentary: true,
                 compExpiry: '31 May 2021',
+                giftExpiry: undefined,
                 hasEnded: false,
                 validUntil: '31 May 2021',
                 willEndSoon: false,
                 trialUntil: undefined,
                 priceLabel: 'Complimentary',
+                validityDetails: ' – Expires 31 May 2021'
+            });
+        });
+
+        it('returns the correct data for a gift subscription with an expiration date', function () {
+            let sub = {
+                id: null,
+                status: 'active',
+                cancel_at_period_end: false,
+                current_period_end: '2021-05-31',
+                trial_end_at: null,
+                tier: {
+                    expiry_at: moment.utc('2021-05-31').toISOString()
+                },
+                price: {
+                    currency: 'usd',
+                    amount: 0,
+                    nickname: 'Complimentary'
+                }
+            };
+            let data = getSubscriptionData(sub, 'gift');
+
+            expect(data).to.include({
+                isGift: true,
+                isComplimentary: false,
+                compExpiry: undefined,
+                giftExpiry: '31 May 2021',
+                hasEnded: false,
+                validUntil: '31 May 2021',
+                willEndSoon: false,
+                trialUntil: undefined,
+                priceLabel: 'Gift subscription',
                 validityDetails: ' – Expires 31 May 2021'
             });
         });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3482

## Summary

Update the Admin member details page to treat gift subscriptions as a distinct subscription type instead of displaying them as complimentary subscriptions.

For gift subscriptions, we now display:

`Gift subscription – Expires {date}`

with no action menu to remove the subscription:

<img width="1590" height="414" alt="CleanShot 2026-04-14 at 20 52 05@2x" src="https://github.com/user-attachments/assets/bda5f902-9690-462d-92a8-2cfebd19a542" />


## What changed

- Added gift-specific subscription normalization in the Admin subscription data helper
- Added a `giftExpiry` helper sourced from `sub.tier.expiry_at`
- Updated the subscription label logic so gift members render `Gift subscription`
- Updated validity details so gift subscriptions render `Expires {date}`
- Hid the action menu for gift subscriptions on the member details page
- Kept complimentary subscriptions unchanged:
  - still render as `Complimentary`
  - still use the complimentary expiry path
  - still show the `Remove complimentary subscription` action
- Tightened `isComplimentary` so it only applies to `comped` members with manual subscriptions

