### PR TITLE
Added pull-requests:read permission to CI Setup job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # Required by dorny/paths-filter, which calls pulls.listFiles on
+      # pull_request events. Private forks of this repo don't grant this
+      # implicitly when an explicit permissions block is present, so it must
+      # be listed here for the Setup job to succeed on those forks.
+      pull-requests: read
     steps:
       - name: Checkout current commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The `Setup` job in `ci.yml` uses `dorny/paths-filter` to decide which downstream jobs need to run. On `pull_request` events that action calls `pulls.listFiles`, which needs the `pull-requests: read` permission. The job already declares an explicit `permissions:` block (`actions: read`, `contents: read`), so any permission it doesn't list is denied.

On the public `TryGhost/Ghost` repo this happens to work because GitHub grants a permissive default token to workflows in public repositories, and `pulls.listFiles` is satisfied by the implicit read access. Private forks don't get that free pass — once an explicit `permissions` block is present, only the scopes listed are granted. `TryGhost/Ghost-Security` (a private fork that mirrors this workflow) currently fails on every PR with `Resource not accessible by integration` coming out of `dorny/paths-filter`, which blocks the rest of the pipeline.

Adding `pull-requests: read` to the `Setup` job's `permissions` block makes the declared permissions match what the action actually needs. On the public repo it's a no-op (that access was already effectively granted), and on private forks it unblocks the Setup job so the rest of CI can run.