### PR TITLE
Fixed AdapterCacheRedis socket access on cloned instances

### DIFF
--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -67,8 +67,19 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         this.currentlyExecutingBackgroundRefreshes = new Set();
         this._keyPrefix = config.keyPrefix || '';
         this._prefixHashInitInFlight = null;
-        this.redisClient = this.cache.store.getClient();
         this.redisClient.on('error', this.handleRedisError);
+    }
+
+    /**
+     * api-framework's pipeline _.cloneDeep's controllers (and the cache
+     * adapter alongside them). Caching the redis client as `this.redisClient`
+     * was breaking on clones because the cloned ioredis instance has the
+     * prototype but no live socket. Going through cache-manager's
+     * `store.getClient()` works because that function captures the original
+     * client via closure, so even on a clone it returns the live one.
+     */
+    get redisClient() {
+        return this.cache.store.getClient();
     }
 
     /**

--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const crypto = require('node:crypto');
+const _ = require('lodash');
 const sinon = require('sinon');
 const config = require('../../../../core/shared/config');
 const RedisCache = require('../../../../core/server/adapters/lib/redis/AdapterCacheRedis');
@@ -20,197 +21,209 @@ function buildCache(prefix, extra = {}) {
     });
 }
 
-describe('Integration: AdapterCacheRedis', function () {
-    const caches = [];
+// Run the full suite against both a fresh adapter and a deep-cloned one.
+// api-framework's pipeline _.cloneDeep's controllers (and the cache
+// adapter alongside them); the cloned scenario protects against the
+// adapter caching non-cloneable state on `this`.
+const SCENARIOS = [
+    {label: 'fresh instance', wrap: c => c},
+    {label: 'deep-cloned instance', wrap: c => _.cloneDeep(c)}
+];
 
-    afterEach(async function () {
-        while (caches.length) {
-            await caches.pop().redisClient.quit();
-        }
-    });
+SCENARIOS.forEach(({label, wrap}) => {
+    describe(`Integration: AdapterCacheRedis on a ${label}`, function () {
+        const caches = [];
 
-    function createCache(extra) {
-        const cache = buildCache(crypto.randomBytes(8).toString('hex') + ':', extra);
-        caches.push(cache);
-        return cache;
-    }
-
-    describe('set / get', function () {
-        it('stores a value and retrieves it by the same key', async function () {
-            const cache = createCache();
-            await cache.set('hello', 'world');
-            assert.equal(await cache.get('hello'), 'world');
+        afterEach(async function () {
+            while (caches.length) {
+                await caches.pop().redisClient.quit();
+            }
         });
 
-        it('returns null for an unknown key', async function () {
-            const cache = createCache();
-            assert.equal(await cache.get('does-not-exist'), null);
-        });
-
-        it('overwrites an existing value', async function () {
-            const cache = createCache();
-            await cache.set('k', 'first');
-            await cache.set('k', 'second');
-            assert.equal(await cache.get('k'), 'second');
-        });
-    });
-
-    describe('reset (invalidation contract)', function () {
-        it('makes previously-set keys invisible to get()', async function () {
-            const cache = createCache();
-            await cache.set('foo', 'bar');
-            assert.equal(await cache.get('foo'), 'bar');
-
-            await cache.reset();
-
-            assert.equal(await cache.get('foo'), null);
-        });
-
-        it('triggers fetchData on the next get(key, fetchData) call', async function () {
-            const cache = createCache();
-            await cache.set('k', 'old');
-
-            await cache.reset();
-
-            const fetcher = sinon.stub().resolves('new');
-            const value = await cache.get('k', fetcher);
-
-            assert.equal(fetcher.callCount, 1);
-            assert.equal(value, 'new');
-        });
-
-        it('caches the value returned by fetchData after a reset', async function () {
-            const cache = createCache();
-            await cache.set('k', 'old');
-
-            await cache.reset();
-
-            const fetcher = sinon.stub().resolves('new');
-            await cache.get('k', fetcher);
-            const second = await cache.get('k', fetcher);
-
-            assert.equal(fetcher.callCount, 1);
-            assert.equal(second, 'new');
-        });
-
-        it('does not affect keys belonging to a different keyPrefix', async function () {
-            const cacheA = createCache();
-            const cacheB = createCache();
-
-            await cacheA.set('shared-name', 'A');
-            await cacheB.set('shared-name', 'B');
-
-            await cacheA.reset();
-
-            assert.equal(await cacheA.get('shared-name'), null);
-            assert.equal(await cacheB.get('shared-name'), 'B');
-        });
-    });
-
-    describe('get with fetchData', function () {
-        it('calls fetchData on a miss and caches the result', async function () {
-            const cache = createCache();
-            const fetcher = sinon.stub().resolves('fetched');
-
-            const v1 = await cache.get('miss-key', fetcher);
-            const v2 = await cache.get('miss-key', fetcher);
-
-            assert.equal(fetcher.callCount, 1);
-            assert.equal(v1, 'fetched');
-            assert.equal(v2, 'fetched');
-        });
-
-        it('does not call fetchData on a hit', async function () {
-            const cache = createCache();
-            await cache.set('hit-key', 'cached');
-
-            const fetcher = sinon.stub().resolves('fresh');
-            const value = await cache.get('hit-key', fetcher);
-
-            assert.equal(fetcher.callCount, 0);
-            assert.equal(value, 'cached');
-        });
-    });
-
-    describe('get with fetchData (error paths)', function () {
-        it('does not cache errors — a subsequent call retries fetchData', async function () {
-            const cache = createCache();
-            const fetcher = sinon.stub();
-            fetcher.onFirstCall().rejects(new Error('transient DB error'));
-            fetcher.onSecondCall().resolves('recovered');
-
-            await cache.get('retry-key', fetcher);
-
-            const value = await cache.get('retry-key', fetcher);
-
-            assert.equal(fetcher.callCount, 2);
-            assert.equal(value, 'recovered');
-        });
-
-        it('stores and retrieves complex nested objects', async function () {
-            const cache = createCache();
-            const complexValue = {
-                posts: [
-                    {
-                        id: 'abc123',
-                        title: 'Test Post',
-                        tags: [{id: 't1', name: 'News'}],
-                        authors: [{id: 'a1', name: 'Jane'}]
-                    }
-                ],
-                meta: {
-                    pagination: {page: 1, limit: 15, pages: 3, total: 42, next: 2, prev: null}
-                }
-            };
-
-            await cache.set('complex', complexValue);
-            const retrieved = await cache.get('complex');
-
-            assert.deepEqual(retrieved, complexValue);
-        });
-    });
-
-    describe('without a keyPrefix', function () {
-        it('still stores and retrieves values', async function () {
-            const cache = buildCache(undefined);
+        function createCache(extra) {
+            const cache = buildCache(crypto.randomBytes(8).toString('hex') + ':', extra);
             caches.push(cache);
+            return wrap(cache);
+        }
 
-            const key = `noprefix-${crypto.randomBytes(8).toString('hex')}`;
-            await cache.set(key, 'value');
-            assert.equal(await cache.get(key), 'value');
-        });
-    });
-
-    describe('getTimeoutMilliseconds', function () {
-        it('returns the value when the underlying get resolves within the timeout', async function () {
-            const cache = createCache({getTimeoutMilliseconds: 1000});
-            await cache.set('fast', 'value');
-            assert.equal(await cache.get('fast'), 'value');
-        });
-
-        it('returns null when the data fetch exceeds the timeout', async function () {
-            const cache = createCache({getTimeoutMilliseconds: 1});
-            await cache.set('slow', 'value');
-
-            const original = cache.cache.get.bind(cache.cache);
-            cache.cache.get = k => new Promise((resolve) => {
-                setTimeout(() => original(k).then(resolve), 50);
+        describe('set / get', function () {
+            it('stores a value and retrieves it by the same key', async function () {
+                const cache = createCache();
+                await cache.set('hello', 'world');
+                assert.equal(await cache.get('hello'), 'world');
             });
 
-            assert.equal(await cache.get('slow'), null);
-        });
-
-        it('returns null when the prefix_hash fetch exceeds the timeout', async function () {
-            const cache = createCache({getTimeoutMilliseconds: 1});
-            // Prime the cache so prefix_hash exists before we slow reads down.
-            await cache.set('foo', 'value');
-
-            const original = cache.redisClient.get.bind(cache.redisClient);
-            cache.redisClient.get = k => new Promise((resolve) => {
-                setTimeout(() => original(k).then(resolve), 50);
+            it('returns null for an unknown key', async function () {
+                const cache = createCache();
+                assert.equal(await cache.get('does-not-exist'), null);
             });
 
-            assert.equal(await cache.get('foo'), null);
+            it('overwrites an existing value', async function () {
+                const cache = createCache();
+                await cache.set('k', 'first');
+                await cache.set('k', 'second');
+                assert.equal(await cache.get('k'), 'second');
+            });
+        });
+
+        describe('reset (invalidation contract)', function () {
+            it('makes previously-set keys invisible to get()', async function () {
+                const cache = createCache();
+                await cache.set('foo', 'bar');
+                assert.equal(await cache.get('foo'), 'bar');
+
+                await cache.reset();
+
+                assert.equal(await cache.get('foo'), null);
+            });
+
+            it('triggers fetchData on the next get(key, fetchData) call', async function () {
+                const cache = createCache();
+                await cache.set('k', 'old');
+
+                await cache.reset();
+
+                const fetcher = sinon.stub().resolves('new');
+                const value = await cache.get('k', fetcher);
+
+                assert.equal(fetcher.callCount, 1);
+                assert.equal(value, 'new');
+            });
+
+            it('caches the value returned by fetchData after a reset', async function () {
+                const cache = createCache();
+                await cache.set('k', 'old');
+
+                await cache.reset();
+
+                const fetcher = sinon.stub().resolves('new');
+                await cache.get('k', fetcher);
+                const second = await cache.get('k', fetcher);
+
+                assert.equal(fetcher.callCount, 1);
+                assert.equal(second, 'new');
+            });
+
+            it('does not affect keys belonging to a different keyPrefix', async function () {
+                const cacheA = createCache();
+                const cacheB = createCache();
+
+                await cacheA.set('shared-name', 'A');
+                await cacheB.set('shared-name', 'B');
+
+                await cacheA.reset();
+
+                assert.equal(await cacheA.get('shared-name'), null);
+                assert.equal(await cacheB.get('shared-name'), 'B');
+            });
+        });
+
+        describe('get with fetchData', function () {
+            it('calls fetchData on a miss and caches the result', async function () {
+                const cache = createCache();
+                const fetcher = sinon.stub().resolves('fetched');
+
+                const v1 = await cache.get('miss-key', fetcher);
+                const v2 = await cache.get('miss-key', fetcher);
+
+                assert.equal(fetcher.callCount, 1);
+                assert.equal(v1, 'fetched');
+                assert.equal(v2, 'fetched');
+            });
+
+            it('does not call fetchData on a hit', async function () {
+                const cache = createCache();
+                await cache.set('hit-key', 'cached');
+
+                const fetcher = sinon.stub().resolves('fresh');
+                const value = await cache.get('hit-key', fetcher);
+
+                assert.equal(fetcher.callCount, 0);
+                assert.equal(value, 'cached');
+            });
+        });
+
+        describe('get with fetchData (error paths)', function () {
+            it('does not cache errors — a subsequent call retries fetchData', async function () {
+                const cache = createCache();
+                const fetcher = sinon.stub();
+                fetcher.onFirstCall().rejects(new Error('transient DB error'));
+                fetcher.onSecondCall().resolves('recovered');
+
+                await cache.get('retry-key', fetcher);
+
+                const value = await cache.get('retry-key', fetcher);
+
+                assert.equal(fetcher.callCount, 2);
+                assert.equal(value, 'recovered');
+            });
+
+            it('stores and retrieves complex nested objects', async function () {
+                const cache = createCache();
+                const complexValue = {
+                    posts: [
+                        {
+                            id: 'abc123',
+                            title: 'Test Post',
+                            tags: [{id: 't1', name: 'News'}],
+                            authors: [{id: 'a1', name: 'Jane'}]
+                        }
+                    ],
+                    meta: {
+                        pagination: {page: 1, limit: 15, pages: 3, total: 42, next: 2, prev: null}
+                    }
+                };
+
+                await cache.set('complex', complexValue);
+                const retrieved = await cache.get('complex');
+
+                assert.deepEqual(retrieved, complexValue);
+            });
+        });
+
+        describe('without a keyPrefix', function () {
+            it('still stores and retrieves values', async function () {
+                const raw = buildCache(undefined);
+                caches.push(raw);
+                const cache = wrap(raw);
+
+                const key = `noprefix-${crypto.randomBytes(8).toString('hex')}`;
+                await cache.set(key, 'value');
+                assert.equal(await cache.get(key), 'value');
+            });
+        });
+
+        describe('getTimeoutMilliseconds', function () {
+            it('returns the value when the underlying get resolves within the timeout', async function () {
+                const cache = createCache({getTimeoutMilliseconds: 1000});
+                await cache.set('fast', 'value');
+                assert.equal(await cache.get('fast'), 'value');
+            });
+
+            it('returns null when the data fetch exceeds the timeout', async function () {
+                const cache = createCache({getTimeoutMilliseconds: 1});
+                await cache.set('slow', 'value');
+
+                const original = cache.cache.get.bind(cache.cache);
+                cache.cache.get = k => new Promise((resolve) => {
+                    setTimeout(() => original(k).then(resolve), 50);
+                });
+
+                assert.equal(await cache.get('slow'), null);
+            });
+
+            it('returns null when the prefix_hash fetch exceeds the timeout', async function () {
+                const cache = createCache({getTimeoutMilliseconds: 1});
+                // Prime the cache so prefix_hash exists before we slow reads down.
+                await cache.set('foo', 'value');
+
+                const original = cache.redisClient.get.bind(cache.redisClient);
+                cache.redisClient.get = k => new Promise((resolve) => {
+                    setTimeout(() => original(k).then(resolve), 50);
+                });
+
+                assert.equal(await cache.get('foo'), null);
+            });
         });
     });
 });


### PR DESCRIPTION
## Why

Follow-up to #27508. That PR fixed the "Receiver must be an instance of class" error from `_.cloneDeep`. The next layer of the same problem then surfaced:

```
TypeError: Illegal invocation
    at Socket.write (...)
    at Redis.sendCommand (...)
    at AdapterCacheRedis.prefixHash (.../AdapterCacheRedis.js:86:58)
```

The adapter cached the ioredis client as `this.redisClient`. On a deep-cloned adapter, `this.redisClient` is a clone with the prototype but no live socket — any call dives into `socket.write` and dies.

The OLD code accidentally got away with this because it only went through cache-manager-ioredis, whose `getClient` is a closure-captured arrow function that returns the original client regardless of which `this` it's called on. Functions are preserved by reference under cloneDeep, so that closure protection carried through. Our prefix-rotation work bypassed cache-manager and went directly to `this.redisClient`, losing that protection.

Fix: `this.redisClient` becomes a getter that delegates to `this.cache.store.getClient()`. Cloned instances now resolve through cache-manager's preserved closure and get the live socket.

## Test

The integration suite is now parametrised to run every test against both a fresh adapter and a deep-cloned one.