### PR TITLE
Fixed ci-release.yml startup_failure blocking tag releases

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,6 +9,15 @@ concurrency:
   group: ci-release-${{ github.ref_name }}
   cancel-in-progress: false
 
+# Workflow-level permissions set the ceiling for the reusable ci.yml.
+# id-token is never in the default token, so it must be granted explicitly
+# here — otherwise the ci: job's `permissions:` block exceeds the caller
+# workflow's permissions and GitHub rejects the run with startup_failure.
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -14,6 +14,7 @@ concurrency:
 # here — otherwise the ci: job's `permissions:` block exceeds the caller
 # workflow's permissions and GitHub rejects the run with startup_failure.
 permissions:
+  actions: read
   contents: write
   packages: write
   id-token: write
@@ -23,6 +24,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
     permissions:
+      actions: read
       contents: write
       packages: write
       id-token: write


### PR DESCRIPTION
## Summary

The v6.31.0 release workflow failed with `startup_failure` and never published: [run 24573212819](https://github.com/TryGhost/Ghost/actions/runs/24573212819). Zero jobs created, no logs. This was `ci-release.yml`'s first real firing since `dd17126f21` split release CI into a reusable-workflow call.

## Root cause

When a caller job invokes a reusable workflow, its `permissions:` block cannot exceed the **calling workflow's** top-level permissions. `ci-release.yml` had no top-level `permissions:` block, so the ceiling fell back to the repo default (`default_workflow_permissions: write`). That default includes `contents: write` and `packages: write`, but `id-token` is never in any default — OIDC must always be granted explicitly.

The `ci:` job then declared `id-token: write`, exceeding the workflow ceiling. GitHub's graph validator rejected the run before scheduling anything.

This never showed up on the PR CI for the split commit, because PR CI hits `ci.yml` directly via `pull_request`, not through `ci-release.yml`. The bug was gated on an actual `v*` tag push.

## Fix

Add a top-level `permissions:` block to `ci-release.yml` matching the caller job's grant. The ceiling now includes `id-token: write`, the caller job's grant is `≤` the ceiling, validation passes.

Also grant `actions: read` at both the workflow and caller-job level. `ci.yml`'s `job_setup` declares it for `nrwl/nx-set-shas`. That step is currently gated off on tag runs (`if: env.IS_TAG != 'true'`), so nothing breaks today if `actions:` silently downgrades to `none` through the reusable-workflow cap — but granting it explicitly documents intent and avoids a latent trap if that gate is ever removed.

## Test plan

- [ ] Next scheduled Friday release completes end-to-end (npm publish + GitHub Release)
- [ ] Alternatively, push a throwaway `v0.0.0-test` tag to a fork to confirm the workflow starts past validation