### PR TITLE
Added integration tests for AdapterCacheRedis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,15 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=12
+      redis:
+        image: redis:7.0
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
     strategy:
       matrix:
         node: ${{ fromJSON(needs.job_setup.outputs.node_test_matrix) }}

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -18,6 +18,12 @@
     "logging": {
         "level": "error"
     },
+    "adapters": {
+        "Redis": {
+            "host": "127.0.0.1",
+            "port": 6379
+        }
+    },
     "security": {
         "staffDeviceVerification": false,
         "allowWebhookInternalIPs": true

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -14,6 +14,12 @@
     "logging": {
         "level": "error"
     },
+    "adapters": {
+        "Redis": {
+            "host": "127.0.0.1",
+            "port": 6379
+        }
+    },
     "security": {
         "staffDeviceVerification": false,
         "allowWebhookInternalIPs": true

--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -1,0 +1,165 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const sinon = require('sinon');
+const config = require('../../../../core/shared/config');
+const RedisCache = require('../../../../core/server/adapters/lib/redis/AdapterCacheRedis');
+
+const REDIS_HOST = config.get('adapters:Redis:host');
+const REDIS_PORT = config.get('adapters:Redis:port');
+
+function buildCache(prefix, extra = {}) {
+    return new RedisCache({
+        host: REDIS_HOST,
+        port: REDIS_PORT,
+        keyPrefix: prefix,
+        storeConfig: {
+            retryStrategy: false
+        },
+        reuseConnection: false,
+        ...extra
+    });
+}
+
+describe('Integration: AdapterCacheRedis', function () {
+    const caches = [];
+
+    afterEach(async function () {
+        while (caches.length) {
+            await caches.pop().redisClient.quit();
+        }
+    });
+
+    function createCache(extra) {
+        const cache = buildCache(crypto.randomBytes(8).toString('hex') + ':', extra);
+        caches.push(cache);
+        return cache;
+    }
+
+    describe('set / get', function () {
+        it('stores a value and retrieves it by the same key', async function () {
+            const cache = createCache();
+            await cache.set('hello', 'world');
+            assert.equal(await cache.get('hello'), 'world');
+        });
+
+        it('returns null for an unknown key', async function () {
+            const cache = createCache();
+            assert.equal(await cache.get('does-not-exist'), null);
+        });
+
+        it('overwrites an existing value', async function () {
+            const cache = createCache();
+            await cache.set('k', 'first');
+            await cache.set('k', 'second');
+            assert.equal(await cache.get('k'), 'second');
+        });
+    });
+
+    describe('reset (invalidation contract)', function () {
+        it('makes previously-set keys invisible to get()', async function () {
+            const cache = createCache();
+            await cache.set('foo', 'bar');
+            assert.equal(await cache.get('foo'), 'bar');
+
+            await cache.reset();
+
+            assert.equal(await cache.get('foo'), null);
+        });
+
+        it('triggers fetchData on the next get(key, fetchData) call', async function () {
+            const cache = createCache();
+            await cache.set('k', 'old');
+
+            await cache.reset();
+
+            const fetcher = sinon.stub().resolves('new');
+            const value = await cache.get('k', fetcher);
+
+            assert.equal(fetcher.callCount, 1);
+            assert.equal(value, 'new');
+        });
+
+        it('caches the value returned by fetchData after a reset', async function () {
+            const cache = createCache();
+            await cache.set('k', 'old');
+
+            await cache.reset();
+
+            const fetcher = sinon.stub().resolves('new');
+            await cache.get('k', fetcher);
+            const second = await cache.get('k', fetcher);
+
+            assert.equal(fetcher.callCount, 1);
+            assert.equal(second, 'new');
+        });
+
+        it('does not affect keys belonging to a different keyPrefix', async function () {
+            const cacheA = createCache();
+            const cacheB = createCache();
+
+            await cacheA.set('shared-name', 'A');
+            await cacheB.set('shared-name', 'B');
+
+            await cacheA.reset();
+
+            assert.equal(await cacheA.get('shared-name'), null);
+            assert.equal(await cacheB.get('shared-name'), 'B');
+        });
+    });
+
+    describe('get with fetchData', function () {
+        it('calls fetchData on a miss and caches the result', async function () {
+            const cache = createCache();
+            const fetcher = sinon.stub().resolves('fetched');
+
+            const v1 = await cache.get('miss-key', fetcher);
+            const v2 = await cache.get('miss-key', fetcher);
+
+            assert.equal(fetcher.callCount, 1);
+            assert.equal(v1, 'fetched');
+            assert.equal(v2, 'fetched');
+        });
+
+        it('does not call fetchData on a hit', async function () {
+            const cache = createCache();
+            await cache.set('hit-key', 'cached');
+
+            const fetcher = sinon.stub().resolves('fresh');
+            const value = await cache.get('hit-key', fetcher);
+
+            assert.equal(fetcher.callCount, 0);
+            assert.equal(value, 'cached');
+        });
+    });
+
+    describe('without a keyPrefix', function () {
+        it('still stores and retrieves values', async function () {
+            const cache = buildCache(undefined);
+            caches.push(cache);
+
+            const key = `noprefix-${crypto.randomBytes(8).toString('hex')}`;
+            await cache.set(key, 'value');
+            assert.equal(await cache.get(key), 'value');
+        });
+    });
+
+    describe('getTimeoutMilliseconds', function () {
+        it('returns the value when the underlying get resolves within the timeout', async function () {
+            const cache = createCache({getTimeoutMilliseconds: 1000});
+            await cache.set('fast', 'value');
+            assert.equal(await cache.get('fast'), 'value');
+        });
+
+        it('returns null when the underlying get exceeds the timeout', async function () {
+            const cache = createCache({getTimeoutMilliseconds: 1});
+            await cache.set('slow', 'value');
+
+            const original = cache.cache.get.bind(cache.cache);
+            cache.cache.get = k => new Promise((resolve) => {
+                setTimeout(() => original(k).then(resolve), 50);
+            });
+
+            assert.equal(await cache.get('slow'), null);
+        });
+    });
+});


### PR DESCRIPTION
## Why

The redis cache adapter only has unit tests today, and they stub the cache layer completely. They verify the implementation but not the behavioural contract against a real Redis. We have changes to the redis cache coming up and want the current behaviour locked in before we touch anything.

## What

- New `ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js` with 12 tests against a real Redis:
  - `set` → `get` round-trip and overwrite
  - Invalidation contract: `set → reset → get === null`, and `fetchData` is re-called after a reset
  - `keyPrefix` isolation: `reset()` on prefix A does not affect prefix B
  - `get(k, fetchData)` cache-miss / cache-hit semantics
  - Behaviour with no `keyPrefix` configured
  - `getTimeoutMilliseconds` short-circuit (under and over the timeout)
- `config.testing.json` / `config.testing-mysql.json`: added a default `adapters.Redis` block (`127.0.0.1:6379`) so the test reads the host via the standard config layer. Override via env (`adapters__Redis__host`, `adapters__Redis__port`).
- `.github/workflows/ci.yml`: added `redis:7.0` as a service to the `Acceptance tests` job, matching how `mysql` is already wired up.

## Coverage

Coverage of `core/server/adapters/lib/redis/AdapterCacheRedis.js` from this suite alone:

| Metric     | Coverage          |
|------------|-------------------|
| Statements | 77.7%  (223/287)  |
| Branches   | 74.35%  (29/39)   |
| Functions  | 71.42% (10/14)    |
| Lines      | 77.7%  (223/287)  |

What's not covered:

- Redis Cluster code paths (see the next section)
- Catch blocks for redis client errors
- The background-refresh path (`refreshAheadFactor`); the existing unit tests already cover this, and timing-based integration tests are flaky
- `keys()` is about to be replaced with a stub that throws (see #27465); the unit-level assertion for the new behaviour lives there

## Cluster: out of scope

The adapter has a `#getPrimaryRedisNode` branch that runs when the underlying client is an ioredis `Cluster`, used to route `SCAN` to a single primary node. This suite doesn't cover it. Adding it would mean spinning up a multi-node cluster (something like `grokzen/redis-cluster`) as a separate CI service. The value isn't there right now, since the planned changes shrink this code path further. Worth revisiting if cluster correctness becomes a concern.

## Notes for reviewers

- Each test uses a random `keyPrefix` (via `crypto.randomBytes`) so tests don't collide. Connections are closed in `afterEach`; any data left behind ages out via the prefix.