### PR TITLE
Remove previous and next post helper pagination counts

### DIFF
--- a/ghost/core/core/frontend/helpers/prev_post.js
+++ b/ghost/core/core/frontend/helpers/prev_post.js
@@ -30,6 +30,7 @@ const buildApiOptions = function buildApiOptions(options, post) {
         include: 'author,authors,tags,tiers',
         order: 'published_at ' + order,
         limit: 1,
+        skipPagination: true,
         // This line deliberately uses double quotes because GQL cannot handle either double quotes
         // or escaped singles, see TryGhost/GQL#34
         filter: "slug:-" + slug + "+published_at:" + op + "'" + publishedAt + "'", // eslint-disable-line quotes

--- a/ghost/core/core/server/api/endpoints/posts-public.js
+++ b/ghost/core/core/server/api/endpoints/posts-public.js
@@ -70,6 +70,7 @@ const controller = {
                     'absolute_urls',
                     'collection'
                 ]),
+                skipPagination: frame.options?.skipPagination === true,
                 auth: generateAuthData(frame),
                 method: 'browse'
             };
@@ -84,7 +85,8 @@ const controller = {
             'page',
             'debug',
             'absolute_urls',
-            'collection'
+            'collection',
+            'skipPagination'
         ],
         validation: {
             options: {

--- a/ghost/core/core/server/models/base/plugins/crud.js
+++ b/ghost/core/core/server/models/base/plugins/crud.js
@@ -19,13 +19,35 @@ const requiredForExcerpt = (requestedColumns) => {
 };
 
 const parsePositiveInteger = (value, defaultValue) => {
-    const parsedValue = parseInt(value, 10);
+    const parsedValue = Number.parseInt(value, 10);
 
     if (Number.isNaN(parsedValue)) {
         return defaultValue;
     }
 
     return Math.max(parsedValue, 1);
+};
+
+// Pre-applies limit/offset so callers can use fetchPage's limit='all'
+// short-circuit (which skips the count query) while still fetching only
+// the requested window.
+const applyManualPaginationWindow = (itemCollection, options) => {
+    if (options.limit === 'all') {
+        return;
+    }
+
+    const limit = parsePositiveInteger(options.limit, 15);
+    const page = parsePositiveInteger(options.page, 1);
+
+    itemCollection
+        .query('limit', limit)
+        .query('offset', limit * (page - 1));
+
+    options.limit = 'all';
+};
+
+const buildPaginationMeta = (skipPagination, pagination) => {
+    return skipPagination ? {} : {pagination};
 };
 
 /**
@@ -162,18 +184,8 @@ module.exports = function (Bookshelf) {
                 options.useSmartCount = true;
             }
 
-            if (skipPagination && options.limit !== 'all') {
-                // fetchPage skips its count query only for limit='all'. Preserve the requested page window
-                // manually before using that path, so callers can avoid pagination metadata without fetching
-                // every matching row.
-                const limit = parsePositiveInteger(options.limit, 15);
-                const page = parsePositiveInteger(options.page, 1);
-
-                itemCollection
-                    .query('limit', limit)
-                    .query('offset', limit * (page - 1));
-
-                options.limit = 'all';
+            if (skipPagination) {
+                applyManualPaginationWindow(itemCollection, options);
             }
 
             const response = await itemCollection.fetchPage(options);
@@ -191,7 +203,7 @@ module.exports = function (Bookshelf) {
 
             return {
                 data: data,
-                meta: skipPagination ? {} : {pagination: response.pagination}
+                meta: buildPaginationMeta(skipPagination, response.pagination)
             };
         },
 

--- a/ghost/core/core/server/models/base/plugins/crud.js
+++ b/ghost/core/core/server/models/base/plugins/crud.js
@@ -18,6 +18,16 @@ const requiredForExcerpt = (requestedColumns) => {
     }
 };
 
+const parsePositiveInteger = (value, defaultValue) => {
+    const parsedValue = parseInt(value, 10);
+
+    if (Number.isNaN(parsedValue)) {
+        return defaultValue;
+    }
+
+    return Math.max(parsedValue, 1);
+};
+
 /**
  * @param {Bookshelf} Bookshelf
  */
@@ -81,6 +91,9 @@ module.exports = function (Bookshelf) {
          */
         findPage: async function findPage(unfilteredOptions) {
             const options = this.filterOptions(unfilteredOptions, 'findPage');
+            const skipPagination = options.skipPagination === true;
+            delete options.skipPagination;
+
             const itemCollection = this.getFilteredCollection(options);
             const requestedColumns = options.columns;
             // make sure we include plaintext and custom_excerpt if excerpt is requested
@@ -149,6 +162,20 @@ module.exports = function (Bookshelf) {
                 options.useSmartCount = true;
             }
 
+            if (skipPagination && options.limit !== 'all') {
+                // fetchPage skips its count query only for limit='all'. Preserve the requested page window
+                // manually before using that path, so callers can avoid pagination metadata without fetching
+                // every matching row.
+                const limit = parsePositiveInteger(options.limit, 15);
+                const page = parsePositiveInteger(options.page, 1);
+
+                itemCollection
+                    .query('limit', limit)
+                    .query('offset', limit * (page - 1));
+
+                options.limit = 'all';
+            }
+
             const response = await itemCollection.fetchPage(options);
             // Attributes are being filtered here, so they are not leaked into calling layer
             // where models are serialized to json and do not do more filtering.
@@ -164,7 +191,7 @@ module.exports = function (Bookshelf) {
 
             return {
                 data: data,
-                meta: {pagination: response.pagination}
+                meta: skipPagination ? {} : {pagination: response.pagination}
             };
         },
 

--- a/ghost/core/core/server/models/base/plugins/sanitize.js
+++ b/ghost/core/core/server/models/base/plugins/sanitize.js
@@ -47,7 +47,7 @@ module.exports = function (Bookshelf) {
             case 'findAll':
                 return [...baseOptions, ...extraOptions, 'filter', 'columns', 'mongoTransformer'];
             case 'findPage':
-                return [...baseOptions, ...extraOptions, 'filter', 'order', 'autoOrder', 'page', 'limit', 'columns', 'mongoTransformer'];
+                return [...baseOptions, ...extraOptions, 'filter', 'order', 'autoOrder', 'page', 'limit', 'columns', 'mongoTransformer', 'skipPagination'];
             default:
                 return [...baseOptions, ...extraOptions];
             }

--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -5,6 +5,7 @@ const config = require('../../../core/shared/config');
 const moment = require('moment');
 const testUtils = require('../../utils');
 const models = require('../../../core/server/models');
+const api = require('../../../core/server/api/endpoints');
 const urlUtilsHelper = require('../../utils/url-utils');
 
 const {agentProvider, fixtureManager, matchers, mockManager} = require('../../utils/e2e-framework');
@@ -437,6 +438,24 @@ describe('Posts Content API', function () {
             const sqlWithoutCount = query.sql.replace(/count\(\*\)/g, '');
             assert(!sqlWithoutCount.includes('*'), 'Query should not select *');
         }
+    });
+
+    it('Can skip pagination counts when skipPagination is true', async function () {
+        const queries = await trackDb(() => {
+            return api.postsPublic.browse({
+                filter: 'published_at:>\'2015-07-20\'',
+                skipPagination: true,
+                limit: 1,
+                order: 'published_at asc',
+                context: {}
+            });
+        }, this.skip.bind(this));
+
+        const postsCountQueries = queries.filter((query) => {
+            return query.sql.includes('count(') && query.sql.includes('`posts`');
+        });
+
+        assert.equal(postsCountQueries.length, 0);
     });
 
     it('Strips out gated blocks not viewable by anonymous viewers ', async function () {

--- a/ghost/core/test/unit/frontend/helpers/next-post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/next-post.test.js
@@ -67,7 +67,13 @@ describe('{{next_post}} helper', function () {
 
             sinon.assert.notCalled(inverse);
 
-            sinon.assert.calledOnceWithExactly(browsePostsStub, sinon.match({include: 'author,authors,tags,tiers'}));
+            sinon.assert.calledOnceWithExactly(
+                browsePostsStub,
+                sinon.match({
+                    include: 'author,authors,tags,tiers',
+                    skipPagination: true
+                })
+            );
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/prev-post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/prev-post.test.js
@@ -68,7 +68,10 @@ describe('{{prev_post}} helper', function () {
 
             sinon.assert.calledOnceWithExactly(
                 browsePostsStub,
-                sinon.match({include: 'author,authors,tags,tiers'})
+                sinon.match({
+                    include: 'author,authors,tags,tiers',
+                    skipPagination: true
+                })
             );
         });
     });

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -131,6 +131,61 @@ describe('Unit: models/post', function () {
             });
         });
 
+        it('can fetch a limited page without a pagination count', function () {
+            const queries = [];
+            tracker.install();
+
+            tracker.on('query', (query) => {
+                queries.push(query);
+                query.response([]);
+            });
+
+            return models.Post.findPage({
+                filter: 'published_at:>\'2015-07-20\'',
+                limit: 1,
+                skipPagination: true,
+                withRelated: ['tags']
+            }).then((result) => {
+                assert.equal(queries.length, 1);
+                assert.equal(queries[0].sql, 'select `posts`.* from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
+                assert.deepEqual(queries[0].bindings, [
+                    '2015-07-20',
+                    'post',
+                    'published',
+                    1
+                ]);
+                assert.deepEqual(result.meta, {});
+            });
+        });
+
+        it('clamps pagination inputs when fetching a limited page without a pagination count', function () {
+            const queries = [];
+            tracker.install();
+
+            tracker.on('query', (query) => {
+                queries.push(query);
+                query.response([]);
+            });
+
+            return models.Post.findPage({
+                filter: 'published_at:>\'2015-07-20\'',
+                limit: -5,
+                page: -2,
+                skipPagination: true,
+                withRelated: ['tags']
+            }).then((result) => {
+                assert.equal(queries.length, 1);
+                assert.equal(queries[0].sql, 'select `posts`.* from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
+                assert.deepEqual(queries[0].bindings, [
+                    '2015-07-20',
+                    'post',
+                    'published',
+                    1
+                ]);
+                assert.deepEqual(result.meta, {});
+            });
+        });
+
         describe('primary_tag/primary_author', function () {
             it('generates correct query for - filter: primary_tag:photo, with related: tags', function () {
                 const queries = [];


### PR DESCRIPTION
## Summary

This changes the previous and next post helpers so their adjacent-post lookups do not calculate pagination totals. Those helpers only render a single neighboring post, so the extra count query was unnecessary and expensive on sites with large post tables and high traffic.

The no-pagination path is opt-in from the helper context, and the public posts cache key includes that mode so cached helper responses stay separate from normal paginated browse responses.

## Testing

- `pnpm --dir ghost/core test:single test/unit/frontend/helpers/prev-post.test.js`
- `pnpm --dir ghost/core test:single test/unit/frontend/helpers/next-post.test.js`
- `pnpm --dir ghost/core test:single test/unit/server/models/post.test.js`
- `pnpm --dir ghost/core test:single test/e2e-frontend/helpers/next-post.test.js`
- `pnpm --dir ghost/core lint`