### PR TITLE
Fixed flaky comments test by pinning `created_at`

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -685,46 +685,6 @@ Object {
       "count": Object {
         "direct_replies": Any<Number>,
         "likes": Any<Number>,
-        "replies": Any<Number>,
-        "reports": Any<Number>,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": Nullable<StringMatching>,
-      "html": "<p>Parent</p>",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "member": Object {
-        "avatar_image": null,
-        "can_comment": true,
-        "commenting": Object {
-          "disabled": false,
-          "disabled_reason": null,
-          "disabled_until": null,
-        },
-        "email": "member1@test.com",
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": "Mr Egg",
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "parent_id": Nullable<StringMatching>,
-      "post": Object {
-        "excerpt": "HTML Ipsum Presents
-
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
-        "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "title": "Ghostly Kitchen Sink",
-        "url": Any<String>,
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "status": "published",
-    },
-    Object {
-      "count": Object {
-        "direct_replies": Any<Number>,
-        "likes": Any<Number>,
         "replies": 0,
         "reports": Any<Number>,
       },
@@ -758,6 +718,46 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
         "member": null,
         "parent_id": Nullable<StringMatching>,
         "status": "published",
+      },
+      "parent_id": Nullable<StringMatching>,
+      "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
+        "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "title": "Ghostly Kitchen Sink",
+        "url": Any<String>,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "status": "published",
+    },
+    Object {
+      "count": Object {
+        "direct_replies": Any<Number>,
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+        "reports": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": Nullable<StringMatching>,
+      "html": "<p>Parent</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "member": Object {
+        "avatar_image": null,
+        "can_comment": true,
+        "commenting": Object {
+          "disabled": false,
+          "disabled_reason": null,
+          "disabled_until": null,
+        },
+        "email": "member1@test.com",
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -1363,14 +1363,20 @@ describe(`Admin Comments API`, function () {
             await dbFns.addCommentWithReplies({
                 member_id: fixtureManager.get('members', 0).id,
                 html: '<p>Parent</p>',
-                replies: [{member_id: fixtureManager.get('members', 1).id, html: '<p>Reply</p>'}]
+                created_at: new Date('2025-01-01T00:00:00.000Z'),
+                replies: [{
+                    member_id: fixtureManager.get('members', 1).id,
+                    html: '<p>Reply</p>',
+                    created_at: new Date('2025-01-01T00:00:01.000Z')
+                }]
             });
 
-            // Both parent and reply appear as separate items in flat list
+            // Both parent and reply appear as separate items in flat list,
+            // reply first because default order is `created_at desc`.
             await adminApi.get('/comments/')
                 .expectStatus(200)
                 .matchBodySnapshot({
-                    comments: [commentMatcher, commentMatcherWithParent]
+                    comments: [commentMatcherWithParent, commentMatcher]
                 });
         });
 


### PR DESCRIPTION
no ref

This is a test-only change.

I think Claude Opus 4.7's explanation is reasonably good:

> The test at `comments.test.js:1362` uses `dbFns.addCommentWithReplies` to create a parent comment and a reply back-to-back without explicit `created_at` values. Both rows rely on the model's default timestamp (`new Date()` at save time).
>
> The admin browseAll controller at `comments-controller.js:166` sorts by `created_at desc` and the SQL has no secondary tiebreak. When the two inserts land in the same millisecond, MySQL happens to return rows in insertion order (parent first, reply second), which matches the stored snapshot `[commentMatcher, commentMatcherWithParent]`. When the reply spills into a newer millisecond, `desc` puts the reply first — the snapshot then sees `parent` (reply's parent object) missing from index 1 and the assertion fails exactly as in the CI log.