### PR TITLE
Bumped tailwind-merge to 3.5.0 in Shade

### DIFF
--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -155,7 +155,7 @@
         "react-world-flags": "1.6.0",
         "recharts": "2.15.4",
         "sonner": "2.0.7",
-        "tailwind-merge": "2.6.0",
+        "tailwind-merge": "3.5.0",
         "validator": "13.12.0",
         "zod": "4.1.12"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1161,8 +1161,8 @@ importers:
         specifier: 2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
-        specifier: 2.6.0
-        version: 2.6.0
+        specifier: 3.5.0
+        version: 3.5.0
       validator:
         specifier: 13.12.0
         version: 13.12.0
@@ -21621,8 +21621,8 @@ packages:
     peerDependencies:
       tailwindcss: ^3.3.0 || ^4.0.0 || ^4.0.0-beta
 
-  tailwind-merge@2.6.0:
-    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@3.4.18:
     resolution: {integrity: sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==}
@@ -48260,7 +48260,7 @@ snapshots:
       local-pkg: 1.1.2
       tailwindcss: 4.2.2
 
-  tailwind-merge@2.6.0: {}
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1351/buttons-look-broken-possibly-from-tailwind-4

- v2.6 doesn't understand Tailwind v4's `h-(--var)` syntax, so className overrides couldn't dedupe defaults like `h-(--control-height)`
- surfaced as inline follow buttons in ActivityPub rendering as pills instead of 16px circles

