### PR TITLE
Added private labs flag for automations

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -12,6 +12,10 @@ type Feature = {
 };
 
 const features: Feature[] = [{
+    title: 'Automations',
+    description: 'Enable automations management interface.',
+    flag: 'automations'
+}, {
     title: 'Stripe Automatic Tax (private beta)',
     description: 'Use Stripe Automatic Tax at Stripe Checkout. Needs to be enabled in Stripe',
     flag: 'stripeAutomaticTax'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -37,6 +37,7 @@ const PUBLIC_BETA_FEATURES = [
 // These features are considered private they live in the private tab of the labs settings page
 // Which is only visible if the developer experiments flag is enabled
 const PRIVATE_FEATURES = [
+    'automations',
     'stripeAutomaticTax',
     'importMemberTier',
     'urlCache',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -11,6 +11,7 @@ Object {
     "labs": Object {
       "additionalPaymentMethods": true,
       "adminUIRefresh": true,
+      "automations": true,
       "commentModeration": true,
       "customFonts": true,
       "editorExcerpt": true,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1237
ref https://github.com/TryGhost/Ghost/pull/27494

![Screenshot](https://github.com/user-attachments/assets/84541197-d0b4-41e0-b34c-700b6db0ee02)

This adds a dormant labs flag, "automations", which will show the automations UI.