### PR TITLE
🐛 Fixed potentially skipping email events

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -448,16 +448,13 @@ module.exports = class EmailAnalyticsService {
             }
         }
 
-        // Small trick: if reached the end of new events, we are going to keep
-        // fetching the same events because 'begin' won't change
-        // So if we didn't have errors while fetching, and total events < maxEvents, increase lastEventTimestamp with one second
+        // Persist cursor position so we can resume after reboot.
+        // We do NOT increment the timestamp — re-fetching the same second on the next
+        // cycle is cheap (event processing deduplicates) and avoids skipping events that
+        // share the same second as the cursor boundary during high-volume sends.
         if (!error && eventCount > 0 && fetchData.lastEventTimestamp && fetchData.lastEventTimestamp.getTime() < Date.now() - 2000) {
-            // set the data on the db so we can store it for fetching after reboot
             await this.queries.setJobTimestamp(fetchData.jobName, 'finished', new Date(fetchData.lastEventTimestamp.getTime()));
-            // increment and store in local memory
-            fetchData.lastEventTimestamp = new Date(fetchData.lastEventTimestamp.getTime() + 1000);
         } else {
-            // set job status to finished
             await this.queries.setJobStatus(fetchData.jobName, 'finished');
         }
 

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -448,12 +448,16 @@ module.exports = class EmailAnalyticsService {
             }
         }
 
-        // Persist cursor position so we can resume after reboot.
-        // We do NOT increment the timestamp — re-fetching the same second on the next
-        // cycle is cheap (event processing deduplicates) and avoids skipping events that
-        // share the same second as the cursor boundary during high-volume sends.
+        // When we've consumed all available events (eventCount < maxEvents), advance the cursor by 1 second
+        // to avoid re-fetching the same batch on the next cycle. When we hit the maxEvents budget mid-second,
+        // do NOT advance — the next pass needs to re-cover that second to pick up any remaining events.
         if (!error && eventCount > 0 && fetchData.lastEventTimestamp && fetchData.lastEventTimestamp.getTime() < Date.now() - 2000) {
+            // Persist cursor to DB so we can resume after reboot
             await this.queries.setJobTimestamp(fetchData.jobName, 'finished', new Date(fetchData.lastEventTimestamp.getTime()));
+            if (eventCount < maxEvents) {
+                // Consumed everything in the window — advance to avoid re-fetching same batch
+                fetchData.lastEventTimestamp = new Date(fetchData.lastEventTimestamp.getTime() + 1000);
+            }
         } else {
             await this.queries.setJobStatus(fetchData.jobName, 'finished');
         }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1624

When fetching events, if we end the job on a particular second, we increment the timestamp to start at the **next** second. This means we drop any remaining events on that second, although they could/should be picked up by the missing events job that runs on a delay.