### PR TITLE
Updated share button in newsletters to show on paid/member posts, and not show on email-only

### DIFF
--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1031,8 +1031,8 @@ class EmailRenderer {
         }
 
         const postUrl = this.#getPostUrl(post);
-        const isPublicPost = post.get('visibility') === 'public';
-        const showShareButton = isPublicPost && newsletter.get('show_share_button');
+        const hasEmailOnlyFlag = post.related('posts_meta')?.get('email_only') ?? false;
+        const showShareButton = newsletter.get('show_share_button') && !hasEmailOnlyFlag;
         const shareUrl = new URL(postUrl);
         shareUrl.hash = '/share';
 
@@ -1057,7 +1057,6 @@ class EmailRenderer {
         const commentUrl = new URL(postUrl);
         commentUrl.hash = '#ghost-comments-root';
 
-        const hasEmailOnlyFlag = post.related('posts_meta')?.get('email_only') ?? false;
         const hasFeedbackButtons = newsletter.get('feedback_enabled');
         const showCommentCta = newsletter.get('show_comment_cta') && this.#settingsCache.get('comments_enabled') !== 'off' && !hasEmailOnlyFlag;
         const feedbackButtonCount = (hasFeedbackButtons ? 2 : 0) + (showCommentCta ? 1 : 0) + (showShareButton ? 1 : 0);

--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -899,7 +899,29 @@ describe.skip('Batch sending tests', function () {
             await models.Newsletter.edit({show_comment_cta: true}, {id: defaultNewsletter.id});
         });
 
-        it('Shows share button when enabled in newsletter for public posts', async function () {
+        it('Shows share button when enabled in newsletter for public, members, paid, and tiers posts', async function () {
+            mockSetting('email_track_clicks', false); // Disable link replacement for this test
+
+            const defaultNewsletter = await getDefaultNewsletter();
+            const originalShowShareButton = defaultNewsletter.get('show_share_button');
+            await models.Newsletter.edit({show_share_button: true}, {id: defaultNewsletter.id});
+
+            try {
+                for (const visibility of ['public', 'members', 'paid', 'tiers']) {
+                    const {html} = await sendEmail(agent, {
+                        title: `This is a test post title (${visibility})`,
+                        mobiledoc: mobileDocExample,
+                        visibility
+                    });
+
+                    assert.match(html, /#\/share/, `Expected share button for "${visibility}" visibility`);
+                }
+            } finally {
+                await models.Newsletter.edit({show_share_button: originalShowShareButton}, {id: defaultNewsletter.id});
+            }
+        });
+
+        it('Hides share button for email-only posts', async function () {
             mockSetting('email_track_clicks', false); // Disable link replacement for this test
 
             const defaultNewsletter = await getDefaultNewsletter();
@@ -910,10 +932,11 @@ describe.skip('Batch sending tests', function () {
                 const {html} = await sendEmail(agent, {
                     title: 'This is a test post title',
                     mobiledoc: mobileDocExample,
-                    visibility: 'public'
+                    visibility: 'members',
+                    email_only: true
                 });
 
-                assert.match(html, /#\/share/);
+                assert.doesNotMatch(html, /#\/share/);
             } finally {
                 await models.Newsletter.edit({show_share_button: originalShowShareButton}, {id: defaultNewsletter.id});
             }

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1439,8 +1439,7 @@ describe('Email renderer', function () {
             assert(response.html.includes('http://feedback-link.com/?score=0'));
         });
 
-        it('includes share links for public posts', async function () {
-            const post = createModel(basePost);
+        it('includes share links for posts with public, members, paid, and tiers visibility', async function () {
             const newsletter = createModel({
                 header_image: null,
                 name: 'Test Newsletter',
@@ -1452,21 +1451,33 @@ describe('Email renderer', function () {
             const segment = null;
             const options = {};
 
-            const response = await emailRenderer.renderBody(
-                post,
-                newsletter,
-                segment,
-                options
-            );
+            for (const visibility of ['public', 'members', 'paid', 'tiers']) {
+                const post = createModel({
+                    ...basePost,
+                    visibility
+                });
 
-            assert(response.html.includes('href="http://example.com/#/share"'));
-            assert(response.html.includes('>Share</p>'));
+                const response = await emailRenderer.renderBody(
+                    post,
+                    newsletter,
+                    segment,
+                    options
+                );
+
+                assert(response.html.includes('href="http://example.com/#/share"'), `Expected share link for "${visibility}" visibility`);
+                assert(response.html.includes('>Share</p>'), `Expected share button text for "${visibility}" visibility`);
+            }
         });
 
-        it('does not include share links for non-public posts', async function () {
+        it('does not include share links for email-only posts', async function () {
             const post = createModel({
                 ...basePost,
-                visibility: 'members'
+                posts_meta: createModel({
+                    feature_image_alt: null,
+                    feature_image_caption: null,
+                    email_only: true
+                }),
+                loaded: ['posts_meta']
             });
             const newsletter = createModel({
                 header_image: null,
@@ -2585,18 +2596,21 @@ describe('Email renderer', function () {
             assert.equal(data.post.publishedAt, '1 Jan 1970');
         });
 
-        it('includes share URL for public posts', async function () {
+        it('includes share URL for posts with public, members, paid, and tiers visibility', async function () {
             const html = '';
-            const post = createModel({
-                posts_meta: createModel({}),
-                loaded: ['posts_meta'],
-                visibility: 'public'
-            });
             const newsletter = createModel({
                 show_share_button: true
             });
-            const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
-            assert.equal(data.post.shareUrl, 'http://example.com/#/share');
+
+            for (const visibility of ['public', 'members', 'paid', 'tiers']) {
+                const post = createModel({
+                    posts_meta: createModel({}),
+                    loaded: ['posts_meta'],
+                    visibility
+                });
+                const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
+                assert.equal(data.post.shareUrl, 'http://example.com/#/share', `Expected share URL for "${visibility}" visibility`);
+            }
         });
 
         it('calculates footer feedback button widths based on visible actions', async function () {
@@ -2632,21 +2646,19 @@ describe('Email renderer', function () {
             assert.equal(data.post.shareUrl, null);
         });
 
-        it('does not include share URL for non-public posts', async function () {
+        it('does not include share URL for email-only posts', async function () {
             const html = '';
+            const post = createModel({
+                posts_meta: createModel({email_only: true}),
+                loaded: ['posts_meta'],
+                visibility: 'members'
+            });
             const newsletter = createModel({
                 show_share_button: true
             });
 
-            for (const visibility of ['members', 'paid', 'tiers']) {
-                const post = createModel({
-                    posts_meta: createModel({}),
-                    loaded: ['posts_meta'],
-                    visibility
-                });
-                const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
-                assert.equal(data.post.shareUrl, null, `Expected no share URL for "${visibility}" visibility`);
-            }
+            const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
+            assert.equal(data.post.shareUrl, null);
         });
 
         it('show feature image if post has feature image', async function () {


### PR DESCRIPTION
no ref

Some small tweaks to the visibility of the share button when it's toggled on for newsletters:
- if it's a paid/members-only post, we want to show the share button. idea is that shares of that post can drive help drive conversion for more members
- if it's an email-only newsletter, do _not_ show the share button. idea is an email-only newsletter isn't meant to be shared as a link

paid preview:
<img width="438" height="525" alt="image" src="https://github.com/user-attachments/assets/e985f5d2-2d8f-461b-abbe-da8e63a2ee53" />
paid email:
<img width="672" height="275" alt="image" src="https://github.com/user-attachments/assets/7ad36622-654c-47c7-b72a-668897a315cd" />
member email:
<img width="630" height="273" alt="image" src="https://github.com/user-attachments/assets/21360b05-84b0-4761-a26c-2d5aef151d4d" />


email only:
<img width="652" height="280" alt="image" src="https://github.com/user-attachments/assets/976bde9b-2d73-42e5-9fd4-5a23632c6c7f" />
