### PR TITLE
Added endpoints for managing drip campaigns

### DIFF
--- a/ghost/core/core/server/api/endpoints/automated-email-sequences.js
+++ b/ghost/core/core/server/api/endpoints/automated-email-sequences.js
@@ -1,0 +1,312 @@
+const tpl = require('@tryghost/tpl');
+const errors = require('@tryghost/errors');
+const models = require('../../models');
+
+const messages = {
+    automationNotFound: 'Automation not found.',
+    emailNotInAutomation: 'One or more email IDs do not belong to this automation.'
+};
+
+const EMAIL_FIELDS = ['delay_days', 'subject', 'lexical', 'sender_name', 'sender_email', 'sender_reply_to', 'email_design_setting_id'];
+
+/**
+ * Walk the linked list of emails and return them in order.
+ *
+ * @param {import('bookshelf').Collection} emailsCollection
+ * @returns {import('bookshelf').Model[]}
+ */
+function orderEmailsByLinkedList(emailsCollection) {
+    const emails = emailsCollection.models;
+    if (emails.length === 0) {
+        return [];
+    }
+
+    // Build a map from id -> model, and find all "next" pointers
+    const byId = new Map(emails.map(e => [e.id, e]));
+    const referencedAsNext = new Set(
+        emails
+            .map(e => e.get('next_welcome_email_automated_email_id'))
+            .filter(Boolean)
+    );
+
+    // The head is the email whose id is NOT referenced as anyone's "next"
+    let head = null;
+    for (const email of emails) {
+        if (!referencedAsNext.has(email.id)) {
+            head = email;
+            break;
+        }
+    }
+
+    // If no head found (circular?), fall back to first email
+    if (!head) {
+        head = emails[0];
+    }
+
+    const ordered = [];
+    let current = head;
+    const visited = new Set();
+    while (current && !visited.has(current.id)) {
+        visited.add(current.id);
+        ordered.push(current);
+        const nextId = current.get('next_welcome_email_automated_email_id');
+        current = nextId ? byId.get(nextId) : null;
+    }
+
+    return ordered;
+}
+
+/**
+ * Format an ordered array of email models into the API response shape.
+ */
+function formatSequenceResponse(automationId, orderedEmails) {
+    return {
+        id: automationId,
+        emails: orderedEmails.map(email => ({
+            id: email.id,
+            delay_days: email.get('delay_days'),
+            subject: email.get('subject'),
+            lexical: email.get('lexical'),
+            sender_name: email.get('sender_name'),
+            sender_email: email.get('sender_email'),
+            sender_reply_to: email.get('sender_reply_to'),
+            email_design_setting_id: email.get('email_design_setting_id')
+        }))
+    };
+}
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'automated_email_sequences',
+
+    read: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [],
+        data: ['id'],
+        permissions: {
+            docName: 'automated_emails',
+            method: 'browse'
+        },
+        async query(frame) {
+            const automation = await models.WelcomeEmailAutomation.findOne(
+                {id: frame.data.id},
+                {withRelated: ['welcomeEmailAutomatedEmails']}
+            );
+
+            if (!automation) {
+                throw new errors.NotFoundError({
+                    message: tpl(messages.automationNotFound)
+                });
+            }
+
+            const ordered = orderEmailsByLinkedList(automation.related('welcomeEmailAutomatedEmails'));
+            return formatSequenceResponse(automation.id, ordered);
+        }
+    },
+
+    edit: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: ['id'],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'automated_emails',
+            method: 'edit'
+        },
+        // eslint-disable-next-line ghost/ghost-custom/max-api-complexity
+        async query(frame) {
+            const db = require('../../data/db');
+            const requestEmails = frame.data.automated_email_sequences[0].emails;
+
+            return models.Base.transaction(async (transacting) => {
+                // A. Load current state
+                const automation = await models.WelcomeEmailAutomation.findOne(
+                    {id: frame.options.id},
+                    {transacting, withRelated: ['welcomeEmailAutomatedEmails']}
+                );
+
+                if (!automation) {
+                    throw new errors.NotFoundError({
+                        message: tpl(messages.automationNotFound)
+                    });
+                }
+
+                const existingEmails = automation.related('welcomeEmailAutomatedEmails');
+                const existingById = new Map(existingEmails.models.map(e => [e.id, e]));
+
+                // B. Compute diff
+                const toUpdate = [];
+                const toCreate = [];
+                const requestIdSet = new Set();
+
+                for (const reqEmail of requestEmails) {
+                    if (reqEmail.id) {
+                        if (!existingById.has(reqEmail.id)) {
+                            throw new errors.ValidationError({
+                                message: tpl(messages.emailNotInAutomation)
+                            });
+                        }
+                        requestIdSet.add(reqEmail.id);
+                        toUpdate.push(reqEmail);
+                    } else {
+                        toCreate.push(reqEmail);
+                    }
+                }
+
+                const toDeleteIds = [];
+                for (const existing of existingEmails.models) {
+                    if (!requestIdSet.has(existing.id)) {
+                        toDeleteIds.push(existing.id);
+                    }
+                }
+
+                // Build old ordered list for run reconciliation
+                const oldOrdered = orderEmailsByLinkedList(existingEmails);
+
+                // C. Create new emails (with null next pointer for now)
+                const createdIdsByIndex = new Map();
+                let requestIndex = 0;
+                for (const reqEmail of requestEmails) {
+                    if (!reqEmail.id) {
+                        const emailData = {};
+                        for (const field of EMAIL_FIELDS) {
+                            if (field in reqEmail) {
+                                emailData[field] = reqEmail[field];
+                            }
+                        }
+                        const created = await models.WelcomeEmailAutomatedEmail.add(
+                            {
+                                ...emailData,
+                                welcome_email_automation_id: automation.id,
+                                next_welcome_email_automated_email_id: null
+                            },
+                            {transacting}
+                        );
+                        createdIdsByIndex.set(requestIndex, created.id);
+                    }
+                    requestIndex++;
+                }
+
+                // D. Update existing emails
+                for (const reqEmail of toUpdate) {
+                    const emailData = {};
+                    for (const field of EMAIL_FIELDS) {
+                        if (field in reqEmail) {
+                            emailData[field] = reqEmail[field];
+                        }
+                    }
+                    await models.WelcomeEmailAutomatedEmail.edit(
+                        {...emailData, next_welcome_email_automated_email_id: null},
+                        {id: reqEmail.id, transacting}
+                    );
+                }
+
+                // E. Set linked-list pointers
+                // Build the final ordered ID list
+                const finalOrderedIds = requestEmails.map((reqEmail, idx) => {
+                    return reqEmail.id || createdIdsByIndex.get(idx);
+                });
+
+                for (let i = 0; i < finalOrderedIds.length; i++) {
+                    const nextId = i + 1 < finalOrderedIds.length ? finalOrderedIds[i + 1] : null;
+                    await models.WelcomeEmailAutomatedEmail.edit(
+                        {next_welcome_email_automated_email_id: nextId},
+                        {id: finalOrderedIds[i], transacting}
+                    );
+                }
+
+                // F. Reconcile runs
+                if (toDeleteIds.length > 0) {
+                    const toDeleteSet = new Set(toDeleteIds);
+                    const finalOrderedIdSet = new Set(finalOrderedIds);
+
+                    // For each deleted email, find replacement: scan forward in old order
+                    // to find first surviving email
+                    const remapping = new Map();
+                    for (let i = 0; i < oldOrdered.length; i++) {
+                        const emailId = oldOrdered[i].id;
+                        if (!toDeleteSet.has(emailId)) {
+                            continue;
+                        }
+                        // Scan forward from position i+1
+                        let replacement = null;
+                        for (let j = i + 1; j < oldOrdered.length; j++) {
+                            if (finalOrderedIdSet.has(oldOrdered[j].id)) {
+                                replacement = oldOrdered[j];
+                                break;
+                            }
+                        }
+                        remapping.set(emailId, replacement);
+                    }
+
+                    // Apply remapping to runs
+                    for (const [deletedId, replacement] of remapping) {
+                        if (replacement) {
+                            const newDelayDays = requestEmails.find(
+                                (e, idx) => (e.id || createdIdsByIndex.get(idx)) === replacement.id
+                            )?.delay_days ?? replacement.get('delay_days');
+
+                            // Fetch affected runs to calculate ready_at in JS (cross-DB compatible)
+                            const affectedRuns = await db.knex('welcome_email_automation_runs')
+                                .where('next_welcome_email_automated_email_id', deletedId)
+                                .whereNull('exit_reason')
+                                .select('id', 'created_at')
+                                .transacting(transacting);
+
+                            for (const run of affectedRuns) {
+                                const readyAt = new Date(new Date(run.created_at).getTime() + newDelayDays * 86400000);
+                                await db.knex('welcome_email_automation_runs')
+                                    .where('id', run.id)
+                                    .update({
+                                        next_welcome_email_automated_email_id: replacement.id,
+                                        ready_at: readyAt,
+                                        step_started_at: null,
+                                        step_attempts: 0,
+                                        updated_at: new Date()
+                                    })
+                                    .transacting(transacting);
+                            }
+                        } else {
+                            await db.knex('welcome_email_automation_runs')
+                                .where('next_welcome_email_automated_email_id', deletedId)
+                                .whereNull('exit_reason')
+                                .update({
+                                    next_welcome_email_automated_email_id: null,
+                                    ready_at: null,
+                                    step_started_at: null,
+                                    step_attempts: 0,
+                                    exit_reason: 'finished',
+                                    updated_at: new Date()
+                                })
+                                .transacting(transacting);
+                        }
+                    }
+                }
+
+                // G. Delete removed emails
+                for (const deleteId of toDeleteIds) {
+                    await models.WelcomeEmailAutomatedEmail.destroy({id: deleteId, transacting});
+                }
+
+                // H. Return the new sequence
+                const updatedAutomation = await models.WelcomeEmailAutomation.findOne(
+                    {id: frame.options.id},
+                    {transacting, withRelated: ['welcomeEmailAutomatedEmails']}
+                );
+                const ordered = orderEmailsByLinkedList(updatedAutomation.related('welcomeEmailAutomatedEmails'));
+                return formatSequenceResponse(automation.id, ordered);
+            });
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -89,6 +89,10 @@ module.exports = {
         return apiFramework.pipeline(require('./automated-email-design'), localUtils);
     },
 
+    get automatedEmailSequences() {
+        return apiFramework.pipeline(require('./automated-email-sequences'), localUtils);
+    },
+
     get membersStripeConnect() {
         return apiFramework.pipeline(require('./members-stripe-connect'), localUtils);
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/automated_email_sequences.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/automated_email_sequences.js
@@ -1,0 +1,7 @@
+module.exports = {
+    all(data, apiConfig, frame) {
+        frame.response = {
+            automated_email_sequences: data
+        };
+    }
+};

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
@@ -151,5 +151,9 @@ module.exports = {
 
     get featurebase() {
         return require('./featurebase');
+    },
+
+    get automated_email_sequences() {
+        return require('./automated_email_sequences');
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/automated_email_sequences.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/automated_email_sequences.js
@@ -1,0 +1,101 @@
+// Filename must match the docName specified in ../../../automated-email-sequences.js
+/* eslint-disable ghost/filenames/match-regex */
+
+const {ValidationError} = require('@tryghost/errors');
+
+const MAX_EMAILS = 10;
+const MAX_DELAY_DAYS = 7;
+
+const messages = {
+    wrapperRequired: 'Request body must contain automated_email_sequences',
+    emailsRequired: 'Emails array is required and must not be empty',
+    tooManyEmails: `A sequence can contain at most ${MAX_EMAILS} emails`,
+    delayDaysRequired: 'delay_days must be a non-negative integer',
+    delayDaysTooHigh: `delay_days must not exceed ${MAX_DELAY_DAYS}`,
+    delayDaysMustBePositiveAfterFirst: 'delay_days must be at least 1 for emails after the first',
+    subjectRequired: 'Subject is required',
+    lexicalRequired: 'Email content is required',
+    invalidLexical: 'Lexical must be valid JSON',
+    fieldMustBeString: (field) => `${field} must be a string`,
+    fieldRequired: (field) => `${field} is required`,
+    duplicateIds: 'Duplicate email IDs in request'
+};
+
+const REQUIRED_STRING_FIELDS = ['sender_name', 'sender_email', 'sender_reply_to', 'email_design_setting_id'];
+
+module.exports = {
+    /**
+     * @param {unknown} apiConfig
+     * @param {{data: unknown}} frame
+     */
+    edit(apiConfig, frame) {
+        const wrapper = frame.data?.automated_email_sequences;
+        if (!Array.isArray(wrapper) || !wrapper[0] || typeof wrapper[0] !== 'object') {
+            throw new ValidationError({message: messages.wrapperRequired});
+        }
+
+        const data = wrapper[0];
+
+        if (!Array.isArray(data.emails) || data.emails.length === 0) {
+            throw new ValidationError({message: messages.emailsRequired});
+        }
+
+        if (data.emails.length > MAX_EMAILS) {
+            throw new ValidationError({message: messages.tooManyEmails});
+        }
+
+        const seenIds = new Set();
+
+        for (let i = 0; i < data.emails.length; i++) {
+            const email = data.emails[i];
+            const isFirst = i === 0;
+
+            // delay_days: required, non-negative integer, max MAX_DELAY_DAYS
+            if (typeof email.delay_days !== 'number' || email.delay_days < 0 || !Number.isInteger(email.delay_days)) {
+                throw new ValidationError({message: messages.delayDaysRequired, property: 'delay_days'});
+            }
+            if (email.delay_days > MAX_DELAY_DAYS) {
+                throw new ValidationError({message: messages.delayDaysTooHigh, property: 'delay_days'});
+            }
+            if (!isFirst && email.delay_days === 0) {
+                throw new ValidationError({message: messages.delayDaysMustBePositiveAfterFirst, property: 'delay_days'});
+            }
+
+            // subject: required, non-empty string
+            if (typeof email.subject !== 'string' || !email.subject.trim()) {
+                throw new ValidationError({message: messages.subjectRequired, property: 'subject'});
+            }
+
+            // lexical: required, valid JSON string
+            if (typeof email.lexical !== 'string' || !email.lexical.trim()) {
+                throw new ValidationError({message: messages.lexicalRequired, property: 'lexical'});
+            }
+            try {
+                JSON.parse(email.lexical);
+            } catch (e) {
+                throw new ValidationError({message: messages.invalidLexical, property: 'lexical'});
+            }
+
+            // Required string fields: must be present and a non-null string
+            for (const field of REQUIRED_STRING_FIELDS) {
+                if (!(field in email)) {
+                    throw new ValidationError({message: messages.fieldRequired(field), property: field});
+                }
+                if (typeof email[field] !== 'string') {
+                    throw new ValidationError({message: messages.fieldMustBeString(field), property: field});
+                }
+            }
+
+            // id: optional, but if present must be a string
+            if (email.id !== undefined) {
+                if (typeof email.id !== 'string') {
+                    throw new ValidationError({message: messages.fieldMustBeString('id'), property: 'id'});
+                }
+                if (seenIds.has(email.id)) {
+                    throw new ValidationError({message: messages.duplicateIds});
+                }
+                seenIds.add(email.id);
+            }
+        }
+    }
+};

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/index.js
@@ -9,6 +9,10 @@ module.exports = {
         return require('./automated_emails');
     },
 
+    get automated_email_sequences() {
+        return require('./automated_email_sequences');
+    },
+
     get password_reset() {
         return require('./password_reset');
     },

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -192,6 +192,13 @@ module.exports = function apiRoutes() {
     router.put('/automated_emails/design', mw.authAdminApi, http(api.automatedEmailDesign.edit));
     router.put('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.edit));
     router.post('/automated_emails/:id/test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automatedEmails.sendTestEmail));
+    router.get('/automated_emails/:id/sequence', mw.authAdminApi, http(api.automatedEmailSequences.read));
+    router.put('/automated_emails/:id/sequence', mw.authAdminApi, function normalizeSequenceBody(req, res, next) {
+        if (req.body && req.body.automated_email_sequences && !Array.isArray(req.body.automated_email_sequences)) {
+            req.body.automated_email_sequences = [req.body.automated_email_sequences];
+        }
+        next();
+    }, http(api.automatedEmailSequences.edit));
 
     // ## Roles
     router.get('/roles/', mw.authAdminApi, http(api.roles.browse));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automated-email-sequences.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automated-email-sequences.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Automated Email Sequences API Read Can read the sequence for an automation 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "521",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Email Sequences API Read Returns 404 for non-existent automation 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Automation not found.",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found error, cannot read automated_email_sequence.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;

--- a/ghost/core/test/e2e-api/admin/automated-email-sequences.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-email-sequences.test.js
@@ -1,0 +1,469 @@
+const {agentProvider, fixtureManager, matchers, dbUtils} = require('../../utils/e2e-framework');
+const {anyContentVersion, anyObjectId, anyErrorId, anyEtag} = matchers;
+const assert = require('node:assert/strict');
+const models = require('../../../core/server/models');
+
+describe('Automated Email Sequences API', function () {
+    let agent;
+
+    const createAutomation = async (overrides = {}) => {
+        const automation = await models.WelcomeEmailAutomation.add({
+            name: 'Welcome Email (Free)',
+            slug: 'member-welcome-email-free',
+            status: 'active',
+            ...overrides
+        });
+        return automation;
+    };
+
+    const createEmail = async (automationId, overrides = {}) => {
+        const email = await models.WelcomeEmailAutomatedEmail.add({
+            welcome_email_automation_id: automationId,
+            delay_days: 0,
+            subject: 'Welcome!',
+            lexical: JSON.stringify({root: {children: []}}),
+            sender_name: null,
+            sender_email: null,
+            sender_reply_to: null,
+            next_welcome_email_automated_email_id: null,
+            ...overrides
+        });
+        return email;
+    };
+
+    const validEmailPayload = (overrides = {}) => ({
+        delay_days: 0,
+        subject: 'Welcome!',
+        lexical: JSON.stringify({root: {children: []}}),
+        sender_name: 'Ghost',
+        sender_email: 'ghost@example.com',
+        sender_reply_to: 'ghost@example.com',
+        email_design_setting_id: undefined, // set per-test
+        ...overrides
+    });
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+        await agent.loginAsOwner();
+    });
+
+    beforeEach(async function () {
+        await dbUtils.truncate('welcome_email_automation_runs');
+        await dbUtils.truncate('welcome_email_automated_emails');
+        await dbUtils.truncate('welcome_email_automations');
+    });
+
+    describe('Read', function () {
+        it('Can read the sequence for an automation', async function () {
+            const automation = await createAutomation();
+            const email1 = await createEmail(automation.id, {delay_days: 0, subject: 'First'});
+            const email2 = await createEmail(automation.id, {delay_days: 3, subject: 'Second'});
+
+            // Link them: email1 -> email2
+            await models.WelcomeEmailAutomatedEmail.edit(
+                {next_welcome_email_automated_email_id: email2.id},
+                {id: email1.id}
+            );
+
+            const {body} = await agent
+                .get(`automated_emails/${automation.id}/sequence`)
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+
+            const seq = body.automated_email_sequences;
+            assert.equal(seq.id, automation.id);
+            assert.equal(seq.emails.length, 2);
+            assert.equal(seq.emails[0].id, email1.id);
+            assert.equal(seq.emails[0].subject, 'First');
+            assert.equal(seq.emails[0].delay_days, 0);
+            assert.equal(seq.emails[1].id, email2.id);
+            assert.equal(seq.emails[1].subject, 'Second');
+            assert.equal(seq.emails[1].delay_days, 3);
+        });
+
+        it('Returns empty emails array for automation with no emails', async function () {
+            const automation = await createAutomation();
+
+            const {body} = await agent
+                .get(`automated_emails/${automation.id}/sequence`)
+                .expectStatus(200);
+
+            assert.equal(body.automated_email_sequences.emails.length, 0);
+        });
+
+        it('Returns 404 for non-existent automation', async function () {
+            await agent
+                .get('automated_emails/aaaaaaaaaaaaaaaaaaaaaaaa/sequence')
+                .expectStatus(404)
+                .matchBodySnapshot({
+                    errors: [{id: anyErrorId}]
+                });
+        });
+    });
+
+    describe('Edit', function () {
+        let defaultDesignSettingId;
+
+        before(async function () {
+            let designSetting = await models.EmailDesignSetting.findOne({slug: 'default-automated-email'});
+            if (!designSetting) {
+                designSetting = await models.EmailDesignSetting.add({slug: 'default-automated-email'});
+            }
+            defaultDesignSettingId = designSetting.id;
+        });
+
+        it('Can create a sequence from scratch', async function () {
+            const automation = await createAutomation();
+
+            const {body} = await agent
+                .put(`automated_emails/${automation.id}/sequence`)
+                .body({automated_email_sequences: {
+                    emails: [
+                        validEmailPayload({delay_days: 0, subject: 'Welcome', email_design_setting_id: defaultDesignSettingId}),
+                        validEmailPayload({delay_days: 3, subject: 'Follow-up', email_design_setting_id: defaultDesignSettingId})
+                    ]
+                }})
+                .expectStatus(200);
+
+            const seq = body.automated_email_sequences;
+            assert.equal(seq.emails.length, 2);
+            assert.equal(seq.emails[0].subject, 'Welcome');
+            assert.equal(seq.emails[0].delay_days, 0);
+            assert.equal(seq.emails[1].subject, 'Follow-up');
+            assert.equal(seq.emails[1].delay_days, 3);
+
+            // Verify linked list in DB
+            const dbEmail1 = await models.WelcomeEmailAutomatedEmail.findOne({id: seq.emails[0].id});
+            assert.equal(dbEmail1.get('next_welcome_email_automated_email_id'), seq.emails[1].id);
+
+            const dbEmail2 = await models.WelcomeEmailAutomatedEmail.findOne({id: seq.emails[1].id});
+            assert.equal(dbEmail2.get('next_welcome_email_automated_email_id'), null);
+        });
+
+        it('Can update existing emails in a sequence', async function () {
+            const automation = await createAutomation();
+            const email = await createEmail(automation.id, {
+                delay_days: 0,
+                subject: 'Old Subject',
+                email_design_setting_id: defaultDesignSettingId
+            });
+
+            const {body} = await agent
+                .put(`automated_emails/${automation.id}/sequence`)
+                .body({automated_email_sequences: {
+                    emails: [
+                        validEmailPayload({
+                            id: email.id,
+                            delay_days: 1,
+                            subject: 'New Subject',
+                            email_design_setting_id: defaultDesignSettingId
+                        })
+                    ]
+                }})
+                .expectStatus(200);
+
+            const seq = body.automated_email_sequences;
+            assert.equal(seq.emails.length, 1);
+            assert.equal(seq.emails[0].id, email.id);
+            assert.equal(seq.emails[0].subject, 'New Subject');
+            assert.equal(seq.emails[0].delay_days, 1);
+        });
+
+        it('Can add new emails to an existing sequence', async function () {
+            const automation = await createAutomation();
+            const existing = await createEmail(automation.id, {
+                delay_days: 0,
+                subject: 'First',
+                email_design_setting_id: defaultDesignSettingId
+            });
+
+            const {body} = await agent
+                .put(`automated_emails/${automation.id}/sequence`)
+                .body({automated_email_sequences: {
+                    emails: [
+                        validEmailPayload({
+                            id: existing.id,
+                            delay_days: 0,
+                            subject: 'First',
+                            email_design_setting_id: defaultDesignSettingId
+                        }),
+                        validEmailPayload({
+                            delay_days: 2,
+                            subject: 'New Second',
+                            email_design_setting_id: defaultDesignSettingId
+                        })
+                    ]
+                }})
+                .expectStatus(200);
+
+            const seq = body.automated_email_sequences;
+            assert.equal(seq.emails.length, 2);
+            assert.equal(seq.emails[0].id, existing.id);
+            assert.ok(seq.emails[1].id);
+            assert.equal(seq.emails[1].subject, 'New Second');
+        });
+
+        it('Deletes emails not in the request', async function () {
+            const automation = await createAutomation();
+            const email1 = await createEmail(automation.id, {
+                delay_days: 0,
+                subject: 'Keep',
+                email_design_setting_id: defaultDesignSettingId
+            });
+            const email2 = await createEmail(automation.id, {
+                delay_days: 1,
+                subject: 'Delete Me',
+                email_design_setting_id: defaultDesignSettingId
+            });
+            await models.WelcomeEmailAutomatedEmail.edit(
+                {next_welcome_email_automated_email_id: email2.id},
+                {id: email1.id}
+            );
+
+            const {body} = await agent
+                .put(`automated_emails/${automation.id}/sequence`)
+                .body({automated_email_sequences: {
+                    emails: [
+                        validEmailPayload({
+                            id: email1.id,
+                            delay_days: 0,
+                            subject: 'Keep',
+                            email_design_setting_id: defaultDesignSettingId
+                        })
+                    ]
+                }})
+                .expectStatus(200);
+
+            const seq = body.automated_email_sequences;
+            assert.equal(seq.emails.length, 1);
+            assert.equal(seq.emails[0].id, email1.id);
+
+            const deleted = await models.WelcomeEmailAutomatedEmail.findOne({id: email2.id});
+            assert.equal(deleted, null);
+        });
+
+        it('Rejects email IDs not belonging to the automation', async function () {
+            const automation1 = await createAutomation({
+                name: 'Welcome Email (Free)',
+                slug: 'member-welcome-email-free'
+            });
+            const automation2 = await createAutomation({
+                name: 'Welcome Email (Paid)',
+                slug: 'member-welcome-email-paid'
+            });
+            const emailFromOther = await createEmail(automation2.id, {
+                email_design_setting_id: defaultDesignSettingId
+            });
+
+            await agent
+                .put(`automated_emails/${automation1.id}/sequence`)
+                .body({automated_email_sequences: {
+                    emails: [
+                        validEmailPayload({
+                            id: emailFromOther.id,
+                            email_design_setting_id: defaultDesignSettingId
+                        })
+                    ]
+                }})
+                .expectStatus(422);
+        });
+
+        it('Returns 404 for non-existent automation', async function () {
+            await agent
+                .put('automated_emails/aaaaaaaaaaaaaaaaaaaaaaaa/sequence')
+                .body({automated_email_sequences: {
+                    emails: [
+                        validEmailPayload({email_design_setting_id: 'bbbbbbbbbbbbbbbbbbbbbbbb'})
+                    ]
+                }})
+                .expectStatus(404);
+        });
+
+        describe('Run Reconciliation', function () {
+            it('Remaps runs from deleted email to next surviving email', async function () {
+                const automation = await createAutomation();
+                const email1 = await createEmail(automation.id, {
+                    delay_days: 0,
+                    subject: 'First',
+                    email_design_setting_id: defaultDesignSettingId
+                });
+                const email2 = await createEmail(automation.id, {
+                    delay_days: 1,
+                    subject: 'Second',
+                    email_design_setting_id: defaultDesignSettingId
+                });
+                const email3 = await createEmail(automation.id, {
+                    delay_days: 3,
+                    subject: 'Third',
+                    email_design_setting_id: defaultDesignSettingId
+                });
+                // Link: email1 -> email2 -> email3
+                await models.WelcomeEmailAutomatedEmail.edit(
+                    {next_welcome_email_automated_email_id: email2.id},
+                    {id: email1.id}
+                );
+                await models.WelcomeEmailAutomatedEmail.edit(
+                    {next_welcome_email_automated_email_id: email3.id},
+                    {id: email2.id}
+                );
+
+                const member = await models.Member.add({
+                    email: 'test-reconcile@example.com',
+                    name: 'Test',
+                    status: 'free',
+                    email_disabled: false
+                });
+
+                // Run pointing to email2 (about to be deleted)
+                await models.WelcomeEmailAutomationRun.add({
+                    welcome_email_automation_id: automation.id,
+                    member_id: member.id,
+                    next_welcome_email_automated_email_id: email2.id,
+                    ready_at: new Date(),
+                    step_started_at: null,
+                    step_attempts: 0,
+                    exit_reason: null
+                });
+
+                // Delete email2, keep email1 and email3
+                await agent
+                    .put(`automated_emails/${automation.id}/sequence`)
+                    .body({automated_email_sequences: {
+                        emails: [
+                            validEmailPayload({
+                                id: email1.id,
+                                delay_days: 0,
+                                subject: 'First',
+                                email_design_setting_id: defaultDesignSettingId
+                            }),
+                            validEmailPayload({
+                                id: email3.id,
+                                delay_days: 3,
+                                subject: 'Third',
+                                email_design_setting_id: defaultDesignSettingId
+                            })
+                        ]
+                    }})
+                    .expectStatus(200);
+
+                const runs = await models.WelcomeEmailAutomationRun.findAll({
+                    filter: `member_id:${member.id}`
+                });
+                assert.equal(runs.models.length, 1);
+                assert.equal(runs.models[0].get('next_welcome_email_automated_email_id'), email3.id);
+                assert.equal(runs.models[0].get('exit_reason'), null);
+            });
+
+            it('Marks runs as finished when deleted email has no replacement', async function () {
+                const automation = await createAutomation();
+                const email1 = await createEmail(automation.id, {
+                    delay_days: 0,
+                    subject: 'First',
+                    email_design_setting_id: defaultDesignSettingId
+                });
+                const email2 = await createEmail(automation.id, {
+                    delay_days: 1,
+                    subject: 'Last',
+                    email_design_setting_id: defaultDesignSettingId
+                });
+                await models.WelcomeEmailAutomatedEmail.edit(
+                    {next_welcome_email_automated_email_id: email2.id},
+                    {id: email1.id}
+                );
+
+                const member = await models.Member.add({
+                    email: 'test-finish@example.com',
+                    name: 'Test',
+                    status: 'free',
+                    email_disabled: false
+                });
+
+                await models.WelcomeEmailAutomationRun.add({
+                    welcome_email_automation_id: automation.id,
+                    member_id: member.id,
+                    next_welcome_email_automated_email_id: email2.id,
+                    ready_at: new Date(),
+                    step_started_at: null,
+                    step_attempts: 0,
+                    exit_reason: null
+                });
+
+                // Keep only email1
+                await agent
+                    .put(`automated_emails/${automation.id}/sequence`)
+                    .body({automated_email_sequences: {
+                        emails: [
+                            validEmailPayload({
+                                id: email1.id,
+                                delay_days: 0,
+                                subject: 'First',
+                                email_design_setting_id: defaultDesignSettingId
+                            })
+                        ]
+                    }})
+                    .expectStatus(200);
+
+                const runs = await models.WelcomeEmailAutomationRun.findAll({
+                    filter: `member_id:${member.id}`
+                });
+                assert.equal(runs.models[0].get('next_welcome_email_automated_email_id'), null);
+                assert.equal(runs.models[0].get('exit_reason'), 'finished');
+            });
+
+            it('Does not modify locked (in-progress) runs when delay_days changes', async function () {
+                const automation = await createAutomation();
+                const email = await createEmail(automation.id, {
+                    delay_days: 1,
+                    subject: 'Test',
+                    email_design_setting_id: defaultDesignSettingId
+                });
+
+                const member = await models.Member.add({
+                    email: 'test-locked@example.com',
+                    name: 'Test',
+                    status: 'free',
+                    email_disabled: false
+                });
+
+                const originalReadyAt = new Date('2026-04-02T00:00:00Z');
+                const lockedAt = new Date();
+                await models.WelcomeEmailAutomationRun.add({
+                    welcome_email_automation_id: automation.id,
+                    member_id: member.id,
+                    next_welcome_email_automated_email_id: email.id,
+                    ready_at: originalReadyAt,
+                    step_started_at: lockedAt,
+                    step_attempts: 1,
+                    exit_reason: null
+                });
+
+                // Change delay from 1 to 5
+                await agent
+                    .put(`automated_emails/${automation.id}/sequence`)
+                    .body({automated_email_sequences: {
+                        emails: [
+                            validEmailPayload({
+                                id: email.id,
+                                delay_days: 5,
+                                subject: 'Test',
+                                email_design_setting_id: defaultDesignSettingId
+                            })
+                        ]
+                    }})
+                    .expectStatus(200);
+
+                const runs = await models.WelcomeEmailAutomationRun.findAll({
+                    filter: `member_id:${member.id}`
+                });
+                const run = runs.models[0];
+                // ready_at should NOT have changed because the run was locked
+                const readyAt = new Date(run.get('ready_at'));
+                assert.equal(readyAt.toISOString().slice(0, 10), originalReadyAt.toISOString().slice(0, 10));
+            });
+        });
+    });
+});

--- a/ghost/core/test/unit/api/canary/utils/validators/input/automated_email_sequences.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/automated_email_sequences.test.js
@@ -1,0 +1,233 @@
+const assert = require('node:assert/strict');
+const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
+
+describe('Unit: endpoints/utils/validators/input/automated_email_sequences', function () {
+    const apiConfig = {
+        docName: 'automated_email_sequences',
+        method: 'edit'
+    };
+
+    function makeFrame(emails) {
+        return {
+            options: {},
+            data: {
+                automated_email_sequences: [{emails}]
+            }
+        };
+    }
+
+    function validEmail(overrides = {}) {
+        return {
+            delay_days: 0,
+            subject: 'Welcome!',
+            lexical: JSON.stringify({root: {children: []}}),
+            sender_name: 'Ghost',
+            sender_email: 'ghost@example.com',
+            sender_reply_to: 'ghost@example.com',
+            email_design_setting_id: 'abc123',
+            ...overrides
+        };
+    }
+
+    function assertValid(emails) {
+        validators.input.automated_email_sequences.edit(apiConfig, makeFrame(emails));
+    }
+
+    function assertInvalid(emails) {
+        assert.throws(
+            () => validators.input.automated_email_sequences.edit(apiConfig, makeFrame(emails)),
+            {errorType: 'ValidationError'}
+        );
+    }
+
+    describe('edit', function () {
+        it('accepts a valid single email', function () {
+            assertValid([validEmail()]);
+        });
+
+        it('accepts a valid sequence of multiple emails', function () {
+            assertValid([
+                validEmail({delay_days: 0}),
+                validEmail({delay_days: 3, subject: 'Follow-up'})
+            ]);
+        });
+
+        it('accepts emails with an id for updates', function () {
+            assertValid([validEmail({id: 'existing123'})]);
+        });
+
+        describe('wrapper structure', function () {
+            it('rejects missing wrapper', function () {
+                const frame = {options: {}, data: {}};
+                assert.throws(
+                    () => validators.input.automated_email_sequences.edit(apiConfig, frame),
+                    {errorType: 'ValidationError'}
+                );
+            });
+
+            it('rejects empty wrapper array', function () {
+                const frame = {options: {}, data: {automated_email_sequences: []}};
+                assert.throws(
+                    () => validators.input.automated_email_sequences.edit(apiConfig, frame),
+                    {errorType: 'ValidationError'}
+                );
+            });
+        });
+
+        describe('emails array', function () {
+            it('rejects missing emails array', function () {
+                const frame = {options: {}, data: {automated_email_sequences: [{}]}};
+                assert.throws(
+                    () => validators.input.automated_email_sequences.edit(apiConfig, frame),
+                    {errorType: 'ValidationError'}
+                );
+            });
+
+            it('rejects empty emails array', function () {
+                assertInvalid([]);
+            });
+
+            it('rejects more than 10 emails', function () {
+                const emails = Array.from({length: 11}, (_, i) => validEmail({delay_days: 1, subject: `Email ${i}`}));
+                assertInvalid(emails);
+            });
+
+            it('accepts exactly 10 emails', function () {
+                const emails = Array.from({length: 10}, (_, i) => validEmail({delay_days: 1, subject: `Email ${i}`}));
+                assertValid(emails);
+            });
+        });
+
+        describe('delay_days', function () {
+            it('rejects missing delay_days', function () {
+                const email = validEmail();
+                delete email.delay_days;
+                assertInvalid([email]);
+            });
+
+            it('rejects negative delay_days', function () {
+                assertInvalid([validEmail({delay_days: -1})]);
+            });
+
+            it('rejects non-integer delay_days', function () {
+                assertInvalid([validEmail({delay_days: 1.5})]);
+            });
+
+            it('rejects delay_days greater than 7', function () {
+                assertInvalid([validEmail({delay_days: 8})]);
+            });
+
+            it('accepts delay_days of exactly 7', function () {
+                assertValid([validEmail({delay_days: 7})]);
+            });
+
+            it('accepts zero delay_days for the first email', function () {
+                assertValid([validEmail({delay_days: 0})]);
+            });
+
+            it('rejects zero delay_days for a non-first email', function () {
+                assertInvalid([
+                    validEmail({delay_days: 0}),
+                    validEmail({delay_days: 0, subject: 'Second'})
+                ]);
+            });
+
+            it('accepts non-zero delay_days for a non-first email', function () {
+                assertValid([
+                    validEmail({delay_days: 0}),
+                    validEmail({delay_days: 1, subject: 'Second'})
+                ]);
+            });
+        });
+
+        describe('subject', function () {
+            it('rejects missing subject', function () {
+                const email = validEmail();
+                delete email.subject;
+                assertInvalid([email]);
+            });
+
+            it('rejects empty subject', function () {
+                assertInvalid([validEmail({subject: ''})]);
+            });
+
+            it('rejects whitespace-only subject', function () {
+                assertInvalid([validEmail({subject: '   '})]);
+            });
+        });
+
+        describe('lexical', function () {
+            it('rejects missing lexical', function () {
+                const email = validEmail();
+                delete email.lexical;
+                assertInvalid([email]);
+            });
+
+            it('rejects invalid JSON in lexical', function () {
+                assertInvalid([validEmail({lexical: 'not json'})]);
+            });
+        });
+
+        describe('required sender fields', function () {
+            it('rejects missing sender_name', function () {
+                const email = validEmail();
+                delete email.sender_name;
+                assertInvalid([email]);
+            });
+
+            it('rejects missing sender_email', function () {
+                const email = validEmail();
+                delete email.sender_email;
+                assertInvalid([email]);
+            });
+
+            it('rejects missing sender_reply_to', function () {
+                const email = validEmail();
+                delete email.sender_reply_to;
+                assertInvalid([email]);
+            });
+
+            it('rejects missing email_design_setting_id', function () {
+                const email = validEmail();
+                delete email.email_design_setting_id;
+                assertInvalid([email]);
+            });
+
+            it('rejects null sender_name', function () {
+                assertInvalid([validEmail({sender_name: null})]);
+            });
+
+            it('rejects null sender_email', function () {
+                assertInvalid([validEmail({sender_email: null})]);
+            });
+
+            it('rejects null sender_reply_to', function () {
+                assertInvalid([validEmail({sender_reply_to: null})]);
+            });
+
+            it('rejects non-string sender_name', function () {
+                assertInvalid([validEmail({sender_name: 123})]);
+            });
+
+            it('rejects non-string email_design_setting_id', function () {
+                assertInvalid([validEmail({email_design_setting_id: null})]);
+            });
+        });
+
+        describe('duplicate IDs', function () {
+            it('rejects duplicate email IDs', function () {
+                assertInvalid([
+                    validEmail({id: 'same-id', delay_days: 0}),
+                    validEmail({id: 'same-id', delay_days: 1})
+                ]);
+            });
+
+            it('allows multiple emails without IDs', function () {
+                assertValid([
+                    validEmail({delay_days: 0}),
+                    validEmail({delay_days: 1})
+                ]);
+            });
+        });
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1229

This adds `GET` and `PUT` `/automated_emails/:id/sequence` to read and write welcome email automations.
