### PR TITLE
Optimize redis cache miss coalescing

### DIFF
--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -65,6 +65,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         this.refreshAheadFactor = config.refreshAheadFactor || 0;
         this.getTimeoutMilliseconds = config.getTimeoutMilliseconds || null;
         this.currentlyExecutingBackgroundRefreshes = new Set();
+        this.currentlyExecutingReads = new Map();
         this._keyPrefix = config.keyPrefix || '';
         this._prefixHashInitInFlight = null;
         this.redisClient.on('error', this.handleRedisError);
@@ -240,9 +241,19 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 }
                 return result;
             } else {
-                const data = await fetchData();
-                await this.set(key, data); // We don't use `internalKey` here because `set` handles it
-                return data;
+                if (this.currentlyExecutingReads.has(key)) {
+                    return this.currentlyExecutingReads.get(key);
+                }
+                const fetchPromise = fetchData().then(async (data) => {
+                    await this.set(key, data);
+                    return data;
+                }).catch((err) => {
+                    logging.error(err);
+                }).finally(() => {
+                    this.currentlyExecutingReads.delete(key);
+                });
+                this.currentlyExecutingReads.set(key, fetchPromise);
+                return fetchPromise;
             }
         } catch (err) {
             logging.error(err);

--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -241,32 +241,30 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 }
                 return result;
             } else {
-                if (internalKey && this.currentlyExecutingReads.has(internalKey)) {
+                if (!internalKey) {
+                    return fetchData();
+                }
+                if (this.currentlyExecutingReads.has(internalKey)) {
                     return this.currentlyExecutingReads.get(internalKey);
                 }
-                const fetchPromise = fetchData().then(async (data) => {
-                    if (internalKey) {
-                        try {
-                            debug('set', internalKey);
-                            await this.cache.set(internalKey, data);
-                        } catch (err) {
-                            logging.error(err);
-                        }
-                    } else {
-                        await this.set(key, data);
-                    }
-                    return data;
-                }).catch((err) => {
+                const fetchPromise = fetchData();
+                const resultPromise = fetchPromise.catch((err) => {
                     logging.error(err);
-                }).finally(() => {
-                    if (internalKey) {
-                        this.currentlyExecutingReads.delete(internalKey);
-                    }
                 });
-                if (internalKey) {
-                    this.currentlyExecutingReads.set(internalKey, fetchPromise);
-                }
-                return fetchPromise;
+                fetchPromise.then(async (data) => {
+                    try {
+                        debug('set', internalKey);
+                        await this.cache.set(internalKey, data);
+                    } catch (err) {
+                        logging.error(err);
+                    }
+                }).catch(() => {
+                    // fetchData rejection — already logged by resultPromise
+                }).finally(() => {
+                    this.currentlyExecutingReads.delete(internalKey);
+                });
+                this.currentlyExecutingReads.set(internalKey, resultPromise);
+                return resultPromise;
             }
         } catch (err) {
             logging.error(err);

--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -241,18 +241,31 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 }
                 return result;
             } else {
-                if (this.currentlyExecutingReads.has(key)) {
-                    return this.currentlyExecutingReads.get(key);
+                if (internalKey && this.currentlyExecutingReads.has(internalKey)) {
+                    return this.currentlyExecutingReads.get(internalKey);
                 }
                 const fetchPromise = fetchData().then(async (data) => {
-                    await this.set(key, data);
+                    if (internalKey) {
+                        try {
+                            debug('set', internalKey);
+                            await this.cache.set(internalKey, data);
+                        } catch (err) {
+                            logging.error(err);
+                        }
+                    } else {
+                        await this.set(key, data);
+                    }
                     return data;
                 }).catch((err) => {
                     logging.error(err);
                 }).finally(() => {
-                    this.currentlyExecutingReads.delete(key);
+                    if (internalKey) {
+                        this.currentlyExecutingReads.delete(internalKey);
+                    }
                 });
-                this.currentlyExecutingReads.set(key, fetchPromise);
+                if (internalKey) {
+                    this.currentlyExecutingReads.set(internalKey, fetchPromise);
+                }
                 return fetchPromise;
             }
         } catch (err) {

--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -143,6 +143,28 @@ SCENARIOS.forEach(({label, wrap}) => {
             });
         });
 
+        describe('concurrent cache miss coalescing', function () {
+            it('calls fetchData only once when multiple callers miss simultaneously', async function () {
+                const cache = createCache();
+                const fetcher = sinon.stub().resolves('shared');
+
+                const [v1, v2, v3] = await Promise.all([
+                    cache.get('same-key', fetcher),
+                    cache.get('same-key', fetcher),
+                    cache.get('same-key', fetcher)
+                ]);
+
+                assert.equal(fetcher.callCount, 1);
+                assert.equal(v1, 'shared');
+                assert.equal(v2, 'shared');
+                assert.equal(v3, 'shared');
+
+                const cached = await cache.get('same-key', fetcher);
+                assert.equal(fetcher.callCount, 1);
+                assert.equal(cached, 'shared');
+            });
+        });
+
         describe('get with fetchData (error paths)', function () {
             it('does not cache errors — a subsequent call retries fetchData', async function () {
                 const cache = createCache();

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -236,6 +236,58 @@ describe('Adapter Cache Redis', function () {
                 assert.equal(value, 'recovered');
             });
 
+            it('does not coalesce fetches across a prefix_hash cycle (reset)', async function () {
+                let prefixHash = 'gen1';
+                const cacheStore = new Map();
+                const redisClient = {
+                    on: sinon.stub(),
+                    get: sinon.stub().callsFake(async (k) => {
+                        if (k === 'prefix_hash') {
+                            return prefixHash;
+                        }
+                        return null;
+                    }),
+                    set: sinon.stub().resolves('OK')
+                };
+                const cacheInstance = {
+                    get: sinon.stub().callsFake(async k => cacheStore.get(k) ?? null),
+                    set: sinon.stub().callsFake(async (k, v) => {
+                        cacheStore.set(k, v);
+                    }),
+                    ttl: sinon.stub(),
+                    store: {getClient: () => redisClient}
+                };
+                const cache = new RedisCache({cache: cacheInstance});
+
+                let resolveSlow;
+                const slowFetch = sinon.stub().returns(new Promise((resolve) => {
+                    resolveSlow = resolve;
+                }));
+                const fastFetch = sinon.stub().resolves('post-reset');
+
+                const pA = cache.get('k', slowFetch);
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 0);
+                });
+                assert.equal(slowFetch.callCount, 1);
+
+                prefixHash = 'gen2';
+
+                const pB = cache.get('k', fastFetch);
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 0);
+                });
+                assert.equal(fastFetch.callCount, 1, 'post-reset caller must not join pre-reset in-flight fetch');
+
+                resolveSlow('pre-reset');
+                const [vA, vB] = await Promise.all([pA, pB]);
+
+                assert.equal(vA, 'pre-reset');
+                assert.equal(vB, 'post-reset');
+                assert.equal(cacheStore.get('gen1k'), 'pre-reset');
+                assert.equal(cacheStore.get('gen2k'), 'post-reset');
+            });
+
             it('fetches independently for different keys', async function () {
                 const cacheStub = createCacheStub();
                 cacheStub.get.resolves(null);

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -170,6 +170,93 @@ describe('Adapter Cache Redis', function () {
             sinon.assert.calledOnce(logging.error);
         });
 
+        describe('concurrent cache miss coalescing', function () {
+            it('calls fetchData only once when multiple callers miss simultaneously', async function () {
+                const KEY = 'concurrent-miss';
+                const cacheStub = createCacheStub();
+                cacheStub.get.resolves(null);
+                cacheStub.set.resolves();
+                const cache = new RedisCache({cache: cacheStub});
+
+                const fetchData = sinon.stub().resolves('shared value');
+
+                const [v1, v2, v3] = await Promise.all([
+                    cache.get(KEY, fetchData),
+                    cache.get(KEY, fetchData),
+                    cache.get(KEY, fetchData)
+                ]);
+
+                assert.equal(fetchData.callCount, 1);
+                assert.equal(v1, 'shared value');
+                assert.equal(v2, 'shared value');
+                assert.equal(v3, 'shared value');
+            });
+
+            it('propagates fetchData rejection to all concurrent callers', async function () {
+                const KEY = 'concurrent-miss-error';
+                const cacheStub = createCacheStub();
+                cacheStub.get.resolves(null);
+                const cache = new RedisCache({cache: cacheStub});
+
+                const fetchData = sinon.stub().rejects(new Error('upstream down'));
+
+                const [v1, v2] = await Promise.all([
+                    cache.get(KEY, fetchData),
+                    cache.get(KEY, fetchData)
+                ]);
+
+                assert.equal(fetchData.callCount, 1);
+                assert.equal(v1, undefined);
+                assert.equal(v2, undefined);
+                sinon.assert.calledOnce(logging.error);
+            });
+
+            it('allows retry after a coalesced fetch rejection', async function () {
+                const KEY = 'concurrent-miss-retry';
+                let cachedValue = null;
+                const cacheStub = createCacheStub();
+                cacheStub.get.callsFake(async () => cachedValue);
+                cacheStub.set.callsFake(async (_key, value) => {
+                    cachedValue = value;
+                });
+                const cache = new RedisCache({cache: cacheStub});
+
+                const fetchData = sinon.stub();
+                fetchData.onFirstCall().rejects(new Error('transient'));
+                fetchData.onSecondCall().resolves('recovered');
+
+                await Promise.all([
+                    cache.get(KEY, fetchData),
+                    cache.get(KEY, fetchData)
+                ]);
+                assert.equal(fetchData.callCount, 1);
+
+                const value = await cache.get(KEY, fetchData);
+                assert.equal(fetchData.callCount, 2);
+                assert.equal(value, 'recovered');
+            });
+
+            it('fetches independently for different keys', async function () {
+                const cacheStub = createCacheStub();
+                cacheStub.get.resolves(null);
+                cacheStub.set.resolves();
+                const cache = new RedisCache({cache: cacheStub});
+
+                const fetchA = sinon.stub().resolves('value-a');
+                const fetchB = sinon.stub().resolves('value-b');
+
+                const [v1, v2] = await Promise.all([
+                    cache.get('key-a', fetchA),
+                    cache.get('key-b', fetchB)
+                ]);
+
+                assert.equal(fetchA.callCount, 1);
+                assert.equal(fetchB.callCount, 1);
+                assert.equal(v1, 'value-a');
+                assert.equal(v2, 'value-b');
+            });
+        });
+
         it('returns the cached value when background refresh fails', async function () {
             const KEY = 'bg-refresh-error';
             let cachedValue = null;


### PR DESCRIPTION
Concurrent requests for the same cache key that all encounter a miss each independently call `fetchData()`, causing a "thundering herd" — N identical queries to the underlying data source when only 1 is needed. This adds request coalescing so that `fetchData()` runs exactly once per cache miss, and all concurrent callers share the same result.

### What changed

- Added a `currentlyExecutingReads` Map to `AdapterCacheRedis` that tracks in-flight fetch promises per key
- On a cache miss, the first caller stores its `fetchData()` promise in the Map; subsequent callers for the same key return the existing promise instead of spawning a new fetch
- The promise is cleaned up via `.finally()` so the next request after completion goes through normally
- Errors from `fetchData()` are caught and logged within the promise chain (matching the existing error-swallowing behavior), so all concurrent callers receive `undefined` and the key is freed for retry on the next request

### Why coalescing is scoped to cache misses only

An earlier approach ([#19627](https://github.com/TryGhost/Ghost/pull/19627)) coalesced the *entire* `get()` flow — including the Redis read, TTL check, and refresh-ahead logic. This means even cache hits were serialized: if 10 requests arrived concurrently for a cached key, 9 of them would wait for the first one's full Redis round-trip + TTL check to complete before returning.

Cache hits are the fast path and don't benefit from serialization — Redis handles concurrent reads efficiently. The expensive part is `fetchData()` (the database or API call behind the cache), and that only runs on a miss. By scoping coalescing to the miss branch:

- **Cache hits stay fast** — each request reads from Redis independently, no artificial queuing
- **Cache misses are protected** — `fetchData()` runs once, all waiters share the result
- **No extra private method needed** — the change stays within the existing `get()` method

### Why the Map is keyed by `internalKey` (not the external `key`)

The cache uses prefix-hash rotation for invalidation — `reset()` changes the prefix hash so all existing keys become invisible. If the coalescing Map were keyed by the external key (e.g. `'foo'`), a `reset()` during an in-flight `fetchData()` would cause two bugs:

1. **Incorrect coalescing** — a post-reset caller looks up `'foo'`, gets a new `internalKey` (`prefix:newHash:foo`), misses, but finds the pre-reset promise under `'foo'` and joins it instead of fetching fresh data
2. **Stale write to new generation** — the original `this.set(key, data)` call re-derives the internal key at write time using the *new* prefix hash, so stale data from the pre-reset fetch lands in the new cache generation

Keying by `internalKey` (which includes the prefix hash) fixes both: after a reset, a new caller gets a different `internalKey` so it won't join the stale promise, and the pre-reset writeback targets the old generation key directly via `this.cache.set(internalKey, data)` — a harmless orphan that nobody will read.

When `internalKey` is null (timeout or Redis failure during lookup), coalescing is skipped entirely — the degraded path doesn't need this protection.

### Test plan

### Unit tests (`adapter-cache-redis.test.js`)
- [x] Concurrent cache misses call `fetchData` only once, all callers receive the value
- [x] `fetchData` rejection propagates to all concurrent callers (all get `undefined`, error logged once)
- [x] After a coalesced fetch rejection, the Map is cleaned up and the next call retries successfully
- [x] Does not coalesce fetches across a `prefix_hash` cycle (reset)
- [x] Concurrent misses for different keys fetch independently (coalescing is per-key, not global)

### Integration test (`adapter-cache-redis.test.js`)
- [x] Concurrent cache misses against real Redis call `fetchData` only once, subsequent cached read also works