### PR TITLE
Added analytics-service tinybird token

### DIFF
--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -1,4 +1,5 @@
 TOKEN "tracker" APPEND
+TOKEN "analytics-service" APPEND
 
 
 SCHEMA >

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -2,6 +2,7 @@
 # A place to send data for testing and monitoring purposes
 
 TOKEN "tracker" APPEND
+TOKEN "analytics-service" APPEND
 
 SCHEMA >
     `timestamp` DateTime `json:$.timestamp`,


### PR DESCRIPTION
This should have no user-facing impact.

Adding a new analytics-service Tinybird token with append scopes to our Tinybird workspace. This will allow the analytics service to send events to Tinybird.