### PR TITLE
🐛 Fixed mobile issues with Portal share modal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.10",
+  "version": "2.68.11",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/share/share-modal.js
+++ b/apps/portal/src/components/pages/share/share-modal.js
@@ -38,8 +38,10 @@ const ShareModal = () => {
         // correct document context where the click events actually fire.
         const doc = moreMenuRef.current?.ownerDocument || document;
 
-        const onDocumentMouseDown = (event) => {
+        const onDocumentClickCapture = (event) => {
             if (moreMenuRef.current && !moreMenuRef.current.contains(event.target)) {
+                event.stopPropagation();
+                event.preventDefault();
                 setIsMoreMenuOpen(false);
             }
         };
@@ -50,11 +52,11 @@ const ShareModal = () => {
             }
         };
 
-        doc.addEventListener('mousedown', onDocumentMouseDown);
+        doc.addEventListener('click', onDocumentClickCapture, true);
         doc.addEventListener('keydown', onDocumentKeyDown);
 
         return () => {
-            doc.removeEventListener('mousedown', onDocumentMouseDown);
+            doc.removeEventListener('click', onDocumentClickCapture, true);
             doc.removeEventListener('keydown', onDocumentKeyDown);
         };
     }, [isMoreMenuOpen]);

--- a/apps/portal/src/components/pages/share/share-modal.styles.js
+++ b/apps/portal/src/components/pages/share/share-modal.styles.js
@@ -263,6 +263,13 @@ export const ShareModalStyles = `
         top: 20px;
     }
 
+    @media (max-width: 480px) {
+        .gh-portal-popup-container.share {
+            flex: 1 0 auto;
+            margin-bottom: 0;
+        }
+    }
+
     @media (max-width: 420px) {
         .gh-portal-share-actions {
             flex-direction: column;
@@ -292,11 +299,8 @@ export const ShareModalStyles = `
             order: 4;
         }
 
-        .gh-portal-share-action.more {
-            order: 5;
-        }
-
         .gh-portal-share-more {
+            order: 5;
             width: 100%;
         }
 

--- a/apps/portal/test/unit/components/pages/share-modal.test.js
+++ b/apps/portal/test/unit/components/pages/share-modal.test.js
@@ -216,7 +216,7 @@ describe('ShareModal', () => {
         expect(getByRole('menu')).toBeInTheDocument();
         expect(moreButton).toHaveAttribute('aria-expanded', 'true');
 
-        fireEvent.mouseDown(getByText('Share'));
+        fireEvent.click(getByText('Share'));
         expect(queryByRole('menu')).not.toBeInTheDocument();
         expect(moreButton).toHaveAttribute('aria-expanded', 'false');
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1238

- Below 480px the share modal now fills the viewport so the empty area under it no longer closes the modal; it can only be dismissed via the X
- Below 420px the "more" button now renders last in the action row; the flex \`order\` was applied to the button rather than its wrapper div, which is the actual flex child, so the wrapper fell back to order 0 and appeared first
- When the more menu is open, outside clicks are now intercepted in the capture phase so the first click only closes the menu instead of also opening a share target or closing the whole modal
