### PR TITLE
Removed drip sequences labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -52,10 +52,6 @@ const features: Feature[] = [{
     description: 'Display a Feedback menu item in the admin sidebar. Requires the new admin experience.',
     flag: 'featurebaseFeedback'
 }, {
-    title: 'Drip Sequences',
-    description: 'Enable welcome email drip sequences',
-    flag: 'dripSequences'
-}, {
     title: 'Picture Element',
     description: 'Use the HTML picture element to serve modern image formats (AVIF, WebP) with automatic fallbacks',
     flag: 'pictureImageFormats'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -47,7 +47,6 @@ const PRIVATE_FEATURES = [
     'emailUniqueid',
     'themeTranslation',
     'indexnow',
-    'dripSequences',
     'pictureImageFormats',
     'smarterCounts',
     'giftSubscriptions'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -13,7 +13,6 @@ Object {
       "adminUIRefresh": true,
       "commentModeration": true,
       "customFonts": true,
-      "dripSequences": true,
       "editorExcerpt": true,
       "emailCustomization": true,
       "emailUniqueid": true,


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1237
ref 643a114e54c3ccb3f1400e9cf29282ac9a285292
ref https://github.com/TryGhost/Ghost/pull/27492

This removes the "drip sequences" labs flag. We'll replace it with something else soon.
