### PR TITLE
Raised CI Playwright test timeout from 30s to 60s

### DIFF
--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -17,7 +17,7 @@ const getWorkerCount = () => {
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
-    timeout: process.env.CI ? 30 * 1000 : 30 * 1000,
+    timeout: process.env.CI ? 60 * 1000 : 30 * 1000,
     expect: {
         timeout: process.env.CI ? 10 * 1000 : 10 * 1000
     },


### PR DESCRIPTION
For private forks with slower GHA runners we were seeing constant timeouts on specific suites of tests with the default of 30s.

This PR changes the default timeout on CI from 30s to 60s to give those slower runners more headroom to finish sooner.