### PR TITLE
Fixed more menu click-outside handling in Portal share modal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.8",
+  "version": "2.68.9",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/share/share-modal.js
+++ b/apps/portal/src/components/pages/share/share-modal.js
@@ -32,6 +32,12 @@ const ShareModal = () => {
             return;
         }
 
+        // Portal renders inside an iframe via createPortal, so `document` here
+        // refers to the parent page's document — not the iframe's. We must use
+        // ownerDocument of the rendered element to attach listeners in the
+        // correct document context where the click events actually fire.
+        const doc = moreMenuRef.current?.ownerDocument || document;
+
         const onDocumentMouseDown = (event) => {
             if (moreMenuRef.current && !moreMenuRef.current.contains(event.target)) {
                 setIsMoreMenuOpen(false);
@@ -44,12 +50,12 @@ const ShareModal = () => {
             }
         };
 
-        document.addEventListener('mousedown', onDocumentMouseDown);
-        document.addEventListener('keydown', onDocumentKeyDown);
+        doc.addEventListener('mousedown', onDocumentMouseDown);
+        doc.addEventListener('keydown', onDocumentKeyDown);
 
         return () => {
-            document.removeEventListener('mousedown', onDocumentMouseDown);
-            document.removeEventListener('keydown', onDocumentKeyDown);
+            doc.removeEventListener('mousedown', onDocumentMouseDown);
+            doc.removeEventListener('keydown', onDocumentKeyDown);
         };
     }, [isMoreMenuOpen]);
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1230/fix-click-outside-the-button-should-close-menu

- Portal renders inside an iframe via createPortal, but the mousedown listener was attached to the parent page's `document` instead of the iframe's document. Events inside the iframe never bubbled to the parent document, so clicking outside the menu had no effect. Additionally, clicking the modal background would close the entire popup without first closing the menu.