### PR TITLE
Added static Automations page behind private feature flag

### DIFF
--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -77,6 +77,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const memberCount = useMemberCount();
     const routing = useEmberRouting();
     const commentModerationEnabled = useFeatureFlag('commentModeration');
+    const automationsEnabled = useFeatureFlag('automations');
     const isMembersRouteActive = useIsActiveLink({path: 'members', activeOnSubpath: true});
 
     const showTags = currentUser && canManageTags(currentUser);
@@ -209,6 +210,18 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             >
                                 <LucideIcon.MessagesSquare />
                                 <NavMenuItem.Label>Comments</NavMenuItem.Label>
+                            </NavMenuItem.Link>
+                        </NavMenuItem>
+                    )}
+
+                    {showMembers && automationsEnabled && (
+                        <NavMenuItem>
+                            <NavMenuItem.Link
+                                to="automations"
+                                activeOnSubpath
+                            >
+                                <LucideIcon.Zap />
+                                <NavMenuItem.Label>Automations</NavMenuItem.Label>
                             </NavMenuItem.Link>
                         </NavMenuItem>
                     )}

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -69,6 +69,10 @@ export const routes: RouteObject[] = [
                 path: 'comments',
                 lazy: lazyComponent(() => import('@views/comments/comments'))
             },
+            {
+                path: 'automations',
+                lazy: lazyComponent(() => import('@views/Automations/automations'))
+            },
 
             // Error handling
             {

--- a/apps/posts/src/views/Automations/automations.tsx
+++ b/apps/posts/src/views/Automations/automations.tsx
@@ -1,0 +1,18 @@
+import AutomationsContent from './components/automations-content';
+import AutomationsHeader from './components/automations-header';
+import AutomationsLayout from './components/automations-layout';
+import AutomationsList from './components/automations-list';
+import React from 'react';
+
+const Automations: React.FC = () => {
+    return (
+        <AutomationsLayout>
+            <AutomationsHeader />
+            <AutomationsContent>
+                <AutomationsList />
+            </AutomationsContent>
+        </AutomationsLayout>
+    );
+};
+
+export default Automations;

--- a/apps/posts/src/views/Automations/components/automations-content.tsx
+++ b/apps/posts/src/views/Automations/components/automations-content.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import {cn} from '@tryghost/shade/utils';
+
+const AutomationsContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
+    return (
+        <section className={cn('flex gap-6 flex-col px-4 lg:px-8 py-2 size-full grow', className)} {...props}>
+            {children}
+        </section>
+    );
+};
+
+export default AutomationsContent;

--- a/apps/posts/src/views/Automations/components/automations-header.tsx
+++ b/apps/posts/src/views/Automations/components/automations-header.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import {ListHeader} from '@tryghost/shade/primitives';
+
+const AutomationsHeader: React.FC = () => {
+    return (
+        <ListHeader className='py-4 sidebar:py-6'>
+            <ListHeader.Left>
+                <ListHeader.Title>Automations</ListHeader.Title>
+            </ListHeader.Left>
+        </ListHeader>
+    );
+};
+
+export default AutomationsHeader;

--- a/apps/posts/src/views/Automations/components/automations-layout.tsx
+++ b/apps/posts/src/views/Automations/components/automations-layout.tsx
@@ -1,0 +1,16 @@
+import MainLayout from '@components/layout/main-layout';
+import React from 'react';
+
+const AutomationsLayout: React.FC<{children: React.ReactNode}> = ({children}) => {
+    return (
+        <MainLayout>
+            <div className="grid w-full grow">
+                <div className="flex h-full flex-col" data-testid="automations-page">
+                    {children}
+                </div>
+            </div>
+        </MainLayout>
+    );
+};
+
+export default AutomationsLayout;

--- a/apps/posts/src/views/Automations/components/automations-list.tsx
+++ b/apps/posts/src/views/Automations/components/automations-list.tsx
@@ -12,6 +12,8 @@ interface AutomationRow {
     lastRun: string;
 }
 
+// TODO(NY-1196): This is sample data, which we'll replace with real data once
+// we have the API in place.
 const automations: AutomationRow[] = [
     {
         id: 'free-members-welcome-email',

--- a/apps/posts/src/views/Automations/components/automations-list.tsx
+++ b/apps/posts/src/views/Automations/components/automations-list.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import {Badge, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
+import {formatNumber} from '@tryghost/shade/utils';
+
+type AutomationStatus = 'Active' | 'Draft';
+
+interface AutomationRow {
+    id: string;
+    name: string;
+    steps: number;
+    status: AutomationStatus;
+    lastRun: string;
+}
+
+const automations: AutomationRow[] = [
+    {
+        id: 'free-members-welcome-email',
+        name: 'Free members welcome email',
+        steps: 2,
+        status: 'Active',
+        lastRun: '2 hours ago'
+    },
+    {
+        id: 'paid-members-welcome-email',
+        name: 'Paid members welcome email',
+        steps: 3,
+        status: 'Active',
+        lastRun: 'Yesterday'
+    }
+];
+
+const AutomationsList: React.FC = () => {
+    return (
+        <Table className="flex table-fixed flex-col lg:table" data-testid="automations-list">
+            <TableHeader className="hidden lg:visible! lg:table-header-group!">
+                <TableRow>
+                    <TableHead className="w-auto px-4">Name</TableHead>
+                    <TableHead className="w-24 px-4">Steps</TableHead>
+                    <TableHead className="w-28 px-4">Status</TableHead>
+                    <TableHead className="w-32 px-4">Last run</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody className="flex flex-col lg:table-row-group">
+                {automations.map(automation => (
+                    <TableRow
+                        key={automation.id}
+                        className="group relative grid w-full cursor-pointer grid-cols-2 items-center gap-x-4 p-2 hover:bg-muted/50 lg:table-row lg:p-0"
+                        data-testid="automation-list-row"
+                    >
+                        <TableCell className="lg:w-auto lg:p-4">
+                            <a
+                                className="before:absolute before:top-0 before:left-0 before:z-10 before:h-full before:w-full"
+                                href={`#/automations/${automation.id}`}
+                            >
+                                <span className="block truncate text-lg font-medium">
+                                    {automation.name}
+                                </span>
+                            </a>
+                        </TableCell>
+                        <TableCell className="lg:p-4">
+                            <span className="text-muted-foreground">
+                                {formatNumber(automation.steps)} {automation.steps === 1 ? 'step' : 'steps'}
+                            </span>
+                        </TableCell>
+                        <TableCell className="lg:p-4">
+                            <Badge variant={automation.status === 'Active' ? 'success' : 'secondary'}>
+                                {automation.status}
+                            </Badge>
+                        </TableCell>
+                        <TableCell className="lg:p-4">
+                            <span className="text-muted-foreground">{automation.lastRun}</span>
+                        </TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+};
+
+export default AutomationsList;

--- a/apps/posts/src/views/Automations/components/automations-list.tsx
+++ b/apps/posts/src/views/Automations/components/automations-list.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Badge, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
-import {formatNumber} from '@tryghost/shade/utils';
+import {formatNumber, formatTimestamp} from '@tryghost/shade/utils';
 
 type AutomationStatus = 'active' | 'inactive';
 
@@ -20,14 +20,14 @@ const automations: AutomationRow[] = [
         name: 'Free members welcome email',
         steps: 2,
         status: 'active',
-        lastRun: '2 hours ago'
+        lastRun: new Date(Date.now() - (2 * 60 * 60 * 1000)).toISOString()
     },
     {
         id: 'paid-members-welcome-email',
         name: 'Paid members welcome email',
         steps: 3,
         status: 'active',
-        lastRun: 'Yesterday'
+        lastRun: new Date(Date.now() - (24 * 60 * 60 * 1000)).toISOString()
     }
 ];
 
@@ -81,7 +81,7 @@ const AutomationsList: React.FC = () => {
                             <AutomationsStatusBadge status={automation.status} />
                         </TableCell>
                         <TableCell className="lg:p-4">
-                            <span className="text-muted-foreground">{automation.lastRun}</span>
+                            <span className="text-muted-foreground">{formatTimestamp(automation.lastRun)}</span>
                         </TableCell>
                     </TableRow>
                 ))}

--- a/apps/posts/src/views/Automations/components/automations-list.tsx
+++ b/apps/posts/src/views/Automations/components/automations-list.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Badge, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
 import {formatNumber} from '@tryghost/shade/utils';
 
-type AutomationStatus = 'Active' | 'Draft';
+type AutomationStatus = 'active' | 'inactive';
 
 interface AutomationRow {
     id: string;
@@ -17,17 +17,30 @@ const automations: AutomationRow[] = [
         id: 'free-members-welcome-email',
         name: 'Free members welcome email',
         steps: 2,
-        status: 'Active',
+        status: 'active',
         lastRun: '2 hours ago'
     },
     {
         id: 'paid-members-welcome-email',
         name: 'Paid members welcome email',
         steps: 3,
-        status: 'Active',
+        status: 'active',
         lastRun: 'Yesterday'
     }
 ];
+
+const AutomationsStatusBadge: React.FC<{status: AutomationStatus}> = ({status}) => {
+    switch (status) {
+    case 'active':
+        return <Badge variant="success">Active</Badge>;
+    case 'inactive':
+        return <Badge variant="secondary">Inactive</Badge>;
+    default: {
+        const invalidStatus: never = status;
+        throw new Error(`Unhandled status: ${invalidStatus}`);
+    }
+    }
+};
 
 const AutomationsList: React.FC = () => {
     return (
@@ -63,9 +76,7 @@ const AutomationsList: React.FC = () => {
                             </span>
                         </TableCell>
                         <TableCell className="lg:p-4">
-                            <Badge variant={automation.status === 'Active' ? 'success' : 'secondary'}>
-                                {automation.status}
-                            </Badge>
+                            <AutomationsStatusBadge status={automation.status} />
                         </TableCell>
                         <TableCell className="lg:p-4">
                             <span className="text-muted-foreground">{automation.lastRun}</span>


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/NY-1239

- introduces the Automations area in the admin sidebar (after Comments) as a static skeleton so backend devs have a visual target to wire dynamic behaviour against
- gated entirely behind the existing private `automations` flag so it stays invisible until we are ready to ship
- new view lives in apps/posts (alongside Comments and Tags) and is built with Shade primitives (ListHeader) and components (Table, Badge) — no API calls, no data hooks