### PR TITLE
Added e2e/blob-report to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,7 @@ yalc.lock
 # e2e test suite
 /e2e/test-results
 /e2e/playwright-report
+/e2e/blob-report
 /e2e/build
 /e2e/playwright
 /e2e/data


### PR DESCRIPTION
no refs

There should be no user-facing impact to this change.

This blob report is sometimes generated when running e2e tests locally, but shouldn't be committed.