### PR TITLE
Added gift subscription label and actions in Admin member page

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -138,6 +138,8 @@
                                                     <span class="gh-badge archived" data-test-text="member-subscription-status">Canceled</span>
                                                 {{else if sub.compExpiry}}
                                                     <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
+                                                {{else if sub.giftExpiry}}
+                                                    <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                                 {{else if sub.trialUntil}}
                                                     <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                                 {{else}}
@@ -153,7 +155,9 @@
                                             </div>
                                             <Member::SubscriptionDetailBox @sub={{sub}} @index={{index}} />
                                         </div>
-                                        {{#if sub.isComplimentary}}
+                                        {{#if sub.isGift}}
+                                            {{! Gift subscriptions have no action menu }}
+                                        {{else if sub.isComplimentary}}
                                             <span class="action-menu">
                                                 <GhDropdownButton
                                                     @dropdownName="subscription-menu-complimentary"
@@ -185,7 +189,12 @@
                                             </span>
                                         {{else}}
                                             <span class="action-menu">
-                                                <GhDropdownButton @dropdownName="subscription-menu-{{sub.id}}" @classNames="gh-btn gh-btn-outline gh-btn-icon fill gh-btn-subscription-action icon-only" @title="Actions">
+                                                <GhDropdownButton
+                                                    @dropdownName="subscription-menu-{{sub.id}}"
+                                                    @classNames="gh-btn gh-btn-outline gh-btn-icon fill gh-btn-subscription-action icon-only"
+                                                    @title="Actions"
+                                                    data-test-button="subscription-actions"
+                                                >
                                                     <span>
                                                         {{svg-jar "dotdotdot"}}
                                                         <span class="hidden">Subscription menu</span>

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -20,7 +20,9 @@ export function getSubscriptionData(sub) {
             nonDecimalAmount: getNonDecimal(sub.price.amount)
         },
         isComplimentary: isComplimentary(sub),
+        isGift: isGift(sub),
         compExpiry: compExpiry(sub),
+        giftExpiry: giftExpiry(sub),
         trialUntil: trialUntil(sub)
     };
 
@@ -57,7 +59,15 @@ export function isActive(sub) {
 }
 
 export function isComplimentary(sub) {
-    return !sub.id;
+    const compedNickname = sub.plan?.nickname?.toLowerCase() === 'complimentary';
+
+    return !sub.id && compedNickname;
+}
+
+export function isGift(sub) {
+    const giftNickname = sub.plan?.nickname?.toLowerCase() === 'gift subscription';
+
+    return !sub.id && giftNickname;
 }
 
 export function isCanceled(sub) {
@@ -69,7 +79,23 @@ export function isSetToCancel(sub) {
 }
 
 export function compExpiry(sub) {
-    if (!sub.id && sub.tier && sub.tier.expiry_at) {
+    if (!isComplimentary(sub)) {
+        return undefined;
+    }
+
+    if (sub.tier && sub.tier.expiry_at) {
+        return moment(sub.tier.expiry_at).utc().format('D MMM YYYY');
+    }
+
+    return undefined;
+}
+
+export function giftExpiry(sub) {
+    if (!isGift(sub)) {
+        return undefined;
+    }
+
+    if (sub.tier && sub.tier.expiry_at) {
         return moment(sub.tier.expiry_at).utc().format('D MMM YYYY');
     }
 
@@ -95,6 +121,14 @@ export function validityDetails(data, separatorNeeded = false) {
     if (data.isComplimentary) {
         if (data.compExpiry) {
             return `${separator}Expires ${data.compExpiry}`;
+        } else {
+            return '';
+        }
+    }
+
+    if (data.isGift) {
+        if (data.giftExpiry) {
+            return `${separator}Expires ${data.giftExpiry}`;
         } else {
             return '';
         }

--- a/ghost/admin/tests/acceptance/members/details-test.js
+++ b/ghost/admin/tests/acceptance/members/details-test.js
@@ -15,6 +15,18 @@ describe('Acceptance: Member details', function () {
     let clock;
     let tier;
 
+    function subscriptionSummaryText(tierId) {
+        const priceLabel = find(`[data-test-tier="${tierId}"] .gh-cp-membertier-pricelabel`)?.textContent?.trim() || '';
+        const renewal = find(`[data-test-tier="${tierId}"] .gh-cp-membertier-renewal`)?.textContent?.trim() || '';
+
+        return [priceLabel, renewal]
+            .filter(Boolean)
+            .join(' ')
+            .replace(/–/g, '-')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
     beforeEach(async function () {
         this.server.loadFixtures('configs');
         this.server.loadFixtures('settings');
@@ -303,6 +315,202 @@ describe('Acceptance: Member details', function () {
             .to.equal(2);
         expect(findAll('[data-test-button="add-complimentary"]').length, '# of add complimentary buttons - after add comped')
             .to.equal(0);
+    });
+
+    it('displays gift subscriptions with expiry text and without an action menu', async function () {
+        const giftTier = this.server.create('tier', {
+            id: 'gift-tier-1',
+            name: 'Gift tier',
+            slug: 'gift-tier',
+            created_at: '2022-02-21T16:47:02.000Z',
+            updated_at: '2022-03-03T15:37:02.000Z',
+            description: null,
+            monthly_price_id: 'gift-monthly-price',
+            yearly_price_id: 'gift-yearly-price',
+            type: 'paid',
+            active: true,
+            welcome_page_url: '/',
+            expiry_at: '2022-04-03T00:00:00.000Z'
+        });
+
+        const member = this.server.create('member', {
+            id: 1,
+            status: 'gift',
+            tiers: [giftTier],
+            subscriptions: [
+                this.server.create('subscription', {
+                    id: '',
+                    tier: giftTier,
+                    customer: {
+                        id: '',
+                        name: 'Gift Receiver',
+                        email: 'gift@example.com'
+                    },
+                    plan: {
+                        id: '',
+                        nickname: 'Gift subscription',
+                        amount: 0,
+                        interval: 'year',
+                        currency: 'USD'
+                    },
+                    status: 'active',
+                    start_date: '2022-03-03T15:36:58.000Z',
+                    default_payment_card_last4: '****',
+                    cancel_at_period_end: false,
+                    cancellation_reason: null,
+                    current_period_end: '2022-04-03T15:36:58.000Z',
+                    price: {
+                        id: '',
+                        price_id: '',
+                        nickname: 'Gift subscription',
+                        amount: 0,
+                        interval: 'year',
+                        type: 'recurring',
+                        currency: 'USD',
+                        tier: {
+                            id: '',
+                            tier_id: giftTier.id
+                        }
+                    },
+                    offer: null
+                })
+            ]
+        });
+
+        await visit(`/members/${member.id}`);
+
+        expect(currentURL()).to.equal(`/members/${member.id}`);
+
+        const tierCard = find(`[data-test-tier="${giftTier.id}"]`);
+
+        expect(subscriptionSummaryText(giftTier.id)).to.equal('Gift subscription - Expires 3 Apr 2022');
+        expect(tierCard).to.contain.text('Gift subscription');
+        expect(find(`[data-test-tier="${giftTier.id}"] [data-test-button="subscription-actions"]`)).to.not.exist;
+    });
+
+    it('displays comped subscriptions with expiry text and a complimentary action menu', async function () {
+        const compedTier = this.server.create('tier', {
+            id: 'comped-tier-1',
+            name: 'Comped tier',
+            slug: 'comped-tier',
+            created_at: '2022-02-21T16:47:02.000Z',
+            updated_at: '2022-03-03T15:37:02.000Z',
+            description: null,
+            monthly_price_id: 'comped-monthly-price',
+            yearly_price_id: 'comped-yearly-price',
+            type: 'paid',
+            active: true,
+            welcome_page_url: '/',
+            expiry_at: '2022-04-03T00:00:00.000Z'
+        });
+
+        const member = this.server.create('member', {
+            id: 1,
+            status: 'comped',
+            tiers: [compedTier],
+            subscriptions: [
+                this.server.create('subscription', {
+                    id: '',
+                    tier: compedTier,
+                    customer: {
+                        id: '',
+                        name: 'Comped Receiver',
+                        email: 'comped@example.com'
+                    },
+                    plan: {
+                        id: '',
+                        nickname: 'Complimentary',
+                        amount: 0,
+                        interval: 'year',
+                        currency: 'USD'
+                    },
+                    status: 'active',
+                    start_date: '2022-03-03T15:36:58.000Z',
+                    default_payment_card_last4: '****',
+                    cancel_at_period_end: false,
+                    cancellation_reason: null,
+                    current_period_end: '2022-04-03T15:36:58.000Z',
+                    price: {
+                        id: '',
+                        price_id: '',
+                        nickname: 'Complimentary',
+                        amount: 0,
+                        interval: 'year',
+                        type: 'recurring',
+                        currency: 'USD',
+                        tier: {
+                            id: '',
+                            tier_id: compedTier.id
+                        }
+                    },
+                    offer: null
+                })
+            ]
+        });
+
+        await visit(`/members/${member.id}`);
+
+        expect(currentURL()).to.equal(`/members/${member.id}`);
+        expect(subscriptionSummaryText(compedTier.id)).to.equal('Complimentary - Expires 3 Apr 2022');
+        expect(find(`[data-test-tier="${compedTier.id}"] [data-test-button="subscription-actions"]`)).to.exist;
+
+        await click(`[data-test-tier="${compedTier.id}"] [data-test-button="subscription-actions"]`);
+        expect(find('.tier-actions-menu')).to.contain.text('Remove complimentary subscription');
+    });
+
+    it('displays paid subscriptions with Stripe actions', async function () {
+        const member = this.server.create('member', {
+            id: 1,
+            subscriptions: [
+                this.server.create('subscription', {
+                    id: 'sub_paid_1',
+                    tier,
+                    customer: {
+                        id: 'cus_paid_1',
+                        name: 'Paid Member',
+                        email: 'paid@example.com'
+                    },
+                    plan: {
+                        id: 'price_paid_1',
+                        nickname: 'Monthly',
+                        amount: 500,
+                        interval: 'month',
+                        currency: 'USD'
+                    },
+                    status: 'active',
+                    start_date: '2022-03-03T15:36:58.000Z',
+                    default_payment_card_last4: '4242',
+                    cancel_at_period_end: false,
+                    cancellation_reason: null,
+                    current_period_end: '2022-04-03T15:36:58.000Z',
+                    price: {
+                        id: 'price_paid_1',
+                        price_id: '6220df272fee0571b5dd0a0a',
+                        nickname: 'Monthly',
+                        amount: 500,
+                        interval: 'month',
+                        type: 'recurring',
+                        currency: 'USD',
+                        tier: {
+                            id: 'prod_paid_1',
+                            tier_id: tier.id
+                        }
+                    },
+                    offer: null
+                })
+            ],
+            tiers: [tier]
+        });
+
+        await visit(`/members/${member.id}`);
+
+        expect(currentURL()).to.equal(`/members/${member.id}`);
+        expect(subscriptionSummaryText(tier.id)).to.equal('Renews 3 Apr 2022');
+        expect(find(`[data-test-tier="${tier.id}"] [data-test-button="subscription-actions"]`)).to.exist;
+
+        await click(`[data-test-tier="${tier.id}"] [data-test-button="subscription-actions"]`);
+        expect(find('.tier-actions-menu')).to.contain.text('View Stripe customer');
+        expect(find('.tier-actions-menu')).to.contain.text('View Stripe subscription');
     });
 
     it('handles multiple tiers', async function () {

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -1,5 +1,5 @@
 import moment from 'moment-timezone';
-import {compExpiry, getDiscountPrice, getOfferDisplayData, getSubscriptionData, isActive, isCanceled, isComplimentary, isSetToCancel, priceLabel, trialUntil, validUntil, validityDetails} from 'ghost-admin/utils/subscription-data';
+import {compExpiry, getDiscountPrice, getOfferDisplayData, getSubscriptionData, giftExpiry, isActive, isCanceled, isComplimentary, isGift, isSetToCancel, priceLabel, trialUntil, validUntil, validityDetails} from 'ghost-admin/utils/subscription-data';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 
@@ -107,13 +107,25 @@ describe('Unit: Util: subscription-data', function () {
 
     describe('isComplimentary', function () {
         it('returns true for complimentary subscriptions', function () {
-            let sub = {id: null};
+            let sub = {id: null, plan: {nickname: 'Complimentary'}};
             expect(isComplimentary(sub)).to.be.true;
         });
 
         it('returns false for paid subscriptions', function () {
             let sub = {id: 'sub_123'};
             expect(isComplimentary(sub)).to.be.false;
+        });
+    });
+
+    describe('isGift', function () {
+        it('returns true for gift subscriptions', function () {
+            let sub = {id: null, plan: {nickname: 'Gift subscription'}};
+            expect(isGift(sub)).to.be.true;
+        });
+
+        it('returns false for complimentary subscriptions', function () {
+            let sub = {id: null, plan: {nickname: 'Complimentary'}};
+            expect(isGift(sub)).to.be.false;
         });
     });
 
@@ -164,14 +176,52 @@ describe('Unit: Util: subscription-data', function () {
     });
 
     describe('compExpiry', function () {
-        it('returns the complimentary expiry date for complimentary subscriptions', function () {
-            let sub = {id: null, tier: {expiry_at: moment.utc('2021-05-31').toISOString()}};
+        it('returns the expiry date for complimentary subscriptions', function () {
+            let sub = {
+                id: null,
+                plan: {nickname: 'Complimentary'},
+                tier: {expiry_at: moment.utc('2021-05-31').toISOString()}
+            };
             expect(compExpiry(sub)).to.equal('31 May 2021');
+        });
+
+        it('returns undefined for gift subscriptions', function () {
+            let sub = {
+                id: null,
+                plan: {nickname: 'Gift subscription'},
+                tier: {expiry_at: moment.utc('2021-05-31').toISOString()}
+            };
+            expect(compExpiry(sub)).to.be.undefined;
         });
 
         it('returns undefined for paid subscriptions', function () {
             let sub = {id: 'sub_123'};
             expect(compExpiry(sub)).to.be.undefined;
+        });
+    });
+
+    describe('giftExpiry', function () {
+        it('returns the expiry date for gift subscriptions', function () {
+            let sub = {
+                id: null,
+                plan: {nickname: 'Gift subscription'},
+                tier: {expiry_at: moment.utc('2021-05-31').toISOString()}
+            };
+            expect(giftExpiry(sub)).to.equal('31 May 2021');
+        });
+
+        it('returns undefined for complimentary subscriptions', function () {
+            let sub = {
+                id: null,
+                plan: {nickname: 'Complimentary'},
+                tier: {expiry_at: moment.utc('2021-05-31').toISOString()}
+            };
+            expect(giftExpiry(sub)).to.be.undefined;
+        });
+
+        it('returns undefined for paid subscriptions', function () {
+            let sub = {id: 'sub_123'};
+            expect(giftExpiry(sub)).to.be.undefined;
         });
     });
 
@@ -210,6 +260,14 @@ describe('Unit: Util: subscription-data', function () {
                 compExpiry: undefined
             };
             expect(validityDetails(data)).to.equal('');
+        });
+
+        it('returns "Expires {giftExpiry}" for gift subscriptions', function () {
+            let data = {
+                isGift: true,
+                giftExpiry: '31 May 2021'
+            };
+            expect(validityDetails(data)).to.equal('Expires 31 May 2021');
         });
 
         it('returns "Ended {validUntil}" for canceled subscriptions', function () {
@@ -261,7 +319,9 @@ describe('Unit: Util: subscription-data', function () {
 
             expect(data).to.include({
                 isComplimentary: false,
+                isGift: false,
                 compExpiry: undefined,
+                giftExpiry: undefined,
                 hasEnded: false,
                 validUntil: '31 May 2021',
                 willEndSoon: false,
@@ -288,7 +348,9 @@ describe('Unit: Util: subscription-data', function () {
 
             expect(data).to.include({
                 isComplimentary: false,
+                isGift: false,
                 compExpiry: undefined,
+                giftExpiry: undefined,
                 hasEnded: false,
                 validUntil: '31 May 2222',
                 willEndSoon: false,
@@ -320,7 +382,9 @@ describe('Unit: Util: subscription-data', function () {
 
             expect(data).to.include({
                 isComplimentary: false,
+                isGift: false,
                 compExpiry: undefined,
+                giftExpiry: undefined,
                 hasEnded: false,
                 validUntil: '31 May 2222',
                 willEndSoon: false,
@@ -347,7 +411,9 @@ describe('Unit: Util: subscription-data', function () {
 
             expect(data).to.include({
                 isComplimentary: false,
+                isGift: false,
                 compExpiry: undefined,
+                giftExpiry: undefined,
                 hasEnded: true,
                 validUntil: '',
                 willEndSoon: false,
@@ -374,7 +440,9 @@ describe('Unit: Util: subscription-data', function () {
 
             expect(data).to.include({
                 isComplimentary: false,
+                isGift: false,
                 compExpiry: undefined,
+                giftExpiry: undefined,
                 hasEnded: false,
                 validUntil: '31 May 2021',
                 willEndSoon: true,
@@ -391,6 +459,9 @@ describe('Unit: Util: subscription-data', function () {
                 cancel_at_period_end: false,
                 current_period_end: '2021-05-31',
                 trial_end_at: null,
+                plan: {
+                    nickname: 'Complimentary'
+                },
                 tier: {
                     expiry_at: null
                 },
@@ -404,7 +475,9 @@ describe('Unit: Util: subscription-data', function () {
 
             expect(data).to.include({
                 isComplimentary: true,
+                isGift: false,
                 compExpiry: undefined,
+                giftExpiry: undefined,
                 hasEnded: false,
                 validUntil: '31 May 2021',
                 willEndSoon: false,
@@ -421,6 +494,9 @@ describe('Unit: Util: subscription-data', function () {
                 cancel_at_period_end: false,
                 current_period_end: '2021-05-31',
                 trial_end_at: null,
+                plan: {
+                    nickname: 'Complimentary'
+                },
                 tier: {
                     expiry_at: moment.utc('2021-05-31').toISOString()
                 },
@@ -434,12 +510,49 @@ describe('Unit: Util: subscription-data', function () {
 
             expect(data).to.include({
                 isComplimentary: true,
+                isGift: false,
                 compExpiry: '31 May 2021',
+                giftExpiry: undefined,
                 hasEnded: false,
                 validUntil: '31 May 2021',
                 willEndSoon: false,
                 trialUntil: undefined,
                 priceLabel: 'Complimentary',
+                validityDetails: ' – Expires 31 May 2021'
+            });
+        });
+
+        it('returns the correct data for a gift subscription with an expiration date', function () {
+            let sub = {
+                id: null,
+                status: 'active',
+                cancel_at_period_end: false,
+                current_period_end: '2021-05-31',
+                trial_end_at: null,
+                plan: {
+                    nickname: 'Gift subscription'
+                },
+                tier: {
+                    expiry_at: moment.utc('2021-05-31').toISOString()
+                },
+                price: {
+                    currency: 'usd',
+                    amount: 0,
+                    nickname: 'Gift subscription'
+                }
+            };
+            let data = getSubscriptionData(sub);
+
+            expect(data).to.include({
+                isComplimentary: false,
+                isGift: true,
+                compExpiry: undefined,
+                giftExpiry: '31 May 2021',
+                hasEnded: false,
+                validUntil: '31 May 2021',
+                willEndSoon: false,
+                trialUntil: undefined,
+                priceLabel: 'Gift subscription',
                 validityDetails: ' – Expires 31 May 2021'
             });
         });

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -79,50 +79,62 @@ module.exports = class MemberBREADService {
         // Remove incomplete subscriptions from the API
         member.subscriptions = member.subscriptions.filter(sub => sub.status !== 'incomplete' && sub.status !== 'incomplete_expired');
 
-        for (const product of member.products) {
-            if (!subscriptionProducts.includes(product.id)) {
-                const productAddEvent = member.productEvents.find(event => event.product_id === product.id);
-                let startDate;
-                if (!productAddEvent || productAddEvent.action !== 'added') {
-                    startDate = moment();
-                } else {
-                    startDate = moment(productAddEvent.created_at);
-                }
-                member.subscriptions.push({
-                    id: '',
-                    tier: product,
-                    customer: {
-                        id: '',
-                        name: member.name,
-                        email: member.email
-                    },
-                    plan: {
-                        id: '',
-                        nickname: 'Complimentary',
-                        interval: 'year',
-                        currency: 'USD',
-                        amount: 0
-                    },
-                    status: 'active',
-                    start_date: startDate,
-                    default_payment_card_last4: '****',
-                    cancel_at_period_end: false,
-                    cancellation_reason: null,
-                    current_period_end: moment(product.expiry_at),
-                    price: {
-                        id: '',
-                        price_id: '',
-                        nickname: 'Complimentary',
-                        amount: 0,
-                        interval: 'year',
-                        type: 'recurring',
-                        currency: 'USD',
-                        product: {
-                            id: '',
-                            product_id: product.id
-                        }
+        // Attach non-Stripe complimentary or gifted subscriptions to member
+        // These subscriptions are either granted by the publisher for free (complimentary) or paid by someone else (gift)
+        // They are not backed by a Stripe subscription as there isn't any recurring charges
+        //
+        // In the logic below, we construct Stripe-alike member subscription API responses, so that the client does not need to handle Stripe vs non-Stripe subscriptions separately.
+        // Note: a complimentary or gift subscription should always be the current member subscription and match its status,
+        // as non-Stripe subscriptions are removed when a member continues with a Stripe paid subscription
+        if (member.status === 'comped' || member.status === 'gift') {
+            for (const product of member.products) {
+                if (!subscriptionProducts.includes(product.id)) {
+                    const productAddEvent = member.productEvents.find(event => event.product_id === product.id && event.action === 'added');
+                    let startDate;
+                    if (!productAddEvent) {
+                        startDate = moment();
+                    } else {
+                        startDate = moment(productAddEvent.created_at);
                     }
-                });
+
+                    const nickname = member.status === 'gift' ? 'Gift subscription' : 'Complimentary';
+
+                    member.subscriptions.push({
+                        id: '',
+                        tier: product,
+                        customer: {
+                            id: '',
+                            name: member.name,
+                            email: member.email
+                        },
+                        plan: {
+                            id: '',
+                            nickname,
+                            interval: 'year',
+                            currency: product.currency,
+                            amount: 0
+                        },
+                        status: 'active',
+                        start_date: startDate,
+                        default_payment_card_last4: '****',
+                        cancel_at_period_end: false,
+                        cancellation_reason: null,
+                        current_period_end: product.expiry_at ? moment(product.expiry_at) : null,
+                        price: {
+                            id: '',
+                            price_id: '',
+                            nickname,
+                            amount: 0,
+                            interval: 'year',
+                            type: 'recurring',
+                            currency: product.currency,
+                            product: {
+                                id: '',
+                                product_id: product.id
+                            }
+                        }
+                    });
+                }
             }
         }
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-newsletters.test.js.snap
@@ -85,7 +85,7 @@ exports[`Members API - With Newsletters - compat mode Can fetch members who are 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2721",
+  "content-length": "1603",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -401,7 +401,7 @@ exports[`Members API - With Newsletters Can fetch members who are NOT subscribed
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2721",
+  "content-length": "1603",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -2388,7 +2388,7 @@ exports[`Members API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "12208",
+  "content-length": "11090",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2590,7 +2590,7 @@ exports[`Members API Can browse with limit 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3631",
+  "content-length": "2513",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2924,7 +2924,7 @@ exports[`Members API Can browse with limit=all 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "12209",
+  "content-length": "11091",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3258,7 +3258,7 @@ exports[`Members API Can browse with more than maximum allowed limit 2: [headers
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "12209",
+  "content-length": "11091",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4297,7 +4297,7 @@ exports[`Members API Can filter by paid status 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9619",
+  "content-length": "8501",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4622,7 +4622,7 @@ exports[`Members API Can filter by tier id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8800",
+  "content-length": "7682",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -5350,7 +5350,7 @@ exports[`Members API Can filter on tier slug 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "23059",
+  "content-length": "21941",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -5629,7 +5629,7 @@ exports[`Members API Can ignore any unknown includes 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9619",
+  "content-length": "8501",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -1415,6 +1415,36 @@ describe('Members API', function () {
         const updatedMember = body2.members[0];
         assert.equal(updatedMember.status, 'comped', 'A comped member should have the comped status');
         assert.equal(updatedMember.tiers.length, 1, 'The member should have one product');
+        assert.equal(
+            updatedMember.subscriptions.length,
+            1,
+            'The member should have one synthetic complimentary subscription'
+        );
+        assert.equal(
+            updatedMember.subscriptions[0].tier.id,
+            product.id,
+            'The subscription should point at the assigned tier'
+        );
+        assert.equal(
+            updatedMember.subscriptions[0].plan.nickname,
+            'Complimentary',
+            'The subscription plan should be marked as complimentary'
+        );
+        assert.equal(
+            updatedMember.subscriptions[0].price.nickname,
+            'Complimentary',
+            'The subscription price should be marked as complimentary'
+        );
+        assert.equal(
+            updatedMember.subscriptions[0].plan.currency.toLowerCase(),
+            product.get('currency').toLowerCase(),
+            'The synthetic subscription plan should reuse the tier currency'
+        );
+        assert.equal(
+            updatedMember.subscriptions[0].price.currency.toLowerCase(),
+            product.get('currency').toLowerCase(),
+            'The synthetic subscription price should reuse the tier currency'
+        );
 
         await assertMemberEvents({
             eventType: 'MemberStatusEvent',
@@ -1961,6 +1991,16 @@ describe('Members API', function () {
 
         const beforeMember = body2.members[0];
         assert.equal(beforeMember.tiers.length, 2, 'The member should have two tiers now');
+        assert.equal(
+            beforeMember.subscriptions.length,
+            1,
+            'Only the Stripe-backed paid subscription should be returned while the member status is paid'
+        );
+        assert.equal(
+            beforeMember.subscriptions[0].tier.id,
+            memberWithPaidSubscription.tiers[0].id,
+            'The returned subscription should stay attached to the paid tier'
+        );
 
         // Now try to remove only the complimentary one
         const compedPayload = {

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -638,6 +638,36 @@ describe('Gift Subscriptions', function () {
                     .expectStatus(200);
 
                 assert.equal(memberResponse.body.status, 'gift');
+                assert.equal(
+                    memberResponse.body.subscriptions.length,
+                    1,
+                    'Gift members should receive a synthetic gift subscription in the member API'
+                );
+                assert.equal(
+                    memberResponse.body.subscriptions[0].tier.id,
+                    paidProduct.id,
+                    'The gift subscription should point at the redeemed tier'
+                );
+                assert.equal(
+                    memberResponse.body.subscriptions[0].plan.nickname,
+                    'Gift subscription',
+                    'The synthetic subscription plan should be marked as a gift'
+                );
+                assert.equal(
+                    memberResponse.body.subscriptions[0].price.nickname,
+                    'Gift subscription',
+                    'The synthetic subscription price should be marked as a gift'
+                );
+                assert.equal(
+                    memberResponse.body.subscriptions[0].plan.currency.toLowerCase(),
+                    paidProduct.get('currency').toLowerCase(),
+                    'The gift subscription plan should reuse the tier currency'
+                );
+                assert.equal(
+                    memberResponse.body.subscriptions[0].price.currency.toLowerCase(),
+                    paidProduct.get('currency').toLowerCase(),
+                    'The gift subscription price should reuse the tier currency'
+                );
 
                 // Verify staff notification email was sent
                 mockManager.assert.sentEmail({

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -312,10 +312,12 @@ describe('MemberBreadService', function () {
             const productsJSON = [
                 {
                     id: 'prod_123',
+                    currency: 'usd',
                     expiry_at: new Date('2023-10-13T15:15:00')
                 },
                 {
                     id: 'prod_456',
+                    currency: 'cad',
                     expiry_at: new Date('2023-10-13T15:15:00')
                 }
             ];
@@ -334,6 +336,11 @@ describe('MemberBreadService', function () {
             const subscriptionsJSON = [
                 {
                     subscription_id: 'sub_123',
+                    plan: {
+                        amount: 1200,
+                        interval: 'year',
+                        currency: 'usd'
+                    },
                     price: {
                         product: {
                             product_id: productsJSON[0].id
@@ -367,6 +374,7 @@ describe('MemberBreadService', function () {
 
             memberModelStub.toJSON.returns({
                 ...memberModelJSON,
+                status: 'comped',
                 subscriptions: subscriptionsJSON,
                 products: productsJSON,
                 productEvents: productEventsJSON
@@ -395,7 +403,7 @@ describe('MemberBreadService', function () {
                     id: '',
                     nickname: 'Complimentary',
                     interval: 'year',
-                    currency: 'USD',
+                    currency: productsJSON[1].currency,
                     amount: 0
                 },
                 status: 'active',
@@ -411,10 +419,145 @@ describe('MemberBreadService', function () {
                     amount: 0,
                     interval: 'year',
                     type: 'recurring',
-                    currency: 'USD',
+                    currency: productsJSON[1].currency,
                     product: {
                         id: '',
                         product_id: productsJSON[1].id
+                    }
+                }
+            });
+        });
+
+        it('does not synthesize complimentary subscriptions for paid members with extra products', async function () {
+            const productsJSON = [
+                {
+                    id: 'prod_123',
+                    currency: 'usd',
+                    expiry_at: new Date('2023-10-13T15:15:00')
+                },
+                {
+                    id: 'prod_456',
+                    currency: 'cad',
+                    expiry_at: new Date('2023-10-13T15:15:00')
+                }
+            ];
+            const subscriptionsJSON = [
+                {
+                    subscription_id: 'sub_123',
+                    plan: {
+                        amount: 1200,
+                        interval: 'year',
+                        currency: 'usd'
+                    },
+                    price: {
+                        product: {
+                            product_id: productsJSON[0].id
+                        }
+                    },
+                    status: 'active',
+                    product_id: productsJSON[0].id
+                }
+            ];
+            const subscriptionModels = subscriptionsJSON.map((subscription, index) => {
+                const model = {
+                    id: `${index + 1}`,
+                    get: sinon.stub()
+                };
+
+                model.get.withArgs('subscription_id').returns(subscription.subscription_id);
+                model.get.withArgs('offer_id').returns(undefined);
+
+                return model;
+            });
+
+            memberModelStub.related
+                .withArgs('stripeSubscriptions')
+                .returns(subscriptionModels);
+
+            memberModelStub.toJSON.returns({
+                ...memberModelJSON,
+                status: 'paid',
+                subscriptions: subscriptionsJSON,
+                products: productsJSON,
+                productEvents: []
+            });
+
+            memberRepositoryStub.isActiveSubscriptionStatus = sinon.stub().returns(true);
+
+            const memberBreadService = getService();
+            const member = await memberBreadService.read({id: MEMBER_ID});
+
+            assert.equal(member.subscriptions.length, 1);
+            assert.equal(member.subscriptions[0].subscription_id, subscriptionsJSON[0].subscription_id);
+        });
+
+        it('returns a member with a gift subscription', async function () {
+            const productsJSON = [
+                {
+                    id: 'prod_789',
+                    currency: 'aud',
+                    expiry_at: new Date('2023-10-13T15:15:00')
+                }
+            ];
+            const productEventsJSON = [
+                {
+                    product_id: productsJSON[0].id,
+                    created_at: new Date('2023-09-13T15:15:00'),
+                    action: 'added'
+                }
+            ];
+
+            memberModelStub.related
+                .withArgs('stripeSubscriptions')
+                .returns([]);
+
+            memberModelStub.toJSON.returns({
+                ...memberModelJSON,
+                status: 'gift',
+                subscriptions: [],
+                products: productsJSON,
+                productEvents: productEventsJSON
+            });
+
+            memberRepositoryStub.isActiveSubscriptionStatus = sinon.stub().returns(true);
+
+            const memberBreadService = getService();
+            const member = await memberBreadService.read({id: MEMBER_ID});
+
+            assert.equal(member.subscriptions.length, 1);
+
+            sinon.assert.match(member.subscriptions[0], {
+                id: '',
+                tier: productsJSON[0],
+                customer: {
+                    id: '',
+                    name: memberModelJSON.name,
+                    email: memberModelJSON.email
+                },
+                plan: {
+                    id: '',
+                    nickname: 'Gift subscription',
+                    interval: 'year',
+                    currency: productsJSON[0].currency,
+                    amount: 0
+                },
+                status: 'active',
+                start_date: moment(productEventsJSON[0].created_at),
+                default_payment_card_last4: '****',
+                cancel_at_period_end: false,
+                cancellation_reason: null,
+                current_period_end: moment(productsJSON[0].expiry_at),
+                price: {
+                    id: '',
+                    price_id: '',
+                    nickname: 'Gift subscription',
+                    amount: 0,
+                    interval: 'year',
+                    type: 'recurring',
+                    currency: productsJSON[0].currency,
+                    product: {
+                        id: '',
+                        product_id: productsJSON[0].id
                     }
                 }
             });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3482

## Summary

Surfaces gift subscriptions on the Admin member detail page by first teaching the members API to distinguish between complimentary and gifted subscriptions, then rendering the new type in Admin. Publishers now see `Gift subscription - Expires {date}` in Admin member page, with no action menu item as gift subscriptions cannot be edited/removed in Admin.

## Background

Gift subscriptions are non-Stripe subscriptions paid for by someone other than the member (vs. complimentary subscriptions, which are granted for free by the publisher). Until now, both cases were collapsed into a single "Complimentary" synthetic subscription in the members API response, so Admin had no way to tell them apart or render them differently.

## Changes

### API (`ghost/core`)

- `member-bread-service.js` now only constructs the synthetic non-Stripe subscription when `member.status` is `comped` or `gift`, instead of running for every member.
- The synthetic plan/price nickname is now `"Gift subscription"` when the member is gifted, and `"Complimentary"` when comped.
- The synthetic plan/price currency is taken from the product instead of being hardcoded to `USD`.
- Added e2e coverage in `test/e2e-api/admin/members.test.js` and `test/e2e-api/members/gift-subscriptions.test.js`, plus unit coverage in `members-bread-service.test.js`.

### Admin (`ghost/admin`)

- `subscription-data.js` exposes new helpers `isGift` / `giftExpiry` alongside the existing complimentary helpers, and `validityDetails` renders `Expires {date}` for gift subs (or an empty string when there's no expiry, matching the complimentary branch).
- `gh-member-settings-form.hbs` shows an **Active** status badge for gifts with an expiry and **hides the action menu** for gift subs — they aren't editable or cancellable from Admin since the gift purchase owns that lifecycle.
- `mirage/serializers/member.js` now treats `sub.gift` the same as `sub.comped` so fixtures match the real API shape.
- Added unit tests in `tests/unit/utils/subscription-data-test.js` and acceptance coverage in `tests/acceptance/members/details-test.js`.




