### PR TITLE
Fixed email analytics timing metrics

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -462,6 +462,11 @@ module.exports = class EmailAnalyticsService {
 
         fetchData.running = false;
 
+        const totalTimeMs = Date.now() - fetchStartMs;
+        // Derived by subtraction because fetchLatest() invokes processBatch internally,
+        // so directly timing fetchLatest() would double-count processing and aggregation time.
+        const apiPollingTimeMs = totalTimeMs - processingTimeMs - aggregationTimeMs;
+
         if (error) {
             throw error;
         }

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -320,7 +320,7 @@ module.exports = class EmailAnalyticsService {
         this.queries.setJobTimestamp(fetchData.jobName, 'started', begin);
 
         // Timing metrics
-        let apiPollingTimeMs = 0;
+        const fetchStartMs = Date.now();
         let processingTimeMs = 0;
         let aggregationTimeMs = 0;
 
@@ -386,9 +386,9 @@ module.exports = class EmailAnalyticsService {
                 // Aggregate and clear the processingResult
                 // We do this here because otherwise it could take a long time before the new events are visible in the stats
                 try {
-                    const aggregationStart = Date.now();
+                    const intermediateAggregationStart = Date.now();
                     await this.aggregateStats(processingResult, includeOpenedEvents);
-                    aggregationTimeMs += (Date.now() - aggregationStart);
+                    aggregationTimeMs += (Date.now() - intermediateAggregationStart);
                     lastAggregation = Date.now();
                     // Remove aggregated emailIds and memberIds from tracking sets to avoid re-aggregating at the end
                     processingResult.emailIds.forEach(id => allEmailIds.delete(id));
@@ -409,9 +409,7 @@ module.exports = class EmailAnalyticsService {
 
         try {
             for (const provider of this.providers) {
-                const apiStart = Date.now();
                 await provider.fetchLatest(processBatch, {begin, end, maxEvents, events: eventTypes});
-                apiPollingTimeMs += (Date.now() - apiStart);
             }
         } catch (err) {
             if (err.message !== 'Fetching canceled') {
@@ -467,6 +465,9 @@ module.exports = class EmailAnalyticsService {
         if (error) {
             throw error;
         }
+
+        const totalTimeMs = Date.now() - fetchStartMs;
+        const apiPollingTimeMs = totalTimeMs - processingTimeMs - aggregationTimeMs;
 
         return {
             eventCount,

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -471,9 +471,6 @@ module.exports = class EmailAnalyticsService {
             throw error;
         }
 
-        const totalTimeMs = Date.now() - fetchStartMs;
-        const apiPollingTimeMs = totalTimeMs - processingTimeMs - aggregationTimeMs;
-
         return {
             eventCount,
             apiPollingTimeMs,


### PR DESCRIPTION
## Summary

- **Fixed double-counted API polling metric** — `apiPollingTimeMs` was wrapping the entire `provider.fetchLatest()` call, which executes `processBatch` (processing + intermediate aggregation) inside Mailgun's pagination loop. This meant API time included processing and aggregation time, causing reported percentages to exceed 100% (e.g., `API 196% / Processing 19% / Aggregation 58%`)
- **API time is now derived by subtraction** — `totalWallClock - processingTime - aggregationTime`, so the three metrics sum to ~100% and accurately reflect where time is spent
- Processing and aggregation timers were already measured independently and correctly; only the API timer was wrong