### PR TITLE
Persisted scheduled email analytics fetch and improved debug UI

### DIFF
--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -375,10 +375,10 @@
                         <td>Last event time:</td>
                         <td>{{ this.analyticsStatus.missing.lastEventTimestamp }}</td>
                     </tr>
+                    <tr>
+                        <td colspan="2"><hr></td>
+                    </tr>
                     {{#if (and this.analyticsStatus this.analyticsStatus.scheduled this.analyticsStatus.scheduled.schedule) }}
-                        <tr>
-                            <td colspan="2"><hr></td>
-                        </tr>
                         <tr>
                             <td>Analytics Scheduled running:</td>
                             <td class="gh-email-debug-settings-icon">
@@ -409,11 +409,29 @@
                             </tr>
                         {{/unless}}
                     {{else}}
-                        <tr>
-                            <td colspan="2">
-                                <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.scheduleAnalytics }}>{{svg-jar "reload"}}Refetch Analytics</button>
-                            </td>
-                        </tr>
+                        {{#if this.showCustomSchedule}}
+                            <tr>
+                                <td><label for="custom-begin-date">Begin:</label></td>
+                                <td><input id="custom-begin-date" type="datetime-local" value={{this.customBeginDate}} {{on "input" this.updateCustomBeginDate}} /></td>
+                            </tr>
+                            <tr>
+                                <td><label for="custom-end-date">End:</label></td>
+                                <td><input id="custom-end-date" type="datetime-local" value={{this.customEndDate}} {{on "input" this.updateCustomEndDate}} /></td>
+                            </tr>
+                            <tr>
+                                <td colspan="2">
+                                    <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.scheduleAnalytics }}>{{svg-jar "reload"}}Schedule Custom Refetch</button>
+                                    <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.toggleCustomSchedule }}>Cancel</button>
+                                </td>
+                            </tr>
+                        {{else}}
+                            <tr>
+                                <td colspan="2">
+                                    <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.scheduleAnalytics }}>{{svg-jar "reload"}}Refetch Analytics</button>
+                                    <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.toggleCustomSchedule }}>Custom Date Range</button>
+                                </td>
+                            </tr>
+                        {{/if}}
                     {{/if}}
                 </tbody>
             </table>

--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -412,11 +412,11 @@
                         {{#if this.showCustomSchedule}}
                             <tr>
                                 <td><label for="custom-begin-date">Begin:</label></td>
-                                <td><input id="custom-begin-date" type="datetime-local" value={{this.customBeginDate}} {{on "input" this.updateCustomBeginDate}} /></td>
+                                <td><input id="custom-begin-date" type="datetime-local" value={{this.customBeginDate}} {{on "input" this.updateCustomBeginDate}} style="border: 1px solid #ddd; padding: 4px 8px; border-radius: 4px;" /></td>
                             </tr>
                             <tr>
                                 <td><label for="custom-end-date">End:</label></td>
-                                <td><input id="custom-end-date" type="datetime-local" value={{this.customEndDate}} {{on "input" this.updateCustomEndDate}} /></td>
+                                <td><input id="custom-end-date" type="datetime-local" value={{this.customEndDate}} {{on "input" this.updateCustomEndDate}} style="border: 1px solid #ddd; padding: 4px 8px; border-radius: 4px;" /></td>
                             </tr>
                             <tr>
                                 <td colspan="2">

--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -412,11 +412,11 @@
                         {{#if this.showCustomSchedule}}
                             <tr>
                                 <td><label for="custom-begin-date">Begin:</label></td>
-                                <td><input id="custom-begin-date" type="datetime-local" value={{this.customBeginDate}} {{on "input" this.updateCustomBeginDate}} style="border: 1px solid #ddd; padding: 4px 8px; border-radius: 4px;" /></td>
+                                <td><input id="custom-begin-date" type="datetime-local" value={{this.customBeginDate}} {{on "input" this.updateCustomBeginDate}} style="border: 1px solid #ccc; padding: 6px 10px; border-radius: 4px; background: #f9f9f9; cursor: pointer; font-size: 1.3rem;" /></td>
                             </tr>
                             <tr>
                                 <td><label for="custom-end-date">End:</label></td>
-                                <td><input id="custom-end-date" type="datetime-local" value={{this.customEndDate}} {{on "input" this.updateCustomEndDate}} style="border: 1px solid #ddd; padding: 4px 8px; border-radius: 4px;" /></td>
+                                <td><input id="custom-end-date" type="datetime-local" value={{this.customEndDate}} {{on "input" this.updateCustomEndDate}} style="border: 1px solid #ccc; padding: 6px 10px; border-radius: 4px; background: #f9f9f9; cursor: pointer; font-size: 1.3rem;" /></td>
                             </tr>
                             <tr>
                                 <td colspan="2">

--- a/ghost/admin/app/components/posts/debug.js
+++ b/ghost/admin/app/components/posts/debug.js
@@ -342,7 +342,7 @@ export default class Debug extends Component {
         if (this.customEndDate) {
             payload.end = new Date(this.customEndDate).toISOString();
         }
-        yield this.ajax.put(statsUrl, {data: JSON.stringify(payload), contentType: 'application/json'});
+        yield this.ajax.put(statsUrl, {data: payload});
         yield this.fetchAnalyticsStatus();
         this.showCustomSchedule = false;
     }

--- a/ghost/admin/app/components/posts/debug.js
+++ b/ghost/admin/app/components/posts/debug.js
@@ -335,14 +335,17 @@ export default class Debug extends Component {
     @task
     *_scheduleAnalytics() {
         let statsUrl = this.ghostPaths.url.api(`/emails/${this.post.email.id}/analytics`);
-        const payload = {};
-        if (this.customBeginDate) {
-            payload.begin = new Date(this.customBeginDate).toISOString();
+        if (this.customBeginDate || this.customEndDate) {
+            const params = new URLSearchParams();
+            if (this.customBeginDate) {
+                params.set('begin', new Date(this.customBeginDate).toISOString());
+            }
+            if (this.customEndDate) {
+                params.set('end', new Date(this.customEndDate).toISOString());
+            }
+            statsUrl = `${statsUrl}?${params.toString()}`;
         }
-        if (this.customEndDate) {
-            payload.end = new Date(this.customEndDate).toISOString();
-        }
-        yield this.ajax.put(statsUrl, {data: payload});
+        yield this.ajax.put(statsUrl, {});
         yield this.fetchAnalyticsStatus();
         this.showCustomSchedule = false;
     }

--- a/ghost/admin/app/components/posts/debug.js
+++ b/ghost/admin/app/components/posts/debug.js
@@ -20,6 +20,9 @@ export default class Debug extends Component {
     @tracked loading = true;
     @tracked analyticsStatus = null;
     @tracked latestEmail = null;
+    @tracked showCustomSchedule = false;
+    @tracked customBeginDate = null;
+    @tracked customEndDate = null;
 
     get post() {
         return this.args.post;
@@ -294,6 +297,27 @@ export default class Debug extends Component {
     }
 
     @action
+    toggleCustomSchedule() {
+        this.showCustomSchedule = !this.showCustomSchedule;
+        if (this.showCustomSchedule && !this.customBeginDate) {
+            this.customBeginDate = moment(this.email?.createdAtUTC).format('YYYY-MM-DDTHH:mm');
+            const createdAt = moment(this.email?.createdAtUTC);
+            const maxEnd = moment.min(moment().subtract(1, 'hour'), createdAt.clone().add(7, 'days'));
+            this.customEndDate = maxEnd.format('YYYY-MM-DDTHH:mm');
+        }
+    }
+
+    @action
+    updateCustomBeginDate(event) {
+        this.customBeginDate = event.target.value;
+    }
+
+    @action
+    updateCustomEndDate(event) {
+        this.customEndDate = event.target.value;
+    }
+
+    @action
     scheduleAnalytics() {
         try {
             if (this._scheduleAnalytics.isRunning) {
@@ -311,8 +335,16 @@ export default class Debug extends Component {
     @task
     *_scheduleAnalytics() {
         let statsUrl = this.ghostPaths.url.api(`/emails/${this.post.email.id}/analytics`);
-        yield this.ajax.put(statsUrl, {});
+        const payload = {};
+        if (this.customBeginDate) {
+            payload.begin = new Date(this.customBeginDate).toISOString();
+        }
+        if (this.customEndDate) {
+            payload.end = new Date(this.customEndDate).toISOString();
+        }
+        yield this.ajax.put(statsUrl, {data: JSON.stringify(payload), contentType: 'application/json'});
         yield this.fetchAnalyticsStatus();
+        this.showCustomSchedule = false;
     }
 
     @action

--- a/ghost/admin/app/components/posts/debug.js
+++ b/ghost/admin/app/components/posts/debug.js
@@ -299,11 +299,14 @@ export default class Debug extends Component {
     @action
     toggleCustomSchedule() {
         this.showCustomSchedule = !this.showCustomSchedule;
-        if (this.showCustomSchedule && !this.customBeginDate) {
+        if (this.showCustomSchedule) {
             this.customBeginDate = moment(this.email?.createdAtUTC).format('YYYY-MM-DDTHH:mm');
             const createdAt = moment(this.email?.createdAtUTC);
             const maxEnd = moment.min(moment().subtract(1, 'hour'), createdAt.clone().add(7, 'days'));
             this.customEndDate = maxEnd.format('YYYY-MM-DDTHH:mm');
+        } else {
+            this.customBeginDate = null;
+            this.customEndDate = null;
         }
     }
 

--- a/ghost/admin/app/components/posts/debug.js
+++ b/ghost/admin/app/components/posts/debug.js
@@ -334,18 +334,14 @@ export default class Debug extends Component {
 
     @task
     *_scheduleAnalytics() {
-        let statsUrl = this.ghostPaths.url.api(`/emails/${this.post.email.id}/analytics`);
-        if (this.customBeginDate || this.customEndDate) {
-            const params = new URLSearchParams();
-            if (this.customBeginDate) {
-                params.set('begin', new Date(this.customBeginDate).toISOString());
-            }
-            if (this.customEndDate) {
-                params.set('end', new Date(this.customEndDate).toISOString());
-            }
-            statsUrl = `${statsUrl}?${params.toString()}`;
+        const url = new URL(this.ghostPaths.url.api(`/emails/${this.post.email.id}/analytics`), window.location.origin);
+        if (this.customBeginDate) {
+            url.searchParams.set('begin', new Date(this.customBeginDate).toISOString());
         }
-        yield this.ajax.put(statsUrl, {});
+        if (this.customEndDate) {
+            url.searchParams.set('end', new Date(this.customEndDate).toISOString());
+        }
+        yield this.ajax.put(url.pathname + url.search, {});
         yield this.fetchAnalyticsStatus();
         this.showCustomSchedule = false;
     }

--- a/ghost/core/core/server/api/endpoints/emails.js
+++ b/ghost/core/core/server/api/endpoints/emails.js
@@ -156,14 +156,22 @@ const controller = {
             method: 'browse'
         },
         data: [
-            'id'
+            'id',
+            'begin',
+            'end'
         ],
         async query(frame) {
-            const model = await models.Email.findOne(frame.data, frame.options);
-            return emailAnalytics.service.schedule({
-                begin: model.get('created_at'),
-                end: new Date(Math.min(Date.now() - 60 * 60 * 1000, model.get('created_at').getTime() + 24 * 60 * 60 * 1000 * 7))
-            });
+            const model = await models.Email.findOne({id: frame.data.id}, frame.options);
+
+            // Use custom dates if provided, otherwise compute defaults from the email
+            const begin = frame.data.begin
+                ? new Date(frame.data.begin)
+                : model.get('created_at');
+            const end = frame.data.end
+                ? new Date(frame.data.end)
+                : new Date(Math.min(Date.now() - 60 * 60 * 1000, model.get('created_at').getTime() + 24 * 60 * 60 * 1000 * 7));
+
+            return emailAnalytics.service.schedule({begin, end});
         }
     },
 

--- a/ghost/core/core/server/api/endpoints/emails.js
+++ b/ghost/core/core/server/api/endpoints/emails.js
@@ -156,19 +156,21 @@ const controller = {
             method: 'browse'
         },
         data: [
-            'id',
+            'id'
+        ],
+        options: [
             'begin',
             'end'
         ],
         async query(frame) {
-            const model = await models.Email.findOne({id: frame.data.id}, frame.options);
+            const model = await models.Email.findOne(frame.data, frame.options);
 
             // Use custom dates if provided, otherwise compute defaults from the email
-            const begin = frame.data.begin
-                ? new Date(frame.data.begin)
+            const begin = frame.options.begin
+                ? new Date(frame.options.begin)
                 : model.get('created_at');
-            const end = frame.data.end
-                ? new Date(frame.data.end)
+            const end = frame.options.end
+                ? new Date(frame.options.end)
                 : new Date(Math.min(Date.now() - 60 * 60 * 1000, model.get('created_at').getTime() + 24 * 60 * 60 * 1000 * 7));
 
             return emailAnalytics.service.schedule({begin, end});

--- a/ghost/core/core/server/api/endpoints/emails.js
+++ b/ghost/core/core/server/api/endpoints/emails.js
@@ -166,7 +166,6 @@ const controller = {
             const {begin: beginParam, end: endParam, ...findOptions} = frame.options;
             const model = await models.Email.findOne(frame.data, findOptions);
 
-            // Use custom dates if provided, otherwise compute defaults from the email
             const begin = beginParam
                 ? new Date(beginParam)
                 : model.get('created_at');

--- a/ghost/core/core/server/api/endpoints/emails.js
+++ b/ghost/core/core/server/api/endpoints/emails.js
@@ -163,14 +163,15 @@ const controller = {
             'end'
         ],
         async query(frame) {
-            const model = await models.Email.findOne(frame.data, frame.options);
+            const {begin: beginParam, end: endParam, ...findOptions} = frame.options;
+            const model = await models.Email.findOne(frame.data, findOptions);
 
             // Use custom dates if provided, otherwise compute defaults from the email
-            const begin = frame.options.begin
-                ? new Date(frame.options.begin)
+            const begin = beginParam
+                ? new Date(beginParam)
                 : model.get('created_at');
-            const end = frame.options.end
-                ? new Date(frame.options.end)
+            const end = endParam
+                ? new Date(endParam)
                 : new Date(Math.min(Date.now() - 60 * 60 * 1000, model.get('created_at').getTime() + 24 * 60 * 60 * 1000 * 7));
 
             return emailAnalytics.service.schedule({begin, end});

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -3,6 +3,8 @@ const metrics = require('@tryghost/metrics');
 const config = require('../../../shared/config');
 
 class EmailAnalyticsServiceWrapper {
+    #restoredSchedule = false;
+
     init() {
         if (this.service) {
             return;
@@ -167,6 +169,11 @@ class EmailAnalyticsServiceWrapper {
     }
 
     async startFetch() {
+        if (!this.#restoredSchedule) {
+            this.#restoredSchedule = true;
+            await this.service.restoreScheduled();
+        }
+
         if (this.fetching) {
             logging.info('Email analytics fetch already running, skipping');
             return;

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -118,6 +118,14 @@ module.exports = class EmailAnalyticsService {
         }
     }
 
+    #clearScheduledData() {
+        this.#fetchScheduledData = {
+            running: false,
+            jobName: 'email-analytics-scheduled'
+        };
+        this.queries.setJobMetadata('email-analytics-scheduled', null);
+    }
+
     getStatus() {
         return {
             latest: this.#fetchLatestNonOpenedData,
@@ -249,28 +257,20 @@ module.exports = class EmailAnalyticsService {
     cancelScheduled() {
         if (this.#fetchScheduledData) {
             if (this.#fetchScheduledData.running) {
-                // Cancel the running fetch
                 this.#fetchScheduledData.canceled = true;
+                // Clear metadata eagerly; fetchScheduled() will clear in-memory state next cycle
+                this.queries.setJobMetadata('email-analytics-scheduled', null);
             } else {
-                this.#fetchScheduledData = {
-                    running: false,
-                    jobName: 'email-analytics-scheduled'
-                };
+                this.#clearScheduledData();
             }
-            this.queries.setJobMetadata('email-analytics-scheduled', null);
         }
     }
 
     /**
      * Restores a previously persisted scheduled fetch from the database.
-     * Called once on startup to resume an in-progress backfill after a restart.
+     * Must only be called once on startup (caller guards against repeated calls).
      */
     async restoreScheduled() {
-        if (this.#fetchScheduledData && this.#fetchScheduledData.schedule) {
-            // Already have an active schedule, don't overwrite
-            return;
-        }
-
         try {
             const jobData = await this.queries.getJobData('email-analytics-scheduled');
             if (!jobData || !jobData.metadata) {
@@ -314,9 +314,7 @@ module.exports = class EmailAnalyticsService {
         }
 
         if (this.#fetchScheduledData.canceled) {
-            // Skip for now
-            this.#fetchScheduledData = null;
-            this.queries.setJobMetadata('email-analytics-scheduled', null);
+            this.#clearScheduledData();
             return createEmptyResult();
         }
 
@@ -329,24 +327,14 @@ module.exports = class EmailAnalyticsService {
         }
 
         if (end <= begin) {
-            // Skip for now
             logging.info('[EmailAnalytics] Ending fetchScheduled because end is before begin');
-            this.#fetchScheduledData = {
-                running: false,
-                jobName: 'email-analytics-scheduled'
-            };
-            this.queries.setJobMetadata('email-analytics-scheduled', null);
+            this.#clearScheduledData();
             return createEmptyResult();
         }
 
         const fetchResult = await this.#fetchEvents(this.#fetchScheduledData, {begin, end, maxEvents});
         if (fetchResult.eventCount === 0 || this.#fetchScheduledData.canceled) {
-            // Reset the scheduled fetch
-            this.#fetchScheduledData = {
-                running: false,
-                jobName: 'email-analytics-scheduled'
-            };
-            this.queries.setJobMetadata('email-analytics-scheduled', null);
+            this.#clearScheduledData();
         }
 
         this.queries.setJobTimestamp(this.#fetchScheduledData.jobName, 'finished', this.#fetchScheduledData.lastEventTimestamp);

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -234,6 +234,10 @@ module.exports = class EmailAnalyticsService {
                 end
             }
         };
+        this.queries.setJobMetadata('email-analytics-scheduled', {
+            begin: begin.toISOString(),
+            end: end.toISOString()
+        });
     }
 
     /**
@@ -253,6 +257,46 @@ module.exports = class EmailAnalyticsService {
                     jobName: 'email-analytics-scheduled'
                 };
             }
+            this.queries.setJobMetadata('email-analytics-scheduled', null);
+        }
+    }
+
+    /**
+     * Restores a previously persisted scheduled fetch from the database.
+     * Called once on startup to resume an in-progress backfill after a restart.
+     */
+    async restoreScheduled() {
+        if (this.#fetchScheduledData && this.#fetchScheduledData.schedule) {
+            // Already have an active schedule, don't overwrite
+            return;
+        }
+
+        try {
+            const jobData = await this.queries.getJobData('email-analytics-scheduled');
+            if (!jobData || !jobData.metadata) {
+                return;
+            }
+
+            const metadata = JSON.parse(jobData.metadata);
+            if (metadata.begin && metadata.end) {
+                const begin = new Date(metadata.begin);
+                const end = new Date(metadata.end);
+
+                this.#fetchScheduledData = {
+                    running: false,
+                    jobName: 'email-analytics-scheduled',
+                    schedule: {begin, end}
+                };
+
+                // Use finished_at as the resume cursor if available
+                if (jobData.finished_at) {
+                    this.#fetchScheduledData.lastEventTimestamp = new Date(jobData.finished_at);
+                }
+
+                logging.info('[EmailAnalytics] Restored scheduled fetch: ' + begin.toISOString() + ' to ' + end.toISOString());
+            }
+        } catch (e) {
+            logging.error('[EmailAnalytics] Failed to restore scheduled fetch', e);
         }
     }
 
@@ -272,6 +316,7 @@ module.exports = class EmailAnalyticsService {
         if (this.#fetchScheduledData.canceled) {
             // Skip for now
             this.#fetchScheduledData = null;
+            this.queries.setJobMetadata('email-analytics-scheduled', null);
             return createEmptyResult();
         }
 
@@ -290,6 +335,7 @@ module.exports = class EmailAnalyticsService {
                 running: false,
                 jobName: 'email-analytics-scheduled'
             };
+            this.queries.setJobMetadata('email-analytics-scheduled', null);
             return createEmptyResult();
         }
 
@@ -300,6 +346,7 @@ module.exports = class EmailAnalyticsService {
                 running: false,
                 jobName: 'email-analytics-scheduled'
             };
+            this.queries.setJobMetadata('email-analytics-scheduled', null);
         }
 
         this.queries.setJobTimestamp(this.#fetchScheduledData.jobName, 'finished', this.#fetchScheduledData.lastEventTimestamp);

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -219,7 +219,7 @@ module.exports = class EmailAnalyticsService {
      * @param {Date} options.end - The end date for the scheduled fetch.
      * @throws {errors.ValidationError} Throws an error if a fetch is already in progress.
      */
-    schedule({begin, end}) {
+    async schedule({begin, end}) {
         if (this.#fetchScheduledData && this.#fetchScheduledData.running) {
             throw new errors.ValidationError({
                 message: 'Already fetching scheduled events. Wait for it to finish before scheduling a new one.'
@@ -234,7 +234,7 @@ module.exports = class EmailAnalyticsService {
                 end
             }
         };
-        this.queries.setJobMetadata('email-analytics-scheduled', {
+        await this.queries.setJobMetadata('email-analytics-scheduled', {
             begin: begin.toISOString(),
             end: end.toISOString()
         });

--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -139,7 +139,7 @@ module.exports = {
                 return JSON.parse(row.metadata);
             }
         } catch (err) {
-            debug(`Error reading metadata for job ${jobName}: ${err.message}`);
+            logging.error(`Error reading metadata for job ${jobName}: ${err.message}`);
         }
         return null;
     },
@@ -165,7 +165,7 @@ module.exports = {
                 });
             }
         } catch (err) {
-            debug(`Error setting metadata for job ${jobName}: ${err.message}`);
+            logging.error(`Error setting metadata for job ${jobName}: ${err.message}`);
         }
     },
 

--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -83,7 +83,7 @@ module.exports = {
      * @returns {Promise<Object|null>} The job data, or null if no job data is found.
      */
     async getJobData(jobName) {
-        return await db.knex('jobs').select('finished_at', 'started_at').where('name', jobName).first();
+        return await db.knex('jobs').select('finished_at', 'started_at', 'metadata').where('name', jobName).first();
     },
 
     /**
@@ -124,6 +124,48 @@ module.exports = {
             }
         } catch (err) {
             debug(`Error setting ${field} timestamp for job ${jobName}: ${err.message}`);
+        }
+    },
+
+    /**
+     * Retrieves and parses the metadata JSON for the specified job.
+     * @param {EmailAnalyticsJobName} jobName - The name of the job.
+     * @returns {Promise<Object|null>} The parsed metadata object, or null.
+     */
+    async getJobMetadata(jobName) {
+        try {
+            const row = await db.knex('jobs').select('metadata').where('name', jobName).first();
+            if (row && row.metadata) {
+                return JSON.parse(row.metadata);
+            }
+        } catch (err) {
+            debug(`Error reading metadata for job ${jobName}: ${err.message}`);
+        }
+        return null;
+    },
+
+    /**
+     * Writes metadata JSON for the specified job.
+     * @param {EmailAnalyticsJobName} jobName - The name of the job.
+     * @param {Object|null} metadata - The metadata to store, or null to clear.
+     * @returns {Promise<void>}
+     */
+    async setJobMetadata(jobName, metadata) {
+        try {
+            const value = metadata ? JSON.stringify(metadata) : null;
+            const result = await db.knex('jobs').update({metadata: value, updated_at: new Date()}).where('name', jobName);
+            if (result === 0 && metadata) {
+                await db.knex('jobs').insert({
+                    id: new ObjectID().toHexString(),
+                    name: jobName,
+                    metadata: value,
+                    updated_at: new Date().toISOString(),
+                    created_at: new Date().toISOString(),
+                    status: 'queued'
+                });
+            }
+        } catch (err) {
+            debug(`Error setting metadata for job ${jobName}: ${err.message}`);
         }
     },
 

--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -153,17 +153,18 @@ module.exports = {
     async setJobMetadata(jobName, metadata) {
         try {
             const value = metadata ? JSON.stringify(metadata) : null;
-            const result = await db.knex('jobs').update({metadata: value, updated_at: new Date()}).where('name', jobName);
-            if (result === 0 && metadata) {
-                await db.knex('jobs').insert({
-                    id: new ObjectID().toHexString(),
-                    name: jobName,
-                    metadata: value,
-                    updated_at: new Date(),
-                    created_at: new Date(),
-                    status: 'queued'
-                });
-            }
+            await db.knex.transaction(async (trx) => {
+                const result = await trx('jobs').update({metadata: value, updated_at: new Date()}).where('name', jobName);
+                if (result === 0 && metadata) {
+                    await trx('jobs').insert({
+                        id: new ObjectID().toHexString(),
+                        name: jobName,
+                        metadata: value,
+                        created_at: new Date(),
+                        status: 'queued'
+                    });
+                }
+            });
         } catch (err) {
             logging.error(`Error setting metadata for job ${jobName}: ${err.message}`);
         }

--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -159,8 +159,8 @@ module.exports = {
                     id: new ObjectID().toHexString(),
                     name: jobName,
                     metadata: value,
-                    updated_at: new Date().toISOString(),
-                    created_at: new Date().toISOString(),
+                    updated_at: new Date(),
+                    created_at: new Date(),
                     status: 'queued'
                 });
             }

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -188,15 +188,18 @@ describe('EmailAnalyticsService', function () {
             let aggregateStatsStub;
             let setJobTimestampStub;
             let setJobStatusStub;
+            let setJobMetadataStub;
 
             beforeEach(function () {
                 setJobTimestampStub = sinon.stub().resolves();
                 setJobStatusStub = sinon.stub().resolves();
+                setJobMetadataStub = sinon.stub().resolves();
                 service = new EmailAnalyticsService({
                     config: createMockConfig(),
                     queries: {
                         setJobTimestamp: setJobTimestampStub,
-                        setJobStatus: setJobStatusStub
+                        setJobStatus: setJobStatusStub,
+                        setJobMetadata: setJobMetadataStub
                     },
                     providers: [{
                         fetchLatest: (fn) => {
@@ -221,7 +224,7 @@ describe('EmailAnalyticsService', function () {
             });
 
             it('returns 0 when fetch is canceled', async function () {
-                service.schedule({
+                await service.schedule({
                     begin: new Date(2023, 0, 1),
                     end: new Date(2023, 0, 2)
                 });
@@ -233,7 +236,7 @@ describe('EmailAnalyticsService', function () {
             });
 
             it('fetches events with correct parameters', async function () {
-                service.schedule({
+                await service.schedule({
                     begin: new Date(2023, 0, 1),
                     end: new Date(2023, 0, 2)
                 });
@@ -246,7 +249,7 @@ describe('EmailAnalyticsService', function () {
             });
 
             it('bails when end date is before begin date', async function () {
-                service.schedule({
+                await service.schedule({
                     begin: new Date(2023, 0, 2),
                     end: new Date(2023, 0, 1)
                 });
@@ -259,7 +262,8 @@ describe('EmailAnalyticsService', function () {
                     config: createMockConfig(),
                     queries: {
                         setJobTimestamp: sinon.stub().resolves(),
-                        setJobStatus: sinon.stub().resolves()
+                        setJobStatus: sinon.stub().resolves(),
+                        setJobMetadata: sinon.stub().resolves()
                     },
                     providers: [{
                         fetchLatest: (fn) => {
@@ -268,12 +272,220 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
 
-                service.schedule({
+                await service.schedule({
                     begin: new Date(2023, 0, 1),
                     end: new Date(2023, 0, 2)
                 });
                 const result = await service.fetchScheduled({maxEvents: 100});
                 assert.equal(result.eventCount, 0);
+            });
+        });
+
+        describe('schedule persistence', function () {
+            let setJobMetadataStub;
+            let service;
+
+            beforeEach(function () {
+                setJobMetadataStub = sinon.stub().resolves();
+                service = new EmailAnalyticsService({
+                    config: createMockConfig(),
+                    queries: {
+                        setJobMetadata: setJobMetadataStub,
+                        setJobTimestamp: sinon.stub().resolves(),
+                        setJobStatus: sinon.stub().resolves()
+                    },
+                    providers: [{
+                        fetchLatest: (fn) => {
+                            fn([]);
+                        }
+                    }]
+                });
+            });
+
+            afterEach(function () {
+                sinon.restore();
+            });
+
+            it('persists metadata when scheduling', async function () {
+                const begin = new Date(2023, 0, 1);
+                const end = new Date(2023, 0, 2);
+                await service.schedule({begin, end});
+
+                sinon.assert.calledOnce(setJobMetadataStub);
+                sinon.assert.calledWith(setJobMetadataStub, 'email-analytics-scheduled', {
+                    begin: begin.toISOString(),
+                    end: end.toISOString()
+                });
+            });
+
+            it('clears metadata when canceling a non-running schedule', async function () {
+                await service.schedule({
+                    begin: new Date(2023, 0, 1),
+                    end: new Date(2023, 0, 2)
+                });
+                setJobMetadataStub.resetHistory();
+
+                service.cancelScheduled();
+
+                sinon.assert.calledOnce(setJobMetadataStub);
+                sinon.assert.calledWith(setJobMetadataStub, 'email-analytics-scheduled', null);
+            });
+
+            it('clears metadata when fetchScheduled completes with no events', async function () {
+                await service.schedule({
+                    begin: new Date(2023, 0, 1),
+                    end: new Date(2023, 0, 2)
+                });
+                setJobMetadataStub.resetHistory();
+
+                await service.fetchScheduled({maxEvents: 100});
+
+                sinon.assert.calledOnce(setJobMetadataStub);
+                sinon.assert.calledWith(setJobMetadataStub, 'email-analytics-scheduled', null);
+            });
+
+            it('clears metadata when fetchScheduled finds end before begin', async function () {
+                await service.schedule({
+                    begin: new Date(2023, 0, 2),
+                    end: new Date(2023, 0, 1)
+                });
+                setJobMetadataStub.resetHistory();
+
+                await service.fetchScheduled({maxEvents: 100});
+
+                sinon.assert.calledOnce(setJobMetadataStub);
+                sinon.assert.calledWith(setJobMetadataStub, 'email-analytics-scheduled', null);
+            });
+
+            it('clears metadata when cancel is called on a non-running schedule', async function () {
+                await service.schedule({
+                    begin: new Date(2023, 0, 1),
+                    end: new Date(2023, 0, 2)
+                });
+                setJobMetadataStub.resetHistory();
+
+                service.cancelScheduled();
+
+                // cancelScheduled on non-running calls #clearScheduledData which clears metadata
+                sinon.assert.calledOnce(setJobMetadataStub);
+                sinon.assert.calledWith(setJobMetadataStub, 'email-analytics-scheduled', null);
+
+                // Subsequent fetchScheduled should be a no-op (nothing scheduled)
+                const result = await service.fetchScheduled();
+                assert.equal(result.eventCount, 0);
+            });
+        });
+
+        describe('restoreScheduled', function () {
+            afterEach(function () {
+                sinon.restore();
+            });
+
+            it('restores schedule from persisted metadata', async function () {
+                const begin = new Date(2023, 0, 1);
+                const end = new Date(2023, 0, 8);
+                const finishedAt = new Date(2023, 0, 3);
+
+                const service = new EmailAnalyticsService({
+                    config: createMockConfig(),
+                    queries: {
+                        getJobData: sinon.stub().resolves({
+                            finished_at: finishedAt,
+                            started_at: null,
+                            metadata: JSON.stringify({
+                                begin: begin.toISOString(),
+                                end: end.toISOString()
+                            })
+                        }),
+                        setJobMetadata: sinon.stub().resolves()
+                    }
+                });
+
+                await service.restoreScheduled();
+
+                const status = service.getStatus();
+                assert.deepEqual(status.scheduled.schedule, {begin, end});
+                assert.deepEqual(status.scheduled.lastEventTimestamp, finishedAt);
+                assert.equal(status.scheduled.running, false);
+            });
+
+            it('does nothing when no job data exists', async function () {
+                const service = new EmailAnalyticsService({
+                    config: createMockConfig(),
+                    queries: {
+                        getJobData: sinon.stub().resolves(null),
+                        setJobMetadata: sinon.stub().resolves()
+                    }
+                });
+
+                await service.restoreScheduled();
+
+                const status = service.getStatus();
+                assert.equal(status.scheduled.schedule, undefined);
+            });
+
+            it('does nothing when metadata is null', async function () {
+                const service = new EmailAnalyticsService({
+                    config: createMockConfig(),
+                    queries: {
+                        getJobData: sinon.stub().resolves({
+                            finished_at: null,
+                            started_at: null,
+                            metadata: null
+                        }),
+                        setJobMetadata: sinon.stub().resolves()
+                    }
+                });
+
+                await service.restoreScheduled();
+
+                const status = service.getStatus();
+                assert.equal(status.scheduled.schedule, undefined);
+            });
+
+            it('restores without resume cursor when finished_at is null', async function () {
+                const begin = new Date(2023, 0, 1);
+                const end = new Date(2023, 0, 8);
+
+                const service = new EmailAnalyticsService({
+                    config: createMockConfig(),
+                    queries: {
+                        getJobData: sinon.stub().resolves({
+                            finished_at: null,
+                            started_at: null,
+                            metadata: JSON.stringify({
+                                begin: begin.toISOString(),
+                                end: end.toISOString()
+                            })
+                        }),
+                        setJobMetadata: sinon.stub().resolves()
+                    }
+                });
+
+                await service.restoreScheduled();
+
+                const status = service.getStatus();
+                assert.deepEqual(status.scheduled.schedule, {begin, end});
+                assert.equal(status.scheduled.lastEventTimestamp, undefined);
+            });
+
+            it('handles corrupt metadata gracefully', async function () {
+                const service = new EmailAnalyticsService({
+                    config: createMockConfig(),
+                    queries: {
+                        getJobData: sinon.stub().resolves({
+                            finished_at: null,
+                            started_at: null,
+                            metadata: 'not-valid-json'
+                        }),
+                        setJobMetadata: sinon.stub().resolves()
+                    }
+                });
+
+                await service.restoreScheduled();
+
+                const status = service.getStatus();
+                assert.equal(status.scheduled.schedule, undefined);
             });
         });
 


### PR DESCRIPTION
## Summary

- Persists the scheduled/backfill email analytics fetch to the database so it survives Ghost restarts. Uses the existing `metadata` column on the `jobs` table to store the begin/end time window as JSON; `finished_at` continues to track progress within that window (same as other fetch types), but since the scheduled job has a fixed time window — not computed relative to now — both the start and end times need explicit persistence.
- On startup, `restoreScheduled()` is called once (on the first `startFetch()` cycle) to restore any in-progress schedule from the database.
- Adds custom date range support to the debug UI (`/posts/analytics/:id/debug`). A "Custom Date Range" option now appears alongside the existing "Refetch Analytics" button, with datetime inputs for arbitrary begin/end dates. The API endpoint accepts optional `begin`/`end` parameters, falling back to the existing computed defaults.

## Changes

**Backend:**
- `queries.js` — Added `getJobMetadata()`/`setJobMetadata()`, updated `getJobData()` to include `metadata`
- `email-analytics-service.js` — `schedule()` persists metadata, `cancelScheduled()`/`fetchScheduled()` clear it on completion, new `restoreScheduled()` method
- `email-analytics-service-wrapper.js` — Calls `restoreScheduled()` once on first fetch cycle
- `emails.js` — `scheduleAnalytics` endpoint accepts optional `begin`/`end` params

**Frontend:**
- `debug.js` — Custom date range state and actions
- `debug.hbs` — "Custom Date Range" toggle with datetime-local inputs

## Test plan

- [ ] Start Ghost, navigate to a post's debug page, schedule a fetch with default dates — verify it appears in the Overview tab
- [ ] Restart Ghost — verify the scheduled fetch is restored and continues processing
- [ ] Cancel a scheduled fetch — verify it stops and metadata is cleared
- [ ] Use custom date range to schedule — verify custom dates are sent and used
- [ ] Schedule with only one custom date (begin or end) — verify the other falls back to default