### PR TITLE
Removed unused "are paths equal?" helper

### DIFF
--- a/apps/admin-x-settings/src/utils/url.ts
+++ b/apps/admin-x-settings/src/utils/url.ts
@@ -13,26 +13,3 @@ export function trimSearchAndHash(url: URL) {
     url.hash = '';
     return url;
 }
-
-/*  Compare two URLs based on their hostname and pathname.
- *  Query params, hash fragements, protocol and www are ignored.
- *
- *  Example:
- *  - https://a.com, http://a.com, https://www.a.com, https://a.com?param1=value, https://a.com/#segment-1 are all considered equal
- *  - but, https://a.com/path-1 and  https://a.com/path-2 are not
- */
-export function arePathsEqual(urlStr1: string, urlStr2: string) {
-    let url1, url2;
-
-    try {
-        url1 = new URL(urlStr1);
-        url2 = new URL(urlStr2);
-    } catch {
-        return false;
-    }
-
-    return (
-        url1.hostname.replace('www.', '') === url2.hostname.replace('www.', '') &&
-        url1.pathname === url2.pathname
-    );
-}

--- a/apps/admin-x-settings/test/unit/utils/url.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/url.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert/strict';
-import {arePathsEqual, trimHash, trimSearch, trimSearchAndHash} from '@src/utils/url';
+import {trimHash, trimSearch, trimSearchAndHash} from '@src/utils/url';
 
 describe('trimSearch', function () {
     it('removes the query parameters from a URL', function () {
@@ -25,70 +25,5 @@ describe('trimSearchAndHash', function () {
         const parsedUrl = new URL(url);
 
         assert.equal(trimSearchAndHash(parsedUrl).toString(), 'https://example.com/path');
-    });
-});
-
-describe('arePathsEqual', function () {
-    it('returns false if one of the param is not a URL', function () {
-        const url1 = 'foo';
-        const url2 = 'https://example.com';
-
-        assert.equal(arePathsEqual(url1, url2), false);
-    });
-
-    it('returns false if hostnames are different', function () {
-        const url1 = 'https://a.com';
-        const url2 = 'https://b.com';
-
-        assert.equal(arePathsEqual(url1, url2), false);
-    });
-
-    it('returns false if top level domains are different', function () {
-        const url1 = 'https://a.io';
-        const url2 = 'https://a.com';
-
-        assert.equal(arePathsEqual(url1, url2), false);
-    });
-
-    it('returns false if sub domains are different', function () {
-        const url1 = 'https://sub.a.com';
-        const url2 = 'https://subdiff.a.com';
-
-        assert.equal(arePathsEqual(url1, url2), false);
-    });
-
-    it('returns false if paths are different', function () {
-        const url1 = 'https://a.com/path-1';
-        const url2 = 'https://a.com/path-2';
-
-        assert.equal(arePathsEqual(url1, url2), false);
-    });
-
-    it('returns true even if protocols are different', function () {
-        const url1 = 'http://a.com';
-        const url2 = 'https://a.com';
-
-        assert.equal(arePathsEqual(url1, url2), true);
-    });
-
-    it('returns true even if www is used in one of the urls', function () {
-        const url1 = 'https://www.a.com';
-        const url2 = 'https://a.com';
-
-        assert.equal(arePathsEqual(url1, url2), true);
-    });
-
-    it('returns true even if query parameters are different', function () {
-        const url1 = 'http://a.com?foo=bar';
-        const url2 = 'http://a.com';
-
-        assert.equal(arePathsEqual(url1, url2), true);
-    });
-
-    it('returns true even if hash segments are different', function () {
-        const url1 = 'http://a.com#segment-1';
-        const url2 = 'http://a.com';
-
-        assert.equal(arePathsEqual(url1, url2), true);
     });
 });


### PR DESCRIPTION
ref fee402a340c539291df889f2f389fab2b71901f5

We had a utility function, `arePathsEqual`, which has been unused since fee402a340c539291df889f2f389fab2b71901f5. Let's remove it.

`git grep arePathsEqual` returns no results after this change.
