### PR TITLE
Update parse-email-address output directory to dist

### DIFF
--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/TryGhost/Ghost/tree/main/ghost/parse-email-address",
   "author": "Ghost Foundation",
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
     "build": "pnpm build:tsc",
@@ -19,7 +19,7 @@
     "lint:test": "eslint -c test/.eslintrc.js test/ --ext .ts --cache"
   },
   "files": [
-    "build"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/ghost/parse-email-address/tsconfig.json
+++ b/ghost/parse-email-address/tsconfig.json
@@ -55,7 +55,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "build",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "dist",                                    /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/27018#pullrequestreview-4096070157

This change should have no user impact.

Let's use Nx's standard output dir for this package. This fixes an issue with Nx's caching.