### PR TITLE
feat: update excerpt length to 2000 chars

### DIFF
--- a/ghost/admin/app/validators/post.js
+++ b/ghost/admin/app/validators/post.js
@@ -61,8 +61,8 @@ export default BaseValidator.create({
     },
 
     customExcerpt(model) {
-        if (!validator.isLength(model.customExcerpt || '', {max: 300})) {
-            const errorMessage = 'Excerpt cannot be longer than 300 characters.';
+        if (!validator.isLength(model.customExcerpt || '', {max: 2000})) {
+            const errorMessage = 'Excerpt cannot be longer than 2000 characters.';
             model.errors.add('customExcerpt', errorMessage);
             this.invalidate();
         } else {

--- a/ghost/admin/tests/acceptance/editor-test.js
+++ b/ghost/admin/tests/acceptance/editor-test.js
@@ -299,7 +299,7 @@ describe('Acceptance: Editor', function () {
             expect(
                 find('[data-test-error="custom-excerpt"]').textContent.trim(),
                 'excerpt too long error'
-            ).to.match(/cannot be longer than 300/);
+            ).to.match(/cannot be longer than 2000/);
 
             expect(
                 this.server.db.posts.find(post.id).customExcerpt,
@@ -536,7 +536,7 @@ describe('Acceptance: Editor', function () {
             await fillIn('[data-test-textarea="excerpt"]', Array(302).join('a'));
 
             expect(find('[data-test-error="excerpt"]'), 'excerpt error').to.exist;
-            expect(find('[data-test-error="excerpt"]')).to.have.trimmed.text('Excerpt cannot be longer than 300 characters.');
+            expect(find('[data-test-error="excerpt"]')).to.have.trimmed.text('Excerpt cannot be longer than 2000 characters.');
 
             await fillIn('[data-test-textarea="excerpt"]', Array(300).join('a'));
 

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -90,7 +90,7 @@ module.exports = {
         updated_at: {type: 'dateTime', nullable: true, index: true},
         published_at: {type: 'dateTime', nullable: true, index: true},
         published_by: {type: 'string', maxlength: 24, nullable: true},
-        custom_excerpt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
+        custom_excerpt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 2000}}},
         codeinjection_head: {type: 'text', maxlength: 65535, nullable: true},
         codeinjection_foot: {type: 'text', maxlength: 65535, nullable: true},
         custom_template: {type: 'string', maxlength: 100, nullable: true},
@@ -414,7 +414,7 @@ module.exports = {
         feature_image: {type: 'string', maxlength: 2000, nullable: true},
         feature_image_alt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 191}}},
         feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
-        custom_excerpt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}}
+        custom_excerpt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 2000}}}
     },
     members: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/test/unit/frontend/helpers/excerpt.test.js
+++ b/ghost/core/test/unit/frontend/helpers/excerpt.test.js
@@ -106,13 +106,13 @@ describe('{{excerpt}} Helper', function () {
     it('does not truncate custom_excerpt if characters options is provided', function () {
         const excerpt = 'Hello World! It\'s me!';
         const customExcerpt = 'This is a custom excerpt. It should always be rendered in full length and not being cut ' +
-                   'off. The maximum length of a custom excerpt is 300 characters. Enough to tell a bit about ' +
+                   'off. The maximum length of a custom excerpt is 2000 characters. Enough to tell a bit about ' +
                    'your story and make a nice summary for your readers. It\s only allowed to truncate anything ' +
-                   'after 300 characters. This give';
+                   'after 2000 characters. This give';
         const expected = 'This is a custom excerpt. It should always be rendered in full length and not being cut ' +
-                   'off. The maximum length of a custom excerpt is 300 characters. Enough to tell a bit about ' +
+                   'off. The maximum length of a custom excerpt is 2000 characters. Enough to tell a bit about ' +
                    'your story and make a nice summary for your readers. It\s only allowed to truncate anything ' +
-            'after 300 characters. This give';
+            'after 2000 characters. This give';
 
         shouldRenderToExpected(
             {
@@ -127,13 +127,13 @@ describe('{{excerpt}} Helper', function () {
     it('does not truncate custom_excerpt if words options is provided', function () {
         const excerpt = 'Hello World! It\'s me!';
         const customExcerpt = 'This is a custom excerpt. It should always be rendered in full length and not being cut ' +
-                   'off. The maximum length of a custom excerpt is 300 characters. Enough to tell a bit about ' +
+                   'off. The maximum length of a custom excerpt is 2000 characters. Enough to tell a bit about ' +
                    'your story and make a nice summary for your readers. It\s only allowed to truncate anything ' +
-                   'after 300 characters. This give';
+                   'after 2000 characters. This give';
         const expected = 'This is a custom excerpt. It should always be rendered in full length and not being cut ' +
-                   'off. The maximum length of a custom excerpt is 300 characters. Enough to tell a bit about ' +
+                   'off. The maximum length of a custom excerpt is 2000 characters. Enough to tell a bit about ' +
                    'your story and make a nice summary for your readers. It\s only allowed to truncate anything ' +
-            'after 300 characters. This give';
+            'after 2000 characters. This give';
 
         shouldRenderToExpected(
             {


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
The database already supports upto 2000 chars on the excerpt.

- What does it do?

Allows 2000 characters to be set on the excerpt.

- Why is this something Ghost users or developers need?

When migrating from other platforms, I have found many WP users have long excerpts. 

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works
