### PR TITLE
Updated gift purchase confirmation page to show gift short URL

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.9",
+  "version": "2.68.10",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/gift-success-page.js
+++ b/apps/portal/src/components/pages/gift-success-page.js
@@ -108,7 +108,7 @@ const GiftSuccessPage = () => {
 
     const token = pageData?.token;
     const siteUrl = site?.url || '';
-    const redeemUrl = `${siteUrl.replace(/\/$/, '')}/#/portal/gift/redeem/${token}`;
+    const redeemUrl = `${siteUrl.replace(/\/$/, '')}/gift/${token}`;
 
     const handleCopy = () => {
         copyTextToClipboard(redeemUrl);

--- a/apps/portal/test/portal-links.test.js
+++ b/apps/portal/test/portal-links.test.js
@@ -608,7 +608,7 @@ describe('Portal Data links:', () => {
             const giftTitle = within(popupFrame.contentDocument).queryByText(/gift ready to share/i);
             expect(giftTitle).toBeInTheDocument();
 
-            const redeemUrl = within(popupFrame.contentDocument).queryByText(/#\/portal\/gift\/redeem\/abc123/);
+            const redeemUrl = within(popupFrame.contentDocument).queryByText(/\/gift\/abc123$/);
             expect(redeemUrl).toBeInTheDocument();
         });
 


### PR DESCRIPTION
no ref

Updated the gift purchase confirmation page to show gift short URL (`/gift/<token>`) instead of the longer redemption URL (`/#/portal/gift/redeem/<token>`)
