### PR TITLE
Skipped flaky welcome emails test

### DIFF
--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -269,7 +269,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button', () => {
         await expect(page).toHaveURL(/\/ghost\/#\/settings\/memberemails$/);
     });
 
-    test('Escape closes welcome email color picker without bypassing unsaved changes confirmation', async ({page}) => {
+    test.skip('Escape closes welcome email color picker without bypassing unsaved changes confirmation', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1234/flaky-member-welcome-emails-e2e-test

This test has been flaky recently. Skipping it for now to avoid disrupting CI while I work on a fix.