### PR TITLE
Fixed broken member name fallback in Comments

### DIFF
--- a/apps/posts/src/views/comments/components/comment-likes-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-likes-modal.tsx
@@ -2,6 +2,7 @@ import {Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, 
 import {Comment, useBrowseCommentLikes} from '@tryghost/admin-x-framework/api/comments';
 import {CommentAvatar} from './comment-avatar';
 import {LucideIcon, formatTimestamp} from '@tryghost/shade/utils';
+import {formatMemberName} from '@tryghost/shade/app';
 
 interface CommentLikesModalProps {
     comment: Comment;
@@ -35,7 +36,7 @@ function CommentLikesModal({comment, open, onOpenChange}: CommentLikesModalProps
                         <div className="flex min-w-0 flex-col overflow-hidden">
                             <div className="flex min-w-0 items-center gap-1 text-sm">
                                 <span className="shrink-0 font-semibold">
-                                    {comment.member?.name || 'Unknown'}
+                                    {comment.member ? formatMemberName(comment.member) : 'Deleted member'}
                                 </span>
                                 <LucideIcon.Dot className="shrink-0 text-muted-foreground/50" size={16} />
                                 <span className="shrink-0 text-muted-foreground">
@@ -76,7 +77,7 @@ function CommentLikesModal({comment, open, onOpenChange}: CommentLikesModalProps
                                             </div>
                                         </div>
                                         <span className="font-medium">
-                                            {like.member?.name || 'Deleted member'}
+                                            {like.member ? formatMemberName(like.member) : 'Deleted member'}
                                         </span>
                                     </div>
                                     <span className="shrink-0 text-sm text-muted-foreground">

--- a/apps/posts/src/views/comments/components/comment-reports-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-reports-modal.tsx
@@ -2,6 +2,7 @@ import {Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, 
 import {Comment, useBrowseCommentReports} from '@tryghost/admin-x-framework/api/comments';
 import {CommentAvatar} from './comment-avatar';
 import {LucideIcon, formatTimestamp} from '@tryghost/shade/utils';
+import {formatMemberName} from '@tryghost/shade/app';
 
 interface CommentReportsModalProps {
     comment: Comment;
@@ -34,7 +35,7 @@ function CommentReportsModal({comment, open, onOpenChange}: CommentReportsModalP
                         <div className="flex min-w-0 flex-col overflow-hidden">
                             <div className="flex min-w-0 items-center gap-1 text-sm">
                                 <span className="shrink-0 font-semibold">
-                                    {comment.member?.name || 'Unknown'}
+                                    {comment.member ? formatMemberName(comment.member) : 'Deleted member'}
                                 </span>
                                 <LucideIcon.Dot className="shrink-0 text-muted-foreground/50" size={16} />
                                 <span className="shrink-0 text-muted-foreground">
@@ -75,7 +76,7 @@ function CommentReportsModal({comment, open, onOpenChange}: CommentReportsModalP
                                             </div>
                                         </div>
                                         <span className="font-medium">
-                                            {report.member?.name || 'Deleted member'}
+                                            {report.member ? formatMemberName(report.member) : 'Deleted member'}
                                         </span>
                                     </div>
                                     <span className="shrink-0 text-sm text-muted-foreground">


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1352/we-incorrectly-use-deleted-member-in-the-likes-and-reports-modals-from

Instead of falling back to the member email if their name wasn't available, we'd just fallback to Deleted member. We now use the Shade utility so that it maps up to how we handle this elsewhere. Covered in the likes and reports modal as well as the comment preview in both.

| Before | After |
|--------|--------|
| <img width="550" height="314" alt="Screenshot 2026-04-16 at 13 23 08" src="https://github.com/user-attachments/assets/45fa2fb2-9fa6-4d7b-9ef2-cbb906079c7e" /> | <img width="554" height="318" alt="Screenshot 2026-04-16 at 13 22 52" src="https://github.com/user-attachments/assets/6a43bea7-8aad-489a-b998-0e0ea8c2a8c4" /> | 