### PR TITLE
Removed install-deps.sh reference from development entrypoint

### DIFF
--- a/docker/development.entrypoint.sh
+++ b/docker/development.entrypoint.sh
@@ -14,13 +14,13 @@ set -euo pipefail
         stored_hash=$(cat "$pnpm_lock_hash_file_path")
         if [ "$calculated_hash" != "$stored_hash" ]; then
             echo "INFO: pnpm-lock.yaml has changed. Running pnpm install..."
-            bash .github/scripts/install-deps.sh
+            pnpm install
             mkdir -p .pnpmhash
             echo "$calculated_hash" > "$pnpm_lock_hash_file_path"
         fi
     else
         echo "WARNING: pnpm-lock.yaml hash file ($pnpm_lock_hash_file_path) not found. Running pnpm install as a precaution."
-        bash .github/scripts/install-deps.sh
+        pnpm install
         mkdir -p .pnpmhash
         echo "$calculated_hash" > "$pnpm_lock_hash_file_path"
     fi


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/27386, https://github.com/TryGhost/Ghost/pull/27407

## Summary

- The `install-deps.sh` script was retired in #27386 and the file deleted
- #27407 removes the reference from the Dockerfile
- This removes the remaining references in `docker/development.entrypoint.sh`, replacing them with direct `pnpm install` calls
- The entrypoint wasn't failing because the hash-check code path only runs when `pnpm-lock.yaml` changes after the container is already built

## Test plan

- [x] Shell syntax validation (`bash -n`) passes
- [ ] Verify `pnpm dev` works after #27407 lands and Docker image is rebuilt