### PR TITLE
Added missing empty state for members

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -109,6 +109,20 @@ export const useBrowseMembers = createQuery<MembersResponseType>({
     path: '/members/'
 });
 
+export type NewMember = {
+    email: string;
+    name?: string | null;
+};
+
+export const useAddMember = createMutation<MembersResponseType, NewMember>({
+    method: 'POST',
+    path: () => '/members/',
+    body: member => ({
+        members: [member]
+    }),
+    invalidateQueries: {dataType}
+});
+
 export const getMember = createQueryWithId<MembersResponseType>({
     dataType,
     path: id => `/members/${id}/`

--- a/apps/posts/src/views/members/components/members-empty-state.tsx
+++ b/apps/posts/src/views/members/components/members-empty-state.tsx
@@ -1,57 +1,39 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback} from 'react';
 import {Button, EmptyIndicator} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
-import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
-import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
+import {useAddMember} from '@tryghost/admin-x-framework/api/members';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
-const MembersEmptyState: React.FC<{onMemberCreated?: () => void}> = ({onMemberCreated}) => {
-    const {data: settingsData} = useBrowseSettings({});
-    const {data: currentUser} = useCurrentUser();
-    const navigate = useNavigate();
-    const [isAdding, setIsAdding] = useState(false);
+interface MembersEmptyStateProps {
+    membershipsEnabled: boolean;
+    onMemberCreated?: () => void | Promise<void>;
+}
 
-    const {assetRoot} = getGhostPaths();
-    const membersSignupAccess = getSettingValue<string>(settingsData?.settings ?? null, 'members_signup_access');
-    const membershipsEnabled = membersSignupAccess !== 'none';
+const MembersEmptyState: React.FC<MembersEmptyStateProps> = ({membershipsEnabled, onMemberCreated}) => {
+    const {data: currentUser, isLoading: isCurrentUserLoading} = useCurrentUser();
+    const {mutateAsync: addMember, isLoading: isAdding} = useAddMember();
+    const handleError = useHandleError();
+    const navigate = useNavigate();
 
     const handleAddYourself = useCallback(async () => {
         if (!currentUser || isAdding) {
             return;
         }
 
-        setIsAdding(true);
         try {
-            const {apiRoot} = getGhostPaths();
-            const response = await fetch(`${apiRoot}/members/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    members: [{
-                        email: currentUser.email,
-                        name: currentUser.name
-                    }]
-                })
+            await addMember({
+                email: currentUser.email,
+                name: currentUser.name
             });
-
-            if (!response.ok) {
-                throw new Error('Failed to create member');
-            }
-
             toast.success('You\'ve been added as a member');
-            onMemberCreated?.();
-        } catch {
-            toast.error('Failed to add member', {
-                description: 'There was a problem adding you as a member. Please try again.'
-            });
-        } finally {
-            setIsAdding(false);
+            await onMemberCreated?.();
+        } catch (error) {
+            handleError(error);
         }
-    }, [currentUser, isAdding, onMemberCreated]);
+    }, [addMember, currentUser, handleError, isAdding, onMemberCreated]);
 
     if (!membershipsEnabled) {
         return (
@@ -78,7 +60,7 @@ const MembersEmptyState: React.FC<{onMemberCreated?: () => void}> = ({onMemberCr
                     actions={
                         <div className="flex flex-col items-center gap-3">
                             <Button
-                                disabled={isAdding}
+                                disabled={isAdding || isCurrentUserLoading || !currentUser}
                                 onClick={handleAddYourself}
                             >
                                 {isAdding ? 'Adding...' : 'Add yourself as a member to test'}
@@ -102,56 +84,6 @@ const MembersEmptyState: React.FC<{onMemberCreated?: () => void}> = ({onMemberCr
                 >
                     <LucideIcon.Users />
                 </EmptyIndicator>
-
-                <div className="mt-4 grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
-                    <a
-                        className="group flex flex-col overflow-hidden rounded-xl border bg-card transition-all hover:shadow-sm"
-                        href="https://ghost.org/resources/build-audience-subscriber-signups/"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        <div
-                            className="h-36 w-full bg-cover bg-center"
-                            style={{backgroundImage: `url(${assetRoot}img/marketing/members-1.jpg)`}}
-                        />
-                        <div className="flex grow flex-col p-5">
-                            <h4 className="text-sm font-semibold">
-                                Building your audience with subscriber signups
-                            </h4>
-                            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
-                                Learn how to turn anonymous visitors into logged-in members with memberships in Ghost.
-                            </p>
-                            <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-foreground">
-                                Start building
-                                <LucideIcon.ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
-                            </span>
-                        </div>
-                    </a>
-
-                    <a
-                        className="group flex flex-col overflow-hidden rounded-xl border bg-card transition-all hover:shadow-sm"
-                        href="https://ghost.org/resources/first-100-email-subscribers/"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        <div
-                            className="h-36 w-full bg-cover bg-center"
-                            style={{backgroundImage: `url(${assetRoot}img/marketing/members-2.jpg)`}}
-                        />
-                        <div className="flex grow flex-col p-5">
-                            <h4 className="text-sm font-semibold">
-                                Get your first 100 email subscribers
-                            </h4>
-                            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
-                                Starting from zero? Use this guide to find your founding audience members.
-                            </p>
-                            <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-foreground">
-                                Become an expert
-                                <LucideIcon.ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
-                            </span>
-                        </div>
-                    </a>
-                </div>
             </div>
         </div>
     );

--- a/apps/posts/src/views/members/components/members-empty-state.tsx
+++ b/apps/posts/src/views/members/components/members-empty-state.tsx
@@ -1,0 +1,160 @@
+import React, {useCallback, useState} from 'react';
+import {Button, EmptyIndicator} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import {toast} from 'sonner';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useNavigate} from '@tryghost/admin-x-framework';
+
+const MembersEmptyState: React.FC<{onMemberCreated?: () => void}> = ({onMemberCreated}) => {
+    const {data: settingsData} = useBrowseSettings({});
+    const {data: currentUser} = useCurrentUser();
+    const navigate = useNavigate();
+    const [isAdding, setIsAdding] = useState(false);
+
+    const {assetRoot} = getGhostPaths();
+    const membersSignupAccess = getSettingValue<string>(settingsData?.settings ?? null, 'members_signup_access');
+    const membershipsEnabled = membersSignupAccess !== 'none';
+
+    const handleAddYourself = useCallback(async () => {
+        if (!currentUser || isAdding) {
+            return;
+        }
+
+        setIsAdding(true);
+        try {
+            const {apiRoot} = getGhostPaths();
+            const response = await fetch(`${apiRoot}/members/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    members: [{
+                        email: currentUser.email,
+                        name: currentUser.name
+                    }]
+                })
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to create member');
+            }
+
+            toast.success('You\'ve been added as a member');
+            onMemberCreated?.();
+        } catch {
+            toast.error('Failed to add member', {
+                description: 'There was a problem adding you as a member. Please try again.'
+            });
+        } finally {
+            setIsAdding(false);
+        }
+    }, [currentUser, isAdding, onMemberCreated]);
+
+    if (!membershipsEnabled) {
+        return (
+            <div className="flex h-full flex-col items-center justify-center px-4">
+                <EmptyIndicator
+                    actions={
+                        <Button variant="outline" asChild>
+                            <a href="#/settings/members">Membership settings</a>
+                        </Button>
+                    }
+                    description="Adjust your membership settings to start adding members."
+                    title="Memberships have been disabled"
+                >
+                    <LucideIcon.Users />
+                </EmptyIndicator>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex h-full flex-col items-center justify-center px-4">
+            <div className="flex max-w-lg flex-col items-center gap-3">
+                <EmptyIndicator
+                    actions={
+                        <div className="flex flex-col items-center gap-3">
+                            <Button
+                                disabled={isAdding}
+                                onClick={handleAddYourself}
+                            >
+                                {isAdding ? 'Adding...' : 'Add yourself as a member to test'}
+                            </Button>
+                            <p className="text-sm text-muted-foreground">
+                                Have members already?{' '}
+                                <a className="font-medium text-foreground hover:underline" href="#/members/new">Add them manually</a>
+                                {' '}or{' '}
+                                <button
+                                    className="font-medium text-foreground hover:underline"
+                                    type="button"
+                                    onClick={() => navigate('/members/import')}
+                                >
+                                    import from CSV
+                                </button>
+                            </p>
+                        </div>
+                    }
+                    description="Use memberships to allow your readers to sign up and subscribe to your content."
+                    title="Start building your audience"
+                >
+                    <LucideIcon.Users />
+                </EmptyIndicator>
+
+                <div className="mt-4 grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
+                    <a
+                        className="group flex flex-col overflow-hidden rounded-xl border bg-card transition-all hover:shadow-sm"
+                        href="https://ghost.org/resources/build-audience-subscriber-signups/"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        <div
+                            className="h-36 w-full bg-cover bg-center"
+                            style={{backgroundImage: `url(${assetRoot}img/marketing/members-1.jpg)`}}
+                        />
+                        <div className="flex grow flex-col p-5">
+                            <h4 className="text-sm font-semibold">
+                                Building your audience with subscriber signups
+                            </h4>
+                            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                                Learn how to turn anonymous visitors into logged-in members with memberships in Ghost.
+                            </p>
+                            <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-foreground">
+                                Start building
+                                <LucideIcon.ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+                            </span>
+                        </div>
+                    </a>
+
+                    <a
+                        className="group flex flex-col overflow-hidden rounded-xl border bg-card transition-all hover:shadow-sm"
+                        href="https://ghost.org/resources/first-100-email-subscribers/"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        <div
+                            className="h-36 w-full bg-cover bg-center"
+                            style={{backgroundImage: `url(${assetRoot}img/marketing/members-2.jpg)`}}
+                        />
+                        <div className="flex grow flex-col p-5">
+                            <h4 className="text-sm font-semibold">
+                                Get your first 100 email subscribers
+                            </h4>
+                            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                                Starting from zero? Use this guide to find your founding audience members.
+                            </p>
+                            <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-foreground">
+                                Become an expert
+                                <LucideIcon.ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+                            </span>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default MembersEmptyState;

--- a/apps/posts/src/views/members/components/members-help-cards.tsx
+++ b/apps/posts/src/views/members/components/members-help-cards.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+
+const MembersHelpCards: React.FC = () => {
+    const {assetRoot} = getGhostPaths();
+
+    return (
+        <div className="mx-auto grid w-full max-w-lg grid-cols-1 gap-4 sm:grid-cols-2">
+            <a
+                className="group flex flex-col overflow-hidden rounded-xl border bg-card transition-all hover:shadow-sm"
+                href="https://ghost.org/resources/build-audience-subscriber-signups/"
+                rel="noopener noreferrer"
+                target="_blank"
+            >
+                <div
+                    className="h-36 w-full bg-cover bg-center"
+                    style={{backgroundImage: `url(${assetRoot}img/marketing/members-1.jpg)`}}
+                />
+                <div className="flex grow flex-col p-5">
+                    <h4 className="text-sm font-semibold">
+                        Building your audience with subscriber signups
+                    </h4>
+                    <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                        Learn how to turn anonymous visitors into logged-in members with memberships in Ghost.
+                    </p>
+                    <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-foreground">
+                        Start building
+                        <LucideIcon.ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+                    </span>
+                </div>
+            </a>
+
+            <a
+                className="group flex flex-col overflow-hidden rounded-xl border bg-card transition-all hover:shadow-sm"
+                href="https://ghost.org/resources/first-100-email-subscribers/"
+                rel="noopener noreferrer"
+                target="_blank"
+            >
+                <div
+                    className="h-36 w-full bg-cover bg-center"
+                    style={{backgroundImage: `url(${assetRoot}img/marketing/members-2.jpg)`}}
+                />
+                <div className="flex grow flex-col p-5">
+                    <h4 className="text-sm font-semibold">
+                        Get your first 100 email subscribers
+                    </h4>
+                    <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                        Starting from zero? Use this guide to find your founding audience members.
+                    </p>
+                    <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-foreground">
+                        Become an expert
+                        <LucideIcon.ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+                    </span>
+                </div>
+            </a>
+        </div>
+    );
+};
+
+export default MembersHelpCards;

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -4,6 +4,7 @@ import MembersEmptyState from './components/members-empty-state';
 import MembersFilters from './components/members-filters';
 import MembersHeader from './components/members-header';
 import MembersHeaderSearch from './components/members-header-search';
+import MembersHelpCards from './components/members-help-cards';
 import MembersLayout from './components/members-layout';
 import MembersList from './components/members-list';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
@@ -12,18 +13,19 @@ import {ListHeader} from '@tryghost/shade/primitives';
 import {LucideIcon, cn} from '@tryghost/shade/utils';
 import {buildMemberListSearchParams, getMemberActiveColumns} from './member-query-params';
 import {canBulkDeleteMembers, shouldShowMembersLoading} from './members-view-state';
+import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {shouldDelayMembersDateFilterHydration, useMembersFilterState} from './hooks/use-members-filter-state';
 import {useActiveMemberView, useMemberViews} from './hooks/use-member-views';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useBrowseMembersInfinite} from '@tryghost/admin-x-framework/api/members';
-import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {useDebounce} from 'use-debounce';
 import {useLocation, useSearchParams} from 'react-router';
 
 const SEARCH_DEBOUNCE_MS = 250;
+const MEMBERS_HELP_CARDS_LIMIT = 6;
 
-const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
+const MembersPage: React.FC<{timezone: string; membershipsEnabled: boolean}> = ({timezone, membershipsEnabled}) => {
     const headerRef = useRef<HTMLDivElement>(null);
     const {filters, nql, search, setFilters, setSearch, hasFilterOrSearch, clearAll} = useMembersFilterState(timezone);
     const location = useLocation();
@@ -75,6 +77,7 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
     const hasFilters = filters.length > 0;
     const shouldShowMobileSearchRow = showMobileSearch;
     const shouldShowFiltersRow = hasFilters;
+    const shouldShowMembersHelpCards = !hasFilterOrSearch && !shouldShowLoading && !isError && totalMembers < MEMBERS_HELP_CARDS_LIMIT;
 
     useEffect(() => {
         setSearchInput(search);
@@ -205,7 +208,7 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
                             </EmptyIndicator>
                         </div>
                     ) : (
-                        <MembersEmptyState onMemberCreated={() => void refetch()} />
+                        <MembersEmptyState membershipsEnabled={membershipsEnabled} onMemberCreated={() => void refetch()} />
                     )
                 ) : (
                     <MembersList
@@ -222,6 +225,7 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
                         totalItems={totalMembers}
                     />
                 )}
+                {shouldShowMembersHelpCards && <MembersHelpCards />}
             </MembersContent>
         </MembersLayout>
     );
@@ -231,9 +235,10 @@ const Members: React.FC = () => {
     const [searchParams] = useSearchParams();
     const {data: settingsData, isLoading: isSettingsLoading} = useBrowseSettings({});
     const filterParam = searchParams.get('filter') ?? undefined;
-    const shouldDelayHydration = shouldDelayMembersDateFilterHydration(filterParam, Boolean(settingsData), isSettingsLoading);
+    const hasResolvedSettings = Boolean(settingsData?.settings);
+    const shouldDelayHydration = shouldDelayMembersDateFilterHydration(filterParam, hasResolvedSettings, isSettingsLoading);
 
-    if (shouldDelayHydration) {
+    if (isSettingsLoading || !settingsData?.settings || shouldDelayHydration) {
         return (
             <MembersLayout>
                 <div className='sticky top-0 z-50 bg-gradient-to-b from-background via-background/70 to-background/70 backdrop-blur-md dark:bg-black'>
@@ -251,9 +256,11 @@ const Members: React.FC = () => {
         );
     }
 
-    const timezone = getSiteTimezone(settingsData?.settings ?? []);
+    const timezone = getSiteTimezone(settingsData.settings);
+    const membersSignupAccess = getSettingValue<string>(settingsData.settings, 'members_signup_access');
+    const membershipsEnabled = membersSignupAccess !== 'none';
 
-    return <MembersPage timezone={timezone} />;
+    return <MembersPage membershipsEnabled={membershipsEnabled} timezone={timezone} />;
 };
 
 export default Members;

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -208,7 +208,7 @@ const MembersPage: React.FC<{timezone: string; membershipsEnabled: boolean}> = (
                             </EmptyIndicator>
                         </div>
                     ) : (
-                        <MembersEmptyState membershipsEnabled={membershipsEnabled} onMemberCreated={() => void refetch()} />
+                        <MembersEmptyState membershipsEnabled={membershipsEnabled} onMemberCreated={() => refetch()} />
                     )
                 ) : (
                     <MembersList

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -208,7 +208,9 @@ const MembersPage: React.FC<{timezone: string; membershipsEnabled: boolean}> = (
                             </EmptyIndicator>
                         </div>
                     ) : (
-                        <MembersEmptyState membershipsEnabled={membershipsEnabled} onMemberCreated={() => refetch()} />
+                        <MembersEmptyState membershipsEnabled={membershipsEnabled} onMemberCreated={async () => {
+                            await refetch();
+                        }} />
                     )
                 ) : (
                     <MembersList

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -1,5 +1,6 @@
 import MembersActions from './components/members-actions';
 import MembersContent from './components/members-content';
+import MembersEmptyState from './components/members-empty-state';
 import MembersFilters from './components/members-filters';
 import MembersHeader from './components/members-header';
 import MembersHeaderSearch from './components/members-header-search';
@@ -187,26 +188,25 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
                         </Button>
                     </div>
                 ) : !data?.members.length ? (
-                    <div className="flex h-full flex-col items-center justify-center">
-                        {hasFilterOrSearch ? (
-                            <>
-                                <EmptyIndicator title="No matching members found.">
-                                    <LucideIcon.Users />
-                                </EmptyIndicator>
-                                <Button
-                                    className="mt-4"
-                                    variant="outline"
-                                    onClick={() => clearAll({replace: false})}
-                                >
-                                    Show all members
-                                </Button>
-                            </>
-                        ) : (
-                            <EmptyIndicator title="No members yet">
+                    hasFilterOrSearch ? (
+                        <div className="flex h-full flex-col items-center justify-center">
+                            <EmptyIndicator
+                                actions={
+                                    <Button
+                                        variant="outline"
+                                        onClick={() => clearAll({replace: false})}
+                                    >
+                                        Show all members
+                                    </Button>
+                                }
+                                title="No matching members found."
+                            >
                                 <LucideIcon.Users />
                             </EmptyIndicator>
-                        )}
-                    </div>
+                        </div>
+                    ) : (
+                        <MembersEmptyState onMemberCreated={() => void refetch()} />
+                    )
                 ) : (
                     <MembersList
                         activeColumns={activeColumns}

--- a/apps/shade/src/components/ui/empty-indicator.tsx
+++ b/apps/shade/src/components/ui/empty-indicator.tsx
@@ -47,7 +47,7 @@ const EmptyIndicator = React.forwardRef<HTMLDivElement, EmptyIndicatorProps>(({c
                 }
             </div>
             {actions && (
-                <div className='mt-4 flex items-center gap-2'>
+                <div className='flex items-center gap-2'>
                     {actions}
                 </div>
             )}

--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -36,7 +36,7 @@ export class MembersListPage extends AdminPage implements MembersListSurface {
         this.newMemberButton = page.getByRole('link', {name: 'New member'});
         this.filterButton = page.getByRole('button', {name: /^(Filter|Add filter)$/});
         this.clearFiltersButton = page.getByRole('button', {name: 'Clear'});
-        this.emptyState = page.getByText('No members yet');
+        this.emptyState = page.getByText('Start building your audience');
         this.noResults = page.getByText('No matching members found.');
         this.showAllButton = page.getByRole('button', {name: 'Show all members'});
     }

--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -23,6 +23,7 @@ export class MembersListPage extends AdminPage implements MembersListSurface {
     readonly filterButton: Locator;
     readonly clearFiltersButton: Locator;
     readonly emptyState: Locator;
+    readonly addYourselfButton: Locator;
     readonly noResults: Locator;
     readonly showAllButton: Locator;
 
@@ -37,6 +38,7 @@ export class MembersListPage extends AdminPage implements MembersListSurface {
         this.filterButton = page.getByRole('button', {name: /^(Filter|Add filter)$/});
         this.clearFiltersButton = page.getByRole('button', {name: 'Clear'});
         this.emptyState = page.getByText('Start building your audience');
+        this.addYourselfButton = page.getByRole('button', {name: 'Add yourself as a member to test'});
         this.noResults = page.getByText('No matching members found.');
         this.showAllButton = page.getByRole('button', {name: 'Show all members'});
     }

--- a/e2e/tests/admin/members/list.test.ts
+++ b/e2e/tests/admin/members/list.test.ts
@@ -38,6 +38,18 @@ test.describe('Ghost Admin - Members List', () => {
         await expect(membersPage.memberRows).toHaveCount(0);
     });
 
+    test('adds the current user as a member from the empty state', async ({page, ghostAccountOwner}) => {
+        const membersPage = new MembersListPage(page);
+        await membersPage.goto();
+
+        await expect(membersPage.emptyState).toBeVisible();
+        await membersPage.addYourselfButton.click();
+
+        await expect(membersPage.memberRows).toHaveCount(1);
+        await expect(membersPage.getMemberByName(ghostAccountOwner.name)).toBeVisible();
+        await expect(membersPage.getMemberByName(ghostAccountOwner.name)).toContainText(ghostAccountOwner.email);
+    });
+
     test('navigates to member detail when clicking a row', async ({page}) => {
         const member = await memberFactory.create({
             name: 'Detail Test Member',

--- a/e2e/tests/admin/members/list.test.ts
+++ b/e2e/tests/admin/members/list.test.ts
@@ -38,7 +38,7 @@ test.describe('Ghost Admin - Members List', () => {
         await expect(membersPage.memberRows).toHaveCount(0);
     });
 
-    test('adds the current user as a member from the empty state', async ({page, ghostAccountOwner}) => {
+    test('add yourself from empty state - creates a member for the current user', async ({page, ghostAccountOwner}) => {
         const membersPage = new MembersListPage(page);
         await membersPage.goto();
 


### PR DESCRIPTION
No ref

Adds back a (Shade-driven) empty state for Members to emulate the existing one in Ember.

<img width="632" height="632" alt="Screenshot 2026-04-20 at 11 45 10" src="https://github.com/user-attachments/assets/518b4eb4-7093-42c1-a050-6574479b93fd" />

.

<img width="464" height="330" alt="Screenshot 2026-04-20 at 11 45 26" src="https://github.com/user-attachments/assets/a7cb4aa7-69da-44fc-a0e6-9da2f77179e9" />
