### PR TITLE
Added staff notification on gift redemption

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -59,6 +59,13 @@ interface StaffServiceEmails {
         cadence: 'month' | 'year';
         duration: number;
     }): Promise<void>;
+    notifyGiftSubscriptionStarted(data: {
+        memberId: string;
+        memberEmail: string;
+        memberName: string | null;
+        tierName: string;
+        buyerEmail: string;
+    }): Promise<void>;
 }
 
 export interface GiftPurchaseData {
@@ -221,10 +228,10 @@ export class GiftService {
     }
 
     async redeem({token, memberId}: {token: string; memberId: string}): Promise<Gift> {
-        return await this.deps.giftRepository.transaction(async (transacting) => {
-            const member = await this.deps.memberRepository.get({id: memberId}, {transacting, forUpdate: true});
+        const {redeemed, member} = await this.deps.giftRepository.transaction(async (transacting) => {
+            const _member = await this.deps.memberRepository.get({id: memberId}, {transacting, forUpdate: true});
 
-            if (!member) {
+            if (!_member) {
                 throw new errors.NotFoundError({message: `Member not found: ${memberId}`});
             }
 
@@ -234,22 +241,45 @@ export class GiftService {
                 throw new errors.NotFoundError({message: tpl(errorMessages.giftNotFound)});
             }
 
-            await this.assertRedeemable(gift, member.get('status'));
+            await this.assertRedeemable(gift, _member.get('status'));
 
-            const redeemed = gift.redeem({memberId});
+            const _redeemed = gift.redeem({memberId});
 
             await this.deps.memberRepository.update({
                 products: [{
-                    id: redeemed.tierId,
-                    expiry_at: redeemed.consumesAt
+                    id: _redeemed.tierId,
+                    expiry_at: _redeemed.consumesAt
                 }],
                 status: 'gift'
             }, {id: memberId, transacting});
 
-            await this.deps.giftRepository.update(redeemed, {transacting});
+            await this.deps.giftRepository.update(_redeemed, {transacting});
 
-            return redeemed;
+            return {
+                redeemed: _redeemed,
+                member: _member
+            };
         });
+
+        try {
+            const tier = await this.deps.tiersService.api.read(redeemed.tierId);
+
+            if (!tier) {
+                throw new errors.NotFoundError({message: `Tier not found: ${redeemed.tierId}`});
+            }
+
+            await this.deps.staffServiceEmails.notifyGiftSubscriptionStarted({
+                memberId: member.id,
+                memberEmail: member.get('email')!,
+                memberName: member.get('name') ?? null,
+                tierName: tier.name,
+                buyerEmail: redeemed.buyerEmail
+            });
+        } catch (err) {
+            logging.error('Failed to notify staff of gift redemption', err);
+        }
+
+        return redeemed;
     }
 
     async refund(paymentIntentId: string): Promise<boolean> {

--- a/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.hbs
+++ b/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.hbs
@@ -1,0 +1,116 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>🎁 New paid subscriber: {{memberData.name}}</title>
+    {{> styles}}
+  </head>
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+      <tr>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+          <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED CONTAINER -->
+            {{#> preview}}
+              {{#*inline "content"}}
+                New paid subscriber: {{memberData.name}}
+              {{/inline}}
+            {{/preview}}
+
+            <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                    {{#if siteIconUrl}}
+                      <tr>
+                        <td align="center" style="padding-bottom: 56px; text-align: center;"><a href="{{siteUrl}}"><img src="{{siteIconUrl}}" alt="{{siteTitle}}" border="0" width="48" height="48"></a></td>
+                      </tr>
+                    {{/if}}
+                    <tr>
+                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
+                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">You have a new paid&nbsp;subscriber</h1>
+                        <table width="100" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background: #F4F5F6; border-radius: 8px;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding: 24px;">
+                                <table border="0" cellpadding="0" cellspacing="0">
+                                  <tr>
+                                    <td style="padding-right: 8px; background-color: #F4F5F6; text-align: left; vertical-align: middle;" valign="middle">
+                                      <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Name</p>
+                                      <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{memberData.name}}{{#if memberData.showEmail}} ({{memberData.email}}){{/if}}</p>
+                                      <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Tier</p>
+                                      <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{tierData.name}}</p>
+                                      <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Source</p>
+                                      <p class="large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">Gift subscription</p>
+                                      <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Gifted by</p>
+                                      <p class="large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{giftedByEmail}}</p>
+                                    </td>
+                                  </tr>
+                                </table>
+                                <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
+                                  <tbody>
+                                    <tr>
+                                      <td align="left" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top;">
+                                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                          <tbody>
+                                            <tr>
+                                              <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; vertical-align: top; background-color: {{accentColor}}; border-radius: 8px; text-align: center;"> <a href="{{memberData.adminUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 8px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 15px; font-weight: normal; margin: 0; padding: 10px 20px; border-color: {{accentColor}};">View member</a></td>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-top: 24px;">
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; color: #7c8b9a; font-weight: normal; margin: 0; line-height: 25px;">Or copy and paste this URL into your browser:</p>
+                                <p class="text-link" style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin:0; color: #7c8b9a; font-weight: normal;">{{memberData.adminUrl}}</p>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+
+                    <!-- START FOOTER -->
+                    <tr>
+                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 12px; vertical-align: top; padding-top: 56px;">
+                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 12px; color: #7C8B9A; font-weight: normal; margin: 0;">This message was sent from <a class="small" href="{{siteUrl}}" style="text-decoration: underline; color: #7C8B9A; font-size: 12px;">{{siteDomain}}</a> to <a class="small" href="mailto:{{toEmail}}" style="text-decoration: underline; color: #7C8B9A; font-size: 12px;">{{toEmail}}</a></p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 12px; vertical-align: top;">
+                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 12px; color: #7C8B9A; font-weight: normal; margin: 0;">Don’t want to receive these emails? Manage your preferences <a class="small" href="{{staffUrl}}" style="text-decoration: underline; color: #7C8B9A; font-size: 12px;">here</a>.</p>
+                      </td>
+                    </tr>
+
+                    <!-- END FOOTER -->
+                  </table>
+                </td>
+              </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+
+          <!-- END CENTERED CONTAINER -->
+          </div>
+        </td>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.txt.js
+++ b/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.txt.js
@@ -1,0 +1,17 @@
+module.exports = function (data) {
+    // Be careful when you indent the email, because whitespaces are visible in emails!
+    return `
+Congratulations!
+
+You have a new paid member: ${data.memberData.name}
+
+Tier: ${data.tierData.name}
+Source: Gift subscription
+Gifted by: ${data.giftedByEmail}
+
+---
+
+Sent to ${data.toEmail} from ${data.siteDomain}.
+If you would no longer like to receive these notifications you can adjust your settings at ${data.staffUrl}.
+    `;
+};

--- a/ghost/core/core/server/services/staff/staff-service-emails.js
+++ b/ghost/core/core/server/services/staff/staff-service-emails.js
@@ -339,45 +339,25 @@ class StaffServiceEmails {
 
     async notifyGiftSubscriptionStarted({memberId, memberName, memberEmail, tierName, buyerEmail}, options = {}) {
         const users = await this.models.User.getEmailAlertUsers('paid-started', options);
+        const memberData = this.getMemberData({
+            id: memberId,
+            name: memberName ?? null,
+            email: memberEmail
+        });
+        const subject = `🎁 New paid subscriber: ${memberData.name}`;
 
-        for (const user of users) {
-            const to = user.email;
-            const memberData = this.getMemberData({
-                id: memberId,
-                name: memberName ?? null,
-                email: memberEmail
-            });
-
-            const subject = `🎁 New paid subscriber: ${memberData.name}`;
-            const tierData = {
-                name: tierName
-            };
-
-            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}/email-notifications`);
-
-            const templateData = {
-                memberData,
-                tierData,
-                giftedByEmail: buyerEmail,
-                siteTitle: this.settingsCache.get('title'),
-                siteIconUrl: this.blogIcon.getIconUrl({absolute: true, fallbackToDefault: false}),
-                siteUrl: this.urlUtils.getSiteUrl(),
-                siteDomain: this.siteDomain,
-                accentColor: this.settingsCache.get('accent_color'),
-                fromEmail: this.fromEmailAddress,
-                toEmail: to,
-                staffUrl: staffUrl
-            };
-
-            const {html, text} = await this.renderEmailTemplate('new-gift-subscription', templateData);
-
-            await this.sendMail({
-                to,
-                subject,
-                html,
-                text
-            });
-        }
+        await this.sendToStaff({
+            users,
+            subject,
+            template: 'new-gift-subscription',
+            memberData,
+            templateData: {
+                tierData: {
+                    name: tierName
+                },
+                giftedByEmail: buyerEmail
+            }
+        });
     }
 
     // Utils

--- a/ghost/core/core/server/services/staff/staff-service-emails.js
+++ b/ghost/core/core/server/services/staff/staff-service-emails.js
@@ -337,6 +337,49 @@ class StaffServiceEmails {
         });
     }
 
+    async notifyGiftSubscriptionStarted({memberId, memberName, memberEmail, tierName, buyerEmail}, options = {}) {
+        const users = await this.models.User.getEmailAlertUsers('paid-started', options);
+
+        for (const user of users) {
+            const to = user.email;
+            const memberData = this.getMemberData({
+                id: memberId,
+                name: memberName ?? null,
+                email: memberEmail
+            });
+
+            const subject = `🎁 New paid subscriber: ${memberData.name}`;
+            const tierData = {
+                name: tierName
+            };
+
+            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}/email-notifications`);
+
+            const templateData = {
+                memberData,
+                tierData,
+                giftedByEmail: buyerEmail,
+                siteTitle: this.settingsCache.get('title'),
+                siteIconUrl: this.blogIcon.getIconUrl({absolute: true, fallbackToDefault: false}),
+                siteUrl: this.urlUtils.getSiteUrl(),
+                siteDomain: this.siteDomain,
+                accentColor: this.settingsCache.get('accent_color'),
+                fromEmail: this.fromEmailAddress,
+                toEmail: to,
+                staffUrl: staffUrl
+            };
+
+            const {html, text} = await this.renderEmailTemplate('new-gift-subscription', templateData);
+
+            await this.sendMail({
+                to,
+                subject,
+                html,
+                text
+            });
+        }
+    }
+
     // Utils
 
     /** @private */

--- a/ghost/core/test/e2e-api/members/gifts.test.js
+++ b/ghost/core/test/e2e-api/members/gifts.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager, mockManager, configUtils} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
+const DomainEvents = require('@tryghost/domain-events');
 
 describe('Members Gifts', function () {
     let membersAgent;
@@ -25,6 +26,7 @@ describe('Members Gifts', function () {
     });
 
     beforeEach(function () {
+        mockManager.mockMail();
         mockManager.mockLabsEnabled('giftSubscriptions');
     });
 
@@ -155,7 +157,7 @@ describe('Members Gifts', function () {
         assert.equal(body.errors[0].message, notFoundMessage);
     });
 
-    it('redeems a gift for a logged-in free member via POST', async function () {
+    it('redeems a gift for a logged-in free member', async function () {
         const agent = membersAgent.duplicate();
         const email = `gift-post-free-${giftSequence + 1}@example.com`;
         const gift = await createGift();
@@ -166,6 +168,8 @@ describe('Members Gifts', function () {
             .post(`/api/gifts/${gift.get('token')}/redeem/`)
             .body({})
             .expectStatus(200);
+
+        await DomainEvents.allSettled();
 
         await gift.refresh();
 
@@ -185,6 +189,12 @@ describe('Members Gifts', function () {
             .expectStatus(200);
 
         assert.equal(memberResponse.body.status, 'gift');
+
+        // Verify staff notification email was sent
+        mockManager.assert.sentEmail({
+            subject: /new paid subscriber/i,
+            to: 'jbloggs@example.com'
+        });
     });
 
     it('returns 401 when redeeming a gift via POST without a member session', async function () {

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -218,6 +218,15 @@ describe('Members Signin', function () {
             assert.equal(gift.get('redeemer_member_id'), member.id);
             assert.ok(gift.get('redeemed_at'));
             assert.ok(gift.get('consumes_at'));
+
+            mockManager.assert.sentEmail({
+                subject: /Free member signup: Gift Receiver/,
+                to: 'jbloggs@example.com'
+            });
+            mockManager.assert.sentEmail({
+                subject: /New paid subscriber: Gift Receiver/,
+                to: 'jbloggs@example.com'
+            });
         } finally {
             await models.Product.edit({
                 welcome_page_url: originalWelcomePageUrl

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -219,14 +219,26 @@ describe('Members Signin', function () {
             assert.ok(gift.get('redeemed_at'));
             assert.ok(gift.get('consumes_at'));
 
-            mockManager.assert.sentEmail({
-                subject: /Free member signup: Gift Receiver/,
-                to: 'jbloggs@example.com'
-            });
-            mockManager.assert.sentEmail({
-                subject: /New paid subscriber: Gift Receiver/,
-                to: 'jbloggs@example.com'
-            });
+            mockManager.assert.sentEmailCount(2);
+
+            const sentEmails = [
+                mockManager.assert.sentEmail({
+                    to: 'jbloggs@example.com'
+                }),
+                mockManager.assert.sentEmail({
+                    to: 'jbloggs@example.com'
+                })
+            ];
+            const sentSubjects = sentEmails.map(mail => mail.subject);
+
+            assert(
+                sentSubjects.some(subject => /Free member signup: Gift Receiver/.test(subject)),
+                `Expected one email subject to match /Free member signup: Gift Receiver/, got ${sentSubjects.join(', ')}`
+            );
+            assert(
+                sentSubjects.some(subject => /New paid subscriber: Gift Receiver/.test(subject)),
+                `Expected one email subject to match /New paid subscriber: Gift Receiver/, got ${sentSubjects.join(', ')}`
+            );
         } finally {
             await models.Product.edit({
                 welcome_page_url: originalWelcomePageUrl

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -1,6 +1,7 @@
 const {assertArrayMatchesWithoutOrder} = require('../../utils/assertions');
 const {agentProvider, mockManager, fixtureManager} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
+const DomainEvents = require('@tryghost/domain-events');
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const members = require('../../../core/server/services/members');
@@ -218,6 +219,8 @@ describe('Members Signin', function () {
             assert.equal(gift.get('redeemer_member_id'), member.id);
             assert.ok(gift.get('redeemed_at'));
             assert.ok(gift.get('consumes_at'));
+
+            await DomainEvents.allSettled();
 
             mockManager.assert.sentEmailCount(2);
 

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -1,7 +1,6 @@
 const {assertArrayMatchesWithoutOrder} = require('../../utils/assertions');
 const {agentProvider, mockManager, fixtureManager} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
-const DomainEvents = require('@tryghost/domain-events');
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const members = require('../../../core/server/services/members');
@@ -177,7 +176,7 @@ describe('Members Signin', function () {
         });
     });
 
-    it('redeems a gift during magic link exchange and redirects to Portal account when no paid welcome page is configured', async function () {
+    it('redeems a gift during magic link confirmation if a valid gift token is provided', async function () {
         mockManager.mockLabsEnabled('giftSubscriptions');
 
         const email = 'gift-redemption-member@test.com';
@@ -219,29 +218,6 @@ describe('Members Signin', function () {
             assert.equal(gift.get('redeemer_member_id'), member.id);
             assert.ok(gift.get('redeemed_at'));
             assert.ok(gift.get('consumes_at'));
-
-            await DomainEvents.allSettled();
-
-            mockManager.assert.sentEmailCount(2);
-
-            const sentEmails = [
-                mockManager.assert.sentEmail({
-                    to: 'jbloggs@example.com'
-                }),
-                mockManager.assert.sentEmail({
-                    to: 'jbloggs@example.com'
-                })
-            ];
-            const sentSubjects = sentEmails.map(mail => mail.subject);
-
-            assert(
-                sentSubjects.some(subject => /Free member signup: Gift Receiver/.test(subject)),
-                `Expected one email subject to match /Free member signup: Gift Receiver/, got ${sentSubjects.join(', ')}`
-            );
-            assert(
-                sentSubjects.some(subject => /New paid subscriber: Gift Receiver/.test(subject)),
-                `Expected one email subject to match /New paid subscriber: Gift Receiver/, got ${sentSubjects.join(', ')}`
-            );
         } finally {
             await models.Product.edit({
                 welcome_page_url: originalWelcomePageUrl

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -24,6 +24,7 @@ describe('GiftService', function () {
     };
     let staffServiceEmails: {
         notifyGiftReceived: sinon.SinonStub;
+        notifyGiftSubscriptionStarted: sinon.SinonStub;
     };
     let giftEmailService: {
         sendPurchaseConfirmation: sinon.SinonStub;
@@ -63,7 +64,8 @@ describe('GiftService', function () {
             update: sinon.stub().resolves(undefined)
         };
         staffServiceEmails = {
-            notifyGiftReceived: sinon.stub()
+            notifyGiftReceived: sinon.stub(),
+            notifyGiftSubscriptionStarted: sinon.stub()
         };
         giftEmailService = {
             sendPurchaseConfirmation: sinon.stub()
@@ -550,11 +552,16 @@ describe('GiftService', function () {
     describe('redeem', function () {
         it('redeems the gift, saves it, and grants gift access to the member', async function () {
             const gift = buildGift();
+            const memberGet = sinon.stub();
+
+            memberGet.withArgs('status').returns('free');
+            memberGet.withArgs('name').returns('Member Name');
+            memberGet.withArgs('email').returns('member@example.com');
 
             giftRepository.getByToken.resolves(gift);
             memberRepository.get.resolves({
                 id: 'member_1',
-                get: sinon.stub().withArgs('status').returns('free')
+                get: memberGet
             });
 
             const service = createService();
@@ -577,9 +584,42 @@ describe('GiftService', function () {
                 transacting: 'trx'
             });
             sinon.assert.calledOnceWithExactly(giftRepository.update, redeemed, {transacting: 'trx'});
+            sinon.assert.calledOnceWithExactly(tiersService.api.read, 'tier_1');
+            sinon.assert.calledOnceWithExactly(staffServiceEmails.notifyGiftSubscriptionStarted, {
+                memberId: 'member_1',
+                memberEmail: 'member@example.com',
+                memberName: 'Member Name',
+                tierName: 'Bronze',
+                buyerEmail: 'buyer@example.com'
+            });
             assert.equal(redeemed.status, 'redeemed');
             assert.equal(redeemed.redeemerMemberId, 'member_1');
             assert.notEqual(redeemed.consumesAt, null);
+        });
+
+        it('does not fail redemption when staff notification email throws', async function () {
+            const gift = buildGift();
+            const memberGet = sinon.stub();
+
+            memberGet.withArgs('status').returns('free');
+            memberGet.withArgs('name').returns('Member Name');
+            memberGet.withArgs('email').returns('member@example.com');
+
+            giftRepository.getByToken.resolves(gift);
+            memberRepository.get.resolves({
+                id: 'member_1',
+                get: memberGet
+            });
+            staffServiceEmails.notifyGiftSubscriptionStarted.rejects(new Error('SMTP error'));
+
+            const service = createService();
+            const redeemed = await service.redeem({
+                token: 'gift-token',
+                memberId: 'member_1'
+            });
+
+            assert.equal(redeemed.status, 'redeemed');
+            sinon.assert.calledOnce(staffServiceEmails.notifyGiftSubscriptionStarted);
         });
 
         it('throws NotFoundError when the member does not exist', async function () {
@@ -600,6 +640,7 @@ describe('GiftService', function () {
 
             sinon.assert.notCalled(memberRepository.update);
             sinon.assert.notCalled(giftRepository.update);
+            sinon.assert.notCalled(staffServiceEmails.notifyGiftSubscriptionStarted);
         });
 
         it('throws NotFoundError when the gift token does not exist', async function () {
@@ -620,6 +661,7 @@ describe('GiftService', function () {
 
             sinon.assert.notCalled(memberRepository.update);
             sinon.assert.notCalled(giftRepository.update);
+            sinon.assert.notCalled(staffServiceEmails.notifyGiftSubscriptionStarted);
         });
 
         it('throws BadRequestError when the member is not eligible', async function () {
@@ -644,6 +686,7 @@ describe('GiftService', function () {
 
             sinon.assert.notCalled(memberRepository.update);
             sinon.assert.notCalled(giftRepository.update);
+            sinon.assert.notCalled(staffServiceEmails.notifyGiftSubscriptionStarted);
         });
     });
 

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -1089,5 +1089,77 @@ describe('StaffService', function () {
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('3 months')));
             });
         });
+
+        describe('notifyGiftSubscriptionStarted', function () {
+            it('sends gift subscription email with correct subject', async function () {
+                await service.emails.notifyGiftSubscriptionStarted({
+                    memberName: 'Jamie',
+                    memberEmail: 'jamie@example.com',
+                    memberId: 'abc',
+                    tierName: 'Premium',
+                    buyerEmail: 'gifter@example.com'
+                });
+
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'paid-started');
+                sinon.assert.calledOnce(mailStub);
+                sinon.assert.calledWith(mailStub, sinon.match.has('subject', sinon.match('New paid subscriber: Jamie')));
+            });
+
+            it('includes the tier in HTML and plain text', async function () {
+                await service.emails.notifyGiftSubscriptionStarted({
+                    memberName: 'Jamie',
+                    memberEmail: 'jamie@example.com',
+                    memberId: 'abc',
+                    tierName: 'Premium',
+                    buyerEmail: 'gifter@example.com'
+                });
+
+                sinon.assert.calledOnce(mailStub);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Premium')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Tier: Premium')));
+            });
+
+            it('includes the member name in HTML and plain text', async function () {
+                await service.emails.notifyGiftSubscriptionStarted({
+                    memberName: 'Jamie',
+                    memberEmail: 'jamie@example.com',
+                    memberId: 'abc',
+                    tierName: 'Premium',
+                    buyerEmail: 'gifter@example.com'
+                });
+
+                sinon.assert.calledOnce(mailStub);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Jamie')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Jamie')));
+            });
+
+            it('includes the source in HTML and plain text', async function () {
+                await service.emails.notifyGiftSubscriptionStarted({
+                    memberName: 'Jamie',
+                    memberEmail: 'jamie@example.com',
+                    memberId: 'abc',
+                    tierName: 'Premium',
+                    buyerEmail: 'gifter@example.com'
+                });
+
+                sinon.assert.calledOnce(mailStub);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Gift subscription')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Source: Gift subscription')));
+            });
+
+            it('includes the buyer email in HTML and plain text', async function () {
+                await service.emails.notifyGiftSubscriptionStarted({
+                    memberName: 'Jamie',
+                    memberEmail: 'jamie@example.com',
+                    memberId: 'abc',
+                    tierName: 'Premium',
+                    buyerEmail: 'gifter@example.com'
+                });
+
+                sinon.assert.calledOnce(mailStub);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('gifter@example.com')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Gifted by: gifter@example.com')));
+            });
+        });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3532

- when a member redeems a gift subscription, we now send a new paid member email notification, with the email body noting "Gift subscription" as source
- we're not introducing a new staff notification setting for this, it's part of the existing "New paid members" setting
- email copy is not finalised

---

## Email copy (to be finalised)

<img width="2288" height="1780" alt="CleanShot 2026-04-15 at 20 37 47@2x" src="https://github.com/user-attachments/assets/3e6142d0-1c7e-484b-aebd-6348d762e092" />





## Staff notification setting

<img width="1160" height="884" alt="CleanShot 2026-04-15 at 20 45 53@2x" src="https://github.com/user-attachments/assets/90250367-fd6c-4d13-be17-efe69df3d00f" />
