### PR TITLE
Updated gift subscription token generation

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -6,9 +6,6 @@ import type {GiftRepository} from './gift-repository';
 import tpl from '@tryghost/tpl';
 import {GIFT_REMINDER_FLOOR_DAYS, GIFT_REMINDER_LEAD_DAYS} from './constants';
 
-const GIFT_TOKEN_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-const GIFT_TOKEN_LENGTH = 12;
-
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const errorMessages = {
@@ -129,10 +126,11 @@ export class GiftService {
     }
 
     generateToken(): string {
+        const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
         let token = '';
 
-        for (let i = 0; i < GIFT_TOKEN_LENGTH; i++) {
-            token += GIFT_TOKEN_ALPHABET[crypto.randomInt(GIFT_TOKEN_ALPHABET.length)];
+        for (let i = 0; i < 12; i++) {
+            token += alphabet[crypto.randomInt(alphabet.length)];
         }
 
         return token;

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -126,6 +126,10 @@ export class GiftService {
     }
 
     generateToken(): string {
+        /**
+         * Combinations: 62^12 ≈ 3.23 × 10^21 (~3.23 sextillion)
+         * Entropy:      12 × log2(62) ≈ 71.45 bits
+         */
         const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
         let token = '';
 

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -1,9 +1,13 @@
+import crypto from 'node:crypto';
 import errors from '@tryghost/errors';
 import logging from '@tryghost/logging';
 import {Gift} from './gift';
 import type {GiftRepository} from './gift-repository';
 import tpl from '@tryghost/tpl';
 import {GIFT_REMINDER_FLOOR_DAYS, GIFT_REMINDER_LEAD_DAYS} from './constants';
+
+const GIFT_TOKEN_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const GIFT_TOKEN_LENGTH = 12;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -122,6 +126,16 @@ export class GiftService {
 
     constructor(deps: GiftServiceDeps) {
         this.deps = deps;
+    }
+
+    generateToken(): string {
+        let token = '';
+
+        for (let i = 0; i < GIFT_TOKEN_LENGTH; i++) {
+            token += GIFT_TOKEN_ALPHABET[crypto.randomInt(GIFT_TOKEN_ALPHABET.length)];
+        }
+
+        return token;
     }
 
     async recordPurchase(data: GiftPurchaseData): Promise<boolean> {

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -187,7 +187,8 @@ module.exports = function MembersAPI({
         Offer,
         offersAPI,
         stripeAPIService,
-        settingsCache
+        settingsCache,
+        giftService
     });
 
     const memberController = new MemberController({

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -1,4 +1,3 @@
-const crypto = require('node:crypto');
 const logging = require('@tryghost/logging');
 const DomainEvents = require('@tryghost/domain-events');
 const TierCreatedEvent = require('../../../tiers/tier-created-event');
@@ -14,6 +13,7 @@ class PaymentsService {
      * @param {import('../../../offers/application/offers-api')} deps.offersAPI
      * @param {import('../../../stripe/stripe-api')} deps.stripeAPIService
      * @param {{get(key: string): any}} deps.settingsCache
+     * @param {{service: import('../../../gifts/gift-service').GiftService}} deps.giftService
      */
     constructor(deps) {
         /** @private */
@@ -30,6 +30,8 @@ class PaymentsService {
         this.stripeAPIService = deps.stripeAPIService;
         /** @private */
         this.settingsCache = deps.settingsCache;
+        /** @private */
+        this.giftService = deps.giftService;
 
         DomainEvents.subscribe(OfferCreatedEvent, async (event) => {
             await this.getCouponForOffer(event.data.offer.id);
@@ -173,7 +175,7 @@ class PaymentsService {
         const amount = tier.getPrice(cadence);
         const currency = tier.currency.toLowerCase();
 
-        const token = crypto.randomBytes(6).toString('base64url');
+        const token = this.giftService.service.generateToken();
 
         const successUrlObj = new URL(successUrl);
         successUrlObj.searchParams.set('stripe', 'gift-purchase-success');

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -123,6 +123,28 @@ describe('GiftService', function () {
         });
     }
 
+    describe('generateToken', function () {
+        it('returns a 12-character base62 string', function () {
+            const service = createService();
+
+            for (let i = 0; i < 50; i++) {
+                assert.match(service.generateToken(), /^[A-Za-z0-9]{12}$/);
+            }
+        });
+
+        it('produces unique tokens across many invocations', function () {
+            const service = createService();
+            const tokens = new Set<string>();
+            const samples = 10_000;
+
+            for (let i = 0; i < samples; i++) {
+                tokens.add(service.generateToken());
+            }
+
+            assert.equal(tokens.size, samples);
+        });
+    });
+
     describe('recordPurchase', function () {
         it('creates a Gift entity and saves it', async function () {
             const service = createService();

--- a/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
@@ -303,14 +303,17 @@ describe('PaymentsService', function () {
 
     describe('getGiftPaymentLink', function () {
         let createGiftCheckoutSessionStub;
+        let generateTokenStub;
         let service;
 
         beforeEach(function () {
             createGiftCheckoutSessionStub = sinon.fake.resolves({
                 url: 'https://checkout.stripe.com/gift-session'
             });
+            generateTokenStub = sinon.stub().returns('AbCdEfGhIjKl');
             service = new PaymentsService({
-                stripeAPIService: {createGiftCheckoutSession: createGiftCheckoutSessionStub}
+                stripeAPIService: {createGiftCheckoutSession: createGiftCheckoutSessionStub},
+                giftService: {service: {generateToken: generateTokenStub}}
             });
         });
 
@@ -361,7 +364,8 @@ describe('PaymentsService', function () {
             assert.equal(args.metadata.duration, '1');
             assert.equal(args.metadata.buyer_email, undefined, 'buyer_email should not be in metadata');
             assert.equal(args.metadata.requestSrc, 'portal');
-            assert.match(args.metadata.gift_token, /^[A-Za-z0-9_-]{8}$/);
+            sinon.assert.calledOnce(generateTokenStub);
+            assert.equal(args.metadata.gift_token, 'AbCdEfGhIjKl');
         });
 
         it('appends gift token to success URL', async function () {


### PR DESCRIPTION
no ref

Updated gift subscription token generation to use an alphabet without special chars. Also moved generation to gift service instead of having inline in the payment service