### PR TITLE
Added member activity on gift redemption

### DIFF
--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -141,7 +141,11 @@ export default class ParseMemberEventHelper extends Helper {
         }
 
         if (event.type === 'gift_purchase_event') {
-            icon = 'subscriptions';
+            icon = 'gift';
+        }
+
+        if (event.type === 'gift_redemption_event') {
+            icon = 'gift';
         }
 
         if (event.type === 'email_change_event') {
@@ -267,6 +271,11 @@ export default class ParseMemberEventHelper extends Helper {
             const cadenceLabel = duration === 1 ? event.data.cadence : event.data.cadence + 's';
 
             return `Purchased a gift subscription for ${formattedAmount} (${tierName}, ${duration} ${cadenceLabel})`;
+        }
+
+        if (event.type === 'gift_redemption_event') {
+            const tierName = event.data.tier_name;
+            return `Started paid subscription (${tierName}) via gift`;
         }
     }
 

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -34,10 +34,12 @@ export function toggleEventType(eventType, eventTypes) {
             excludedEvents.delete('payment_event');
             excludedEvents.delete('donation_event');
             excludedEvents.delete('gift_purchase_event');
+            excludedEvents.delete('gift_redemption_event');
         } else {
             excludedEvents.add('payment_event');
             excludedEvents.add('donation_event');
             excludedEvents.add('gift_purchase_event');
+            excludedEvents.add('gift_redemption_event');
         }
     } else {
         if (excludedEvents.has(eventType)) {

--- a/ghost/admin/public/assets/icons/event-gift.svg
+++ b/ghost/admin/public/assets/icons/event-gift.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4.75 11.5v8a.75.75 0 0 0 .75.75h13a.75.75 0 0 0 .75-.75v-8M3.25 7.75h17.5v3.75H3.25zM12 7.75v12.5M12 7.75c-.75-2.25-2.25-4-4-4a2 2 0 0 0 0 4h4zM12 7.75c.75-2.25 2.25-4 4-4a2 2 0 0 1 0 4h-4z" stroke="#6C747D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -24,7 +24,7 @@ describe('Unit | Utility | event-type-utils', function () {
 
         const newExcludedEvents = toggleEventType('payment_event', eventTypes);
 
-        expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event');
+        expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event,gift_redemption_event');
     });
 
     it('should toggle both payment_event and donation_event off when toggling payment_event off', function () {

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -85,7 +85,8 @@ module.exports = class EventRepository {
                 {type: 'login_event', action: 'getLoginEvents'},
                 {type: 'payment_event', action: 'getPaymentEvents'},
                 {type: 'email_change_event', action: 'getEmailChangeEvent'},
-                {type: 'gift_purchase_event', action: 'getGiftPurchaseEvents'}
+                {type: 'gift_purchase_event', action: 'getGiftPurchaseEvents'},
+                {type: 'gift_redemption_event', action: 'getGiftRedemptionEvents'}
             );
 
             if (this._AutomatedEmailRecipient) {
@@ -464,6 +465,55 @@ module.exports = class EventRepository {
                     amount: json.amount,
                     currency: json.currency,
                     created_at: json.purchased_at
+                }
+            };
+        });
+
+        return {
+            data,
+            meta
+        };
+    }
+
+    async getGiftRedemptionEvents(options = {}, filter) {
+        options = {
+            ...options,
+            withRelated: ['redeemer', 'tier'],
+            filter: 'redeemer_member_id:-null+custom:true',
+            useBasicCount: true,
+            mongoTransformer: chainTransformers(
+                // First set the filter manually
+                replaceCustomFilterTransformer(filter),
+
+                // Map the used keys in that filter
+                ...mapKeys({
+                    'data.created_at': 'redeemed_at',
+                    'data.member_id': 'redeemer_member_id'
+                })
+            )
+        };
+
+        if (options.order) {
+            options.order = options.order.replace(/created_at/g, 'redeemed_at');
+        }
+
+        const {data: models, meta} = await this._Gift.findPage(options);
+
+        const data = models.map((model) => {
+            const json = model.toJSON(options);
+
+            return {
+                type: 'gift_redemption_event',
+                data: {
+                    id: json.id,
+                    member: json.redeemer || null,
+                    member_id: json.redeemer_member_id,
+                    tier_name: json.tier?.name,
+                    cadence: json.cadence,
+                    duration: json.duration,
+                    amount: json.amount,
+                    currency: json.currency,
+                    created_at: json.redeemed_at
                 }
             };
         });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -535,4 +535,127 @@ describe('EventRepository', function () {
             assert.equal(event.data.member_id, null);
         });
     });
+
+    describe('getGiftRedemptionEvents', function () {
+        let eventRepository;
+        let fake;
+
+        before(function () {
+            fake = sinon.fake.returns({data: [{
+                toJSON: () => ({
+                    id: 'gift123',
+                    redeemer_member_id: 'member789',
+                    redeemer: {id: 'member789', name: 'Test Redeemer', email: 'redeemer@example.com'},
+                    tier: {name: 'Gold'},
+                    amount: 5000,
+                    currency: 'usd',
+                    cadence: 'year',
+                    duration: 1,
+                    redeemed_at: '2024-08-20T09:30:00.000Z',
+                    token: 'secret-token',
+                    stripe_checkout_session_id: 'cs_123',
+                    stripe_payment_intent_id: 'pi_123',
+                    status: 'redeemed'
+                })
+            }]});
+            eventRepository = new EventRepository({
+                EmailRecipient: null,
+                MemberSubscribeEvent: null,
+                MemberPaymentEvent: null,
+                MemberStatusEvent: null,
+                MemberLoginEvent: null,
+                MemberPaidSubscriptionEvent: null,
+                labsService: null,
+                Gift: {
+                    findPage: fake
+                }
+            });
+        });
+
+        afterEach(function () {
+            fake.resetHistory();
+        });
+
+        it('queries with correct options', async function () {
+            await eventRepository.getGiftRedemptionEvents({
+                filter: 'not used',
+                order: 'created_at desc, id desc'
+            }, {
+                type: 'unused'
+            });
+
+            sinon.assert.calledOnceWithMatch(fake, {
+                withRelated: ['redeemer', 'tier'],
+                filter: 'redeemer_member_id:-null+custom:true',
+                order: 'redeemed_at desc, id desc'
+            });
+        });
+
+        it('returns correctly formatted gift_redemption_event', async function () {
+            const result = await eventRepository.getGiftRedemptionEvents({
+                order: 'created_at desc, id desc'
+            }, {});
+
+            assert.equal(result.data.length, 1);
+
+            const event = result.data[0];
+
+            assert.equal(event.type, 'gift_redemption_event');
+            assert.equal(event.data.id, 'gift123');
+            assert.equal(event.data.amount, 5000);
+            assert.equal(event.data.currency, 'usd');
+            assert.equal(event.data.tier_name, 'Gold');
+            assert.equal(event.data.cadence, 'year');
+            assert.equal(event.data.duration, 1);
+            assert.equal(event.data.member_id, 'member789');
+            assert.equal(event.data.created_at, '2024-08-20T09:30:00.000Z');
+            assert.deepEqual(event.data.member, {
+                id: 'member789',
+                name: 'Test Redeemer',
+                email: 'redeemer@example.com'
+            });
+        });
+
+        it('excludes internal fields from event data', async function () {
+            const result = await eventRepository.getGiftRedemptionEvents({}, {});
+
+            const event = result.data[0];
+
+            assert.equal(event.data.token, undefined);
+            assert.equal(event.data.stripe_checkout_session_id, undefined);
+            assert.equal(event.data.stripe_payment_intent_id, undefined);
+            assert.equal(event.data.status, undefined);
+        });
+
+        it('sets member to null when redeemer is not present', async function () {
+            const nullRedeemerFake = sinon.fake.returns({data: [{
+                toJSON: () => ({
+                    id: 'gift999',
+                    redeemer_member_id: null,
+                    redeemer: null,
+                    amount: 3000,
+                    currency: 'eur',
+                    redeemed_at: '2024-09-01T12:00:00.000Z'
+                })
+            }]});
+            const repo = new EventRepository({
+                EmailRecipient: null,
+                MemberSubscribeEvent: null,
+                MemberPaymentEvent: null,
+                MemberStatusEvent: null,
+                MemberLoginEvent: null,
+                MemberPaidSubscriptionEvent: null,
+                labsService: null,
+                Gift: {
+                    findPage: nullRedeemerFake
+                }
+            });
+
+            const result = await repo.getGiftRedemptionEvents({}, {});
+            const event = result.data[0];
+
+            assert.equal(event.data.member, null);
+            assert.equal(event.data.member_id, null);
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3533

- adds a `gift_redemption_event` to the member activity feed so that when a member redeems a gift subscription, their timeline shows a dedicated entry:

> **🎁 Started paid subscription (Ultra) via gift**

- the existing `gift_purchase_event` also adopts the new gift icon so both sides of a gift read consistently in the buyer's and redeemer's member pages

