### PR TITLE
Skipped member aggregation for non-opened email analytics events

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -630,6 +630,13 @@ module.exports = class EmailAnalyticsService {
             await this.aggregateEmailStats(emailId, includeOpenedEvents);
         }
 
+        // Member stats (email_count, email_opened_count, email_open_rate) only depend on
+        // opened_at — they are unaffected by delivered/failed events. Skip the expensive
+        // member aggregation entirely when no opens were processed.
+        if (!includeOpenedEvents) {
+            return;
+        }
+
         // @ts-expect-error
         const memberMetric = this.prometheusClient?.getMetric('email_analytics_aggregate_member_stats_count');
 


### PR DESCRIPTION
## Summary

- **Skips member aggregation entirely when processing non-opened events** (delivered, failed, unsubscribed, complained). This eliminates the most expensive operation in the email analytics pipeline for the highest-volume job.

## Why this is safe

The three member-level stats updated by `aggregateMemberStatsBatch` are:

| Field | Calculation | Source column |
|-------|------------|---------------|
| `email_count` | `COUNT(email_recipients.id)` | Row existence (set at send time) |
| `email_opened_count` | `SUM(CASE WHEN opened_at IS NOT NULL)` | `opened_at` |
| `email_open_rate` | `ROUND(email_opened_count / tracked_count * 100)` | `opened_at` + `emails.track_opens` |

None of these fields reference `delivered_at` or `failed_at`. When we process a delivered or failed event, we set `delivered_at`/`failed_at` on the `email_recipients` row, but no member stat depends on those columns. The member aggregation was recounting everything and writing back identical values.

The `includeOpenedEvents` flag is already `false` for `fetchLatestNonOpenedEvents` (which only processes delivered/failed/unsubscribed/complained) and for `fetchMissing`/`fetchScheduled` (which pass no event type filter, causing the flag to default to `false`). The only job where `includeOpenedEvents` is `true` is `fetchLatestOpenedEvents`, which is unaffected by this change.

## Impact

For large senders (~500k recipients/newsletter), member aggregation dominated the analytics job — observed at ~58s of a 58s cycle. This change eliminates that cost for the non-opened job, which processes the bulk of events during and after a send. The opened job continues to aggregate member stats as before.