### PR TITLE
Fixed AdapterCacheRedis blowing up under api-framework cloning

### DIFF
--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -9,8 +9,6 @@ const redisStoreFactory = require('./redis-store-factory');
 const PREFIX_HASH_KEY = 'prefix_hash';
 
 class AdapterCacheRedis extends BaseCacheAdapter {
-    #prefixHashInitInFlight = null;
-
     /**
      *
      * @param {Object} config
@@ -68,6 +66,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         this.getTimeoutMilliseconds = config.getTimeoutMilliseconds || null;
         this.currentlyExecutingBackgroundRefreshes = new Set();
         this._keyPrefix = config.keyPrefix || '';
+        this._prefixHashInitInFlight = null;
         this.redisClient = this.cache.store.getClient();
         this.redisClient.on('error', this.handleRedisError);
     }
@@ -88,20 +87,20 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         if (currentPrefixHash) {
             return currentPrefixHash;
         }
-        return this.#initPrefixHash();
+        return this._initPrefixHash();
     }
 
     /**
      * Lazily creates the prefix_hash. Concurrent callers in this process
-     * share one in-flight init via #prefixHashInitInFlight; SET NX ensures
+     * share one in-flight init via _prefixHashInitInFlight; SET NX ensures
      * only one writer wins across processes.
      */
-    #initPrefixHash() {
-        if (this.#prefixHashInitInFlight) {
-            return this.#prefixHashInitInFlight;
+    _initPrefixHash() {
+        if (this._prefixHashInitInFlight) {
+            return this._prefixHashInitInFlight;
         }
         const value = crypto.randomBytes(12).toString('hex');
-        this.#prefixHashInitInFlight = this.redisClient
+        this._prefixHashInitInFlight = this.redisClient
             .set(this._keyPrefix + PREFIX_HASH_KEY, value, 'NX')
             .then(async (result) => {
                 if (result === 'OK') {
@@ -111,9 +110,9 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 return await this.redisClient.get(this._keyPrefix + PREFIX_HASH_KEY);
             })
             .finally(() => {
-                this.#prefixHashInitInFlight = null;
+                this._prefixHashInitInFlight = null;
             });
-        return this.#prefixHashInitInFlight;
+        return this._prefixHashInitInFlight;
     }
 
     async keyPrefix() {
@@ -169,7 +168,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * @param {string} key
      * @returns {Promise<{internalKey: string|null, result: any}>}
      */
-    #lookupWithTimeout(key) {
+    _lookupWithTimeout(key) {
         const lookup = (async () => {
             const internalKey = await this._buildKey(key);
             const result = await this.cache.get(internalKey);
@@ -203,7 +202,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      */
     async get(key, fetchData) {
         try {
-            const {internalKey, result} = await this.#lookupWithTimeout(key);
+            const {internalKey, result} = await this._lookupWithTimeout(key);
             debug(`get ${key}: Cache ${result ? 'HIT' : 'MISS'}`);
             if (!fetchData) {
                 return result;

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const _ = require('lodash');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
@@ -357,6 +358,46 @@ describe('Adapter Cache Redis', function () {
                 () => cache.keys(),
                 err => err instanceof errors.IncorrectUsageError
             );
+        });
+    });
+
+    describe('survives deep cloning', function () {
+        // Regression: api-framework's pipeline calls _.cloneDeep on the
+        // controller, which deep-clones the cache adapter instance. The clone
+        // keeps the prototype but loses the per-instance internal slot used
+        // for #-private methods, so any this.#privateMethod() call throws
+        // "Receiver must be an instance of class AdapterCacheRedis". Using
+        // `_`-prefixed private members keeps this working.
+        it('cache.get works on a cloned instance', async function () {
+            const cacheStub = createCacheStub();
+            cacheStub.get.resolves('value from cache');
+            const cache = new RedisCache({cache: cacheStub});
+
+            const cloned = _.cloneDeep(cache);
+
+            const value = await cloned.get('key');
+            assert.equal(value, 'value from cache');
+        });
+
+        it('cache.set works on a cloned instance', async function () {
+            const cacheStub = createCacheStub();
+            const cache = new RedisCache({cache: cacheStub});
+
+            const cloned = _.cloneDeep(cache);
+
+            const value = await cloned.set('key', 'value');
+            assert.equal(value, 'value');
+        });
+
+        it('cache.reset works on a cloned instance', async function () {
+            const cacheStub = createCacheStub();
+            const cache = new RedisCache({cache: cacheStub});
+
+            const cloned = _.cloneDeep(cache);
+
+            await cloned.reset();
+            const redisSet = cacheStub.store.getClient().set;
+            assert.equal(redisSet.lastCall.args[0], 'prefix_hash');
         });
     });
 });


### PR DESCRIPTION
## Why

The redis cache adapter started throwing in production after the prefix-rotation change landed:

```
TypeError: Receiver must be an instance of class AdapterCacheRedis
    at AdapterCacheRedis.get (.../AdapterCacheRedis.js:206:54)
```

api-framework's pipeline deep-clones the entire controller (including the cache adapter) via `_.cloneDeep` before wrapping each method ([`pipeline.js:195`](https://github.com/TryGhost/api-framework/blob/main/lib/pipeline.js#L195)). The clone keeps the prototype but loses the per-instance internal slots that hold `#` private methods, so the receiver check fails the moment any code on the clone hits one.

Renamed the `#` privates to `_` so privacy is convention-only and there's no engine-enforced receiver check.

## Test

Added a unit test that `_.cloneDeep`s the cache adapter and calls `get`/`set`/`reset` on the clone — fails on `#`, passes on `_`.