### PR TITLE
Tweaked gift purchase event copy in member activity

### DIFF
--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -270,7 +270,7 @@ export default class ParseMemberEventHelper extends Helper {
             const duration = event.data.duration;
             const cadenceLabel = duration === 1 ? event.data.cadence : event.data.cadence + 's';
 
-            return `Purchased a gift subscription for ${formattedAmount} (${tierName}, ${duration} ${cadenceLabel})`;
+            return `Purchased gift subscription for ${formattedAmount} (${tierName}, ${duration} ${cadenceLabel})`;
         }
 
         if (event.type === 'gift_redemption_event') {


### PR DESCRIPTION
no issues

Dropped "a" from the gift purchase event in member activity which makes it consistent with other events.