### PR TITLE
Switched to more correct JSDoc types for primitives

### DIFF
--- a/ghost/admin/app/utils/currency.js
+++ b/ghost/admin/app/utils/currency.js
@@ -167,8 +167,8 @@ export function getCurrencyOptions() {
 * Returns the minimum charge amount for a given currency,
 * based on Stripe's requirements. Values here are double the Stripe limits, to take conversions to the settlement currency into account.
 * @see https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
-* @param {String} currency — Currency in the 3-letter ISO format (e.g. "USD", "EUR")
-* @returns {Number} — Minimum amount
+* @param {string} currency — Currency in the 3-letter ISO format (e.g. "USD", "EUR")
+* @returns {number} — Minimum amount
 */
 export function minimumAmountForCurrency(currency) {
     const isoCurrency = currency?.toUpperCase();

--- a/ghost/admin/app/validators/mixins/password.js
+++ b/ghost/admin/app/validators/mixins/password.js
@@ -17,8 +17,8 @@ export default Mixin.create({
     /**
     * Counts repeated characters if a string. When 50% or more characters are the same,
     * we return false and therefore invalidate the string.
-    * @param {String} stringToTest The password string to check.
-    * @return {Boolean}
+    * @param {string} stringToTest The password string to check.
+    * @return {boolean}
     */
     _characterOccurance(stringToTest) {
         let chars = {};

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -225,8 +225,8 @@ async function initFrontend(dataService) {
  * What we want is to be able to optionally load various components and mount them
  * So eventually this function should go away
  * @param {Object} options
- * @param {Boolean} options.backend
- * @param {Boolean} options.frontend
+ * @param {boolean} options.backend
+ * @param {boolean} options.frontend
  * @param {Object} options.config
  */
 async function initExpressApps({frontend, backend, config}) {

--- a/ghost/core/core/frontend/helpers/collection.js
+++ b/ghost/core/core/frontend/helpers/collection.js
@@ -36,9 +36,9 @@ function parseOptions(options) {
 
 /**
  *
- * @param {String} resource
- * @param {String} controllerName
- * @param {String} action
+ * @param {string} resource
+ * @param {string} controllerName
+ * @param {string} action
  * @param {Object} apiOptions
  * @returns {Promise<Object>}
  */

--- a/ghost/core/core/frontend/helpers/get.js
+++ b/ghost/core/core/frontend/helpers/get.js
@@ -150,8 +150,8 @@ function isBrowse(options) {
  * Find and resolve path strings
  *
  * @param {Object} data
- * @param {String} value
- * @returns {String}
+ * @param {string} value
+ * @returns {string}
  */
 function resolvePaths(globals, data, value) {
     const regex = /\{\{(.*?)\}\}/g;
@@ -285,9 +285,9 @@ function optimiseFilterCacheability(resource, options) {
 
 /**
  *
- * @param {String} resource
- * @param {String} controllerName
- * @param {String} action
+ * @param {string} resource
+ * @param {string} controllerName
+ * @param {string} action
  * @param {GetHelperAPIOptions} apiOptions
  * @returns {Promise<Object>}
  */
@@ -381,7 +381,7 @@ function renderResponse(response, resource, options, data) {
 
 /**
  * ## Get
- * @param {String} resource
+ * @param {string} resource
  * @param {Object} options
  * @returns {Promise<any>}
  */

--- a/ghost/core/core/frontend/helpers/has.js
+++ b/ghost/core/core/frontend/helpers/has.js
@@ -101,8 +101,8 @@ function evaluateStringMatch(expr, str, ci) {
 
 /**
  *
- * @param {String} type - either some or every - the lodash function to use
- * @param {String} expr - the attribute value passed into {{#has}}
+ * @param {string} type - either some or every - the lodash function to use
+ * @param {string} expr - the attribute value passed into {{#has}}
  * @param {Object} obj - "this" context from the helper
  * @param {Object} data - global params
  */

--- a/ghost/core/core/frontend/services/data/entry-lookup.js
+++ b/ghost/core/core/frontend/services/data/entry-lookup.js
@@ -5,7 +5,7 @@ const routeMatch = require('path-match')();
 
 /**
  * Query API for a single entry/resource.
- * @param {String} postUrl
+ * @param {string} postUrl
  * @param {Object} routerOptions
  * @param {Object} locals
  * @returns {*}

--- a/ghost/core/core/frontend/services/data/fetch-data.js
+++ b/ghost/core/core/frontend/services/data/fetch-data.js
@@ -39,7 +39,7 @@ defaultPostQuery.options = defaultQueryOptions.options;
  * Converts the query config to a promise for the result
  *
  * @param {Object} query
- * @param {String} slugParam
+ * @param {string} slugParam
  * @returns {Promise}
  */
 function processQuery(query, slugParam, locals) {

--- a/ghost/core/core/frontend/services/rendering/templates.js
+++ b/ghost/core/core/frontend/services/rendering/templates.js
@@ -107,7 +107,7 @@ _private.getEntryTemplateHierarchy = function getEntryTemplateHierarchy(postObje
  * Cycle through and find the first one which has a match in the theme
  *
  * @param {Array|String} templateList
- * @param {String} fallback - a fallback template
+ * @param {string} fallback - a fallback template
  */
 _private.pickTemplate = function pickTemplate(templateList, fallback) {
     let template;

--- a/ghost/core/core/frontend/services/routing/collection-router.js
+++ b/ghost/core/core/frontend/services/routing/collection-router.js
@@ -135,7 +135,7 @@ class CollectionRouter extends ParentRouter {
     /**
      * @description Get index route e.g. /, /blog/
      * @param {Object} options
-     * @returns {String}
+     * @returns {string}
      */
     getRoute(options) {
         options = options || {};
@@ -146,7 +146,7 @@ class CollectionRouter extends ParentRouter {
     /**
      * @description Generate rss url.
      * @param {Object} options
-     * @returns {String}
+     * @returns {string}
      */
     getRssUrl(options) {
         if (!this.rss) {

--- a/ghost/core/core/frontend/services/routing/middleware/page-param.js
+++ b/ghost/core/core/frontend/services/routing/middleware/page-param.js
@@ -11,7 +11,7 @@ const messages = {
  * @param {Object} req
  * @param {Object} res
  * @param {Function} next
- * @param {Number} page
+ * @param {number} page
  * @returns {*}
  */
 module.exports = function handlePageParam(req, res, next, page) {

--- a/ghost/core/core/frontend/services/routing/parent-router.js
+++ b/ghost/core/core/frontend/services/routing/parent-router.js
@@ -79,7 +79,7 @@ class ParentRouter {
      * @param {Object} req
      * @param {Object} res
      * @param {Function} next
-     * @param {String} slug
+     * @param {string} slug
      * @private
      */
     _respectDominantRouter(req, res, next, slug) {
@@ -133,7 +133,7 @@ class ParentRouter {
 
     /**
      * @description Mount a route on this router.
-     * @param {String} path
+     * @param {string} path
      * @param {Function} controller
      */
     mountRoute(path, controller) {
@@ -148,7 +148,7 @@ class ParentRouter {
      *
      * Not used at the moment, but useful to keep for e.g. deregister routes on runtime.
      *
-     * @param {String} path
+     * @param {string} path
      */
     unmountRoute(path) {
         let indexToRemove = null;
@@ -187,7 +187,7 @@ class ParentRouter {
      * because the subdirectory is already mounted as exclusive feature (independent of dynamic routing).
      *
      * @param {Object} options
-     * @returns {String}
+     * @returns {string}
      */
     getRoute(options) {
         options = options || {};
@@ -197,8 +197,8 @@ class ParentRouter {
 
     /**
      * @description Figure out if the router has a redirect enabled.
-     * @param {String} routerType
-     * @param {String} slug
+     * @param {string} routerType
+     * @param {string} slug
      * @returns {boolean}
      */
     isRedirectEnabled(routerType, slug) {

--- a/ghost/core/core/frontend/services/routing/registry.js
+++ b/ghost/core/core/frontend/services/routing/registry.js
@@ -8,8 +8,8 @@ let routers = {};
 module.exports = {
     /**
      * @description Get's called if you register a url pattern in express.
-     * @param {String} routerName
-     * @param {String} route
+     * @param {string} routerName
+     * @param {string} route
      */
     setRoute(routerName, route) {
         routes.push({route: route, from: routerName});
@@ -72,7 +72,7 @@ module.exports = {
      * More context: https://github.com/TryGhost/Team/issues/65#issuecomment-393622816
      *
      * @param {Object} options
-     * @returns {String}
+     * @returns {string}
      */
     getRssUrl(options) {
         let rssUrl = null;

--- a/ghost/core/core/frontend/services/sitemap/base-site-map-generator.js
+++ b/ghost/core/core/frontend/services/sitemap/base-site-map-generator.js
@@ -118,7 +118,7 @@ class BaseSiteMapGenerator {
 
     /**
      *
-     * @param {String} url
+     * @param {string} url
      * @param {Object} datum
      * @returns
      */

--- a/ghost/core/core/frontend/services/theme-engine/i18n/i18n.js
+++ b/ghost/core/core/frontend/services/theme-engine/i18n/i18n.js
@@ -129,7 +129,7 @@ class I18n {
     /**
      * Do the lookup within the translation strings
      *
-     * @param {String} msgPath
+     * @param {string} msgPath
      */
     _getCandidateString(msgPath) {
         let fallback = null;
@@ -208,7 +208,7 @@ class I18n {
 
     /**
      * Format the string using the correct locale and applying any bindings
-     * @param {String} string
+     * @param {string} string
      * @param {Object} bindings
      */
     _formatMessage(string, bindings) {

--- a/ghost/core/core/frontend/services/theme-engine/i18n/theme-i18n.js
+++ b/ghost/core/core/frontend/services/theme-engine/i18n/theme-i18n.js
@@ -19,8 +19,8 @@ class ThemeI18n extends I18n {
      *  - Load correct language file into memory
      *
      * @param {object} options
-     * @param {String} options.activeTheme - name of the currently loaded theme
-     * @param {String} options.locale - name of the currently loaded locale
+     * @param {string} options.activeTheme - name of the currently loaded theme
+     * @param {string} options.locale - name of the currently loaded locale
      *
      */
     init({activeTheme, locale} = {}) {

--- a/ghost/core/core/server/adapters/cache/AdapterCacheMemoryTTL.js
+++ b/ghost/core/core/server/adapters/cache/AdapterCacheMemoryTTL.js
@@ -14,8 +14,8 @@ class AdapterCacheMemoryTTL extends Base {
     /**
      *
      * @param {Object} [deps]
-     * @param {Number} [deps.max] - The max number of items to keep in the cache.
-     * @param {Number} [deps.ttl] - The max time in ms to store items
+     * @param {number} [deps.max] - The max number of items to keep in the cache.
+     * @param {number} [deps.ttl] - The max time in ms to store items
      */
     constructor({max = Infinity, ttl = Infinity} = {}) {
         super();
@@ -29,10 +29,10 @@ class AdapterCacheMemoryTTL extends Base {
 
     /**
      *
-     * @param {String} key
+     * @param {string} key
      * @param {*} value
      * @param {Object} [options]
-     * @param {Number} [options.ttl]
+     * @param {number} [options.ttl]
     */
     set(key, value, {ttl} = {}) {
         this.#cache.set(key, value, {ttl});

--- a/ghost/core/core/server/adapters/cache/MemoryCache.js
+++ b/ghost/core/core/server/adapters/cache/MemoryCache.js
@@ -13,7 +13,7 @@ class MemoryCache extends Base {
 
     /**
      *
-     * @param {String} key
+     * @param {string} key
      * @param {*} value
      */
     set(key, value) {

--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -11,16 +11,16 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      *
      * @param {Object} config
      * @param {Object} [config.cache] - caching instance compatible with cache-manager's redis store
-     * @param {String} [config.host] - redis host used in case no cache instance provided
-     * @param {Number} [config.port] - redis port used in case no cache instance provided
-     * @param {String} [config.password] - redis password used in case no cache instance provided
+     * @param {string} [config.host] - redis host used in case no cache instance provided
+     * @param {number} [config.port] - redis port used in case no cache instance provided
+     * @param {string} [config.password] - redis password used in case no cache instance provided
      * @param {Object} [config.clusterConfig] - redis cluster config used in case no cache instance provided
      * @param {Object} [config.storeConfig] - extra redis client config used in case no cache instance provided
-     * @param {Number} [config.ttl] - default cached value Time To Live (expiration) in *seconds*
-     * @param {Number} [config.getTimeoutMilliseconds] - default timeout for cache get operations in *milliseconds*
-     * @param {Number} [config.refreshAheadFactor] - 0-1 number to use to determine how old (as a percentage of ttl) an entry should be before refreshing it
-     * @param {String} [config.keyPrefix] - prefix to use when building a unique cache key, e.g.: 'some_id:image-sizes:'
-     * @param {Boolean} [config.reuseConnection] - specifies if the redis store/connection should be reused within the process
+     * @param {number} [config.ttl] - default cached value Time To Live (expiration) in *seconds*
+     * @param {number} [config.getTimeoutMilliseconds] - default timeout for cache get operations in *milliseconds*
+     * @param {number} [config.refreshAheadFactor] - 0-1 number to use to determine how old (as a percentage of ttl) an entry should be before refreshing it
+     * @param {string} [config.keyPrefix] - prefix to use when building a unique cache key, e.g.: 'some_id:image-sizes:'
+     * @param {boolean} [config.reuseConnection] - specifies if the redis store/connection should be reused within the process
      */
     constructor(config) {
         super();
@@ -140,7 +140,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
 
     /**
      *
-     * @param {String} internalKey
+     * @param {string} internalKey
      */
     async shouldRefresh(internalKey) {
         if (this.refreshAheadFactor === 0) {
@@ -232,7 +232,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
 
     /**
      *
-     * @param {String} key
+     * @param {string} key
      * @param {*} value
      */
     async set(key, value) {

--- a/ghost/core/core/server/adapters/scheduling/scheduling-default.js
+++ b/ghost/core/core/server/adapters/scheduling/scheduling-default.js
@@ -46,11 +46,11 @@ util.inherits(SchedulingDefault, SchedulingBase);
  * A new job get's added when the post scheduler module receives a new model event e.g. "post.scheduled".
  *
  * @param {Object} object
- * @param {Number} object.time - unix timestamp
- * @param {String} object.url - full post/page API url to publish the resource.
+ * @param {number} object.time - unix timestamp
+ * @param {string} object.url - full post/page API url to publish the resource.
  * @param {Object} object.extra
- * @param {String} object.extra.httpMethod - the method of the target API endpoint.
- * @param {Number} object.extra.oldTime - the previous published time.
+ * @param {string} object.extra.httpMethod - the method of the target API endpoint.
+ * @param {number} object.extra.oldTime - the previous published time.
  */
 SchedulingDefault.prototype.schedule = function (object) {
     this._addJob(object);
@@ -62,13 +62,13 @@ SchedulingDefault.prototype.schedule = function (object) {
  * Unscheduling means: scheduled -> draft.
  *
  * @param {Object} object
- * @param {Number} object.time - unix timestamp
- * @param {String} object.url - full post/page API url to publish the resource.
+ * @param {number} object.time - unix timestamp
+ * @param {string} object.url - full post/page API url to publish the resource.
  * @param {Object} object.extra
- * @param {String} object.extra.httpMethod - the method of the target API endpoint.
- * @param {Number} object.extra.oldTime - the previous published time.
+ * @param {string} object.extra.httpMethod - the method of the target API endpoint.
+ * @param {number} object.extra.oldTime - the previous published time.
  * @param {Object} options
- * @param {Boolean} [options.bootstrap]
+ * @param {boolean} [options.bootstrap]
  */
 SchedulingDefault.prototype.unschedule = function (object, options = {bootstrap: false}) {
     /**

--- a/ghost/core/core/server/adapters/storage/LocalStorageBase.js
+++ b/ghost/core/core/server/adapters/storage/LocalStorageBase.js
@@ -21,13 +21,13 @@ class LocalStorageBase extends StorageBase {
     /**
      *
      * @param {Object} options
-     * @param {String} options.storagePath
-     * @param {String} options.siteUrl
-     * @param {String} [options.staticFileURLPrefix]
+     * @param {string} options.storagePath
+     * @param {string} options.siteUrl
+     * @param {string} [options.staticFileURLPrefix]
      * @param {Object} [options.errorMessages]
-     * @param {String} [options.errorMessages.notFound]
-     * @param {String} [options.errorMessages.notFoundWithRef]
-     * @param {String} [options.errorMessages.cannotRead]
+     * @param {string} [options.errorMessages.notFound]
+     * @param {string} [options.errorMessages.notFoundWithRef]
+     * @param {string} [options.errorMessages.cannotRead]
      */
     constructor({storagePath, staticFileURLPrefix, siteUrl, errorMessages}) {
         super();
@@ -67,9 +67,9 @@ class LocalStorageBase extends StorageBase {
      * Supports relative paths (preferred) and absolute paths (legacy).
      * TODO: remove absolute path support once all callers pass relative paths
      *
-     * @param {String} [targetDir] absolute or relative directory
-     * @param {String} [fileName] file name to normalize and append
-     * @returns {String} resolved absolute path inside storagePath
+     * @param {string} [targetDir] absolute or relative directory
+     * @param {string} [fileName] file name to normalize and append
+     * @returns {string} resolved absolute path inside storagePath
      */
     _resolveAndValidateStoragePath(targetDir, fileName) {
         const resolvedRoot = path.resolve(this.storagePath);
@@ -113,7 +113,7 @@ class LocalStorageBase extends StorageBase {
      * - returns a promise which ultimately returns the full url to the uploaded file
      *
      * @param {StorageBase.Image} file
-     * @param {String} targetDir
+     * @param {string} targetDir
      * @returns {Promise<String>}
      */
     async save(file, targetDir) {
@@ -153,7 +153,7 @@ class LocalStorageBase extends StorageBase {
     /**
      * Saves a buffer in the targetPath
      * @param {Buffer} buffer is an instance of Buffer
-     * @param {String} targetPath relative path NOT including storage path to which the buffer should be written
+     * @param {string} targetPath relative path NOT including storage path to which the buffer should be written
      * @returns {Promise<String>} a URL to retrieve the data
      */
     async saveRaw(buffer, targetPath) {
@@ -174,8 +174,8 @@ class LocalStorageBase extends StorageBase {
     }
 
     /**
-     * @param {String} url full url under which the stored content is served, result of save method
-     * @returns {String} relative path under which the content is stored
+     * @param {string} url full url under which the stored content is served, result of save method
+     * @returns {string} relative path under which the content is stored
      */
     urlToPath(url) {
         let relativePath;
@@ -275,7 +275,7 @@ class LocalStorageBase extends StorageBase {
     }
 
     /**
-     * @param {String} filePath
+     * @param {string} filePath
      * @returns {Promise.<*>}
      */
     async delete(fileName, targetDir) {

--- a/ghost/core/core/server/adapters/storage/utils.js
+++ b/ghost/core/core/server/adapters/storage/utils.js
@@ -39,8 +39,8 @@ exports.getLocalImagesStoragePath = function getLocalImagesStoragePath(imagePath
 
 /**
  * @description compares the imagePath with a regex that reflects our local file storage
- * @param {String} imagePath as URL or filepath
- * @returns {Boolean}
+ * @param {string} imagePath as URL or filepath
+ * @returns {boolean}
  */
 
 exports.isLocalImage = function isLocalImage(imagePath) {
@@ -55,8 +55,8 @@ exports.isLocalImage = function isLocalImage(imagePath) {
 
 /**
  * @description Checks whether the image is managed by Ghost storage (local or CDN)
- * @param {String} imagePath as URL or filepath
- * @returns {Boolean}
+ * @param {string} imagePath as URL or filepath
+ * @returns {boolean}
  */
 exports.isInternalImage = function isInternalImage(imagePath) {
     if (this.isLocalImage(imagePath)) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/settings.js
@@ -8,7 +8,7 @@ const mappers = require('./mappers');
  * Filters an object based on a given filter object
  * @private
  * @param {Object} settings
- * @param {String} filter
+ * @param {string} filter
  * @returns {*}
  */
 function settingsFilter(settings, filter) {

--- a/ghost/core/core/server/data/importer/import-manager.js
+++ b/ghost/core/core/server/data/importer/import-manager.js
@@ -139,7 +139,7 @@ class ImportManager {
     /**
      * Convert items into a glob string
      * @param {String[]} items
-     * @returns {String}
+     * @returns {string}
      */
     getGlobPattern(items) {
         return '+(' + _.reduce(items, function (memo, ext) {
@@ -149,8 +149,8 @@ class ImportManager {
 
     /**
      * @param {String[]} extensions
-     * @param {Number} [level]
-     * @returns {String}
+     * @param {number} [level]
+     * @returns {string}
      */
     getExtensionGlob(extensions, level) {
         const prefix = level === ALL_DIRS ? '**/*' :
@@ -162,8 +162,8 @@ class ImportManager {
     /**
      *
      * @param {String[]} directories
-     * @param {Number} [level]
-     * @returns {String}
+     * @param {number} [level]
+     * @returns {string}
      */
     getDirectoryGlob(directories, level) {
         const prefix = level === ALL_DIRS ? '**/' :
@@ -185,7 +185,7 @@ class ImportManager {
      * Importable content includes any files or directories which the handlers can process
      * Importable content must be found either in the root, or inside one base directory
      *
-     * @param {String} directory
+     * @param {string} directory
      * @returns {boolean}
      */
     isValidZip(directory) {
@@ -255,7 +255,7 @@ class ImportManager {
      * Use the handler extensions to get a globbing pattern, then use that to fetch all the files from the zip which
      * are relevant to the given handler, and return them as a name and path combo
      * @param {Object} handler
-     * @param {String} directory
+     * @param {string} directory
      * @returns {File[]} Files
      */
     getFilesFromZip(handler, directory) {
@@ -267,8 +267,8 @@ class ImportManager {
 
     /**
      * Get the name of the single base directory if there is one, else return an empty string
-     * @param {String} directory
-     * @returns {String}
+     * @param {string} directory
+     * @returns {string}
      */
     getBaseDirectory(directory) {
         // Globs match root level only

--- a/ghost/core/core/server/data/importer/importers/content-file-importer.js
+++ b/ghost/core/core/server/data/importer/importers/content-file-importer.js
@@ -19,8 +19,8 @@ replaceImage = function (markdown, image) {
  * @param {Object} data
  * @param {Object[]} data.posts
  * @param {Object} contentFile
- * @param {String} contentFile.originalPath
- * @param {String} contentFile.newPath
+ * @param {string} contentFile.originalPath
+ * @param {string} contentFile.newPath
  */
 preProcessPosts = function (data, contentFile) {
     _.each(data.posts, function (post) {

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -330,8 +330,8 @@ async function hasForeignSQLite({fromTable, fromColumn, toTable, toColumn, trans
  * @param {string} configuration.toTable - name of the table to point the foreign key to
  * @param {string} configuration.toColumn - column of the table to point the foreign key to
  * @param {string} [configuration.constraintName] - name of the FK to create
- * @param {Boolean} [configuration.cascadeDelete] - adds the "on delete cascade" option if true
- * @param {Boolean} [configuration.setNullDelete] - adds the "on delete SET NULL" option if true
+ * @param {boolean} [configuration.cascadeDelete] - adds the "on delete cascade" option if true
+ * @param {boolean} [configuration.setNullDelete] - adds the "on delete SET NULL" option if true
  * @param {import('knex').Knex} [configuration.transaction] - connection object containing knex reference
  */
 async function addForeign({fromTable, fromColumn, toTable, toColumn, constraintName, cascadeDelete = false, setNullDelete = false, transaction = db.knex}) {
@@ -487,7 +487,7 @@ async function addPrimaryKey(tableName, columns, transaction = db.knex) {
  * NOTE: this function does NOT check if the table already exists - use the migration
  * utils if you want that
  *
- * @param {String} table - name of the table to create
+ * @param {string} table - name of the table to create
  * @param {import('knex').Knex} [transaction] - connection to the DB
  * @param {Object} [tableSpec] - table schema to generate table with
  */

--- a/ghost/core/core/server/data/schema/fixtures/fixture-manager.js
+++ b/ghost/core/core/server/data/schema/fixtures/fixture-manager.js
@@ -141,7 +141,7 @@ class FixtureManager {
      * ### Find Model Fixture
      * Finds a model fixture based on model name
      * @api private
-     * @param {String} modelName
+     * @param {string} modelName
      * @returns {Object} model fixture
      */
     findModelFixture(modelName) {
@@ -153,7 +153,7 @@ class FixtureManager {
     /**
      * ### Find Model Fixture Entry
      * Find a single model fixture entry by model name & a matching expression for the FIND function
-     * @param {String} modelName
+     * @param {string} modelName
      * @param {String|Object|Function} matchExpr
      * @returns {Object} model fixture entry
      */
@@ -164,7 +164,7 @@ class FixtureManager {
     /**
      * ### Find Model Fixtures
      * Find a  model fixture name & a matching expression for the FILTER function
-     * @param {String} modelName
+     * @param {string} modelName
      * @param {String|Object|Function} matchExpr
      * @returns {Object} model fixture
      */
@@ -178,8 +178,8 @@ class FixtureManager {
      * ### Find Relation Fixture
      * Find a relation fixture by from & to models
      * @api private
-     * @param {String} from
-     * @param {String} to
+     * @param {string} from
+     * @param {string} to
      * @returns {Object} relation fixture
      */
     findRelationFixture(from, to) {
@@ -191,7 +191,7 @@ class FixtureManager {
     /**
      * ### Find Permission Relations For Object
      * Specialist function can return the permission relation fixture with only entries for a particular object.model
-     * @param {String} objName
+     * @param {string} objName
      * @returns {Object} fixture relation
      */
     findPermissionRelationsForObject(objName, role) {

--- a/ghost/core/core/server/ghost-server.js
+++ b/ghost/core/core/server/ghost-server.js
@@ -40,13 +40,13 @@ class GhostServer {
     /**
      *
      * @param {Object}  options
-     * @param {String}  options.url
-     * @param {String}  options.env development|production|testing
+     * @param {string}  options.url
+     * @param {string}  options.env development|production|testing
      * @param {Object}  options.serverConfig
-     * @param {String}  options.serverConfig.host
-     * @param {Number}  options.serverConfig.port
-     * @param {Number}  options.serverConfig.shutdownTimeout
-     * @param {Boolean} options.serverConfig.testmode
+     * @param {string}  options.serverConfig.host
+     * @param {number}  options.serverConfig.port
+     * @param {number}  options.serverConfig.shutdownTimeout
+     * @param {boolean} options.serverConfig.testmode
      */
     constructor({url, env, serverConfig}) {
         this.url = url;

--- a/ghost/core/core/server/lib/common/events.js
+++ b/ghost/core/core/server/lib/common/events.js
@@ -18,9 +18,9 @@ class EventRegistry extends events.EventEmitter {
      * This is method is semi-hack to make sure listeners are only registered once
      * during the lifetime of the process. And example problem it solves is
      * registering duplicate listeners between Ghost instance reboots when running tests.
-     * @param {String} eventName
-     * @param {String} listenerName named function name registered as a listener for the event
-     * @returns {Boolean}
+     * @param {string} eventName
+     * @param {string} listenerName named function name registered as a listener for the event
+     * @returns {boolean}
      */
     hasRegisteredListener(eventName, listenerName) {
         return !!(this.listeners(eventName).find(listener => (listener.name === listenerName)));

--- a/ghost/core/core/server/lib/validate-password.js
+++ b/ghost/core/core/server/lib/validate-password.js
@@ -14,8 +14,8 @@ const messages = {
 /**
  * Counts repeated characters in a string. When 50% or more characters are the same,
  * we return false and therefore invalidate the string.
- * @param {String} stringToTest The password string to check.
- * @return {Boolean}
+ * @param {string} stringToTest The password string to check.
+ * @return {boolean}
  */
 function characterOccurance(stringToTest) {
     const chars = {};
@@ -48,9 +48,9 @@ function characterOccurance(stringToTest) {
 /**
  * Validation against simple password rules
  * Returns false when validation fails and true for a valid password
- * @param {String} password The password string to check.
- * @param {String} email The users email address to validate agains password.
- * @param {String} [blogTitle] Optional blogTitle value, when blog title is not set yet, e. g. in setup process.
+ * @param {string} password The password string to check.
+ * @param {string} email The users email address to validate agains password.
+ * @param {string} [blogTitle] Optional blogTitle value, when blog title is not set yet, e. g. in setup process.
  * @return {Object} example for returned validation Object:
  * invalid password: `validationResult: {isValid: false, message: 'Sorry, you cannot use an insecure password.'}`
  * valid password: `validationResult: {isValid: true}`

--- a/ghost/core/core/server/models/base/plugins/generate-slug.js
+++ b/ghost/core/core/server/models/base/plugins/generate-slug.js
@@ -12,7 +12,7 @@ module.exports = function (Bookshelf) {
          * ### Generate Slug
          * Create a string to act as the permalink for an object.
          * @param {Bookshelf['Model']} Model Model type to generate a slug for
-         * @param {String} base The string for which to generate a slug, usually a title or name
+         * @param {string} base The string for which to generate a slug, usually a title or name
          * @param {GenerateSlugOptions} [options] Options to pass to findOne
          * @return {Promise<String>} Resolves to a unique slug string
          */

--- a/ghost/core/core/server/models/base/plugins/sanitize.js
+++ b/ghost/core/core/server/models/base/plugins/sanitize.js
@@ -149,7 +149,7 @@ module.exports = function (Bookshelf) {
         /**
          * Filters potentially unsafe `options` in a model method's arguments, so you can pass them to Bookshelf / Knex.
          * @param {Object} unfilteredOptions Represents options to filter in order to be passed to the Bookshelf query.
-         * @param {String} methodName The name of the method to check valid options for.
+         * @param {string} methodName The name of the method to check valid options for.
          * @return {Object} The filtered results of `options`.
          */
         filterOptions: function filterOptions(unfilteredOptions, methodName, filterConfig) {

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -336,7 +336,7 @@ const Comment = ghostBookshelf.Model.extend({
 
     /**
      * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
-     * @param {String} methodName The name of the method to check valid options for.
+     * @param {string} methodName The name of the method to check valid options for.
      * @return {Array} Keys allowed in the `options` hash of the model's method.
      */
     permittedOptions: function permittedOptions(methodName) {

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -448,7 +448,7 @@ const Member = ghostBookshelf.Model.extend({
 }, {
     /**
      * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
-     * @param {String} methodName The name of the method to check valid options for.
+     * @param {string} methodName The name of the method to check valid options for.
      * @return {Array} Keys allowed in the `options` hash of the model's method.
      */
     permittedOptions: function permittedOptions(methodName) {

--- a/ghost/core/core/server/models/newsletter.js
+++ b/ghost/core/core/server/models/newsletter.js
@@ -122,7 +122,7 @@ const Newsletter = ghostBookshelf.Model.extend({
 }, {
     /**
      * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
-     * @param {String} methodName The name of the method to check valid options for.
+     * @param {string} methodName The name of the method to check valid options for.
      * @return {Array} Keys allowed in the `options` hash of the model's method.
      */
     permittedOptions: function permittedOptions(methodName) {

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -1190,7 +1190,7 @@ Post = ghostBookshelf.Model.extend({
 
     /**
      * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
-     * @param {String} methodName The name of the method to check valid options for.
+     * @param {string} methodName The name of the method to check valid options for.
      * @return {Array} Keys allowed in the `options` hash of the model's method.
      */
     permittedOptions: function permittedOptions(methodName) {

--- a/ghost/core/core/server/models/role.js
+++ b/ghost/core/core/server/models/role.js
@@ -36,7 +36,7 @@ Role = ghostBookshelf.Model.extend({
 }, {
     /**
      * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
-     * @param {String} methodName The name of the method to check valid options for.
+     * @param {string} methodName The name of the method to check valid options for.
      * @return {Array} Keys allowed in the `options` hash of the model's method.
      */
     permittedOptions: function permittedOptions(methodName) {

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -384,7 +384,7 @@ User = ghostBookshelf.Model.extend({
 
     /**
      * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
-     * @param {String} methodName The name of the method to check valid options for.
+     * @param {string} methodName The name of the method to check valid options for.
      * @return {Array} Keys allowed in the `options` hash of the model's method.
      */
     permittedOptions: function permittedOptions(methodName, options) {

--- a/ghost/core/core/server/services/adapter-manager/index.js
+++ b/ghost/core/core/server/services/adapter-manager/index.js
@@ -20,7 +20,7 @@ adapterManager.registerAdapter('cache', require('@tryghost/adapter-base-cache'))
 module.exports = {
     /**
      *
-     * @param {String} name - one of 'storage', 'scheduling', 'sso', 'cache' etc. Or can contain a "resource" extension like "storage:image"
+     * @param {string} name - one of 'storage', 'scheduling', 'sso', 'cache' etc. Or can contain a "resource" extension like "storage:image"
      * @returns {Object} instance of an adapter
      */
     getAdapter(name) {

--- a/ghost/core/core/server/services/adapter-manager/options-resolver.js
+++ b/ghost/core/core/server/services/adapter-manager/options-resolver.js
@@ -2,7 +2,7 @@
  * Resolves full configuration for an adapter. Combining base class configurations
  * along with feature-specific ones
  * 
- * @param {String} name
+ * @param {string} name
  * @param {Object} adapterServiceConfig
  * 
  * @returns {{adapterClassName: String, adapterConfig: Object}} 

--- a/ghost/core/core/server/services/custom-redirects/custom-redirects-api.js
+++ b/ghost/core/core/server/services/custom-redirects/custom-redirects-api.js
@@ -17,8 +17,8 @@ const messages = {
 /**
  * Redirect configuration object
  * @typedef {Object} RedirectConfig
- * @property {String} from - Defines the relative incoming URL or pattern (regex)
- * @property {String} to - Defines where the incoming traffic should be redirected to, which can be a static URL, or a dynamic value using regex (example: "to": "/$1/")
+ * @property {string} from - Defines the relative incoming URL or pattern (regex)
+ * @property {string} to - Defines where the incoming traffic should be redirected to, which can be a static URL, or a dynamic value using regex (example: "to": "/$1/")
  * @property {boolean} [permanent] - Can be defined with true for a permanent HTTP 301 redirect, or false for a temporary HTTP 302 redirect
  */
 
@@ -46,8 +46,8 @@ const readRedirectsFile = async (redirectsPath) => {
 
 /**
  *
- * @param {String} content serialized JSON or YAML configuration
- * @param {String} ext one of `.json` or `.yaml` extensions
+ * @param {string} content serialized JSON or YAML configuration
+ * @param {string} ext one of `.json` or `.yaml` extensions
  *
  * @returns {RedirectConfig[]} of parsed redirect config objects
  */

--- a/ghost/core/core/server/services/custom-redirects/validation.js
+++ b/ghost/core/core/server/services/custom-redirects/validation.js
@@ -11,8 +11,8 @@ const messages = {
 /**
  * Redirect configuration object
  * @typedef {Object} RedirectConfig
- * @property {String} from - Defines the relative incoming URL or pattern (regex)
- * @property {String} to - Defines where the incoming traffic should be redirected to, which can be a static URL, or a dynamic value using regex (example: "to": "/$1/")
+ * @property {string} from - Defines the relative incoming URL or pattern (regex)
+ * @property {string} to - Defines where the incoming traffic should be redirected to, which can be a static URL, or a dynamic value using regex (example: "to": "/$1/")
  * @property {boolean} [permanent] - Can be defined with true for a permanent HTTP 301 redirect, or false for a temporary HTTP 302 redirect
  */
 

--- a/ghost/core/core/server/services/email-analytics/email-analytics-provider-mailgun.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-provider-mailgun.js
@@ -23,7 +23,7 @@ class EmailAnalyticsProviderMailgun {
      *
      * @param {Function} batchHandler
      * @param {Object} [options]
-     * @param {Number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
+     * @param {number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
      * @param {Date} [options.begin]
      * @param {Date} [options.end]
      * @param {String[]} [options.events]
@@ -45,14 +45,14 @@ class EmailAnalyticsProviderMailgun {
 
     /**
      * @param {Object} mailgunOptions
-     * @param {Number} mailgunOptions.limit
-     * @param {String} mailgunOptions.event
-     * @param {String} mailgunOptions.tags
-     * @param {String} [mailgunOptions.begin]
-     * @param {String} [mailgunOptions.ascending]
+     * @param {number} mailgunOptions.limit
+     * @param {string} mailgunOptions.event
+     * @param {string} mailgunOptions.tags
+     * @param {string} [mailgunOptions.begin]
+     * @param {string} [mailgunOptions.ascending]
      * @param {Function} batchHandler
      * @param {Object} [options]
-     * @param {Number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
+     * @param {number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
      */
     async #fetchAnalytics(mailgunOptions, batchHandler, options) {
         return await this.mailgunClient.fetchEvents(mailgunOptions, batchHandler, options);

--- a/ghost/core/core/server/services/lib/mailgun-client.js
+++ b/ghost/core/core/server/services/lib/mailgun-client.js
@@ -208,7 +208,7 @@ module.exports = class MailgunClient {
      * @param {Object} mailgunOptions
      * @param {Function} batchHandler
      * @param {Object} options
-     * @param {Number} options.maxEvents
+     * @param {number} options.maxEvents
      * @returns {Promise<void>}
      */
     async #fetchEventsFromDomain(domain, mailgunInstance, mailgunOptions, batchHandler, {maxEvents}) {

--- a/ghost/core/core/server/services/link-redirection/link-redirect-repository.js
+++ b/ghost/core/core/server/services/link-redirection/link-redirect-repository.js
@@ -7,7 +7,7 @@ module.exports = class LinkRedirectRepository {
     #LinkRedirect;
     /** @type {Object} */
     #urlUtils;
-    /** @type {Boolean} */
+    /** @type {boolean} */
     #cacheEnabled;
     /** @type {Object} */
     #cache;

--- a/ghost/core/core/server/services/members/importer/members-csv-importer-stripe-utils.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer-stripe-utils.js
@@ -45,8 +45,8 @@ module.exports = class MembersCSVImporterStripeUtils {
      * flexibility and reduce duplication
      *
      * @param {Object} data
-     * @param {String} data.customer_id - Stripe customer ID
-     * @param {String} data.product_id - Ghost product ID
+     * @param {string} data.customer_id - Stripe customer ID
+     * @param {string} data.product_id - Ghost product ID
      * @param {Object} options
      * @returns {Promise<Object>}
      */
@@ -185,7 +185,7 @@ module.exports = class MembersCSVImporterStripeUtils {
     /**
      * Archive a price in Stripe
      *
-     * @param {Number} stripePriceId
+     * @param {number} stripePriceId
      * @returns {Promise<void>}
      */
     async archivePrice(stripePriceId) {

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -340,13 +340,13 @@ module.exports = class MembersCSVImporter {
      * Send email with attached CSV containing error rows info
      *
      * @param {Object} config
-     * @param {String} config.emailRecipient - email recipient for error file
-     * @param {String} config.emailSubject - email subject
-     * @param {String} config.emailContent - html content of email
-     * @param {String} config.errorCSV - error CSV content
+     * @param {string} config.emailRecipient - email recipient for error file
+     * @param {string} config.emailSubject - email subject
+     * @param {string} config.emailContent - html content of email
+     * @param {string} config.errorCSV - error CSV content
      * @param {Object} config.emailSubject - email subject
      * @param {Object} config.importLabel -
-     * @param {String} config.importLabel.name - label name
+     * @param {string} config.importLabel.name - label name
      */
     async sendErrorEmail({emailRecipient, emailSubject, emailContent, errorCSV, importLabel}) {
         await this._sendEmail({
@@ -368,15 +368,15 @@ module.exports = class MembersCSVImporter {
      * Processes CSV file and imports member&label records depending on the size of the imported set
      *
      * @param {Object} config
-     * @param {String} config.pathToCSV - path where imported csv with members records is stored
+     * @param {string} config.pathToCSV - path where imported csv with members records is stored
      * @param {Object} config.headerMapping - mapping of CSV headers to member record fields
      * @param {Object} [config.globalLabels] - labels to be applied to whole imported members set
      * @param {Object} config.importLabel -
-     * @param {String} config.importLabel.name - label name
+     * @param {string} config.importLabel.name - label name
      * @param {Object} config.user
-     * @param {String} config.user.email - calling user email
+     * @param {string} config.user.email - calling user email
      * @param {Object} config.LabelModel - instance of Ghosts Label model
-     * @param {Boolean} config.forceInline - allows to force performing imports not in a job (used in test environment)
+     * @param {boolean} config.forceInline - allows to force performing imports not in a job (used in test environment)
      * @param {{testImportThreshold: () => Promise<void>}} config.verificationTrigger
      */
     async process({pathToCSV, headerMapping, globalLabels, importLabel, user, LabelModel, forceInline, verificationTrigger}) {

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -977,9 +977,9 @@ module.exports = class MemberRepository {
     /**
      *
      * @param {Object} data
-     * @param {String} data.id - member ID
+     * @param {string} data.id - member ID
      * @param {Object} data.subscription
-     * @param {String} data.offerId
+     * @param {string} data.offerId
      * @param {import('@tryghost/member-attribution/lib/Attribution').AttributionResource} [data.attribution]
      * @param {*} options
      * @returns
@@ -1888,7 +1888,7 @@ module.exports = class MemberRepository {
     /**
      *
      * @param {Object} data
-     * @param {String} data.id - member ID
+     * @param {string} data.id - member ID
      * @param {Object} options
      * @param {Object} [options.transacting]
      */
@@ -2025,7 +2025,7 @@ module.exports = class MemberRepository {
     /**
      *
      * @param {Object} data
-     * @param {String} data.id - member ID
+     * @param {string} data.id - member ID
      * @param {Object} options
      * @param {Object} [options.transacting]
      */

--- a/ghost/core/core/server/services/members/stats/members-stats.js
+++ b/ghost/core/core/server/services/members/stats/members-stats.js
@@ -6,7 +6,7 @@ class MembersStats {
      * @param {Object} config
      * @param {Object} config.db - an instance holding knex connection to the database
      * @param {Object} config.settingsCache - an instance of the Ghost Settings Cache
-     * @param {Boolean} config.isSQLite - flag identifying if storage is connected to SQLite
+     * @param {boolean} config.isSQLite - flag identifying if storage is connected to SQLite
      */
     constructor({db, settingsCache, isSQLite}) {
         this._db = db;
@@ -25,8 +25,8 @@ class MembersStats {
     /**
      *
      * @param {Number | String} days  - number of days to fetch of 'all-time' to get for all existing records
-     * @param {Number} totalMembers - number of registered members
-     * @param {String} siteTimezone - site's current timezone
+     * @param {number} totalMembers - number of registered members
+     * @param {string} siteTimezone - site's current timezone
      */
     async getTotalMembersInRange({days, totalMembers, siteTimezone}) {
         if (days === 'all-time') {
@@ -41,7 +41,7 @@ class MembersStats {
     /**
      * Fetches member signups for current day
      *
-     * @param {String} siteTimezone - site's current timezone
+     * @param {string} siteTimezone - site's current timezone
      */
     async getNewMembersToday({siteTimezone}) {
         const startOfToday = moment.tz(siteTimezone).startOf('day').utc().format(dateFormat);
@@ -52,8 +52,8 @@ class MembersStats {
     /**
      *
      * @param {Number | String} days  - number of days to fetch of 'all-time' to get for all existing records
-     * @param {Number} totalMembers - number of registered members
-     * @param {String} siteTimezone - site's current timezone
+     * @param {number} totalMembers - number of registered members
+     * @param {string} siteTimezone - site's current timezone
      */
     async getTotalMembersOnDatesInRange({days, totalMembers, siteTimezone}) {
         const startOfRange = moment.tz(siteTimezone).subtract(days - 1, 'days').startOf('day').utc().format(dateFormat);

--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -134,7 +134,7 @@ class OEmbedService {
 
     /**
      * Fetches the image buffer from a URL using this.externalRequest
-     * @param {String} imageUrl - URL of the image to fetch
+     * @param {string} imageUrl - URL of the image to fetch
      * @returns {Promise<Buffer>} - Promise resolving to the image buffer
      */
     async fetchImageBuffer(imageUrl) {
@@ -144,8 +144,8 @@ class OEmbedService {
 
     /**
      * Process and store image from a URL
-     * @param {String} imageUrl - URL of the image to process
-     * @param {String} imageType - What is the image used for. Example - icon, thumbnail
+     * @param {string} imageUrl - URL of the image to process
+     * @param {string} imageType - What is the image used for. Example - icon, thumbnail
      * @returns {Promise<String>} - URL where the image is stored
      */
     async processImageFromUrl(imageUrl, imageType) {

--- a/ghost/core/core/server/services/posts/post-email-handler.js
+++ b/ghost/core/core/server/services/posts/post-email-handler.js
@@ -127,9 +127,9 @@ class PostEmailHandler {
     /**
      * Calculates if the email should be tried to be sent out
      *
-     * @param {String} currentStatus current status from the post model
-     * @param {String} previousStatus previous status from the post model
-     * @returns {Boolean}
+     * @param {string} currentStatus current status from the post model
+     * @param {string} previousStatus previous status from the post model
+     * @returns {boolean}
      */
     shouldSendEmail(currentStatus, previousStatus) {
         return EMAIL_SENDING_STATUSES.includes(currentStatus)

--- a/ghost/core/core/server/services/posts/post-scheduling-service.js
+++ b/ghost/core/core/server/services/posts/post-scheduling-service.js
@@ -14,9 +14,9 @@ class PostSchedulingService {
     /**
      * Publishes scheduled resource (a post or a page at the moment of writing)
      *
-     * @param {String} resourceType one of 'post' or 'page' resources
-     * @param {String} id resource id
-     * @param {Boolean} force force publish flag
+     * @param {string} resourceType one of 'post' or 'page' resources
+     * @param {string} id resource id
+     * @param {boolean} force force publish flag
      * @param {Object} options api query options
      * @returns {Promise<Object, Object>}
      */

--- a/ghost/core/core/server/services/route-settings/default-settings-manager.js
+++ b/ghost/core/core/server/services/route-settings/default-settings-manager.js
@@ -12,10 +12,10 @@ class DefaultSettingsManager {
     /**
      *
      * @param {Object} options
-     * @param {String} options.type - name of the setting file
-     * @param {String} options.extension - settings file extension
-     * @param {String} options.destinationFolderPath - path to store the default setting config
-     * @param {String} options.sourceFolderPath - path where the default config can be seeded from
+     * @param {string} options.type - name of the setting file
+     * @param {string} options.extension - settings file extension
+     * @param {string} options.destinationFolderPath - path to store the default setting config
+     * @param {string} options.sourceFolderPath - path where the default config can be seeded from
      */
     constructor({type, extension, destinationFolderPath, sourceFolderPath}) {
         this.type = type;

--- a/ghost/core/core/server/services/route-settings/route-settings.js
+++ b/ghost/core/core/server/services/route-settings/route-settings.js
@@ -28,8 +28,8 @@ class RouteSettings {
      *
      * @param {Object} options
      * @param {Object} options.settingsLoader
-     * @param {String} options.settingsPath
-     * @param {String} options.backupPath
+     * @param {string} options.settingsPath
+     * @param {string} options.backupPath
      */
     constructor({settingsLoader, settingsPath, backupPath}) {
         /**
@@ -45,8 +45,8 @@ class RouteSettings {
 
     /**
      * @private
-     * @param {String} settingsPath
-     * @param {String} backupPath
+     * @param {string} settingsPath
+     * @param {string} backupPath
      */
     async createBackupFile(settingsPath, backupPath) {
         return await fs.copy(settingsPath, backupPath);
@@ -54,8 +54,8 @@ class RouteSettings {
 
     /**
      * @private
-     * @param {String} settingsPath
-     * @param {String} backupPath
+     * @param {string} settingsPath
+     * @param {string} backupPath
      */
     async restoreBackupFile(settingsPath, backupPath) {
         return await fs.copy(backupPath, settingsPath);
@@ -63,8 +63,8 @@ class RouteSettings {
 
     /**
      * @private
-     * @param {String} filePath
-     * @param {String} settingsPath
+     * @param {string} filePath
+     * @param {string} settingsPath
      */
     async saveFile(filePath, settingsPath) {
         return await fs.copy(filePath, settingsPath);
@@ -72,7 +72,7 @@ class RouteSettings {
 
     /**
      * @private
-     * @param {String} settingsFilePath
+     * @param {string} settingsFilePath
      */
     async readFile(settingsFilePath) {
         return fs.readFile(settingsFilePath, 'utf-8')

--- a/ghost/core/core/server/services/route-settings/settings-loader.js
+++ b/ghost/core/core/server/services/route-settings/settings-loader.js
@@ -12,7 +12,7 @@ class SettingsLoader {
     /**
      * @param {Object} options
      * @param {Function} options.parseYaml yaml parser
-     * @param {String} options.settingFilePath routes settings file path
+     * @param {string} options.settingFilePath routes settings file path
      */
     constructor({parseYaml, settingFilePath}) {
         this.parseYaml = parseYaml;

--- a/ghost/core/core/server/services/route-settings/settings-path-manager.js
+++ b/ghost/core/core/server/services/route-settings/settings-path-manager.js
@@ -12,7 +12,7 @@ class SettingsPathManager {
      *
      * @param {Object} options
      * @param {String[]} options.paths - file location paths ordered in priority by where to locate them first
-     * @param {String} options.type setting file type, e.g: 'routes' or 'redirects'
+     * @param {string} options.type setting file type, e.g: 'routes' or 'redirects'
      * @param {String[]} [options.extensions] the supported file extensions with 'yaml' and 'json' defaults. Note 'yml' extension is ignored on purpose
     */
     constructor({type, paths, extensions = ['yaml', 'json']}) {

--- a/ghost/core/core/server/services/route-settings/yaml-parser.js
+++ b/ghost/core/core/server/services/route-settings/yaml-parser.js
@@ -15,7 +15,7 @@ const messages = {
 
 /**
  * Takes a YAML formatted string and parses it and returns a JSON Object
- * @param {String} file the YAML file utf8 encoded
+ * @param {string} file the YAML file utf8 encoded
  * @returns {Object} parsed
  */
 module.exports = function parseYaml(file) {

--- a/ghost/core/core/server/services/settings/settings-bread-service.js
+++ b/ghost/core/core/server/services/settings/settings-bread-service.js
@@ -101,7 +101,7 @@ class SettingsBREADService {
 
     /**
      *
-     * @param {String} key setting key
+     * @param {string} key setting key
      * @param {Object} [context] API context instance
      * @returns {Object} an object with a filled out key that comes in a parameter
      */

--- a/ghost/core/core/server/services/settings/settings-utils.js
+++ b/ghost/core/core/server/services/settings/settings-utils.js
@@ -9,8 +9,8 @@ const obfuscatedSetting = '••••••••';
 /**
  * @description // The function used to decide whether a setting is write-only
  * @param {Object} setting setting record
- * @param {String} setting.key
- * @returns {Boolean}
+ * @param {string} setting.key
+ * @returns {boolean}
  */
 function isSecretSetting(setting) {
     return /secret|api_key/.test(setting.key);
@@ -19,8 +19,8 @@ function isSecretSetting(setting) {
 /**
  * @description The function that obfuscates a write-only setting
  * @param {Object} setting setting record
- * @param {String} setting.value
- * @param {String} setting.key
+ * @param {string} setting.value
+ * @param {string} setting.key
  * @returns {Object} settings record with obfuscated value if it's a secret
  */
 function hideValueIfSecret(setting) {
@@ -36,7 +36,7 @@ let SITE_UUID;
  * @description Get or generate a site UUID, used for seeding the site_uuid setting
  * Uses the configured site_uuid if valid, otherwise generates a new one
  * To get the `site_uuid` setting, use `settingsCache.get('site_uuid')` instead
- * @returns {String} lowercase UUID
+ * @returns {string} lowercase UUID
  */
 function getOrGenerateSiteUuid() {
     if (!SITE_UUID) {

--- a/ghost/core/core/server/services/themes/installer.js
+++ b/ghost/core/core/server/services/themes/installer.js
@@ -13,7 +13,7 @@ const messages = {
 
 /**
  *
- * @param {String} ref - theme reference in "Org/RepoName" format
+ * @param {string} ref - theme reference in "Org/RepoName" format
  * @returns {Promise<any>}
  */
 const installFromGithub = async (ref) => {

--- a/ghost/core/core/server/services/themes/theme-storage.js
+++ b/ghost/core/core/server/services/themes/theme-storage.js
@@ -60,8 +60,8 @@ class ThemeStorage extends LocalStorageBase {
     /**
      * Rename a file / folder
      *
-     * @param {String} srcName
-     * @param {String} destName
+     * @param {string} srcName
+     * @param {string} destName
      */
     rename(srcName, destName) {
         let src = path.join(this.getTargetDir(), srcName);
@@ -73,7 +73,7 @@ class ThemeStorage extends LocalStorageBase {
     /**
      * Remove a file / folder
      *
-     * @param {String} fileName
+     * @param {string} fileName
      * @returns {Promise<void>}
      */
     delete(fileName) {

--- a/ghost/core/core/server/services/update-check/index.js
+++ b/ghost/core/core/server/services/update-check/index.js
@@ -15,9 +15,9 @@ const UpdateCheckService = require('./update-check-service');
 /**
  * Initializes and triggers update check
  * @param {Object} [options]
- * @param {Boolean} [options.rethrowErrors] - if true, errors will be thrown instead of logged
- * @param {Boolean} [options.forceUpdate] - if true, the update check will be triggered regardless of the environment or scheudle, defaults to config if no value provided
- * @param {String} [options.updateCheckUrl] - the url to check for updates against, defaults to config if no value provided
+ * @param {boolean} [options.rethrowErrors] - if true, errors will be thrown instead of logged
+ * @param {boolean} [options.forceUpdate] - if true, the update check will be triggered regardless of the environment or scheudle, defaults to config if no value provided
+ * @param {string} [options.updateCheckUrl] - the url to check for updates against, defaults to config if no value provided
  * @returns {Promise<any>}
  */
 module.exports = async ({

--- a/ghost/core/core/server/services/url/local-file-cache.js
+++ b/ghost/core/core/server/services/url/local-file-cache.js
@@ -4,8 +4,8 @@ const path = require('path');
 class LocalFileCache {
     /**
      * @param {Object} options
-     * @param {String} options.storagePath - cached storage path
-     * @param {Boolean} options.writeDisabled - controls if cache can write
+     * @param {string} options.storagePath - cached storage path
+     * @param {boolean} options.writeDisabled - controls if cache can write
      */
     constructor({storagePath, writeDisabled}) {
         const urlsStoragePath = path.join(storagePath, 'urls.json');
@@ -21,7 +21,7 @@ class LocalFileCache {
     /**
      * Handles reading and parsing JSON from the filesystem.
      * In case the file is corrupted or does not exist, returns null.
-     * @param {String} filePath path to read from
+     * @param {string} filePath path to read from
      * @returns {Promise<Object>}
      * @private
      */

--- a/ghost/core/core/server/services/url/resource.js
+++ b/ghost/core/core/server/services/url/resource.js
@@ -23,7 +23,7 @@ class Resource extends EventEmitter {
 
     /**
      * @description Get the type of the resource e.g. posts, users ...
-     * @returns {String} type
+     * @returns {string} type
      */
     getType() {
         return this.config.type;

--- a/ghost/core/core/server/services/url/resources.js
+++ b/ghost/core/core/server/services/url/resources.js
@@ -39,7 +39,7 @@ class Resources {
      * @description Little helper to register on Ghost events and remember the listener functions to be able
      * to unsubscribe.
      *
-     * @param {String} eventName
+     * @param {string} eventName
      * @param {Function} listener
      * @private
      */
@@ -156,7 +156,7 @@ class Resources {
      * See https://github.com/TryGhost/Ghost/issues/10124.
      *
      * @param {Object} resourceConfig
-     * @param {String} id
+     * @param {string} id
      * @returns {Promise}
      * @private
      */

--- a/ghost/core/core/server/services/url/url-generator.js
+++ b/ghost/core/core/server/services/url/url-generator.js
@@ -34,14 +34,14 @@ const EXPANSIONS = [{
 class UrlGenerator {
     /**
      * @param {Object} options
-     * @param {String} options.identifier frontend router ID reference
-     * @param {String} options.filter NQL filter string
-     * @param {String} options.resourceType resource type (e.g. 'posts', 'tags')
-     * @param {String} options.permalink permalink string
+     * @param {string} options.identifier frontend router ID reference
+     * @param {string} options.filter NQL filter string
+     * @param {string} options.resourceType resource type (e.g. 'posts', 'tags')
+     * @param {string} options.permalink permalink string
      * @param {Object} options.queue instance of the backend Queue
      * @param {Object} options.resources instance of the backend Resources
      * @param {Object} options.urls instance of the backend URLs (used to store the urls)
-     * @param {Number} options.position an ID of the generator
+     * @param {number} options.position an ID of the generator
      */
     constructor({identifier, filter, resourceType, permalink, queue, resources, urls, position}) {
         this.identifier = identifier;
@@ -133,8 +133,8 @@ class UrlGenerator {
     /**
      * @description Listener which get's called when a resource was added on runtime.
      * @param {Object} event
-     * @param {String} event.type
-     * @param {String} event.id
+     * @param {string} event.type
+     * @param {string} event.id
      * @private
      */
     _onAdded(event) {
@@ -250,7 +250,7 @@ class UrlGenerator {
 
     /**
      * @description Figure out if this url generator own's a resource id.
-     * @param {String} id
+     * @param {string} id
      * @returns {boolean}
      */
     hasId(id) {

--- a/ghost/core/core/server/services/url/url-service.js
+++ b/ghost/core/core/server/services/url/url-service.js
@@ -63,7 +63,7 @@ class UrlService {
      * The "init" event is basically the bootstrap event, which is the siganliser if url generation
      * is in progress or not.
      *
-     * @param {String} event
+     * @param {string} event
      * @private
      */
     _onQueueStarted(event) {
@@ -75,7 +75,7 @@ class UrlService {
 
     /**
      * @description The queue will notify us if the queue has ended with an event.
-     * @param {String} event
+     * @param {string} event
      * @private
      */
     _onQueueEnded(event) {
@@ -90,10 +90,10 @@ class UrlService {
 
     /**
      * @description Router was created, connect it with a url generator.
-     * @param {String} identifier frontend router ID reference
-     * @param {String} filter NQL filter
-     * @param {String} resourceType
-     * @param {String} permalink
+     * @param {string} identifier frontend router ID reference
+     * @param {string} filter NQL filter
+     * @param {string} resourceType
+     * @param {string} permalink
      */
     onRouterAddedType(identifier, filter, resourceType, permalink) {
         debug('Registering route:', filter, resourceType, permalink);
@@ -113,7 +113,7 @@ class UrlService {
 
     /**
      * @description Router update handler - regenerates it's resources
-     * @param {String} identifier router ID linked to the UrlGenerator
+     * @param {string} identifier router ID linked to the UrlGenerator
      */
     onRouterUpdated(identifier) {
         const generator = this.urlGenerators.find(g => g.identifier === identifier);
@@ -141,7 +141,7 @@ class UrlService {
      *
      * @NOTE: only accepts relative urls at the moment.
      *
-     * @param {String} url
+     * @param {string} url
      * @param {Object} options
      * @returns {Object}
      */
@@ -188,7 +188,7 @@ class UrlService {
 
     /**
      * @description Get resource by id.
-     * @param {String} resourceId
+     * @param {string} resourceId
      * @returns {Object}
      */
     getResourceById(resourceId) {
@@ -222,11 +222,11 @@ class UrlService {
      * You will see a suggestion of posts, but they all don't belong to a collection.
      * They would show localhost:2368/null/.
      *
-     * @param {String} id
+     * @param {string} id
      * @param {Object} [options]
      * @param {Object} [options.absolute]
      * @param {Object} [options.withSubdirectory]
-     * @returns {String}
+     * @returns {string}
      */
     getUrlByResourceId(id, options = {}) {
         const obj = this.urls.getByResourceId(id);
@@ -256,8 +256,8 @@ class UrlService {
 
     /**
      * @description Check whether a router owns a resource id.
-     * @param {String} routerId
-     * @param {String} id
+     * @param {string} routerId
+     * @param {string} id
      * @returns {boolean}
      */
     owns(routerId, id) {
@@ -273,7 +273,7 @@ class UrlService {
 
     /**
      * @description Get permlink structure for url.
-     * @param {String} url
+     * @param {string} url
      * @param {object} options
      * @returns {*}
      */
@@ -298,7 +298,7 @@ class UrlService {
     /**
      * @description Initializes components needed for the URL Service to function
      * @param {Object} options
-     * @param {Boolean} [options.urlCache] - whether to init using url cache or not
+     * @param {boolean} [options.urlCache] - whether to init using url cache or not
      */
     async init({urlCache} = {}) {
         let persistedUrls;

--- a/ghost/core/core/server/services/url/urls.js
+++ b/ghost/core/core/server/services/url/urls.js
@@ -68,7 +68,7 @@ class Urls {
 
     /**
      * @description Get url by resource id.
-     * @param {String} id
+     * @param {string} id
      * @returns {Url}
      */
     getByResourceId(id) {
@@ -77,7 +77,7 @@ class Urls {
 
     /**
      * @description Get all urls by generator id.
-     * @param {String} generatorId
+     * @param {string} generatorId
      * @returns {Url[]}
      */
     getByGeneratorId(generatorId) {

--- a/ghost/core/core/server/web/api/middleware/upload.js
+++ b/ghost/core/core/server/web/api/middleware/upload.js
@@ -167,7 +167,7 @@ const checkFileIsValid = (fileData, types, extensions) => {
 
 /**
  *
- * @param {String} filepath
+ * @param {string} filepath
  * @returns {Promise<String | null>}
  *
  * Reads the SVG file, sanitizes it, and writes the sanitized content back to the file.
@@ -193,7 +193,7 @@ const sanitizeSvg = async (filepath, isZipped = false) => {
 
 /**
  *
- * @param {String} content
+ * @param {string} content
  * @returns {String | null}
  *
  * Returns sanitized SVG content, or null if the content is invalid.
@@ -218,8 +218,8 @@ const sanitizeSvgContent = (content) => {
 
 /**
  *
- * @param {String} filepath
- * @param {Boolean} isZipped
+ * @param {string} filepath
+ * @param {boolean} isZipped
  * @returns {Promise<String | null>}
  *
  * Reads .svg or .svgz files and returns the content as a string.
@@ -236,9 +236,9 @@ const readSvg = async (filepath, isZipped = false) => {
 
 /**
  *
- * @param {String} filepath
- * @param {String} content
- * @param {Boolean} isZipped
+ * @param {string} filepath
+ * @param {string} content
+ * @param {boolean} isZipped
  *
  * Writes SVG content to a .svg or .svgz file.
  */
@@ -253,7 +253,7 @@ const writeSvg = async (filepath, content, isZipped = false) => {
 /**
  *
  * @param {Object} options
- * @param {String} options.type - type of the file
+ * @param {string} options.type - type of the file
  * @returns {import('express').RequestHandler}
  */
 const validation = function ({type}) {
@@ -306,7 +306,7 @@ const validation = function ({type}) {
 /**
  *
  * @param {Object} options
- * @param {String} options.type - type of the file
+ * @param {string} options.type - type of the file
  * @returns {import('express').RequestHandler}
  */
 const mediaValidation = function ({type}) {
@@ -367,7 +367,7 @@ const mediaValidation = function ({type}) {
  * we derive the storage content type from the extension via getStorageContentType().
  *
  * @param {Object} options
- * @param {String} options.type - config key under uploads (e.g. 'files')
+ * @param {string} options.type - config key under uploads (e.g. 'files')
  * @returns {import('express').RequestHandler}
  */
 const fileValidation = function ({type}) {

--- a/ghost/core/core/shared/express.js
+++ b/ghost/core/core/shared/express.js
@@ -7,7 +7,7 @@ const lazyLoad = createLazyRouter();
 
 /**
  *
- * @param {String} name
+ * @param {string} name
  * @returns {import('express').Application}
  */
 module.exports = (name) => {

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -49,8 +49,8 @@ describe('MembersCSVImporterStripeUtils', function () {
      * Returns a stubbed Stripe API service
      *
      * @param {Object} options
-     * @param {Boolean} [options.configured] - Whether the Stripe API service is configured, defaults to true
-     * @param {Boolean} [options.resolveCustomer] - Whether the Stripe API service should resolve the customer, defaults to true
+     * @param {boolean} [options.configured] - Whether the Stripe API service is configured, defaults to true
+     * @param {boolean} [options.resolveCustomer] - Whether the Stripe API service should resolve the customer, defaults to true
      * @returns {Object}
      */
     const getStripeApiServiceStub = ({
@@ -76,9 +76,9 @@ describe('MembersCSVImporterStripeUtils', function () {
      * Returns a stubbed product repository
      *
      * @param {Object} options
-     * @param {String} [options.ghostProductStripePriceId] - The Stripe price ID of the Ghost product, defaults to the Stripe price ID of the Stripe customer's existing subscription
-     * @param {Boolean} [options.resolveGhostProductPrice] - Whether the product repository should resolve the Ghost product price, defaults to true
-     * @param {Boolean} [options.resolveStripeProduct] - Whether the product repository should resolve the Stripe product, defaults to true
+     * @param {string} [options.ghostProductStripePriceId] - The Stripe price ID of the Ghost product, defaults to the Stripe price ID of the Stripe customer's existing subscription
+     * @param {boolean} [options.resolveGhostProductPrice] - Whether the product repository should resolve the Ghost product price, defaults to true
+     * @param {boolean} [options.resolveStripeProduct] - Whether the product repository should resolve the Stripe product, defaults to true
      * @returns {Object}
      */
     const getProductRepositoryStub = ({

--- a/ghost/core/test/utils/agents/admin-api-test-agent.js
+++ b/ghost/core/test/utils/agents/admin-api-test-agent.js
@@ -48,8 +48,8 @@ const createValidAPIToken = (apiKeyId, apiKeySecret) => {
  * @constructor
  * @param {Object} app  Ghost express app instance
  * @param {Object} options
- * @param {String} options.apiURL
- * @param {String} options.originURL
+ * @param {string} options.apiURL
+ * @param {string} options.originURL
  */
 class AdminAPITestAgent extends TestAgent {
     constructor(app, options) {
@@ -112,8 +112,8 @@ class AdminAPITestAgent extends TestAgent {
 
     /**
      * Use
-     * @param {String} apiKeyId
-     * @param {String} apiKeySecret
+     * @param {string} apiKeyId
+     * @param {string} apiKeySecret
      */
     async useToken(apiKeyId, apiKeySecret) {
         this.resetAuthentication();
@@ -129,7 +129,7 @@ class AdminAPITestAgent extends TestAgent {
 
     /**
      * Gets a staff token for the specified role and sets it as the Authorization header
-     * @param {String} role - The role to get a token for (owner, admin, editor, etc.)
+     * @param {string} role - The role to get a token for (owner, admin, editor, etc.)
      * @returns {Promise<void>}
      */
     async useStaffTokenFor(role) {

--- a/ghost/core/test/utils/agents/content-api-test-agent.js
+++ b/ghost/core/test/utils/agents/content-api-test-agent.js
@@ -7,8 +7,8 @@ const defaultContentAPISecretKey = DataGenerator.Content.api_keys[1].secret;
  * @constructor
  * @param {Object} app  Ghost express app instance
  * @param {Object} options
- * @param {String} options.apiURL
- * @param {String} options.originURL
+ * @param {string} options.apiURL
+ * @param {string} options.originURL
  */
 class ContentAPITestAgent extends TestAgent {
     constructor(app, options) {

--- a/ghost/core/test/utils/agents/ghost-api-test-agent.js
+++ b/ghost/core/test/utils/agents/ghost-api-test-agent.js
@@ -7,8 +7,8 @@ const TestAgent = require('./test-agent');
  * @constructor
  * @param {Object} app  Ghost express app instance
  * @param {Object} options
- * @param {String} options.apiURL
- * @param {String} options.originURL
+ * @param {string} options.apiURL
+ * @param {string} options.originURL
  */
 class GhostAPITestAgent extends TestAgent {
     constructor(app, options) {

--- a/ghost/core/test/utils/agents/members-api-test-agent.js
+++ b/ghost/core/test/utils/agents/members-api-test-agent.js
@@ -8,8 +8,8 @@ const errors = require('@tryghost/errors');
  * @constructor
  * @param {Object} app  Ghost express app instance
  * @param {Object} options
- * @param {String} options.apiURL
- * @param {String} options.originURL
+ * @param {string} options.apiURL
+ * @param {string} options.originURL
  */
 class MembersAPITestAgent extends TestAgent {
     #bootOptions = null;

--- a/ghost/core/test/utils/agents/test-agent.js
+++ b/ghost/core/test/utils/agents/test-agent.js
@@ -4,8 +4,8 @@ const Agent = require('@tryghost/express-test');
  * @constructor
  * @param {Object} app  Ghost express app instance
  * @param {Object} options
- * @param {String} options.apiURL
- * @param {String} options.originURL
+ * @param {string} options.apiURL
+ * @param {string} options.originURL
  */
 class TestAgent extends Agent {
     constructor(app, options) {

--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -20,7 +20,7 @@ let dbInitialized = false;
 
 /**
  * Checks if the current active connection is a MySQL database
- * @returns {Boolean} isMySQL
+ * @returns {boolean} isMySQL
  */
 module.exports.isMySQL = () => {
     return DatabaseInfo.isMySQL(db.knex);
@@ -28,7 +28,7 @@ module.exports.isMySQL = () => {
 
 /**
  * Checks if the current active connection is a SQLite database
- * @returns {Boolean} isSQLite
+ * @returns {boolean} isSQLite
  */
 module.exports.isSQLite = () => {
     return DatabaseInfo.isSQLite(db.knex);
@@ -40,7 +40,7 @@ module.exports.isSQLite = () => {
  * - has many behind the scenes tricks to try to do this as fast as possible
  *
  * @param {Object} options
- * @param {Boolean} options.truncate whether to truncate rather thann fully reset
+ * @param {boolean} options.truncate whether to truncate rather thann fully reset
  */
 module.exports.reset = async ({truncate} = {truncate: false}) => {
     if (module.exports.isSQLite()) {

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -53,9 +53,9 @@ let totalBoots = 0;
 
 /**
  * @param {Object} [options={}]
- * @param {Boolean} [options.backend] Boot the backend
- * @param {Boolean} [options.frontend] Boot the frontend
- * @param {Boolean} [options.server] Start a server
+ * @param {boolean} [options.backend] Boot the backend
+ * @param {boolean} [options.frontend] Boot the frontend
+ * @param {boolean} [options.server] Start a server
  * @returns {Promise<Express.Application>} ghost
  */
 const startGhost = async (options = {}) => {
@@ -221,7 +221,7 @@ const getContentAPIAgent = async () => {
  * agent.get('/posts/') without having to worry about URL paths
  *
  * @param {Object} [options={}]
- * @param {Boolean} [options.members] Include members in the boot process
+ * @param {boolean} [options.members] Include members in the boot process
  * @returns {Promise<InstanceType<AdminAPITestAgent>>} agent
  */
 const getAdminAPIAgent = async (options = {}) => {

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -128,11 +128,11 @@ const _startGhost = async (options) => {
  * @param {boolean} [options.backend]
  * @param {boolean} [options.frontend]
  * @param {boolean} [options.redirectsFile]
- * @param {String} [options.redirectsFileExt]
+ * @param {string} [options.redirectsFileExt]
  * @param {boolean} [options.copyThemes]
  * @param {boolean} [options.copySettings]
- * @param {String} [options.routesFilePath] - path to a routes configuration file to start the instance with
- * @param {String} [options.contentFolder]
+ * @param {string} [options.routesFilePath] - path to a routes configuration file to start the instance with
+ * @param {string} [options.contentFolder]
  * @param {boolean} [options.subdir]
  * @returns {Promise<GhostServer>}
  */


### PR DESCRIPTION
no ref

This is a types-only change that should have no user impact.

This is, effectively, the whole diff:

```diff
-@param {String} foo
+@param {string} foo
```

`String` is less correct than `string`, and [will not be supported by TypeScript in an upcoming version][0].

All I did was run `sed` on a bunch of files.

[0]: https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/#javascript-checking-and-jsdoc-compatibility
