### PR TITLE
Updated Admin member stats service to include gift members

### DIFF
--- a/ghost/admin/app/services/members-stats.js
+++ b/ghost/admin/app/services/members-stats.js
@@ -23,8 +23,9 @@ export default class MembersStatsService extends Service {
         if (!stats) {
             return 0;
         }
-        const {free, paid, comped} = stats.meta.totals;
-        const total = free + paid + comped || 0;
+        // TODO: remove gift default once API includes `gift`
+        const {free, paid, comped, gift = 0} = stats.meta.totals;
+        const total = free + paid + comped + gift || 0;
         return total;
     }
 

--- a/ghost/admin/tests/unit/services/member-stats-test.js
+++ b/ghost/admin/tests/unit/services/member-stats-test.js
@@ -82,4 +82,25 @@ describe('Unit: Service: membersStats', function () {
         expect(keys[keys.length - 1]).to.equal(moment().format('YYYY-MM-DD'));
         expect(values[values.length - 1]).to.equal(14459);
     });
+
+    describe('memberCount getter', function () {
+        it('returns 0 when totalMemberCount has not been fetched', function () {
+            memberStatsService.totalMemberCount = null;
+            expect(memberStatsService.memberCount).to.equal(0);
+        });
+
+        it('sums all member categories', function () {
+            memberStatsService.totalMemberCount = {
+                meta: {totals: {paid: 10, free: 100, comped: 5, gift: 2}}
+            };
+            expect(memberStatsService.memberCount).to.equal(117);
+        });
+
+        it('defaults gift to 0 when missing from API response', function () {
+            memberStatsService.totalMemberCount = {
+                meta: {totals: {paid: 10, free: 100, comped: 5}}
+            };
+            expect(memberStatsService.memberCount).to.equal(115);
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3544

- the `memberCount` getter on the `membersStats` service was summing only `paid` + `free` + `comped`
- user-visible impact is narrow: the "existing members will be updated" notice on the CSV import modal is gated by this getter, so a site with only gift members would see the notice hidden
- defaulted `gift = 0` in the destructure to guard against admin being deployed ahead of the API change, with a TODO to remove once the API is guaranteed to include gift everywhere