### PR TITLE
Added ability for gift members to continue as paid without losing remaining days

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.14",
+  "version": "2.68.15",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -316,6 +316,20 @@ async function checkoutPlan({data, state, api}) {
     }
 }
 
+async function continueGiftSubscription({state, api}) {
+    try {
+        await api.member.continueGiftCheckout();
+    } catch (e) {
+        return {
+            action: 'continueGiftSubscription:failed',
+            popupNotification: createPopupNotification({
+                type: 'continueGiftSubscription:failed', autoHide: false, closeable: true, state, status: 'error',
+                message: t('Failed to process checkout, please try again')
+            })
+        };
+    }
+}
+
 async function checkoutGift({data, state, api}) {
     try {
         const {tierId, cadence} = data;
@@ -790,6 +804,7 @@ const Actions = {
     editBilling,
     manageBilling,
     checkoutPlan,
+    continueGiftSubscription,
     checkoutGift,
     updateNewsletterPreference,
     showPopupNotification,

--- a/apps/portal/src/components/pages/AccountHomePage/components/account-main.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/account-main.js
@@ -3,6 +3,7 @@ import CloseButton from '../../../common/close-button';
 import UserHeader from './user-header';
 import AccountWelcome from './account-welcome';
 import ContinueSubscriptionButton from './continue-subscription-button';
+import ContinueGiftSubscriptionBanner from './continue-gift-subscription-banner';
 import AccountActions from './account-actions';
 
 const AccountMain = () => {
@@ -12,6 +13,7 @@ const AccountMain = () => {
             <UserHeader />
             <section className='gh-portal-account-data'>
                 <AccountWelcome />
+                <ContinueGiftSubscriptionBanner />
                 <ContinueSubscriptionButton />
                 <AccountActions />
             </section>

--- a/apps/portal/src/components/pages/AccountHomePage/components/account-welcome.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/account-welcome.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getSubscriptionExpiry, getMemberSubscription, hasOnlyFreePlan, isComplimentaryMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getSubscriptionExpiry, getMemberSubscription, hasOnlyFreePlan, isComplimentaryMember, isGiftMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {useContext} from 'react';
 
@@ -15,14 +15,16 @@ const AccountWelcome = () => {
     }
     const subscription = getMemberSubscription({member});
     const isComplimentary = isComplimentaryMember({member});
-    const isGiftMember = member?.status === 'gift';
     if (isComplimentary && !subscription) {
         return null;
     }
     if (subscription) {
         const currentPeriodEnd = subscription?.current_period_end;
         const subscriptionExpiry = getSubscriptionExpiry({member});
-        if ((isComplimentary || isGiftMember) && subscriptionExpiry) {
+        if (isGiftMember({member})) {
+            return null;
+        }
+        if (isComplimentary && subscriptionExpiry) {
             return (
                 <div className='gh-portal-section'>
                     <p className='gh-portal-text-center gh-portal-free-ctatext'>{t(`Your subscription will expire on {expiryDate}`, {expiryDate: subscriptionExpiry})}</p>

--- a/apps/portal/src/components/pages/AccountHomePage/components/continue-gift-subscription-banner.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/continue-gift-subscription-banner.js
@@ -15,7 +15,7 @@ const ContinueGiftSubscriptionBanner = () => {
         return null;
     }
 
-    const isRunning = ['continueGiftSubscription:running'].includes(action);
+    const isRunning = action === 'continueGiftSubscription:running';
 
     // TODO: Add translation strings once copy has been finalised
     /* eslint-disable i18next/no-literal-string */

--- a/apps/portal/src/components/pages/AccountHomePage/components/continue-gift-subscription-banner.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/continue-gift-subscription-banner.js
@@ -1,0 +1,44 @@
+import AppContext from '../../../../app-context';
+import ActionButton from '../../../common/action-button';
+import {getSubscriptionExpiry, isGiftMember} from '../../../../utils/helpers';
+import {useContext} from 'react';
+
+const ContinueGiftSubscriptionBanner = () => {
+    const {member, doAction, action, brandColor} = useContext(AppContext);
+
+    if (!isGiftMember({member})) {
+        return null;
+    }
+
+    const expiryDate = getSubscriptionExpiry({member});
+    if (!expiryDate) {
+        return null;
+    }
+
+    const isRunning = ['continueGiftSubscription:running'].includes(action);
+
+    // TODO: Add translation strings once copy has been finalised
+    /* eslint-disable i18next/no-literal-string */
+    return (
+        <div className='gh-portal-cancelcontinue-container'>
+            <div className='gh-portal-cancel-banner'>
+                <p style={{maxWidth: 'none', margin: '0 0 16px', textAlign: 'center'}}>
+                    Your gift subscription ends on <strong>{expiryDate}</strong>. Continue with a paid subscription to keep reading. Any remaining days will be added as free trial time.
+                </p>
+                <ActionButton
+                    onClick={() => doAction('continueGiftSubscription')}
+                    isRunning={isRunning}
+                    disabled={isRunning}
+                    isPrimary={true}
+                    brandColor={brandColor}
+                    label='Continue subscription'
+                    style={{
+                        width: '100%'
+                    }}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default ContinueGiftSubscriptionBanner;

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isGiftMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as GiftIcon} from '../../../../images/icons/gift.svg';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
@@ -35,9 +35,8 @@ const PaidAccountActions = () => {
         }
 
         const subscriptionExpiry = getSubscriptionExpiry({member});
-        const isGiftMember = member?.status === 'gift';
 
-        if (isGiftMember && subscriptionExpiry) {
+        if (isGiftMember({member}) && subscriptionExpiry) {
             return (
                 <p className="gh-portal-account-discountcontainer">
                     <GiftIcon className="gh-portal-account-tagicon" />
@@ -100,6 +99,16 @@ const PaidAccountActions = () => {
     const PlanUpdateButton = ({isPaid}) => {
         if (hasOnlyFreePlan({site}) && !isPaid) {
             return null;
+        }
+        if (isGiftMember({member})) {
+            return (
+                <button
+                    className='gh-portal-btn gh-portal-btn-list' onClick={() => doAction('continueGiftSubscription')}
+                    data-test-button='continue-gift-subscription'
+                >
+                    {t('Continue')}
+                </button>
+            );
         }
         return (
             <button

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
+import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, getSubscriptionExpiry, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 import {translateCadence} from '../../utils/helpers';
@@ -91,6 +91,41 @@ const Header = ({showConfirmation, confirmationType, pendingOffer}) => {
         <header className='gh-portal-detail-header'>
             <h3 className='gh-portal-main-title'>{title}</h3>
         </header>
+    );
+};
+
+const GiftTrialBanner = () => {
+    const {member} = useContext(AppContext);
+    const isGift = member?.status === 'gift';
+    const subscriptionExpiry = getSubscriptionExpiry({member});
+
+    if (!isGift || !subscriptionExpiry) {
+        return null;
+    }
+
+    return (
+        <div style={{
+            display: 'flex',
+            justifyContent: 'center',
+            margin: '8px 0 32px'
+        }}>
+            <div style={{
+                background: '#FEF3C7',
+                borderRadius: '5px',
+                padding: '16px 24px',
+                maxWidth: '420px',
+                fontSize: '1.35rem',
+                lineHeight: '1.5em',
+                color: '#1d1d1d',
+                textAlign: 'center'
+            }}>
+                {/* TODO: Add translation strings once copy has been finalised */}
+                {/* eslint-disable i18next/no-literal-string */}
+                <p>
+                    Your gift subscription is valid until <strong>{subscriptionExpiry}</strong>. If you continue with a paid subscription, the remaining days will be added as a free trial.
+                </p>
+            </div>
+        </div>
     );
 };
 
@@ -750,6 +785,7 @@ export default class AccountPlanPage extends React.Component {
                         pendingOffer={pendingOffer}
                         showConfirmation={showConfirmation}
                     />
+                    {!showConfirmation && <GiftTrialBanner />}
                     <PlansContainer
                         {...{plans, selectedPlan, showConfirmation, confirmationPlan, confirmationType, pendingOffer}}
                         onConfirm={(...args) => this.onConfirm(...args)}

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, getSubscriptionExpiry, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
+import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 import {translateCadence} from '../../utils/helpers';
@@ -91,41 +91,6 @@ const Header = ({showConfirmation, confirmationType, pendingOffer}) => {
         <header className='gh-portal-detail-header'>
             <h3 className='gh-portal-main-title'>{title}</h3>
         </header>
-    );
-};
-
-const GiftTrialBanner = () => {
-    const {member} = useContext(AppContext);
-    const isGift = member?.status === 'gift';
-    const subscriptionExpiry = getSubscriptionExpiry({member});
-
-    if (!isGift || !subscriptionExpiry) {
-        return null;
-    }
-
-    return (
-        <div style={{
-            display: 'flex',
-            justifyContent: 'center',
-            margin: '8px 0 32px'
-        }}>
-            <div style={{
-                background: '#FEF3C7',
-                borderRadius: '5px',
-                padding: '16px 24px',
-                maxWidth: '420px',
-                fontSize: '1.35rem',
-                lineHeight: '1.5em',
-                color: '#1d1d1d',
-                textAlign: 'center'
-            }}>
-                {/* TODO: Add translation strings once copy has been finalised */}
-                {/* eslint-disable i18next/no-literal-string */}
-                <p>
-                    Your gift subscription is valid until <strong>{subscriptionExpiry}</strong>. If you continue with a paid subscription, the remaining days will be added as a free trial.
-                </p>
-            </div>
-        </div>
     );
 };
 
@@ -785,7 +750,6 @@ export default class AccountPlanPage extends React.Component {
                         pendingOffer={pendingOffer}
                         showConfirmation={showConfirmation}
                     />
-                    {!showConfirmation && <GiftTrialBanner />}
                     <PlansContainer
                         {...{plans, selectedPlan, showConfirmation, confirmationPlan, confirmationType, pendingOffer}}
                         onConfirm={(...args) => this.onConfirm(...args)}

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -554,6 +554,56 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             });
         },
 
+        async continueGiftCheckout() {
+            const siteUrlObj = new URL(siteUrl);
+            const identity = await api.member.identity();
+            const url = endpointFor({type: 'members', resource: 'create-stripe-checkout-session'});
+
+            const checkoutCancelUrl = window.location.href.startsWith(siteUrlObj.href) ? new URL(window.location.href) : new URL(siteUrl);
+            checkoutCancelUrl.searchParams.set('stripe', 'cancel');
+
+            const body = {
+                type: 'subscription',
+                continueFromGift: true,
+                identity,
+                successUrl: siteUrl,
+                cancelUrl: checkoutCancelUrl.href,
+                metadata: {
+                    checkoutType: 'upgrade',
+                    requestSrc: 'portal',
+                    urlHistory: getUrlHistory()
+                }
+            };
+
+            return makeRequest({
+                url,
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(body)
+            }).then(async function (res) {
+                if (!res.ok) {
+                    const errData = await res.json();
+                    const errMssg = errData?.errors?.[0]?.message || 'Failed to continue gift subscription, please try again.';
+                    throw new Error(errMssg);
+                }
+                return res.json();
+            }).then(function (responseBody) {
+                if (responseBody.url) {
+                    return window.location.assign(responseBody.url);
+                }
+                const stripe = window.Stripe(responseBody.publicKey);
+                return stripe.redirectToCheckout({
+                    sessionId: responseBody.sessionId
+                }).then(function (redirectResult) {
+                    if (redirectResult.error) {
+                        throw new Error(redirectResult.error.message);
+                    }
+                });
+            });
+        },
+
         async checkoutGift({tierId, cadence} = {}) {
             const url = endpointFor({type: 'members', resource: 'create-stripe-checkout-session'});
 

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -71,6 +71,10 @@ export function isPaidMember({member = {}}) {
     return (member && member.paid);
 }
 
+export function isGiftMember({member = {}}) {
+    return member?.status === 'gift';
+}
+
 export function getProductCurrency({product}) {
     if (!product?.monthlyPrice) {
         return null;

--- a/apps/portal/test/unit/components/pages/AccountHomePage/account-welcome.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/account-welcome.test.js
@@ -14,40 +14,6 @@ const setup = (overrides) => {
 };
 
 describe('AccountWelcome', () => {
-    test('shows expiry date for gift memberships with an expiry', () => {
-        const products = getProductsData({numOfProducts: 1});
-        const site = getSiteData({products, portalProducts: products.map(p => p.id)});
-
-        const member = getMemberData({
-            paid: true,
-            status: 'gift',
-            subscriptions: [
-                getSubscriptionData({
-                    status: 'active',
-                    amount: 0,
-                    currency: 'USD',
-                    interval: 'month',
-                    currentPeriodEnd: '2099-01-15T12:00:00.000Z',
-                    tier: {
-                        expiry_at: '2099-01-15T12:00:00.000Z'
-                    },
-                    nextPayment: getNextPaymentData({
-                        originalAmount: 0,
-                        amount: 0,
-                        interval: 'month',
-                        currency: 'USD',
-                        discount: null
-                    })
-                })
-            ]
-        });
-
-        const {queryByText} = setup({site, member});
-
-        expect(queryByText('Your subscription will expire on 15 Jan 2099')).toBeInTheDocument();
-        expect(queryByText('Your subscription will renew on 15 Jan 2099')).not.toBeInTheDocument();
-    });
-
     test('uses current period end for renewal date on free months offers', () => {
         const products = getProductsData({numOfProducts: 1});
         const site = getSiteData({products, portalProducts: products.map(p => p.id)});

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -18,6 +18,7 @@ import {
     isActiveOffer,
     isRetentionOffer,
     isInviteOnly,
+    isGiftMember,
     isPaidMember,
     isPaidMembersOnly,
     isSameCurrency,
@@ -77,6 +78,38 @@ describe('Helpers - ', () => {
 
         test('returns false for free member', () => {
             const value = isPaidMember({member: FixtureMember.free});
+            expect(value).toBe(false);
+        });
+    });
+
+    describe('isGiftMember -', () => {
+        test('returns true when member status is "gift"', () => {
+            const value = isGiftMember({member: {status: 'gift'}});
+            expect(value).toBe(true);
+        });
+
+        test('returns false for free member', () => {
+            const value = isGiftMember({member: FixtureMember.free});
+            expect(value).toBe(false);
+        });
+
+        test('returns false for paid member', () => {
+            const value = isGiftMember({member: FixtureMember.paid});
+            expect(value).toBe(false);
+        });
+
+        test('returns false for complimentary member', () => {
+            const value = isGiftMember({member: FixtureMember.complimentary});
+            expect(value).toBe(false);
+        });
+
+        test('returns false when member is null', () => {
+            const value = isGiftMember({member: null});
+            expect(value).toBe(false);
+        });
+
+        test('returns false when member arg is omitted', () => {
+            const value = isGiftMember({});
             expect(value).toBe(false);
         });
     });

--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -76,14 +76,11 @@ export class GiftBookshelfRepository implements GiftRepository {
         return model ? this.toGift(model) : null;
     }
 
-    async getRedeemedByMember(memberId: string): Promise<Gift | null> {
-        const collection = await this.model.findAll({
-            filter: `redeemer_member_id:'${memberId}'+status:redeemed`,
-            order: 'redeemed_at DESC',
-            limit: 1
-        });
-
-        const model = collection.models[0];
+    async getActiveGift(memberId: string): Promise<Gift | null> {
+        const model = await this.model.findOne({
+            redeemer_member_id: memberId,
+            status: 'redeemed'
+        }, {require: false});
 
         return model ? this.toGift(model) : null;
     }

--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -76,7 +76,7 @@ export class GiftBookshelfRepository implements GiftRepository {
         return model ? this.toGift(model) : null;
     }
 
-    async getActiveGift(memberId: string): Promise<Gift | null> {
+    async getActiveByMember(memberId: string): Promise<Gift | null> {
         const model = await this.model.findOne({
             redeemer_member_id: memberId,
             status: 'redeemed'

--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -76,6 +76,18 @@ export class GiftBookshelfRepository implements GiftRepository {
         return model ? this.toGift(model) : null;
     }
 
+    async getRedeemedByMember(memberId: string): Promise<Gift | null> {
+        const collection = await this.model.findAll({
+            filter: `redeemer_member_id:'${memberId}'+status:redeemed`,
+            order: 'redeemed_at DESC',
+            limit: 1
+        });
+
+        const model = collection.models[0];
+
+        return model ? this.toGift(model) : null;
+    }
+
     async findPendingConsumption(): Promise<Gift[]> {
         const now = new Date();
 

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -19,6 +19,7 @@ export interface GiftRepository {
     findPendingConsumption(): Promise<Gift[]>;
     findPendingExpiration(): Promise<Gift[]>;
     findPendingReminder(options: FindPendingReminderOptions): Promise<Gift[]>;
+    getRedeemedByMember(memberId: string): Promise<Gift | null>;
     create(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     update(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -19,7 +19,7 @@ export interface GiftRepository {
     findPendingConsumption(): Promise<Gift[]>;
     findPendingExpiration(): Promise<Gift[]>;
     findPendingReminder(options: FindPendingReminderOptions): Promise<Gift[]>;
-    getRedeemedByMember(memberId: string): Promise<Gift | null>;
+    getActiveGift(memberId: string): Promise<Gift | null>;
     create(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     update(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -19,7 +19,7 @@ export interface GiftRepository {
     findPendingConsumption(): Promise<Gift[]>;
     findPendingExpiration(): Promise<Gift[]>;
     findPendingReminder(options: FindPendingReminderOptions): Promise<Gift[]>;
-    getActiveGift(memberId: string): Promise<Gift | null>;
+    getActiveByMember(memberId: string): Promise<Gift | null>;
     create(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     update(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -335,11 +335,21 @@ export class GiftService {
         return redeemed;
     }
 
-    async getActiveGift(memberId: string): Promise<Gift | null> {
+    async getActiveByMember(memberId: string): Promise<Gift | null> {
         if (!memberId) {
             return null;
         }
-        return this.deps.giftRepository.getActiveGift(memberId);
+        return this.deps.giftRepository.getActiveByMember(memberId);
+    }
+
+    getRemainingActiveDays(gift: Gift, now: Date = new Date()): number {
+        if (!gift.isRedeemed() || !gift.consumesAt || gift.isConsumed()) {
+            return 0;
+        }
+
+        const diffDays = Math.ceil((gift.consumesAt.getTime() - now.getTime()) / MS_PER_DAY);
+
+        return Math.max(0, diffDays);
     }
 
     async refund(paymentIntentId: string): Promise<boolean> {

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -335,14 +335,11 @@ export class GiftService {
         return redeemed;
     }
 
-    async getRedeemedByMember(memberId: string): Promise<Gift | null> {
-        const gift = await this.deps.giftRepository.getRedeemedByMember(memberId);
-
-        if (!gift) {
+    async getActiveGift(memberId: string): Promise<Gift | null> {
+        if (!memberId) {
             return null;
         }
-
-        return gift;
+        return this.deps.giftRepository.getActiveGift(memberId);
     }
 
     async refund(paymentIntentId: string): Promise<boolean> {

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -335,6 +335,16 @@ export class GiftService {
         return redeemed;
     }
 
+    async getRedeemedByMember(memberId: string): Promise<Gift | null> {
+        const gift = await this.deps.giftRepository.getRedeemedByMember(memberId);
+
+        if (!gift) {
+            return null;
+        }
+
+        return gift;
+    }
+
     async refund(paymentIntentId: string): Promise<boolean> {
         const gift = await this.deps.giftRepository.getByPaymentIntentId(paymentIntentId);
 

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -107,7 +107,8 @@ module.exports = class RouterController {
         settingsCache,
         settingsHelpers,
         urlUtils,
-        emailAddressService
+        emailAddressService,
+        giftService
     }) {
         this._offersAPI = offersAPI;
         this._paymentsService = paymentsService;
@@ -127,6 +128,7 @@ module.exports = class RouterController {
         this._settingsHelpers = settingsHelpers;
         this._urlUtils = urlUtils;
         this._emailAddressService = emailAddressService;
+        this._giftService = giftService;
     }
 
     async ensureStripe(_req, res, next) {
@@ -455,6 +457,7 @@ module.exports = class RouterController {
      * @param {string} options.cancelUrl URL to redirect to after cancelled checkout
      * @param {string} [options.email] Email address of the customer
      * @param {object} [options.member] Currently authenticated member OR member associated with the email address
+     * @param {object} [options.gift] Active gift subscription for the member
      * @param {boolean} options.isAuthenticated
      * @param {object} options.metadata Metadata to be passed to Stripe
      * @returns
@@ -708,18 +711,52 @@ module.exports = class RouterController {
                 });
             }
 
-            // Get selected tier, offer and cadence
-            const data = await this._getSubscriptionCheckoutData(req.body);
+            let tier;
+            let cadence;
+            let offer;
+            let gift;
+
+            if (req.body.continueFromGift) {
+                if (!isAuthenticated || !member) {
+                    throw new UnauthorizedError({
+                        message: tpl(messages.badRequest)
+                    });
+                }
+                if (member.get('status') !== 'gift') {
+                    throw new BadRequestError({
+                        message: tpl(messages.badRequest),
+                        context: 'Member does not have an active gift subscription'
+                    });
+                }
+
+                gift = await this._giftService.service.getActiveGift(member.id);
+                if (!gift) {
+                    throw new BadRequestError({
+                        message: tpl(messages.badRequest),
+                        context: 'No active gift subscription found for member'
+                    });
+                }
+
+                ({tier, cadence} = await this._getSubscriptionCheckoutData({
+                    tierId: gift.tierId,
+                    cadence: gift.cadence
+                }));
+            } else {
+                ({tier, cadence, offer} = await this._getSubscriptionCheckoutData(req.body));
+            }
 
             // Check the checkout session
             response = await this._createSubscriptionCheckoutSession({
                 ...options,
-                ...data
+                tier,
+                cadence,
+                offer,
+                gift
             });
 
             // Add welcome_page_url to the response if available and member is authenticated
-            if (isAuthenticated && data.tier && data.tier.welcomePageURL) {
-                response.welcomePageUrl = data.tier.welcomePageURL;
+            if (isAuthenticated && tier && tier.welcomePageURL) {
+                response.welcomePageUrl = tier.welcomePageURL;
             }
         } else if (type === 'donation') {
             options.personalNote = parsePersonalNote(req.body.personalNote);

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -34,7 +34,8 @@ const messages = {
     archivedNewsletters: 'Cannot subscribe to archived newsletters {newsletters}',
     otcNotSupported: 'OTC verification not supported.',
     invalidCode: 'Invalid verification code.',
-    failedToVerifyCode: 'Failed to verify code, please try again.'
+    failedToVerifyCode: 'Failed to verify code, please try again.',
+    signInRequired: 'You must be signed in to continue.'
 };
 
 // helper utility for logic shared between sendMagicLink and verifyOTC
@@ -719,7 +720,7 @@ module.exports = class RouterController {
             if (req.body.continueFromGift) {
                 if (!isAuthenticated || !member) {
                     throw new UnauthorizedError({
-                        message: tpl(messages.badRequest)
+                        message: tpl(messages.signInRequired)
                     });
                 }
                 if (member.get('status') !== 'gift') {
@@ -729,7 +730,7 @@ module.exports = class RouterController {
                     });
                 }
 
-                gift = await this._giftService.service.getActiveGift(member.id);
+                gift = await this._giftService.service.getActiveByMember(member.id);
                 if (!gift) {
                     throw new BadRequestError({
                         message: tpl(messages.badRequest),

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -220,7 +220,8 @@ module.exports = function MembersAPI({
         settingsHelpers,
         sentry,
         urlUtils,
-        emailAddressService
+        emailAddressService,
+        giftService
     });
 
     const wellKnownController = new WellKnownController({

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -94,12 +94,10 @@ class PaymentsService {
         }
 
         // If continuing from a gift subscription, add gift remaining days as trial
-        if (trialDays === null && gift && gift.consumesAt) {
-            const now = new Date();
-            const diffMs = gift.consumesAt.getTime() - now.getTime();
-            const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
-            if (diffDays > 0) {
-                trialDays = Math.min(diffDays, 730); // Stripe max trial period
+        if (trialDays === null && gift) {
+            const remainingDays = this.giftService.service.getRemainingActiveDays(gift);
+            if (remainingDays > 0) {
+                trialDays = Math.min(remainingDays, 730); // Stripe max trial period
             }
         }
 

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -64,6 +64,7 @@ class PaymentsService {
      * @param {Tier.Cadence} params.cadence
      * @param {Offer} [params.offer]
      * @param {Member} [params.member]
+     * @param {import('../../../gifts/gift').Gift} [params.gift]
      * @param {Object.<string, any>} [params.metadata]
      * @param {string} params.successUrl
      * @param {string} params.cancelUrl
@@ -71,7 +72,7 @@ class PaymentsService {
      *
      * @returns {Promise<URL>}
      */
-    async getPaymentLink({tier, cadence, offer, member, metadata, successUrl, cancelUrl, email}) {
+    async getPaymentLink({tier, cadence, offer, member, gift, metadata, successUrl, cancelUrl, email}) {
         let coupon = null;
         let trialDays = null;
         if (offer) {
@@ -92,17 +93,13 @@ class PaymentsService {
             }
         }
 
-        // If active gift subscription, add remaining days as trial
-        if (trialDays === null && member) {
-            const gift = await this.giftService.service.getRedeemedByMember(member.id);
-
-            if (gift && gift.consumesAt) {
-                const now = new Date();
-                const diffMs = gift.consumesAt.getTime() - now.getTime();
-                const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
-                if (diffDays > 0) {
-                    trialDays = Math.min(diffDays, 730); // Stripe max trial period
-                }
+        // If continuing from a gift subscription, add gift remaining days as trial
+        if (trialDays === null && gift && gift.consumesAt) {
+            const now = new Date();
+            const diffMs = gift.consumesAt.getTime() - now.getTime();
+            const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+            if (diffDays > 0) {
+                trialDays = Math.min(diffDays, 730); // Stripe max trial period
             }
         }
 

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -92,6 +92,20 @@ class PaymentsService {
             }
         }
 
+        // If active gift subscription, add remaining days as trial
+        if (trialDays === null && member) {
+            const gift = await this.giftService.service.getRedeemedByMember(member.id);
+
+            if (gift && gift.consumesAt) {
+                const now = new Date();
+                const diffMs = gift.consumesAt.getTime() - now.getTime();
+                const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+                if (diffDays > 0) {
+                    trialDays = Math.min(diffDays, 730); // Stripe max trial period
+                }
+            }
+        }
+
         let customer = null;
         if (member) {
             customer = await this.getCustomerForMember(member);

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -4,6 +4,7 @@ const {agentProvider, mockManager, fixtureManager, configUtils, matchers} = requ
 const {stripeMocker} = require('../../utils/e2e-framework-mock-manager');
 const models = require('../../../core/server/models');
 const membersService = require('../../../core/server/services/members');
+const tiersService = require('../../../core/server/services/tiers');
 const urlUtils = require('../../../core/shared/url-utils');
 const {anyErrorId} = matchers;
 
@@ -993,30 +994,33 @@ describe('Gift Subscriptions', function () {
     });
 
     describe('Continue a gift subscription as paid subscription', function () {
-        it('Passes remaining gift days as trial_period_days when gift member upgrades', async function () {
-            const paidTier = await getPaidTier();
-            const email = 'gift-upgrade-trial@example.com';
+        let continueSequence = 0;
 
-            // Create a member and redeem a gift for them
-            const member = await membersService.api.members.create({email, name: 'Gift Upgrader'});
+        async function setupGiftMember({cadence = 'year', consumesInDays = 30, tierId, giftTierId} = {}) {
+            continueSequence += 1;
+            const paidTier = await getPaidTier();
+            const effectiveTierId = tierId ?? paidTier.id;
+            const effectiveGiftTierId = giftTierId ?? effectiveTierId;
+            const email = `gift-continue-${continueSequence}@example.com`;
+
+            const member = await membersService.api.members.create({email, name: `Gift Continuer ${continueSequence}`});
             const identityToken = await membersService.api.getMemberIdentityToken(member.get('transient_id'));
 
-            // Create a redeemed gift that expires 30 days from now
             const now = new Date();
             const consumesAt = new Date(now);
-            consumesAt.setDate(consumesAt.getDate() + 30);
+            consumesAt.setDate(consumesAt.getDate() + consumesInDays);
 
             const gift = await models.Gift.add({
-                token: 'gift-upgrade-trial-token',
-                buyer_email: 'gift-buyer-upgrade@example.com',
+                token: `gift-continue-token-${continueSequence}`,
+                buyer_email: `gift-continue-buyer-${continueSequence}@example.com`,
                 redeemer_member_id: member.id,
-                tier_id: paidTier.id,
-                cadence: 'year',
+                tier_id: effectiveGiftTierId,
+                cadence,
                 duration: 1,
                 currency: 'usd',
                 amount: 5000,
-                stripe_checkout_session_id: 'cs_gift_upgrade_trial',
-                stripe_payment_intent_id: 'pi_gift_upgrade_trial',
+                stripe_checkout_session_id: `cs_gift_continue_${continueSequence}`,
+                stripe_payment_intent_id: `pi_gift_continue_${continueSequence}`,
                 consumes_at: consumesAt,
                 expires_at: new Date('2030-01-01T00:00:00.000Z'),
                 status: 'redeemed',
@@ -1024,23 +1028,26 @@ describe('Gift Subscriptions', function () {
                 redeemed_at: now
             });
 
-            // Set the member as a gift member with the product
             await models.Member.edit({
                 status: 'gift',
                 products: [{
-                    id: paidTier.id,
+                    id: effectiveTierId,
                     expiry_at: consumesAt
                 }]
             }, {id: member.id});
 
             await DomainEvents.allSettled();
 
-            // Create a subscription checkout session as the gift member
+            return {member, identityToken, gift, paidTier, consumesAt};
+        }
+
+        it('applies remaining gift days as trial and continues on the same tier/cadence as gift', async function () {
+            const {identityToken, gift, paidTier} = await setupGiftMember({cadence: 'month', consumesInDays: 30});
+
             await membersAgent.post('/api/create-stripe-checkout-session/')
                 .body({
                     type: 'subscription',
-                    tierId: paidTier.id,
-                    cadence: 'year',
+                    continueFromGift: true,
                     identity: identityToken,
                     metadata: {
                         checkoutType: 'upgrade'
@@ -1052,14 +1059,99 @@ describe('Gift Subscriptions', function () {
 
             assert.ok(checkoutSession, 'Checkout session should be created');
 
-            // Verify that trial_period_days is set to approximately 30 days
             const trialDays = checkoutSession.subscription_data?.trial_period_days;
             assert.ok(trialDays, 'Should have trial_period_days set');
             assert.ok(trialDays >= 29 && trialDays <= 31, `Trial days should be approximately 30, got ${trialDays}`);
 
-            // Verify the gift is still in redeemed state (not yet consumed)
+            const priceId = checkoutSession.subscription_data?.items?.[0]?.plan;
+            assert.ok(priceId, 'Checkout session should carry a Stripe price');
+
+            const price = stripeMocker.prices.find(p => p.id === priceId);
+            assert.ok(price, 'Stripe price should exist in mocker');
+            assert.equal(price.recurring?.interval, 'month', 'Should use the gift\'s cadence');
+
             const giftRecord = await models.Gift.findOne({token: gift.get('token')}, {require: true});
             assert.equal(giftRecord.get('status'), 'redeemed');
+            assert.equal(giftRecord.get('tier_id'), paidTier.id);
+        });
+
+        it('Returns 401 for unauthenticated members', async function () {
+            await membersAgent.post('/api/create-stripe-checkout-session/')
+                .body({
+                    type: 'subscription',
+                    continueFromGift: true,
+                    metadata: {
+                        checkoutType: 'upgrade'
+                    }
+                })
+                .expectStatus(401);
+        });
+
+        it('Returns 400 when member is not a gift member', async function () {
+            const paidTier = await getPaidTier();
+            const email = 'gift-continue-not-gift@example.com';
+
+            const member = await membersService.api.members.create({email, name: 'Not A Gift Member'});
+            const identityToken = await membersService.api.getMemberIdentityToken(member.get('transient_id'));
+
+            // Deliberately leave the member as a free member — no status change, no gift record.
+            // Verify we still reject even if a stale gift exists on another member.
+            await models.Gift.add({
+                token: 'gift-continue-unrelated-token',
+                buyer_email: 'gift-continue-unrelated@example.com',
+                redeemer_member_id: null,
+                tier_id: paidTier.id,
+                cadence: 'year',
+                duration: 1,
+                currency: 'usd',
+                amount: 5000,
+                stripe_checkout_session_id: 'cs_gift_continue_unrelated',
+                stripe_payment_intent_id: 'pi_gift_continue_unrelated',
+                consumes_at: null,
+                expires_at: new Date('2030-01-01T00:00:00.000Z'),
+                status: 'purchased',
+                purchased_at: new Date()
+            });
+
+            await membersAgent.post('/api/create-stripe-checkout-session/')
+                .body({
+                    type: 'subscription',
+                    continueFromGift: true,
+                    identity: identityToken,
+                    metadata: {
+                        checkoutType: 'upgrade'
+                    }
+                })
+                .expectStatus(400);
+        });
+
+        it('Returns 403 when gift tier is archived', async function () {
+            const archivedTier = await tiersService.api.add({
+                name: `Archived Gift Tier ${continueSequence + 1}`,
+                type: 'paid',
+                currency: 'USD',
+                monthlyPrice: 500,
+                yearlyPrice: 5000
+            });
+
+            const {identityToken} = await setupGiftMember({
+                cadence: 'year',
+                consumesInDays: 30,
+                tierId: archivedTier.id.toHexString()
+            });
+
+            await tiersService.api.edit(archivedTier.id.toHexString(), {status: 'archived'});
+
+            await membersAgent.post('/api/create-stripe-checkout-session/')
+                .body({
+                    type: 'subscription',
+                    continueFromGift: true,
+                    identity: identityToken,
+                    metadata: {
+                        checkoutType: 'upgrade'
+                    }
+                })
+                .expectStatus(403);
         });
     });
 });

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -991,4 +991,75 @@ describe('Gift Subscriptions', function () {
             });
         });
     });
+
+    describe('Continue a gift subscription as paid subscription', function () {
+        it('Passes remaining gift days as trial_period_days when gift member upgrades', async function () {
+            const paidTier = await getPaidTier();
+            const email = 'gift-upgrade-trial@example.com';
+
+            // Create a member and redeem a gift for them
+            const member = await membersService.api.members.create({email, name: 'Gift Upgrader'});
+            const identityToken = await membersService.api.getMemberIdentityToken(member.get('transient_id'));
+
+            // Create a redeemed gift that expires 30 days from now
+            const now = new Date();
+            const consumesAt = new Date(now);
+            consumesAt.setDate(consumesAt.getDate() + 30);
+
+            const gift = await models.Gift.add({
+                token: 'gift-upgrade-trial-token',
+                buyer_email: 'gift-buyer-upgrade@example.com',
+                redeemer_member_id: member.id,
+                tier_id: paidTier.id,
+                cadence: 'year',
+                duration: 1,
+                currency: 'usd',
+                amount: 5000,
+                stripe_checkout_session_id: 'cs_gift_upgrade_trial',
+                stripe_payment_intent_id: 'pi_gift_upgrade_trial',
+                consumes_at: consumesAt,
+                expires_at: new Date('2030-01-01T00:00:00.000Z'),
+                status: 'redeemed',
+                purchased_at: now,
+                redeemed_at: now
+            });
+
+            // Set the member as a gift member with the product
+            await models.Member.edit({
+                status: 'gift',
+                products: [{
+                    id: paidTier.id,
+                    expiry_at: consumesAt
+                }]
+            }, {id: member.id});
+
+            await DomainEvents.allSettled();
+
+            // Create a subscription checkout session as the gift member
+            await membersAgent.post('/api/create-stripe-checkout-session/')
+                .body({
+                    type: 'subscription',
+                    tierId: paidTier.id,
+                    cadence: 'year',
+                    identity: identityToken,
+                    metadata: {
+                        checkoutType: 'upgrade'
+                    }
+                })
+                .expectStatus(200);
+
+            const checkoutSession = getLatestCheckoutSession();
+
+            assert.ok(checkoutSession, 'Checkout session should be created');
+
+            // Verify that trial_period_days is set to approximately 30 days
+            const trialDays = checkoutSession.subscription_data?.trial_period_days;
+            assert.ok(trialDays, 'Should have trial_period_days set');
+            assert.ok(trialDays >= 29 && trialDays <= 31, `Trial days should be approximately 30, got ${trialDays}`);
+
+            // Verify the gift is still in redeemed state (not yet consumed)
+            const giftRecord = await models.Gift.findOne({token: gift.get('token')}, {require: true});
+            assert.equal(giftRecord.get('status'), 'redeemed');
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
@@ -450,6 +450,70 @@ describe('GiftBookshelfRepository', function () {
         assert.equal(savedRow.consumes_soon_reminder_sent_at, reminderSentAt);
     });
 
+    describe('getRedeemedByMember', function () {
+        function stubGiftModel({models}: {models: unknown[]}) {
+            return {
+                add: sinon.stub(),
+                transaction: sinon.stub(),
+                findOne: sinon.stub(),
+                findAll: sinon.stub().resolves({models})
+            };
+        }
+
+        it('returns the most recently redeemed gift for a member', async function () {
+            const GiftModel = stubGiftModel({
+                models: [{
+                    toJSON() {
+                        return {
+                            token: 'gift-token',
+                            buyer_email: 'buyer@example.com',
+                            buyer_member_id: 'buyer_member_1',
+                            redeemer_member_id: 'member_2',
+                            tier_id: 'tier_1',
+                            cadence: 'year',
+                            duration: 1,
+                            currency: 'usd',
+                            amount: 5000,
+                            stripe_checkout_session_id: 'cs_123',
+                            stripe_payment_intent_id: 'pi_456',
+                            consumes_at: new Date('2027-01-01T00:00:00.000Z'),
+                            expires_at: new Date('2030-01-01T00:00:00.000Z'),
+                            status: 'redeemed',
+                            purchased_at: new Date('2026-01-01T00:00:00.000Z'),
+                            redeemed_at: new Date('2026-06-01T00:00:00.000Z'),
+                            consumed_at: null,
+                            expired_at: null,
+                            refunded_at: null
+                        };
+                    }
+                }]
+            });
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const gift = await repository.getRedeemedByMember('member_2');
+
+            assert.ok(gift instanceof Gift);
+            assert.equal(gift?.token, 'gift-token');
+            assert.equal(gift?.status, 'redeemed');
+
+            sinon.assert.calledOnce(GiftModel.findAll);
+
+            const callArgs = GiftModel.findAll.getCall(0).args[0];
+            assert.equal(callArgs.filter, 'redeemer_member_id:\'member_2\'+status:redeemed');
+            assert.equal(callArgs.order, 'redeemed_at DESC');
+            assert.equal(callArgs.limit, 1);
+        });
+
+        it('returns null when no redeemed gift exists for the member', async function () {
+            const GiftModel = stubGiftModel({models: []});
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const gift = await repository.getRedeemedByMember('member_without_gift');
+
+            assert.equal(gift, null);
+        });
+    });
+
     it('finds gifts pending expiration using current time', async function () {
         const before = new Date();
 

--- a/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
@@ -450,70 +450,6 @@ describe('GiftBookshelfRepository', function () {
         assert.equal(savedRow.consumes_soon_reminder_sent_at, reminderSentAt);
     });
 
-    describe('getRedeemedByMember', function () {
-        function stubGiftModel({models}: {models: unknown[]}) {
-            return {
-                add: sinon.stub(),
-                transaction: sinon.stub(),
-                findOne: sinon.stub(),
-                findAll: sinon.stub().resolves({models})
-            };
-        }
-
-        it('returns the most recently redeemed gift for a member', async function () {
-            const GiftModel = stubGiftModel({
-                models: [{
-                    toJSON() {
-                        return {
-                            token: 'gift-token',
-                            buyer_email: 'buyer@example.com',
-                            buyer_member_id: 'buyer_member_1',
-                            redeemer_member_id: 'member_2',
-                            tier_id: 'tier_1',
-                            cadence: 'year',
-                            duration: 1,
-                            currency: 'usd',
-                            amount: 5000,
-                            stripe_checkout_session_id: 'cs_123',
-                            stripe_payment_intent_id: 'pi_456',
-                            consumes_at: new Date('2027-01-01T00:00:00.000Z'),
-                            expires_at: new Date('2030-01-01T00:00:00.000Z'),
-                            status: 'redeemed',
-                            purchased_at: new Date('2026-01-01T00:00:00.000Z'),
-                            redeemed_at: new Date('2026-06-01T00:00:00.000Z'),
-                            consumed_at: null,
-                            expired_at: null,
-                            refunded_at: null
-                        };
-                    }
-                }]
-            });
-            const repository = new GiftBookshelfRepository({GiftModel});
-
-            const gift = await repository.getRedeemedByMember('member_2');
-
-            assert.ok(gift instanceof Gift);
-            assert.equal(gift?.token, 'gift-token');
-            assert.equal(gift?.status, 'redeemed');
-
-            sinon.assert.calledOnce(GiftModel.findAll);
-
-            const callArgs = GiftModel.findAll.getCall(0).args[0];
-            assert.equal(callArgs.filter, 'redeemer_member_id:\'member_2\'+status:redeemed');
-            assert.equal(callArgs.order, 'redeemed_at DESC');
-            assert.equal(callArgs.limit, 1);
-        });
-
-        it('returns null when no redeemed gift exists for the member', async function () {
-            const GiftModel = stubGiftModel({models: []});
-            const repository = new GiftBookshelfRepository({GiftModel});
-
-            const gift = await repository.getRedeemedByMember('member_without_gift');
-
-            assert.equal(gift, null);
-        });
-    });
-
     it('finds gifts pending expiration using current time', async function () {
         const before = new Date();
 
@@ -569,5 +505,111 @@ describe('GiftBookshelfRepository', function () {
 
         assert.ok(filterDate >= before);
         assert.ok(filterDate <= after);
+    });
+
+    describe('getActiveGift', function () {
+        function stubGiftModel({model}: {model: {toJSON(): {status?: string}} | null}) {
+            // Mimic bookshelf's findOne: only matches when every field in the
+            // query equals the corresponding field on the row.
+            const findOne = sinon.stub().callsFake((data: Record<string, unknown>) => {
+                if (!model) {
+                    return Promise.resolve(null);
+                }
+                const row = model.toJSON() as Record<string, unknown>;
+                const matches = Object.entries(data).every(([key, value]) => row[key] === value);
+                return Promise.resolve(matches ? model : null);
+            });
+            return {
+                add: sinon.stub(),
+                transaction: sinon.stub(),
+                findAll: sinon.stub(),
+                findOne
+            };
+        }
+
+        function buildGiftRow(overrides: Record<string, unknown> = {}) {
+            return {
+                token: 'gift-token',
+                buyer_email: 'buyer@example.com',
+                buyer_member_id: 'buyer_member_1',
+                redeemer_member_id: 'member_2',
+                tier_id: 'tier_1',
+                cadence: 'year',
+                duration: 1,
+                currency: 'usd',
+                amount: 5000,
+                stripe_checkout_session_id: 'cs_123',
+                stripe_payment_intent_id: 'pi_456',
+                consumes_at: new Date('2027-01-01T00:00:00.000Z'),
+                expires_at: new Date('2030-01-01T00:00:00.000Z'),
+                status: 'redeemed',
+                purchased_at: new Date('2026-01-01T00:00:00.000Z'),
+                redeemed_at: new Date('2026-06-01T00:00:00.000Z'),
+                consumed_at: null,
+                expired_at: null,
+                refunded_at: null,
+                ...overrides
+            };
+        }
+
+        it('returns the redeemed gift for a member', async function () {
+            const GiftModel = stubGiftModel({
+                model: {toJSON: () => buildGiftRow()}
+            });
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const gift = await repository.getActiveGift('member_2');
+
+            assert.ok(gift instanceof Gift);
+            assert.equal(gift?.token, 'gift-token');
+            assert.equal(gift?.status, 'redeemed');
+
+            sinon.assert.calledOnce(GiftModel.findOne);
+
+            const [data, options] = GiftModel.findOne.getCall(0).args;
+            assert.deepEqual(data, {redeemer_member_id: 'member_2', status: 'redeemed'});
+            assert.equal(options.require, false);
+        });
+
+        it('returns null when no redeemed gift exists for the member', async function () {
+            const GiftModel = stubGiftModel({model: null});
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const gift = await repository.getActiveGift('member_without_gift');
+
+            assert.equal(gift, null);
+        });
+
+        it('returns null when redeemed gift is consumed', async function () {
+            const GiftModel = stubGiftModel({
+                model: {
+                    toJSON: () => buildGiftRow({
+                        status: 'consumed',
+                        consumed_at: new Date('2027-01-01T00:00:00.000Z')
+                    })
+                }
+            });
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const gift = await repository.getActiveGift('member_2');
+
+            assert.equal(gift, null);
+        });
+
+        it('returns null when redeemed gift is refunded', async function () {
+            const GiftModel = stubGiftModel({
+                model: {
+                    toJSON: () => buildGiftRow({
+                        status: 'refunded',
+                        refunded_at: new Date('2026-07-01T00:00:00.000Z')
+                    })
+                }
+            });
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const gift = await repository.getActiveGift('member_2');
+
+            assert.equal(gift, null);
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
@@ -507,7 +507,7 @@ describe('GiftBookshelfRepository', function () {
         assert.ok(filterDate <= after);
     });
 
-    describe('getActiveGift', function () {
+    describe('getActiveByMember', function () {
         function stubGiftModel({model}: {model: {toJSON(): {status?: string}} | null}) {
             // Mimic bookshelf's findOne: only matches when every field in the
             // query equals the corresponding field on the row.
@@ -558,7 +558,7 @@ describe('GiftBookshelfRepository', function () {
             });
             const repository = new GiftBookshelfRepository({GiftModel});
 
-            const gift = await repository.getActiveGift('member_2');
+            const gift = await repository.getActiveByMember('member_2');
 
             assert.ok(gift instanceof Gift);
             assert.equal(gift?.token, 'gift-token');
@@ -575,7 +575,7 @@ describe('GiftBookshelfRepository', function () {
             const GiftModel = stubGiftModel({model: null});
             const repository = new GiftBookshelfRepository({GiftModel});
 
-            const gift = await repository.getActiveGift('member_without_gift');
+            const gift = await repository.getActiveByMember('member_without_gift');
 
             assert.equal(gift, null);
         });
@@ -591,7 +591,7 @@ describe('GiftBookshelfRepository', function () {
             });
             const repository = new GiftBookshelfRepository({GiftModel});
 
-            const gift = await repository.getActiveGift('member_2');
+            const gift = await repository.getActiveByMember('member_2');
 
             assert.equal(gift, null);
         });
@@ -607,7 +607,7 @@ describe('GiftBookshelfRepository', function () {
             });
             const repository = new GiftBookshelfRepository({GiftModel});
 
-            const gift = await repository.getActiveGift('member_2');
+            const gift = await repository.getActiveByMember('member_2');
 
             assert.equal(gift, null);
         });

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -32,7 +32,7 @@ describe('GiftService', function () {
         existsByCheckoutSessionId: sinon.SinonStub<[string], Promise<boolean>>;
         getByToken: sinon.SinonStub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>;
         getByPaymentIntentId: sinon.SinonStub<[string], Promise<Gift | null>>;
-        getActiveGift: sinon.SinonStub<[string], Promise<Gift | null>>;
+        getActiveByMember: sinon.SinonStub<[string], Promise<Gift | null>>;
         findPendingConsumption: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingExpiration: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingReminder: sinon.SinonStub<[FindPendingReminderOptions], Promise<Gift[]>>;
@@ -77,7 +77,7 @@ describe('GiftService', function () {
             existsByCheckoutSessionId: sinon.stub<[string], Promise<boolean>>().resolves(false),
             getByToken: sinon.stub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>().resolves(null),
             getByPaymentIntentId: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
-            getActiveGift: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
+            getActiveByMember: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
             findPendingConsumption: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingExpiration: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingReminder: sinon.stub<[FindPendingReminderOptions], Promise<Gift[]>>().resolves([]),
@@ -1316,39 +1316,137 @@ describe('GiftService', function () {
         });
     });
 
-    describe('getActiveGift', function () {
+    describe('getActiveByMember', function () {
+        const MS_PER_DAY = 24 * 60 * 60 * 1000;
+        const daysFromNow = (days: number) => new Date(Date.now() + days * MS_PER_DAY);
+
         it('returns the redeemed gift from the repository', async function () {
             const gift = buildGift({
                 status: 'redeemed',
                 redeemerMemberId: 'member_1',
-                redeemedAt: new Date('2026-06-01T00:00:00.000Z'),
-                consumesAt: new Date('2027-06-01T00:00:00.000Z')
+                redeemedAt: daysFromNow(-30),
+                consumesAt: daysFromNow(335)
             });
 
-            giftRepository.getActiveGift.resolves(gift);
+            giftRepository.getActiveByMember.resolves(gift);
 
             const service = createService();
-            const result = await service.getActiveGift('member_1');
+            const result = await service.getActiveByMember('member_1');
 
             assert.equal(result, gift);
-            sinon.assert.calledOnceWithExactly(giftRepository.getActiveGift, 'member_1');
+            sinon.assert.calledOnceWithExactly(giftRepository.getActiveByMember, 'member_1');
         });
 
         it('returns null when the repository has no redeemed gift for the member', async function () {
-            giftRepository.getActiveGift.resolves(null);
+            giftRepository.getActiveByMember.resolves(null);
 
             const service = createService();
-            const result = await service.getActiveGift('member_without_gift');
+            const result = await service.getActiveByMember('member_without_gift');
 
             assert.equal(result, null);
         });
 
         it('returns null without hitting the repository when memberId is falsy', async function () {
             const service = createService();
-            const result = await service.getActiveGift('');
+            const result = await service.getActiveByMember('');
 
             assert.equal(result, null);
-            sinon.assert.notCalled(giftRepository.getActiveGift);
+            sinon.assert.notCalled(giftRepository.getActiveByMember);
+        });
+    });
+
+    describe('getRemainingActiveDays', function () {
+        const MS_PER_DAY = 24 * 60 * 60 * 1000;
+        let now: Date;
+        let redeemedAt: Date;
+        const daysFromNow = (days: number) => new Date(now.getTime() + days * MS_PER_DAY);
+
+        beforeEach(function () {
+            now = new Date();
+            redeemedAt = new Date(now.getTime() - 30 * MS_PER_DAY);
+        });
+
+        it('returns 0 when the gift has not been redeemed', function () {
+            const gift = buildGift({
+                status: 'purchased',
+                redeemedAt: null,
+                consumesAt: daysFromNow(10)
+            });
+            const service = createService();
+
+            assert.equal(service.getRemainingActiveDays(gift, now), 0);
+        });
+
+        it('returns 0 when a redeemed gift has no consumesAt', function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemedAt,
+                consumesAt: null
+            });
+            const service = createService();
+
+            assert.equal(service.getRemainingActiveDays(gift, now), 0);
+        });
+
+        it('returns 0 when the redeemed gift has already been consumed', function () {
+            const consumedAt = daysFromNow(-1);
+            const gift = buildGift({
+                status: 'consumed',
+                redeemedAt,
+                consumesAt: consumedAt,
+                consumedAt
+            });
+            const service = createService();
+
+            assert.equal(service.getRemainingActiveDays(gift, now), 0);
+        });
+
+        it('returns the number of whole days until consumesAt, rounded up', function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemedAt,
+                consumesAt: daysFromNow(10.5)
+            });
+            const service = createService();
+
+            // 10.5 days → ceil → 11
+            assert.equal(service.getRemainingActiveDays(gift, now), 11);
+        });
+
+        it('returns 0 when consumesAt is in the past', function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemedAt,
+                consumesAt: daysFromNow(-5)
+            });
+            const service = createService();
+
+            assert.equal(service.getRemainingActiveDays(gift, now), 0);
+        });
+
+        it('returns 0 when consumesAt equals now', function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemedAt,
+                consumesAt: now
+            });
+            const service = createService();
+
+            assert.equal(service.getRemainingActiveDays(gift, now), 0);
+        });
+
+        it('defaults `now` to the current time when omitted', function () {
+            const consumesAt = daysFromNow(5);
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemedAt,
+                consumesAt
+            });
+            const service = createService();
+
+            const result = service.getRemainingActiveDays(gift);
+
+            assert.ok(result === 5 || result === 4, `expected 4 or 5, got ${result}`);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -32,6 +32,7 @@ describe('GiftService', function () {
         existsByCheckoutSessionId: sinon.SinonStub<[string], Promise<boolean>>;
         getByToken: sinon.SinonStub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>;
         getByPaymentIntentId: sinon.SinonStub<[string], Promise<Gift | null>>;
+        getRedeemedByMember: sinon.SinonStub<[string], Promise<Gift | null>>;
         findPendingConsumption: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingExpiration: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingReminder: sinon.SinonStub<[FindPendingReminderOptions], Promise<Gift[]>>;
@@ -76,6 +77,7 @@ describe('GiftService', function () {
             existsByCheckoutSessionId: sinon.stub<[string], Promise<boolean>>().resolves(false),
             getByToken: sinon.stub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>().resolves(null),
             getByPaymentIntentId: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
+            getRedeemedByMember: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
             findPendingConsumption: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingExpiration: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingReminder: sinon.stub<[FindPendingReminderOptions], Promise<Gift[]>>().resolves([]),
@@ -1311,6 +1313,34 @@ describe('GiftService', function () {
 
             assert.equal(result, true);
             sinon.assert.notCalled(giftRepository.update);
+        });
+    });
+
+    describe('getRedeemedByMember', function () {
+        it('returns the redeemed gift from the repository', async function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemerMemberId: 'member_1',
+                redeemedAt: new Date('2026-06-01T00:00:00.000Z'),
+                consumesAt: new Date('2027-06-01T00:00:00.000Z')
+            });
+
+            giftRepository.getRedeemedByMember.resolves(gift);
+
+            const service = createService();
+            const result = await service.getRedeemedByMember('member_1');
+
+            assert.equal(result, gift);
+            sinon.assert.calledOnceWithExactly(giftRepository.getRedeemedByMember, 'member_1');
+        });
+
+        it('returns null when the repository has no redeemed gift for the member', async function () {
+            giftRepository.getRedeemedByMember.resolves(null);
+
+            const service = createService();
+            const result = await service.getRedeemedByMember('member_without_gift');
+
+            assert.equal(result, null);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -32,7 +32,7 @@ describe('GiftService', function () {
         existsByCheckoutSessionId: sinon.SinonStub<[string], Promise<boolean>>;
         getByToken: sinon.SinonStub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>;
         getByPaymentIntentId: sinon.SinonStub<[string], Promise<Gift | null>>;
-        getRedeemedByMember: sinon.SinonStub<[string], Promise<Gift | null>>;
+        getActiveGift: sinon.SinonStub<[string], Promise<Gift | null>>;
         findPendingConsumption: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingExpiration: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingReminder: sinon.SinonStub<[FindPendingReminderOptions], Promise<Gift[]>>;
@@ -77,7 +77,7 @@ describe('GiftService', function () {
             existsByCheckoutSessionId: sinon.stub<[string], Promise<boolean>>().resolves(false),
             getByToken: sinon.stub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>().resolves(null),
             getByPaymentIntentId: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
-            getRedeemedByMember: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
+            getActiveGift: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
             findPendingConsumption: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingExpiration: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingReminder: sinon.stub<[FindPendingReminderOptions], Promise<Gift[]>>().resolves([]),
@@ -1316,7 +1316,7 @@ describe('GiftService', function () {
         });
     });
 
-    describe('getRedeemedByMember', function () {
+    describe('getActiveGift', function () {
         it('returns the redeemed gift from the repository', async function () {
             const gift = buildGift({
                 status: 'redeemed',
@@ -1325,22 +1325,30 @@ describe('GiftService', function () {
                 consumesAt: new Date('2027-06-01T00:00:00.000Z')
             });
 
-            giftRepository.getRedeemedByMember.resolves(gift);
+            giftRepository.getActiveGift.resolves(gift);
 
             const service = createService();
-            const result = await service.getRedeemedByMember('member_1');
+            const result = await service.getActiveGift('member_1');
 
             assert.equal(result, gift);
-            sinon.assert.calledOnceWithExactly(giftRepository.getRedeemedByMember, 'member_1');
+            sinon.assert.calledOnceWithExactly(giftRepository.getActiveGift, 'member_1');
         });
 
         it('returns null when the repository has no redeemed gift for the member', async function () {
-            giftRepository.getRedeemedByMember.resolves(null);
+            giftRepository.getActiveGift.resolves(null);
 
             const service = createService();
-            const result = await service.getRedeemedByMember('member_without_gift');
+            const result = await service.getActiveGift('member_without_gift');
 
             assert.equal(result, null);
+        });
+
+        it('returns null without hitting the repository when memberId is falsy', async function () {
+            const service = createService();
+            const result = await service.getActiveGift('');
+
+            assert.equal(result, null);
+            sinon.assert.notCalled(giftRepository.getActiveGift);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3477

## Summary

Allows gift members to continue as a paid subscriber without losing the remainder of their gift: any remaining gift days are converted to free trial days. As the trial mechanism only works if the member continues on the same tier (can't convert gift days on tier A to trial days on tier B), the UI for gift members now only shows an option to continue on the same tier.

## Changes

### Portal (UI)

- New `<ContinueGiftSubscriptionBanner>` on Account Home explains when
  the gift ends and offers a **Continue subscription** button. The
  existing welcome message is suppressed for gift members so the banner
  is the single source of truth.
- The plan list in `<PaidAccountActions>` now shows a **Continue**
  button (instead of **Change**) for gift members, wired to the same
  action.
- New `continueGiftSubscription` action calls a new
  `api.member.continueGiftCheckout()` helper that POSTs to the existing
  `/create-stripe-checkout-session/` endpoint with
  `continueFromGift: true`.
- New shared helper `isGiftMember({member})` replaces the inline
  `member?.status === 'gift'` checks scattered across the home-page
  components.

### Backend

- `RouterController.createCheckoutSession` gains a `continueFromGift`
  branch that:
  - Requires an authenticated gift member (401 / 400 otherwise).
  - Looks up the active redeemed gift via the new
    `GiftService.getActiveGift(memberId)` (returns 400 if none).
  - Forces `tier` and `cadence` to match the gift — the member can't
    swap tier or cadence as part of the upgrade.
  - Forwards the gift to `_createSubscriptionCheckoutSession`.
- `PaymentsService.getPaymentLink` now accepts an optional `gift` param;
  when present and the gift hasn't been consumed, it sets Stripe's
  `trial_period_days` to the remaining gift days (capped at Stripe's
  730-day max).
- New `GiftService.getActiveGift(memberId)` / `GiftRepository.getActiveGift(memberId)`
  — returns the redeemed gift for a member (only one is possible at a
  time), with a falsy-`memberId` guard. Implemented as a single
  `findOne({redeemer_member_id, status: 'redeemed'})`.

## Tests

- **e2e** (`gift-subscriptions.test.js`):
  - Success: applies remaining gift days as trial and continues on the
    same tier/cadence as the gift.
  - 401 for unauthenticated members.
  - 400 when the member is not a gift member (even if a stale gift
    record exists for someone else).
  - 403 when the gift's tier has been archived.
- **unit** — `GiftBookshelfRepository.getActiveGift`: returns the
  redeemed gift, returns `null` when none exists, returns `null` when
  the gift is `consumed` or `refunded`.
- **unit** — `GiftService.getActiveGift`: forwards to the repository,
  returns `null` for a falsy `memberId` without hitting the repo.
- **unit** — `isGiftMember` helper covered against gift / paid / free /
  complimentary fixtures plus null/empty member edge cases.
- **unit** — updated `AccountWelcome` test to reflect that the gift
  expiry message has moved to `<ContinueGiftSubscriptionBanner>`.

## Test plan

- [ ] Sign in as a gift member with an unexpired gift; confirm the
      banner renders on Account Home with the correct expiry date.
- [ ] Click **Continue subscription**; confirm Stripe Checkout opens for
      the gift's tier/cadence with a trial period equal to the remaining
      gift days.
- [ ] Complete checkout; confirm the member becomes a paid subscriber
      and the banner disappears.
- [ ] Confirm the **Continue** button on the plan row triggers the same
      flow.
- [ ] Confirm a non-gift member never sees the banner or the Continue
      button.

## Follow-ups

- Banner copy is hardcoded with a `// TODO: Add translation strings
  once copy has been finalised` — i18n wiring is intentionally deferred
  until copy is signed off.