### PR TITLE
Used correct type when posts aren't rescheduled

### DIFF
--- a/ghost/core/core/server/services/post-scheduling/index.js
+++ b/ghost/core/core/server/services/post-scheduling/index.js
@@ -32,7 +32,7 @@ const init = async ({adapter, apiUrl, integration}) => {
     let scheduledResources;
 
     if (!adapter.rescheduleOnBoot) {
-        scheduledResources = [];
+        scheduledResources = {};
     } else {
         scheduledResources = await loadScheduledResources();
     }


### PR DESCRIPTION
no ref

This change should have no user impact.

`PostSchedulerService` expects the list of scheduled resources to be an object, but we sometimes pass it an array. It turns out that was fine in this case (it was using `Object.keys()` which happens to behave the same), but that's not what we intended. Let's fix that.
