### PR TITLE
Fixed paid messaging in Portal being shown to comped members

### DIFF
--- a/apps/portal/src/components/pages/account-email-page.js
+++ b/apps/portal/src/components/pages/account-email-page.js
@@ -1,6 +1,6 @@
 import AppContext from '../../app-context';
 import {useContext, useEffect, useState} from 'react';
-import {isPaidMember, getSiteNewsletters, hasNewsletterSendingEnabled} from '../../utils/helpers';
+import {isPaidMember, isComplimentaryMember, getSiteNewsletters, hasNewsletterSendingEnabled} from '../../utils/helpers';
 import NewsletterManagement from '../common/newsletter-management';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
@@ -115,7 +115,7 @@ export default function AccountEmailPage() {
                 }
                 doAction('updateNewsletterPreference', data);
             }}
-            isPaidMember={isPaidMember({member})}
+            isPaidMember={isPaidMember({member}) && !isComplimentaryMember({member})}
             isCommentsEnabled={commentsEnabled !== 'off'}
             enableCommentNotifications={enableCommentNotifications}
         />

--- a/apps/portal/src/components/pages/unsubscribe-page.js
+++ b/apps/portal/src/components/pages/unsubscribe-page.js
@@ -266,7 +266,7 @@ export default function UnsubscribePage() {
                 await unsubscribeAll();
                 setHasInteracted(true);
             }}
-            isPaidMember={member?.status !== 'free'}
+            isPaidMember={member?.status === 'paid'}
             isCommentsEnabled={commentsEnabled !== 'off'}
             enableCommentNotifications={enableCommentNotifications}
         />


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1264/unsubscribe-modal-still-references-paid-subscription-for-free-users

We used != free to control paid member messaging in Portal. This inadvertently included comped members (Not free). They'd then confusingly see messaging about a paid subscription which they don't have.