### PR TITLE
Fixed invalid currency errors for comped subscriptions

### DIFF
--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -111,7 +111,7 @@ module.exports = class MemberBREADService {
                             id: '',
                             nickname,
                             interval: 'year',
-                            currency: product.currency,
+                            currency: 'USD',
                             amount: 0
                         },
                         status: 'active',
@@ -127,7 +127,7 @@ module.exports = class MemberBREADService {
                             amount: 0,
                             interval: 'year',
                             type: 'recurring',
-                            currency: product.currency,
+                            currency: 'USD',
                             product: {
                                 id: '',
                                 product_id: product.id

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -1435,16 +1435,6 @@ describe('Members API', function () {
             'Complimentary',
             'The subscription price should be marked as complimentary'
         );
-        assert.equal(
-            updatedMember.subscriptions[0].plan.currency.toLowerCase(),
-            product.get('currency').toLowerCase(),
-            'The synthetic subscription plan should reuse the tier currency'
-        );
-        assert.equal(
-            updatedMember.subscriptions[0].price.currency.toLowerCase(),
-            product.get('currency').toLowerCase(),
-            'The synthetic subscription price should reuse the tier currency'
-        );
 
         await assertMemberEvents({
             eventType: 'MemberStatusEvent',

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -658,16 +658,6 @@ describe('Gift Subscriptions', function () {
                     'Gift subscription',
                     'The synthetic subscription price should be marked as a gift'
                 );
-                assert.equal(
-                    memberResponse.body.subscriptions[0].plan.currency.toLowerCase(),
-                    paidProduct.get('currency').toLowerCase(),
-                    'The gift subscription plan should reuse the tier currency'
-                );
-                assert.equal(
-                    memberResponse.body.subscriptions[0].price.currency.toLowerCase(),
-                    paidProduct.get('currency').toLowerCase(),
-                    'The gift subscription price should reuse the tier currency'
-                );
 
                 // Verify staff notification email was sent
                 mockManager.assert.sentEmail({

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -403,7 +403,7 @@ describe('MemberBreadService', function () {
                     id: '',
                     nickname: 'Complimentary',
                     interval: 'year',
-                    currency: productsJSON[1].currency,
+                    currency: 'USD',
                     amount: 0
                 },
                 status: 'active',
@@ -419,7 +419,7 @@ describe('MemberBreadService', function () {
                     amount: 0,
                     interval: 'year',
                     type: 'recurring',
-                    currency: productsJSON[1].currency,
+                    currency: 'USD',
                     product: {
                         id: '',
                         product_id: productsJSON[1].id
@@ -538,7 +538,7 @@ describe('MemberBreadService', function () {
                     id: '',
                     nickname: 'Gift subscription',
                     interval: 'year',
-                    currency: productsJSON[0].currency,
+                    currency: 'USD',
                     amount: 0
                 },
                 status: 'active',
@@ -554,7 +554,7 @@ describe('MemberBreadService', function () {
                     amount: 0,
                     interval: 'year',
                     type: 'recurring',
-                    currency: productsJSON[0].currency,
+                    currency: 'USD',
                     product: {
                         id: '',
                         product_id: productsJSON[0].id


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1669

- in change https://github.com/TryGhost/Ghost/pull/27461, we updated the member subscriptions API response for comped subscriptions: from a hardcoded "USD" currency, to reading the actual currency of the tier. However, some sites in production seem to have a comped subscription on the Free tier, which does not have a currency
- This fix reverts back to using a hardcoded "USD" currency for comped subscriptions

