### PR TITLE
🐛 Prevented Escape keypresses in welcome emails Customize modal from exiting settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
@@ -80,7 +80,7 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
         resetInteractionState();
         setOpen(false);
     };
-    const attachEarlyEscapeListener = useCallback(() => {
+    const attachEarlyEscapeListener = () => {
         if (earlyEscapeHandler.current) {
             return;
         }
@@ -92,14 +92,12 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
 
             event.preventDefault();
             event.stopPropagation();
-            detachEarlyEscapeListener();
-            resetInteractionState();
-            setOpen(false);
+            closePopover();
         };
 
         earlyEscapeHandler.current = handleEarlyEscape;
         window.addEventListener('keydown', handleEarlyEscape, true);
-    }, [detachEarlyEscapeListener]);
+    };
 
     useEffect(() => {
         return () => {

--- a/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
@@ -63,10 +63,10 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
     const selectedSwatch = swatches.find((swatch) => {
         return swatch.value === value || (value && swatch.hex.toLowerCase() === value.toLowerCase());
     });
-    const resetInteractionState = useCallback(() => {
+    const resetInteractionState = () => {
         allowPickerChanges.current = false;
         suppressPickerChanges.current = false;
-    }, []);
+    };
     const detachEarlyEscapeListener = useCallback(() => {
         if (!earlyEscapeHandler.current) {
             return;
@@ -75,11 +75,11 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
         window.removeEventListener('keydown', earlyEscapeHandler.current, true);
         earlyEscapeHandler.current = null;
     }, []);
-    const closePopover = useCallback(() => {
+    const closePopover = () => {
         detachEarlyEscapeListener();
         resetInteractionState();
         setOpen(false);
-    }, [detachEarlyEscapeListener, resetInteractionState]);
+    };
     const attachEarlyEscapeListener = useCallback(() => {
         if (earlyEscapeHandler.current) {
             return;
@@ -93,12 +93,13 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
             event.preventDefault();
             event.stopPropagation();
             detachEarlyEscapeListener();
-            closePopover();
+            resetInteractionState();
+            setOpen(false);
         };
 
         earlyEscapeHandler.current = handleEarlyEscape;
         window.addEventListener('keydown', handleEarlyEscape, true);
-    }, [closePopover, detachEarlyEscapeListener]);
+    }, [detachEarlyEscapeListener]);
 
     useEffect(() => {
         return () => {

--- a/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {ColorPicker} from '@tryghost/shade/patterns';
 import {Popover, PopoverContent, PopoverTrigger} from '@tryghost/shade/components';
 
@@ -59,16 +59,63 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
     const normalizedValue = normalizeColorValue(value, accentColor, swatches);
     const allowPickerChanges = useRef(false);
     const suppressPickerChanges = useRef(false);
+    const earlyEscapeHandler = useRef<((event: KeyboardEvent) => void) | null>(null);
     const selectedSwatch = swatches.find((swatch) => {
         return swatch.value === value || (value && swatch.hex.toLowerCase() === value.toLowerCase());
     });
+    const resetInteractionState = useCallback(() => {
+        allowPickerChanges.current = false;
+        suppressPickerChanges.current = false;
+    }, []);
+    const detachEarlyEscapeListener = useCallback(() => {
+        if (!earlyEscapeHandler.current) {
+            return;
+        }
+
+        window.removeEventListener('keydown', earlyEscapeHandler.current, true);
+        earlyEscapeHandler.current = null;
+    }, []);
+    const closePopover = useCallback(() => {
+        detachEarlyEscapeListener();
+        resetInteractionState();
+        setOpen(false);
+    }, [detachEarlyEscapeListener, resetInteractionState]);
+    const attachEarlyEscapeListener = useCallback(() => {
+        if (earlyEscapeHandler.current) {
+            return;
+        }
+
+        const handleEarlyEscape = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            detachEarlyEscapeListener();
+            closePopover();
+        };
+
+        earlyEscapeHandler.current = handleEarlyEscape;
+        window.addEventListener('keydown', handleEarlyEscape, true);
+    }, [closePopover, detachEarlyEscapeListener]);
+
+    useEffect(() => {
+        return () => {
+            detachEarlyEscapeListener();
+        };
+    }, [detachEarlyEscapeListener]);
 
     return (
         <Popover
             open={open}
             onOpenChange={(nextOpen) => {
-                allowPickerChanges.current = false;
-                suppressPickerChanges.current = false;
+                resetInteractionState();
+                if (nextOpen) {
+                    attachEarlyEscapeListener();
+                } else {
+                    detachEarlyEscapeListener();
+                }
                 setOpen(nextOpen);
             }}
         >
@@ -94,7 +141,7 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
                                                 allowPickerChanges.current = false;
                                                 suppressPickerChanges.current = true;
                                                 onChange(swatchValue);
-                                                setOpen(false);
+                                                closePopover();
                                             }}
                                         >
                                             {isTransparent(swatch.hex) && <TransparentIndicator />}

--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -30,13 +30,21 @@ const MainContent: React.FC = () => {
     const navigateAway = (escLocation: string) => {
         window.location.hash = escLocation;
     };
+    const hasOpenModal = () => {
+        if (document.getElementById('modal-backdrop')) {
+            return true;
+        }
+
+        return Boolean(document.querySelector(
+            '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]'
+        ));
+    };
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
                 // Don't navigate away if a modal is open - let the modal handle ESC
-                const modalBackdrop = document.getElementById('modal-backdrop');
-                if (modalBackdrop) {
+                if (hasOpenModal()) {
                     return;
                 }
 

--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -10,6 +10,7 @@ import {useGlobalData} from './components/providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 const EMPTY_KEYWORDS: string[] = [];
+const OPEN_SHADE_MODAL_SELECTOR = ':is([role="dialog"], [role="alertdialog"])[data-state="open"]';
 
 const Page: React.FC<{children: ReactNode}> = ({children}) => {
     return <>
@@ -31,13 +32,13 @@ const MainContent: React.FC = () => {
         window.location.hash = escLocation;
     };
     const hasOpenModal = () => {
+        // Legacy admin-x-design-system modals render a dedicated backdrop element.
         if (document.getElementById('modal-backdrop')) {
             return true;
         }
 
-        return Boolean(document.querySelector(
-            '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]'
-        ));
+        // Newer Shade/Radix dialogs expose their open state via dialog roles.
+        return Boolean(document.querySelector(OPEN_SHADE_MODAL_SELECTOR));
     };
 
     useEffect(() => {

--- a/apps/admin-x-settings/test/unit/membership/welcome-email-customize-modal.test.tsx
+++ b/apps/admin-x-settings/test/unit/membership/welcome-email-customize-modal.test.tsx
@@ -82,16 +82,15 @@ describe('Welcome email customize modal', function () {
         assert.ok(screen.getByTestId('welcome-email-customize-modal'));
     });
 
-    it('keeps the customize modal open when Escape is pressed before the color picker has mounted', async function () {
+    it('keeps the customize modal open when Escape is pressed immediately after opening the color picker', async function () {
         vi.useFakeTimers();
         const onClose = vi.fn();
 
         render(<TestModal onClose={onClose} />);
 
-        fireEvent.click(screen.getByText('Button color'));
-        assert.equal(screen.queryByRole('textbox'), null);
-
         await act(async () => {
+            fireEvent.click(screen.getByText('Button color'));
+            assert.equal(screen.queryByRole('textbox'), null);
             fireEvent.keyDown(document, {key: 'Escape'});
         });
 

--- a/apps/admin-x-settings/test/unit/membership/welcome-email-customize-modal.test.tsx
+++ b/apps/admin-x-settings/test/unit/membership/welcome-email-customize-modal.test.tsx
@@ -1,0 +1,101 @@
+import EmailDesignModal from '@src/components/settings/email-design/email-design-modal';
+import React, {useState} from 'react';
+import assert from 'node:assert/strict';
+import {ButtonColorField} from '@src/components/settings/email-design/design-fields/button-color-field';
+import {DEFAULT_EMAIL_DESIGN} from '@src/components/settings/email-design/types';
+import {EmailDesignProvider} from '@src/components/settings/email-design/email-design-context';
+import {act, fireEvent, render, screen} from '@testing-library/react';
+
+vi.mock('@tryghost/shade/components', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/shade/components')>('@tryghost/shade/components');
+    const react = await vi.importActual<typeof import('react')>('react');
+
+    const DelayedPopoverContent = ({children, ...props}: React.ComponentProps<typeof actual.PopoverContent>) => {
+        const [ready, setReady] = react.useState(false);
+
+        react.useEffect(() => {
+            const timeout = window.setTimeout(() => {
+                setReady(true);
+            }, 50);
+
+            return () => window.clearTimeout(timeout);
+        }, []);
+
+        return ready ? <actual.PopoverContent {...props}>{children}</actual.PopoverContent> : null;
+    };
+
+    return {
+        ...actual,
+        PopoverContent: DelayedPopoverContent
+    };
+});
+
+const TestModal = ({onClose}: {onClose?: () => void}) => {
+    const [open, setOpen] = useState(true);
+
+    return (
+        <EmailDesignProvider
+            accentColor="#ff0088"
+            settings={DEFAULT_EMAIL_DESIGN}
+            onSettingsChange={() => {}}
+        >
+            <EmailDesignModal
+                open={open}
+                preview={<div>Preview</div>}
+                sidebar={<ButtonColorField />}
+                testId="welcome-email-customize-modal"
+                title="Customize welcome email"
+                onClose={() => {
+                    onClose?.();
+                    setOpen(false);
+                }}
+                onSave={() => {}}
+            />
+        </EmailDesignProvider>
+    );
+};
+
+describe('Welcome email customize modal', function () {
+    afterEach(function () {
+        vi.useRealTimers();
+    });
+
+    it('keeps the customize modal open when Escape is pressed after the color picker has mounted', async function () {
+        vi.useFakeTimers();
+        const onClose = vi.fn();
+
+        render(<TestModal onClose={onClose} />);
+
+        fireEvent.click(screen.getByText('Button color'));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(50);
+        });
+
+        assert.ok(screen.getByRole('textbox'));
+
+        await act(async () => {
+            fireEvent.keyDown(document, {key: 'Escape'});
+        });
+
+        assert.equal(onClose.mock.calls.length, 0);
+        assert.ok(screen.getByTestId('welcome-email-customize-modal'));
+    });
+
+    it('keeps the customize modal open when Escape is pressed before the color picker has mounted', async function () {
+        vi.useFakeTimers();
+        const onClose = vi.fn();
+
+        render(<TestModal onClose={onClose} />);
+
+        fireEvent.click(screen.getByText('Button color'));
+        assert.equal(screen.queryByRole('textbox'), null);
+
+        await act(async () => {
+            fireEvent.keyDown(document, {key: 'Escape'});
+        });
+
+        assert.ok(screen.queryByTestId('welcome-email-customize-modal'));
+        assert.equal(onClose.mock.calls.length, 0);
+    });
+});

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -347,7 +347,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button', () => {
         await expect(welcomeEmailsSection.customizeModalFooterTextarea).toHaveValue('Persisted footer');
     });
 
-    test('Escape shows unsaved changes confirmation for welcome email customization', async ({page}) => {
+    test('escape behavior - shows unsaved changes confirmation for welcome email customization', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();
@@ -363,7 +363,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button', () => {
         await expect(page).toHaveURL(/\/ghost\/#\/settings\/memberemails$/);
     });
 
-    test('Escape closes welcome email customization confirmation without closing the customize modal', async ({page}) => {
+    test('escape behavior - closes welcome email customization confirmation without closing the customize modal', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();
@@ -381,7 +381,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button', () => {
         await expect(page).toHaveURL(/\/ghost\/#\/settings\/memberemails$/);
     });
 
-    test('Escape closes welcome email color picker without bypassing unsaved changes confirmation', async ({page}) => {
+    test('escape behavior - closes welcome email color picker without bypassing unsaved changes confirmation', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();
@@ -411,7 +411,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button', () => {
         await expect(page).toHaveURL(/\/ghost\/#\/settings\/memberemails$/);
     });
 
-    test('Escape closes welcome email font select without bypassing unsaved changes confirmation', async ({page}) => {
+    test('escape behavior - closes welcome email font select without bypassing unsaved changes confirmation', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -381,7 +381,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button', () => {
         await expect(page).toHaveURL(/\/ghost\/#\/settings\/memberemails$/);
     });
 
-    test.skip('Escape closes welcome email color picker without bypassing unsaved changes confirmation', async ({page}) => {
+    test('Escape closes welcome email color picker without bypassing unsaved changes confirmation', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
         await welcomeEmailsSection.goto();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1234/flaky-member-welcome-emails-e2e-test

## Why this change?

Pressing `Escape` inside the welcome emails "Customize" flow could exit settings instead of just dismissing the active UI layer. That made the interaction flaky in E2E and, more importantly, let a nested control bypass the expected unsaved-changes flow.

## Reproduction
1. Go to Settings > Welcome emails
2. Open the "Customize" modal
3. Go to the Design tab
4. In rapid succession: click on one of the color swatches and immediately hit Escape

## Expected behavior
Escape should close the color picker, but leave the Customize modal open

## Actual behavior
If you time it just right, the Customize modal will close, then Settings will close, and you'll land on the Analytics screen (or where ever you were before opening settings to begin with).

## Root cause

`admin-x-settings` has a page-level `Escape` handler that navigates away from settings when no modal is open.

The welcome email customize UI is built with Shade/Radix dialogs and popovers, but the page-level guard was still only checking for the legacy `#modal-backdrop` element. That created two failure modes:

1. The customize modal and dirty-confirm dialog were not always recognized as "an open modal", so the page-level handler could still react to `Escape`.
6. The color picker popover mounts through a portal. Right after opening it, there is a brief window where the popover has been requested but its content has not mounted yet, so its `onEscapeKeyDown` handler cannot intercept the keypress. In that gap, `Escape` can bubble to the page-level handler and exit settings.

## Why this fix is correct

This fix closes the gap at the right layers instead of weakening the global shortcut.

- `MainContent` now treats open Radix `dialog` and `alertdialog` elements as active modals, not just the legacy backdrop. That keeps the page-level `Escape` shortcut disabled while the customize modal or unsaved-changes confirmation is open.
- `ColorPickerField` attaches an early capture-phase `Escape` listener as soon as the popover is opened. That means the first `Escape` is claimed by the color picker even if the popover content has not mounted yet. Once the popover is mounted, the normal popover escape handling still applies, and the temporary listener is removed when the popover closes or the component unmounts.

Together, those changes preserve the intended dismissal order:

1. First `Escape`: close the nested color picker.
2. Next `Escape`: show or dismiss the customize modal's unsaved-changes confirmation (if dirty).
7. Only when no modal is open should the settings page itself handle `Escape`.

## Test coverage

The PR adds:

- unit coverage for both the mounted-popover case and the immediate-after-open race
- e2e coverage proving `Escape` closes the color picker first and still respects the unsaved-changes confirmation flow
