### PR TITLE
Added expired gift cleanup to the gift cleanup job

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -85,6 +85,16 @@ export class GiftBookshelfRepository implements GiftRepository {
         return collection.models.map(model => this.toGift(model));
     }
 
+    async findPendingExpiration(): Promise<Gift[]> {
+        const now = new Date();
+
+        const collection = await this.model.findAll({
+            filter: `status:purchased+expires_at:<'${now.toISOString()}'`
+        });
+
+        return collection.models.map(model => this.toGift(model));
+    }
+
     async create(gift: Gift, options: RepositoryTransactionOptions = {}) {
         await this.model.add(this.toRow(gift), options);
     }

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -10,6 +10,7 @@ export interface GiftRepository {
     getByToken(token: string, options?: RepositoryTransactionOptions): Promise<Gift | null>;
     getByPaymentIntentId(paymentIntentId: string): Promise<Gift | null>;
     findPendingConsumption(): Promise<Gift[]>;
+    findPendingExpiration(): Promise<Gift[]>;
     create(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     update(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -320,4 +320,28 @@ export class GiftService {
 
         return {consumedCount, updatedMemberCount};
     }
+
+    async processExpired(): Promise<{expiredCount: number}> {
+        const toExpire = await this.deps.giftRepository.findPendingExpiration();
+
+        if (toExpire.length === 0) {
+            return {expiredCount: 0};
+        }
+
+        let expiredCount = 0;
+
+        for (const gift of toExpire) {
+            const expired = gift.expire();
+
+            if (!expired) {
+                continue;
+            }
+
+            await this.deps.giftRepository.update(expired);
+
+            expiredCount += 1;
+        }
+
+        return {expiredCount};
+    }
 }

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -294,28 +294,35 @@ export class GiftService {
         let updatedMemberCount = 0;
 
         for (const gift of toConsume) {
-            const consumed = gift.consume();
-
-            if (!consumed) {
-                continue;
-            }
-
             await this.deps.giftRepository.transaction(async (transacting) => {
-                const member = await this.deps.memberRepository.get({id: gift.redeemerMemberId}, {transacting});
+                // Re-fetch with a row lock to prevent races with concurrent refunds
+                const locked = await this.deps.giftRepository.getByToken(gift.token, {transacting, forUpdate: true});
+
+                if (locked?.status !== 'redeemed') {
+                    return;
+                }
+
+                const consumed = locked.consume();
+
+                if (!consumed) {
+                    return;
+                }
+
+                const member = await this.deps.memberRepository.get({id: locked.redeemerMemberId}, {transacting});
 
                 if (member && member.get('status') === 'gift') {
                     await this.deps.memberRepository.update({
                         products: [],
                         status: 'free'
-                    }, {id: gift.redeemerMemberId, transacting});
+                    }, {id: locked.redeemerMemberId, transacting});
 
                     updatedMemberCount += 1;
                 }
 
                 await this.deps.giftRepository.update(consumed, {transacting});
-            });
 
-            consumedCount += 1;
+                consumedCount += 1;
+            });
         }
 
         return {consumedCount, updatedMemberCount};
@@ -331,15 +338,24 @@ export class GiftService {
         let expiredCount = 0;
 
         for (const gift of toExpire) {
-            const expired = gift.expire();
+            await this.deps.giftRepository.transaction(async (transacting) => {
+                // Re-fetch with a row lock to prevent races with concurrent redeems / refunds
+                const locked = await this.deps.giftRepository.getByToken(gift.token, {transacting, forUpdate: true});
 
-            if (!expired) {
-                continue;
-            }
+                if (locked?.status !== 'purchased') {
+                    return;
+                }
 
-            await this.deps.giftRepository.update(expired);
+                const expired = locked.expire();
 
-            expiredCount += 1;
+                if (!expired) {
+                    return;
+                }
+
+                await this.deps.giftRepository.update(expired, {transacting});
+
+                expiredCount += 1;
+            });
         }
 
         return {expiredCount};

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -308,7 +308,7 @@ export class GiftService {
                     return;
                 }
 
-                const member = await this.deps.memberRepository.get({id: locked.redeemerMemberId}, {transacting});
+                const member = await this.deps.memberRepository.get({id: locked.redeemerMemberId}, {transacting, forUpdate: true});
 
                 if (member && member.get('status') === 'gift') {
                     await this.deps.memberRepository.update({

--- a/ghost/core/core/server/services/gifts/gift.ts
+++ b/ghost/core/core/server/services/gifts/gift.ts
@@ -187,4 +187,16 @@ export class Gift {
             consumedAt: new Date()
         });
     }
+
+    expire(): Gift | null {
+        if (this.isExpired()) {
+            return null;
+        }
+
+        return new Gift({
+            ...this,
+            status: 'expired',
+            expiredAt: new Date()
+        });
+    }
 }

--- a/ghost/core/core/server/services/members/jobs/clean-gifts.js
+++ b/ghost/core/core/server/services/members/jobs/clean-gifts.js
@@ -1,14 +1,14 @@
 const {parentPort} = require('node:worker_threads');
-const debug = require('@tryghost/debug')('jobs:clean-consumed-gifts');
+const debug = require('@tryghost/debug')('jobs:clean-gifts');
 
-// recurring job to clean consumed gift subscriptions
+// recurring job to clean consumed and expired gifts
 
 // Exit early when cancelled to prevent stalling shutdown. No cleanup needed
 // when cancelling as everything is idempotent and will pick up where it left
 // off on next run
 function cancel() {
     if (parentPort) {
-        parentPort.postMessage('Consumed gift subscriptions cleanup cancelled before completion');
+        parentPort.postMessage('Gift cleanup cancelled before completion');
         parentPort.postMessage('cancelled');
     } else {
         setTimeout(() => {
@@ -28,14 +28,16 @@ if (parentPort) {
 (async () => {
     try {
         const cleanupStartDate = new Date();
-        debug('Starting cleanup of consumed gift subscriptions');
+        debug('Starting gift cleanup');
 
         const giftService = require('../../gifts');
         await giftService.init();
 
         const {consumedCount, updatedMemberCount} = await giftService.service.processConsumed();
+        const {expiredCount} = await giftService.service.processExpired();
+
         const cleanupEndDate = new Date();
-        const message = `Consumed ${consumedCount} gifts, updated ${updatedMemberCount} members in ${cleanupEndDate.valueOf() - cleanupStartDate.valueOf()}ms`;
+        const message = `Consumed ${consumedCount} gifts, updated ${updatedMemberCount} members, expired ${expiredCount} gifts in ${cleanupEndDate.valueOf() - cleanupStartDate.valueOf()}ms`;
 
         debug(message);
 

--- a/ghost/core/core/server/services/members/jobs/index.js
+++ b/ghost/core/core/server/services/members/jobs/index.js
@@ -3,7 +3,7 @@ const jobsService = require('../../jobs');
 
 let hasScheduled = {
     expiredComped: false,
-    consumedGifts: false,
+    gifts: false,
     tokens: false
 };
 
@@ -32,8 +32,8 @@ module.exports = {
         return scheduleJob('expiredComped', 'clean-expired-comped', 'clean-expired-comped.js');
     },
 
-    async scheduleConsumedGiftCleanupJob() {
-        return scheduleJob('consumedGifts', 'clean-consumed-gifts', 'clean-consumed-gifts.js');
+    async scheduleGiftCleanupJob() {
+        return scheduleJob('gifts', 'clean-gifts', 'clean-gifts.js');
     },
 
     async scheduleTokenCleanupJob() {

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -166,9 +166,9 @@ module.exports = {
         // Schedule daily cron job to clean expired tokens
         memberJobs.scheduleTokenCleanupJob();
 
-        // Schedule daily cron job to clean consumed gift subscriptions
+        // Schedule daily cron job to clean consumed and expired gifts
         if (labsService.isSet('giftSubscriptions')) {
-            memberJobs.scheduleConsumedGiftCleanupJob();
+            memberJobs.scheduleGiftCleanupJob();
         }
     },
     contentGating: require('./content-gating'),

--- a/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
@@ -269,4 +269,61 @@ describe('GiftBookshelfRepository', function () {
         assert.ok(filterDate >= before);
         assert.ok(filterDate <= after);
     });
+
+    it('finds gifts pending expiration using current time', async function () {
+        const before = new Date();
+
+        const GiftModel = {
+            add: sinon.stub(),
+            transaction: sinon.stub(),
+            findOne: sinon.stub(),
+            findAll: sinon.stub().resolves({
+                models: [{
+                    toJSON() {
+                        return {
+                            token: 'gift-token',
+                            buyer_email: 'buyer@example.com',
+                            buyer_member_id: 'buyer_member_1',
+                            redeemer_member_id: null,
+                            tier_id: 'tier_1',
+                            cadence: 'year',
+                            duration: 1,
+                            currency: 'usd',
+                            amount: 5000,
+                            stripe_checkout_session_id: 'cs_123',
+                            stripe_payment_intent_id: 'pi_456',
+                            consumes_at: null,
+                            expires_at: new Date('2025-01-01T00:00:00.000Z'),
+                            status: 'purchased',
+                            purchased_at: new Date('2024-01-01T00:00:00.000Z'),
+                            redeemed_at: null,
+                            consumed_at: null,
+                            expired_at: null,
+                            refunded_at: null
+                        };
+                    }
+                }]
+            })
+        };
+        const repository = new GiftBookshelfRepository({GiftModel});
+
+        const gifts = await repository.findPendingExpiration();
+
+        const after = new Date();
+
+        assert.equal(gifts.length, 1);
+        assert.equal(gifts[0].token, 'gift-token');
+        assert.equal(gifts[0].status, 'purchased');
+
+        sinon.assert.calledOnce(GiftModel.findAll);
+
+        const filterArg = GiftModel.findAll.getCall(0).args[0].filter;
+        assert.ok(filterArg.startsWith('status:purchased+expires_at:<\''));
+
+        const dateStr = filterArg.match(/expires_at:<'(.+)'/)[1];
+        const filterDate = new Date(dateStr);
+
+        assert.ok(filterDate >= before);
+        assert.ok(filterDate <= after);
+    });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -12,6 +12,7 @@ describe('GiftService', function () {
         getByToken: sinon.SinonStub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>;
         getByPaymentIntentId: sinon.SinonStub<[string], Promise<Gift | null>>;
         findPendingConsumption: sinon.SinonStub<[], Promise<Gift[]>>;
+        findPendingExpiration: sinon.SinonStub<[], Promise<Gift[]>>;
         create: sinon.SinonStub;
         update: sinon.SinonStub;
         transaction: sinon.SinonStub<Parameters<GiftRepository['transaction']>, Promise<unknown>>;
@@ -52,6 +53,7 @@ describe('GiftService', function () {
             getByToken: sinon.stub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>().resolves(null),
             getByPaymentIntentId: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
             findPendingConsumption: sinon.stub<[], Promise<Gift[]>>().resolves([]),
+            findPendingExpiration: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             create: sinon.stub(),
             update: sinon.stub(),
             transaction: sinon.stub<Parameters<GiftRepository['transaction']>, Promise<unknown>>().callsFake(async (callback) => {
@@ -543,6 +545,58 @@ describe('GiftService', function () {
             assert.equal(result.consumedCount, 2);
             assert.equal(result.updatedMemberCount, 2);
             assert.equal(memberRepository.update.callCount, 2);
+            assert.equal(giftRepository.update.callCount, 2);
+        });
+    });
+
+    describe('processExpired', function () {
+        it('returns zero count when no gifts are pending expiration', async function () {
+            giftRepository.findPendingExpiration.resolves([]);
+
+            const service = createService();
+            const result = await service.processExpired();
+
+            assert.deepEqual(result, {expiredCount: 0});
+            sinon.assert.notCalled(giftRepository.update);
+        });
+
+        it('marks purchased gifts past their expiry as expired', async function () {
+            const gift = buildGift({
+                status: 'purchased',
+                expiresAt: new Date('2026-01-01T00:00:00.000Z')
+            });
+
+            giftRepository.findPendingExpiration.resolves([gift]);
+
+            const service = createService();
+            const result = await service.processExpired();
+
+            assert.equal(result.expiredCount, 1);
+
+            sinon.assert.calledOnce(giftRepository.update);
+            const savedGift = giftRepository.update.getCall(0).args[0];
+            assert.equal(savedGift.status, 'expired');
+            assert.notEqual(savedGift.expiredAt, null);
+        });
+
+        it('handles multiple expired gifts', async function () {
+            const gift1 = buildGift({
+                token: 'gift-1',
+                status: 'purchased',
+                expiresAt: new Date('2025-06-01T00:00:00.000Z')
+            });
+            const gift2 = buildGift({
+                token: 'gift-2',
+                status: 'purchased',
+                expiresAt: new Date('2025-12-01T00:00:00.000Z')
+            });
+
+            giftRepository.findPendingExpiration.resolves([gift1, gift2]);
+
+            const service = createService();
+            const result = await service.processExpired();
+
+            assert.equal(result.expiredCount, 2);
             assert.equal(giftRepository.update.callCount, 2);
         });
     });

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -560,11 +560,11 @@ describe('GiftService', function () {
                 .withArgs('gift-1', {transacting: 'trx', forUpdate: true}).resolves(gift1)
                 .withArgs('gift-2', {transacting: 'trx', forUpdate: true}).resolves(gift2);
             memberRepository.get
-                .withArgs({id: 'member_1'}, {transacting: 'trx'}).resolves({
+                .withArgs({id: 'member_1'}, {transacting: 'trx', forUpdate: true}).resolves({
                     id: 'member_1',
                     get: sinon.stub().withArgs('status').returns('gift')
                 })
-                .withArgs({id: 'member_2'}, {transacting: 'trx'}).resolves({
+                .withArgs({id: 'member_2'}, {transacting: 'trx', forUpdate: true}).resolves({
                     id: 'member_2',
                     get: sinon.stub().withArgs('status').returns('gift')
                 });

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -446,6 +446,7 @@ describe('GiftService', function () {
             });
 
             giftRepository.findPendingConsumption.resolves([gift]);
+            giftRepository.getByToken.resolves(gift);
             memberRepository.get.resolves({
                 id: 'member_1',
                 get: sinon.stub().withArgs('status').returns('gift')
@@ -458,6 +459,7 @@ describe('GiftService', function () {
             assert.equal(result.updatedMemberCount, 1);
 
             sinon.assert.calledOnce(giftRepository.transaction);
+            sinon.assert.calledOnceWithExactly(giftRepository.getByToken, gift.token, {transacting: 'trx', forUpdate: true});
             sinon.assert.calledOnceWithExactly(memberRepository.update, {
                 products: [],
                 status: 'free'
@@ -469,6 +471,29 @@ describe('GiftService', function () {
             assert.notEqual(savedGift.consumedAt, null);
         });
 
+        it('skips gifts that are no longer redeemed when re-loaded', async function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemerMemberId: 'member_1',
+                redeemedAt: new Date('2025-04-01T00:00:00.000Z'),
+                consumesAt: new Date('2026-04-01T00:00:00.000Z')
+            });
+
+            giftRepository.findPendingConsumption.resolves([gift]);
+            giftRepository.getByToken.resolves(buildGift({
+                status: 'refunded',
+                refundedAt: new Date()
+            }));
+
+            const service = createService();
+            const result = await service.processConsumed();
+
+            assert.equal(result.consumedCount, 0);
+            assert.equal(result.updatedMemberCount, 0);
+            sinon.assert.notCalled(giftRepository.update);
+            sinon.assert.notCalled(memberRepository.get);
+        });
+
         it('skips members that are no longer in gift status', async function () {
             const gift = buildGift({
                 status: 'redeemed',
@@ -478,6 +503,7 @@ describe('GiftService', function () {
             });
 
             giftRepository.findPendingConsumption.resolves([gift]);
+            giftRepository.getByToken.resolves(gift);
             memberRepository.get.resolves({
                 id: 'member_1',
                 get: sinon.stub().withArgs('status').returns('paid')
@@ -502,6 +528,7 @@ describe('GiftService', function () {
             });
 
             giftRepository.findPendingConsumption.resolves([gift]);
+            giftRepository.getByToken.resolves(gift);
             memberRepository.get.resolves(null);
 
             const service = createService();
@@ -529,6 +556,9 @@ describe('GiftService', function () {
             });
 
             giftRepository.findPendingConsumption.resolves([gift1, gift2]);
+            giftRepository.getByToken
+                .withArgs('gift-1', {transacting: 'trx', forUpdate: true}).resolves(gift1)
+                .withArgs('gift-2', {transacting: 'trx', forUpdate: true}).resolves(gift2);
             memberRepository.get
                 .withArgs({id: 'member_1'}, {transacting: 'trx'}).resolves({
                     id: 'member_1',
@@ -567,16 +597,41 @@ describe('GiftService', function () {
             });
 
             giftRepository.findPendingExpiration.resolves([gift]);
+            giftRepository.getByToken.resolves(gift);
 
             const service = createService();
             const result = await service.processExpired();
 
             assert.equal(result.expiredCount, 1);
 
+            sinon.assert.calledOnce(giftRepository.transaction);
+            sinon.assert.calledOnceWithExactly(giftRepository.getByToken, gift.token, {transacting: 'trx', forUpdate: true});
+
             sinon.assert.calledOnce(giftRepository.update);
             const savedGift = giftRepository.update.getCall(0).args[0];
             assert.equal(savedGift.status, 'expired');
             assert.notEqual(savedGift.expiredAt, null);
+        });
+
+        it('skips gifts that are no longer purchased when re-loaded', async function () {
+            const gift = buildGift({
+                status: 'purchased',
+                expiresAt: new Date('2026-01-01T00:00:00.000Z')
+            });
+
+            giftRepository.findPendingExpiration.resolves([gift]);
+            giftRepository.getByToken.resolves(buildGift({
+                status: 'redeemed',
+                redeemedAt: new Date(),
+                redeemerMemberId: 'member_1',
+                consumesAt: new Date('2027-01-01T00:00:00.000Z')
+            }));
+
+            const service = createService();
+            const result = await service.processExpired();
+
+            assert.equal(result.expiredCount, 0);
+            sinon.assert.notCalled(giftRepository.update);
         });
 
         it('handles multiple expired gifts', async function () {
@@ -592,6 +647,9 @@ describe('GiftService', function () {
             });
 
             giftRepository.findPendingExpiration.resolves([gift1, gift2]);
+            giftRepository.getByToken
+                .withArgs('gift-1', {transacting: 'trx', forUpdate: true}).resolves(gift1)
+                .withArgs('gift-2', {transacting: 'trx', forUpdate: true}).resolves(gift2);
 
             const service = createService();
             const result = await service.processExpired();

--- a/ghost/core/test/unit/server/services/gifts/gift.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift.test.ts
@@ -249,6 +249,37 @@ describe('Gift', function () {
         });
     });
 
+    describe('expire', function () {
+        it('returns an expired gift without mutating the original', function () {
+            const gift = buildGift();
+            const before = new Date();
+
+            const expired = gift.expire();
+
+            const after = new Date();
+
+            assert.ok(expired);
+            assert.notEqual(expired, gift);
+            assert.equal(gift.status, 'purchased');
+            assert.equal(gift.expiredAt, null);
+            assert.equal(expired.status, 'expired');
+            assert.ok(expired.expiredAt);
+            assert.ok(expired.expiredAt >= before);
+            assert.ok(expired.expiredAt <= after);
+        });
+
+        it('returns null if already expired', function () {
+            const gift = buildGift({
+                status: 'expired',
+                expiredAt: new Date('2026-02-01T00:00:00.000Z')
+            });
+
+            const result = gift.expire();
+
+            assert.equal(result, null);
+        });
+    });
+
     describe('refund', function () {
         it('returns a refunded gift without mutating the original', function () {
             const gift = buildGift();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3527

Unredeemed gifts past their `expires_at` date were left in purchased status indefinitely. This expands the existing consumed gift cleanup job to also transition these to `expired` status, preventing them from being redeemable