### PR TITLE
Add llms.txt exports and AI crawler toggle

### DIFF
--- a/apps/admin-x-framework/src/test/msw-utils.ts
+++ b/apps/admin-x-framework/src/test/msw-utils.ts
@@ -29,7 +29,10 @@ export const fixtures = {
         codeinjection_head: null,
         codeinjection_foot: null,
         navigation: [],
-        secondary_navigation: []
+        secondary_navigation: [],
+        llms_enabled: true,
+        meta_title: null,
+        meta_description: null
     },
 
     site: {

--- a/apps/admin-x-framework/src/test/responses/settings.json
+++ b/apps/admin-x-framework/src/test/responses/settings.json
@@ -65,6 +65,10 @@
             "value": null
         },
         {
+            "key": "llms_enabled",
+            "value": true
+        },
+        {
             "key": "og_image",
             "value": null
         },

--- a/apps/admin-x-settings/src/components/settings/general/general-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/general-settings.tsx
@@ -15,7 +15,7 @@ export const searchKeywords = {
     timeZone: ['general', 'time', 'date', 'site timezone', 'time zone'],
     publicationLanguage: ['general', 'publication language', 'locale'],
     users: ['general', 'users and permissions', 'roles', 'staff', 'invite people', 'contributors', 'editors', 'authors', 'administrators'],
-    metadata: ['general', 'metadata', 'title', 'description', 'search', 'engine', 'google', 'meta data', 'twitter card', 'structured data', 'rich cards', 'x card', 'social', 'facebook card'],
+    metadata: ['general', 'metadata', 'title', 'description', 'search', 'engine', 'google', 'meta data', 'twitter card', 'structured data', 'rich cards', 'x card', 'social', 'facebook card', 'llms', 'ai', 'ai search engines', 'llm'],
     socialAccounts: ['general', 'social accounts', 'facebook', 'twitter', 'structured data', 'rich cards'],
     lockSite: ['general', 'password protection', 'lock site', 'make this site private'],
     analytics: ['membership', 'analytics', 'tracking', 'privacy', 'membership']

--- a/apps/admin-x-settings/src/components/settings/general/seo-meta.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/seo-meta.tsx
@@ -3,7 +3,7 @@ import TopLevelGroup from '../../top-level-group';
 import usePinturaEditor from '../../../hooks/use-pintura-editor';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {FacebookLogo, GoogleLogo, Icon, ImageUpload, SettingGroupContent, TabView, TextField, XLogo, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {FacebookLogo, GoogleLogo, Icon, ImageUpload, SettingGroupContent, TabView, TextField, Toggle, XLogo, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -79,19 +79,21 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     // Get all settings needed for all tabs
     const [
-        metaTitle,
-        metaDescription,
-        siteTitle,
-        siteDescription,
-        facebookTitle,
-        facebookDescription,
-        facebookImage,
-        twitterTitle,
-        twitterDescription,
-        twitterImage
+        metaTitleValue,
+        metaDescriptionValue,
+        llmsEnabledValue,
+        siteTitleValue,
+        siteDescriptionValue,
+        facebookTitleValue,
+        facebookDescriptionValue,
+        facebookImageValue,
+        twitterTitleValue,
+        twitterDescriptionValue,
+        twitterImageValue
     ] = getSettingValues(localSettings, [
         'meta_title',
         'meta_description',
+        'llms_enabled',
         'title',
         'description',
         'og_title',
@@ -100,7 +102,19 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
         'twitter_title',
         'twitter_description',
         'twitter_image'
-    ]).map(value => value || '') as string[];
+    ]);
+
+    const metaTitle = (metaTitleValue || '') as string;
+    const metaDescription = (metaDescriptionValue || '') as string;
+    const llmsEnabled = llmsEnabledValue !== false;
+    const siteTitle = (siteTitleValue || '') as string;
+    const siteDescription = (siteDescriptionValue || '') as string;
+    const facebookTitle = (facebookTitleValue || '') as string;
+    const facebookDescription = (facebookDescriptionValue || '') as string;
+    const facebookImage = (facebookImageValue || '') as string;
+    const twitterTitle = (twitterTitleValue || '') as string;
+    const twitterDescription = (twitterDescriptionValue || '') as string;
+    const twitterImage = (twitterImageValue || '') as string;
 
     // Tab management
     const [selectedTab, setSelectedTab] = useState('metadata');
@@ -136,6 +150,12 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
     };
 
     // Meta data handlers
+    const handleLlmsToggleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        updateSetting('llms_enabled', e.target.checked);
+        if (!isEditing) {
+            handleEditingChange(true);
+        }
+    };
     const handleMetaTitleChange = createSettingHandler('meta_title');
     const handleMetaDescriptionChange = createSettingHandler('meta_description');
 
@@ -155,6 +175,12 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const metadataTabContent = (
         <>
             <SettingGroupContent className="my-6 gap-3">
+                <Toggle
+                    checked={llmsEnabled}
+                    direction='rtl'
+                    label='Enable structured data for LLMs and AI search engines'
+                    onChange={handleLlmsToggleChange}
+                />
                 <TextField
                     hint="Recommended: 70 characters"
                     inputRef={focusRef}

--- a/apps/admin-x-settings/test/acceptance/general/seometa.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/seometa.test.ts
@@ -2,6 +2,32 @@ import {expect, test} from '@playwright/test';
 import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
 
 test.describe('SEO Meta settings', async () => {
+    test('Supports toggling LLM structured data in Search tab', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'llms_enabled', value: false}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('seometa');
+        const toggle = section.getByLabel('Enable structured data for LLMs and AI search engines');
+
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toBeChecked();
+
+        await toggle.uncheck();
+        await section.getByRole('button', {name: 'Save'}).click();
+
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [
+                {key: 'llms_enabled', value: false}
+            ]
+        });
+    });
+
     test('Supports editing metadata in Search tab', async ({page}) => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,

--- a/ghost/core/core/frontend/services/llms/handler.js
+++ b/ghost/core/core/frontend/services/llms/handler.js
@@ -1,0 +1,138 @@
+const config = require('../../../shared/config');
+const settingsCache = require('../../../shared/settings-cache');
+const urlUtils = require('../../../shared/url-utils');
+const urlService = require('../../../server/services/url');
+const llmsService = require('./service');
+const {
+    getMarkdownPath,
+    getResourcePathFromMarkdownPath,
+    renderEntryMarkdown
+} = require('./markdown');
+
+function getRequestSearch(req) {
+    const searchIndex = req.originalUrl?.indexOf('?') ?? -1;
+
+    if (searchIndex === -1) {
+        return '';
+    }
+
+    return req.originalUrl.slice(searchIndex);
+}
+
+function redirectToWebRoute(res, pathname, search = '') {
+    return res.redirect(302, `${urlUtils.urlFor({relativeUrl: pathname})}${search}`);
+}
+
+function handleDisabledLlmsRequest(req, res, next, pathname) {
+    if (settingsCache.get('is_private')) {
+        return next();
+    }
+
+    return redirectToWebRoute(res, pathname, getRequestSearch(req));
+}
+
+function setLlmsHeaders(res) {
+    res.set({
+        'Cache-Control': `public, max-age=${config.get('caching:llms:maxAge')}`,
+        'Content-Type': 'text/plain; charset=utf-8'
+    });
+}
+
+function setMarkdownHeaders(res, contentType) {
+    res.set({
+        'Content-Type': `${contentType}; charset=utf-8`
+    });
+}
+
+async function serveLlms(req, res, next, format) {
+    if (!llmsService.isEnabled()) {
+        return handleDisabledLlmsRequest(req, res, next, '/');
+    }
+
+    const content = format === 'full'
+        ? await llmsService.getLlmsFullTxt()
+        : await llmsService.getLlmsTxt();
+
+    if (!content) {
+        return next();
+    }
+
+    setLlmsHeaders(res);
+    return res.send(content);
+}
+
+function mountLlmsRoutes(siteApp) {
+    siteApp.get('/llms.txt', async function serveLlmsTxt(req, res, next) {
+        try {
+            return await serveLlms(req, res, next, 'index');
+        } catch (err) {
+            return next(err);
+        }
+    });
+
+    siteApp.get('/llms-full.txt', async function serveLlmsFullTxt(req, res, next) {
+        try {
+            return await serveLlms(req, res, next, 'full');
+        } catch (err) {
+            return next(err);
+        }
+    });
+
+    siteApp.get('/.well-known/llms.txt', async function serveWellKnownLlmsTxt(req, res, next) {
+        try {
+            return await serveLlms(req, res, next, 'index');
+        } catch (err) {
+            return next(err);
+        }
+    });
+
+    siteApp.get('/.well-known/llms-full.txt', async function serveWellKnownLlmsFullTxt(req, res, next) {
+        try {
+            return await serveLlms(req, res, next, 'full');
+        } catch (err) {
+            return next(err);
+        }
+    });
+}
+
+function mountMarkdownRoutes(siteApp) {
+    siteApp.get(/.+\.md$/, async function serveMarkdownEntry(req, res, next) {
+        const resourcePath = getResourcePathFromMarkdownPath(req.path);
+
+        if (!resourcePath) {
+            return next();
+        }
+
+        if (!llmsService.isEnabled()) {
+            return handleDisabledLlmsRequest(req, res, next, resourcePath);
+        }
+
+        let resource;
+        try {
+            resource = urlService.getResource(resourcePath);
+        } catch (err) {
+            return next(err);
+        }
+
+        if (!resource || !['posts', 'pages'].includes(resource.config.type) || resource.data.visibility !== 'public') {
+            return next();
+        }
+
+        try {
+            const entry = await llmsService.fetchPublicEntry(resource.config.type, resource.data.id, req.member || null);
+
+            if (!entry) {
+                return next();
+            }
+
+            setMarkdownHeaders(res, 'text/markdown');
+            res.set('Content-Location', getMarkdownPath(new URL(entry.url).pathname));
+            return res.send(renderEntryMarkdown(entry));
+        } catch (err) {
+            return next(err);
+        }
+    });
+}
+
+module.exports = mountLlmsRoutes;
+module.exports.mountMarkdownRoutes = mountMarkdownRoutes;

--- a/ghost/core/core/frontend/services/llms/markdown.js
+++ b/ghost/core/core/frontend/services/llms/markdown.js
@@ -1,0 +1,172 @@
+const {NodeHtmlMarkdown} = require('node-html-markdown');
+const htmlToPlaintext = require('@tryghost/html-to-plaintext');
+const urlUtils = require('../../../shared/url-utils');
+
+const MAX_DESCRIPTION_LENGTH = 300;
+
+const nhm = new NodeHtmlMarkdown({
+    bulletMarker: '-',
+    codeFence: '```',
+    emDelimiter: '*',
+    strongDelimiter: '**'
+});
+
+function collapseWhitespace(value) {
+    return (value || '').replace(/\s+/g, ' ').trim();
+}
+
+function truncateDescription(value, maxLength = MAX_DESCRIPTION_LENGTH) {
+    const collapsed = collapseWhitespace(value);
+
+    if (!collapsed || collapsed.length <= maxLength) {
+        return collapsed;
+    }
+
+    return `${collapsed.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function getMarkdownPath(pathname) {
+    if (!pathname || pathname === '/') {
+        return '/index.md';
+    }
+
+    const normalizedPath = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+    return `${normalizedPath}.md`;
+}
+
+function getMarkdownUrl(url) {
+    const parsedUrl = new URL(url);
+    parsedUrl.pathname = getMarkdownPath(parsedUrl.pathname);
+    return parsedUrl.toString();
+}
+
+function getResourcePathFromMarkdownPath(pathname) {
+    if (!pathname || !pathname.endsWith('.md')) {
+        return null;
+    }
+
+    const resourcePath = pathname.slice(0, -3) || '/';
+    return resourcePath.endsWith('/') ? resourcePath : `${resourcePath}/`;
+}
+
+function getAcceptedMarkdownContentType(req) {
+    const acceptHeader = req.get('Accept');
+
+    if (!acceptHeader || (!acceptHeader.includes('text/markdown') && !acceptHeader.includes('text/plain'))) {
+        return null;
+    }
+
+    const preferredType = req.accepts(['text/markdown', 'text/plain', 'text/html']);
+
+    if (!preferredType || preferredType === 'text/html') {
+        return null;
+    }
+
+    return preferredType;
+}
+
+function markdownFromHtml(html) {
+    const markdown = collapseWhitespace(nhm.translate(html || ''));
+
+    if (!markdown) {
+        return null;
+    }
+
+    return markdown.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+function formatIsoDate(value) {
+    if (!value) {
+        return null;
+    }
+
+    return new Date(value).toISOString();
+}
+
+function getPrimaryAuthorName(entry) {
+    if (entry.primary_author?.name) {
+        return entry.primary_author.name;
+    }
+
+    if (Array.isArray(entry.authors) && entry.authors[0]?.name) {
+        return entry.authors[0].name;
+    }
+
+    return null;
+}
+
+function getPrimaryTagName(entry) {
+    if (entry.primary_tag?.name) {
+        return entry.primary_tag.name;
+    }
+
+    if (Array.isArray(entry.tags) && entry.tags[0]?.name) {
+        return entry.tags[0].name;
+    }
+
+    return null;
+}
+
+function getLlmsIndexUrl(entry) {
+    return urlUtils.urlFor({relativeUrl: '/llms.txt'}, true);
+}
+
+function renderEntryMarkdownBody(entry) {
+    const markdown = markdownFromHtml(entry.html);
+
+    if (markdown) {
+        return markdown;
+    }
+
+    if (entry.plaintext) {
+        return collapseWhitespace(entry.plaintext);
+    }
+
+    return collapseWhitespace(htmlToPlaintext.excerpt(entry.html || ''));
+}
+
+function renderEntryMarkdown(entry) {
+    const metadata = [
+        entry.url ? `- URL: ${entry.url}` : null,
+        formatIsoDate(entry.published_at) ? `- Published: ${formatIsoDate(entry.published_at)}` : null,
+        formatIsoDate(entry.updated_at) ? `- Updated: ${formatIsoDate(entry.updated_at)}` : null,
+        collapseWhitespace(entry.custom_excerpt) ? `- Description: ${collapseWhitespace(entry.custom_excerpt)}` : null,
+        getPrimaryAuthorName(entry) ? `- Author: ${getPrimaryAuthorName(entry)}` : null,
+        getPrimaryTagName(entry) ? `- Primary tag: ${getPrimaryTagName(entry)}` : null
+    ].filter(Boolean);
+
+    const body = renderEntryMarkdownBody(entry) || '_No content available._';
+    const lines = [
+        '> ## Content Index',
+        `> Fetch the complete content index at: ${getLlmsIndexUrl(entry)}`,
+        '> Use this file to discover other available public pages before exploring further.',
+        '',
+        `# ${entry.title || 'Untitled'}`
+    ];
+
+    if (metadata.length) {
+        lines.push(...metadata, '');
+    } else {
+        lines.push('');
+    }
+
+    lines.push(body);
+
+    return lines.join('\n');
+}
+
+module.exports = {
+    MAX_DESCRIPTION_LENGTH,
+    collapseWhitespace,
+    formatIsoDate,
+    getAcceptedMarkdownContentType,
+    getMarkdownPath,
+    getMarkdownUrl,
+    getLlmsIndexUrl,
+    getPrimaryAuthorName,
+    getPrimaryTagName,
+    getResourcePathFromMarkdownPath,
+    renderEntryMarkdown,
+    renderEntryMarkdownBody,
+    truncateDescription
+};

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -1,0 +1,256 @@
+const settingsCache = require('../../../shared/settings-cache');
+const config = require('../../../shared/config');
+const urlUtils = require('../../../shared/url-utils');
+const models = require('../../../server/models');
+const urlService = require('../../../server/services/url');
+const events = require('../../../server/lib/common/events');
+const routing = require('../routing');
+const {api} = require('../proxy');
+const {
+    getMarkdownUrl,
+    renderEntryMarkdownBody,
+    truncateDescription
+} = require('./markdown');
+
+const FIVE_MIB = 5 * 1024 * 1024;
+
+class LlmsService {
+    constructor({events: eventBus = events, apiService = api} = {}) {
+        this.events = eventBus;
+        this.api = apiService;
+        this.cache = new Map();
+        this.invalidate = this.invalidate.bind(this);
+        this.handleSettingEdited = this.handleSettingEdited.bind(this);
+
+        this.events.on('site.changed', this.invalidate);
+        this.events.on('routers.reset', this.invalidate);
+        this.events.on('url.added', this.invalidate);
+        this.events.on('url.removed', this.invalidate);
+        this.events.on('settings.title.edited', this.invalidate);
+        this.events.on('settings.description.edited', this.invalidate);
+        this.events.on('settings.meta_description.edited', this.invalidate);
+        this.events.on('settings.llms_enabled.edited', this.invalidate);
+        this.events.on('settings.edited', this.handleSettingEdited);
+    }
+
+    invalidate() {
+        this.cache.clear();
+    }
+
+    handleSettingEdited(settingModel) {
+        const key = settingModel?.get?.('key') || settingModel?.attributes?.key || settingModel?.key;
+
+        if (key === 'url' || key === 'site_url') {
+            this.invalidate();
+        }
+    }
+
+    isEnabled() {
+        return !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
+    }
+
+    async fetchPublicEntry(resourceType, id, member = null) {
+        const controller = resourceType === 'pages' ? this.api.pagesPublic : this.api.postsPublic;
+        const responseKey = resourceType === 'pages' ? 'pages' : 'posts';
+        const response = await controller.read({
+            id,
+            formats: 'html,plaintext',
+            include: 'authors,tags',
+            context: {member}
+        });
+
+        return response?.[responseKey]?.[0] || null;
+    }
+
+    async getLlmsTxt() {
+        return await this.#getOrBuild('llms.txt', () => this.#buildLlmsTxt());
+    }
+
+    async getLlmsFullTxt() {
+        return await this.#getOrBuild('llms-full.txt', () => this.#buildLlmsFullTxt());
+    }
+
+    async #getOrBuild(key, builder) {
+        if (!this.isEnabled()) {
+            return null;
+        }
+
+        if (this.cache.has(key)) {
+            return this.cache.get(key);
+        }
+
+        const content = await builder();
+        this.cache.set(key, content);
+        return content;
+    }
+
+    async #buildLlmsTxt() {
+        const [pages, posts] = await Promise.all([
+            this.#fetchPublicEntries('page'),
+            this.#fetchPublicEntries('post')
+        ]);
+
+        const sections = [
+            this.#buildHeader(),
+            'Public Ghost content for AI and LLM tooling. Use `/llms-full.txt` for consolidated page and post context.',
+            '',
+            '## Pages',
+            this.#buildIndexSection(pages),
+            '',
+            '## Posts',
+            this.#buildIndexSection(posts),
+            '',
+            '## Optional',
+            this.#buildOptionalSection()
+        ];
+
+        return `${sections.join('\n').trim()}\n`;
+    }
+
+    async #buildLlmsFullTxt() {
+        const [pages, posts] = await Promise.all([
+            this.#fetchPublicEntries('page'),
+            this.#fetchPublicEntries('post')
+        ]);
+
+        const header = [
+            this.#buildHeader(),
+            'Public Ghost content for AI and LLM tooling. This file includes a bounded export of public pages first, then recent public posts.',
+            ''
+        ].join('\n');
+
+        let output = header;
+        let wasTruncated = false;
+
+        const pageSection = this.#appendBoundedSection(output, 'Pages', pages, entry => this.#buildFullEntry(entry));
+        output = pageSection.output;
+        wasTruncated = pageSection.wasTruncated;
+
+        if (!wasTruncated) {
+            const postSection = this.#appendBoundedSection(output, 'Posts', posts, entry => this.#buildFullEntry(entry));
+            output = postSection.output;
+            wasTruncated = postSection.wasTruncated;
+        }
+
+        if (wasTruncated) {
+            output += '\n_Truncated after 5 MiB. Use `/llms.txt` for the complete index of older public content._\n';
+        }
+
+        return output.trimEnd() + '\n';
+    }
+
+    #appendBoundedSection(prefix, heading, entries, formatter) {
+        const headingBlock = `${prefix}## ${heading}\n`;
+
+        if (Buffer.byteLength(headingBlock, 'utf8') > FIVE_MIB) {
+            return {output: prefix, wasTruncated: true};
+        }
+
+        let output = headingBlock;
+        let wasTruncated = false;
+
+        if (!entries.length) {
+            const emptySection = `${output}_No public content available._\n`;
+
+            if (Buffer.byteLength(emptySection, 'utf8') <= FIVE_MIB) {
+                output = emptySection;
+            } else {
+                wasTruncated = true;
+            }
+
+            return {output, wasTruncated};
+        }
+
+        for (const entry of entries) {
+            const formattedEntry = formatter(entry);
+            const candidate = `${output}${formattedEntry}\n`;
+
+            if (Buffer.byteLength(candidate, 'utf8') > FIVE_MIB) {
+                wasTruncated = true;
+                break;
+            }
+
+            output = candidate;
+        }
+
+        return {output, wasTruncated};
+    }
+
+    #buildHeader() {
+        const siteTitle = settingsCache.get('title') || new URL(config.get('url')).hostname;
+        const siteDescription = settingsCache.get('meta_description') || settingsCache.get('description');
+
+        return [
+            `# ${siteTitle}`,
+            siteDescription ? `> ${siteDescription}` : '> Public Ghost publication content.'
+        ].join('\n');
+    }
+
+    #buildIndexSection(entries) {
+        if (!entries.length) {
+            return '_No public content available._';
+        }
+
+        return entries.map((entry) => {
+            const description = truncateDescription(entry.custom_excerpt || entry.plaintext);
+            const linkLine = `- [${entry.title}](${getMarkdownUrl(entry.url)})`;
+
+            if (!description) {
+                return linkLine;
+            }
+
+            return `${linkLine} - ${description}`;
+        }).join('\n');
+    }
+
+    #buildOptionalSection() {
+        const optionalLinks = [];
+        const rssUrl = routing.registry.getRssUrl({absolute: true});
+
+        if (rssUrl) {
+            optionalLinks.push(`- [RSS Feed](${rssUrl})`);
+        }
+
+        optionalLinks.push(`- [Sitemap](${urlUtils.urlFor({relativeUrl: '/sitemap.xml'}, true)})`);
+
+        return optionalLinks.join('\n');
+    }
+
+    #buildFullEntry(entry) {
+        const lastUpdated = entry.updated_at || entry.published_at || entry.created_at;
+        const lastUpdatedLine = lastUpdated ? `Last updated: ${new Date(lastUpdated).toISOString()}` : null;
+        const markdownBody = renderEntryMarkdownBody(entry) || '_No content available._';
+
+        return [
+            `### ${entry.title}`,
+            `URL: ${entry.url}`,
+            lastUpdatedLine,
+            '',
+            markdownBody
+        ].filter(Boolean).join('\n');
+    }
+
+    async #fetchPublicEntries(type) {
+        const page = await models.Post.findPage({
+            limit: 'all',
+            order: type === 'post' ? 'published_at desc' : 'id asc',
+            filter: `status:published+visibility:public+type:${type}`,
+            columns: ['id', 'title', 'html', 'plaintext', 'custom_excerpt', 'updated_at', 'published_at', 'created_at']
+        });
+
+        const entries = page.data.map((model) => {
+            const entry = model.toJSON();
+            entry.url = urlService.getUrlByResourceId(entry.id, {absolute: true});
+            return entry;
+        }).filter(entry => entry.url && !entry.url.endsWith('/404/'));
+
+        if (type === 'page') {
+            entries.sort((left, right) => left.url.localeCompare(right.url));
+        }
+
+        return entries;
+    }
+}
+
+module.exports = new LlmsService();
+module.exports.LlmsService = LlmsService;

--- a/ghost/core/core/frontend/services/routing/controllers/entry.js
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.js
@@ -5,6 +5,11 @@ const {routerManager} = require('../');
 const urlUtils = require('../../../../shared/url-utils');
 const dataService = require('../../data');
 const renderer = require('../../rendering');
+const llmsService = require('../../llms/service');
+const {
+    getAcceptedMarkdownContentType,
+    renderEntryMarkdown
+} = require('../../llms/markdown');
 
 /**
  * @description Entry controller.
@@ -15,6 +20,7 @@ const renderer = require('../../rendering');
  */
 module.exports = function entryController(req, res, next) {
     debug('entryController', res.routerOptions);
+    const markdownContentType = getAcceptedMarkdownContentType(req);
 
     return dataService.entryLookup(req.path, res.routerOptions, res.locals)
         .then(function then(lookup) {
@@ -82,6 +88,18 @@ module.exports = function entryController(req, res, next) {
                     pathname: url.parse(entry.url).pathname,
                     search: url.parse(req.originalUrl).search
                 }));
+            }
+
+            if (markdownContentType && llmsService.isEnabled() && entry.visibility === 'public') {
+                return llmsService.fetchPublicEntry(res.routerOptions.resourceType, entry.id)
+                    .then((markdownEntry) => {
+                        if (!markdownEntry) {
+                            return next();
+                        }
+
+                        res.type(markdownContentType);
+                        res.send(renderEntryMarkdown(markdownEntry));
+                    });
             }
 
             return renderer.renderEntry(req, res)(entry);

--- a/ghost/core/core/frontend/web/middleware/index.js
+++ b/ghost/core/core/frontend/web/middleware/index.js
@@ -3,6 +3,7 @@ module.exports = {
     errorHandler: require('./error-handler'),
     frontendCaching: require('./frontend-caching'),
     handleImageSizes: require('./handle-image-sizes'),
+    llmsDiscovery: require('./llms-discovery'),
     redirectGhostToAdmin: require('./redirect-ghost-to-admin'),
     serveIndexNowKey: require('./serve-indexnow-key'),
     staticTheme: require('./static-theme')

--- a/ghost/core/core/frontend/web/middleware/llms-discovery.js
+++ b/ghost/core/core/frontend/web/middleware/llms-discovery.js
@@ -1,0 +1,37 @@
+const onHeaders = require('on-headers');
+const settingsCache = require('../../../shared/settings-cache');
+
+function appendHeaderValue(existingValue, newValue) {
+    if (!existingValue) {
+        return newValue;
+    }
+
+    const values = Array.isArray(existingValue) ? existingValue : [existingValue];
+
+    if (values.includes(newValue)) {
+        return existingValue;
+    }
+
+    return values.concat(newValue).join(', ');
+}
+
+module.exports = function llmsDiscovery(req, res, next) {
+    if (settingsCache.get('is_private') || settingsCache.get('llms_enabled') === false) {
+        return next();
+    }
+
+    onHeaders(res, function addLlmsDiscoveryHeaders() {
+        if (settingsCache.get('is_private') || settingsCache.get('llms_enabled') === false) {
+            return;
+        }
+
+        const linkHeader = appendHeaderValue(this.getHeader('Link'), '</llms.txt>; rel="llms-txt"');
+        this.setHeader('Link', appendHeaderValue(linkHeader, '</llms-full.txt>; rel="llms-full-txt"'));
+
+        if (!this.getHeader('X-Llms-Txt')) {
+            this.setHeader('X-Llms-Txt', '/llms.txt');
+        }
+    });
+
+    next();
+};

--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -58,6 +58,10 @@ function isAllowedFile(normalizedPath) {
  */
 function isFallthroughFile(filePath) {
     const fallthroughFiles = [
+        '/.well-known/llms-full.txt',
+        '/.well-known/llms.txt',
+        '/llms-full.txt',
+        '/llms.txt',
         '/robots.txt',
         '/sitemap.xml',
         '/sitemap.xsl'

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -8,6 +8,7 @@ const {MemberPageViewEvent} = require('../../shared/events');
 const config = require('../../shared/config');
 const storage = require('../../server/adapters/storage');
 const urlUtils = require('../../shared/url-utils');
+const llmsHandler = require('../services/llms/handler');
 const sitemapHandler = require('../services/sitemap/handler');
 const serveFavicon = require('./routers/serve-favicon');
 const servePublicFiles = require('./routers/serve-public-file');
@@ -67,6 +68,7 @@ module.exports = function setupSiteApp(routerConfig) {
 
     // Public files (sitemap.xsl, stylesheets, scripts, etc.)
     servePublicFiles(siteApp);
+    siteApp.use(mw.llmsDiscovery);
 
     // Serve site images using the storage adapter
     siteApp.use(STATIC_IMAGE_URL_PREFIX, mw.handleImageSizes, storage.getStorage('images').serve());
@@ -104,6 +106,7 @@ module.exports = function setupSiteApp(routerConfig) {
 
     // site map - this should probably be refactored to be an internal app
     sitemapHandler(siteApp);
+    llmsHandler(siteApp);
 
     // Global handling for member session, ensures a member is logged in to the frontend
     siteApp.use(membersService.middleware.loadMemberSession);
@@ -128,6 +131,8 @@ module.exports = function setupSiteApp(routerConfig) {
             return next();
         }
     });
+
+    llmsHandler.mountMarkdownRoutes(siteApp);
 
     siteApp.use(function memberPageViewMiddleware(req, res, next) {
         if (req.member) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -20,6 +20,7 @@ const EDITABLE_SETTINGS = [
     'secondary_navigation',
     'meta_title',
     'meta_description',
+    'llms_enabled',
     'og_image',
     'og_title',
     'og_description',

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/settings-key-group-mapper.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/settings-key-group-mapper.js
@@ -27,6 +27,7 @@ const keyGroupMapping = {
     secondary_navigation: 'site',
     meta_title: 'site',
     meta_description: 'site',
+    llms_enabled: 'site',
     og_image: 'site',
     og_title: 'site',
     og_description: 'site',

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/settings-key-type-mapper.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/settings-key-type-mapper.js
@@ -19,6 +19,7 @@ const keyTypeMapping = {
     twitter: 'string',
     meta_title: 'string',
     meta_description: 'string',
+    llms_enabled: 'boolean',
     og_image: 'string',
     og_title: 'string',
     og_description: 'string',

--- a/ghost/core/core/server/data/migrations/versions/6.31/2026-04-14-22-07-44-add-llms-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/6.31/2026-04-14-22-07-44-add-llms-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'llms_enabled',
+    value: true,
+    type: 'boolean',
+    group: 'site'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -176,6 +176,10 @@
             },
             "type": "string"
         },
+        "llms_enabled": {
+            "defaultValue": true,
+            "type": "boolean"
+        },
         "og_image": {
             "defaultValue": null,
             "validations": {

--- a/ghost/core/core/server/web/shared/middleware/pretty-urls.js
+++ b/ghost/core/core/server/web/shared/middleware/pretty-urls.js
@@ -7,15 +7,26 @@
 // Uncapitalise changes case to lowercase
 // @TODO optimize this to reduce the number of redirects required to get to a pretty URL
 // @TODO move this to being used by routers?
+const path = require('path');
 const slashes = require('connect-slashes');
 const config = require('../../../../shared/config');
 
+const ensureTrailingSlash = slashes(true, {
+    headers: {
+        'Cache-Control': `public, max-age=${config.get('caching:301:maxAge')}`
+    }
+});
+
+function skipSlashesForFilePaths(req, res, next) {
+    if (path.extname(req.path || '')) {
+        return next();
+    }
+
+    return ensureTrailingSlash(req, res, next);
+}
+
 module.exports = [
-    slashes(true, {
-        headers: {
-            'Cache-Control': `public, max-age=${config.get('caching:301:maxAge')}`
-        }
-    }),
+    skipSlashesForFilePaths,
     require('./redirect-amp-urls'),
     require('./uncapitalise')
 ];

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -167,6 +167,9 @@
         "sitemapXSL": {
             "maxAge": 86400
         },
+        "llms": {
+            "maxAge": 3600
+        },
         "robotstxt": {
             "maxAge": 3600
         },

--- a/ghost/core/core/shared/settings-cache/cache-manager.js
+++ b/ghost/core/core/shared/settings-cache/cache-manager.js
@@ -32,6 +32,7 @@ const _ = require('lodash');
  * @property {string|null} secondary_navigation - JSON string of secondary navigation items
  * @property {string|null} meta_title - Custom meta title
  * @property {string|null} meta_description - Custom meta description
+ * @property {boolean|null} llms_enabled - Whether llms.txt exports are enabled
  * @property {string|null} og_image - Open Graph image URL
  * @property {string|null} og_title - Open Graph title
  * @property {string|null} og_description - Open Graph description

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -206,6 +206,7 @@
     "mysql2": "3.18.1",
     "nconf": "0.13.0",
     "node-fetch": "2.7.0",
+    "node-html-markdown": "2.0.0",
     "node-jose": "2.2.0",
     "nodemailer": "6.10.1",
     "on-headers": "^1.1.0",

--- a/ghost/core/test/e2e-frontend/llms.test.js
+++ b/ghost/core/test/e2e-frontend/llms.test.js
@@ -1,0 +1,136 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const supertest = require('supertest');
+
+const testUtils = require('../utils');
+const configUtils = require('../utils/config-utils');
+const settingsCache = require('../../core/shared/settings-cache');
+
+function assertCorrectFrontendHeaders(res) {
+    assert.equal(res.headers['x-cache-invalidate'], undefined);
+    assert.equal(res.headers['x-csrf-token'], undefined);
+    assert.equal(res.headers['set-cookie'], undefined);
+    assert.ok(res.headers.date);
+}
+
+describe('LLMS frontend routes', function () {
+    let request;
+
+    before(async function () {
+        await testUtils.startGhost();
+        request = supertest.agent(configUtils.config.get('url'));
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('serves /llms.txt with discovery headers', async function () {
+        const res = await request.get('/llms.txt')
+            .expect(200)
+            .expect('Cache-Control', testUtils.cacheRules.hour)
+            .expect('Content-Type', /text\/plain/)
+            .expect('X-Llms-Txt', '/llms.txt')
+            .expect(assertCorrectFrontendHeaders);
+
+        assert.match(res.headers.link, /<\/llms\.txt>; rel="llms-txt"/);
+        assert.match(res.headers.link, /<\/llms-full\.txt>; rel="llms-full-txt"/);
+        assert.match(res.text, /^# /m);
+        assert.match(res.text, /## Pages/);
+        assert.match(res.text, /## Posts/);
+        assert.match(res.text, /\[.*\]\(http:\/\/127\.0\.0\.1:\d+\/welcome\.md\)/);
+    });
+
+    it('serves /.well-known/llms.txt as an alias', async function () {
+        const [rootRes, aliasRes] = await Promise.all([
+            request.get('/llms.txt'),
+            request.get('/.well-known/llms.txt')
+        ]);
+
+        assert.equal(aliasRes.status, 200);
+        assert.equal(aliasRes.text, rootRes.text);
+    });
+
+    it('serves /llms-full.txt', async function () {
+        const res = await request.get('/llms-full.txt')
+            .expect(200)
+            .expect('Cache-Control', testUtils.cacheRules.hour)
+            .expect('Content-Type', /text\/plain/)
+            .expect(assertCorrectFrontendHeaders);
+
+        assert.match(res.text, /## Pages/);
+        assert.match(res.text, /## Posts/);
+        assert.match(res.text, /### Start here for a quick overview of everything you need to know/);
+        assert.match(res.text, /URL: http:\/\/127\.0\.0\.1:\d+\/welcome\//);
+    });
+
+    it('serves markdown for a public post via .md URL', async function () {
+        const res = await request.get('/welcome.md')
+            .expect(200)
+            .expect('Content-Type', /text\/markdown/)
+            .expect('Content-Location', '/welcome.md')
+            .expect('X-Llms-Txt', '/llms.txt')
+            .expect(assertCorrectFrontendHeaders);
+
+        assert.match(res.text, /^> ## Content Index/m);
+        assert.match(res.text, /^# Start here for a quick overview of everything you need to know/m);
+        assert.match(res.text, /- Published: /);
+    });
+
+    it('serves markdown for a public post via Accept negotiation on the canonical URL', async function () {
+        const res = await request.get('/welcome/')
+            .set('Accept', 'text/markdown')
+            .expect(200)
+            .expect('Content-Type', /text\/markdown/)
+            .expect(assertCorrectFrontendHeaders);
+
+        assert.match(res.text, /^> ## Content Index/m);
+        assert.match(res.text, /^# Start here for a quick overview of everything you need to know/m);
+    });
+
+    it('respects private-site behavior for llms routes', async function () {
+        const originalSettingsCacheGet = settingsCache.get;
+
+        sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
+            if (key === 'is_private') {
+                return true;
+            }
+
+            return originalSettingsCacheGet.call(this, key, options);
+        });
+
+        await request.get('/llms.txt')
+            .expect(302)
+            .expect('Location', '/private/?r=%2Fllms.txt')
+            .expect(assertCorrectFrontendHeaders);
+    });
+
+    it('disables llms routes and discovery headers when llms_enabled is false', async function () {
+        const originalSettingsCacheGet = settingsCache.get;
+
+        sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
+            if (key === 'llms_enabled') {
+                return false;
+            }
+
+            return originalSettingsCacheGet.call(this, key, options);
+        });
+
+        await request.get('/llms.txt')
+            .expect(302)
+            .expect('Location', '/')
+            .expect(assertCorrectFrontendHeaders);
+
+        await request.get('/welcome.md')
+            .expect(302)
+            .expect('Location', '/welcome/')
+            .expect(assertCorrectFrontendHeaders);
+
+        const res = await request.get('/welcome/')
+            .expect(200)
+            .expect(assertCorrectFrontendHeaders);
+
+        assert.equal(res.headers['x-llms-txt'], undefined);
+        assert.ok(!res.headers.link || !res.headers.link.includes('rel="llms-txt"'));
+    });
+});

--- a/ghost/core/test/unit/frontend/services/llms/handler.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/handler.test.js
@@ -1,0 +1,193 @@
+const sinon = require('sinon');
+const request = require('supertest');
+
+const express = require('../../../../../core/shared/express');
+const configUtils = require('../../../../utils/config-utils');
+const settingsCache = require('../../../../../core/shared/settings-cache');
+const urlService = require('../../../../../core/server/services/url');
+const llmsHandler = require('../../../../../core/frontend/services/llms/handler');
+const llmsService = require('../../../../../core/frontend/services/llms/service');
+
+describe('Unit: frontend/services/llms/handler', function () {
+    let app;
+
+    beforeEach(function () {
+        app = express('test');
+        llmsHandler(app);
+        llmsHandler.mountMarkdownRoutes(app);
+        app.use((req, res) => res.sendStatus(404));
+
+        sinon.stub(settingsCache, 'get').callsFake((key) => {
+            if (key === 'is_private') {
+                return false;
+            }
+
+            return null;
+        });
+    });
+
+    afterEach(function () {
+        configUtils.restore();
+        sinon.restore();
+    });
+
+    it('serves generated llms files and well-known aliases', async function () {
+        sinon.stub(llmsService, 'getLlmsTxt').resolves('# llms');
+        sinon.stub(llmsService, 'getLlmsFullTxt').resolves('# llms full');
+
+        await request(app)
+            .get('/llms.txt')
+            .expect(200)
+            .expect('Cache-Control', 'public, max-age=3600')
+            .expect('Content-Type', /text\/plain/)
+            .expect('# llms');
+
+        await request(app)
+            .get('/.well-known/llms-full.txt')
+            .expect(200)
+            .expect('# llms full');
+    });
+
+    it('serves markdown for public entry .md URLs', async function () {
+        sinon.stub(urlService, 'getResource').returns({
+            config: {type: 'posts'},
+            data: {id: 'post-id', visibility: 'public'}
+        });
+
+        sinon.stub(llmsService, 'fetchPublicEntry').resolves({
+            title: 'Hello world',
+            url: 'https://example.com/hello-world/',
+            published_at: '2026-04-14T12:00:00.000Z',
+            updated_at: '2026-04-14T13:00:00.000Z',
+            custom_excerpt: 'Short summary',
+            visibility: 'public',
+            primary_author: {name: 'John'},
+            primary_tag: {name: 'News'},
+            html: '<p>Hello <strong>world</strong></p>',
+            plaintext: 'Hello world'
+        });
+
+        await request(app)
+            .get('/hello-world.md')
+            .expect(200)
+            .expect('Content-Type', /text\/markdown/)
+            .expect('Content-Location', '/hello-world.md')
+            .expect(/^> ## Content Index/m)
+            .expect(/Fetch the complete content index at: http:\/\/127\.0\.0\.1:\d+\/llms\.txt/)
+            .expect(/# Hello world/)
+            .expect(/- Published: 2026-04-14T12:00:00.000Z/)
+            .expect(/- Author: John/)
+            .expect((response) => {
+                if (response.text.includes('- Visibility:')) {
+                    throw new Error('Visibility metadata should not be rendered');
+                }
+            })
+            .expect(/Hello \*\*world\*\*/);
+    });
+
+    it('skips llms routes for private sites', async function () {
+        settingsCache.get.restore();
+        sinon.stub(settingsCache, 'get').callsFake(key => key === 'is_private');
+
+        sinon.stub(llmsService, 'getLlmsTxt').resolves('# llms');
+
+        await request(app)
+            .get('/llms.txt')
+            .expect(404);
+    });
+
+    it('redirects llms.txt to the site root when llms is disabled', async function () {
+        settingsCache.get.restore();
+        sinon.stub(settingsCache, 'get').callsFake((key) => {
+            if (key === 'is_private') {
+                return false;
+            }
+
+            if (key === 'llms_enabled') {
+                return false;
+            }
+
+            return null;
+        });
+
+        await request(app)
+            .get('/llms.txt?ref=test')
+            .expect(302)
+            .expect('Location', '/?ref=test');
+    });
+
+    it('redirects markdown entry URLs to their canonical path when llms is disabled', async function () {
+        settingsCache.get.restore();
+        sinon.stub(settingsCache, 'get').callsFake((key) => {
+            if (key === 'is_private') {
+                return false;
+            }
+
+            if (key === 'llms_enabled') {
+                return false;
+            }
+
+            return null;
+        });
+
+        await request(app)
+            .get('/hello-world.md?ref=test')
+            .expect(302)
+            .expect('Location', '/hello-world/?ref=test');
+    });
+
+    it('uses the site subdirectory for redirects and llms index links', async function () {
+        configUtils.set('url', 'http://127.0.0.1:2368/blog');
+
+        settingsCache.get.restore();
+        sinon.stub(settingsCache, 'get').callsFake((key) => {
+            if (key === 'is_private') {
+                return false;
+            }
+
+            if (key === 'llms_enabled') {
+                return false;
+            }
+
+            return null;
+        });
+
+        await request(app)
+            .get('/llms.txt?ref=test')
+            .expect(302)
+            .expect('Location', '/blog/?ref=test');
+
+        await request(app)
+            .get('/hello-world.md?ref=test')
+            .expect(302)
+            .expect('Location', '/blog/hello-world/?ref=test');
+
+        settingsCache.get.restore();
+        sinon.stub(settingsCache, 'get').callsFake((key) => {
+            if (key === 'is_private') {
+                return false;
+            }
+
+            return null;
+        });
+
+        sinon.stub(urlService, 'getResource').returns({
+            config: {type: 'posts'},
+            data: {id: 'post-id', visibility: 'public'}
+        });
+
+        sinon.stub(llmsService, 'fetchPublicEntry').resolves({
+            title: 'Hello world',
+            url: 'http://127.0.0.1:2368/blog/hello-world/',
+            published_at: '2026-04-14T12:00:00.000Z',
+            updated_at: '2026-04-14T13:00:00.000Z',
+            html: '<p>Hello <strong>world</strong></p>',
+            plaintext: 'Hello world'
+        });
+
+        await request(app)
+            .get('/hello-world.md')
+            .expect(200)
+            .expect(/Fetch the complete content index at: http:\/\/127\.0\.0\.1:\d+\/blog\/llms\.txt/);
+    });
+});

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -1,0 +1,151 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const EventEmitter = require('events');
+
+const settingsCache = require('../../../../../core/shared/settings-cache');
+const models = require('../../../../../core/server/models');
+const urlService = require('../../../../../core/server/services/url');
+const routing = require('../../../../../core/frontend/services/routing');
+const {LlmsService} = require('../../../../../core/frontend/services/llms/service');
+
+describe('Unit: frontend/services/llms/service', function () {
+    let eventBus;
+    let service;
+
+    before(function () {
+        models.init();
+    });
+
+    beforeEach(function () {
+        eventBus = new EventEmitter();
+        service = new LlmsService({events: eventBus, apiService: {}});
+
+        sinon.stub(settingsCache, 'get').callsFake((key) => {
+            const values = {
+                description: 'Short description',
+                is_private: false,
+                meta_description: 'Meta description',
+                title: 'Ghost Site'
+            };
+
+            return values[key];
+        });
+
+        sinon.stub(routing.registry, 'getRssUrl').returns('https://example.com/rss/');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('builds llms.txt with markdown URLs, stable page ordering, and truncated descriptions', async function () {
+        const longDescription = 'A'.repeat(320);
+
+        sinon.stub(models.Post, 'findPage').callsFake(async (options) => {
+            if (options.filter.includes('type:page')) {
+                return {
+                    data: [
+                        {toJSON: () => ({id: 'page-b', title: 'B Page', custom_excerpt: 'Second page'})},
+                        {toJSON: () => ({id: 'page-a', title: 'A Page', custom_excerpt: 'First page'})}
+                    ]
+                };
+            }
+
+            return {
+                data: [
+                    {toJSON: () => ({id: 'post-a', title: 'Recent Post', custom_excerpt: longDescription})},
+                    {toJSON: () => ({id: 'post-b', title: 'Older Post', plaintext: 'Older summary'})}
+                ]
+            };
+        });
+
+        sinon.stub(urlService, 'getUrlByResourceId').callsFake((id) => {
+            const urls = {
+                'page-a': 'https://example.com/about/',
+                'page-b': 'https://example.com/contact/',
+                'post-a': 'https://example.com/2026/04/recent-post/',
+                'post-b': 'https://example.com/2026/03/older-post/'
+            };
+
+            return urls[id];
+        });
+
+        const llmsTxt = await service.getLlmsTxt();
+
+        assert.match(llmsTxt, /^# Ghost Site/m);
+        assert.match(llmsTxt, /^> Meta description/m);
+        assert.match(llmsTxt, /## Pages[\s\S]*\[A Page\]\(https:\/\/example\.com\/about\.md\)[\s\S]*\[B Page\]\(https:\/\/example\.com\/contact\.md\)/m);
+        assert.match(llmsTxt, /\[Recent Post\]\(https:\/\/example\.com\/2026\/04\/recent-post\.md\) - A{299}…/);
+        assert.match(llmsTxt, /## Optional[\s\S]*\[RSS Feed\]\(https:\/\/example\.com\/rss\/\)/m);
+        assert.match(llmsTxt, /\[Sitemap\]\(http:\/\/127\.0\.0\.1:\d+\/sitemap\.xml\)/);
+    });
+
+    it('bounds llms-full.txt at 5 MiB and appends a truncation note', async function () {
+        sinon.stub(models.Post, 'findPage').callsFake(async (options) => {
+            if (options.filter.includes('type:page')) {
+                return {
+                    data: [
+                        {
+                            toJSON: () => ({
+                                id: 'page-a',
+                                title: 'Large Page',
+                                html: `<p>${'x'.repeat((5 * 1024 * 1024) + 1000)}</p>`,
+                                plaintext: 'large page body',
+                                updated_at: '2026-04-14T00:00:00.000Z'
+                            })
+                        }
+                    ]
+                };
+            }
+
+            return {
+                data: [
+                    {
+                        toJSON: () => ({
+                            id: 'post-a',
+                            title: 'Post That Should Not Fit',
+                            html: '<p>post body</p>',
+                            plaintext: 'post body',
+                            updated_at: '2026-04-14T00:00:00.000Z'
+                        })
+                    }
+                ]
+            };
+        });
+
+        sinon.stub(urlService, 'getUrlByResourceId').callsFake((id) => {
+            const urls = {
+                'page-a': 'https://example.com/about/',
+                'post-a': 'https://example.com/post/'
+            };
+
+            return urls[id];
+        });
+
+        const llmsFullTxt = await service.getLlmsFullTxt();
+
+        assert.match(llmsFullTxt, /## Pages/);
+        assert.doesNotMatch(llmsFullTxt, /## Posts/);
+        assert.match(llmsFullTxt, /Truncated after 5 MiB/);
+    });
+
+    it('invalidates cached output when the site URL setting is edited', async function () {
+        sinon.stub(models.Post, 'findPage').resolves({data: []});
+        sinon.stub(urlService, 'getUrlByResourceId').returns(null);
+
+        await service.getLlmsTxt();
+        assert.equal(service.cache.has('llms.txt'), true);
+
+        eventBus.emit('settings.edited', {
+            get(key) {
+                if (key === 'key') {
+                    return 'url';
+                }
+
+                return null;
+            }
+        });
+
+        assert.equal(service.cache.size, 0);
+    });
+});

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -8,6 +8,7 @@ const routerManager = require('../../../../../../core/frontend/services/routing/
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
 const renderer = require('../../../../../../core/frontend/services/rendering');
 const dataService = require('../../../../../../core/frontend/services/data');
+const llmsService = require('../../../../../../core/frontend/services/llms/service');
 const EDITOR_URL = `/#/editor/post/`;
 
 describe('Unit - services/routing/controllers/entry', function () {
@@ -18,6 +19,7 @@ describe('Unit - services/routing/controllers/entry', function () {
     let urlUtilsRedirect301Stub;
     let routerManagerGetResourceByIdStub;
     let urlUtilsRedirectToAdminStub;
+    let fetchPublicEntryStub;
     let post;
 
     beforeEach(function () {
@@ -38,11 +40,14 @@ describe('Unit - services/routing/controllers/entry', function () {
         urlUtilsRedirectToAdminStub = sinon.stub(urlUtils, 'redirectToAdmin');
         urlUtilsRedirect301Stub = sinon.stub(urlUtils, 'redirect301');
         routerManagerGetResourceByIdStub = sinon.stub(routerManager, 'getResourceById');
+        fetchPublicEntryStub = sinon.stub(llmsService, 'fetchPublicEntry');
 
         req = {
             path: '/',
             params: {},
-            route: {}
+            route: {},
+            get: sinon.stub(),
+            accepts: sinon.stub()
         };
 
         res = {
@@ -51,7 +56,13 @@ describe('Unit - services/routing/controllers/entry', function () {
             },
             render: sinon.spy(),
             redirect: sinon.spy(),
-            locals: {}
+            locals: {
+                member: {
+                    uuid: 'member-id'
+                }
+            },
+            send: sinon.spy(),
+            type: sinon.spy()
         };
     });
 
@@ -229,6 +240,51 @@ describe('Unit - services/routing/controllers/entry', function () {
             controllers.entry(req, res, function (err) {
                 done(err);
             });
+        });
+
+        it('serves markdown when text/markdown is preferred for a public post', function (done) {
+            req.path = post.url;
+            req.originalUrl = req.path;
+            req.get.withArgs('Accept').returns('text/markdown');
+            req.accepts.returns('text/markdown');
+            post.visibility = 'public';
+
+            routerManagerGetResourceByIdStub.withArgs(post.id).returns({
+                config: {
+                    type: 'posts'
+                }
+            });
+
+            entryLookUpStub.withArgs(req.path, res.routerOptions)
+                .resolves({
+                    entry: post
+                });
+
+            fetchPublicEntryStub.resolves({
+                title: 'Hello world',
+                url: 'https://example.com/hello-world/',
+                published_at: '2026-04-14T12:00:00.000Z',
+                updated_at: '2026-04-14T13:00:00.000Z',
+                custom_excerpt: 'Short summary',
+                visibility: 'public',
+                html: '<p>Hello <strong>world</strong></p>',
+                plaintext: 'Hello world'
+            });
+
+            controllers.entry(req, res, function (err) {
+                done(err || new Error('next should not be called'));
+            }).then(() => {
+                sinon.assert.calledOnceWithExactly(fetchPublicEntryStub, 'posts', post.id);
+                sinon.assert.calledOnceWithExactly(res.type, 'text/markdown');
+                sinon.assert.match(res.send.firstCall.args[0], /^> ## Content Index/m);
+                sinon.assert.match(res.send.firstCall.args[0], /Fetch the complete content index at: http:\/\/127\.0\.0\.1:\d+\/llms\.txt/);
+                sinon.assert.match(res.send.firstCall.args[0], /^# Hello world/m);
+                sinon.assert.match(res.send.firstCall.args[0], /- Published: 2026-04-14T12:00:00.000Z/);
+                assert.equal(res.send.firstCall.args[0].includes('- Visibility:'), false);
+                sinon.assert.match(res.send.firstCall.args[0], /Hello \*\*world\*\*/);
+                sinon.assert.notCalled(renderStub);
+                done();
+            }).catch(done);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/web/middleware/llms-discovery.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/llms-discovery.test.js
@@ -1,0 +1,44 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const request = require('supertest');
+
+const express = require('../../../../../core/shared/express');
+const settingsCache = require('../../../../../core/shared/settings-cache');
+const llmsDiscovery = require('../../../../../core/frontend/web/middleware/llms-discovery');
+
+describe('Unit: frontend/web/middleware/llms-discovery', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('adds llms discovery headers and preserves existing Link headers', async function () {
+        sinon.stub(settingsCache, 'get').returns(false);
+
+        const app = express('test');
+        app.use(llmsDiscovery);
+        app.get('/', (req, res) => {
+            res.set('Link', '</existing>; rel="preload"');
+            res.send('ok');
+        });
+
+        const response = await request(app).get('/').expect(200);
+
+        assert.match(response.headers.link, /<\/existing>; rel="preload"/);
+        assert.match(response.headers.link, /<\/llms\.txt>; rel="llms-txt"/);
+        assert.match(response.headers.link, /<\/llms-full\.txt>; rel="llms-full-txt"/);
+        assert.equal(response.headers['x-llms-txt'], '/llms.txt');
+    });
+
+    it('does not add llms discovery headers for private sites', async function () {
+        sinon.stub(settingsCache, 'get').returns(true);
+
+        const app = express('test');
+        app.use(llmsDiscovery);
+        app.get('/', (req, res) => res.send('ok'));
+
+        const response = await request(app).get('/').expect(200);
+
+        assert.equal(response.headers.link, undefined);
+        assert.equal(response.headers['x-llms-txt'], undefined);
+    });
+});

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -117,6 +117,20 @@ describe('staticTheme', function () {
         });
     });
 
+    it('should enable fallthrough for generated llms files', function (done) {
+        req.path = '/llms.txt';
+
+        staticTheme()(req, res, function next() {
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
+
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, true);
+
+            done();
+        });
+    });
+
     it('should call express.static for .js file', function (done) {
         req.path = 'myvalidfile.js';
 

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'b8b90b21a8581d55655fa6ba6b4d91b1';
     const currentFixturesHash = '2f86ab1e3820e86465f9ad738dd0ee93';
-    const currentSettingsHash = 'a102b80d2ab0cd92325ed007c94d7da6';
+    const currentSettingsHash = '8a101f7207ef23833b25713e4763f47e';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/unit/server/web/shared/middleware/pretty-urls.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/pretty-urls.test.js
@@ -1,0 +1,45 @@
+const sinon = require('sinon');
+const prettyUrls = require('../../../../../../core/server/web/shared/middleware/pretty-urls');
+
+describe('Middleware: prettyUrls', function () {
+    let req;
+    let res;
+    let next;
+
+    beforeEach(function () {
+        req = {
+            path: '',
+            url: ''
+        };
+        res = {
+            redirect: sinon.spy(),
+            setHeader: sinon.spy(),
+            set: sinon.spy()
+        };
+        next = sinon.spy();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('skips trailing slash redirects for markdown paths', function () {
+        req.path = '/coming-soon.md';
+        req.url = req.path;
+
+        prettyUrls[0](req, res, next);
+
+        sinon.assert.calledOnce(next);
+        sinon.assert.notCalled(res.redirect);
+    });
+
+    it('skips trailing slash redirects for other file paths', function () {
+        req.path = '/llms.txt';
+        req.url = req.path;
+
+        prettyUrls[0](req, res, next);
+
+        sinon.assert.calledOnce(next);
+        sinon.assert.notCalled(res.redirect);
+    });
+});

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -176,6 +176,10 @@
             },
             "type": "string"
         },
+        "llms_enabled": {
+            "defaultValue": true,
+            "type": "boolean"
+        },
         "og_image": {
             "defaultValue": null,
             "validations": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2377,6 +2377,9 @@ importers:
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
+      node-html-markdown:
+        specifier: 2.0.0
+        version: 2.0.0
       node-jose:
         specifier: 2.2.0
         version: 2.2.0
@@ -18255,6 +18258,13 @@ packages:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
     engines: {node: '>= 10.12.0'}
     hasBin: true
+
+  node-html-markdown@2.0.0:
+    resolution: {integrity: sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==}
+    engines: {node: '>=20.0.0'}
+
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -44115,6 +44125,15 @@ snapshots:
       - bluebird
       - supports-color
     optional: true
+
+  node-html-markdown@2.0.0:
+    dependencies:
+      node-html-parser: 6.1.13
+
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
 
   node-int64@0.4.0: {}
 


### PR DESCRIPTION
## Summary
- add `llms.txt` and `llms-full.txt` generation plus per-entry Markdown export for public posts and pages
- add an `llms_enabled` site setting and expose it in Admin under Meta data > Search
- redirect llms-specific `.txt` and `.md` routes back to canonical HTML routes when the setting is disabled

<img width="2962" height="1758" alt="CleanShot 2026-04-14 at 18 26 53@2x" src="https://github.com/user-attachments/assets/1f30be52-cc44-492a-8c3f-9c1d18f7481e" />
