### PR TITLE
Started bailing out of automation run if member no longer exists

### DIFF
--- a/ghost/core/core/server/services/welcome-email-automations/poll.js
+++ b/ghost/core/core/server/services/welcome-email-automations/poll.js
@@ -182,7 +182,22 @@ async function processRun({
     try {
         const member = await Member.findOne({id: run.member_id}, {withRelated: ['newsletters']});
 
-        // TODO(NY-1192): Bail if member no longer exists
+        // When a member is deleted, the run is cascade-deleted. In this edge
+        // case, when a member is deleted after the run is loaded but before
+        // it's processed, bail. (There's no run to update any longer.)
+        if (!member) {
+            logging.warn(
+                {
+                    system: {
+                        event: 'welcome_email_automations.member_not_found',
+                        run_id: run.id
+                    }
+                },
+                `${LOG_KEY} Member not found for run ${run.id}`
+            );
+            return;
+        }
+
         // TODO(NY-1193): Bail if member is unsubscribed
         // TODO(NY-1194): Bail if member's status has changed
 

--- a/ghost/core/test/integration/services/welcome-email-automations/poll.test.js
+++ b/ghost/core/test/integration/services/welcome-email-automations/poll.test.js
@@ -7,7 +7,7 @@ const testUtils = require('../../../utils');
 
 const {poll} = require('../../../../core/server/services/welcome-email-automations/poll');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../../core/server/services/member-welcome-emails/constants');
-const {WelcomeEmailAutomationRun} = require('../../../../core/server/models');
+const {Member, WelcomeEmailAutomationRun} = require('../../../../core/server/models');
 
 const RETRY_DELAY_MS = 10 * 60 * 1000;
 const LOCK_TIMEOUT_MS = 30 * 60 * 1000;
@@ -398,6 +398,35 @@ describe('welcome email automations poll', function () {
         assert.equal(updatedRun.ready_at, null);
         assert.equal(updatedRun.step_started_at, null);
         assert.equal(updatedRun.step_attempts, 0);
+    });
+
+    it('does not send email if member is deleted mid-run (race condition)', async function () {
+        const automation = await createAutomation();
+        const automatedEmail = await createAutomatedEmail({
+            welcome_email_automation_id: automation.id
+        });
+        const member = await createMember();
+        const run = await createRun({
+            welcome_email_automation_id: automation.id,
+            member_id: member.id,
+            next_welcome_email_automated_email_id: automatedEmail.id,
+            ready_at: new Date(Date.now() - 1000)
+        });
+
+        // Simulate race: member (and run, via cascade) deleted while run is being processed
+        const originalFindOne = Member.findOne;
+        sinon.stub(Member, 'findOne').callsFake(async function () {
+            await testUtils.knex('members').where({id: member.id}).del();
+            return originalFindOne.apply(this, arguments);
+        });
+
+        await poll(options);
+
+        sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
+        sinon.assert.notCalled(options.enqueueAnotherPollNow);
+        sinon.assert.notCalled(options.enqueueAnotherPollAt);
+        assert.equal(await readRun(run.id), undefined);
+        assert.deepEqual(await readTrackedRecipients(), []);
     });
 
     it('fails if run stored with more attempts than now supported', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1192

This addresses the following race condition:

1. An automation run is loaded.
2. The run's associated member is deleted. (This causes a cascade delete of the run in the database.)
3. The run begins to execute.
