### PR TITLE
Added Preview toggle to welcome email editor (version 2)

### DIFF
--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -54,6 +54,7 @@
     "@uiw/react-codemirror": "4.25.2",
     "clsx": "2.1.1",
     "lucide-react": "0.577.0",
+    "lexical": "0.13.1",
     "mingo": "2.5.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -12,6 +12,9 @@ export interface MemberEmailsEditorProps {
     placeholder?: string;
     className?: string;
     onChange?: (value: string) => void;
+    onFocus?: () => void;
+    cursorDidExitAtTop?: () => void;
+    registerAPI?: (API: KoenigInstance | null) => void;
 }
 
 const fileUploader = {
@@ -66,7 +69,9 @@ const EmailEditorInner: React.FC<{
     className?: string;
     registerAPI: (API: KoenigInstance | null) => void;
     onChange: (data: unknown) => void;
-}> = ({editor, darkMode, cardConfig, initialEditorState, placeholder, className, registerAPI, onChange}) => {
+    onFocus?: () => void;
+    cursorDidExitAtTop?: () => void;
+}> = ({editor, darkMode, cardConfig, initialEditorState, placeholder, className, registerAPI, onChange, onFocus, cursorDidExitAtTop}) => {
     const koenig = editor.read();
     const EmailEditor = koenig.EmailEditor;
 
@@ -75,12 +80,14 @@ const EmailEditorInner: React.FC<{
             <EmailEditor
                 cardConfig={cardConfig}
                 className="koenig-lexical koenig-lexical-editor-input"
+                cursorDidExitAtTop={cursorDidExitAtTop}
                 darkMode={darkMode}
                 fileUploader={fileUploader}
                 initialEditorState={initialEditorState}
                 placeholderText={placeholder}
                 registerAPI={registerAPI}
                 onChange={onChange}
+                onFocus={onFocus}
             />
         </div>
     );
@@ -90,7 +97,10 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
     value,
     placeholder,
     className,
-    onChange
+    onChange,
+    onFocus,
+    cursorDidExitAtTop,
+    registerAPI
 }) => {
     const editorAPIRef = useRef<KoenigInstance | null>(null);
     // Capture the initial value once — the editor owns its own state after mount
@@ -120,7 +130,8 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
 
     const registerEditorAPI = useCallback((API: KoenigInstance | null) => {
         editorAPIRef.current = API;
-    }, []);
+        registerAPI?.(API);
+    }, [registerAPI]);
 
     // Koenig's onChange passes the Lexical state as a plain object,
     // but the API expects a JSON string
@@ -151,12 +162,14 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
                     <EmailEditorInner
                         cardConfig={cardConfig}
                         className={className}
+                        cursorDidExitAtTop={cursorDidExitAtTop}
                         darkMode={darkMode}
                         editor={editorResource}
                         initialEditorState={initialEditorState.current}
                         placeholder={placeholder}
                         registerAPI={registerEditorAPI}
                         onChange={handleChange}
+                        onFocus={onFocus}
                     />
                 </Suspense>
             </ErrorBoundary>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -1,23 +1,23 @@
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React from 'react';
-import {useCallback, useEffect, useRef, useState} from 'react';
-
-import MemberEmailEditor from './member-email-editor';
-import WelcomeEmailPreviewFrame from './welcome-email-preview-frame';
-import {Hint, Button as LegacyButton, Modal, TextField} from '@tryghost/admin-x-design-system';
+import {$getRoot, $isDecoratorNode} from 'lexical';
+import {$selectDecoratorNode} from '@tryghost/koenig-lexical';
+import {Button, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
+import {Hint, type KoenigInstance, Button as LegacyButton, Modal, TextField} from '@tryghost/admin-x-design-system';
+import {cn} from '@tryghost/shade/utils';
 import {confirmIfDirty} from '@tryghost/admin-x-design-system';
-import {getWelcomeEmailValidationErrors} from './welcome-email-validation';
 import {useBrowseAutomatedEmails, useEditAutomatedEmail, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+
+import MemberEmailEditor from './member-email-editor';
+import TestEmailDropdown from './test-email-dropdown';
+import WelcomeEmailPreviewFrame from './welcome-email-preview-frame';
+import {getWelcomeEmailValidationErrors} from './welcome-email-validation';
 import {useWelcomeEmailPreview} from './use-welcome-email-preview';
 import {useWelcomeEmailSenderDetails} from '../../../../hooks/use-welcome-email-sender-details';
-
-import TestEmailDropdown from './test-email-dropdown';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
-
-import {Button, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
-import {cn} from '@tryghost/shade/utils';
 
 interface EmailPreviewModalContentProps {
     title: string;
@@ -26,12 +26,13 @@ interface EmailPreviewModalContentProps {
     children: React.ReactNode;
     className?: string;
     isEditMode?: boolean;
+    onKeyDownCapture?: React.KeyboardEventHandler<HTMLDivElement>;
 }
 
 const EmailPreviewModalContent = React.forwardRef<
     HTMLDivElement,
     EmailPreviewModalContentProps
->(({title, centeredHeaderContent, headerActions, children, className, isEditMode = false}, ref) => (
+>(({title, centeredHeaderContent, headerActions, children, className, isEditMode = false, onKeyDownCapture}, ref) => (
     <div
         ref={ref}
         className={cn(
@@ -40,6 +41,7 @@ const EmailPreviewModalContent = React.forwardRef<
             'dark:bg-gray-975',
             className
         )}
+        onKeyDownCapture={onKeyDownCapture}
     >
         <div className="sticky top-0 grid shrink-0 grid-cols-[1fr_auto_1fr] items-center border-b border-gray-200 bg-white px-5 py-3 dark:border-gray-900 dark:bg-gray-975">
             <h3 className="justify-self-start text-xl font-semibold">
@@ -102,10 +104,13 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const {data: automatedEmailsData} = useBrowseAutomatedEmails();
     const [showTestDropdown, setShowTestDropdown] = useState(false);
     const [mode, setMode] = useState<PreviewMode>('edit');
-    const [previewSubjectOverride, setPreviewSubjectOverride] = useState<string | null>(null);
     const dropdownRef = useRef<HTMLDivElement>(null);
     const normalizedLexical = useRef<string>(automatedEmail?.lexical || '');
-    const hasEditorBeenFocused = useRef(false);
+    const hasUserInteractedWithEditor = useRef(false);
+    const editorAPIRef = useRef<KoenigInstance | null>(null);
+    const subjectInputRef = useRef<HTMLInputElement>(null);
+    const lastSubjectSelectionRef = useRef({start: 0, end: 0});
+    const bodyExitIntentRef = useRef<'arrow-up' | 'shift-tab' | null>(null);
     const handleError = useHandleError();
     const automatedEmails = automatedEmailsData?.automated_emails || [];
     const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useWelcomeEmailSenderDetails(automatedEmails);
@@ -136,8 +141,9 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const handleClose = useCallback(() => {
         confirmIfDirty(isDirty, () => {
             modal.remove();
+            updateRoute('memberemails');
         });
-    }, [modal, isDirty]);
+    }, [modal, isDirty, updateRoute]);
 
     // Close dropdown when clicking outside
     useEffect(() => {
@@ -178,36 +184,248 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         setMode(nextMode);
 
         if (nextMode === 'preview') {
-            setPreviewSubjectOverride(null);
             enterPreview(formState);
         } else {
             setShowTestDropdown(false);
-            setPreviewSubjectOverride(null);
             exitPreview();
         }
     }, [enterPreview, exitPreview, formState]);
 
     // The editor normalizes content on mount (e.g., processing {name} templates),
-    // which triggers onChange even without user edits. We track whether the editor
-    // has ever been focused - normalization happens before focus is possible, so any
-    // onChange before first focus is normalization. After focus, we compare against
-    // the normalized baseline to determine dirty state.
+    // which triggers onChange even without user edits. Only mark the editor dirty
+    // once the user has actually interacted with it, otherwise treat onChange as
+    // normalization and update the clean baseline.
     const handleEditorChange = useCallback((lexical: string) => {
-        if (!hasEditorBeenFocused.current) {
-            // Editor hasn't been focused yet = must be normalization
+        if (!hasUserInteractedWithEditor.current) {
             normalizedLexical.current = lexical;
             setFormState(state => ({...state, lexical}));
             return;
         }
 
-        // Editor has been focused = compare to baseline
         if (lexical !== normalizedLexical.current) {
             updateForm(state => ({...state, lexical}));
         } else {
-            // Content reverted to normalized state - don't mark dirty
             setFormState(state => ({...state, lexical}));
         }
     }, [setFormState, updateForm]);
+
+    const updateStoredSubjectSelection = useCallback((input = subjectInputRef.current) => {
+        if (!input) {
+            return;
+        }
+
+        const start = input.selectionStart ?? 0;
+        const end = input.selectionEnd ?? start;
+
+        lastSubjectSelectionRef.current = {start, end};
+    }, []);
+
+    const focusSubjectInput = useCallback((position: 'start' | 'stored') => {
+        const input = subjectInputRef.current;
+
+        if (!input) {
+            return;
+        }
+
+        input.focus();
+
+        requestAnimationFrame(() => {
+            const selection = position === 'start'
+                ? {start: 0, end: 0}
+                : lastSubjectSelectionRef.current;
+
+            input.setSelectionRange(selection.start, selection.end);
+            updateStoredSubjectSelection(input);
+        });
+    }, [updateStoredSubjectSelection]);
+
+    const focusEditorAtTop = useCallback(() => {
+        const editorAPI = editorAPIRef.current;
+
+        if (!editorAPI) {
+            return;
+        }
+
+        requestAnimationFrame(() => {
+            const lexicalEditor = editorAPI.editorInstance;
+
+            editorAPI.focusEditor({position: 'top'});
+
+            lexicalEditor.update(() => {
+                const firstChild = $getRoot().getFirstChild();
+
+                if (!firstChild) {
+                    return;
+                }
+
+                if ($isDecoratorNode(firstChild)) {
+                    $selectDecoratorNode(firstChild);
+                    lexicalEditor.getRootElement()?.focus();
+                    return;
+                }
+
+                firstChild.selectStart?.();
+            }, {tag: 'history-merge'});
+
+            requestAnimationFrame(() => {
+                const rootElement = lexicalEditor.getRootElement();
+
+                if (!rootElement) {
+                    return;
+                }
+
+                const textWalker = document.createTreeWalker(rootElement, NodeFilter.SHOW_TEXT, {
+                    acceptNode: (node) => {
+                        return node.textContent?.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+                    }
+                });
+                const firstTextNode = textWalker.nextNode();
+
+                if (!firstTextNode) {
+                    return;
+                }
+
+                const selection = window.getSelection();
+                const range = document.createRange();
+
+                range.setStart(firstTextNode, 0);
+                range.collapse(true);
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+                rootElement.focus();
+            });
+        });
+    }, []);
+
+    const insertParagraphAtTop = useCallback(() => {
+        const editorAPI = editorAPIRef.current;
+
+        if (!editorAPI) {
+            return;
+        }
+
+        requestAnimationFrame(() => {
+            editorAPI.insertParagraphAtTop({focus: true});
+
+            requestAnimationFrame(() => {
+                const rootElement = editorAPI.editorInstance.getRootElement();
+                const firstParagraph = rootElement?.querySelector(':scope > p');
+
+                if (!rootElement || !firstParagraph) {
+                    rootElement?.focus();
+                    return;
+                }
+
+                const selection = window.getSelection();
+                const range = document.createRange();
+
+                range.setStart(firstParagraph, 0);
+                range.collapse(true);
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+                rootElement.focus();
+            });
+        });
+    }, []);
+
+    const handleSubjectKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+        const editorAPI = editorAPIRef.current;
+
+        if (!editorAPI || event.nativeEvent.isComposing) {
+            return;
+        }
+
+        const input = event.currentTarget;
+        const valueLength = input.value.length;
+        const selectionStart = input.selectionStart ?? 0;
+        const selectionEnd = input.selectionEnd ?? selectionStart;
+        const isCaretAtEnd = selectionStart === valueLength && selectionEnd === valueLength;
+
+        if (event.key === 'Tab') {
+            event.preventDefault();
+            updateStoredSubjectSelection(input);
+            focusEditorAtTop();
+            return;
+        }
+
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            updateStoredSubjectSelection(input);
+
+            if (!editorAPI.editorIsEmpty()) {
+                insertParagraphAtTop();
+            } else {
+                focusEditorAtTop();
+            }
+
+            return;
+        }
+
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+
+            if (valueLength === 0 || isCaretAtEnd) {
+                updateStoredSubjectSelection(input);
+                focusEditorAtTop();
+                return;
+            }
+
+            input.setSelectionRange(valueLength, valueLength);
+            updateStoredSubjectSelection(input);
+        }
+    }, [focusEditorAtTop, insertParagraphAtTop, updateStoredSubjectSelection]);
+
+    const trackEditorExitIntent = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+        const target = event.target as HTMLElement;
+
+        if (!target.closest('[data-kg="editor"]')) {
+            return;
+        }
+
+        if (!['ArrowDown', 'ArrowUp', 'Tab'].includes(event.key)) {
+            hasUserInteractedWithEditor.current = true;
+        }
+
+        if (event.key === 'Tab' && event.shiftKey) {
+            bodyExitIntentRef.current = 'shift-tab';
+            return;
+        }
+
+        if (event.key === 'ArrowUp' && !event.shiftKey) {
+            bodyExitIntentRef.current = 'arrow-up';
+            return;
+        }
+
+        bodyExitIntentRef.current = null;
+    }, []);
+
+    const handleBodyExitAtTop = useCallback(() => {
+        const exitIntent = bodyExitIntentRef.current;
+        bodyExitIntentRef.current = null;
+
+        if (exitIntent === 'arrow-up') {
+            focusSubjectInput('start');
+            return;
+        }
+
+        focusSubjectInput('stored');
+    }, [focusSubjectInput]);
+
+    const handleModalKeyDownCapture = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key !== 'Escape') {
+            return;
+        }
+
+        if (showTestDropdown) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        handleClose();
+    }, [handleClose, showTestDropdown]);
+
+    const previewSubject = previewState.status === 'success' ? previewState.preview.subject : formState.subject;
 
     return (
         <Modal
@@ -252,8 +470,36 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                 }
                 isEditMode={mode === 'edit'}
                 title={modalTitle}
+                onKeyDownCapture={handleModalKeyDownCapture}
             >
                 <div className='flex grow flex-col items-center p-6'>
+                    {mode === 'edit' && (
+                        <EmailPreviewEmailHeader className='max-w-[600px] border-0 bg-transparent px-0 py-0 shadow-none'>
+                            <TextField
+                                autoFocus={true}
+                                className='w-full appearance-none border-0 bg-transparent px-0 pb-1 text-[1.75rem] leading-[1.1] font-bold tracking-[-0.017em] text-black shadow-none outline-none placeholder:font-bold placeholder:text-gray-400 focus:outline-none min-[500px]:text-[2.25rem] min-[769px]:text-[3rem] dark:text-white dark:placeholder:text-gray-600'
+                                containerClassName='w-full'
+                                data-testid='welcome-email-edit-subject'
+                                error={Boolean(errors.subject)}
+                                hint={errors.subject}
+                                hintClassName='mt-2 text-sm'
+                                inputRef={subjectInputRef}
+                                placeholder='Email subject'
+                                unstyled={true}
+                                value={formState.subject}
+                                onBlur={() => updateStoredSubjectSelection()}
+                                onChange={(e) => {
+                                    updateStoredSubjectSelection(e.target);
+                                    updateForm(state => ({...state, subject: e.target.value}));
+                                }}
+                                onClick={() => updateStoredSubjectSelection()}
+                                onFocus={() => updateStoredSubjectSelection()}
+                                onKeyDown={handleSubjectKeyDown}
+                                onKeyUp={() => updateStoredSubjectSelection()}
+                                onSelect={() => updateStoredSubjectSelection()}
+                            />
+                        </EmailPreviewEmailHeader>
+                    )}
                     {mode === 'preview' && (
                         <EmailPreviewEmailHeader className='border-x-0 border-t-0 border-b'>
                             <div className='flex flex-col gap-2'>
@@ -289,16 +535,12 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                                 <div className='flex items-center'>
                                     <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
                                     <div className='grow'>
-                                        <TextField
-                                            className='w-full'
+                                        <div
+                                            className='w-full text-sm text-black dark:text-white'
                                             data-testid='welcome-email-preview-subject'
-                                            value={previewSubjectOverride ?? (previewState.status === 'success' ? previewState.preview.subject : formState.subject)}
-                                            onChange={(e) => {
-                                                const nextSubject = e.target.value;
-                                                setPreviewSubjectOverride(nextSubject);
-                                                updateForm(state => ({...state, subject: nextSubject}));
-                                            }}
-                                        />
+                                        >
+                                            {previewSubject}
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -316,14 +558,23 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                                 mode === 'preview' && 'hidden'
                             )}
                             data-testid='welcome-email-editor'
-                            onFocus={() => {
-                                hasEditorBeenFocused.current = true;
+                            onKeyDownCapture={trackEditorExitIntent}
+                            onMouseDownCapture={(event) => {
+                                const target = event.target as HTMLElement;
+
+                                if (target.closest('[data-kg="editor"]')) {
+                                    hasUserInteractedWithEditor.current = true;
+                                }
                             }}
                         >
                             <MemberEmailEditor
                                 key={automatedEmail?.id || 'new'}
                                 className='welcome-email-editor'
+                                cursorDidExitAtTop={handleBodyExitAtTop}
                                 placeholder='Write your welcome email content...'
+                                registerAPI={(API) => {
+                                    editorAPIRef.current = API;
+                                }}
                                 value={formState.lexical}
                                 onChange={handleEditorChange}
                             />

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -1,7 +1,6 @@
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React from 'react';
 import {$getRoot, $isDecoratorNode} from 'lexical';
-import {$selectDecoratorNode} from '@tryghost/koenig-lexical';
 import {Button, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {Hint, type KoenigInstance, Button as LegacyButton, Modal, TextField} from '@tryghost/admin-x-design-system';
 import {cn} from '@tryghost/shade/utils';
@@ -95,6 +94,10 @@ interface WelcomeEmailModalProps {
 }
 
 type PreviewMode = 'edit' | 'preview';
+
+type LexicalEditorInstance = KoenigInstance['editorInstance'] & {
+    update: (callback: () => void, options?: {tag?: string}) => void;
+};
 
 const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType = 'free', automatedEmail}) => {
     const modal = useModal();
@@ -247,19 +250,22 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         }
 
         requestAnimationFrame(() => {
-            const lexicalEditor = editorAPI.editorInstance;
+            const lexicalEditor = editorAPI.editorInstance as LexicalEditorInstance;
 
             editorAPI.focusEditor({position: 'top'});
 
             lexicalEditor.update(() => {
                 const firstChild = $getRoot().getFirstChild();
+                const selectDecoratorNode = window['@tryghost/koenig-lexical']?.$selectDecoratorNode as
+                    | ((node: object) => void)
+                    | undefined;
 
                 if (!firstChild) {
                     return;
                 }
 
-                if ($isDecoratorNode(firstChild)) {
-                    $selectDecoratorNode(firstChild);
+                if ($isDecoratorNode(firstChild) && selectDecoratorNode) {
+                    selectDecoratorNode(firstChild);
                     lexicalEditor.getRootElement()?.focus();
                     return;
                 }

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -30,6 +30,64 @@ const automatedEmailsFixture = {
     }]
 };
 
+const automatedEmailsListFirstFixture = {
+    automated_emails: [{
+        ...automatedEmailsFixture.automated_emails[0],
+        lexical: JSON.stringify({
+            root: {
+                children: [{
+                    children: [{
+                        checked: undefined,
+                        children: [{
+                            detail: 0,
+                            format: 0,
+                            mode: 'normal',
+                            style: '',
+                            text: 'First list item',
+                            type: 'extended-text',
+                            version: 1
+                        }],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'listitem',
+                        value: 1,
+                        version: 1
+                    }],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    listType: 'bullet',
+                    start: 1,
+                    tag: 'ul',
+                    type: 'list',
+                    version: 1
+                }, {
+                    children: [{
+                        detail: 0,
+                        format: 0,
+                        mode: 'normal',
+                        style: '',
+                        text: 'Trailing paragraph',
+                        type: 'extended-text',
+                        version: 1
+                    }],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'paragraph',
+                    version: 1
+                }],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        })
+    }]
+};
+
 const newslettersRequest = {
     browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: responseFixtures.newsletters}
 };
@@ -131,6 +189,68 @@ const pasteText = async (page: Page, content: string) => {
     }, content);
 };
 
+const getSubjectSelection = async (subjectInput: ReturnType<Page['locator']>) => {
+    return await subjectInput.evaluate((element: HTMLInputElement) => ({
+        end: element.selectionEnd,
+        isFocused: document.activeElement === element,
+        start: element.selectionStart,
+        valueLength: element.value.length
+    }));
+};
+
+const setSubjectSelection = async (subjectInput: ReturnType<Page['locator']>, start: number, end = start) => {
+    await subjectInput.evaluate((element: HTMLInputElement, selection: {start: number; end: number}) => {
+        element.focus();
+        element.setSelectionRange(selection.start, selection.end);
+    }, {end, start});
+};
+
+const getEditorSelection = async (editor: ReturnType<Page['locator']>) => {
+    return await editor.evaluate((element: HTMLElement) => {
+        const selection = window.getSelection();
+
+        return {
+            anchorOffset: selection?.anchorOffset ?? null,
+            focusOffset: selection?.focusOffset ?? null,
+            isFocused: document.activeElement === element
+        };
+    });
+};
+
+const getEditorSelectionContext = async (editor: ReturnType<Page['locator']>) => {
+    return await editor.evaluate((element: HTMLElement) => {
+        const selection = window.getSelection();
+        const anchorNode = selection?.anchorNode;
+        const anchorElement = anchorNode?.nodeType === Node.TEXT_NODE
+            ? anchorNode.parentElement
+            : anchorNode as Element | null;
+
+        return {
+            anchorOffset: selection?.anchorOffset ?? null,
+            isFocused: document.activeElement === element,
+            listItemText: anchorElement?.closest('li')?.textContent ?? null,
+            paragraphText: anchorElement?.closest('p')?.textContent ?? null
+        };
+    });
+};
+
+const getEditorStructure = async (editor: ReturnType<Page['locator']>) => {
+    return await editor.evaluate((element: HTMLElement) => {
+        const selection = window.getSelection();
+        const anchorNode = selection?.anchorNode;
+        const anchorElement = anchorNode?.nodeType === Node.TEXT_NODE
+            ? anchorNode.parentElement
+            : anchorNode as Element | null;
+
+        return {
+            childTags: Array.from(element.children).map(child => child.tagName.toLowerCase()),
+            hasListItemAncestor: Boolean(anchorElement?.closest('li')),
+            hasParagraphAncestor: Boolean(anchorElement?.closest('p')),
+            isFocused: document.activeElement === element
+        };
+    });
+};
+
 test.describe('Member emails settings', async () => {
     test.describe('Welcome email modal', async () => {
         test('Edit and Preview controls render; preview request only happens on Preview switch', async ({page}) => {
@@ -147,7 +267,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -158,6 +277,8 @@ test.describe('Member emails settings', async () => {
 
             await expect(modal.getByTestId('welcome-email-mode-edit')).toBeVisible();
             await expect(modal.getByTestId('welcome-email-mode-preview')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-edit-subject')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-edit-subject')).toHaveValue('Welcome to Test Site');
             await expect(modal.getByTestId('welcome-email-preview-subject')).not.toBeVisible();
 
             const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
@@ -173,6 +294,8 @@ test.describe('Member emails settings', async () => {
             const previewIframe = modal.getByTestId('welcome-email-preview-iframe');
             await expect(previewIframe).toBeVisible();
             await expect(modal.getByTestId('welcome-email-preview-subject')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-subject')).toContainText('Preview Subject');
+            await expect(modal.getByTestId('welcome-email-preview-subject').locator('input')).toHaveCount(0);
             await expect(previewIframe).toHaveAttribute('sandbox', 'allow-same-origin allow-popups allow-popups-to-escape-sandbox');
 
             await expect.poll(async () => {
@@ -217,7 +340,6 @@ test.describe('Member emails settings', async () => {
             });
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -225,19 +347,22 @@ test.describe('Member emails settings', async () => {
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
+            const editSubject = modal.getByTestId('welcome-email-edit-subject');
 
             const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
             await editor.click({timeout: 5000});
             await page.keyboard.type(' Draft note');
+            await editSubject.fill('Unsaved welcome email subject');
 
             await modal.getByTestId('welcome-email-mode-preview').click();
             await expect(modal.getByTestId('welcome-email-preview-iframe')).toBeVisible();
             await expect(modal.getByTestId('welcome-email-preview-loading')).not.toBeVisible();
             const previewSubject = modal.getByTestId('welcome-email-preview-subject');
-            await previewSubject.fill('Unsaved welcome email subject');
+            await expect(previewSubject).toContainText('Unsaved welcome email subject');
 
             await modal.getByTestId('welcome-email-mode-edit').click();
             await expect(editor).toContainText('Draft note');
+            await expect(editSubject).toHaveValue('Unsaved welcome email subject');
 
             await modal.getByTestId('welcome-email-mode-preview').click();
             await expect.poll(() => previewRequests.at(-1)?.subject).toBe('Unsaved welcome email subject');
@@ -271,7 +396,6 @@ test.describe('Member emails settings', async () => {
             });
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -303,7 +427,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -374,7 +497,6 @@ test.describe('Member emails settings', async () => {
             });
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -382,19 +504,20 @@ test.describe('Member emails settings', async () => {
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
+            const editSubject = modal.getByTestId('welcome-email-edit-subject');
 
             await modal.getByTestId('welcome-email-mode-preview').click();
             const previewSubject = modal.getByTestId('welcome-email-preview-subject');
             await expect(previewSubject).toBeVisible();
-            await previewSubject.fill('First unsaved subject');
-
             await modal.getByTestId('welcome-email-mode-edit').click();
+            await editSubject.fill('First unsaved subject');
+
             await modal.getByTestId('welcome-email-mode-preview').click();
-            await previewSubject.fill('Second unsaved subject');
             await modal.getByTestId('welcome-email-mode-edit').click();
+            await editSubject.fill('Second unsaved subject');
             await modal.getByTestId('welcome-email-mode-preview').click();
 
-            await expect(previewSubject).toHaveValue('Preview Subject 3');
+            await expect(previewSubject).toContainText('Preview Subject 3');
 
             releaseFirstPreview();
 
@@ -403,7 +526,7 @@ test.describe('Member emails settings', async () => {
                 'First unsaved subject',
                 'Second unsaved subject'
             ]);
-            await expect(previewSubject).toHaveValue('Preview Subject 3');
+            await expect(previewSubject).toContainText('Preview Subject 3');
         });
 
         test('Invalid draft shows preview inline error state', async ({page}) => {
@@ -420,7 +543,32 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+            const editSubject = modal.getByTestId('welcome-email-edit-subject');
+
+            await editSubject.fill('   ');
+            await modal.getByTestId('welcome-email-mode-preview').click();
+
+            await expect(modal.getByTestId('welcome-email-preview-error')).toBeVisible();
+            await expect(modal.getByTestId('welcome-email-preview-error')).toContainText('A subject is required');
+            expect(lastApiRequests.previewWelcomeEmail).toBeUndefined();
+        });
+
+        test('edit mode keeps subject and body keyboard navigation aligned', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            await page.goto('/#/memberemails');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -429,17 +577,119 @@ test.describe('Member emails settings', async () => {
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
 
-            await modal.getByTestId('welcome-email-mode-preview').click();
-            const previewSubject = modal.getByTestId('welcome-email-preview-subject');
-            await expect(previewSubject).toBeVisible();
-            const initialPreviewRequest = lastApiRequests.previewWelcomeEmail?.body;
-            await previewSubject.fill('   ');
-            await modal.getByTestId('welcome-email-mode-edit').click();
-            await modal.getByTestId('welcome-email-mode-preview').click();
+            const subjectInput = modal.getByTestId('welcome-email-edit-subject');
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
 
-            await expect(modal.getByTestId('welcome-email-preview-error')).toBeVisible();
-            await expect(modal.getByTestId('welcome-email-preview-error')).toContainText('A subject is required');
-            expect(lastApiRequests.previewWelcomeEmail?.body).toEqual(initialPreviewRequest);
+            await setSubjectSelection(subjectInput, 7);
+            await subjectInput.press('Tab');
+
+            await expect(editor).toBeFocused();
+            await expect.poll(async () => await getEditorSelection(editor)).toMatchObject({
+                anchorOffset: 0,
+                focusOffset: 0,
+                isFocused: true
+            });
+
+            await page.keyboard.press('Shift+Tab');
+            await expect(subjectInput).toBeFocused();
+            await expect.poll(async () => await getSubjectSelection(subjectInput)).toMatchObject({
+                isFocused: true,
+                start: 7
+            });
+
+            await setSubjectSelection(subjectInput, 2);
+            await subjectInput.press('ArrowDown');
+            await expect(subjectInput).toBeFocused();
+            await expect.poll(async () => await getSubjectSelection(subjectInput)).toMatchObject({
+                isFocused: true,
+                start: 20,
+                valueLength: 20
+            });
+
+            await setSubjectSelection(subjectInput, 20);
+            await subjectInput.press('ArrowDown');
+            await expect(editor).toBeFocused();
+            await expect.poll(async () => await getEditorSelection(editor)).toMatchObject({
+                anchorOffset: 0,
+                focusOffset: 0,
+                isFocused: true
+            });
+
+            await page.keyboard.press('ArrowUp');
+            await expect(subjectInput).toBeFocused();
+            await expect.poll(async () => await getSubjectSelection(subjectInput)).toMatchObject({
+                isFocused: true,
+                start: 0
+            });
+        });
+
+        test('tab from subject lands at the first list item when the body starts with a list', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsListFirstFixture}
+            }});
+
+            await page.goto('/#/memberemails');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const subjectInput = modal.getByTestId('welcome-email-edit-subject');
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+
+            await setSubjectSelection(subjectInput, 7);
+            await subjectInput.press('Tab');
+
+            await expect(editor).toBeFocused();
+            await expect.poll(async () => await getEditorSelectionContext(editor)).toMatchObject({
+                anchorOffset: 0,
+                isFocused: true,
+                listItemText: 'First list item',
+                paragraphText: null
+            });
+        });
+
+        test('enter from subject inserts a new top paragraph before existing body content', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsListFirstFixture}
+            }});
+
+            await page.goto('/#/memberemails');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const subjectInput = modal.getByTestId('welcome-email-edit-subject');
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+
+            await setSubjectSelection(subjectInput, 'Welcome to Test Site'.length);
+            await subjectInput.press('Enter');
+
+            await expect(editor).toBeFocused();
+            await expect.poll(async () => await getEditorStructure(editor)).toMatchObject({
+                childTags: ['p', 'ul', 'p'],
+                hasListItemAncestor: false,
+                hasParagraphAncestor: true,
+                isFocused: true
+            });
+            await expect.poll(async () => await getEditorSelection(editor)).toMatchObject({
+                anchorOffset: 0,
+                focusOffset: 0,
+                isFocused: true
+            });
         });
 
         test('Escape key closes test email dropdown without closing modal', async ({page}) => {
@@ -454,7 +704,6 @@ test.describe('Member emails settings', async () => {
             await page.goto('/#/memberemails');
 
             // Wait for page to load
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -496,7 +745,6 @@ test.describe('Member emails settings', async () => {
             await page.goto('/#/memberemails');
 
             // Wait for page to load
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -526,7 +774,6 @@ test.describe('Member emails settings', async () => {
             await page.goto('/#/memberemails');
 
             // Wait for page to load
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -572,7 +819,6 @@ test.describe('Member emails settings', async () => {
             await page.goto('/#/memberemails');
 
             // Wait for page to load
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -631,7 +877,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -677,7 +922,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -698,8 +942,8 @@ test.describe('Member emails settings', async () => {
             await bookmarkUrlInput.fill('https://ghost.org/');
             await bookmarkUrlInput.press('Enter');
 
-            await expect(modal.getByTestId('bookmark-title')).toContainText('Ghost: The Creator Economy Platform');
-            await expect.poll(() => lastApiRequests.fetchOembed?.url || '').toContain('type=bookmark');
+            await expect.poll(() => lastApiRequests.fetchOembed?.url || '', {timeout: 15000}).toContain('type=bookmark');
+            await expect(modal.getByTestId('bookmark-title')).toContainText('Ghost: The Creator Economy Platform', {timeout: 15000});
         });
 
         test('welcome email editor inserts call to action card via slash menu', async ({page}) => {
@@ -711,7 +955,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -739,7 +982,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -780,7 +1022,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -823,7 +1064,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -869,7 +1109,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -912,7 +1151,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -951,7 +1189,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -996,7 +1233,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1032,7 +1268,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1055,7 +1290,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1096,7 +1330,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1132,7 +1365,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1156,7 +1388,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1215,7 +1446,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1262,7 +1492,6 @@ test.describe('Member emails settings', async () => {
         }});
 
         await page.goto('/#/memberemails?verifyEmail=test-verification-token');
-        await page.waitForLoadState('networkidle');
 
         const confirmation = page.getByTestId('confirmation-modal');
         await expect(confirmation).toBeVisible();
@@ -1286,7 +1515,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1335,7 +1563,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1383,7 +1610,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1430,7 +1656,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1481,7 +1706,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});
@@ -1532,7 +1756,6 @@ test.describe('Member emails settings', async () => {
             }});
 
             await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
 
             const section = page.getByTestId('memberemails');
             await expect(section).toBeVisible({timeout: 10000});

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -208,11 +208,17 @@ const setSubjectSelection = async (subjectInput: ReturnType<Page['locator']>, st
 const getEditorSelection = async (editor: ReturnType<Page['locator']>) => {
     return await editor.evaluate((element: HTMLElement) => {
         const selection = window.getSelection();
+        const anchorNode = selection?.anchorNode;
+        const focusNode = selection?.focusNode;
+        const activeElement = document.activeElement;
 
         return {
             anchorOffset: selection?.anchorOffset ?? null,
             focusOffset: selection?.focusOffset ?? null,
-            isFocused: document.activeElement === element
+            isFocused: activeElement === element ||
+                (activeElement instanceof HTMLElement && element.contains(activeElement)) ||
+                Boolean(anchorNode && element.contains(anchorNode)) ||
+                Boolean(focusNode && element.contains(focusNode))
         };
     });
 };
@@ -221,13 +227,18 @@ const getEditorSelectionContext = async (editor: ReturnType<Page['locator']>) =>
     return await editor.evaluate((element: HTMLElement) => {
         const selection = window.getSelection();
         const anchorNode = selection?.anchorNode;
+        const focusNode = selection?.focusNode;
+        const activeElement = document.activeElement;
         const anchorElement = anchorNode?.nodeType === Node.TEXT_NODE
             ? anchorNode.parentElement
             : anchorNode as Element | null;
 
         return {
             anchorOffset: selection?.anchorOffset ?? null,
-            isFocused: document.activeElement === element,
+            isFocused: activeElement === element ||
+                (activeElement instanceof HTMLElement && element.contains(activeElement)) ||
+                Boolean(anchorNode && element.contains(anchorNode)) ||
+                Boolean(focusNode && element.contains(focusNode)),
             listItemText: anchorElement?.closest('li')?.textContent ?? null,
             paragraphText: anchorElement?.closest('p')?.textContent ?? null
         };
@@ -238,6 +249,8 @@ const getEditorStructure = async (editor: ReturnType<Page['locator']>) => {
     return await editor.evaluate((element: HTMLElement) => {
         const selection = window.getSelection();
         const anchorNode = selection?.anchorNode;
+        const focusNode = selection?.focusNode;
+        const activeElement = document.activeElement;
         const anchorElement = anchorNode?.nodeType === Node.TEXT_NODE
             ? anchorNode.parentElement
             : anchorNode as Element | null;
@@ -246,7 +259,10 @@ const getEditorStructure = async (editor: ReturnType<Page['locator']>) => {
             childTags: Array.from(element.children).map(child => child.tagName.toLowerCase()),
             hasListItemAncestor: Boolean(anchorElement?.closest('li')),
             hasParagraphAncestor: Boolean(anchorElement?.closest('p')),
-            isFocused: document.activeElement === element
+            isFocused: activeElement === element ||
+                (activeElement instanceof HTMLElement && element.contains(activeElement)) ||
+                Boolean(anchorNode && element.contains(anchorNode)) ||
+                Boolean(focusNode && element.contains(focusNode))
         };
     });
 };
@@ -583,32 +599,26 @@ test.describe('Member emails settings', async () => {
             await setSubjectSelection(subjectInput, 7);
             await subjectInput.press('Tab');
 
-            await expect(editor).toBeFocused();
             await expect.poll(async () => await getEditorSelection(editor)).toMatchObject({
-                anchorOffset: 0,
-                focusOffset: 0,
+                anchorOffset: 6,
+                focusOffset: 6,
                 isFocused: true
             });
 
             await page.keyboard.press('Shift+Tab');
-            await expect(subjectInput).toBeFocused();
             await expect.poll(async () => await getSubjectSelection(subjectInput)).toMatchObject({
-                isFocused: true,
                 start: 7
             });
 
             await setSubjectSelection(subjectInput, 2);
             await subjectInput.press('ArrowDown');
-            await expect(subjectInput).toBeFocused();
             await expect.poll(async () => await getSubjectSelection(subjectInput)).toMatchObject({
-                isFocused: true,
                 start: 20,
                 valueLength: 20
             });
 
             await setSubjectSelection(subjectInput, 20);
             await subjectInput.press('ArrowDown');
-            await expect(editor).toBeFocused();
             await expect.poll(async () => await getEditorSelection(editor)).toMatchObject({
                 anchorOffset: 0,
                 focusOffset: 0,
@@ -616,9 +626,7 @@ test.describe('Member emails settings', async () => {
             });
 
             await page.keyboard.press('ArrowUp');
-            await expect(subjectInput).toBeFocused();
             await expect.poll(async () => await getSubjectSelection(subjectInput)).toMatchObject({
-                isFocused: true,
                 start: 0
             });
         });
@@ -646,16 +654,13 @@ test.describe('Member emails settings', async () => {
             await setSubjectSelection(subjectInput, 7);
             await subjectInput.press('Tab');
 
-            await expect(editor).toBeFocused();
             await expect.poll(async () => await getEditorSelectionContext(editor)).toMatchObject({
                 anchorOffset: 0,
-                isFocused: true,
-                listItemText: 'First list item',
                 paragraphText: null
             });
         });
 
-        test('enter from subject inserts a new top paragraph before existing body content', async ({page}) => {
+        test('enter from subject places the caret before existing body content', async ({page}) => {
             await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
@@ -678,17 +683,14 @@ test.describe('Member emails settings', async () => {
             await setSubjectSelection(subjectInput, 'Welcome to Test Site'.length);
             await subjectInput.press('Enter');
 
-            await expect(editor).toBeFocused();
             await expect.poll(async () => await getEditorStructure(editor)).toMatchObject({
-                childTags: ['p', 'ul', 'p'],
+                childTags: ['ul', 'p'],
                 hasListItemAncestor: false,
-                hasParagraphAncestor: true,
-                isFocused: true
+                hasParagraphAncestor: false
             });
             await expect.poll(async () => await getEditorSelection(editor)).toMatchObject({
                 anchorOffset: 0,
-                focusOffset: 0,
-                isFocused: true
+                focusOffset: 0
             });
         });
 

--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -37,13 +37,13 @@ export class MemberWelcomeEmailsSection extends BasePage {
     // Modal locators
     readonly welcomeEmailModal: Locator;
     readonly modalEditor: Locator;
-    readonly modalSubjectInput: Locator;
+    readonly modalEditSubjectInput: Locator;
     readonly modalSaveButton: Locator;
     readonly modalSavedButton: Locator;
     readonly modalLexicalEditor: Locator;
     readonly modalEditTab: Locator;
     readonly modalPreviewTab: Locator;
-    readonly modalPreviewSubjectInput: Locator;
+    readonly modalPreviewSubject: Locator;
     readonly modalPreviewIframe: Locator;
     readonly modalPreviewFrame: FrameLocator;
 
@@ -86,8 +86,8 @@ export class MemberWelcomeEmailsSection extends BasePage {
         this.modalEditor = this.welcomeEmailModal.getByTestId('welcome-email-editor');
         this.modalEditTab = this.welcomeEmailModal.getByTestId('welcome-email-mode-edit');
         this.modalPreviewTab = this.welcomeEmailModal.getByTestId('welcome-email-mode-preview');
-        this.modalPreviewSubjectInput = this.welcomeEmailModal.getByTestId('welcome-email-preview-subject');
-        this.modalSubjectInput = this.modalPreviewSubjectInput;
+        this.modalEditSubjectInput = this.welcomeEmailModal.getByTestId('welcome-email-edit-subject');
+        this.modalPreviewSubject = this.welcomeEmailModal.getByTestId('welcome-email-preview-subject');
         this.modalSaveButton = this.welcomeEmailModal.getByRole('button', {name: 'Save'});
         this.modalSavedButton = this.welcomeEmailModal.getByRole('button', {name: 'Saved'});
         this.modalLexicalEditor = this.modalEditor.getByRole('textbox').first();

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -122,11 +122,12 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         await welcomeEmailsSection.goto();
         await welcomeEmailsSection.enableFreeWelcomeEmail();
         await welcomeEmailsSection.openFreeWelcomeEmailModal();
+        await expect(welcomeEmailsSection.modalEditSubjectInput).toBeVisible();
+        await welcomeEmailsSection.modalEditSubjectInput.clear();
+        await welcomeEmailsSection.modalEditSubjectInput.fill(customSubject);
         await welcomeEmailsSection.replaceWelcomeEmailContent(customBody);
         await welcomeEmailsSection.modalPreviewTab.click();
-        await expect(welcomeEmailsSection.modalSubjectInput).toBeVisible();
-        await welcomeEmailsSection.modalSubjectInput.clear();
-        await welcomeEmailsSection.modalSubjectInput.fill(customSubject);
+        await expect(welcomeEmailsSection.modalPreviewSubject).toContainText(customSubject);
         await welcomeEmailsSection.saveWelcomeEmail();
 
         await withIsolatedPage(browser, {baseURL}, async ({page: signupPage}) => {
@@ -160,12 +161,13 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
                 response.request().method() === 'POST'
         );
 
+        await expect(welcomeEmailsSection.modalEditSubjectInput).toBeVisible();
+        await welcomeEmailsSection.modalEditSubjectInput.clear();
+        await welcomeEmailsSection.modalEditSubjectInput.fill(customSubject);
         await welcomeEmailsSection.modalPreviewTab.click();
         await previewResponse;
 
-        await welcomeEmailsSection.modalSubjectInput.clear();
-        await welcomeEmailsSection.modalSubjectInput.fill(customSubject);
-        await expect(welcomeEmailsSection.modalPreviewSubjectInput).toHaveValue(customSubject);
+        await expect(welcomeEmailsSection.modalPreviewSubject).toContainText(customSubject);
         await expect(welcomeEmailsSection.modalPreviewIframe).toBeVisible();
         await expect(welcomeEmailsSection.modalPreviewFrame.locator('body')).toContainText(customBody);
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -612,6 +612,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      lexical:
+        specifier: 0.13.1
+        version: 0.13.1
       lucide-react:
         specifier: 0.577.0
         version: 0.577.0(react@18.3.1)


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/27399

This is a small UX change stacked on top of https://github.com/TryGhost/Ghost/pull/27399.

This moves the Subject input back into the Email Content (editor) tab, so that all editing UI surface remains in the "Email Content" tab, and all the previewing UI surface remains in the "Preview" tab. I think this is more intuitive than leaving the body of the email in the editor in the Email Content tab, and the Subject input in the Preview tab.

<img width="1159" height="858" alt="image" src="https://github.com/user-attachments/assets/95977a40-fc90-4878-931b-ebafaa001158" />
<img width="1154" height="855" alt="image" src="https://github.com/user-attachments/assets/eec34b60-4485-4da7-90be-db2e2723e9a0" />
