### PR TITLE
Ensure sqlite3 is installed for ghost:core unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,11 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # sqlite3 is an optionalDependency. Without --force, pnpm may skip
+        # installing/linking it when restoring from a cached store. --force
+        # ensures all optional deps are installed regardless.
+        # (ghost core's test:unit job requires sqlite3)
+        run: pnpm install --frozen-lockfile --force
 
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0


### PR DESCRIPTION
this PR adds `--force` to pnpm install for the unit tests job, since sqlite3 appears to be required for ghost:core unit tests (see test failures on #27348, #27401)

this wasn't caught during the changes in #27386 likely because the ghost/core package wasn't changed, so it was never fully verified - some of the future work around `nx affected` detection should be able to catch this going forward.

~second commit is temporary, to verify force install fixes unit tests~ second commit removed, see https://github.com/TryGhost/Ghost/actions/runs/24446750005/job/71425107814 to verify unit test job works 👍🏻 