### PR TITLE
Updated gift redemption success state

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.13",
+  "version": "2.68.14",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -1,5 +1,6 @@
 import setupGhostApi from './utils/api';
 import {chooseBestErrorMessage} from './utils/errors';
+import {getGiftRedemptionSuccessMessage} from './utils/gift-redemption-notification';
 import {createNotification, createPopupNotification, getMemberEmail, getMemberName, getProductCadenceFromPrice, removePortalLinkFromUrl, getRefDomain} from './utils/helpers';
 import {t} from './utils/i18n';
 
@@ -218,6 +219,10 @@ async function signup({data, state, api}) {
 
 async function redeemGift({data, state, api}) {
     try {
+        const gift = state.pageData.gift;
+        if (!gift) {
+            throw new Error('Gift not found');
+        }
         let {email, name, giftToken} = data;
         name = name?.trim();
 
@@ -229,13 +234,22 @@ async function redeemGift({data, state, api}) {
                 status: 'success',
                 autoHide: true,
                 closeable: true,
-                state
+                state,
+                message: getGiftRedemptionSuccessMessage({
+                    tierName: gift.tier.name,
+                    cadence: gift.cadence,
+                    duration: gift.duration
+                })
             });
+            removePortalLinkFromUrl();
 
             return {
                 action: 'redeemGift:success',
                 member,
-                page: 'accountHome',
+                showPopup: false,
+                lastPage: null,
+                pageQuery: '',
+                popupNotification: null,
                 notification,
                 notificationSequence: notification.count
             };
@@ -243,10 +257,13 @@ async function redeemGift({data, state, api}) {
 
         const integrityToken = await api.member.getIntegrityToken();
         const redirectUrl = new URL(state?.site?.url || window.location.href);
-        const hashParams = new URLSearchParams({
-            giftRedemption: 'true'
-        });
-        redirectUrl.hash = `/portal/account?${hashParams.toString()}`;
+        redirectUrl.search = new URLSearchParams({
+            giftRedemption: 'true',
+            giftTier: gift.tier.name,
+            giftCadence: gift.cadence,
+            giftDuration: String(gift.duration)
+        }).toString();
+        redirectUrl.hash = '';
 
         const {otc_ref: otcRef, inboxLinks} = await api.member.sendMagicLink({
             email: (email || '').trim(),

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -219,10 +219,6 @@ async function signup({data, state, api}) {
 
 async function redeemGift({data, state, api}) {
     try {
-        const gift = state.pageData.gift;
-        if (!gift) {
-            throw new Error('Gift not found');
-        }
         let {email, name, giftToken} = data;
         name = name?.trim();
 
@@ -235,11 +231,7 @@ async function redeemGift({data, state, api}) {
                 autoHide: true,
                 closeable: true,
                 state,
-                message: getGiftRedemptionSuccessMessage({
-                    tierName: gift.tier.name,
-                    cadence: gift.cadence,
-                    duration: gift.duration
-                })
+                message: getGiftRedemptionSuccessMessage({member})
             });
             removePortalLinkFromUrl();
 
@@ -258,10 +250,7 @@ async function redeemGift({data, state, api}) {
         const integrityToken = await api.member.getIntegrityToken();
         const redirectUrl = new URL(state?.site?.url || window.location.href);
         redirectUrl.search = new URLSearchParams({
-            giftRedemption: 'true',
-            giftTier: gift.tier.name,
-            giftCadence: gift.cadence,
-            giftDuration: String(gift.duration)
+            giftRedemption: 'true'
         }).toString();
         redirectUrl.hash = '';
 

--- a/apps/portal/src/components/notification.js
+++ b/apps/portal/src/components/notification.js
@@ -7,6 +7,7 @@ import {ReactComponent as CloseIcon} from '../images/icons/close.svg';
 import {ReactComponent as CheckmarkIcon} from '../images/icons/checkmark-fill.svg';
 import {ReactComponent as WarningIcon} from '../images/icons/warning-fill.svg';
 import NotificationParser, {clearURLParams} from '../utils/notifications';
+import {getGiftRedemptionSuccessMessage} from '../utils/gift-redemption-notification';
 import {getPortalLink} from '../utils/helpers';
 import {t} from '../utils/i18n';
 
@@ -107,12 +108,17 @@ const NotificationText = ({type, status, message, context}) => {
             </p>
         );
     } else if (type === 'giftRedeem' && status === 'success') {
+        // TODO: Add translation strings once copy has been finalised
+        const successMessage = getGiftRedemptionSuccessMessage({member: context.member})
+            || 'Gift redeemed! You\'re all set.';
+
         return (
             <p>
-                {message}
+                {successMessage}
             </p>
         );
     } else if (type === 'giftRedeem' && status === 'error') {
+        // TODO: Add translation strings once copy has been finalised
         return (
             <p>
                 {'We couldn\'t redeem this gift for your account.'}
@@ -289,7 +295,7 @@ export default class Notification extends React.Component {
             if (['signin', 'signup', 'giftRedeem'].includes(type)) {
                 deleteParams.push('action', 'success');
                 if (type === 'giftRedeem') {
-                    deleteParams.push('giftRedemption', 'giftTier', 'giftCadence', 'giftDuration');
+                    deleteParams.push('giftRedemption');
                 }
             } else if (['stripe:checkout'].includes(type)) {
                 deleteParams.push('stripe');

--- a/apps/portal/src/components/notification.js
+++ b/apps/portal/src/components/notification.js
@@ -107,10 +107,9 @@ const NotificationText = ({type, status, message, context}) => {
             </p>
         );
     } else if (type === 'giftRedeem' && status === 'success') {
-        // TODO: Add translation strings once copy has been finalised
         return (
             <p>
-                {'Gift redeemed! You\'re all set.'}
+                {message}
             </p>
         );
     } else if (type === 'giftRedeem' && status === 'error') {
@@ -290,7 +289,7 @@ export default class Notification extends React.Component {
             if (['signin', 'signup', 'giftRedeem'].includes(type)) {
                 deleteParams.push('action', 'success');
                 if (type === 'giftRedeem') {
-                    deleteParams.push('giftRedemption');
+                    deleteParams.push('giftRedemption', 'giftTier', 'giftCadence', 'giftDuration');
                 }
             } else if (['stripe:checkout'].includes(type)) {
                 deleteParams.push('stripe');

--- a/apps/portal/src/utils/gift-redemption-notification.js
+++ b/apps/portal/src/utils/gift-redemption-notification.js
@@ -12,6 +12,15 @@ export function getGiftDurationLabel({cadence, duration} = {}) {
         : t('{months} months', {months: duration});
 }
 
+export function getGiftRedemptionSuccessMessage({tierName, cadence, duration} = {}) {
+    if (!tierName || !cadence || !duration) {
+        return null;
+    }
+    const durationLabel = getGiftDurationLabel({cadence, duration});
+    // TODO: Add translation strings once copy has been finalised
+    return `You now have access to ${tierName} for ${durationLabel}. Enjoy!`;
+}
+
 export function getGiftRedemptionErrorMessage(error) {
     const subtitle = error?.message && error.message !== 'Failed to load gift data'
         ? error.message

--- a/apps/portal/src/utils/gift-redemption-notification.js
+++ b/apps/portal/src/utils/gift-redemption-notification.js
@@ -1,3 +1,4 @@
+import {getMemberTierName, getSubscriptionExpiry} from './helpers';
 import {t} from './i18n';
 
 export function getGiftDurationLabel({cadence, duration} = {}) {
@@ -12,13 +13,14 @@ export function getGiftDurationLabel({cadence, duration} = {}) {
         : t('{months} months', {months: duration});
 }
 
-export function getGiftRedemptionSuccessMessage({tierName, cadence, duration} = {}) {
-    if (!tierName || !cadence || !duration) {
+export function getGiftRedemptionSuccessMessage({member} = {}) {
+    const tierName = getMemberTierName({member});
+    const expiryDate = getSubscriptionExpiry({member});
+    if (!tierName || !expiryDate) {
         return null;
     }
-    const durationLabel = getGiftDurationLabel({cadence, duration});
     // TODO: Add translation strings once copy has been finalised
-    return `You now have access to ${tierName} for ${durationLabel}. Enjoy!`;
+    return `You now have access to ${tierName} until ${expiryDate}. Enjoy!`;
 }
 
 export function getGiftRedemptionErrorMessage(error) {

--- a/apps/portal/src/utils/notifications.js
+++ b/apps/portal/src/utils/notifications.js
@@ -1,3 +1,5 @@
+import {getGiftRedemptionSuccessMessage} from './gift-redemption-notification';
+
 const getHashData = () => {
     const hash = window.location.hash || '';
     const [hashPath = '', hashQueryString = ''] = hash.replace(/^#/, '').split('?');
@@ -12,17 +14,21 @@ const getURLParam = ({searchParams, hashParams}, name) => {
     return searchParams.get(name) ?? hashParams.get(name);
 };
 
-export const handleGiftRedemptionAction = ({status}) => {
-    const successStatus = JSON.parse(status);
+export const handleGiftRedemptionAction = ({status, giftTier, giftCadence, giftDuration}) => {
+    const successStatus = status === 'true';
+    // TODO: Add translation strings once copy has been finalised
+    const successMessage = getGiftRedemptionSuccessMessage({
+        tierName: giftTier,
+        cadence: giftCadence,
+        duration: Number(giftDuration)
+    }) || 'Gift redeemed! You\'re all set.';
 
     return {
         type: 'giftRedeem',
         status: successStatus ? 'success' : 'error',
         duration: successStatus ? 5000 : 3000,
         autoHide: successStatus,
-        ...(successStatus ? {
-            message: 'Gift redeemed! You\'re all set.' // TODO: Add translation strings once copy has been finalised
-        } : {})
+        ...(successStatus ? {message: successMessage} : {})
     };
 };
 
@@ -101,7 +107,15 @@ export default function NotificationParser({billingOnly = false} = {}) {
     }
 
     if ((giftRedemption || action === 'giftRedeem') && successStatus && !billingOnly) {
-        return handleGiftRedemptionAction({status: successStatus});
+        const giftTier = getURLParam({searchParams, hashParams}, 'giftTier');
+        const giftCadence = getURLParam({searchParams, hashParams}, 'giftCadence');
+        const giftDuration = getURLParam({searchParams, hashParams}, 'giftDuration');
+        return handleGiftRedemptionAction({
+            status: successStatus,
+            giftTier,
+            giftCadence,
+            giftDuration
+        });
     }
 
     if (action && successStatus && !billingOnly) {

--- a/apps/portal/src/utils/notifications.js
+++ b/apps/portal/src/utils/notifications.js
@@ -1,5 +1,3 @@
-import {getGiftRedemptionSuccessMessage} from './gift-redemption-notification';
-
 const getHashData = () => {
     const hash = window.location.hash || '';
     const [hashPath = '', hashQueryString = ''] = hash.replace(/^#/, '').split('?');
@@ -14,21 +12,12 @@ const getURLParam = ({searchParams, hashParams}, name) => {
     return searchParams.get(name) ?? hashParams.get(name);
 };
 
-export const handleGiftRedemptionAction = ({status, giftTier, giftCadence, giftDuration}) => {
-    const successStatus = status === 'true';
-    // TODO: Add translation strings once copy has been finalised
-    const successMessage = getGiftRedemptionSuccessMessage({
-        tierName: giftTier,
-        cadence: giftCadence,
-        duration: Number(giftDuration)
-    }) || 'Gift redeemed! You\'re all set.';
-
+export const handleGiftRedemptionAction = ({success}) => {
     return {
         type: 'giftRedeem',
-        status: successStatus ? 'success' : 'error',
-        duration: successStatus ? 5000 : 3000,
-        autoHide: successStatus,
-        ...(successStatus ? {message: successMessage} : {})
+        status: success ? 'success' : 'error',
+        duration: success ? 5000 : 3000,
+        autoHide: success
     };
 };
 
@@ -106,16 +95,9 @@ export default function NotificationParser({billingOnly = false} = {}) {
         return handleStripeActions({status: stripeStatus, billingOnly});
     }
 
-    if ((giftRedemption || action === 'giftRedeem') && successStatus && !billingOnly) {
-        const giftTier = getURLParam({searchParams, hashParams}, 'giftTier');
-        const giftCadence = getURLParam({searchParams, hashParams}, 'giftCadence');
-        const giftDuration = getURLParam({searchParams, hashParams}, 'giftDuration');
-        return handleGiftRedemptionAction({
-            status: successStatus,
-            giftTier,
-            giftCadence,
-            giftDuration
-        });
+    if (giftRedemption && successStatus) {
+        const success = successStatus === 'true';
+        return handleGiftRedemptionAction({success});
     }
 
     if (action && successStatus && !billingOnly) {

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -64,7 +64,14 @@ describe('redeemGift action', () => {
                     name: 'Jamie Larson',
                     email: 'jamie@example.com',
                     paid: true,
-                    status: 'gift'
+                    status: 'gift',
+                    subscriptions: [{
+                        status: 'active',
+                        tier: {
+                            name: 'Premium',
+                            expiry_at: '2027-05-29T12:00:00.000Z'
+                        }
+                    }]
                 })),
                 getIntegrityToken: vi.fn(),
                 sendMagicLink: vi.fn()
@@ -113,7 +120,7 @@ describe('redeemGift action', () => {
             notification: {
                 type: 'giftRedeem',
                 status: 'success',
-                message: 'You now have access to Premium for 1 year. Enjoy!'
+                message: 'You now have access to Premium until 29 May 2027. Enjoy!'
             }
         });
         // Ensure the account page is no longer rendered after redemption.
@@ -156,7 +163,7 @@ describe('redeemGift action', () => {
             api: mockApi
         });
 
-        const expectedRedirect = 'https://example.com/?giftRedemption=true&giftTier=Ultra&giftCadence=month&giftDuration=3';
+        const expectedRedirect = 'https://example.com/?giftRedemption=true';
 
         expect(mockApi.member.sendMagicLink).toHaveBeenCalledWith({
             email: 'jamie@example.com',

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -48,6 +48,8 @@ describe('signup action', () => {
 
 describe('redeemGift action', () => {
     test('redeems a gift directly for a logged-in member and refreshes member data', async () => {
+        window.history.replaceState({}, '', '/#/portal/gift/redeem/gift-token-123');
+
         const mockApi = {
             gift: {
                 redeem: vi.fn(() => Promise.resolve({
@@ -101,15 +103,23 @@ describe('redeemGift action', () => {
         expect(mockApi.member.sendMagicLink).not.toHaveBeenCalled();
         expect(result).toMatchObject({
             action: 'redeemGift:success',
-            page: 'accountHome',
+            showPopup: false,
+            lastPage: null,
+            pageQuery: '',
+            popupNotification: null,
             member: {
                 status: 'gift'
             },
             notification: {
                 type: 'giftRedeem',
-                status: 'success'
+                status: 'success',
+                message: 'You now have access to Premium for 1 year. Enjoy!'
             }
         });
+        // Ensure the account page is no longer rendered after redemption.
+        expect(result).not.toHaveProperty('page');
+        // Redemption hash is cleared so a refresh doesn't re-trigger the redeemed-token flow.
+        expect(window.location.hash).toBe('');
     });
 
     test('sends a subscribe magic link with the gift token and redirects back to Portal account', async () => {
@@ -124,7 +134,14 @@ describe('redeemGift action', () => {
                 url: 'https://example.com/'
             },
             pageData: {
-                token: 'gift-token-123'
+                token: 'gift-token-123',
+                gift: {
+                    cadence: 'month',
+                    duration: 3,
+                    tier: {
+                        name: 'Ultra'
+                    }
+                }
             }
         };
 
@@ -139,12 +156,14 @@ describe('redeemGift action', () => {
             api: mockApi
         });
 
+        const expectedRedirect = 'https://example.com/?giftRedemption=true&giftTier=Ultra&giftCadence=month&giftDuration=3';
+
         expect(mockApi.member.sendMagicLink).toHaveBeenCalledWith({
             email: 'jamie@example.com',
             emailType: 'subscribe',
             integrityToken: 'token-123',
             includeOTC: true,
-            redirect: 'https://example.com/#/portal/account?giftRedemption=true',
+            redirect: expectedRedirect,
             giftToken: 'gift-token-123',
             name: 'Jamie Larson'
         });
@@ -156,7 +175,7 @@ describe('redeemGift action', () => {
             pageData: {
                 token: 'gift-token-123',
                 email: 'jamie@example.com',
-                redirect: 'https://example.com/#/portal/account?giftRedemption=true'
+                redirect: expectedRedirect
             }
         });
     });

--- a/apps/portal/test/unit/components/notification.test.js
+++ b/apps/portal/test/unit/components/notification.test.js
@@ -122,7 +122,7 @@ describe('Notification', () => {
 
         fireEvent.click(container.querySelector('.gh-portal-notification-closeicon'));
 
-        expect(clearURLParams).toHaveBeenCalledWith(['action', 'success', 'giftRedemption']);
+        expect(clearURLParams).toHaveBeenCalledWith(['action', 'success', 'giftRedemption', 'giftTier', 'giftCadence', 'giftDuration']);
         expect(doAction).toHaveBeenCalledWith('refreshMemberData');
     });
 

--- a/apps/portal/test/unit/components/notification.test.js
+++ b/apps/portal/test/unit/components/notification.test.js
@@ -91,7 +91,6 @@ describe('Notification', () => {
         NotificationParser.mockReturnValue({
             type: 'giftRedeem',
             status: 'success',
-            message: 'Gift redeemed! You\'re all set.',
             autoHide: true,
             duration: 5000
         });
@@ -122,7 +121,7 @@ describe('Notification', () => {
 
         fireEvent.click(container.querySelector('.gh-portal-notification-closeicon'));
 
-        expect(clearURLParams).toHaveBeenCalledWith(['action', 'success', 'giftRedemption', 'giftTier', 'giftCadence', 'giftDuration']);
+        expect(clearURLParams).toHaveBeenCalledWith(['action', 'success', 'giftRedemption']);
         expect(doAction).toHaveBeenCalledWith('refreshMemberData');
     });
 
@@ -130,7 +129,6 @@ describe('Notification', () => {
         NotificationParser.mockReturnValue({
             type: 'giftRedeem',
             status: 'success',
-            message: 'Gift redeemed! You\'re all set.',
             autoHide: true,
             duration: 5000
         });
@@ -164,5 +162,47 @@ describe('Notification', () => {
         });
 
         expect(container.querySelector('.gh-portal-notification')).not.toHaveClass('slideout');
+    });
+
+    test('derives gift redemption success message from member tier in context', async () => {
+        NotificationParser.mockReturnValue({
+            type: 'giftRedeem',
+            status: 'success',
+            autoHide: true,
+            duration: 5000
+        });
+
+        const doAction = vi.fn();
+        const site = {
+            url: 'https://example.com',
+            title: 'Example Site'
+        };
+
+        const {getByText} = render(
+            <AppContext.Provider value={{
+                site,
+                member: {
+                    paid: true,
+                    subscriptions: [{
+                        status: 'active',
+                        tier: {
+                            name: 'Ultra',
+                            expiry_at: '2027-05-29T12:00:00.000Z'
+                        }
+                    }]
+                },
+                brandColor: '#000000',
+                showPopup: true,
+                doAction,
+                notification: null
+            }}
+            >
+                <Notification />
+            </AppContext.Provider>
+        );
+
+        await waitFor(() => {
+            expect(getByText('You now have access to Ultra until 29 May 2027. Enjoy!')).toBeInTheDocument();
+        });
     });
 });

--- a/apps/portal/test/unit/notifications.test.js
+++ b/apps/portal/test/unit/notifications.test.js
@@ -30,6 +30,28 @@ describe('notifications utils', () => {
         });
     });
 
+    test('builds tier/duration message when giftTier, giftCadence, and giftDuration params are present', () => {
+        window.history.replaceState({}, '', '/?success=true&giftRedemption=true&giftTier=Ultra&giftCadence=month&giftDuration=1');
+
+        expect(NotificationParser()).toMatchObject({
+            type: 'giftRedeem',
+            status: 'success',
+            autoHide: true,
+            duration: 5000,
+            message: 'You now have access to Ultra for 1 month. Enjoy!'
+        });
+    });
+
+    test('handles plural durations for the tier/duration message', () => {
+        window.history.replaceState({}, '', '/?success=true&giftRedemption=true&giftTier=Premium&giftCadence=year&giftDuration=2');
+
+        expect(NotificationParser()).toMatchObject({
+            type: 'giftRedeem',
+            status: 'success',
+            message: 'You now have access to Premium for 2 years. Enjoy!'
+        });
+    });
+
     test('reads gift redemption failure params from action subscribe plus portal hash query', () => {
         window.history.replaceState({}, '', '/?action=subscribe&success=false#/portal/account?giftRedemption=true');
 

--- a/apps/portal/test/unit/notifications.test.js
+++ b/apps/portal/test/unit/notifications.test.js
@@ -9,46 +9,11 @@ describe('notifications utils', () => {
     test('reads gift redemption params from action subscribe plus portal hash query', () => {
         window.history.replaceState({}, '', '/?action=subscribe&success=true#/portal/account?giftRedemption=true');
 
-        expect(NotificationParser()).toMatchObject({
+        expect(NotificationParser()).toEqual({
             type: 'giftRedeem',
             status: 'success',
             autoHide: true,
-            duration: 5000,
-            message: 'Gift redeemed! You\'re all set.'
-        });
-    });
-
-    test('reads gift redemption params from legacy giftRedeem action', () => {
-        window.history.replaceState({}, '', '/#/portal/account?action=giftRedeem&success=true');
-
-        expect(NotificationParser()).toMatchObject({
-            type: 'giftRedeem',
-            status: 'success',
-            autoHide: true,
-            duration: 5000,
-            message: 'Gift redeemed! You\'re all set.'
-        });
-    });
-
-    test('builds tier/duration message when giftTier, giftCadence, and giftDuration params are present', () => {
-        window.history.replaceState({}, '', '/?success=true&giftRedemption=true&giftTier=Ultra&giftCadence=month&giftDuration=1');
-
-        expect(NotificationParser()).toMatchObject({
-            type: 'giftRedeem',
-            status: 'success',
-            autoHide: true,
-            duration: 5000,
-            message: 'You now have access to Ultra for 1 month. Enjoy!'
-        });
-    });
-
-    test('handles plural durations for the tier/duration message', () => {
-        window.history.replaceState({}, '', '/?success=true&giftRedemption=true&giftTier=Premium&giftCadence=year&giftDuration=2');
-
-        expect(NotificationParser()).toMatchObject({
-            type: 'giftRedeem',
-            status: 'success',
-            message: 'You now have access to Premium for 2 years. Enjoy!'
+            duration: 5000
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3477

## Summary

- the previous flow showed a generic **"Gift redeemed! You're all set."** toast and then rendered the Portal account page
- now, we don't render the Portal account page after redemption and the
toast includes the tier and expiry date (e.g. **"You now have access to Ultra until 27 May 2026. Enjoy!"**)
- why: the account page is going to display a call-to-action to "Continue subscription" with a paid subscription for gift subscribers in a follow-up PR. This call-to-action should however not be shown during the gift redemption flow. Therefore, we don't open the account page as part of the gift redemption success state anymore.

## User flows

### Anonymous visitor:

https://github.com/user-attachments/assets/1cdb9cda-4e7c-45df-8137-e0295543c669


### Logged-in member


https://github.com/user-attachments/assets/f943e0da-48ba-4c71-be25-f432f4d52375


