### PR TITLE
Fixed flaky test for welcome email customization

### DIFF
--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -31,6 +31,7 @@ export class MemberWelcomeEmailsSection extends BasePage {
     readonly customizeModalButtonColorField: Locator;
     readonly customizeModalButtonColorPickerTrigger: Locator;
     readonly customizeModalButtonColorAccentSwatch: Locator;
+    readonly customizeModalButtonColorAutoSwatch: Locator;
     readonly customizeModalColorPickerPopover: Locator;
 
     // Modal locators
@@ -72,6 +73,7 @@ export class MemberWelcomeEmailsSection extends BasePage {
         this.customizeModalButtonColorField = this.customizeModal.getByText('Button color').locator('..');
         this.customizeModalButtonColorPickerTrigger = this.customizeModalButtonColorField.getByRole('button', {name: 'Pick color'});
         this.customizeModalButtonColorAccentSwatch = this.customizeModal.getByRole('button', {name: 'Accent'});
+        this.customizeModalButtonColorAutoSwatch = this.customizeModal.getByRole('button', {name: 'Auto'});
         this.customizeModalColorPickerPopover = page.locator('[data-radix-popper-content-wrapper]');
 
         // Modal locators

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -281,6 +281,8 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag enabled', () 
         await welcomeEmailsSection.customizeModalButtonColorPickerTrigger.click();
         await expect(welcomeEmailsSection.customizeModalButtonColorAccentSwatch).toBeVisible();
         await welcomeEmailsSection.customizeModalButtonColorAccentSwatch.click();
+        await welcomeEmailsSection.customizeModalButtonColorPickerTrigger.click();
+        await welcomeEmailsSection.customizeModalButtonColorAutoSwatch.click();
 
         await welcomeEmailsSection.customizeModalButtonColorPickerTrigger.click();
         await expect(welcomeEmailsSection.customizeModalButtonColorAccentSwatch).toBeVisible();


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/24453350917/job/71449353776

### Changes
- Updated `Escape closes welcome email color picker without bypassing unsaved changes confirmation` in [e2e/tests/admin/settings/member-welcome-emails.test.ts](/Users/troy/work/Ghost/e2e/tests/admin/settings/member-welcome-emails.test.ts).
- Replaced implicit dirty-state setup with a deterministic color-change sequence:
  - open picker
  - click `Accent`
  - reopen picker
  - click `Auto`
- Kept Escape assertions unchanged:
  - first `Escape` closes only the color picker
  - second `Escape` shows unsaved-changes confirmation and keeps the customize modal open

### Why
The test was intermittent because dirty state was not always guaranteed before `Escape`.