### PR TITLE
Fixed unwanted new free member notification when redeeming a gift

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-controller.ts
+++ b/ghost/core/core/server/services/gifts/gift-controller.ts
@@ -99,10 +99,7 @@ export class GiftController {
             });
         }
 
-        const gift = await this.service.redeem({
-            token,
-            memberId: member.id
-        });
+        const gift = await this.service.redeem(token, member.id);
 
         return this.serializeGift(gift);
     }

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -247,56 +247,68 @@ export class GiftService {
         return gift;
     }
 
-    async redeem({token, memberId}: {token: string; memberId: string}): Promise<Gift> {
-        const {redeemed, member} = await this.deps.giftRepository.transaction(async (transacting) => {
-            const _member = await this.deps.memberRepository.get({id: memberId}, {transacting, forUpdate: true});
-
-            if (!_member) {
+    async redeem(token: string, memberId: string, options: {transacting?: {executionPromise: Promise<unknown>}; newMember?: boolean} = {}): Promise<Gift> {
+        const run = async (transacting: unknown) => {
+            const member = await this.deps.memberRepository.get({id: memberId}, {transacting, forUpdate: true});
+            if (!member) {
                 throw new errors.NotFoundError({message: `Member not found: ${memberId}`});
             }
 
             const gift = await this.deps.giftRepository.getByToken(token, {transacting, forUpdate: true});
-
             if (!gift) {
                 throw new errors.NotFoundError({message: tpl(errorMessages.giftNotFound)});
             }
 
-            await this.assertRedeemable(gift, _member.get('status'));
+            if (options.newMember) {
+                await this.assertRedeemable(gift, null);
+            } else {
+                await this.assertRedeemable(gift, member.get('status'));
+            }
 
-            const _redeemed = gift.redeem({memberId});
+            const redeemed = gift.redeem({memberId});
 
             await this.deps.memberRepository.update({
                 products: [{
-                    id: _redeemed.tierId,
-                    expiry_at: _redeemed.consumesAt
+                    id: redeemed.tierId,
+                    expiry_at: redeemed.consumesAt
                 }],
                 status: 'gift'
             }, {id: memberId, transacting});
 
-            await this.deps.giftRepository.update(_redeemed, {transacting});
+            await this.deps.giftRepository.update(redeemed, {transacting});
 
-            return {
-                redeemed: _redeemed,
-                member: _member
-            };
-        });
+            return {redeemed, member};
+        };
 
-        try {
-            const tier = await this.deps.tiersService.api.read(redeemed.tierId);
+        const {redeemed, member} = options.transacting
+            ? await run(options.transacting)
+            : await this.deps.giftRepository.transaction(run);
 
-            if (!tier) {
-                throw new errors.NotFoundError({message: `Tier not found: ${redeemed.tierId}`});
+        const notify = async () => {
+            try {
+                const tier = await this.deps.tiersService.api.read(redeemed.tierId);
+
+                if (!tier) {
+                    throw new errors.NotFoundError({message: `Tier not found: ${redeemed.tierId}`});
+                }
+
+                await this.deps.staffServiceEmails.notifyGiftSubscriptionStarted({
+                    memberId: member.id,
+                    memberEmail: member.get('email'),
+                    memberName: member.get('name'),
+                    tierName: tier.name,
+                    buyerEmail: redeemed.buyerEmail
+                });
+            } catch (err) {
+                logging.error('Failed to notify staff of gift redemption', err);
             }
+        };
 
-            await this.deps.staffServiceEmails.notifyGiftSubscriptionStarted({
-                memberId: member.id,
-                memberEmail: member.get('email'),
-                memberName: member.get('name'),
-                tierName: tier.name,
-                buyerEmail: redeemed.buyerEmail
-            });
-        } catch (err) {
-            logging.error('Failed to notify staff of gift redemption', err);
+        if (options.transacting) {
+            // Only notify once the transaction has finished
+            options.transacting.executionPromise.then(notify, () => {});
+        } else {
+            await notify();
         }
 
         return redeemed;

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -278,10 +278,7 @@ module.exports = function MembersAPI({
             }
 
             if (giftToken && giftSubscriptionsEnabled) {
-                await giftService.service.redeem({
-                    token: giftToken,
-                    memberId: member.id
-                });
+                await giftService.service.redeem(giftToken, member.id);
             }
 
             await MemberLoginEvent.add({member_id: member.id});
@@ -306,13 +303,19 @@ module.exports = function MembersAPI({
             }
         }
 
-        const newMember = await users.create({name, email, labels, newsletters, attribution, geolocation});
+        let newMember;
 
         if (giftToken && giftSubscriptionsEnabled) {
-            await giftService.service.redeem({
-                token: giftToken,
-                memberId: newMember.id
+            newMember = await Member.transaction(async (transacting) => {
+                const created = await users.create(
+                    {name, email, labels, newsletters, attribution, geolocation, status: 'gift'},
+                    {transacting}
+                );
+                await giftService.service.redeem(giftToken, created.id, {transacting, newMember: true});
+                return created;
             });
+        } else {
+            newMember = await users.create({name, email, labels, newsletters, attribution, geolocation});
         }
 
         await MemberLoginEvent.add({member_id: newMember.id});

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -287,6 +287,7 @@ module.exports = class MemberRepository {
      * @param {Object[]} [data.newsletters]
      * @param {Object} [data.stripeCustomer]
      * @param {string} [data.offerId]
+     * @param {string} [data.status]
      * @param {import('@tryghost/member-attribution/lib/Attribution').AttributionResource} [data.attribution]
      * @param {boolean} [data.email_disabled]
      * @param {*} options
@@ -312,7 +313,7 @@ module.exports = class MemberRepository {
             });
         }
 
-        const memberData = _.pick(data, ['email', 'name', 'note', 'subscribed', 'geolocation', 'created_at', 'products', 'newsletters', 'email_disabled']);
+        const memberData = _.pick(data, ['email', 'name', 'note', 'subscribed', 'geolocation', 'created_at', 'products', 'newsletters', 'email_disabled', 'status']);
 
         // Generate a random transient_id
         memberData.transient_id = await this._generateTransientId();
@@ -340,12 +341,12 @@ module.exports = class MemberRepository {
             }
         }
 
-        const memberStatusData = {
-            status: 'free'
-        };
-
-        if (memberData.products && memberData.products.length === 1) {
-            memberStatusData.status = 'comped';
+        if (!memberData.status) {
+            if (memberData.products && memberData.products.length === 1) {
+                memberData.status = 'comped';
+            } else {
+                memberData.status = 'free';
+            }
         }
 
         // Subscribe members to default newsletters
@@ -369,7 +370,7 @@ module.exports = class MemberRepository {
         const memberAddOptions = {...(options || {}), withRelated};
         let member;
 
-        const isFreeSignup = !stripeCustomer;
+        const isFreeSignup = !stripeCustomer && memberData.status === 'free';
         const shouldCheckFreeWelcomeEmail = WELCOME_EMAIL_SOURCES.includes(source) && isFreeSignup;
         let isFreeWelcomeEmailActive = false;
         let freeWelcomeAutomation = null;
@@ -393,7 +394,6 @@ module.exports = class MemberRepository {
             const runMemberCreation = async (transacting) => {
                 const newMember = await this._Member.add({
                     ...memberData,
-                    ...memberStatusData,
                     labels
                 }, {...memberAddOptions, transacting});
 
@@ -420,7 +420,6 @@ module.exports = class MemberRepository {
         } else {
             member = await this._Member.add({
                 ...memberData,
-                ...memberStatusData,
                 labels
             }, memberAddOptions);
         }

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -11,6 +11,7 @@ const crypto = require('crypto');
 const hasActiveOffer = require('../utils/has-active-offer');
 const StartAutomationsPollEvent = require('../../../welcome-email-automations/events/start-automations-poll-event');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../member-welcome-emails/constants');
+
 const messages = {
     noStripeConnection: 'Cannot {action} without a Stripe Connection',
     moreThanOneProduct: 'A member cannot have more than one Product',
@@ -32,12 +33,13 @@ const messages = {
     offerAlreadyRedeemed: 'This offer has already been redeemed on this subscription',
     subscriptionNotActive: 'Cannot apply offer to an inactive subscription',
     subscriptionHasOffer: 'Subscription already has an offer applied',
-    subscriptionCancelling: 'Cannot apply retention offer to a subscription that is already cancelling'
+    subscriptionCancelling: 'Cannot apply retention offer to a subscription that is already cancelling',
+    invalidMemberStatus: 'Invalid member status, must be one of {statuses}'
 };
 
 const SUBSCRIPTION_STATUS_TRIALING = 'trialing';
-
 const WELCOME_EMAIL_SOURCES = ['member'];
+const MEMBER_STATUSES = ['free', 'paid', 'comped', 'gift'];
 
 /**
  * @typedef {object} ITokenService
@@ -341,6 +343,13 @@ module.exports = class MemberRepository {
             }
         }
 
+        if (memberData.status && !MEMBER_STATUSES.includes(memberData.status)) {
+            throw new errors.ValidationError({
+                message: tpl(messages.invalidMemberStatus, {statuses: MEMBER_STATUSES.join(', ')}),
+                property: 'status'
+            });
+        }
+
         if (!memberData.status) {
             if (memberData.products && memberData.products.length === 1) {
                 memberData.status = 'comped';
@@ -580,6 +589,13 @@ module.exports = class MemberRepository {
             throw new errors.ValidationError({
                 message: tpl(messages.invalidEmail),
                 property: 'email'
+            });
+        }
+
+        if (data.status && !MEMBER_STATUSES.includes(data.status)) {
+            throw new errors.ValidationError({
+                message: tpl(messages.invalidMemberStatus, {statuses: MEMBER_STATUSES.join(', ')}),
+                property: 'status'
             });
         }
 

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -755,6 +755,25 @@ describe('Gift Subscriptions', function () {
                     const existingMember = await models.Member.findOne({email}, {require: false});
                     assert.equal(existingMember, null, 'Member should not exist before magic link confirmation');
 
+                    // Set up an active free welcome email automation so the test would catch
+                    // any regression that re-introduces the spurious automation run for gift members
+                    const emailDesignSetting = await models.EmailDesignSetting.findOne(
+                        {slug: 'default-automated-email'},
+                        {require: true}
+                    );
+                    const welcomeEmailAutomation = await models.WelcomeEmailAutomation.add({
+                        name: 'Free welcome email',
+                        slug: 'member-welcome-email-free',
+                        status: 'active'
+                    });
+                    await models.WelcomeEmailAutomatedEmail.add({
+                        welcome_email_automation_id: welcomeEmailAutomation.id,
+                        delay_days: 0,
+                        subject: 'Welcome to the site!',
+                        lexical: JSON.stringify({root: {children: [{type: 'paragraph', children: [{text: 'Welcome'}]}]}}),
+                        email_design_setting_id: emailDesignSetting.id
+                    });
+
                     try {
                         await models.Product.edit({
                             welcome_page_url: ''
@@ -791,12 +810,19 @@ describe('Gift Subscriptions', function () {
                         assert.ok(gift.get('redeemed_at'));
                         assert.ok(gift.get('consumes_at'));
 
-                        // TODO: Re-enable this once we've gotten rid of the unwanted "New free member" notification
-                        // // Verify gift subscription started staff notification was sent
-                        // mockManager.assert.sentEmail({
-                        //     subject: /new paid subscriber/i,
-                        //     to: 'jbloggs@example.com'
-                        // });
+                        // Verify the free welcome automation did NOT enqueue a run for this gift member
+                        const welcomeRuns = await models.WelcomeEmailAutomationRun.findAll({
+                            filter: `member_id:'${member.id}'`
+                        });
+                        assert.equal(welcomeRuns.length, 0, 'Should not enqueue free welcome email automation for gift member');
+
+                        // Verify gift subscription started staff notification was sent,
+                        // and that no other unwanted staff notifications were sent (i.e. no "Free member signup" email)
+                        mockManager.assert.sentEmail({
+                            subject: /new paid subscriber/i,
+                            to: 'jbloggs@example.com'
+                        });
+                        mockManager.assert.sentEmailCount(1);
 
                         // Verify the redirect URL was used
                         assert.equal(location.searchParams.get('action'), 'subscribe');
@@ -809,6 +835,7 @@ describe('Gift Subscriptions', function () {
                         }, {
                             id: paidProduct.id
                         });
+                        await models.WelcomeEmailAutomation.destroy({id: welcomeEmailAutomation.id});
                     }
                 });
             });

--- a/ghost/core/test/unit/server/services/gifts/gift-controller.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-controller.test.ts
@@ -288,10 +288,7 @@ describe('GiftController', function () {
                 }
             });
 
-            sinon.assert.calledOnceWithExactly(service.redeem, {
-                token: 'gift-token',
-                memberId: 'member_1'
-            });
+            sinon.assert.calledOnceWithExactly(service.redeem, 'gift-token', 'member_1');
             sinon.assert.calledOnceWithExactly(tiersService.api.read, 'tier_1');
             assert.deepEqual(result, {
                 token: 'gift-token',

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -963,10 +963,7 @@ describe('GiftService', function () {
             });
 
             const service = createService();
-            const redeemed = await service.redeem({
-                token: 'gift-token',
-                memberId: 'member_1'
-            });
+            const redeemed = await service.redeem('gift-token', 'member_1');
 
             sinon.assert.calledOnce(giftRepository.transaction);
             sinon.assert.calledOnceWithExactly(giftRepository.getByToken, 'gift-token', {transacting: 'trx', forUpdate: true});
@@ -1011,13 +1008,69 @@ describe('GiftService', function () {
             staffServiceEmails.notifyGiftSubscriptionStarted.rejects(new Error('SMTP error'));
 
             const service = createService();
-            const redeemed = await service.redeem({
-                token: 'gift-token',
-                memberId: 'member_1'
-            });
+            const redeemed = await service.redeem('gift-token', 'member_1');
 
             assert.equal(redeemed.status, 'redeemed');
             sinon.assert.calledOnce(staffServiceEmails.notifyGiftSubscriptionStarted);
+        });
+
+        it('uses an external transaction when provided instead of creating its own', async function () {
+            const gift = buildGift();
+
+            giftRepository.getByToken.resolves(gift);
+            memberRepository.get.resolves({
+                id: 'member_1',
+                get: sinon.stub().withArgs('status').returns('free')
+            });
+
+            const service = createService();
+            const externalTrx = {executionPromise: Promise.resolve()};
+            const redeemed = await service.redeem('gift-token', 'member_1', {transacting: externalTrx});
+
+            sinon.assert.notCalled(giftRepository.transaction);
+            sinon.assert.calledOnceWithExactly(giftRepository.getByToken, 'gift-token', {transacting: externalTrx, forUpdate: true});
+            sinon.assert.calledOnceWithExactly(memberRepository.get, {id: 'member_1'}, {transacting: externalTrx, forUpdate: true});
+            sinon.assert.calledOnceWithExactly(memberRepository.update, {
+                products: [{
+                    id: 'tier_1',
+                    expiry_at: redeemed.consumesAt
+                }],
+                status: 'gift'
+            }, {
+                id: 'member_1',
+                transacting: externalTrx
+            });
+            sinon.assert.calledOnceWithExactly(giftRepository.update, redeemed, {transacting: externalTrx});
+            assert.equal(redeemed.status, 'redeemed');
+        });
+
+        it('allows a newly created gift member to redeem when newMember is true', async function () {
+            const gift = buildGift();
+
+            giftRepository.getByToken.resolves(gift);
+            memberRepository.get.resolves({
+                id: 'member_1',
+                get: sinon.stub().withArgs('status').returns('gift')
+            });
+
+            const service = createService();
+            const redeemed = await service.redeem('gift-token', 'member_1', {newMember: true});
+
+            sinon.assert.calledOnce(giftRepository.transaction);
+            sinon.assert.calledOnceWithExactly(memberRepository.get, {id: 'member_1'}, {transacting: 'trx', forUpdate: true});
+            sinon.assert.calledOnceWithExactly(giftRepository.getByToken, 'gift-token', {transacting: 'trx', forUpdate: true});
+            sinon.assert.calledOnceWithExactly(memberRepository.update, {
+                products: [{
+                    id: 'tier_1',
+                    expiry_at: redeemed.consumesAt
+                }],
+                status: 'gift'
+            }, {
+                id: 'member_1',
+                transacting: 'trx'
+            });
+            sinon.assert.calledOnceWithExactly(giftRepository.update, redeemed, {transacting: 'trx'});
+            assert.equal(redeemed.status, 'redeemed');
         });
 
         it('throws NotFoundError when the member does not exist', async function () {
@@ -1025,10 +1078,7 @@ describe('GiftService', function () {
 
             const service = createService();
             await assert.rejects(
-                () => service.redeem({
-                    token: 'gift-token',
-                    memberId: 'missing-member'
-                }),
+                () => service.redeem('gift-token', 'missing-member'),
                 (err: any) => {
                     assert.equal(err.errorType, 'NotFoundError');
                     assert.equal(err.message, 'Member not found: missing-member');
@@ -1046,10 +1096,7 @@ describe('GiftService', function () {
 
             const service = createService();
             await assert.rejects(
-                () => service.redeem({
-                    token: 'missing-token',
-                    memberId: 'member_1'
-                }),
+                () => service.redeem('missing-token', 'member_1'),
                 (err: any) => {
                     assert.equal(err.errorType, 'NotFoundError');
                     assert.equal(err.message, 'This gift does not exist.');
@@ -1071,10 +1118,7 @@ describe('GiftService', function () {
 
             const service = createService();
             await assert.rejects(
-                () => service.redeem({
-                    token: 'gift-token',
-                    memberId: 'member_1'
-                }),
+                () => service.redeem('gift-token', 'member_1'),
                 (err: any) => {
                     assert.equal(err.errorType, 'BadRequestError');
                     assert.equal(err.message, 'You already have an active subscription.');

--- a/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
@@ -12,6 +12,7 @@ describe('MembersAPI', function () {
     let memberLoginEvent;
     let labsService;
     let tokenData;
+    let MemberModel;
 
     const createRouterStub = () => {
         const router = {};
@@ -106,7 +107,7 @@ describe('MembersAPI', function () {
                 EmailRecipient: {},
                 StripeCustomer: {},
                 StripeCustomerSubscription: {},
-                Member: {},
+                Member: MemberModel,
                 MemberNewsletter: {},
                 MemberCancelEvent: {},
                 MemberSubscribeEvent: {},
@@ -187,6 +188,11 @@ describe('MembersAPI', function () {
         labsService = {
             isSet: sinon.stub().returns(true)
         };
+        MemberModel = {
+            transaction: sinon.stub().callsFake(async (callback) => {
+                return await callback('trx');
+            })
+        };
 
         membersAPI = buildMembersAPI();
     });
@@ -210,10 +216,7 @@ describe('MembersAPI', function () {
         sinon.assert.calledTwice(memberBREADService.read);
         sinon.assert.calledWithExactly(memberBREADService.read.firstCall, {email: 'jamie@example.com'});
         sinon.assert.calledOnceWithExactly(memberLoginEvent.add, {member_id: 'member_1'});
-        sinon.assert.calledOnceWithExactly(giftRedeem, {
-            token: 'gift-token-123',
-            memberId: 'member_1'
-        });
+        sinon.assert.calledOnceWithExactly(giftRedeem, 'gift-token-123', 'member_1');
         sinon.assert.callOrder(giftRedeem, memberLoginEvent.add);
         assert.equal(result, existingMember);
     });
@@ -232,13 +235,13 @@ describe('MembersAPI', function () {
 
         const result = await membersAPI.getMemberDataFromMagicLinkToken('magic-token');
 
+        sinon.assert.calledOnce(MemberModel.transaction);
         sinon.assert.calledOnce(memberRepository.create);
         assert.equal(memberRepository.create.firstCall.args[0].email, 'jamie@example.com');
         assert.equal(memberRepository.create.firstCall.args[0].name, 'Jamie Larson');
-        sinon.assert.calledOnceWithExactly(giftRedeem, {
-            token: 'gift-token-123',
-            memberId: 'member_2'
-        });
+        assert.equal(memberRepository.create.firstCall.args[0].status, 'gift');
+        assert.deepEqual(memberRepository.create.firstCall.args[1], {transacting: 'trx'});
+        sinon.assert.calledOnceWithExactly(giftRedeem, 'gift-token-123', 'member_2', {transacting: 'trx', newMember: true});
         sinon.assert.calledOnceWithExactly(memberLoginEvent.add, {member_id: 'member_2'});
         sinon.assert.callOrder(giftRedeem, memberLoginEvent.add);
         assert.equal(result, createdMember);
@@ -276,9 +279,6 @@ describe('MembersAPI', function () {
         );
 
         sinon.assert.notCalled(memberLoginEvent.add);
-        sinon.assert.calledOnceWithExactly(giftRedeem, {
-            token: 'gift-token-123',
-            memberId: 'member_1'
-        });
+        sinon.assert.calledOnceWithExactly(giftRedeem, 'gift-token-123', 'member_1');
     });
 });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1682,6 +1682,25 @@ describe('MemberRepository', function () {
             sinon.assert.notCalled(WelcomeEmailAutomation.findOne);
             sinon.assert.notCalled(Member.transaction);
         });
+
+        it('does NOT create automation run when member is created with a non-free status (e.g. gift)', async function () {
+            const repo = new MemberRepository({
+                Member,
+                Outbox,
+                WelcomeEmailAutomationRun,
+                MemberStatusEvent,
+                MemberSubscribeEventModel: MemberSubscribeEvent,
+                newslettersService,
+                WelcomeEmailAutomation,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            await repo.create({email: 'test@example.com', name: 'Test Member', status: 'gift'}, {});
+
+            sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
+            sinon.assert.notCalled(WelcomeEmailAutomation.findOne);
+            sinon.assert.notCalled(Member.transaction);
+        });
     });
 
     describe('linkSubscription - automation run integration', function () {
@@ -1994,6 +2013,96 @@ describe('MemberRepository', function () {
             });
 
             sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
+        });
+    });
+
+    describe('create - status handling', function () {
+        let Member;
+        let MemberStatusEvent;
+        let MemberSubscribeEvent;
+        let newslettersService;
+        let WelcomeEmailAutomation;
+        let productRepository;
+        let memberAdd;
+
+        beforeEach(function () {
+            memberAdd = sinon.stub().resolves({
+                id: 'member_id_status',
+                get: sinon.stub().callsFake((key) => {
+                    const data = {
+                        email: 'test@example.com',
+                        status: 'free',
+                        created_at: new Date()
+                    };
+                    return data[key];
+                }),
+                related: sinon.stub().returns({models: []})
+            });
+
+            Member = {
+                transaction: sinon.stub().callsFake((callback) => {
+                    return callback({executionPromise: Promise.resolve()});
+                }),
+                add: memberAdd
+            };
+
+            MemberStatusEvent = {add: sinon.stub().resolves()};
+            MemberSubscribeEvent = {add: sinon.stub().resolves()};
+
+            newslettersService = {
+                getDefaultNewsletters: sinon.stub().resolves([]),
+                getAll: sinon.stub().resolves([])
+            };
+
+            WelcomeEmailAutomation = {
+                findOne: sinon.stub().resolves(null)
+            };
+
+            productRepository = {
+                get: sinon.stub().resolves({
+                    id: 'tier_1',
+                    get: sinon.stub().withArgs('active').returns(true)
+                })
+            };
+        });
+
+        const buildRepo = () => new MemberRepository({
+            Member,
+            MemberStatusEvent,
+            MemberSubscribeEventModel: MemberSubscribeEvent,
+            newslettersService,
+            WelcomeEmailAutomation,
+            productRepository,
+            OfferRedemption: mockOfferRedemption
+        });
+
+        it('defaults status to "free" when no status and no products are provided', async function () {
+            await buildRepo().create({email: 'test@example.com', name: 'Test Member'}, {});
+
+            sinon.assert.calledOnce(memberAdd);
+            assert.equal(memberAdd.firstCall.args[0].status, 'free');
+        });
+
+        it('defaults status to "comped" when no status is provided but a product is', async function () {
+            await buildRepo().create({
+                email: 'test@example.com',
+                name: 'Test Member',
+                products: [{id: 'tier_1'}]
+            }, {});
+
+            sinon.assert.calledOnce(memberAdd);
+            assert.equal(memberAdd.firstCall.args[0].status, 'comped');
+        });
+
+        it('respects the status passed in data instead of overriding it', async function () {
+            await buildRepo().create({
+                email: 'test@example.com',
+                name: 'Test Member',
+                status: 'gift'
+            }, {});
+
+            sinon.assert.calledOnce(memberAdd);
+            assert.equal(memberAdd.firstCall.args[0].status, 'gift');
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -2016,7 +2016,7 @@ describe('MemberRepository', function () {
         });
     });
 
-    describe('create - status handling', function () {
+    describe('create - member status', function () {
         let Member;
         let MemberStatusEvent;
         let MemberSubscribeEvent;
@@ -2103,6 +2103,211 @@ describe('MemberRepository', function () {
 
             sinon.assert.calledOnce(memberAdd);
             assert.equal(memberAdd.firstCall.args[0].status, 'gift');
+        });
+
+        it('respects the status passed in data even when a product is passed', async function () {
+            await buildRepo().create({
+                email: 'test@example.com',
+                name: 'Test Member',
+                status: 'gift',
+                products: [{id: 'tier_1'}]
+            }, {});
+
+            sinon.assert.calledOnce(memberAdd);
+            assert.equal(memberAdd.firstCall.args[0].status, 'gift');
+        });
+
+        it('rejects invalid status in create', async function () {
+            const repo = buildRepo();
+
+            try {
+                await repo.create({
+                    email: 'test@example.com',
+                    name: 'Test Member',
+                    status: 'not-a-real-status'
+                }, {});
+
+                assert.fail('Expected create to reject invalid status');
+            } catch (err) {
+                assert.equal(err instanceof errors.ValidationError, true);
+                assert.equal(err.property, 'status');
+                assert.equal(err.message, 'Invalid member status, must be one of free, paid, comped, gift');
+            }
+
+            sinon.assert.notCalled(Member.add);
+            sinon.assert.notCalled(Member.transaction);
+        });
+    });
+
+    describe('update - member status', function () {
+        let Member;
+        let MemberProductEvent;
+        let MemberStatusEvent;
+        let MemberSubscribeEvent;
+        let newslettersService;
+        let WelcomeEmailAutomation;
+        let productRepository;
+        let stripeAPIService;
+        let memberEdit;
+        let existingProducts;
+        let existingSubscriptions;
+        let initialMember;
+
+        beforeEach(function () {
+            memberEdit = sinon.stub().callsFake((data) => {
+                return {
+                    id: 'member_id_status',
+                    updated_at: new Date(),
+                    attributes: {
+                        email: 'test@example.com',
+                        status: data.status
+                    },
+                    _previousAttributes: {
+                        email: 'test@example.com',
+                        status: data.status
+                    },
+                    _changed: {},
+                    get: sinon.stub().callsFake((key) => {
+                        const memberData = {
+                            email: 'test@example.com',
+                            status: data.status
+                        };
+                        return memberData[key];
+                    }),
+                    related: sinon.stub().withArgs('stripeCustomers').returns({
+                        fetch: sinon.stub().resolves(),
+                        models: []
+                    })
+                };
+            });
+
+            existingProducts = [];
+            existingSubscriptions = [];
+
+            initialMember = {
+                get: sinon.stub().withArgs('email').returns('test@example.com'),
+                related: sinon.stub().callsFake((relation) => {
+                    if (relation === 'products') {
+                        return {models: existingProducts};
+                    }
+
+                    if (relation === 'stripeSubscriptions') {
+                        return {models: existingSubscriptions};
+                    }
+
+                    if (relation === 'newsletters') {
+                        return {models: []};
+                    }
+
+                    return {models: []};
+                }),
+                load: sinon.stub().resolves()
+            };
+
+            Member = {
+                edit: memberEdit,
+                findOne: sinon.stub().resolves(initialMember)
+            };
+
+            MemberProductEvent = {add: sinon.stub().resolves()};
+            MemberStatusEvent = {add: sinon.stub().resolves()};
+            MemberSubscribeEvent = {add: sinon.stub().resolves()};
+
+            newslettersService = {
+                getDefaultNewsletters: sinon.stub().resolves([]),
+                getAll: sinon.stub().resolves([])
+            };
+
+            WelcomeEmailAutomation = {
+                findOne: sinon.stub().resolves(null)
+            };
+
+            productRepository = {
+                get: sinon.stub().resolves({
+                    id: 'tier_1',
+                    get: sinon.stub().withArgs('active').returns(true)
+                })
+            };
+
+            stripeAPIService = {
+                configured: false
+            };
+        });
+
+        const buildRepo = () => new MemberRepository({
+            Member,
+            MemberProductEvent,
+            MemberStatusEvent,
+            MemberSubscribeEventModel: MemberSubscribeEvent,
+            newslettersService,
+            WelcomeEmailAutomation,
+            productRepository,
+            stripeAPIService,
+            OfferRedemption: mockOfferRedemption
+        });
+
+        it('rejects invalid status in update', async function () {
+            const repo = buildRepo();
+
+            try {
+                await repo.update({
+                    status: 'not-a-real-status'
+                }, {
+                    id: 'member_id_123'
+                });
+
+                assert.fail('Expected update to reject invalid status');
+            } catch (err) {
+                assert.equal(err instanceof errors.ValidationError, true);
+                assert.equal(err.property, 'status');
+                assert.equal(err.message, 'Invalid member status, must be one of free, paid, comped, gift');
+            }
+
+            sinon.assert.notCalled(Member.edit);
+        });
+
+        it('defaults status to "comped" when adding a product without an explicit status', async function () {
+            const repo = buildRepo();
+            stripeAPIService.configured = true;
+
+            await repo.update({
+                products: [{id: 'tier_1'}]
+            }, {
+                id: 'member_id_123'
+            });
+
+            sinon.assert.calledOnce(memberEdit);
+            assert.equal(memberEdit.firstCall.args[0].status, 'comped');
+        });
+
+        it('respects an explicit status when adding a product', async function () {
+            const repo = buildRepo();
+            stripeAPIService.configured = true;
+
+            await repo.update({
+                status: 'gift',
+                products: [{id: 'tier_1'}]
+            }, {
+                id: 'member_id_123'
+            });
+
+            sinon.assert.calledOnce(memberEdit);
+            assert.equal(memberEdit.firstCall.args[0].status, 'gift');
+        });
+
+        it('defaults status to "free" when removing all products without active subscriptions', async function () {
+            const repo = buildRepo();
+            stripeAPIService.configured = true;
+            existingProducts = [{id: 'tier_1'}];
+
+            await repo.update({
+                products: []
+            }, {
+                id: 'member_id_123'
+            });
+
+            sinon.assert.calledOnce(memberEdit);
+            assert.equal(memberEdit.firstCall.args[0].status, 'free');
         });
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3476

- when a new member redeemed a gift subscription, they were briefly created with status 'free' and only flipped to 'gift' by the subsequent redeem call, which triggered the "new free signup" staff notification - now fixed
- they would also receive the free member welcome email - now fixed
- wrapped member creation and gift redemption in a transaction to ensure atomicity

