### PR TITLE
🐛 Fixed welcome email color picker Escape flakiness

### DIFF
--- a/apps/shade/src/components/ui/popover.tsx
+++ b/apps/shade/src/components/ui/popover.tsx
@@ -4,7 +4,64 @@ import {SHADE_APP_NAMESPACES} from '@/shade-app';
 
 import {cn} from '@/lib/utils';
 
-const Popover = PopoverPrimitive.Root;
+// Radix's Popover dismisses via DismissableLayer → useEscapeKeydown →
+// useCallbackRef. The callback ref is updated in a useEffect, so on the first
+// render after PopoverContent mounts the document-level Escape listener still
+// invokes the prior closure with a stale layer index. isHighestLayer returns
+// false, Radix bails out, and Escape propagates to ancestor layers (e.g.
+// closing the wrong modal). Attach our own capture-phase Escape handler while
+// the popover is open so dismissal is deterministic regardless of effect order.
+type PopoverRootProps = React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Root>;
+
+const Popover: React.FC<PopoverRootProps> = ({
+    open: controlledOpen,
+    defaultOpen,
+    onOpenChange,
+    children,
+    ...rest
+}) => {
+    const isControlled = controlledOpen !== undefined;
+    const [internalOpen, setInternalOpen] = React.useState(defaultOpen ?? false);
+    const open = isControlled ? controlledOpen : internalOpen;
+
+    const handleOpenChange = React.useCallback((next: boolean) => {
+        if (!isControlled) {
+            setInternalOpen(next);
+        }
+        onOpenChange?.(next);
+    }, [isControlled, onOpenChange]);
+
+    const handleOpenChangeRef = React.useRef(handleOpenChange);
+    React.useEffect(() => {
+        handleOpenChangeRef.current = handleOpenChange;
+    }, [handleOpenChange]);
+
+    React.useEffect(() => {
+        if (!open) {
+            return;
+        }
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            handleOpenChangeRef.current(false);
+        };
+        document.addEventListener('keydown', handleEscape, {capture: true});
+        return () => document.removeEventListener('keydown', handleEscape, {capture: true});
+    }, [open]);
+
+    return (
+        <PopoverPrimitive.Root
+            {...rest}
+            open={open}
+            onOpenChange={handleOpenChange}
+        >
+            {children}
+        </PopoverPrimitive.Root>
+    );
+};
 
 const PopoverTrigger = PopoverPrimitive.Trigger;
 


### PR DESCRIPTION
## Summary

Fixes the flaky `Escape closes welcome email color picker without bypassing unsaved changes confirmation` e2e test. Root cause was a Radix `DismissableLayer` timing bug affecting every Shade `Popover` that opens inside a Dialog, so the fix lives in the Shade design system.

## Root cause

Radix `PopoverContent` handles Escape via `DismissableLayer` → `useEscapeKeydown` → `useCallbackRef`. The callback ref is updated inside a `useEffect`, so on the render immediately after content mounts (before that effect flushes) the document-level listener still invokes the prior closure with a stale `index = -1`. `isHighestLayer` returns false, Radix bails out of dismissing, Escape bubbles, and the surrounding `EmailDesignModal` Dialog's handler runs — which ends up closing the customize modal or showing the unsaved-changes confirm dialog on the very first Escape.

Confirmed by monkey-patching `Document.prototype.addEventListener` in the test to wrap every keydown-capture listener and observing per-iteration which handlers fire. In failing iterations the Dialog's and Popover's Radix listeners both fire but neither user callback runs (both `isHighestLayer` checks fail); in passing iterations the Popover's user callback runs as expected.

## Fix

`apps/shade/src/components/ui/popover.tsx` now wraps `PopoverPrimitive.Root` with a small controlled/uncontrolled state bridge. While `open` is true it registers a capture-phase document-level Escape handler that calls `onOpenChange(false)` and `stopPropagation()`, so no outer dismissable layer sees the keypress.

Fix placed in Shade because:
- Every Shade `Popover` consumer inherits the same latent bug whenever a Popover is rendered inside a Dialog/AlertDialog.
- Audit of Shade `Popover` consumers showed none rely on the broken behaviour (no consumers want Escape to close both the popover AND an ancestor layer simultaneously).
- The public API is preserved — controlled `open` + `onOpenChange` continue to work; uncontrolled usage falls through to internal state.

## Test plan

- [x] Serial 10× stress test: 10/10 passed
- [x] Serial 20× stress test: 20/20 passed
- [x] `pnpm --filter @tryghost/shade test:types` clean
- [x] `eslint` clean on `apps/shade/src/components/ui/popover.tsx`