### PR TITLE
Added safety tests for AdapterCacheRedis error and edge-case paths

### DIFF
--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -132,6 +132,44 @@ describe('Integration: AdapterCacheRedis', function () {
         });
     });
 
+    describe('get with fetchData (error paths)', function () {
+        it('does not cache errors — a subsequent call retries fetchData', async function () {
+            const cache = createCache();
+            const fetcher = sinon.stub();
+            fetcher.onFirstCall().rejects(new Error('transient DB error'));
+            fetcher.onSecondCall().resolves('recovered');
+
+            await cache.get('retry-key', fetcher);
+
+            const value = await cache.get('retry-key', fetcher);
+
+            assert.equal(fetcher.callCount, 2);
+            assert.equal(value, 'recovered');
+        });
+
+        it('stores and retrieves complex nested objects', async function () {
+            const cache = createCache();
+            const complexValue = {
+                posts: [
+                    {
+                        id: 'abc123',
+                        title: 'Test Post',
+                        tags: [{id: 't1', name: 'News'}],
+                        authors: [{id: 'a1', name: 'Jane'}]
+                    }
+                ],
+                meta: {
+                    pagination: {page: 1, limit: 15, pages: 3, total: 42, next: 2, prev: null}
+                }
+            };
+
+            await cache.set('complex', complexValue);
+            const retrieved = await cache.get('complex');
+
+            assert.deepEqual(retrieved, complexValue);
+        });
+    });
+
     describe('without a keyPrefix', function () {
         it('still stores and retrieves values', async function () {
             const cache = buildCache(undefined);

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -124,6 +124,120 @@ describe('Adapter Cache Redis', function () {
             }
         });
 
+        it('returns undefined and logs error when fetchData rejects on a cache miss', async function () {
+            const redisCacheInstanceStub = {
+                get: sinon.stub().resolves(null),
+                set: sinon.stub().resolves(),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub
+            });
+
+            const fetchData = sinon.stub().rejects(new Error('DB is down'));
+
+            const value = await cache.get('key', fetchData);
+
+            assert.equal(value, undefined);
+            sinon.assert.calledOnce(fetchData);
+            sinon.assert.calledOnce(logging.error);
+        });
+
+        it('retries fetchData on next call after a previous fetchData rejection', async function () {
+            let cachedValue = null;
+            const redisCacheInstanceStub = {
+                get: sinon.stub().callsFake(() => cachedValue),
+                set: sinon.stub().callsFake((_key, value) => {
+                    cachedValue = value;
+                }),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub
+            });
+
+            const fetchData = sinon.stub();
+            fetchData.onFirstCall().rejects(new Error('transient failure'));
+            fetchData.onSecondCall().resolves('recovered value');
+
+            await cache.get('key', fetchData);
+
+            const value = await cache.get('key', fetchData);
+
+            assert.equal(fetchData.callCount, 2);
+            assert.equal(value, 'recovered value');
+        });
+
+        it('does not call fetchData when the underlying Redis get throws', async function () {
+            const redisCacheInstanceStub = {
+                get: sinon.stub().rejects(new Error('Redis connection lost')),
+                set: sinon.stub().resolves(),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub
+            });
+
+            const fetchData = sinon.stub().resolves('fallback value');
+
+            const value = await cache.get('key', fetchData);
+
+            assert.equal(value, undefined);
+            assert.equal(fetchData.callCount, 0);
+            sinon.assert.calledOnce(logging.error);
+        });
+
+        it('returns the cached value when background refresh fails', async function () {
+            const KEY = 'bg-refresh-error';
+            let cachedValue = null;
+
+            const redisCacheInstanceStub = {
+                get: function (key) {
+                    assert(key === KEY);
+                    return cachedValue;
+                },
+                set: function (key, value) {
+                    assert(key === KEY);
+                    cachedValue = value;
+                },
+                ttl: function () {
+                    return 5;
+                },
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub,
+                ttl: 100,
+                refreshAheadFactor: 0.2
+            });
+
+            const fetchData = sinon.stub();
+            fetchData.onFirstCall().resolves('Original Value');
+            fetchData.onSecondCall().rejects(new Error('refresh failed'));
+
+            const first = await cache.get(KEY, fetchData);
+            assert.equal(first, 'Original Value');
+
+            const second = await cache.get(KEY, fetchData);
+            assert.equal(second, 'Original Value');
+        });
+
         it('Can do a background update of the cache', async function () {
             const KEY = 'update-cache-in-background';
             let cachedValue = null;
@@ -226,6 +340,25 @@ describe('Adapter Cache Redis', function () {
 
             assert.equal(value, 'new value');
             assert.equal(redisCacheInstanceStub.set.args[0][0], 'key-here');
+        });
+
+        it('logs error and does not throw when the underlying Redis set throws', async function () {
+            const redisCacheInstanceStub = {
+                set: sinon.stub().rejects(new Error('Redis write failed')),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub
+            });
+
+            const value = await cache.set('key-here', 'new value');
+
+            assert.equal(value, undefined);
+            sinon.assert.calledOnce(logging.error);
         });
 
         it('sets a key based on keyPrefix', async function () {

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -233,9 +233,19 @@ describe('Adapter Cache Redis', function () {
 
             const first = await cache.get(KEY, fetchData);
             assert.equal(first, 'Original Value');
+            sinon.assert.calledOnce(fetchData);
 
             const second = await cache.get(KEY, fetchData);
             assert.equal(second, 'Original Value');
+            sinon.assert.calledTwice(fetchData);
+
+            // The .catch() handler fires asynchronously — wait for it to settle
+            await new Promise((resolve) => { 
+                setTimeout(resolve, 10); 
+            });
+            sinon.assert.calledOnce(logging.error);
+            assert.equal(logging.error.firstCall.args[0].message, 'There was an error refreshing cache data in the background');
+            assert.equal(logging.error.firstCall.args[0].error.message, 'refresh failed');
         });
 
         it('Can do a background update of the cache', async function () {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/19627  [HKG-1709](https://linear.app/ghost/issue/HKG-1709/deduplicate-concurrent-cache-misses)

- We're preparing to merge changes to the Redis cache adapter(concurrent read deduplication). These tests lock in the current error-handling behavior, so any behavioral regression is caught immediately.
- The current adapter silently swallows errors in several paths and the exact behavior isn't documented by existing tests. The concurrent read deduplication PR will change the `get` method structure to share in-flight promises, which makes error paths more sensitive — one failure now affects all callers waiting on the same key. We need to know exactly how errors behave today before changing anything.
