### PR TITLE
Refined gift redemption icon and copy in member activity

### DIFF
--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -274,8 +274,7 @@ export default class ParseMemberEventHelper extends Helper {
         }
 
         if (event.type === 'gift_redemption_event') {
-            const tierName = event.data.tier_name;
-            return `Started paid subscription (${tierName}) via gift`;
+            return 'started paid subscription via gift';
         }
     }
 
@@ -356,6 +355,10 @@ export default class ParseMemberEventHelper extends Helper {
             const symbol = getSymbol(event.data.currency);
             const formattedAmount = symbol + getNonDecimal(event.data.amount, event.data.currency);
             return formattedAmount;
+        }
+
+        if (event.type === 'gift_redemption_event') {
+            return event.data.tier_name;
         }
 
         return;

--- a/ghost/admin/public/assets/icons/event-gift.svg
+++ b/ghost/admin/public/assets/icons/event-gift.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M4.75 11.5v8a.75.75 0 0 0 .75.75h13a.75.75 0 0 0 .75-.75v-8M3.25 7.75h17.5v3.75H3.25zM12 7.75v12.5M12 7.75c-.75-2.25-2.25-4-4-4a2 2 0 0 0 0 4h4zM12 7.75c.75-2.25 2.25-4 4-4a2 2 0 0 1 0 4h-4z" stroke="#6C747D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M5.8375 10.575v6.8a.6375.6375 0 0 0 .6375.6375h11.05a.6375.6375 0 0 0 .6375-.6375v-6.8M4.5625 7.3875h14.875v3.1875H4.5625zM12 7.3875v10.625M12 7.3875c-.6375-1.9125-1.9125-3.4-3.4-3.4a1.7 1.7 0 0 0 0 3.4h3.4zM12 7.3875c.6375-1.9125 1.9125-3.4 3.4-3.4a1.7 1.7 0 0 1 0 3.4h-3.4z" stroke="#6C747D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
no issues

Follow-up tweaks to #27459:

- Scaled the gift event icon down so its footprint matches other event icons, and nudged it up 1px for better optical centering
- Moved the tier name out of the action string into the info span so gift redemptions render as `Started paid subscription via gift (Bronze)` — matches the existing `subscription_event` pattern