### PR TITLE
Fixed reference to missing install deps script

### DIFF
--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -35,7 +35,7 @@ RUN corepack enable
 
 # Install deps with a persistent pnpm store cache to speed up rebuilds
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
-    bash .github/scripts/install-deps.sh
+    pnpm install --frozen-lockfile --prefer-offline
 
 # Copy entrypoint script that optionally loads Tinybird config
 COPY docker/ghost-dev/entrypoint.sh entrypoint.sh


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/27386

As part of the above PR `.github/scripts/install-deps.sh` was removed, but it is still referenced in the Dockerfile which causes `pnpm dev` to fail:

```
=> ERROR [ghost-dev stage-0 11/14] RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store     bash .github/scripts/install-deps.sh                   0.6s
------
 > [ghost-dev stage-0 11/14] RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store     bash .github/scripts/install-deps.sh:
0.345 bash: .github/scripts/install-deps.sh: No such file or directory
------
Dockerfile:37

--------------------

  36 |     # Install deps with a persistent pnpm store cache to speed up rebuilds

  37 | >>> RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \

  38 | >>>     bash .github/scripts/install-deps.sh

  39 |

--------------------

target ghost-dev: failed to solve: process "/bin/sh -c bash .github/scripts/install-deps.sh" did not complete successfully: exit code: 127
```

