### PR TITLE
Updated GiftService.getByToken to return null for missing gifts

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -165,16 +165,8 @@ export class GiftService {
         return true;
     }
 
-    async getByToken(token: string): Promise<Gift> {
-        const gift = await this.deps.giftRepository.getByToken(token);
-
-        if (!gift) {
-            throw new errors.NotFoundError({
-                message: tpl(errorMessages.giftNotFound)
-            });
-        }
-
-        return gift;
+    async getByToken(token: string): Promise<Gift | null> {
+        return this.deps.giftRepository.getByToken(token);
     }
 
     async assertRedeemable(gift: Gift, memberStatus: string | null): Promise<Gift> {

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -295,18 +295,14 @@ describe('GiftService', function () {
             assert.equal(result, expectedGift);
         });
 
-        it('throws NotFoundError when the token does not exist', async function () {
+        it('returns null when the token does not exist', async function () {
             giftRepository.getByToken.resolves(null);
 
             const service = createService();
-            await assert.rejects(
-                () => service.getByToken('missing-token'),
-                (err: any) => {
-                    assert.equal(err.errorType, 'NotFoundError');
-                    assert.equal(err.message, 'This gift does not exist.');
-                    return true;
-                }
-            );
+            const result = await service.getByToken('missing-token');
+
+            sinon.assert.calledOnceWithExactly(giftRepository.getByToken, 'missing-token');
+            assert.equal(result, null);
         });
     });
 


### PR DESCRIPTION
no issue

Previously threw NotFoundError when the gift did not exist, forcing callers to wrap the call in a try/catch just to check existence

