### PR TITLE
Aligned gift subscription staff email with new paid subscriber pattern

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -85,6 +85,8 @@ interface StaffServiceEmails {
         memberEmail: string;
         memberName: string | null;
         tierName: string;
+        cadence: 'month' | 'year';
+        duration: number;
         buyerEmail: string;
     }): Promise<void>;
 }
@@ -313,6 +315,8 @@ export class GiftService {
                     memberEmail: member.get('email'),
                     memberName: member.get('name'),
                     tierName: tier.name,
+                    cadence: redeemed.cadence,
+                    duration: redeemed.duration,
                     buyerEmail: redeemed.buyerEmail
                 });
             } catch (err) {

--- a/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.hbs
+++ b/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.hbs
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>🎁 New paid subscriber: {{memberData.name}}</title>
+    <title>🎁 Paid subscription started: {{memberData.name}}</title>
     {{> styles}}
   </head>
   <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
@@ -44,9 +44,7 @@
                                       <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Name</p>
                                       <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{memberData.name}}{{#if memberData.showEmail}} ({{memberData.email}}){{/if}}</p>
                                       <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Tier</p>
-                                      <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{tierData.name}}</p>
-                                      <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Source</p>
-                                      <p class="large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">Gift subscription</p>
+                                      <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{tierData.name}}{{#if tierData.details}} &bull; {{tierData.details}}{{/if}}</p>
                                       <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Gifted by</p>
                                       <p class="large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{giftedByEmail}}</p>
                                     </td>

--- a/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.txt.js
+++ b/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.txt.js
@@ -5,8 +5,7 @@ Congratulations!
 
 You have a new paid member: ${data.memberData.name}
 
-Tier: ${data.tierData.name}
-Source: Gift subscription
+Tier: ${data.tierData.name}${data.tierData.details ? ` • ${data.tierData.details}` : ''}
 Gifted by: ${data.giftedByEmail}
 
 ---

--- a/ghost/core/core/server/services/staff/staff-service-emails.js
+++ b/ghost/core/core/server/services/staff/staff-service-emails.js
@@ -337,14 +337,15 @@ class StaffServiceEmails {
         });
     }
 
-    async notifyGiftSubscriptionStarted({memberId, memberName, memberEmail, tierName, buyerEmail}, options = {}) {
+    async notifyGiftSubscriptionStarted({memberId, memberName, memberEmail, tierName, cadence, duration, buyerEmail}, options = {}) {
         const users = await this.models.User.getEmailAlertUsers('paid-started', options);
         const memberData = this.getMemberData({
             id: memberId,
             name: memberName ?? null,
             email: memberEmail
         });
-        const subject = `🎁 New paid subscriber: ${memberData.name}`;
+        const subject = `🎁 Paid subscription started: ${memberData.name}`;
+        const cadenceLabel = duration === 1 ? `1 ${cadence}` : `${duration} ${cadence}s`;
 
         await this.sendToStaff({
             users,
@@ -353,7 +354,8 @@ class StaffServiceEmails {
             memberData,
             templateData: {
                 tierData: {
-                    name: tierName
+                    name: tierName,
+                    details: cadenceLabel
                 },
                 giftedByEmail: buyerEmail
             }

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -671,7 +671,7 @@ describe('Gift Subscriptions', function () {
 
                 // Verify staff notification email was sent
                 mockManager.assert.sentEmail({
-                    subject: /new paid subscriber/i,
+                    subject: /paid subscription started/i,
                     to: 'jbloggs@example.com'
                 });
             });
@@ -849,7 +849,7 @@ describe('Gift Subscriptions', function () {
                         // Verify gift subscription started staff notification was sent,
                         // and that no other unwanted staff notifications were sent (i.e. no "Free member signup" email)
                         mockManager.assert.sentEmail({
-                            subject: /new paid subscriber/i,
+                            subject: /paid subscription started/i,
                             to: 'jbloggs@example.com'
                         });
                         mockManager.assert.sentEmailCount(1);
@@ -920,7 +920,7 @@ describe('Gift Subscriptions', function () {
 
                         // Verify gift subscription started staff notification was sent
                         mockManager.assert.sentEmail({
-                            subject: /new paid subscriber/i,
+                            subject: /paid subscription started/i,
                             to: 'jbloggs@example.com'
                         });
 

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -1007,6 +1007,8 @@ describe('GiftService', function () {
                 memberEmail: 'member@example.com',
                 memberName: 'Member Name',
                 tierName: 'Bronze',
+                cadence: 'year',
+                duration: 1,
                 buyerEmail: 'buyer@example.com'
             });
             assert.equal(redeemed.status, 'redeemed');

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -1097,26 +1097,47 @@ describe('StaffService', function () {
                     memberEmail: 'jamie@example.com',
                     memberId: 'abc',
                     tierName: 'Premium',
+                    cadence: 'year',
+                    duration: 1,
                     buyerEmail: 'gifter@example.com'
                 });
 
                 sinon.assert.calledWith(getEmailAlertUsersStub, 'paid-started');
                 sinon.assert.calledOnce(mailStub);
-                sinon.assert.calledWith(mailStub, sinon.match.has('subject', sinon.match('New paid subscriber: Jamie')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('subject', sinon.match('🎁 Paid subscription started: Jamie')));
             });
 
-            it('includes the tier in HTML and plain text', async function () {
+            it('includes the tier and cadence in HTML and plain text', async function () {
                 await service.emails.notifyGiftSubscriptionStarted({
                     memberName: 'Jamie',
                     memberEmail: 'jamie@example.com',
                     memberId: 'abc',
                     tierName: 'Premium',
+                    cadence: 'year',
+                    duration: 1,
                     buyerEmail: 'gifter@example.com'
                 });
 
                 sinon.assert.calledOnce(mailStub);
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Premium')));
-                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Tier: Premium')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('1 year')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Tier: Premium • 1 year')));
+            });
+
+            it('pluralises the cadence when duration is greater than 1', async function () {
+                await service.emails.notifyGiftSubscriptionStarted({
+                    memberName: 'Jamie',
+                    memberEmail: 'jamie@example.com',
+                    memberId: 'abc',
+                    tierName: 'Premium',
+                    cadence: 'month',
+                    duration: 3,
+                    buyerEmail: 'gifter@example.com'
+                });
+
+                sinon.assert.calledOnce(mailStub);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('3 months')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Tier: Premium • 3 months')));
             });
 
             it('includes the member name in HTML and plain text', async function () {
@@ -1125,6 +1146,8 @@ describe('StaffService', function () {
                     memberEmail: 'jamie@example.com',
                     memberId: 'abc',
                     tierName: 'Premium',
+                    cadence: 'year',
+                    duration: 1,
                     buyerEmail: 'gifter@example.com'
                 });
 
@@ -1133,26 +1156,14 @@ describe('StaffService', function () {
                 sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Jamie')));
             });
 
-            it('includes the source in HTML and plain text', async function () {
-                await service.emails.notifyGiftSubscriptionStarted({
-                    memberName: 'Jamie',
-                    memberEmail: 'jamie@example.com',
-                    memberId: 'abc',
-                    tierName: 'Premium',
-                    buyerEmail: 'gifter@example.com'
-                });
-
-                sinon.assert.calledOnce(mailStub);
-                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Gift subscription')));
-                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Source: Gift subscription')));
-            });
-
             it('includes the buyer email in HTML and plain text', async function () {
                 await service.emails.notifyGiftSubscriptionStarted({
                     memberName: 'Jamie',
                     memberEmail: 'jamie@example.com',
                     memberId: 'abc',
                     tierName: 'Premium',
+                    cadence: 'year',
+                    duration: 1,
                     buyerEmail: 'gifter@example.com'
                 });
 


### PR DESCRIPTION
no issues

Follow-up design/copy pass on the gift redemption staff notification added in #27414, to bring it in line with the existing "new paid subscriber" email.

- Subject is now `🎁 Paid subscription started: {name}` — mirrors the existing `💸 Paid subscription started: {name}` pattern used for regular paid signups
- Tier row now includes the gift cadence (e.g. `Premium • 1 year`) instead of just the tier name
- Dropped the `Source: Gift subscription` row — `Gifted by` already conveys that, and the regular paid email omits source when there's no attribution