### PR TITLE
Split email and member aggregation timing in analytics logs

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -75,7 +75,7 @@ class EmailAnalyticsServiceWrapper {
      * @param {number} totalDurationMs - Total duration in milliseconds
      */
     _logJobCompletion(jobType, fetchResult, totalDurationMs) {
-        const {eventCount, apiPollingTimeMs, processingTimeMs, aggregationTimeMs, result} = fetchResult;
+        const {eventCount, apiPollingTimeMs, processingTimeMs, aggregationTimeMs, emailAggregationTimeMs, memberAggregationTimeMs, result} = fetchResult;
 
         if (eventCount === 0) {
             return;
@@ -91,7 +91,7 @@ class EmailAnalyticsServiceWrapper {
             `[EmailAnalytics] Job complete: ${jobType}`,
             `${eventCount} events in ${(totalDurationMs / 1000).toFixed(1)}s (${throughput.toFixed(2)} events/s)`,
             `Mode: ${batchMode}`,
-            `Timings: API ${(apiPollingTimeMs / 1000).toFixed(1)}s (${apiPercent}%) / Processing ${(processingTimeMs / 1000).toFixed(1)}s (${processingPercent}%) / Aggregation ${(aggregationTimeMs / 1000).toFixed(1)}s (${aggregationPercent}%)`,
+            `Timings: API ${(apiPollingTimeMs / 1000).toFixed(1)}s (${apiPercent}%) / Processing ${(processingTimeMs / 1000).toFixed(1)}s (${processingPercent}%) / Aggregation ${(aggregationTimeMs / 1000).toFixed(1)}s (${aggregationPercent}%) [Email ${(emailAggregationTimeMs / 1000).toFixed(1)}s / Member ${(memberAggregationTimeMs / 1000).toFixed(1)}s]`,
             `Events: opened=${result.opened} delivered=${result.delivered} failed=${result.permanentFailed + result.temporaryFailed} unprocessable=${result.unprocessable}`
         ].join(' | ');
 

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -30,6 +30,8 @@ const errors = require('@tryghost/errors');
  * @property {number} apiPollingTimeMs - Time spent polling the API in milliseconds
  * @property {number} processingTimeMs - Time spent processing events in milliseconds
  * @property {number} aggregationTimeMs - Time spent aggregating stats in milliseconds
+ * @property {number} emailAggregationTimeMs - Time spent aggregating email stats in milliseconds
+ * @property {number} memberAggregationTimeMs - Time spent aggregating member stats in milliseconds
  * @property {EventProcessingResult} result - The processing result with event breakdown
  */
 
@@ -46,6 +48,8 @@ function createEmptyResult() {
         apiPollingTimeMs: 0,
         processingTimeMs: 0,
         aggregationTimeMs: 0,
+        emailAggregationTimeMs: 0,
+        memberAggregationTimeMs: 0,
         result: new EventProcessingResult()
     };
 }
@@ -323,6 +327,8 @@ module.exports = class EmailAnalyticsService {
         const fetchStartMs = Date.now();
         let processingTimeMs = 0;
         let aggregationTimeMs = 0;
+        let emailAggregationTimeMs = 0;
+        let memberAggregationTimeMs = 0;
 
         let lastAggregation = Date.now();
         let eventCount = 0;
@@ -387,8 +393,10 @@ module.exports = class EmailAnalyticsService {
                 // We do this here because otherwise it could take a long time before the new events are visible in the stats
                 try {
                     const intermediateAggregationStart = Date.now();
-                    await this.aggregateStats(processingResult, includeOpenedEvents);
+                    const aggregationTimings = await this.aggregateStats(processingResult, includeOpenedEvents);
                     aggregationTimeMs += (Date.now() - intermediateAggregationStart);
+                    emailAggregationTimeMs += aggregationTimings.emailAggregationTimeMs;
+                    memberAggregationTimeMs += aggregationTimings.memberAggregationTimeMs;
                     lastAggregation = Date.now();
                     // Remove aggregated emailIds and memberIds from tracking sets to avoid re-aggregating at the end
                     processingResult.emailIds.forEach(id => allEmailIds.delete(id));
@@ -434,8 +442,10 @@ module.exports = class EmailAnalyticsService {
                     emailIds: finalEmailIds,
                     memberIds: finalMemberIds
                 };
-                await this.aggregateStats(finalAggregationResult, includeOpenedEvents);
+                const aggregationTimings = await this.aggregateStats(finalAggregationResult, includeOpenedEvents);
                 aggregationTimeMs += (Date.now() - aggregationStart);
+                emailAggregationTimeMs += aggregationTimings.emailAggregationTimeMs;
+                memberAggregationTimeMs += aggregationTimings.memberAggregationTimeMs;
             } catch (err) {
                 logging.error('[EmailAnalytics] Error while aggregating stats');
                 logging.error(err);
@@ -476,6 +486,8 @@ module.exports = class EmailAnalyticsService {
             apiPollingTimeMs,
             processingTimeMs,
             aggregationTimeMs,
+            emailAggregationTimeMs,
+            memberAggregationTimeMs,
             result: cumulativeResult
         };
     }
@@ -625,17 +637,21 @@ module.exports = class EmailAnalyticsService {
     /**
      * @param {{emailIds?: string[], memberIds?: string[]}} stats
      * @param {boolean} includeOpenedEvents
+     * @returns {Promise<{emailAggregationTimeMs: number, memberAggregationTimeMs: number}>}
      */
     async aggregateStats({emailIds = [], memberIds = []}, includeOpenedEvents = true) {
         const useBatchProcessing = this.config.get('emailAnalytics:batchProcessing');
 
+        const emailAggregationStart = Date.now();
         for (const emailId of emailIds) {
             await this.aggregateEmailStats(emailId, includeOpenedEvents);
         }
+        const emailAggregationTimeMs = Date.now() - emailAggregationStart;
 
         // @ts-expect-error
         const memberMetric = this.prometheusClient?.getMetric('email_analytics_aggregate_member_stats_count');
 
+        const memberAggregationStart = Date.now();
         if (useBatchProcessing) {
             // Batched mode: process 100 members at a time
             logging.info(`[EmailAnalytics] Aggregating stats for ${memberIds.length} members using BATCHED mode (batch size: 100)`);
@@ -653,6 +669,9 @@ module.exports = class EmailAnalyticsService {
                 memberMetric?.inc();
             }
         }
+        const memberAggregationTimeMs = Date.now() - memberAggregationStart;
+
+        return {emailAggregationTimeMs, memberAggregationTimeMs};
     }
 
     /**

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -206,7 +206,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 processEventBatchStub = sinon.stub(service, 'processEventBatch').resolves();
-                aggregateStatsStub = sinon.stub(service, 'aggregateStats').resolves();
+                aggregateStatsStub = sinon.stub(service, 'aggregateStats').resolves({emailAggregationTimeMs: 0, memberAggregationTimeMs: 0});
             });
 
             afterEach(function () {


### PR DESCRIPTION
## Summary
- Breaks down the single `Aggregation` timing metric in email analytics job logs into separate `Email` and `Member` aggregation measurements
- Log line now shows: `Aggregation 5.2s (40%) [Email 1.1s / Member 4.1s]` instead of just `Aggregation 5.2s (40%)`
- Helps identify whether email or member aggregation is the bottleneck in slow analytics jobs

## Test plan
- [x] Existing unit tests pass (49/49)
- [ ] Verify log output in staging shows the new `[Email Xs / Member Xs]` breakdown