### PR TITLE
Stubbed AdapterCacheRedis.keys() with an IncorrectUsageError

### DIFF
--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -1,4 +1,5 @@
 const BaseCacheAdapter = require('@tryghost/adapter-base-cache');
+const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const metrics = require('@tryghost/metrics');
 const debug = require('@tryghost/debug')('redis-cache');
@@ -270,17 +271,14 @@ class AdapterCacheRedis extends BaseCacheAdapter {
     }
 
     /**
-     * Helper method to assist "getAll" type of operations
-     * @returns {Promise<Array<String>>} all keys present in the cache
+     * @deprecated The cache adapter interface still requires a `keys` method
+     *             (see @tryghost/adapter-base-cache#requiredFns), but the
+     *             redis adapter does not support enumerating its keys.
      */
-    async keys() {
-        try {
-            return (await this.#getKeys()).map((key) => {
-                return this._removeKeyPrefix(key);
-            });
-        } catch (err) {
-            logging.error(err);
-        }
+    keys() {
+        throw new errors.IncorrectUsageError({
+            message: 'AdapterCacheRedis does not support keys()'
+        });
     }
 }
 

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
+const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const RedisCache = require('../../../../../../core/server/adapters/lib/redis/AdapterCacheRedis');
 
@@ -265,6 +266,26 @@ describe('Adapter Cache Redis', function () {
             await cache.reset();
 
             sinon.assert.calledOnce(logging.error);
+        });
+    });
+
+    describe('keys', function () {
+        it('throws an IncorrectUsageError - this adapter does not support enumerating keys', function () {
+            const redisCacheInstanceStub = {
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub
+            });
+
+            assert.throws(
+                () => cache.keys(),
+                err => err instanceof errors.IncorrectUsageError
+            );
         });
     });
 });


### PR DESCRIPTION
## Why

`AdapterCacheRedis.keys()` is async — it has to be, since it's an O(n) SCAN against redis — but its only consumer, `settings-cache.getAll()`, calls it without `await` and treats the result as a sync array. So if anything ever wired Redis to the settings cache, every `GET /settings` and `PUT /settings` would crash with `keys.forEach is not a function`. Nothing does today, so the path is unreachable, but it's a latent footgun.

The method is also documented as transitional in `@tryghost/adapter-base-cache`:

> NOTE: "keys" method is only here to provide smooth migration from deprecated "getAll" method
>       once use of "getAll" is eradicated, can also remove the "keys" method form the interface

We can't just delete `keys()` though. `BaseCacheAdapter.requiredFns` (defined in the external package) lists it, and `adapter-manager` validates every loaded adapter against that list. Removing the method would crash Ghost at boot.

So this PR swaps the public `keys()` for a stub that throws `IncorrectUsageError`. The stub is intentionally sync, not async, so the throw surfaces directly to the same sync caller pattern that exposed the original bug, rather than becoming an unhandled rejection.

## Cleanup path (follow-up, not in this PR)

1. Update `settings-cache.getAll()` so it no longer depends on `cacheStore.keys()`.
2. Bump `@tryghost/adapter-base-cache` to drop `"keys"` from `requiredFns`, then delete the stub.
3. Once #19518's prefix-rotation `reset()` lands, the SCAN helpers (`#getKeys`, `#scanNodeForKeys`, `#getPrimaryRedisNode`) become dead and can go too.

## Notes for reviewers

- Adapter-manager validation still passes at runtime (the method exists), and a direct call to `cache.keys()` throws `IncorrectUsageError` synchronously.
- Existing 11 `AdapterCacheRedis` unit tests still pass; an additional unit test asserts the throw.