### PR TITLE
Create scheduling adapter synchronously

### DIFF
--- a/ghost/core/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/ghost/core/core/server/adapters/scheduling/post-scheduling/index.js
@@ -32,7 +32,7 @@ const loadScheduledResources = async function () {
 
 const init = async (options) => {
     const integration = await getSchedulerIntegration();
-    const adapter = await localUtils.createAdapter();
+    const adapter = localUtils.createAdapter();
 
     let scheduledResources;
 

--- a/ghost/core/core/server/adapters/scheduling/utils.js
+++ b/ghost/core/core/server/adapters/scheduling/utils.js
@@ -1,6 +1,6 @@
 const adapterManager = require('../../services/adapter-manager');
 
-async function createAdapter() {
+function createAdapter() {
     return adapterManager.getAdapter('scheduling');
 }
 

--- a/ghost/core/test/unit/server/adapters/scheduling/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/utils.test.js
@@ -24,14 +24,12 @@ describe('Scheduling: utils', function () {
     });
 
     describe('success', function () {
-        it('create good adapter', function (done) {
-            schedulingUtils.createAdapter().then(function (adapter) {
-                assertExists(adapter);
-                done();
-            }).catch(done);
+        it('create good adapter', function () {
+            const adapter = schedulingUtils.createAdapter();
+            assertExists(adapter);
         });
 
-        it('create good adapter from custom file', function (done) {
+        it('create good adapter from custom file', function () {
             scope.adapter = schedulingPath + 'another-scheduler.js';
 
             configUtils.set({
@@ -53,15 +51,13 @@ describe('Scheduling: utils', function () {
 
             fs.writeFileSync(scope.adapter, jsFile);
 
-            schedulingUtils.createAdapter().then(function (adapter) {
-                assertExists(adapter);
-                done();
-            }).catch(done);
+            const adapter = schedulingUtils.createAdapter();
+            assertExists(adapter);
         });
     });
 
     describe('error', function () {
-        it('create with adapter, but missing fn\'s', function (done) {
+        it('create with adapter, but missing fn\'s', function () {
             scope.adapter = schedulingPath + 'bad-adapter.js';
             const jsFile = '' +
                 'var util = require(\'util\');' +
@@ -78,11 +74,15 @@ describe('Scheduling: utils', function () {
                     active: 'bad-adapter'
                 }
             });
-            schedulingUtils.createAdapter().catch(function (err) {
-                assertExists(err);
-                assert.equal(err.errorType, 'IncorrectUsageError');
-                done();
-            });
+
+            assert.throws(
+                () => schedulingUtils.createAdapter(),
+                (err) => {
+                    assertExists(err);
+                    assert.equal(err.errorType, 'IncorrectUsageError');
+                    return true;
+                }
+            );
         });
     });
 });


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1191

We marked the "get scheduling adapter" function asynchronous, but it doesn't need to be. The function itself doesn't `await` anything, nor does anything downstream.

This change should have no user impact (maybe startup is *slightly* faster), but it makes an upcoming change slightly easier.
