### PR TITLE
🎨 Added Preview tab to welcome email editor

### DIFF
--- a/apps/admin-x-framework/src/api/automated-emails.ts
+++ b/apps/admin-x-framework/src/api/automated-emails.ts
@@ -28,6 +28,16 @@ export interface AutomatedEmailsVerifyResponseType extends AutomatedEmailsRespon
     meta?: Meta & {email_verified: string};
 }
 
+export type AutomatedEmailPreview = {
+    html: string;
+    plaintext: string;
+    subject: string;
+}
+
+export interface AutomatedEmailsPreviewResponseType {
+    automated_emails: AutomatedEmailPreview[];
+}
+
 const dataType = 'AutomatedEmailsResponseType';
 
 export const useBrowseAutomatedEmails = createQuery<AutomatedEmailsResponseType>({
@@ -89,4 +99,10 @@ export const useSendTestWelcomeEmail = createMutation<unknown, {id: string; emai
     method: 'POST',
     path: ({id}) => `/automated_emails/${id}/test/`,
     body: ({email, subject, lexical}) => ({email, subject, lexical})
+});
+
+export const usePreviewWelcomeEmail = createMutation<AutomatedEmailsPreviewResponseType, {id: string; subject: string; lexical: string}>({
+    method: 'POST',
+    path: ({id}) => `/automated_emails/${id}/preview/`,
+    body: ({subject, lexical}) => ({subject, lexical})
 });

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -27,7 +27,7 @@ const baseEditorStyles = cn(
     // Dark mode
     'dark:text-white dark:selection:bg-[rgba(88,101,116,0.99)]',
     // Placeholder styling
-    '[&_.koenig-lexical-editor-input-placeholder]:font-sans! [&_.koenig-lexical-editor-input-placeholder]:text-xl [&_.koenig-lexical-editor-input-placeholder]:tracking-tight',
+    '[&_.koenig-lexical-editor-input-placeholder]:font-sans! [&_.koenig-lexical-editor-input-placeholder]:text-[1.6rem] [&_.koenig-lexical-editor-input-placeholder]:tracking-tight',
     // Headings dark mode
     '[&_:is(h2,h3)]:dark:text-white',
     // Inputs
@@ -37,7 +37,7 @@ const baseEditorStyles = cn(
     // Settings panel
     '[&_[data-kg-card-selected]]:isolate',
     // Content typography
-    '[&_:is(p,blockquote,aside,ul,ol)]:font-sans! [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight',
+    '[&_:is(p,blockquote,aside,ul,ol)]:tracking-tight',
     // Reset content typography inside card captions to match Koenig's caption styles
     '[&_figcaption_:is(p,blockquote,aside,ul,ol)]:text-[1.4rem] [&_figcaption_:is(p,blockquote,aside,ul,ol)]:tracking-[.025em]',
     '[&_figcaption_p]:mb-0',
@@ -49,7 +49,7 @@ const baseEditorStyles = cn(
     // Keep settings panel copy compact
     '[&_[data-kg-settings-panel]_p]:!mb-0',
     // Nested-editor (callout, etc.) fixes: align placeholder with text
-    '[&_.not-kg-prose>div]:font-sans! [&_.not-kg-prose>div]:tracking-tight! [&_.not-kg-prose>div]:text-xl! [&_.not-kg-prose>div]:leading-[1.6]!',
+    '[&_.not-kg-prose>div]:font-sans! [&_.not-kg-prose>div]:tracking-tight! [&_.not-kg-prose>div]:text-[1.6rem]! [&_.not-kg-prose>div]:leading-[1.6]!',
     '[&_.kg-inherit-styles_p]:mb-0!',
     '[&_.kg-inherit-styles]:pt-[3px]!',
     // CTA card: keep sponsor label at its intended 12.5px size

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/use-welcome-email-preview.ts
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/use-welcome-email-preview.ts
@@ -1,5 +1,5 @@
 import {JSONError} from '@tryghost/admin-x-framework/errors';
-import {useCallback, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 
 import {type WelcomeEmailDraft, getWelcomeEmailValidationErrors} from './welcome-email-validation';
 
@@ -63,12 +63,12 @@ export const useWelcomeEmailPreview = ({automatedEmailId, previewWelcomeEmail, s
     const [previewState, setPreviewState] = useState<WelcomeEmailPreviewState>({status: 'idle'});
     const previewRequestIdRef = useRef(0);
 
-    const exitPreview = useCallback(() => {
+    const exitPreview = () => {
         previewRequestIdRef.current += 1;
         setPreviewState({status: 'idle'});
-    }, []);
+    };
 
-    const runPreview = useCallback(async (draft: WelcomeEmailDraft) => {
+    const enterPreview = async (draft: WelcomeEmailDraft) => {
         const requestId = previewRequestIdRef.current + 1;
         previewRequestIdRef.current = requestId;
 
@@ -121,11 +121,7 @@ export const useWelcomeEmailPreview = ({automatedEmailId, previewWelcomeEmail, s
                 message: getPreviewErrorMessage(error)
             });
         }
-    }, [automatedEmailId, previewWelcomeEmail, setErrors]);
-
-    const enterPreview = useCallback((draft: WelcomeEmailDraft) => {
-        runPreview(draft);
-    }, [runPreview]);
+    };
 
     return {
         previewFrameState:

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/use-welcome-email-preview.ts
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/use-welcome-email-preview.ts
@@ -1,10 +1,7 @@
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {useCallback, useRef, useState} from 'react';
 
-export type WelcomeEmailDraft = {
-    subject: string;
-    lexical: string;
-};
+import {type WelcomeEmailDraft, getWelcomeEmailValidationErrors} from './welcome-email-validation';
 
 export type WelcomeEmailPreview = {
     html: string;
@@ -42,45 +39,6 @@ const preparePreviewHtml = (html: string) => {
     });
 
     return `<!doctype html>${parsed.documentElement.outerHTML}`;
-};
-
-const isEmptyLexical = (lexical: string | null | undefined): boolean => {
-    if (!lexical) {
-        return true;
-    }
-
-    try {
-        const parsed = JSON.parse(lexical);
-        const children = parsed?.root?.children;
-
-        // Empty if no children or only an empty paragraph
-        if (!children || children.length === 0) {
-            return true;
-        }
-        if (children.length === 1 &&
-            children[0].type === 'paragraph' &&
-            (!children[0].children || children[0].children.length === 0)) {
-            return true;
-        }
-
-        return false;
-    } catch {
-        return true;
-    }
-};
-
-export const getWelcomeEmailValidationErrors = (state: WelcomeEmailDraft): Record<string, string> => {
-    const newErrors: Record<string, string> = {};
-
-    if (!state.subject?.trim()) {
-        newErrors.subject = 'A subject is required';
-    }
-
-    if (isEmptyLexical(state.lexical)) {
-        newErrors.lexical = 'Email content is required';
-    }
-
-    return newErrors;
 };
 
 const getPreviewErrorMessage = (error: unknown) => {

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/use-welcome-email-preview.ts
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/use-welcome-email-preview.ts
@@ -123,13 +123,16 @@ export const useWelcomeEmailPreview = ({automatedEmailId, previewWelcomeEmail, s
         }
     };
 
+    let previewFrameState: WelcomeEmailPreviewFrameState = {status: 'loading'};
+
+    if (previewState.status === 'success') {
+        previewFrameState = {status: 'success', html: previewState.preview.html};
+    } else if (previewState.status === 'error' || previewState.status === 'invalid') {
+        previewFrameState = {status: previewState.status, message: previewState.message};
+    }
+
     return {
-        previewFrameState:
-            previewState.status === 'success'
-                ? {status: 'success' as const, html: previewState.preview.html}
-                : previewState.status === 'error' || previewState.status === 'invalid'
-                    ? {status: previewState.status, message: previewState.message}
-                    : {status: 'loading' as const},
+        previewFrameState,
         previewState,
         enterPreview,
         exitPreview

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -6,7 +6,6 @@ import MemberEmailEditor from './member-email-editor';
 import WelcomeEmailPreviewFrame from './welcome-email-preview-frame';
 import {Hint, Button as LegacyButton, Modal, TextField} from '@tryghost/admin-x-design-system';
 import {confirmIfDirty} from '@tryghost/admin-x-design-system';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {getWelcomeEmailValidationErrors, useWelcomeEmailPreview} from '../../../../hooks/use-welcome-email-preview';
 import {useBrowseAutomatedEmails, useEditAutomatedEmail, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -14,7 +13,6 @@ import {useRouting} from '@tryghost/admin-x-framework/routing';
 import {useWelcomeEmailSenderDetails} from '../../../../hooks/use-welcome-email-sender-details';
 
 import TestEmailDropdown from './test-email-dropdown';
-import {useGlobalData} from '../../../../components/providers/global-data-provider';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 
 import {Button, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
@@ -26,16 +24,18 @@ interface EmailPreviewModalContentProps {
     headerActions?: React.ReactNode;
     children: React.ReactNode;
     className?: string;
+    isEditMode?: boolean;
 }
 
 const EmailPreviewModalContent = React.forwardRef<
     HTMLDivElement,
     EmailPreviewModalContentProps
->(({title, centeredHeaderContent, headerActions, children, className}, ref) => (
+>(({title, centeredHeaderContent, headerActions, children, className, isEditMode = false}, ref) => (
     <div
         ref={ref}
         className={cn(
-            'flex h-full w-full flex-col gap-0 overflow-hidden rounded-xl bg-gray-100 p-0',
+            'flex h-full w-full flex-col gap-0 overflow-hidden rounded-xl p-0',
+            isEditMode ? 'bg-white' : 'bg-gray-100',
             'dark:bg-gray-975',
             className
         )}
@@ -79,7 +79,7 @@ interface EmailPreviewBodyProps {
 
 const EmailPreviewBody: React.FC<EmailPreviewBodyProps> = ({children, className}) => (
     <div className={cn(
-        'flex mx-auto w-full rounded-b-lg bg-white shadow-sm transition-[max-width,height,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:bg-grey-975 dark:shadow-none grow max-w-[780px] px-6',
+        'flex mx-auto w-full rounded-b-lg transition-[max-width,height,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:shadow-none grow max-w-[780px]',
         className
     )}>
         {children}
@@ -101,12 +101,11 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const {data: automatedEmailsData} = useBrowseAutomatedEmails();
     const [showTestDropdown, setShowTestDropdown] = useState(false);
     const [mode, setMode] = useState<PreviewMode>('edit');
+    const [previewSubjectOverride, setPreviewSubjectOverride] = useState<string | null>(null);
     const dropdownRef = useRef<HTMLDivElement>(null);
     const normalizedLexical = useRef<string>(automatedEmail?.lexical || '');
     const hasEditorBeenFocused = useRef(false);
     const handleError = useHandleError();
-    const {settings} = useGlobalData();
-    const [siteTitle] = getSettingValues<string>(settings, ['title']);
     const automatedEmails = automatedEmailsData?.automated_emails || [];
     const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useWelcomeEmailSenderDetails(automatedEmails);
     const emailTypeLabel = emailType === 'paid' ? 'Paid' : 'Free';
@@ -178,8 +177,11 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         setMode(nextMode);
 
         if (nextMode === 'preview') {
+            setPreviewSubjectOverride(null);
             enterPreview(formState);
         } else {
+            setShowTestDropdown(false);
+            setPreviewSubjectOverride(null);
             exitPreview();
         }
     }, [enterPreview, exitPreview, formState]);
@@ -229,9 +231,9 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                         variant='segmented-sm'
                         onValueChange={value => value && handleModeChange(value as PreviewMode)}
                     >
-                        <TabsList className='bg-gray-100 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]'>
-                            <TabsTrigger data-testid='welcome-email-mode-edit' value='edit'>Edit</TabsTrigger>
-                            <TabsTrigger data-testid='welcome-email-mode-preview' value='preview'>Preview</TabsTrigger>
+                        <TabsList className='grid w-[240px] grid-cols-2 bg-gray-100 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]'>
+                            <TabsTrigger className='w-full justify-center data-[state=active]:bg-white dark:data-[state=active]:bg-white dark:data-[state=active]:text-black' data-testid='welcome-email-mode-edit' value='edit'>Email content</TabsTrigger>
+                            <TabsTrigger className='w-full justify-center' data-testid='welcome-email-mode-preview' value='preview'>Preview</TabsTrigger>
                         </TabsList>
                     </Tabs>
                 }
@@ -247,68 +249,66 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                         </Button>
                     </>
                 }
+                isEditMode={mode === 'edit'}
                 title={modalTitle}
             >
                 <div className='flex grow flex-col items-center p-6'>
-                    <EmailPreviewEmailHeader className='border-x-0 border-t-0 border-b'>
-                        <div className='flex flex-col gap-2'>
-                            <div className='flex items-center py-1'>
-                                <div className='w-20 shrink-0 text-sm font-semibold'>From:</div>
-                                <div className='min-w-0 grow pr-4 text-sm'>
-                                    <span className='flex gap-1 truncate whitespace-nowrap'>
-                                        <span>{resolvedSenderName}</span>
-                                        <span className='text-gray-500 dark:text-gray-400'>{`<${resolvedSenderEmail}>`}</span>
-                                    </span>
-                                </div>
-                                <div ref={dropdownRef} className='relative'>
-                                    <LegacyButton
-                                        className='border border-grey-200 font-semibold hover:border-grey-300 hover:bg-white! dark:border-grey-900 dark:hover:border-grey-800 dark:hover:bg-grey-950!'
-                                        color="clear"
-                                        icon='send'
-                                        label="Test"
-                                        onClick={() => setShowTestDropdown(!showTestDropdown)}
-                                    />
-                                    {showTestDropdown && (
-                                        <TestEmailDropdown automatedEmailId={automatedEmail.id} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
-                                    )}
-                                </div>
-                            </div>
-                            {hasDistinctReplyTo && (
-                                <div className='flex items-center'>
-                                    <div className='w-20 shrink-0 text-sm font-semibold'>Reply-to:</div>
-                                    <div className='grow text-sm text-gray-500 dark:text-gray-400'>
-                                        {resolvedReplyToEmail}
+                    {mode === 'preview' && (
+                        <EmailPreviewEmailHeader className='border-x-0 border-t-0 border-b'>
+                            <div className='flex flex-col gap-2'>
+                                <div className='flex items-center py-1'>
+                                    <div className='w-20 shrink-0 text-sm font-semibold'>From:</div>
+                                    <div className='min-w-0 grow pr-4 text-sm'>
+                                        <span className='flex gap-1 truncate whitespace-nowrap'>
+                                            <span>{resolvedSenderName}</span>
+                                            <span className='text-gray-500 dark:text-gray-400'>{`<${resolvedSenderEmail}>`}</span>
+                                        </span>
+                                    </div>
+                                    <div ref={dropdownRef} className='relative'>
+                                        <LegacyButton
+                                            className='border border-grey-200 font-semibold hover:border-grey-300 hover:bg-white! dark:border-grey-900 dark:hover:border-grey-800 dark:hover:bg-grey-950!'
+                                            color="clear"
+                                            icon='send'
+                                            label="Test"
+                                            onClick={() => setShowTestDropdown(!showTestDropdown)}
+                                        />
+                                        {showTestDropdown && (
+                                            <TestEmailDropdown automatedEmailId={automatedEmail.id} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
+                                        )}
                                     </div>
                                 </div>
-                            )}
-                            <div className='flex items-center'>
-                                <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
-                                <div className='grow'>
-                                    {mode === 'edit' ? (
+                                {hasDistinctReplyTo && (
+                                    <div className='flex items-center'>
+                                        <div className='w-20 shrink-0 text-sm font-semibold'>Reply-to:</div>
+                                        <div className='grow text-sm text-gray-500 dark:text-gray-400'>
+                                            {resolvedReplyToEmail}
+                                        </div>
+                                    </div>
+                                )}
+                                <div className='flex items-center'>
+                                    <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
+                                    <div className='grow'>
                                         <TextField
                                             className='w-full'
-                                            error={Boolean(errors.subject)}
-                                            hint={errors.subject || ''}
-                                            maxLength={300}
-                                            placeholder={`Welcome to ${siteTitle}`}
-                                            value={formState.subject}
-                                            onChange={e => updateForm(state => ({...state, subject: e.target.value}))}
-                                        />
-                                    ) : (
-                                        <TextField
-                                            className='w-full cursor-default caret-transparent'
                                             data-testid='welcome-email-preview-subject'
-                                            tabIndex={-1}
-                                            value={previewState.status === 'success' ? previewState.preview.subject : formState.subject}
-                                            readOnly
-                                            onFocus={e => e.currentTarget.blur()}
+                                            value={previewSubjectOverride ?? (previewState.status === 'success' ? previewState.preview.subject : formState.subject)}
+                                            onChange={(e) => {
+                                                const nextSubject = e.target.value;
+                                                setPreviewSubjectOverride(nextSubject);
+                                                updateForm(state => ({...state, subject: nextSubject}));
+                                            }}
                                         />
-                                    )}
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    </EmailPreviewEmailHeader>
-                    <EmailPreviewBody className={mode === 'edit' && errors.lexical ? 'border border-red-500' : ''}>
+                        </EmailPreviewEmailHeader>
+                    )}
+                    <EmailPreviewBody className={cn(
+                        mode === 'preview' && 'shadow-sm bg-white dark:bg-grey-975',
+                        mode === 'edit' && 'px-6',
+                        mode === 'edit' && 'rounded-lg',
+                        mode === 'edit' && errors.lexical && 'border border-red-500'
+                    )}>
                         <div
                             className={cn(
                                 'mx-auto w-full max-w-[600px] pt-10 pb-8 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none',

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -3,23 +3,26 @@ import React from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 import MemberEmailEditor from './member-email-editor';
+import WelcomeEmailPreviewFrame from './welcome-email-preview-frame';
 import {Hint, Button as LegacyButton, Modal, TextField} from '@tryghost/admin-x-design-system';
 import {confirmIfDirty} from '@tryghost/admin-x-design-system';
+import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {getWelcomeEmailValidationErrors, useWelcomeEmailPreview} from '../../../../hooks/use-welcome-email-preview';
+import {useBrowseAutomatedEmails, useEditAutomatedEmail, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useRouting} from '@tryghost/admin-x-framework/routing';
 import {useWelcomeEmailSenderDetails} from '../../../../hooks/use-welcome-email-sender-details';
 
 import TestEmailDropdown from './test-email-dropdown';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
-import {useBrowseAutomatedEmails, useEditAutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useGlobalData} from '../../../../components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 
-import {Button} from '@tryghost/shade/components';
+import {Button, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {cn} from '@tryghost/shade/utils';
 
 interface EmailPreviewModalContentProps {
     title: string;
+    centeredHeaderContent?: React.ReactNode;
     headerActions?: React.ReactNode;
     children: React.ReactNode;
     className?: string;
@@ -28,7 +31,7 @@ interface EmailPreviewModalContentProps {
 const EmailPreviewModalContent = React.forwardRef<
     HTMLDivElement,
     EmailPreviewModalContentProps
->(({title, headerActions, children, className}, ref) => (
+>(({title, centeredHeaderContent, headerActions, children, className}, ref) => (
     <div
         ref={ref}
         className={cn(
@@ -37,15 +40,18 @@ const EmailPreviewModalContent = React.forwardRef<
             className
         )}
     >
-        <div className="sticky top-0 flex shrink-0 items-center justify-between border-b border-gray-200 bg-white px-5 py-3 dark:border-gray-900 dark:bg-gray-975">
-            <h3 className="text-xl font-semibold">
+        <div className="sticky top-0 grid shrink-0 grid-cols-[1fr_auto_1fr] items-center border-b border-gray-200 bg-white px-5 py-3 dark:border-gray-900 dark:bg-gray-975">
+            <h3 className="justify-self-start text-xl font-semibold">
                 {title}
             </h3>
-            <div className="flex items-center gap-2">
+            <div className="justify-self-center">
+                {centeredHeaderContent}
+            </div>
+            <div className="flex items-center gap-2 justify-self-end">
                 {headerActions}
             </div>
         </div>
-        <div className="flex h-[clamp(0px,calc(100dvh-320px),82vh)] min-h-0 grow flex-col overflow-y-auto">
+        <div className="flex h-[clamp(0px,calc(100dvh-320px),82vh)] min-h-0 grow flex-col overflow-y-auto [scrollbar-gutter:stable]">
             {children}
         </div>
     </div>
@@ -85,37 +91,16 @@ interface WelcomeEmailModalProps {
     automatedEmail: AutomatedEmail;
 }
 
-const isEmptyLexical = (lexical: string | null | undefined): boolean => {
-    if (!lexical) {
-        return true;
-    }
-
-    try {
-        const parsed = JSON.parse(lexical);
-        const children = parsed?.root?.children;
-
-        // Empty if no children or only an empty paragraph
-        if (!children || children.length === 0) {
-            return true;
-        }
-        if (children.length === 1 &&
-            children[0].type === 'paragraph' &&
-            (!children[0].children || children[0].children.length === 0)) {
-            return true;
-        }
-
-        return false;
-    } catch {
-        return true;
-    }
-};
+type PreviewMode = 'edit' | 'preview';
 
 const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType = 'free', automatedEmail}) => {
     const modal = useModal();
     const {updateRoute} = useRouting();
     const {mutateAsync: editAutomatedEmail} = useEditAutomatedEmail();
+    const {mutateAsync: previewWelcomeEmail} = usePreviewWelcomeEmail();
     const {data: automatedEmailsData} = useBrowseAutomatedEmails();
     const [showTestDropdown, setShowTestDropdown] = useState(false);
+    const [mode, setMode] = useState<PreviewMode>('edit');
     const dropdownRef = useRef<HTMLDivElement>(null);
     const normalizedLexical = useRef<string>(automatedEmail?.lexical || '');
     const hasEditorBeenFocused = useRef(false);
@@ -127,7 +112,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const emailTypeLabel = emailType === 'paid' ? 'Paid' : 'Free';
     const modalTitle = `${emailTypeLabel} members welcome email`;
 
-    const {formState, saveState, updateForm, setFormState, handleSave, okProps, errors, validate} = useForm({
+    const {formState, saveState, updateForm, setFormState, setErrors, handleSave, okProps, errors, validate} = useForm({
         initialState: {
             subject: automatedEmail?.subject || 'Welcome',
             lexical: automatedEmail?.lexical || ''
@@ -137,21 +122,14 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
             await editAutomatedEmail({...automatedEmail, ...state});
         },
         onSaveError: handleError,
-        onValidate: (state) => {
-            const newErrors: Record<string, string> = {};
-
-            if (!state.subject?.trim()) {
-                newErrors.subject = 'A subject is required';
-            }
-
-            if (isEmptyLexical(state.lexical)) {
-                newErrors.lexical = 'Email content is required';
-            }
-
-            return newErrors;
-        }
+        onValidate: getWelcomeEmailValidationErrors
     });
     const saveButtonLabel = okProps.label || 'Save';
+    const {previewFrameState, previewState, enterPreview, exitPreview} = useWelcomeEmailPreview({
+        automatedEmailId: automatedEmail.id,
+        previewWelcomeEmail,
+        setErrors
+    });
 
     const isDirty = saveState === 'unsaved';
 
@@ -196,6 +174,16 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         };
     }, []);
 
+    const handleModeChange = useCallback((nextMode: PreviewMode) => {
+        setMode(nextMode);
+
+        if (nextMode === 'preview') {
+            enterPreview(formState);
+        } else {
+            exitPreview();
+        }
+    }, [enterPreview, exitPreview, formState]);
+
     // The editor normalizes content on mount (e.g., processing {name} templates),
     // which triggers onChange even without user edits. We track whether the editor
     // has ever been focused - normalization happens before focus is possible, so any
@@ -234,6 +222,19 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
             width='full'
         >
             <EmailPreviewModalContent
+                centeredHeaderContent={
+                    <Tabs
+                        data-testid='welcome-email-mode-toggle'
+                        value={mode}
+                        variant='segmented-sm'
+                        onValueChange={value => value && handleModeChange(value as PreviewMode)}
+                    >
+                        <TabsList className='bg-gray-100 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]'>
+                            <TabsTrigger data-testid='welcome-email-mode-edit' value='edit'>Edit</TabsTrigger>
+                            <TabsTrigger data-testid='welcome-email-mode-preview' value='preview'>Preview</TabsTrigger>
+                        </TabsList>
+                    </Tabs>
+                }
                 className='dark:bg-[#151719]'
                 headerActions={
                     <>
@@ -283,22 +284,36 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                             <div className='flex items-center'>
                                 <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
                                 <div className='grow'>
-                                    <TextField
-                                        className='w-full'
-                                        error={Boolean(errors.subject)}
-                                        hint={errors.subject || ''}
-                                        maxLength={300}
-                                        placeholder={`Welcome to ${siteTitle}`}
-                                        value={formState.subject}
-                                        onChange={e => updateForm(state => ({...state, subject: e.target.value}))}
-                                    />
+                                    {mode === 'edit' ? (
+                                        <TextField
+                                            className='w-full'
+                                            error={Boolean(errors.subject)}
+                                            hint={errors.subject || ''}
+                                            maxLength={300}
+                                            placeholder={`Welcome to ${siteTitle}`}
+                                            value={formState.subject}
+                                            onChange={e => updateForm(state => ({...state, subject: e.target.value}))}
+                                        />
+                                    ) : (
+                                        <TextField
+                                            className='w-full cursor-default caret-transparent'
+                                            data-testid='welcome-email-preview-subject'
+                                            tabIndex={-1}
+                                            value={previewState.status === 'success' ? previewState.preview.subject : formState.subject}
+                                            readOnly
+                                            onFocus={e => e.currentTarget.blur()}
+                                        />
+                                    )}
                                 </div>
                             </div>
                         </div>
                     </EmailPreviewEmailHeader>
-                    <EmailPreviewBody className={errors.lexical ? 'border border-red-500' : ''}>
+                    <EmailPreviewBody className={mode === 'edit' && errors.lexical ? 'border border-red-500' : ''}>
                         <div
-                            className='mx-auto w-full max-w-[600px] pt-10 pb-8 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none'
+                            className={cn(
+                                'mx-auto w-full max-w-[600px] pt-10 pb-8 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none',
+                                mode === 'preview' && 'hidden'
+                            )}
                             data-testid='welcome-email-editor'
                             onFocus={() => {
                                 hasEditorBeenFocused.current = true;
@@ -308,13 +323,15 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                                 key={automatedEmail?.id || 'new'}
                                 className='welcome-email-editor'
                                 placeholder='Write your welcome email content...'
-
-                                value={automatedEmail?.lexical || ''}
+                                value={formState.lexical}
                                 onChange={handleEditorChange}
                             />
                         </div>
+                        {mode === 'preview' && (
+                            <WelcomeEmailPreviewFrame previewState={previewFrameState} />
+                        )}
                     </EmailPreviewBody>
-                    {errors.lexical && <Hint className='mt-2 max-w-[740px]' color='red'>{errors.lexical}</Hint>}
+                    {mode === 'edit' && errors.lexical && <Hint className='mt-2 max-w-[740px]' color='red'>{errors.lexical}</Hint>}
                 </div>
             </EmailPreviewModalContent>
         </Modal>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -6,10 +6,11 @@ import MemberEmailEditor from './member-email-editor';
 import WelcomeEmailPreviewFrame from './welcome-email-preview-frame';
 import {Hint, Button as LegacyButton, Modal, TextField} from '@tryghost/admin-x-design-system';
 import {confirmIfDirty} from '@tryghost/admin-x-design-system';
-import {getWelcomeEmailValidationErrors, useWelcomeEmailPreview} from '../../../../hooks/use-welcome-email-preview';
+import {getWelcomeEmailValidationErrors} from './welcome-email-validation';
 import {useBrowseAutomatedEmails, useEditAutomatedEmail, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useWelcomeEmailPreview} from './use-welcome-email-preview';
 import {useWelcomeEmailSenderDetails} from '../../../../hooks/use-welcome-email-sender-details';
 
 import TestEmailDropdown from './test-email-dropdown';

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -299,6 +299,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                                                 updateForm(state => ({...state, subject: nextSubject}));
                                             }}
                                         />
+                                        {errors.subject && <Hint className='mt-2' color='red'>{errors.subject}</Hint>}
                                     </div>
                                 </div>
                             </div>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -125,7 +125,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         onValidate: getWelcomeEmailValidationErrors
     });
     const saveButtonLabel = okProps.label || 'Save';
-    const {previewFrameState, previewState, enterPreview, exitPreview} = useWelcomeEmailPreview({
+    const {previewFrameState, enterPreview, exitPreview} = useWelcomeEmailPreview({
         automatedEmailId: automatedEmail.id,
         previewWelcomeEmail,
         setErrors
@@ -292,7 +292,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                                         <TextField
                                             className='w-full'
                                             data-testid='welcome-email-preview-subject'
-                                            value={previewSubjectOverride ?? (previewState.status === 'success' ? previewState.preview.subject : formState.subject)}
+                                            value={previewSubjectOverride ?? formState.subject}
                                             onChange={(e) => {
                                                 const nextSubject = e.target.value;
                                                 setPreviewSubjectOverride(nextSubject);

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {Hint, LoadingIndicator} from '@tryghost/admin-x-design-system';
 import {cn} from '@tryghost/shade/utils';
 import type {WelcomeEmailPreviewFrameState} from './use-welcome-email-preview';
@@ -10,12 +10,13 @@ interface WelcomeEmailPreviewFrameProps {
 const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({previewState}) => {
     const [previewHeight, setPreviewHeight] = useState<number | null>(null);
     const [isPreviewReady, setIsPreviewReady] = useState(false);
+    const isPreviewReadyRef = useRef(false);
     const previewIframeRef = useRef<HTMLIFrameElement>(null);
     const previewResizeObserverRef = useRef<ResizeObserver | null>(null);
     const previewMeasureFrameRef = useRef<number | null>(null);
     const previewRevealFrameRef = useRef<number | null>(null);
 
-    const cleanupPreviewMeasurement = useCallback(() => {
+    function cleanupPreviewMeasurement() {
         previewResizeObserverRef.current?.disconnect();
         previewResizeObserverRef.current = null;
 
@@ -28,19 +29,22 @@ const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({prev
             window.cancelAnimationFrame(previewRevealFrameRef.current);
             previewRevealFrameRef.current = null;
         }
-    }, []);
+    }
 
     const previewHtml = previewState.status === 'success' ? previewState.html : '';
 
     useEffect(() => {
         cleanupPreviewMeasurement();
+        isPreviewReadyRef.current = false;
         setIsPreviewReady(false);
         setPreviewHeight(null);
 
-        return cleanupPreviewMeasurement;
-    }, [cleanupPreviewMeasurement, previewHtml, previewState.status]);
+        return () => {
+            cleanupPreviewMeasurement();
+        };
+    }, [previewHtml, previewState.status]);
 
-    const syncPreviewHeight = useCallback(() => {
+    function syncPreviewHeight() {
         const iframe = previewIframeRef.current;
         const doc = iframe?.contentDocument;
 
@@ -61,18 +65,19 @@ const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({prev
         if (nextHeight > 0) {
             setPreviewHeight(previousHeight => (previousHeight === nextHeight ? previousHeight : nextHeight));
 
-            if (!isPreviewReady && previewRevealFrameRef.current === null) {
+            if (!isPreviewReadyRef.current && previewRevealFrameRef.current === null) {
                 previewRevealFrameRef.current = window.requestAnimationFrame(() => {
                     previewRevealFrameRef.current = window.requestAnimationFrame(() => {
                         previewRevealFrameRef.current = null;
+                        isPreviewReadyRef.current = true;
                         setIsPreviewReady(true);
                     });
                 });
             }
         }
-    }, [isPreviewReady]);
+    }
 
-    const queuePreviewHeightSync = useCallback(() => {
+    function queuePreviewHeightSync() {
         if (previewMeasureFrameRef.current !== null) {
             window.cancelAnimationFrame(previewMeasureFrameRef.current);
         }
@@ -81,9 +86,9 @@ const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({prev
             previewMeasureFrameRef.current = null;
             syncPreviewHeight();
         });
-    }, [syncPreviewHeight]);
+    }
 
-    const handlePreviewLoad = useCallback(() => {
+    function handlePreviewLoad() {
         const iframe = previewIframeRef.current;
         const doc = iframe?.contentDocument;
 
@@ -103,7 +108,7 @@ const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({prev
             observer.observe(doc.body);
             previewResizeObserverRef.current = observer;
         }
-    }, [cleanupPreviewMeasurement, queuePreviewHeightSync]);
+    }
 
     const showPreviewLoading = previewState.status === 'loading' || (previewState.status === 'success' && !isPreviewReady);
 

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
@@ -1,0 +1,151 @@
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {Hint, LoadingIndicator} from '@tryghost/admin-x-design-system';
+import {cn} from '@tryghost/shade/utils';
+import type {WelcomeEmailPreviewFrameState} from '../../../../hooks/use-welcome-email-preview';
+
+interface WelcomeEmailPreviewFrameProps {
+    previewState: WelcomeEmailPreviewFrameState;
+}
+
+const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({previewState}) => {
+    const [previewHeight, setPreviewHeight] = useState<number | null>(null);
+    const [isPreviewReady, setIsPreviewReady] = useState(false);
+    const previewIframeRef = useRef<HTMLIFrameElement>(null);
+    const previewResizeObserverRef = useRef<ResizeObserver | null>(null);
+    const previewMeasureFrameRef = useRef<number | null>(null);
+    const previewRevealFrameRef = useRef<number | null>(null);
+
+    const cleanupPreviewMeasurement = useCallback(() => {
+        previewResizeObserverRef.current?.disconnect();
+        previewResizeObserverRef.current = null;
+
+        if (previewMeasureFrameRef.current !== null) {
+            window.cancelAnimationFrame(previewMeasureFrameRef.current);
+            previewMeasureFrameRef.current = null;
+        }
+
+        if (previewRevealFrameRef.current !== null) {
+            window.cancelAnimationFrame(previewRevealFrameRef.current);
+            previewRevealFrameRef.current = null;
+        }
+    }, []);
+
+    const previewHtml = previewState.status === 'success' ? previewState.html : '';
+
+    useEffect(() => {
+        cleanupPreviewMeasurement();
+        setIsPreviewReady(false);
+        setPreviewHeight(null);
+    }, [cleanupPreviewMeasurement, previewHtml, previewState.status]);
+
+    useEffect(() => cleanupPreviewMeasurement, [cleanupPreviewMeasurement]);
+
+    const syncPreviewHeight = useCallback(() => {
+        const iframe = previewIframeRef.current;
+        const doc = iframe?.contentDocument;
+
+        if (!iframe || !doc) {
+            return;
+        }
+
+        doc.documentElement.style.overflowY = 'hidden';
+        doc.body.style.overflowY = 'hidden';
+
+        const nextHeight = Math.max(
+            doc.documentElement?.scrollHeight || 0,
+            doc.body?.scrollHeight || 0,
+            doc.documentElement?.offsetHeight || 0,
+            doc.body?.offsetHeight || 0
+        );
+
+        if (nextHeight > 0) {
+            setPreviewHeight(previousHeight => (previousHeight === nextHeight ? previousHeight : nextHeight));
+
+            if (!isPreviewReady && previewRevealFrameRef.current === null) {
+                previewRevealFrameRef.current = window.requestAnimationFrame(() => {
+                    previewRevealFrameRef.current = window.requestAnimationFrame(() => {
+                        previewRevealFrameRef.current = null;
+                        setIsPreviewReady(true);
+                    });
+                });
+            }
+        }
+    }, [isPreviewReady]);
+
+    const queuePreviewHeightSync = useCallback(() => {
+        if (previewMeasureFrameRef.current !== null) {
+            window.cancelAnimationFrame(previewMeasureFrameRef.current);
+        }
+
+        previewMeasureFrameRef.current = window.requestAnimationFrame(() => {
+            previewMeasureFrameRef.current = null;
+            syncPreviewHeight();
+        });
+    }, [syncPreviewHeight]);
+
+    const handlePreviewLoad = useCallback(() => {
+        const iframe = previewIframeRef.current;
+        const doc = iframe?.contentDocument;
+
+        if (!iframe || !doc) {
+            return;
+        }
+
+        cleanupPreviewMeasurement();
+        queuePreviewHeightSync();
+
+        if (typeof ResizeObserver !== 'undefined') {
+            const observer = new ResizeObserver(() => {
+                queuePreviewHeightSync();
+            });
+
+            observer.observe(doc.documentElement);
+            observer.observe(doc.body);
+            previewResizeObserverRef.current = observer;
+        }
+    }, [cleanupPreviewMeasurement, queuePreviewHeightSync]);
+
+    const showPreviewLoading = previewState.status === 'loading' || (previewState.status === 'success' && !isPreviewReady);
+
+    return (
+        <div className='relative mx-auto w-full max-w-[740px] py-6' data-testid='welcome-email-preview'>
+            {showPreviewLoading && (
+                <div
+                    className='flex min-h-full items-start justify-center pt-24'
+                    data-testid='welcome-email-preview-loading'
+                    style={previewHeight ? {height: `${previewHeight}px`} : undefined}
+                >
+                    <LoadingIndicator />
+                </div>
+            )}
+            {previewState.status === 'success' && (
+                <div
+                    aria-hidden={!isPreviewReady}
+                    className={cn(
+                        'w-full',
+                        !isPreviewReady && 'pointer-events-none absolute left-0 top-6 opacity-0'
+                    )}
+                >
+                    {/* Keep the iframe hidden until it has been measured to avoid a visible resize jump. */}
+                    <iframe
+                        ref={previewIframeRef}
+                        className='w-full rounded bg-white'
+                        data-testid='welcome-email-preview-iframe'
+                        sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+                        srcDoc={previewState.html}
+                        style={{height: previewHeight ? `${previewHeight}px` : '600px'}}
+                        title='Welcome email preview'
+                        onLoad={handlePreviewLoad}
+                    />
+                </div>
+            )}
+            {(previewState.status === 'error' || previewState.status === 'invalid') && (
+                <div className='flex h-full items-center justify-center px-4' data-testid='welcome-email-preview-error'>
+                    <Hint color='red'>{previewState.message}</Hint>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default WelcomeEmailPreviewFrame;

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
@@ -36,9 +36,9 @@ const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({prev
         cleanupPreviewMeasurement();
         setIsPreviewReady(false);
         setPreviewHeight(null);
-    }, [cleanupPreviewMeasurement, previewHtml, previewState.status]);
 
-    useEffect(() => cleanupPreviewMeasurement, [cleanupPreviewMeasurement]);
+        return cleanupPreviewMeasurement;
+    }, [cleanupPreviewMeasurement, previewHtml, previewState.status]);
 
     const syncPreviewHeight = useCallback(() => {
         const iframe = previewIframeRef.current;

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Hint, LoadingIndicator} from '@tryghost/admin-x-design-system';
 import {cn} from '@tryghost/shade/utils';
-import type {WelcomeEmailPreviewFrameState} from '../../../../hooks/use-welcome-email-preview';
+import type {WelcomeEmailPreviewFrameState} from './use-welcome-email-preview';
 
 interface WelcomeEmailPreviewFrameProps {
     previewState: WelcomeEmailPreviewFrameState;

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-preview-frame.tsx
@@ -108,7 +108,7 @@ const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({prev
     const showPreviewLoading = previewState.status === 'loading' || (previewState.status === 'success' && !isPreviewReady);
 
     return (
-        <div className='relative mx-auto w-full max-w-[740px] py-6' data-testid='welcome-email-preview'>
+        <div className='relative w-full' data-testid='welcome-email-preview'>
             {showPreviewLoading && (
                 <div
                     className='flex min-h-full items-start justify-center pt-24'
@@ -123,7 +123,7 @@ const WelcomeEmailPreviewFrame: React.FC<WelcomeEmailPreviewFrameProps> = ({prev
                     aria-hidden={!isPreviewReady}
                     className={cn(
                         'w-full',
-                        !isPreviewReady && 'pointer-events-none absolute left-0 top-6 opacity-0'
+                        !isPreviewReady && 'pointer-events-none absolute left-0 top-0 opacity-0'
                     )}
                 >
                     {/* Keep the iframe hidden until it has been measured to avoid a visible resize jump. */}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-validation.ts
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-validation.ts
@@ -1,0 +1,43 @@
+export type WelcomeEmailDraft = {
+    subject: string;
+    lexical: string;
+};
+
+const isEmptyLexical = (lexical: string | null | undefined): boolean => {
+    if (!lexical) {
+        return true;
+    }
+
+    try {
+        const parsed = JSON.parse(lexical);
+        const children = parsed?.root?.children;
+
+        // Empty if no children or only an empty paragraph
+        if (!children || children.length === 0) {
+            return true;
+        }
+        if (children.length === 1 &&
+            children[0].type === 'paragraph' &&
+            (!children[0].children || children[0].children.length === 0)) {
+            return true;
+        }
+
+        return false;
+    } catch {
+        return true;
+    }
+};
+
+export const getWelcomeEmailValidationErrors = (state: WelcomeEmailDraft): Record<string, string> => {
+    const newErrors: Record<string, string> = {};
+
+    if (!state.subject?.trim()) {
+        newErrors.subject = 'A subject is required';
+    }
+
+    if (isEmptyLexical(state.lexical)) {
+        newErrors.lexical = 'Email content is required';
+    }
+
+    return newErrors;
+};

--- a/apps/admin-x-settings/src/hooks/use-welcome-email-preview.ts
+++ b/apps/admin-x-settings/src/hooks/use-welcome-email-preview.ts
@@ -1,0 +1,183 @@
+import {JSONError} from '@tryghost/admin-x-framework/errors';
+import {useCallback, useRef, useState} from 'react';
+
+export type WelcomeEmailDraft = {
+    subject: string;
+    lexical: string;
+};
+
+export type WelcomeEmailPreview = {
+    html: string;
+    plaintext: string;
+    subject: string;
+};
+
+export type WelcomeEmailPreviewResponse = {
+    automated_emails?: WelcomeEmailPreview[];
+};
+
+export type WelcomeEmailPreviewState =
+    | {status: 'idle'}
+    | {status: 'loading'}
+    | {status: 'success'; preview: WelcomeEmailPreview}
+    | {status: 'error'; message: string}
+    | {status: 'invalid'; message: string};
+
+export type WelcomeEmailPreviewFrameState =
+    | {status: 'loading'}
+    | {status: 'success'; html: string}
+    | {status: 'error' | 'invalid'; message: string};
+
+const preparePreviewHtml = (html: string) => {
+    if (typeof DOMParser === 'undefined') {
+        return html;
+    }
+
+    const parser = new DOMParser();
+    const parsed = parser.parseFromString(html, 'text/html');
+
+    parsed.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((link) => {
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+    });
+
+    return `<!doctype html>${parsed.documentElement.outerHTML}`;
+};
+
+const isEmptyLexical = (lexical: string | null | undefined): boolean => {
+    if (!lexical) {
+        return true;
+    }
+
+    try {
+        const parsed = JSON.parse(lexical);
+        const children = parsed?.root?.children;
+
+        // Empty if no children or only an empty paragraph
+        if (!children || children.length === 0) {
+            return true;
+        }
+        if (children.length === 1 &&
+            children[0].type === 'paragraph' &&
+            (!children[0].children || children[0].children.length === 0)) {
+            return true;
+        }
+
+        return false;
+    } catch {
+        return true;
+    }
+};
+
+export const getWelcomeEmailValidationErrors = (state: WelcomeEmailDraft): Record<string, string> => {
+    const newErrors: Record<string, string> = {};
+
+    if (!state.subject?.trim()) {
+        newErrors.subject = 'A subject is required';
+    }
+
+    if (isEmptyLexical(state.lexical)) {
+        newErrors.lexical = 'Email content is required';
+    }
+
+    return newErrors;
+};
+
+const getPreviewErrorMessage = (error: unknown) => {
+    const fallbackMessage = 'Failed to render preview';
+
+    if (error instanceof JSONError && error.data?.errors?.[0]) {
+        return error.data.errors[0].context || error.data.errors[0].message || fallbackMessage;
+    }
+
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return fallbackMessage;
+};
+
+export const useWelcomeEmailPreview = ({automatedEmailId, previewWelcomeEmail, setErrors}: {
+    automatedEmailId: string;
+    previewWelcomeEmail: (payload: WelcomeEmailDraft & {id: string}) => Promise<WelcomeEmailPreviewResponse>;
+    setErrors: (errors: Record<string, string>) => void;
+}) => {
+    const [previewState, setPreviewState] = useState<WelcomeEmailPreviewState>({status: 'idle'});
+    const previewRequestIdRef = useRef(0);
+
+    const exitPreview = useCallback(() => {
+        previewRequestIdRef.current += 1;
+        setPreviewState({status: 'idle'});
+    }, []);
+
+    const runPreview = useCallback(async (draft: WelcomeEmailDraft) => {
+        const requestId = previewRequestIdRef.current + 1;
+        previewRequestIdRef.current = requestId;
+
+        const validationErrors = getWelcomeEmailValidationErrors(draft);
+        setErrors(validationErrors);
+
+        const hasValidationErrors = Boolean(validationErrors.subject || validationErrors.lexical);
+        if (hasValidationErrors) {
+            setPreviewState({
+                status: 'invalid',
+                message: validationErrors.subject || validationErrors.lexical
+            });
+            return;
+        }
+
+        setPreviewState({status: 'loading'});
+
+        try {
+            // Only the latest preview request is allowed to update preview state.
+            const response = await previewWelcomeEmail({
+                id: automatedEmailId,
+                subject: draft.subject,
+                lexical: draft.lexical
+            });
+
+            if (previewRequestIdRef.current !== requestId) {
+                return;
+            }
+
+            const preview = response.automated_emails?.[0];
+
+            if (!preview?.html || !preview?.plaintext || !preview?.subject) {
+                throw new Error('Preview response was incomplete');
+            }
+
+            setPreviewState({
+                status: 'success',
+                preview: {
+                    ...preview,
+                    html: preparePreviewHtml(preview.html)
+                }
+            });
+        } catch (error) {
+            if (previewRequestIdRef.current !== requestId) {
+                return;
+            }
+
+            setPreviewState({
+                status: 'error',
+                message: getPreviewErrorMessage(error)
+            });
+        }
+    }, [automatedEmailId, previewWelcomeEmail, setErrors]);
+
+    const enterPreview = useCallback((draft: WelcomeEmailDraft) => {
+        runPreview(draft);
+    }, [runPreview]);
+
+    return {
+        previewFrameState:
+            previewState.status === 'success'
+                ? {status: 'success' as const, html: previewState.preview.html}
+                : previewState.status === 'error' || previewState.status === 'invalid'
+                    ? {status: previewState.status, message: previewState.message}
+                    : {status: 'loading' as const},
+        previewState,
+        enterPreview,
+        exitPreview
+    };
+};

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -131,23 +131,6 @@ const pasteText = async (page: Page, content: string) => {
     }, content);
 };
 
-const getWelcomeEmailModalLayoutMetrics = async (page: Page, mode: 'edit' | 'preview') => {
-    return await page.getByTestId('welcome-email-modal').evaluate((node, currentMode) => {
-        const subject = currentMode === 'preview'
-            ? node.querySelector('[data-testid="welcome-email-preview-subject"]')
-            : node.querySelector('input');
-        const content = currentMode === 'preview'
-            ? node.querySelector('[data-testid="welcome-email-preview"]')
-            : node.querySelector('[data-testid="welcome-email-editor"]');
-        const body = content?.parentElement;
-
-        return {
-            bodyTop: body?.getBoundingClientRect().top ?? 0,
-            subjectHeight: subject?.getBoundingClientRect().height ?? 0
-        };
-    }, mode);
-};
-
 test.describe('Member emails settings', async () => {
     test.describe('Welcome email modal', async () => {
         test('Edit and Preview controls render; preview request only happens on Preview switch', async ({page}) => {
@@ -175,18 +158,21 @@ test.describe('Member emails settings', async () => {
 
             await expect(modal.getByTestId('welcome-email-mode-edit')).toBeVisible();
             await expect(modal.getByTestId('welcome-email-mode-preview')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-subject')).not.toBeVisible();
 
-            const subjectInput = modal.locator('input').first();
-            await subjectInput.fill('Unsaved subject for preview');
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+            await editor.click({timeout: 5000});
+            await page.keyboard.type(' Draft note');
 
             expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
 
             await modal.getByTestId('welcome-email-mode-preview').click();
 
-            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {subject?: string} | undefined)?.subject).toBe('Unsaved subject for preview');
-            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Welcome');
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {subject?: string} | undefined)?.subject).toBeTruthy();
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Draft note');
             const previewIframe = modal.getByTestId('welcome-email-preview-iframe');
             await expect(previewIframe).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-subject')).toBeVisible();
             await expect(previewIframe).toHaveAttribute('sandbox', 'allow-same-origin allow-popups allow-popups-to-escape-sandbox');
 
             await expect.poll(async () => {
@@ -205,17 +191,30 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Preview/Edit toggle preserves unsaved draft subject and lexical', async ({page}) => {
-            const {lastApiRequests} = await mockApi({page, requests: {
+            await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
                 browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
-                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
-                previewWelcomeEmail: {
-                    method: 'POST',
-                    path: '/automated_emails/free-welcome-email-id/preview/',
-                    response: automatedEmailPreviewFixture
-                }
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
             }});
+
+            const previewRequests: Array<{subject?: string; lexical?: string}> = [];
+
+            await page.route(/\/ghost\/api\/admin\/automated_emails\/free-welcome-email-id\/preview\/$/, async (route) => {
+                const body = JSON.parse(route.request().postData() || '{}') as {subject?: string; lexical?: string};
+                previewRequests.push(body);
+
+                await route.fulfill({
+                    status: 200,
+                    body: JSON.stringify({
+                        automated_emails: [{
+                            html: '<!doctype html><html><body><p>Preview</p></body></html>',
+                            plaintext: 'Preview',
+                            subject: body.subject || 'Preview Subject'
+                        }]
+                    })
+                });
+            });
 
             await page.goto('/#/memberemails');
             await page.waitForLoadState('networkidle');
@@ -227,28 +226,22 @@ test.describe('Member emails settings', async () => {
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
 
-            const subjectInput = modal.locator('input').first();
-            await subjectInput.fill('Unsaved welcome email subject');
-
             const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
             await editor.click({timeout: 5000});
             await page.keyboard.type(' Draft note');
 
-            const editLayout = await getWelcomeEmailModalLayoutMetrics(page, 'edit');
-
             await modal.getByTestId('welcome-email-mode-preview').click();
-            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Draft note');
             await expect(modal.getByTestId('welcome-email-preview-iframe')).toBeVisible();
             await expect(modal.getByTestId('welcome-email-preview-loading')).not.toBeVisible();
-
-            const previewLayout = await getWelcomeEmailModalLayoutMetrics(page, 'preview');
-            expect(Math.abs(previewLayout.bodyTop - editLayout.bodyTop)).toBeLessThan(1);
-            expect(previewLayout.subjectHeight).toBe(editLayout.subjectHeight);
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await previewSubject.fill('Unsaved welcome email subject');
 
             await modal.getByTestId('welcome-email-mode-edit').click();
-
-            await expect(subjectInput).toHaveValue('Unsaved welcome email subject');
             await expect(editor).toContainText('Draft note');
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await expect.poll(() => previewRequests.at(-1)?.subject).toBe('Unsaved welcome email subject');
+            await expect(previewSubject).toBeVisible();
         });
 
         test('Preview refetches when re-entering Preview mode', async ({page}) => {
@@ -370,7 +363,7 @@ test.describe('Member emails settings', async () => {
                     }]
                 };
 
-                if (previewIndex === 1) {
+                if (previewIndex === 2) {
                     await firstPreviewReleased;
                 }
 
@@ -390,25 +383,27 @@ test.describe('Member emails settings', async () => {
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
 
-            const subjectInput = modal.locator('input').first();
-            await subjectInput.fill('First unsaved subject');
             await modal.getByTestId('welcome-email-mode-preview').click();
-            await expect(modal.getByTestId('welcome-email-preview-loading')).toBeVisible();
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await expect(previewSubject).toBeVisible();
+            await previewSubject.fill('First unsaved subject');
 
             await modal.getByTestId('welcome-email-mode-edit').click();
-            await subjectInput.fill('Second unsaved subject');
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await previewSubject.fill('Second unsaved subject');
+            await modal.getByTestId('welcome-email-mode-edit').click();
             await modal.getByTestId('welcome-email-mode-preview').click();
 
-            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
-            await expect(previewSubject).toHaveValue('Preview Subject 2');
+            await expect(previewSubject).toHaveValue('Preview Subject 3');
 
             releaseFirstPreview();
 
             await expect.poll(() => previewRequests.map(request => request.subject)).toEqual([
+                automatedEmailsFixture.automated_emails[0].subject,
                 'First unsaved subject',
                 'Second unsaved subject'
             ]);
-            await expect(previewSubject).toHaveValue('Preview Subject 2');
+            await expect(previewSubject).toHaveValue('Preview Subject 3');
         });
 
         test('Invalid draft shows preview inline error state', async ({page}) => {
@@ -434,14 +429,17 @@ test.describe('Member emails settings', async () => {
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
 
-            const subjectInput = modal.locator('input').first();
-            await subjectInput.fill('   ');
-
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await expect(previewSubject).toBeVisible();
+            const initialPreviewRequest = lastApiRequests.previewWelcomeEmail?.body;
+            await previewSubject.fill('   ');
+            await modal.getByTestId('welcome-email-mode-edit').click();
             await modal.getByTestId('welcome-email-mode-preview').click();
 
             await expect(modal.getByTestId('welcome-email-preview-error')).toBeVisible();
             await expect(modal.getByTestId('welcome-email-preview-error')).toContainText('A subject is required');
-            expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
+            expect(lastApiRequests.previewWelcomeEmail?.body).toEqual(initialPreviewRequest);
         });
 
         test('Escape key closes test email dropdown without closing modal', async ({page}) => {
@@ -466,6 +464,8 @@ test.describe('Member emails settings', async () => {
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
 
             // Click the Test button to open the dropdown
             await modal.getByRole('button', {name: 'Test'}).click();
@@ -545,16 +545,14 @@ test.describe('Member emails settings', async () => {
             await section.getByTestId('free-welcome-email-preview').click();
             await expect(modal).toBeVisible();
 
-            // Edit subject to mark dirty
-            const subjectInput = modal.locator('input').first();
-            await expect(subjectInput).toHaveValue('Welcome to Test Site');
-            await subjectInput.fill('Updated subject');
-            await expect(subjectInput).toHaveValue('Updated subject');
+            // Edit lexical content to mark dirty
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+            await editor.click({timeout: 5000});
+            await page.keyboard.type(' Updated');
+            await expect(editor).toContainText('Updated');
 
             // Close with unsaved changes - should show confirmation modal
-            // First Escape blurs the input, second triggers modal close
-            await page.keyboard.press('Escape');
-            await page.keyboard.press('Escape');
+            await modal.getByRole('button', {name: 'Close'}).click();
             const confirmationModal = page.getByTestId('confirmation-modal');
             await expect(confirmationModal).toBeVisible();
             await confirmationModal.getByRole('button', {name: 'Stay'}).click();
@@ -879,6 +877,7 @@ test.describe('Member emails settings', async () => {
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
+            await modal.getByTestId('welcome-email-mode-preview').click();
             await expect(modal).toContainText('Automated Sender');
             await expect(modal).toContainText('automated@example.com');
             await expect(modal).toContainText('reply-automated@example.com');
@@ -921,6 +920,7 @@ test.describe('Member emails settings', async () => {
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
+            await modal.getByTestId('welcome-email-mode-preview').click();
             await expect(modal).toContainText('Newsletter Sender');
             await expect(modal).toContainText('newsletter@example.com');
             await expect(modal).toContainText('support@example.com');

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -120,23 +120,6 @@ const pasteText = async (page: Page, content: string) => {
     }, content);
 };
 
-const getWelcomeEmailModalLayoutMetrics = async (page: Page, mode: 'edit' | 'preview') => {
-    return await page.getByTestId('welcome-email-modal').evaluate((node, currentMode) => {
-        const subject = currentMode === 'preview'
-            ? node.querySelector('[data-testid="welcome-email-preview-subject"]')
-            : node.querySelector('input');
-        const content = currentMode === 'preview'
-            ? node.querySelector('[data-testid="welcome-email-preview"]')
-            : node.querySelector('[data-testid="welcome-email-editor"]');
-        const body = content?.parentElement;
-
-        return {
-            bodyTop: body?.getBoundingClientRect().top ?? 0,
-            subjectHeight: subject?.getBoundingClientRect().height ?? 0
-        };
-    }, mode);
-};
-
 test.describe('Member emails settings', async () => {
     test.describe('Welcome email modal', async () => {
         test('Edit and Preview controls render; preview request only happens on Preview switch', async ({page}) => {
@@ -164,18 +147,21 @@ test.describe('Member emails settings', async () => {
 
             await expect(modal.getByTestId('welcome-email-mode-edit')).toBeVisible();
             await expect(modal.getByTestId('welcome-email-mode-preview')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-subject')).not.toBeVisible();
 
-            const subjectInput = modal.locator('input').first();
-            await subjectInput.fill('Unsaved subject for preview');
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+            await editor.click({timeout: 5000});
+            await page.keyboard.type(' Draft note');
 
             expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
 
             await modal.getByTestId('welcome-email-mode-preview').click();
 
-            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {subject?: string} | undefined)?.subject).toBe('Unsaved subject for preview');
-            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Welcome');
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {subject?: string} | undefined)?.subject).toBeTruthy();
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Draft note');
             const previewIframe = modal.getByTestId('welcome-email-preview-iframe');
             await expect(previewIframe).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-subject')).toBeVisible();
             await expect(previewIframe).toHaveAttribute('sandbox', 'allow-same-origin allow-popups allow-popups-to-escape-sandbox');
 
             await expect.poll(async () => {
@@ -194,17 +180,30 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Preview/Edit toggle preserves unsaved draft subject and lexical', async ({page}) => {
-            const {lastApiRequests} = await mockApi({page, requests: {
+            await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
                 browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
-                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
-                previewWelcomeEmail: {
-                    method: 'POST',
-                    path: '/automated_emails/free-welcome-email-id/preview/',
-                    response: automatedEmailPreviewFixture
-                }
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
             }});
+
+            const previewRequests: Array<{subject?: string; lexical?: string}> = [];
+
+            await page.route(/\/ghost\/api\/admin\/automated_emails\/free-welcome-email-id\/preview\/$/, async (route) => {
+                const body = JSON.parse(route.request().postData() || '{}') as {subject?: string; lexical?: string};
+                previewRequests.push(body);
+
+                await route.fulfill({
+                    status: 200,
+                    body: JSON.stringify({
+                        automated_emails: [{
+                            html: '<!doctype html><html><body><p>Preview</p></body></html>',
+                            plaintext: 'Preview',
+                            subject: body.subject || 'Preview Subject'
+                        }]
+                    })
+                });
+            });
 
             await page.goto('/#/memberemails');
             await page.waitForLoadState('networkidle');
@@ -216,28 +215,22 @@ test.describe('Member emails settings', async () => {
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
 
-            const subjectInput = modal.locator('input').first();
-            await subjectInput.fill('Unsaved welcome email subject');
-
             const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
             await editor.click({timeout: 5000});
             await page.keyboard.type(' Draft note');
 
-            const editLayout = await getWelcomeEmailModalLayoutMetrics(page, 'edit');
-
             await modal.getByTestId('welcome-email-mode-preview').click();
-            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Draft note');
             await expect(modal.getByTestId('welcome-email-preview-iframe')).toBeVisible();
             await expect(modal.getByTestId('welcome-email-preview-loading')).not.toBeVisible();
-
-            const previewLayout = await getWelcomeEmailModalLayoutMetrics(page, 'preview');
-            expect(Math.abs(previewLayout.bodyTop - editLayout.bodyTop)).toBeLessThan(1);
-            expect(previewLayout.subjectHeight).toBe(editLayout.subjectHeight);
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await previewSubject.fill('Unsaved welcome email subject');
 
             await modal.getByTestId('welcome-email-mode-edit').click();
-
-            await expect(subjectInput).toHaveValue('Unsaved welcome email subject');
             await expect(editor).toContainText('Draft note');
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await expect.poll(() => previewRequests.at(-1)?.subject).toBe('Unsaved welcome email subject');
+            await expect(previewSubject).toBeVisible();
         });
 
         test('Preview refetches when re-entering Preview mode', async ({page}) => {
@@ -359,7 +352,7 @@ test.describe('Member emails settings', async () => {
                     }]
                 };
 
-                if (previewIndex === 1) {
+                if (previewIndex === 2) {
                     await firstPreviewReleased;
                 }
 
@@ -379,25 +372,27 @@ test.describe('Member emails settings', async () => {
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
 
-            const subjectInput = modal.locator('input').first();
-            await subjectInput.fill('First unsaved subject');
             await modal.getByTestId('welcome-email-mode-preview').click();
-            await expect(modal.getByTestId('welcome-email-preview-loading')).toBeVisible();
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await expect(previewSubject).toBeVisible();
+            await previewSubject.fill('First unsaved subject');
 
             await modal.getByTestId('welcome-email-mode-edit').click();
-            await subjectInput.fill('Second unsaved subject');
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await previewSubject.fill('Second unsaved subject');
+            await modal.getByTestId('welcome-email-mode-edit').click();
             await modal.getByTestId('welcome-email-mode-preview').click();
 
-            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
-            await expect(previewSubject).toHaveValue('Preview Subject 2');
+            await expect(previewSubject).toHaveValue('Preview Subject 3');
 
             releaseFirstPreview();
 
             await expect.poll(() => previewRequests.map(request => request.subject)).toEqual([
+                automatedEmailsFixture.automated_emails[0].subject,
                 'First unsaved subject',
                 'Second unsaved subject'
             ]);
-            await expect(previewSubject).toHaveValue('Preview Subject 2');
+            await expect(previewSubject).toHaveValue('Preview Subject 3');
         });
 
         test('Invalid draft shows preview inline error state', async ({page}) => {
@@ -423,14 +418,17 @@ test.describe('Member emails settings', async () => {
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
 
-            const subjectInput = modal.locator('input').first();
-            await subjectInput.fill('   ');
-
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await expect(previewSubject).toBeVisible();
+            const initialPreviewRequest = lastApiRequests.previewWelcomeEmail?.body;
+            await previewSubject.fill('   ');
+            await modal.getByTestId('welcome-email-mode-edit').click();
             await modal.getByTestId('welcome-email-mode-preview').click();
 
             await expect(modal.getByTestId('welcome-email-preview-error')).toBeVisible();
             await expect(modal.getByTestId('welcome-email-preview-error')).toContainText('A subject is required');
-            expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
+            expect(lastApiRequests.previewWelcomeEmail?.body).toEqual(initialPreviewRequest);
         });
 
         test('Escape key closes test email dropdown without closing modal', async ({page}) => {
@@ -455,6 +453,8 @@ test.describe('Member emails settings', async () => {
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
 
             // Click the Test button to open the dropdown
             await modal.getByRole('button', {name: 'Test'}).click();
@@ -534,16 +534,14 @@ test.describe('Member emails settings', async () => {
             await section.getByTestId('free-welcome-email-preview').click();
             await expect(modal).toBeVisible();
 
-            // Edit subject to mark dirty
-            const subjectInput = modal.locator('input').first();
-            await expect(subjectInput).toHaveValue('Welcome to Test Site');
-            await subjectInput.fill('Updated subject');
-            await expect(subjectInput).toHaveValue('Updated subject');
+            // Edit lexical content to mark dirty
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+            await editor.click({timeout: 5000});
+            await page.keyboard.type(' Updated');
+            await expect(editor).toContainText('Updated');
 
             // Close with unsaved changes - should show confirmation modal
-            // First Escape blurs the input, second triggers modal close
-            await page.keyboard.press('Escape');
-            await page.keyboard.press('Escape');
+            await modal.getByRole('button', {name: 'Close'}).click();
             const confirmationModal = page.getByTestId('confirmation-modal');
             await expect(confirmationModal).toBeVisible();
             await confirmationModal.getByRole('button', {name: 'Stay'}).click();
@@ -868,6 +866,7 @@ test.describe('Member emails settings', async () => {
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
+            await modal.getByTestId('welcome-email-mode-preview').click();
             await expect(modal).toContainText('Automated Sender');
             await expect(modal).toContainText('automated@example.com');
             await expect(modal).toContainText('reply-automated@example.com');
@@ -910,6 +909,7 @@ test.describe('Member emails settings', async () => {
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
+            await modal.getByTestId('welcome-email-mode-preview').click();
             await expect(modal).toContainText('Newsletter Sender');
             await expect(modal).toContainText('newsletter@example.com');
             await expect(modal).toContainText('support@example.com');

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -30,6 +30,13 @@ const automatedEmailsFixture = {
     }]
 };
 
+const automatedEmailsWithTemplateSubjectFixture = {
+    automated_emails: [{
+        ...automatedEmailsFixture.automated_emails[0],
+        subject: 'Welcome {first_name}'
+    }]
+};
+
 const newslettersRequest = {
     browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: responseFixtures.newsletters}
 };
@@ -233,6 +240,58 @@ test.describe('Member emails settings', async () => {
             await expect(previewSubject).toBeVisible();
         });
 
+        test('Preview keeps the raw template subject editable and saves it without rendering replacements into the draft', async ({page}) => {
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsWithTemplateSubjectFixture},
+                editAutomatedEmail: {
+                    method: 'PUT',
+                    path: '/automated_emails/free-welcome-email-id/',
+                    response: automatedEmailsWithTemplateSubjectFixture
+                }
+            }});
+
+            await page.route(/\/ghost\/api\/admin\/automated_emails\/free-welcome-email-id\/preview\/$/, async (route) => {
+                await route.fulfill({
+                    status: 200,
+                    body: JSON.stringify({
+                        automated_emails: [{
+                            html: '<!doctype html><html><body><p>Preview</p></body></html>',
+                            plaintext: 'Preview',
+                            subject: 'Welcome Jamie'
+                        }]
+                    })
+                });
+            });
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await expect(previewSubject).toHaveValue('Welcome {first_name}');
+
+            await previewSubject.press('End');
+            await previewSubject.type('!');
+            await modal.getByRole('button', {name: 'Save'}).click();
+
+            await expect.poll(() => lastApiRequests.editAutomatedEmail?.body).toMatchObject({
+                automated_emails: [{
+                    subject: 'Welcome {first_name}!'
+                }]
+            });
+        });
+
         test('Preview refetches when re-entering Preview mode', async ({page}) => {
             await mockApi({page, requests: {
                 ...globalDataRequests,
@@ -383,7 +442,7 @@ test.describe('Member emails settings', async () => {
             await modal.getByTestId('welcome-email-mode-edit').click();
             await modal.getByTestId('welcome-email-mode-preview').click();
 
-            await expect(previewSubject).toHaveValue('Preview Subject 3');
+            await expect(previewSubject).toHaveValue('Second unsaved subject');
 
             releaseFirstPreview();
 
@@ -392,7 +451,7 @@ test.describe('Member emails settings', async () => {
                 'First unsaved subject',
                 'Second unsaved subject'
             ]);
-            await expect(previewSubject).toHaveValue('Preview Subject 3');
+            await expect(previewSubject).toHaveValue('Second unsaved subject');
         });
 
         test('Invalid draft shows preview inline error state', async ({page}) => {

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -89,6 +89,22 @@ const settingsWithPublicationIcon = updatedSettingsResponse([
     {key: 'icon', value: 'https://example.com/content/images/icon.png'}
 ]);
 
+const automatedEmailPreviewFixture = {
+    automated_emails: [{
+        html: '<!doctype html><html><body><h1>Preview content</h1><p>Welcome preview body.</p><a href="https://example.com/preferences">Manage preferences</a></body></html>',
+        plaintext: 'Preview content\nWelcome preview body.',
+        subject: 'Preview Subject'
+    }]
+};
+
+const longAutomatedEmailPreviewFixture = {
+    automated_emails: [{
+        html: `<!doctype html><html><body>${'<p>Long preview paragraph.</p>'.repeat(80)}</body></html>`,
+        plaintext: 'Long preview paragraph.',
+        subject: 'Long Preview Subject'
+    }]
+};
+
 const pasteText = async (page: Page, content: string) => {
     await page.evaluate((text: string) => {
         const dataTransfer = new DataTransfer();
@@ -104,8 +120,319 @@ const pasteText = async (page: Page, content: string) => {
     }, content);
 };
 
+const getWelcomeEmailModalLayoutMetrics = async (page: Page, mode: 'edit' | 'preview') => {
+    return await page.getByTestId('welcome-email-modal').evaluate((node, currentMode) => {
+        const subject = currentMode === 'preview'
+            ? node.querySelector('[data-testid="welcome-email-preview-subject"]')
+            : node.querySelector('input');
+        const content = currentMode === 'preview'
+            ? node.querySelector('[data-testid="welcome-email-preview"]')
+            : node.querySelector('[data-testid="welcome-email-editor"]');
+        const body = content?.parentElement;
+
+        return {
+            bodyTop: body?.getBoundingClientRect().top ?? 0,
+            subjectHeight: subject?.getBoundingClientRect().height ?? 0
+        };
+    }, mode);
+};
+
 test.describe('Member emails settings', async () => {
     test.describe('Welcome email modal', async () => {
+        test('Edit and Preview controls render; preview request only happens on Preview switch', async ({page}) => {
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                previewWelcomeEmail: {
+                    method: 'POST',
+                    path: '/automated_emails/free-welcome-email-id/preview/',
+                    response: automatedEmailPreviewFixture
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            await expect(modal.getByTestId('welcome-email-mode-edit')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-mode-preview')).toBeVisible();
+
+            const subjectInput = modal.locator('input').first();
+            await subjectInput.fill('Unsaved subject for preview');
+
+            expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {subject?: string} | undefined)?.subject).toBe('Unsaved subject for preview');
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Welcome');
+            const previewIframe = modal.getByTestId('welcome-email-preview-iframe');
+            await expect(previewIframe).toBeVisible();
+            await expect(previewIframe).toHaveAttribute('sandbox', 'allow-same-origin allow-popups allow-popups-to-escape-sandbox');
+
+            await expect.poll(async () => {
+                return await previewIframe.evaluate((node: HTMLIFrameElement) => {
+                    const link = node.contentDocument?.querySelector('a[href]');
+
+                    return {
+                        rel: link?.getAttribute('rel'),
+                        target: link?.getAttribute('target')
+                    };
+                });
+            }).toEqual({
+                rel: 'noopener noreferrer',
+                target: '_blank'
+            });
+        });
+
+        test('Preview/Edit toggle preserves unsaved draft subject and lexical', async ({page}) => {
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                previewWelcomeEmail: {
+                    method: 'POST',
+                    path: '/automated_emails/free-welcome-email-id/preview/',
+                    response: automatedEmailPreviewFixture
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const subjectInput = modal.locator('input').first();
+            await subjectInput.fill('Unsaved welcome email subject');
+
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+            await editor.click({timeout: 5000});
+            await page.keyboard.type(' Draft note');
+
+            const editLayout = await getWelcomeEmailModalLayoutMetrics(page, 'edit');
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Draft note');
+            await expect(modal.getByTestId('welcome-email-preview-iframe')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-loading')).not.toBeVisible();
+
+            const previewLayout = await getWelcomeEmailModalLayoutMetrics(page, 'preview');
+            expect(Math.abs(previewLayout.bodyTop - editLayout.bodyTop)).toBeLessThan(1);
+            expect(previewLayout.subjectHeight).toBe(editLayout.subjectHeight);
+
+            await modal.getByTestId('welcome-email-mode-edit').click();
+
+            await expect(subjectInput).toHaveValue('Unsaved welcome email subject');
+            await expect(editor).toContainText('Draft note');
+        });
+
+        test('Preview refetches when re-entering Preview mode', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            const previewRequests: Array<{subject?: string; lexical?: string}> = [];
+
+            await page.route(/\/ghost\/api\/admin\/automated_emails\/free-welcome-email-id\/preview\/$/, async (route) => {
+                const body = JSON.parse(route.request().postData() || '{}') as {subject?: string; lexical?: string};
+                previewRequests.push(body);
+
+                await route.fulfill({
+                    status: 200,
+                    body: JSON.stringify({
+                        automated_emails: [{
+                            html: '<!doctype html><html><body><p>Preview</p></body></html>',
+                            plaintext: 'Preview',
+                            subject: body.subject || 'Preview'
+                        }]
+                    })
+                });
+            });
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await expect(modal.getByTestId('welcome-email-preview-iframe')).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-edit').click();
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect.poll(() => previewRequests.length).toBe(2);
+        });
+
+        test('Preview iframe expands to document height so the modal body owns scrolling', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                previewWelcomeEmail: {
+                    method: 'POST',
+                    path: '/automated_emails/free-welcome-email-id/preview/',
+                    response: longAutomatedEmailPreviewFixture
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect(modal.getByTestId('welcome-email-preview-loading')).toBeVisible();
+
+            const previewIframe = modal.getByTestId('welcome-email-preview-iframe');
+            await expect(previewIframe).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-loading')).not.toBeVisible();
+
+            await expect.poll(async () => {
+                const {documentHeight, iframeHeight} = await previewIframe.evaluate((node: HTMLIFrameElement) => {
+                    const nextIframeHeight = node.clientHeight;
+                    const doc = node.contentDocument;
+                    const nextDocumentHeight = Math.max(
+                        doc?.documentElement?.scrollHeight || 0,
+                        doc?.body?.scrollHeight || 0
+                    );
+
+                    return {documentHeight: nextDocumentHeight, iframeHeight: nextIframeHeight};
+                });
+
+                return iframeHeight === documentHeight && documentHeight > 600;
+            }).toBe(true);
+        });
+
+        test('Preview ignores out-of-order responses and keeps the latest draft visible', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            const previewRequests: Array<{subject?: string; lexical?: string}> = [];
+            let releaseFirstPreview!: () => void;
+            const firstPreviewReleased = new Promise<void>((resolve) => {
+                releaseFirstPreview = resolve;
+            });
+
+            await page.route(/\/ghost\/api\/admin\/automated_emails\/free-welcome-email-id\/preview\/$/, async (route) => {
+                const body = JSON.parse(route.request().postData() || '{}') as {subject?: string; lexical?: string};
+                previewRequests.push(body);
+
+                const previewIndex = previewRequests.length;
+                const previewResponse = {
+                    automated_emails: [{
+                        html: `<!doctype html><html><body><h1>Preview ${previewIndex}</h1></body></html>`,
+                        plaintext: `Preview ${previewIndex}`,
+                        subject: `Preview Subject ${previewIndex}`
+                    }]
+                };
+
+                if (previewIndex === 1) {
+                    await firstPreviewReleased;
+                }
+
+                await route.fulfill({
+                    status: 200,
+                    body: JSON.stringify(previewResponse)
+                });
+            });
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const subjectInput = modal.locator('input').first();
+            await subjectInput.fill('First unsaved subject');
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await expect(modal.getByTestId('welcome-email-preview-loading')).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-edit').click();
+            await subjectInput.fill('Second unsaved subject');
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await expect(previewSubject).toHaveValue('Preview Subject 2');
+
+            releaseFirstPreview();
+
+            await expect.poll(() => previewRequests.map(request => request.subject)).toEqual([
+                'First unsaved subject',
+                'Second unsaved subject'
+            ]);
+            await expect(previewSubject).toHaveValue('Preview Subject 2');
+        });
+
+        test('Invalid draft shows preview inline error state', async ({page}) => {
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                previewWelcomeEmail: {
+                    method: 'POST',
+                    path: '/automated_emails/free-welcome-email-id/preview/',
+                    response: automatedEmailPreviewFixture
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const subjectInput = modal.locator('input').first();
+            await subjectInput.fill('   ');
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect(modal.getByTestId('welcome-email-preview-error')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-error')).toContainText('A subject is required');
+            expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
+        });
+
         test('Escape key closes test email dropdown without closing modal', async ({page}) => {
             await mockApi({page, requests: {
                 ...globalDataRequests,

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -100,6 +100,22 @@ const settingsWithPublicationIcon = updatedSettingsResponse([
     {key: 'icon', value: 'https://example.com/content/images/icon.png'}
 ]);
 
+const automatedEmailPreviewFixture = {
+    automated_emails: [{
+        html: '<!doctype html><html><body><h1>Preview content</h1><p>Welcome preview body.</p><a href="https://example.com/preferences">Manage preferences</a></body></html>',
+        plaintext: 'Preview content\nWelcome preview body.',
+        subject: 'Preview Subject'
+    }]
+};
+
+const longAutomatedEmailPreviewFixture = {
+    automated_emails: [{
+        html: `<!doctype html><html><body>${'<p>Long preview paragraph.</p>'.repeat(80)}</body></html>`,
+        plaintext: 'Long preview paragraph.',
+        subject: 'Long Preview Subject'
+    }]
+};
+
 const pasteText = async (page: Page, content: string) => {
     await page.evaluate((text: string) => {
         const dataTransfer = new DataTransfer();
@@ -115,8 +131,319 @@ const pasteText = async (page: Page, content: string) => {
     }, content);
 };
 
+const getWelcomeEmailModalLayoutMetrics = async (page: Page, mode: 'edit' | 'preview') => {
+    return await page.getByTestId('welcome-email-modal').evaluate((node, currentMode) => {
+        const subject = currentMode === 'preview'
+            ? node.querySelector('[data-testid="welcome-email-preview-subject"]')
+            : node.querySelector('input');
+        const content = currentMode === 'preview'
+            ? node.querySelector('[data-testid="welcome-email-preview"]')
+            : node.querySelector('[data-testid="welcome-email-editor"]');
+        const body = content?.parentElement;
+
+        return {
+            bodyTop: body?.getBoundingClientRect().top ?? 0,
+            subjectHeight: subject?.getBoundingClientRect().height ?? 0
+        };
+    }, mode);
+};
+
 test.describe('Member emails settings', async () => {
     test.describe('Welcome email modal', async () => {
+        test('Edit and Preview controls render; preview request only happens on Preview switch', async ({page}) => {
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                previewWelcomeEmail: {
+                    method: 'POST',
+                    path: '/automated_emails/free-welcome-email-id/preview/',
+                    response: automatedEmailPreviewFixture
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            await expect(modal.getByTestId('welcome-email-mode-edit')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-mode-preview')).toBeVisible();
+
+            const subjectInput = modal.locator('input').first();
+            await subjectInput.fill('Unsaved subject for preview');
+
+            expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {subject?: string} | undefined)?.subject).toBe('Unsaved subject for preview');
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Welcome');
+            const previewIframe = modal.getByTestId('welcome-email-preview-iframe');
+            await expect(previewIframe).toBeVisible();
+            await expect(previewIframe).toHaveAttribute('sandbox', 'allow-same-origin allow-popups allow-popups-to-escape-sandbox');
+
+            await expect.poll(async () => {
+                return await previewIframe.evaluate((node: HTMLIFrameElement) => {
+                    const link = node.contentDocument?.querySelector('a[href]');
+
+                    return {
+                        rel: link?.getAttribute('rel'),
+                        target: link?.getAttribute('target')
+                    };
+                });
+            }).toEqual({
+                rel: 'noopener noreferrer',
+                target: '_blank'
+            });
+        });
+
+        test('Preview/Edit toggle preserves unsaved draft subject and lexical', async ({page}) => {
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                previewWelcomeEmail: {
+                    method: 'POST',
+                    path: '/automated_emails/free-welcome-email-id/preview/',
+                    response: automatedEmailPreviewFixture
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const subjectInput = modal.locator('input').first();
+            await subjectInput.fill('Unsaved welcome email subject');
+
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+            await editor.click({timeout: 5000});
+            await page.keyboard.type(' Draft note');
+
+            const editLayout = await getWelcomeEmailModalLayoutMetrics(page, 'edit');
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await expect.poll(() => (lastApiRequests.previewWelcomeEmail?.body as {lexical?: string} | undefined)?.lexical || '').toContain('Draft note');
+            await expect(modal.getByTestId('welcome-email-preview-iframe')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-loading')).not.toBeVisible();
+
+            const previewLayout = await getWelcomeEmailModalLayoutMetrics(page, 'preview');
+            expect(Math.abs(previewLayout.bodyTop - editLayout.bodyTop)).toBeLessThan(1);
+            expect(previewLayout.subjectHeight).toBe(editLayout.subjectHeight);
+
+            await modal.getByTestId('welcome-email-mode-edit').click();
+
+            await expect(subjectInput).toHaveValue('Unsaved welcome email subject');
+            await expect(editor).toContainText('Draft note');
+        });
+
+        test('Preview refetches when re-entering Preview mode', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            const previewRequests: Array<{subject?: string; lexical?: string}> = [];
+
+            await page.route(/\/ghost\/api\/admin\/automated_emails\/free-welcome-email-id\/preview\/$/, async (route) => {
+                const body = JSON.parse(route.request().postData() || '{}') as {subject?: string; lexical?: string};
+                previewRequests.push(body);
+
+                await route.fulfill({
+                    status: 200,
+                    body: JSON.stringify({
+                        automated_emails: [{
+                            html: '<!doctype html><html><body><p>Preview</p></body></html>',
+                            plaintext: 'Preview',
+                            subject: body.subject || 'Preview'
+                        }]
+                    })
+                });
+            });
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await expect(modal.getByTestId('welcome-email-preview-iframe')).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-edit').click();
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect.poll(() => previewRequests.length).toBe(2);
+        });
+
+        test('Preview iframe expands to document height so the modal body owns scrolling', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                previewWelcomeEmail: {
+                    method: 'POST',
+                    path: '/automated_emails/free-welcome-email-id/preview/',
+                    response: longAutomatedEmailPreviewFixture
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect(modal.getByTestId('welcome-email-preview-loading')).toBeVisible();
+
+            const previewIframe = modal.getByTestId('welcome-email-preview-iframe');
+            await expect(previewIframe).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-loading')).not.toBeVisible();
+
+            await expect.poll(async () => {
+                const {documentHeight, iframeHeight} = await previewIframe.evaluate((node: HTMLIFrameElement) => {
+                    const nextIframeHeight = node.clientHeight;
+                    const doc = node.contentDocument;
+                    const nextDocumentHeight = Math.max(
+                        doc?.documentElement?.scrollHeight || 0,
+                        doc?.body?.scrollHeight || 0
+                    );
+
+                    return {documentHeight: nextDocumentHeight, iframeHeight: nextIframeHeight};
+                });
+
+                return iframeHeight === documentHeight && documentHeight > 600;
+            }).toBe(true);
+        });
+
+        test('Preview ignores out-of-order responses and keeps the latest draft visible', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            const previewRequests: Array<{subject?: string; lexical?: string}> = [];
+            let releaseFirstPreview!: () => void;
+            const firstPreviewReleased = new Promise<void>((resolve) => {
+                releaseFirstPreview = resolve;
+            });
+
+            await page.route(/\/ghost\/api\/admin\/automated_emails\/free-welcome-email-id\/preview\/$/, async (route) => {
+                const body = JSON.parse(route.request().postData() || '{}') as {subject?: string; lexical?: string};
+                previewRequests.push(body);
+
+                const previewIndex = previewRequests.length;
+                const previewResponse = {
+                    automated_emails: [{
+                        html: `<!doctype html><html><body><h1>Preview ${previewIndex}</h1></body></html>`,
+                        plaintext: `Preview ${previewIndex}`,
+                        subject: `Preview Subject ${previewIndex}`
+                    }]
+                };
+
+                if (previewIndex === 1) {
+                    await firstPreviewReleased;
+                }
+
+                await route.fulfill({
+                    status: 200,
+                    body: JSON.stringify(previewResponse)
+                });
+            });
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const subjectInput = modal.locator('input').first();
+            await subjectInput.fill('First unsaved subject');
+            await modal.getByTestId('welcome-email-mode-preview').click();
+            await expect(modal.getByTestId('welcome-email-preview-loading')).toBeVisible();
+
+            await modal.getByTestId('welcome-email-mode-edit').click();
+            await subjectInput.fill('Second unsaved subject');
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
+            await expect(previewSubject).toHaveValue('Preview Subject 2');
+
+            releaseFirstPreview();
+
+            await expect.poll(() => previewRequests.map(request => request.subject)).toEqual([
+                'First unsaved subject',
+                'Second unsaved subject'
+            ]);
+            await expect(previewSubject).toHaveValue('Preview Subject 2');
+        });
+
+        test('Invalid draft shows preview inline error state', async ({page}) => {
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture},
+                previewWelcomeEmail: {
+                    method: 'POST',
+                    path: '/automated_emails/free-welcome-email-id/preview/',
+                    response: automatedEmailPreviewFixture
+                }
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const subjectInput = modal.locator('input').first();
+            await subjectInput.fill('   ');
+
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect(modal.getByTestId('welcome-email-preview-error')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-error')).toContainText('A subject is required');
+            expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
+        });
+
         test('Escape key closes test email dropdown without closing modal', async ({page}) => {
             await mockApi({page, requests: {
                 ...globalDataRequests,

--- a/apps/admin-x-settings/test/unit/hooks/use-welcome-email-preview.test.tsx
+++ b/apps/admin-x-settings/test/unit/hooks/use-welcome-email-preview.test.tsx
@@ -1,7 +1,7 @@
-import * as assert from 'assert/strict';
+import * as assert from 'node:assert/strict';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {act, renderHook, waitFor} from '@testing-library/react';
-import {useWelcomeEmailPreview} from '@src/hooks/use-welcome-email-preview';
+import {useWelcomeEmailPreview} from '@src/components/settings/membership/member-emails/use-welcome-email-preview';
 
 const validLexical = JSON.stringify({
     root: {

--- a/apps/admin-x-settings/test/unit/hooks/use-welcome-email-preview.test.tsx
+++ b/apps/admin-x-settings/test/unit/hooks/use-welcome-email-preview.test.tsx
@@ -1,0 +1,175 @@
+import * as assert from 'assert/strict';
+import {JSONError} from '@tryghost/admin-x-framework/errors';
+import {act, renderHook, waitFor} from '@testing-library/react';
+import {useWelcomeEmailPreview} from '@src/hooks/use-welcome-email-preview';
+
+const validLexical = JSON.stringify({
+    root: {
+        children: [{
+            type: 'paragraph',
+            children: [{
+                detail: 0,
+                format: 0,
+                mode: 'normal',
+                style: '',
+                text: 'Welcome!',
+                type: 'text',
+                version: 1
+            }],
+            direction: 'ltr',
+            format: '',
+            indent: 0,
+            version: 1
+        }],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        type: 'root',
+        version: 1
+    }
+});
+
+const createDeferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    let reject!: (error?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {promise, resolve, reject};
+};
+
+describe('useWelcomeEmailPreview', function () {
+    it('returns invalid state and skips network for invalid drafts', async function () {
+        const previewWelcomeEmail = vi.fn();
+        const setErrors = vi.fn();
+        const {result} = renderHook(() => useWelcomeEmailPreview({
+            automatedEmailId: 'welcome-email-id',
+            previewWelcomeEmail,
+            setErrors
+        }));
+
+        act(() => {
+            result.current.enterPreview({subject: '   ', lexical: ''});
+        });
+
+        assert.equal(previewWelcomeEmail.mock.calls.length, 0);
+        assert.equal(result.current.previewState.status, 'invalid');
+        assert.equal(result.current.previewState.message, 'A subject is required');
+        assert.deepEqual(setErrors.mock.calls[0][0], {
+            subject: 'A subject is required',
+            lexical: 'Email content is required'
+        });
+    });
+
+    it('keeps the latest preview response when requests resolve out of order', async function () {
+        const firstPreview = createDeferred<{automated_emails: [{html: string; plaintext: string; subject: string}]}>();
+        const secondPreview = createDeferred<{automated_emails: [{html: string; plaintext: string; subject: string}]}>();
+        const previewWelcomeEmail = vi
+            .fn()
+            .mockImplementationOnce(() => firstPreview.promise)
+            .mockImplementationOnce(() => secondPreview.promise);
+        const {result} = renderHook(() => useWelcomeEmailPreview({
+            automatedEmailId: 'welcome-email-id',
+            previewWelcomeEmail,
+            setErrors: vi.fn()
+        }));
+
+        act(() => {
+            result.current.enterPreview({subject: 'First', lexical: validLexical});
+            result.current.enterPreview({subject: 'Second', lexical: validLexical});
+        });
+
+        await act(async () => {
+            secondPreview.resolve({
+                automated_emails: [{
+                    html: '<!doctype html><html><body><p>Second</p></body></html>',
+                    plaintext: 'Second',
+                    subject: 'Second subject'
+                }]
+            });
+            await secondPreview.promise;
+        });
+
+        await waitFor(() => {
+            assert.equal(result.current.previewState.status, 'success');
+            assert.equal(result.current.previewState.preview.subject, 'Second subject');
+        });
+
+        await act(async () => {
+            firstPreview.resolve({
+                automated_emails: [{
+                    html: '<!doctype html><html><body><p>First</p></body></html>',
+                    plaintext: 'First',
+                    subject: 'First subject'
+                }]
+            });
+            await firstPreview.promise;
+        });
+
+        await waitFor(() => {
+            assert.equal(result.current.previewState.status, 'success');
+            assert.equal(result.current.previewState.preview.subject, 'Second subject');
+        });
+    });
+
+    it('maps API errors to error state messages', async function () {
+        const previewWelcomeEmail = vi.fn().mockRejectedValue(new JSONError(
+            new Response('{}', {status: 500, headers: {'content-type': 'application/json'}}),
+            {
+                errors: [{
+                    code: 'UNKNOWN',
+                    context: 'Preview failed on the server',
+                    details: null,
+                    ghostErrorCode: null,
+                    help: '',
+                    id: '1',
+                    message: 'Preview failed',
+                    property: null,
+                    type: 'InternalServerError'
+                }]
+            }
+        ));
+        const {result} = renderHook(() => useWelcomeEmailPreview({
+            automatedEmailId: 'welcome-email-id',
+            previewWelcomeEmail,
+            setErrors: vi.fn()
+        }));
+
+        act(() => {
+            result.current.enterPreview({subject: 'Welcome', lexical: validLexical});
+        });
+
+        await waitFor(() => {
+            assert.equal(result.current.previewState.status, 'error');
+            assert.equal(result.current.previewState.message, 'Preview failed on the server');
+        });
+    });
+
+    it('transforms preview HTML and returns success state', async function () {
+        const previewWelcomeEmail = vi.fn().mockResolvedValue({
+            automated_emails: [{
+                html: '<!doctype html><html><body><a href="https://example.com">Preferences</a></body></html>',
+                plaintext: 'Preferences',
+                subject: 'Preview subject'
+            }]
+        });
+        const {result} = renderHook(() => useWelcomeEmailPreview({
+            automatedEmailId: 'welcome-email-id',
+            previewWelcomeEmail,
+            setErrors: vi.fn()
+        }));
+
+        act(() => {
+            result.current.enterPreview({subject: 'Welcome', lexical: validLexical});
+        });
+
+        await waitFor(() => {
+            assert.equal(result.current.previewState.status, 'success');
+            assert.equal(result.current.previewState.preview.subject, 'Preview subject');
+            assert.match(result.current.previewState.preview.html, /target="_blank"/);
+            assert.match(result.current.previewState.preview.html, /rel="noopener noreferrer"/);
+        });
+    });
+});

--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -1,5 +1,5 @@
 import {BasePage} from '@/helpers/pages';
-import {Locator, Page} from '@playwright/test';
+import {FrameLocator, Locator, Page} from '@playwright/test';
 
 export class MemberWelcomeEmailsSection extends BasePage {
     readonly section: Locator;
@@ -41,6 +41,11 @@ export class MemberWelcomeEmailsSection extends BasePage {
     readonly modalSaveButton: Locator;
     readonly modalSavedButton: Locator;
     readonly modalLexicalEditor: Locator;
+    readonly modalEditTab: Locator;
+    readonly modalPreviewTab: Locator;
+    readonly modalPreviewSubjectInput: Locator;
+    readonly modalPreviewIframe: Locator;
+    readonly modalPreviewFrame: FrameLocator;
 
     constructor(page: Page) {
         super(page, '/ghost/#/settings/memberemails');
@@ -83,6 +88,11 @@ export class MemberWelcomeEmailsSection extends BasePage {
         this.modalSaveButton = this.welcomeEmailModal.getByRole('button', {name: 'Save'});
         this.modalSavedButton = this.welcomeEmailModal.getByRole('button', {name: 'Saved'});
         this.modalLexicalEditor = this.modalEditor.getByRole('textbox').first();
+        this.modalEditTab = this.welcomeEmailModal.getByTestId('welcome-email-mode-edit');
+        this.modalPreviewTab = this.welcomeEmailModal.getByTestId('welcome-email-mode-preview');
+        this.modalPreviewSubjectInput = this.welcomeEmailModal.getByTestId('welcome-email-preview-subject');
+        this.modalPreviewIframe = this.welcomeEmailModal.getByTestId('welcome-email-preview-iframe');
+        this.modalPreviewFrame = page.frameLocator('iframe[title="Welcome email preview"]');
     }
 
     async enableFreeWelcomeEmail(): Promise<void> {

--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -84,13 +84,13 @@ export class MemberWelcomeEmailsSection extends BasePage {
         // Modal locators
         this.welcomeEmailModal = page.getByTestId('welcome-email-modal');
         this.modalEditor = this.welcomeEmailModal.getByTestId('welcome-email-editor');
-        this.modalSubjectInput = this.welcomeEmailModal.locator('input').first();
-        this.modalSaveButton = this.welcomeEmailModal.getByRole('button', {name: 'Save'});
-        this.modalSavedButton = this.welcomeEmailModal.getByRole('button', {name: 'Saved'});
-        this.modalLexicalEditor = this.modalEditor.getByRole('textbox').first();
         this.modalEditTab = this.welcomeEmailModal.getByTestId('welcome-email-mode-edit');
         this.modalPreviewTab = this.welcomeEmailModal.getByTestId('welcome-email-mode-preview');
         this.modalPreviewSubjectInput = this.welcomeEmailModal.getByTestId('welcome-email-preview-subject');
+        this.modalSubjectInput = this.modalPreviewSubjectInput;
+        this.modalSaveButton = this.welcomeEmailModal.getByRole('button', {name: 'Save'});
+        this.modalSavedButton = this.welcomeEmailModal.getByRole('button', {name: 'Saved'});
+        this.modalLexicalEditor = this.modalEditor.getByRole('textbox').first();
         this.modalPreviewIframe = this.welcomeEmailModal.getByTestId('welcome-email-preview-iframe');
         this.modalPreviewFrame = page.frameLocator('iframe[title="Welcome email preview"]');
     }

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -9,12 +9,17 @@ import {faker} from '@faker-js/faker';
 import {signupViaPortal} from '@/helpers/playwright/flows/signup';
 
 interface AutomatedEmail {
+    id?: string;
+    name?: string;
     slug: string;
     status: string;
     subject?: string;
+    lexical?: string | null;
     sender_name?: string | null;
     sender_email?: string | null;
     sender_reply_to?: string | null;
+    created_at?: string;
+    updated_at?: string | null;
 }
 
 interface AutomatedEmailsResponse {
@@ -47,6 +52,8 @@ interface AutomatedEmailDesignResponse {
     automated_email_design: AutomatedEmailDesign[];
 }
 
+const DEFAULT_FREE_WELCOME_EMAIL_SUBJECT = 'Welcome to Test Blog';
+
 async function retrieveLatestEmailMessage(emailClient: EmailClient, emailAddress: string, timeoutMs: number = 10000) {
     const messages = await emailClient.searchByRecipient(emailAddress, {timeoutMs});
     return await emailClient.getMessageDetailed(messages[0]);
@@ -75,6 +82,30 @@ async function expectWelcomeEmailCount(emailClient: EmailClient, emailAddress: s
     }, {timeout: 5000}).toBe(expectedCount);
 }
 
+async function getFreeWelcomeEmail(page: Page): Promise<AutomatedEmail> {
+    const response = await page.request.get('/ghost/api/admin/automated_emails/');
+    expect(response.ok()).toBe(true);
+
+    const data = await response.json() as AutomatedEmailsResponse;
+    const freeWelcomeEmail = data.automated_emails.find(email => email.slug === 'member-welcome-email-free');
+
+    expect(freeWelcomeEmail).toBeDefined();
+
+    return freeWelcomeEmail!;
+}
+
+async function restoreWelcomeEmail(page: Page, automatedEmail: AutomatedEmail): Promise<void> {
+    expect(automatedEmail.id).toBeDefined();
+
+    const response = await page.request.put(`/ghost/api/admin/automated_emails/${automatedEmail.id}/`, {
+        data: {
+            automated_emails: [automatedEmail]
+        }
+    });
+
+    expect(response.ok()).toBe(true);
+}
+
 test.describe('Ghost Admin - Member Welcome Emails', () => {
     test('new sites do not send welcome emails by default', async ({page}) => {
         const emailClient = new MailPit();
@@ -101,13 +132,13 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
             await completeSignupViaMagicLink(emailClient, signupPage, emailAddress);
 
             const welcomeMessages = await emailClient.search(
-                {to: emailAddress, subject: 'Welcome to Test Blog'},
+                {to: emailAddress, subject: DEFAULT_FREE_WELCOME_EMAIL_SUBJECT},
                 {timeoutMs: 10000}
             );
             const welcomeEmail = await emailClient.getMessageDetailed(welcomeMessages[0]);
 
             expect(welcomeEmail.From.Name).toContain('Test Blog');
-            expect(welcomeEmail.Subject).toBe('Welcome to Test Blog');
+            expect(welcomeEmail.Subject).toBe(DEFAULT_FREE_WELCOME_EMAIL_SUBJECT);
             expect(welcomeEmail.Text).toContain('Thanks for subscribing');
             expect(welcomeEmail.HTML).toContain('Thanks for subscribing');
         });
@@ -168,6 +199,59 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         await expect(welcomeEmailsSection.modalPreviewSubjectInput).toHaveValue(customSubject);
         await expect(welcomeEmailsSection.modalPreviewIframe).toBeVisible();
         await expect(welcomeEmailsSection.modalPreviewFrame.locator('body')).toContainText(customBody);
+    });
+
+    test('free welcome email preview preserves subject tokens when edited and saved', async ({page, browser, baseURL}) => {
+        const emailClient = new MailPit();
+        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
+        const templatedSubject = 'Welcome {first_name}';
+        const templatedSubjectWithSuffix = `${templatedSubject}!`;
+
+        try {
+            await welcomeEmailsSection.goto();
+            await welcomeEmailsSection.enableFreeWelcomeEmail();
+            await welcomeEmailsSection.openFreeWelcomeEmailModal();
+
+            await welcomeEmailsSection.modalPreviewTab.click();
+            await expect(welcomeEmailsSection.modalSubjectInput).toBeVisible();
+            await welcomeEmailsSection.modalSubjectInput.clear();
+            await welcomeEmailsSection.modalSubjectInput.fill(templatedSubject);
+
+            await welcomeEmailsSection.modalEditTab.click();
+            await welcomeEmailsSection.modalPreviewTab.click();
+
+            await expect(welcomeEmailsSection.modalPreviewSubjectInput).toHaveValue(templatedSubject);
+
+            await welcomeEmailsSection.modalSubjectInput.press('End');
+            await welcomeEmailsSection.modalSubjectInput.type('!');
+            await welcomeEmailsSection.saveWelcomeEmail();
+
+            const freeWelcomeEmail = await getFreeWelcomeEmail(page);
+            expect(freeWelcomeEmail.subject).toBe(templatedSubjectWithSuffix);
+
+            await withIsolatedPage(browser, {baseURL}, async ({page: signupPage}) => {
+                const {emailAddress, name} = await signupViaPortal(signupPage);
+                await completeSignupViaMagicLink(emailClient, signupPage, emailAddress);
+
+                const firstName = name.trim().split(/\s+/)[0];
+                const personalizedSubject = `Welcome ${firstName}!`;
+
+                const welcomeMessages = await emailClient.search(
+                    {to: emailAddress, subject: personalizedSubject},
+                    {timeoutMs: 10000}
+                );
+                const welcomeEmail = await emailClient.getMessageDetailed(welcomeMessages[0]);
+
+                expect(welcomeEmail.Subject).toBe(personalizedSubject);
+                expect(welcomeEmail.Subject).not.toContain('{first_name}');
+            });
+        } finally {
+            const freeWelcomeEmail = await getFreeWelcomeEmail(page);
+            await restoreWelcomeEmail(page, {
+                ...freeWelcomeEmail,
+                subject: DEFAULT_FREE_WELCOME_EMAIL_SUBJECT
+            });
+        }
     });
 
     test('disabling free welcome email stops delivery', async ({page, browser, baseURL}) => {

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -176,7 +176,7 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         });
     });
 
-    test('free welcome email preview renders edited subject and body', async ({page}) => {
+    test('free welcome email preview - renders edited subject and body', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
         const customSubject = 'Preview subject from the browser test';
         const customBody = 'Preview body content rendered from an unsaved draft.';
@@ -198,10 +198,10 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         await welcomeEmailsSection.modalSubjectInput.fill(customSubject);
         await expect(welcomeEmailsSection.modalPreviewSubjectInput).toHaveValue(customSubject);
         await expect(welcomeEmailsSection.modalPreviewIframe).toBeVisible();
-        await expect(welcomeEmailsSection.modalPreviewFrame.locator('body')).toContainText(customBody);
+        await expect(welcomeEmailsSection.modalPreviewFrame.getByText(customBody)).toBeVisible();
     });
 
-    test('free welcome email preview preserves subject tokens when edited and saved', async ({page, browser, baseURL}) => {
+    test('free welcome email preview - preserves subject tokens when edited and saved', async ({page, browser, baseURL}) => {
         const emailClient = new MailPit();
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
         const templatedSubject = 'Welcome {first_name}';

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -120,10 +120,13 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         const customBody = 'This welcome body was edited through the admin UI.';
 
         await welcomeEmailsSection.goto();
+        await welcomeEmailsSection.enableFreeWelcomeEmail();
         await welcomeEmailsSection.openFreeWelcomeEmailModal();
+        await welcomeEmailsSection.replaceWelcomeEmailContent(customBody);
+        await welcomeEmailsSection.modalPreviewTab.click();
+        await expect(welcomeEmailsSection.modalSubjectInput).toBeVisible();
         await welcomeEmailsSection.modalSubjectInput.clear();
         await welcomeEmailsSection.modalSubjectInput.fill(customSubject);
-        await welcomeEmailsSection.replaceWelcomeEmailContent(customBody);
         await welcomeEmailsSection.saveWelcomeEmail();
 
         await withIsolatedPage(browser, {baseURL}, async ({page: signupPage}) => {
@@ -149,9 +152,6 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
 
         await welcomeEmailsSection.goto();
         await welcomeEmailsSection.openFreeWelcomeEmailModal();
-
-        await welcomeEmailsSection.modalSubjectInput.clear();
-        await welcomeEmailsSection.modalSubjectInput.fill(customSubject);
         await welcomeEmailsSection.replaceWelcomeEmailContent(customBody);
 
         const previewResponse = page.waitForResponse(
@@ -163,6 +163,8 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         await welcomeEmailsSection.modalPreviewTab.click();
         await previewResponse;
 
+        await welcomeEmailsSection.modalSubjectInput.clear();
+        await welcomeEmailsSection.modalSubjectInput.fill(customSubject);
         await expect(welcomeEmailsSection.modalPreviewSubjectInput).toHaveValue(customSubject);
         await expect(welcomeEmailsSection.modalPreviewIframe).toBeVisible();
         await expect(welcomeEmailsSection.modalPreviewFrame.locator('body')).toContainText(customBody);

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -142,6 +142,32 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         });
     });
 
+    test('free welcome email preview renders edited subject and body', async ({page}) => {
+        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
+        const customSubject = 'Preview subject from the browser test';
+        const customBody = 'Preview body content rendered from an unsaved draft.';
+
+        await welcomeEmailsSection.goto();
+        await welcomeEmailsSection.openFreeWelcomeEmailModal();
+
+        await welcomeEmailsSection.modalSubjectInput.clear();
+        await welcomeEmailsSection.modalSubjectInput.fill(customSubject);
+        await welcomeEmailsSection.replaceWelcomeEmailContent(customBody);
+
+        const previewResponse = page.waitForResponse(
+            response => response.url().includes('/ghost/api/admin/automated_emails/') &&
+                response.url().includes('/preview/') &&
+                response.request().method() === 'POST'
+        );
+
+        await welcomeEmailsSection.modalPreviewTab.click();
+        await previewResponse;
+
+        await expect(welcomeEmailsSection.modalPreviewSubjectInput).toHaveValue(customSubject);
+        await expect(welcomeEmailsSection.modalPreviewIframe).toBeVisible();
+        await expect(welcomeEmailsSection.modalPreviewFrame.locator('body')).toContainText(customBody);
+    });
+
     test('disabling free welcome email stops delivery', async ({page, browser, baseURL}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
         const emailClient = new MailPit();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1228/add-the-frontend-editpreview-toggle-to-the-welcome-email-edit-modal

## What this changes

- adds an `Edit` / `Preview` toggle to the welcome email modal in Admin
- lets admins preview unsaved subject and body changes before saving
- loads the preview from the automated email preview endpoint and renders it in an iframe sized to the email content
- preserves unsaved draft state when switching between edit and preview
- shows inline validation and preview loading/error states in the modal
- ignores stale out-of-order preview responses so older requests cannot overwrite a newer draft

## Why

The welcome email editor previously only exposed the raw editing experience, which made it harder to verify the final email output before saving. This change adds an in-context preview flow so admins can check both copy and rendered layout while keeping their draft intact.

## Implementation notes

- adds a dedicated `usePreviewWelcomeEmail` mutation and preview response types in `admin-x-framework`
- updates the modal header layout to host the segmented mode switch
- normalizes preview HTML links to open safely in a new tab
- measures iframe height so the modal owns scrolling instead of the preview document
- extends acceptance and browser E2E coverage for preview rendering and draft preservation