### PR TITLE
Fixed issue with NaN in posts bulk actions

### DIFF
--- a/ghost/admin/app/components/posts-list/selection-list.js
+++ b/ghost/admin/app/components/posts-list/selection-list.js
@@ -123,11 +123,11 @@ export default class SelectionList {
         }
         
         const models = this.infinityModel;
-        let total;
+        let total = 0;
         for (const key in models) {
-            total += models[key].meta?.pagination?.total;
-        }   
-        return Math.max((total ?? 0) - this.selectedIds.size, 1);
+            total += models[key].meta?.pagination?.total ?? 0;
+        }
+        return Math.max(total - this.selectedIds.size, 1);
     }
 
     isSelected(id) {


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1053/nan-showing-in-change-post-access-dialog-when-bulk-editing-in-posts

We would previously show NaN when using Cmd+A because the total started as undefined instead of 0, which made all the math return NaN. Now we properly initialise the total to 0 and handle missing pagination values in the loop, so the count works correctly.

