### PR TITLE
Added dry-run mode to ci-release.yml for manual validation

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -3,11 +3,18 @@ on:
   push:
     tags:
       - 'v[0-9]*'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Skip actual npm publish / GitHub Release / CD dispatch; validate everything else'
+        type: boolean
+        default: true
 
-# Tags must never be cancelled — each is a public release
+# Real tag runs are never cancelled (each is a public release).
+# Dispatched dry-runs can be cancelled so iterating is cheap.
 concurrency:
-  group: ci-release-${{ github.ref_name }}
-  cancel-in-progress: false
+  group: ci-release-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 # Workflow-level permissions set the ceiling for the reusable ci.yml.
 # id-token is never in the default token, so it must be granted explicitly
@@ -28,3 +35,5 @@ jobs:
       contents: write
       packages: write
       id-token: write
+    with:
+      dry-run: ${{ inputs.dry-run == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
     tags-ignore:
       - '**' # Tags handled by ci-release.yml
   workflow_call: # Called by ci-release.yml for uninterruptible release CI
+    inputs:
+      dry-run:
+        description: 'When true, npm publish runs with --dry-run and external side effects (GitHub Release, CD dispatch) are skipped'
+        type: boolean
+        default: false
 
 env:
   FORCE_COLOR: 1
@@ -1670,6 +1675,7 @@ jobs:
       && needs.job_setup.result == 'success'
       && needs.job_build_artifacts.result == 'success'
       && needs.job_build_artifacts.outputs.use-artifact != 'true'
+      && !inputs.dry-run
     steps:
       - name: Determine dispatch parameters
         id: params
@@ -1719,10 +1725,13 @@ jobs:
     name: Publish Ghost to npm
     runs-on: ubuntu-latest
     if: |
-      startsWith(github.ref, 'refs/tags/v')
+      (startsWith(github.ref, 'refs/tags/v') || inputs.dry-run)
       && github.repository == 'TryGhost/Ghost'
       && needs.job_build_artifacts.result == 'success'
-    environment: npm-release
+    # npm-release has a branch policy restricted to tag refs. On a dry-run we
+    # may be running from main or a feature branch, so skip the environment
+    # (empty string = no environment). OIDC still works via id-token: write.
+    environment: ${{ !inputs.dry-run && 'npm-release' || '' }}
     permissions:
       id-token: write
     steps:
@@ -1750,7 +1759,7 @@ jobs:
           tar -xOf ghost-*.tgz package/package.json | jq -e '.packageManager' >/dev/null || { echo "::error::packageManager not found in packaged package.json"; exit 1; }
 
       - name: Publish to npm
-        run: npm publish ghost-*.tgz --access public
+        run: npm publish ghost-*.tgz --access public ${{ inputs.dry-run && '--dry-run' || '' }}
 
       - uses: tryghost/actions/actions/slack-build@20b5ae5f266e86f7b5f0815d92731d6388b8ce46 # main
         if: failure()
@@ -1766,7 +1775,7 @@ jobs:
     needs: [publish_ghost]
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !inputs.dry-run
     permissions:
       contents: write
     env:


### PR DESCRIPTION
## Summary

Adds a `dry-run` input to `ci-release.yml` (via `workflow_dispatch`) that lets us validate release CI end-to-end without actually publishing. Addresses the pain of only discovering release regressions when the scheduled Friday tag push fires.

## Why

Recent release failures (v6.31.0 `startup_failure`, v6.32.0 `ENEEDAUTH`) have only been visible against a real `v*` tag. That's a painful feedback loop — the CI split landed Apr 14 and broke two consecutive releases before we caught all the downstream config mismatches. A dependable manual dry-run cuts that loop down to "run it once before merging any release workflow change."

## How to use

```bash
gh workflow run ci-release.yml --ref <branch> -f dry-run=true
```

Default is `dry-run=true` on manual dispatch, so the UI button does the safe thing. Tag-push releases continue to run with `dry-run=false` — no behaviour change for real releases.

## What dry-run does

- Runs the entire `ci.yml` reusable workflow (graph validation, permissions chain, OIDC token minting, build, tarball creation).
- `publish_ghost` job runs, with `npm publish` invoked as `npm publish ghost-*.tgz --access public --dry-run`. The tarball is assembled and validated locally; no registry HTTP call.
- `create_github_release` and `trigger_cd` are skipped (they'd create real side effects on GitHub and Ghost-Moya otherwise).
- The `npm-release` GitHub environment is bypassed on dry-run (its branch policy is tag-only, and a manual dispatch from any other ref would hang on approval). OIDC token minting still works via `id-token: write`.

## What dry-run does NOT catch

- **npm Trusted Publisher misconfiguration** (the v6.32.0 failure). `npm publish --dry-run` skips the registry call entirely, so there's no OIDC exchange to reject. That class of failure can only be caught by a real publish. The mitigation is documentation: remember to update the Trusted Publisher config on npmjs.com whenever the initiating workflow filename changes.
- Registry-side rejections (duplicate version, revoked maintainer, etc.).

Everything else — permissions, id-token propagation, tarball contents, package.json validation — is covered.

## Auto-trigger on PRs

Deliberately not included. Considered `pull_request: paths: ['.github/workflows/ci*.yml']` but it would double CI cost on those PRs (ci.yml already runs via the standard PR trigger) and introduce concurrency complexity. Manual dispatch is more explicit and can be added as a PR-check later if we find we forget to run it.

## Test plan

- [ ] `gh workflow run ci-release.yml --ref feat/release-dry-run -f dry-run=true` — verify run reaches `Publish Ghost to npm` and the step logs `npm notice` + `--dry-run` output without a real publish
- [ ] Confirm `create_github_release` and `trigger_cd` jobs show as skipped
- [ ] Confirm no GitHub Release is created and no dispatch hits Ghost-Moya
- [ ] Next real tag push (v6.33.0) still publishes normally — no change to the non-dry-run path

## Notes for reviewer

- The `environment: ${{ !inputs.dry-run && 'npm-release' || '' }}` trick — empty-string evaluates as "no environment" in GHA. This is a common pattern but isn't officially documented; if it breaks we can split `publish_ghost` into two jobs instead.
- `inputs.dry-run` is `false` (the default) whenever `ci.yml` is triggered outside `workflow_call` (direct pushes, PR CI), so non-release codepaths are unchanged.