### PR TITLE
Added gift icon to Portal account subscription label

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.8",
+  "version": "2.68.9",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/account-home-page.css
+++ b/apps/portal/src/components/pages/AccountHomePage/account-home-page.css
@@ -162,7 +162,7 @@ footer.gh-portal-account-footer {
     width: 16px;
     height: 16px;
     color: var(--brandcolor);
-    margin-inline-end: 5px;
+    margin-inline-end: 4px;
     z-index: 999;
 }
 

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,6 +1,7 @@
 import AppContext from '../../../../app-context';
 import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
+import {ReactComponent as GiftIcon} from '../../../../images/icons/gift.svg';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
 import {ReactComponent as OfferTagIcon} from '../../../../images/icons/offer-tag.svg';
 import {useContext} from 'react';
@@ -37,7 +38,12 @@ const PaidAccountActions = () => {
         const isGiftMember = member?.status === 'gift';
 
         if (isGiftMember && subscriptionExpiry) {
-            label = `${t('Gift subscription')} - ${t('Expires {expiryDate}', {expiryDate: subscriptionExpiry})}`;
+            return (
+                <p className="gh-portal-account-discountcontainer">
+                    <GiftIcon className="gh-portal-account-tagicon" />
+                    <span>{`${t('Gift subscription')} - ${t('Expires {expiryDate}', {expiryDate: subscriptionExpiry})}`}</span>
+                </p>
+            );
         } else if (isComplimentary) {
             if (subscriptionExpiry) {
                 label = `${t('Complimentary')} - ${t('Expires {expiryDate}', {expiryDate: subscriptionExpiry})}`;


### PR DESCRIPTION
no issues

Shows a gift icon next to the "Gift subscription — Expires {date}" label on the account screen, so the gift state is distinguishable from other subscription states at a glance.