### PR TITLE
Improved tag deletion modal messaging

### DIFF
--- a/ghost/admin/app/components/tags/delete-tag-modal.hbs
+++ b/ghost/admin/app/components/tags/delete-tag-modal.hbs
@@ -5,10 +5,11 @@
     <button type="button" class="close"title="Close" {{on "click" @close}}>{{svg-jar "close"}}<span class="hidden">Close</span></button>
 
     <div class="modal-body">
+        You’re about to delete the tag "<strong>{{@data.tag.name}}</strong>".
         {{#if @data.tag.count.posts}}
-            <span class="red">This tag is attached to <span data-test-text="posts-count">{{gh-pluralize @data.tag.count.posts "post"}}</span>.</span>
+            It will be removed from <span data-test-text="posts-count">{{gh-pluralize @data.tag.count.posts "post"}}</span>.
         {{/if}}
-        You’re about to delete "<strong>{{@data.tag.name}}</strong>". This is permanent! We warned you, k?
+        This is permanent! We warned you, k?
     </div>
 
     <div class="modal-footer">


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1349/clarify-delete-tag-confirmation-copy-and-warning-styling

Improved the messaging to tell users exactly what will happen when a tag is deleted. Also removed the eh red from the post count.

| Before | After |
|--------|--------|
| <img width="607" height="274" alt="Screenshot 2026-04-16 at 13 00 54" src="https://github.com/user-attachments/assets/044b3c84-b0bc-4c5e-bbc3-1b2879584f64" /> | <img width="596" height="261" alt="Screenshot 2026-04-16 at 13 00 36" src="https://github.com/user-attachments/assets/3be21b5d-0581-4615-be13-d265f4f13c41" /> | 
