### PR TITLE
Fixed Stripe Service coming up if billing portal manager errors

### DIFF
--- a/ghost/core/core/server/services/stripe/billing-portal-manager.js
+++ b/ghost/core/core/server/services/stripe/billing-portal-manager.js
@@ -1,3 +1,5 @@
+const logging = require('@tryghost/logging');
+
 const CONFIGURATION_ID_SETTING = 'stripe_billing_portal_configuration_id';
 
 const DEFAULT_FEATURES = {
@@ -91,7 +93,13 @@ class BillingPortalManager {
                 const configuration = await this.api.createBillingPortalConfiguration(this.getConfigurationOptions());
                 return configuration.id;
             }
-            throw err;
+
+            logging.error('Failed to update the billing portal configuration', {
+                err
+            });
+
+            // Couldn't modify configuration, means it's likely the default config
+            return id;
         }
     }
 

--- a/ghost/core/test/unit/server/services/stripe/billing-portal-manager.test.js
+++ b/ghost/core/test/unit/server/services/stripe/billing-portal-manager.test.js
@@ -173,7 +173,7 @@ describe('BillingPortalManager', function () {
             sinon.assert.calledOnce(mockApi.createBillingPortalConfiguration);
         });
 
-        it('throws error when update fails with non-resource_missing error', async function () {
+        it('returns the passed id when failing with a non-resource based error', async function () {
             mockSettingsCache.get.withArgs('title').returns('Test Site');
             const genericError = new Error('Stripe API error');
             mockApi.updateBillingPortalConfiguration.rejects(genericError);
@@ -185,10 +185,8 @@ describe('BillingPortalManager', function () {
             });
             manager.configure({siteUrl: 'https://example.com'});
 
-            await assert.rejects(
-                () => manager.createOrUpdateConfiguration('bpc_existing'),
-                {message: 'Stripe API error'}
-            );
+            const result = await manager.createOrUpdateConfiguration('bpc_existing');
+            assert.equal(result, 'bpc_existing');
         });
     });
 


### PR DESCRIPTION
ref ONC-1656

Prevents the whole Stripe Service from erroring if the billing portal manager encounters an error while trying to update the billing portal configuration. This can happen if the billing portal configuration that Ghost has created has been made the default one by the Stripe Account owner.
