### PR TITLE
Bumped @tryghost/tpl to 2.1.0

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -138,7 +138,7 @@
     "@tryghost/security": "1.0.6",
     "@tryghost/social-urls": "0.1.60",
     "@tryghost/string": "0.3.2",
-    "@tryghost/tpl": "0.1.40",
+    "@tryghost/tpl": "2.1.0",
     "@tryghost/url-utils": "5.1.2",
     "@tryghost/validator": "0.2.22",
     "@tryghost/version": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2135,8 +2135,8 @@ importers:
         specifier: 0.3.2
         version: 0.3.2
       '@tryghost/tpl':
-        specifier: 0.1.40
-        version: 0.1.40
+        specifier: 2.1.0
+        version: 2.1.0
       '@tryghost/url-utils':
         specifier: 5.1.2
         version: 5.1.2
@@ -9345,8 +9345,8 @@ packages:
   '@tryghost/tpl@0.1.40':
     resolution: {integrity: sha512-8w94lbNxXptRCIS8pe/IHjzgVFLxljxXx8+UQLO8NRFKraoEXthkPjAphN2MXKp1UGtj5ldh4Ye4D82bUWceOw==}
 
-  '@tryghost/tpl@2.0.3':
-    resolution: {integrity: sha512-v3BCkpcjEpYG7gPBntOjUYhADYfxbb+3tlt0KxqhZ9RYm+1sQ6wdsfZ+6Yh0akOwp/caifWIVuuvfcbL7x4SFA==}
+  '@tryghost/tpl@2.1.0':
+    resolution: {integrity: sha512-NIzGwyHcFUnJRmaDkd5wx6X+lXfqXqUbsICKO4KcPFtwmqLVButlbidNZsXLdoblyI2J5jS6JIGY22TB+mtiBw==}
 
   '@tryghost/url-utils@5.1.2':
     resolution: {integrity: sha512-GGZRfdVdk7jE1puqfBCeaAMeQ/Gd0NUkbqhj4gRSCWKW97JDpoiu5Fwyutt3vq3U3X4ZsfLfKs0NtAfUez0oog==}
@@ -31142,7 +31142,7 @@ snapshots:
       '@tryghost/debug': 2.1.0
       '@tryghost/errors': 1.3.13
       '@tryghost/nql': 0.12.10
-      '@tryghost/tpl': 2.0.3
+      '@tryghost/tpl': 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -31167,7 +31167,7 @@ snapshots:
   '@tryghost/bookshelf-pagination@2.0.3':
     dependencies:
       '@tryghost/errors': 1.3.13
-      '@tryghost/tpl': 2.0.3
+      '@tryghost/tpl': 2.1.0
       lodash: 4.17.23
     transitivePeerDependencies:
       - supports-color
@@ -31714,7 +31714,7 @@ snapshots:
     dependencies:
       lodash.template: 4.5.0
 
-  '@tryghost/tpl@2.0.3': {}
+  '@tryghost/tpl@2.1.0': {}
 
   '@tryghost/url-utils@5.1.2':
     dependencies:


### PR DESCRIPTION
## Summary

Wave 3 of the TryGhost/Framework monorepo catch-up (Waves 1 and 2: #27514, #27517). Single package.

| Package | From | To |
|---|---|---|
| `@tryghost/tpl` | 0.1.40 | 2.1.0 |

Split out from the other leaf utilities because the upstream rewrite swaps the `lodash.template` backend for a native `String#replace`, which is a meaningfully different execution path.

## Behaviour comparison

| Case | Old (`lodash.template`) | New (`String#replace`) | Ghost risk |
|---|---|---|---|
| `tpl('Hi {name}', {name: 'x'})` | `"Hi x"` | `"Hi x"` | — |
| `tpl('Hi {name}', {})` missing key | `ReferenceError: name is not defined` (via `with()`) | `ReferenceError: name is not defined` (explicit check) | — |
| `tpl('{{#get}} took {ms}', {ms: 5})` handlebars passthrough | `"{{#get}} took 5"` | `"{{#get}} took 5"` | — |
| `tpl('{{{helperName}}}', {helperName:'get'})` triple-brace | ignored | ignored | — |
| `tpl('\\\\{\\\\{{h}}\\\\}\\\\}', {h:'get'})` escaping | `"{{get}}"` | `"{{get}}"` | — |
| `tpl('Hi {user.name}', {user:{name:'x'}})` nested access | `"Hi x"` | `ReferenceError: user.name is not defined` | grep'd every callsite — Ghost doesn't use this |
| `tpl('Hi {name}', {name: null})` | `"Hi "` | `"Hi null"` | runtime-only, test suites catch regressions |

Bare minimum: if any code path feeds `null`/`undefined` into a `tpl` call, the error message text changes. All four ghost/core suites still pass locally, so no such regression is exercised by the existing coverage.

## Test plan

- [x] `pnpm install` — clean
- [x] `cd ghost/core && pnpm test:unit` — 6121 passing
- [x] `cd ghost/core && pnpm test:integration` — 242 passing
- [x] `cd ghost/core && pnpm test:e2e` — 1569 passing
- [x] `cd ghost/core && pnpm test:legacy` — 451 passing
- [x] `cd ghost/core && pnpm lint` — clean
- [x] `@tryghost/tpl` is only pinned in `ghost/core`, so no app version bumps required
- [ ] CI green