### PR TITLE
Updated stats app to include gift members in segmentation

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -22,6 +22,7 @@ export type MemberStatusItem = {
     paid: number;
     free: number;
     comped: number;
+    gift?: number;
     paid_subscribed: number;
     paid_canceled: number;
 }

--- a/apps/admin-x-framework/src/test/msw-utils.ts
+++ b/apps/admin-x-framework/src/test/msw-utils.ts
@@ -82,8 +82,8 @@ export const fixtures = {
     // Stats fixtures (from our previous work)
     memberCountHistory: {
         stats: [
-            {date: '2024-01-01', paid: 100, free: 500, comped: 10, paid_subscribed: 5, paid_canceled: 2},
-            {date: '2024-01-02', paid: 102, free: 505, comped: 10, paid_subscribed: 3, paid_canceled: 1}
+            {date: '2024-01-01', paid: 100, free: 500, comped: 10, gift: 7, paid_subscribed: 5, paid_canceled: 2},
+            {date: '2024-01-02', paid: 102, free: 505, comped: 10, gift: 8, paid_subscribed: 3, paid_canceled: 1}
         ],
         meta: {totals: {paid: 102, free: 505, comped: 10, gift: 8}}
     },

--- a/apps/admin-x-framework/src/test/responses/member_count_history.json
+++ b/apps/admin-x-framework/src/test/responses/member_count_history.json
@@ -5,6 +5,7 @@
             "paid": 100,
             "free": 500,
             "comped": 10,
+            "gift": 3,
             "paid_subscribed": 5,
             "paid_canceled": 2
         },
@@ -13,6 +14,7 @@
             "paid": 103,
             "free": 510,
             "comped": 10,
+            "gift": 4,
             "paid_subscribed": 3,
             "paid_canceled": 0
         },
@@ -21,6 +23,7 @@
             "paid": 105,
             "free": 520,
             "comped": 11,
+            "gift": 5,
             "paid_subscribed": 2,
             "paid_canceled": 0
         },
@@ -29,6 +32,7 @@
             "paid": 108,
             "free": 525,
             "comped": 11,
+            "gift": 6,
             "paid_subscribed": 3,
             "paid_canceled": 0
         },
@@ -37,6 +41,7 @@
             "paid": 110,
             "free": 530,
             "comped": 12,
+            "gift": 8,
             "paid_subscribed": 2,
             "paid_canceled": 0
         }

--- a/apps/stats/src/hooks/use-growth-stats.ts
+++ b/apps/stats/src/hooks/use-growth-stats.ts
@@ -9,7 +9,7 @@ import {useMemo} from 'react';
 export type DiffDirection = 'up' | 'down' | 'same';
 
 // Calculate totals from member data
-const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem[], dateFrom: string, memberCountTotals?: {paid: number; free: number; comped: number}) => {
+const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem[], dateFrom: string, memberCountTotals?: {paid: number; free: number; comped: number; gift: number}) => {
     if (!memberData.length) {
         return {
             totalMembers: 0,
@@ -33,12 +33,12 @@ const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
 
     // Use current totals from API meta if available (like Ember), otherwise use latest time series data
     const currentTotals = memberCountTotals || memberData[memberData.length - 1];
-    const latest = memberData.length > 0 ? memberData[memberData.length - 1] : {free: 0, paid: 0, comped: 0};
+    const latest = memberData.length > 0 ? memberData[memberData.length - 1] : {free: 0, paid: 0, comped: 0, gift: 0};
 
     const latestMrr = mrrData.length > 0 ? mrrData[mrrData.length - 1] : {mrr: 0};
 
     // Calculate total members using current totals (like Ember dashboard)
-    const totalMembers = currentTotals.free + currentTotals.paid + currentTotals.comped;
+    const totalMembers = currentTotals.free + currentTotals.paid + currentTotals.comped + (currentTotals.gift ?? 0);
 
     const totalMrr = latestMrr.mrr;
 
@@ -60,7 +60,7 @@ const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
     if (memberData.length > 1) {
         // Get first day in range
         const first = memberData[0];
-        const firstTotal = first.free + first.paid + first.comped;
+        const firstTotal = first.free + first.paid + first.comped + (first.gift ?? 0);
 
         if (firstTotal > 0) {
             const totalChange = ((totalMembers - firstTotal) / firstTotal) * 100;
@@ -74,9 +74,9 @@ const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
             directions.free = freeChange > 0 ? 'up' : freeChange < 0 ? 'down' : 'same';
         }
 
-        const firstPaidTotal = first.paid + first.comped;
-        const latestPaidTotal = latest.paid + latest.comped;
-        
+        const firstPaidTotal = first.paid + first.comped + (first.gift ?? 0);
+        const latestPaidTotal = latest.paid + latest.comped + (latest.gift ?? 0);
+
         if (firstPaidTotal > 0) {
             const paidChange = ((latestPaidTotal - firstPaidTotal) / firstPaidTotal) * 100;
             percentChanges.paid = formatPercentage(paidChange / 100);
@@ -131,7 +131,7 @@ const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
     return {
         totalMembers,
         freeMembers: currentTotals.free,
-        paidMembers: currentTotals.paid + currentTotals.comped,
+        paidMembers: currentTotals.paid + currentTotals.comped + (currentTotals.gift ?? 0),
         mrr: totalMrr,
         percentChanges,
         directions
@@ -169,7 +169,8 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
         const free = lastMemberItem?.free ?? 0;
         const paid = lastMemberItem?.paid ?? 0;
         const comped = lastMemberItem?.comped ?? 0;
-        const paidTotal = paid + comped;
+        const gift = lastMemberItem?.gift ?? 0;
+        const paidTotal = paid + comped + gift;
         const value = free + paidTotal;
         const mrr = lastMrrItem?.mrr ?? 0;
         const paidSubscribed = lastMemberItem?.paid_subscribed ?? 0;
@@ -181,6 +182,7 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
             free,
             paid: paidTotal,
             comped,
+            gift,
             mrr,
             paid_subscribed: paidSubscribed,
             paid_canceled: paidCanceled,

--- a/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
@@ -15,6 +15,7 @@ type ChartDataItem = {
     free: number;
     paid: number;
     comped: number;
+    gift: number;
     mrr: number;
     paid_subscribed?: number;
     paid_canceled?: number;
@@ -50,24 +51,26 @@ const isValidTab = (tab: string | null | undefined): tab is KpiTab => {
 // Extended data type for paid members chart with additional tooltip fields
 type PaidMembersChartDataItem = GhAreaChartDataItem & {
     comped: number;
+    gift: number;
     paid_subscribed?: number;
 };
 
 // Custom tooltip for paid members chart
-const PaidMembersTooltipContent = ({active, payload, range, color, showBreakdown}: {
+const PaidMembersTooltipContent = ({active, payload, range, color, showBreakdown, showGift}: {
     active?: boolean;
     payload?: Array<{value: number; payload: PaidMembersChartDataItem}>;
     range?: number;
     color?: string;
     showBreakdown?: boolean;
+    showGift?: boolean;
 }) => {
     if (!active || !payload?.length) {
         return null;
     }
 
     const data = payload[0].payload;
-    const {date, formattedValue, label, comped} = data;
-    const paidSubscriptions = data.value - (comped || 0);
+    const {date, formattedValue, label, comped, gift} = data;
+    const paidSubscriptions = data.value - (comped || 0) - (showGift ? (gift || 0) : 0);
 
     return (
         <div className="min-w-[200px] rounded-lg border bg-background px-3 py-2 shadow-lg">
@@ -87,6 +90,14 @@ const PaidMembersTooltipContent = ({active, payload, range, color, showBreakdown
                                 <div className="font-mono text-xs">{(comped !== undefined && comped > 0) ? (formatNumber(comped)) : '0'}</div>
                             </div>
                         </div>
+                        {showGift && (
+                            <div className='flex items-center gap-2'>
+                                <div className='flex grow items-center justify-between gap-5'>
+                                    <div className="text-sm text-muted-foreground">Gift</div>
+                                    <div className="font-mono text-xs">{(gift !== undefined && gift > 0) ? (formatNumber(gift)) : '0'}</div>
+                                </div>
+                            </div>
+                        )}
                         <Separator />
                     </>
                 )}
@@ -112,8 +123,9 @@ const GrowthKPIs: React.FC<{
 }> = ({chartData: allChartData, totals, initialTab, currencySymbol, isLoading, onTabChange}) => {
     const validatedInitialTab = isValidTab(initialTab) ? initialTab : 'total-members';
     const [currentTab, setCurrentTab] = useState<KpiTab>(validatedInitialTab);
-    const {range} = useGlobalData();
+    const {range, data: config} = useGlobalData();
     const {appSettings} = useAppContext();
+    const giftSubscriptionsEnabled = config?.labs?.giftSubscriptions === true;
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
 
@@ -185,6 +197,7 @@ const GrowthKPIs: React.FC<{
                     formattedValue: formatNumber(item.paid),
                     label: 'Paid members',
                     comped: item.comped,
+                    gift: item.gift,
                     paid_subscribed: item.paid_subscribed
                 };
             });
@@ -358,7 +371,7 @@ const GrowthKPIs: React.FC<{
                         formatNumber}
                     id={currentTab}
                     range={range}
-                    tooltipContent={currentTab === 'paid-members' ? <PaidMembersTooltipContent color={tabConfig['paid-members'].color} range={range} showBreakdown={true} /> : undefined}
+                    tooltipContent={currentTab === 'paid-members' ? <PaidMembersTooltipContent color={tabConfig['paid-members'].color} range={range} showBreakdown={true} showGift={giftSubscriptionsEnabled} /> : undefined}
                 />
             </div>
         </Tabs>

--- a/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
@@ -93,7 +93,7 @@ const PaidMembersTooltipContent = ({active, payload, range, color, showBreakdown
                         {showGift && (
                             <div className='flex items-center gap-2'>
                                 <div className='flex grow items-center justify-between gap-5'>
-                                    <div className="text-sm text-muted-foreground">Gift</div>
+                                    <div className="text-sm text-muted-foreground">Gift subscriptions</div>
                                     <div className="font-mono text-xs">{(gift !== undefined && gift > 0) ? (formatNumber(gift)) : '0'}</div>
                                 </div>
                             </div>

--- a/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
@@ -84,12 +84,6 @@ const PaidMembersTooltipContent = ({active, payload, range, color, showBreakdown
                                 <div className="font-mono text-xs">{formatNumber(paidSubscriptions)}</div>
                             </div>
                         </div>
-                        <div className='flex items-center gap-2'>
-                            <div className='flex grow items-center justify-between gap-5'>
-                                <div className="text-sm text-muted-foreground">Complimentary</div>
-                                <div className="font-mono text-xs">{(comped !== undefined && comped > 0) ? (formatNumber(comped)) : '0'}</div>
-                            </div>
-                        </div>
                         {showGift && (
                             <div className='flex items-center gap-2'>
                                 <div className='flex grow items-center justify-between gap-5'>
@@ -98,6 +92,12 @@ const PaidMembersTooltipContent = ({active, payload, range, color, showBreakdown
                                 </div>
                             </div>
                         )}
+                        <div className='flex items-center gap-2'>
+                            <div className='flex grow items-center justify-between gap-5'>
+                                <div className="text-sm text-muted-foreground">Complimentary</div>
+                                <div className="font-mono text-xs">{(comped !== undefined && comped > 0) ? (formatNumber(comped)) : '0'}</div>
+                            </div>
+                        </div>
                         <Separator />
                     </>
                 )}

--- a/apps/stats/src/views/Stats/Growth/components/new-subscribers-cadence.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/new-subscribers-cadence.tsx
@@ -1,10 +1,11 @@
-import React, {useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import moment from 'moment';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, EmptyIndicator, Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@tryghost/shade/components';
 import {LucideIcon, Recharts, formatNumber} from '@tryghost/shade/utils';
 import {formatQueryDate, getRangeDates} from '@tryghost/shade/app';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {useGlobalData} from '@src/providers/global-data-provider';
 import {useMemberCountHistory, useSubscriptionStats} from '@tryghost/admin-x-framework/api/stats';
 
 type NewSubscribersCadenceProps = {
@@ -53,6 +54,8 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
         }
     });
     const {data: {tiers: tierObjects = []} = {}} = useBrowseTiers();
+    const {data: globalConfig} = useGlobalData();
+    const giftSubscriptionsEnabled = globalConfig?.labs?.giftSubscriptions === true;
     const [breakdownType, setBreakdownType] = useState<BreakdownType>('billing-period');
 
     // Calculate date range for filtering
@@ -70,8 +73,9 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
             }));
     }, [tierObjects]);
 
-    // Calculate complimentary member signups (change in comped) within date range
-    const compedSignups = useMemo(() => {
+    // Helper: compute positive delta for a given status field (e.g. comped, gift)
+    // from the first to the last data point within the date range.
+    const calculateStatusSignups = useCallback((statusField: 'comped' | 'gift') => {
         if (!memberCountResponse?.stats || memberCountResponse.stats.length === 0) {
             return 0;
         }
@@ -80,7 +84,6 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
         const dateFromMoment = moment(dateFrom);
         const dateToMoment = moment(dateTo);
 
-        // Filter stats to the date range
         const filteredStats = stats.filter((item) => {
             const itemDate = moment(item.date);
             return itemDate.isSameOrAfter(dateFromMoment) && itemDate.isSameOrBefore(dateToMoment);
@@ -90,18 +93,26 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
             return 0;
         }
 
-        // Sort by date to get first and last in range
         const sortedStats = [...filteredStats].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
         );
 
-        const firstComped = sortedStats[0].comped;
-        const lastComped = sortedStats[sortedStats.length - 1].comped;
+        const firstValue = sortedStats[0][statusField] ?? 0;
+        const lastValue = sortedStats[sortedStats.length - 1][statusField] ?? 0;
 
-        // Return the delta (new complimentary signups in the period)
-        // Only return positive values (new signups, not removals)
-        const delta = lastComped - firstComped;
+        // Only count positive deltas (new signups, not removals)
+        const delta = lastValue - firstValue;
         return delta > 0 ? delta : 0;
     }, [memberCountResponse, dateFrom, dateTo]);
+
+    // Calculate complimentary member signups (change in comped) within date range
+    const compedSignups = useMemo(() => calculateStatusSignups('comped'), [calculateStatusSignups]);
+
+    // Calculate gift member signups (change in gift) within date range.
+    // Skipped when the giftSubscriptions labs flag is off — keeps cadence UI unchanged for sites not using gifts.
+    const giftSignups = useMemo(
+        () => (giftSubscriptionsEnabled ? calculateStatusSignups('gift') : 0),
+        [calculateStatusSignups, giftSubscriptionsEnabled]
+    );
 
     // Process subscription data for billing period breakdown (cadence) - NEW SUBSCRIBERS in date range
     const billingPeriodData = useMemo(() => {
@@ -132,6 +143,10 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
             cadenceTotals.complimentary = compedSignups;
         }
 
+        if (giftSignups > 0) {
+            cadenceTotals.gift = giftSignups;
+        }
+
         // Convert to array format for pie chart
         const chartData = Object.entries(cadenceTotals).map(([cadence, count], index) => {
             // Map cadence values to display labels and colors
@@ -151,6 +166,10 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
                 label = 'Complimentary';
                 fillGradient = 'url(#gradientBlue)';
                 solidColor = 'var(--chart-blue)';
+            } else if (cadence === 'gift') {
+                label = 'Gift';
+                fillGradient = 'url(#gradientRose)';
+                solidColor = 'var(--chart-rose)';
             }
 
             return {
@@ -163,7 +182,7 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
         });
 
         return chartData;
-    }, [subscriptionStatsResponse, dateFrom, dateTo, compedSignups]);
+    }, [subscriptionStatsResponse, dateFrom, dateTo, compedSignups, giftSignups]);
 
     // Process subscription data for tier breakdown - NEW SUBSCRIBERS in date range
     const tierData = useMemo(() => {

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -61,6 +61,7 @@ type GrowthChartDataItem = {
     free: number;
     paid: number;
     comped: number;
+    gift: number;
     mrr: number;
     formattedValue: string;
     label?: string;

--- a/apps/stats/test/unit/components/growth/new-subscribers-cadence.test.tsx
+++ b/apps/stats/test/unit/components/growth/new-subscribers-cadence.test.tsx
@@ -14,6 +14,12 @@ vi.mock('@tryghost/admin-x-framework/api/tiers', () => ({
     useBrowseTiers: vi.fn()
 }));
 
+vi.mock('@src/providers/global-data-provider', () => ({
+    useGlobalData: vi.fn(() => ({
+        data: {labs: {giftSubscriptions: true}}
+    }))
+}));
+
 // Mock date helpers from @tryghost/shade/app
 vi.mock('@tryghost/shade/app', async () => {
     const actual = await vi.importActual('@tryghost/shade/app');
@@ -41,11 +47,13 @@ vi.mock('@tryghost/shade/utils', async () => {
 });
 
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {useGlobalData} from '@src/providers/global-data-provider';
 import {useMemberCountHistory, useSubscriptionStats} from '@tryghost/admin-x-framework/api/stats';
 
 const mockedUseSubscriptionStats = useSubscriptionStats as ReturnType<typeof vi.fn>;
 const mockedUseMemberCountHistory = useMemberCountHistory as ReturnType<typeof vi.fn>;
 const mockedUseBrowseTiers = useBrowseTiers as ReturnType<typeof vi.fn>;
+const mockedUseGlobalData = useGlobalData as ReturnType<typeof vi.fn>;
 
 describe('NewSubscribersCadence Component', () => {
     beforeEach(() => {
@@ -205,6 +213,54 @@ describe('NewSubscribersCadence Component', () => {
         expect(screen.getByText('50%')).toBeInTheDocument();
         expect(screen.getByText('30%')).toBeInTheDocument();
         expect(screen.getByText('20%')).toBeInTheDocument();
+    });
+
+    it('shows Gift slice when giftSubscriptions labs flag is enabled and gift count increases', () => {
+        mockedUseGlobalData.mockReturnValue({data: {labs: {giftSubscriptions: true}}});
+
+        mockSuccess(mockedUseSubscriptionStats, {
+            stats: [
+                {date: '2024-01-15', tier: 'tier-1', cadence: 'month', signups: 50, cancellations: 0, count: 100}
+            ],
+            meta: {totals: [{tier: 'tier-1', cadence: 'month', count: 100}]}
+        });
+
+        mockSuccess(mockedUseMemberCountHistory, {
+            stats: [
+                {date: '2024-01-01', paid: 80, free: 50, comped: 0, gift: 0},
+                {date: '2024-01-31', paid: 100, free: 60, comped: 0, gift: 10}
+            ],
+            meta: {totals: {paid: 100, free: 60, comped: 0, gift: 10}}
+        });
+
+        render(<NewSubscribersCadence isLoading={false} range={30} />);
+
+        expect(screen.getByText('Monthly')).toBeInTheDocument();
+        expect(screen.getByText('Gift')).toBeInTheDocument();
+    });
+
+    it('hides Gift slice when giftSubscriptions labs flag is disabled, even when gift count increases', () => {
+        mockedUseGlobalData.mockReturnValue({data: {labs: {giftSubscriptions: false}}});
+
+        mockSuccess(mockedUseSubscriptionStats, {
+            stats: [
+                {date: '2024-01-15', tier: 'tier-1', cadence: 'month', signups: 50, cancellations: 0, count: 100}
+            ],
+            meta: {totals: [{tier: 'tier-1', cadence: 'month', count: 100}]}
+        });
+
+        mockSuccess(mockedUseMemberCountHistory, {
+            stats: [
+                {date: '2024-01-01', paid: 80, free: 50, comped: 0, gift: 0},
+                {date: '2024-01-31', paid: 100, free: 60, comped: 0, gift: 10}
+            ],
+            meta: {totals: {paid: 100, free: 60, comped: 0, gift: 10}}
+        });
+
+        render(<NewSubscribersCadence isLoading={false} range={30} />);
+
+        expect(screen.getByText('Monthly')).toBeInTheDocument();
+        expect(screen.queryByText('Gift')).not.toBeInTheDocument();
     });
 
     it('does not show complimentary when comped count does not increase', () => {

--- a/apps/stats/test/unit/hooks/use-growth-stats.test.tsx
+++ b/apps/stats/test/unit/hooks/use-growth-stats.test.tsx
@@ -45,9 +45,9 @@ const mockedGetRangeDates = getRangeDates as ReturnType<typeof vi.fn>;
 
 // Mock data for testing
 const mockMemberData = [
-    {date: '2024-06-25', free: 100, paid: 50, comped: 5, paid_subscribed: 5, paid_canceled: 2},
-    {date: '2024-06-26', free: 105, paid: 52, comped: 5, paid_subscribed: 3, paid_canceled: 1},
-    {date: '2024-06-27', free: 110, paid: 55, comped: 5, paid_subscribed: 4, paid_canceled: 1}
+    {date: '2024-06-25', free: 100, paid: 50, comped: 5, gift: 6, paid_subscribed: 5, paid_canceled: 2},
+    {date: '2024-06-26', free: 105, paid: 52, comped: 5, gift: 7, paid_subscribed: 3, paid_canceled: 1},
+    {date: '2024-06-27', free: 110, paid: 55, comped: 5, gift: 8, paid_subscribed: 4, paid_canceled: 1}
 ];
 
 const mockMrrData = [
@@ -80,7 +80,7 @@ describe('useGrowthStats', () => {
         mockSuccess(mockedUseMemberCountHistory, {
             stats: mockMemberData,
             meta: {
-                totals: {paid: 55, free: 110, comped: 5}
+                totals: {paid: 55, free: 110, comped: 5, gift: 8}
             }
         });
 
@@ -129,9 +129,9 @@ describe('useGrowthStats', () => {
                 expect(result.current.isLoading).toBe(false);
             });
 
-            expect(result.current.totals.totalMembers).toBe(170); // 110 + 55 + 5
+            expect(result.current.totals.totalMembers).toBe(178); // 110 + 55 + 5 + 8
             expect(result.current.totals.freeMembers).toBe(110);
-            expect(result.current.totals.paidMembers).toBe(60); // 55 + 5
+            expect(result.current.totals.paidMembers).toBe(68); // 55 + 5 + 8 (gift treated like comped)
             expect(result.current.totals.mrr).toBe(5500);
         });
 
@@ -151,7 +151,7 @@ describe('useGrowthStats', () => {
         it('handles empty member data response', async () => {
             mockSuccess(mockedUseMemberCountHistory, {
                 stats: [],
-                meta: {totals: {paid: 0, free: 0, comped: 0}}
+                meta: {totals: {paid: 0, free: 0, comped: 0, gift: 0}}
             });
 
             const {result} = renderHook(() => useGrowthStats(30));
@@ -391,6 +391,7 @@ describe('useGrowthStats', () => {
             expect(firstPoint).toHaveProperty('free');
             expect(firstPoint).toHaveProperty('paid');
             expect(firstPoint).toHaveProperty('comped');
+            expect(firstPoint).toHaveProperty('gift');
             expect(firstPoint).toHaveProperty('mrr');
             expect(firstPoint).toHaveProperty('formattedValue');
         });
@@ -481,9 +482,9 @@ describe('useGrowthStats', () => {
             });
 
             // Should use meta totals when available
-            expect(result.current.totals.totalMembers).toBe(170);
+            expect(result.current.totals.totalMembers).toBe(178);
             expect(result.current.totals.freeMembers).toBe(110);
-            expect(result.current.totals.paidMembers).toBe(60);
+            expect(result.current.totals.paidMembers).toBe(68);
         });
     });
 

--- a/ghost/core/core/server/models/member-status-event.js
+++ b/ghost/core/core/server/models/member-status-event.js
@@ -33,6 +33,11 @@ const MemberStatusEvent = ghostBookshelf.Model.extend({
                     WHEN from_status='free' THEN -1
                     ELSE 0 END
                 ) as free_delta`))
+                .select(knex.raw(`SUM(
+                    CASE WHEN to_status='gift' THEN 1
+                    WHEN from_status='gift' THEN -1
+                    ELSE 0 END
+                ) as gift_delta`))
                 .groupByRaw('DATE(created_at)')
                 .orderByRaw('DATE(created_at)');
         }

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -1132,14 +1132,16 @@ module.exports = class EventRepository {
                     date: result.date,
                     paid: result.paid_delta,
                     comped: result.comped_delta,
-                    free: result.free_delta
+                    free: result.free_delta,
+                    gift: result.gift_delta
                 }];
             }
             return accumulator.concat([{
                 date: result.date,
                 paid: result.paid_delta + accumulator[index - 1].paid,
                 comped: result.comped_delta + accumulator[index - 1].comped,
-                free: result.free_delta + accumulator[index - 1].free
+                free: result.free_delta + accumulator[index - 1].free,
+                gift: result.gift_delta + accumulator[index - 1].gift
             }]);
         }, []);
 

--- a/ghost/core/core/server/services/stats/members-stats-service.js
+++ b/ghost/core/core/server/services/stats/members-stats-service.js
@@ -65,6 +65,11 @@ class MembersStatsService {
                 WHEN from_status='free' THEN -1
                 ELSE 0 END
             ) as free_delta`))
+            .select(knex.raw(`SUM(
+                CASE WHEN to_status='gift' THEN 1
+                WHEN from_status='gift' THEN -1
+                ELSE 0 END
+            ) as gift_delta`))
             .where('created_at', '>=', formattedStartDate)
             .groupByRaw('DATE(created_at)');
         return /** @type {MemberStatusDelta[]} */ (/** @type {unknown} */ (rows));
@@ -120,6 +125,7 @@ class MembersStatsService {
         let runningPaid = totals.paid;
         let runningFree = totals.free;
         let runningComped = totals.comped;
+        let runningGift = totals.gift;
 
         const historicalTotalsMap = new Map();
         
@@ -137,6 +143,7 @@ class MembersStatsService {
                 paid: Math.max(0, runningPaid),
                 free: Math.max(0, runningFree),
                 comped: Math.max(0, runningComped),
+                gift: Math.max(0, runningGift),
                 paid_subscribed: row.paid_subscribed,
                 paid_canceled: row.paid_canceled
             });
@@ -145,6 +152,7 @@ class MembersStatsService {
             runningPaid -= row.paid_subscribed - row.paid_canceled;
             runningFree -= row.free_delta;
             runningComped -= row.comped_delta;
+            runningGift -= row.gift_delta;
         }
 
         // Generate complete date range from startDate to today
@@ -155,7 +163,8 @@ class MembersStatsService {
         let lastKnownTotals = {
             paid: Math.max(0, runningPaid), // Historical baseline before all events
             free: Math.max(0, runningFree),
-            comped: Math.max(0, runningComped)
+            comped: Math.max(0, runningComped),
+            gift: Math.max(0, runningGift)
         };
 
         while (currentDate.isSameOrBefore(endDateMoment)) {
@@ -167,13 +176,15 @@ class MembersStatsService {
                 lastKnownTotals = {
                     paid: eventData.paid,
                     free: eventData.free,
-                    comped: eventData.comped
+                    comped: eventData.comped,
+                    gift: eventData.gift
                 };
                 results.push({
                     date: dateStr,
                     paid: eventData.paid,
                     free: eventData.free,
                     comped: eventData.comped,
+                    gift: eventData.gift,
                     paid_subscribed: eventData.paid_subscribed,
                     paid_canceled: eventData.paid_canceled
                 });
@@ -184,6 +195,7 @@ class MembersStatsService {
                     paid: lastKnownTotals.paid,
                     free: lastKnownTotals.free,
                     comped: lastKnownTotals.comped,
+                    gift: lastKnownTotals.gift,
                     paid_subscribed: 0,
                     paid_canceled: 0
                 });
@@ -208,7 +220,7 @@ class MembersStatsService {
      * @returns {Object} Sparse date range data
      */
     _generateSparseRange(rows, totals, today) {
-        let {paid, free, comped} = totals;
+        let {paid, free, comped, gift} = totals;
         const cumulativeResults = [];
 
         rows.sort((a, b) => moment(a.date).valueOf() - moment(b.date).valueOf());
@@ -228,6 +240,7 @@ class MembersStatsService {
                 paid: Math.max(0, paid),
                 free: Math.max(0, free),
                 comped: Math.max(0, comped),
+                gift: Math.max(0, gift),
 
                 // Deltas
                 paid_subscribed: row.paid_subscribed,
@@ -238,6 +251,7 @@ class MembersStatsService {
             paid -= row.paid_subscribed - row.paid_canceled;
             free -= row.free_delta;
             comped -= row.comped_delta;
+            gift -= row.gift_delta;
         }
 
         // Now also add the oldest day we have left over (this one will be zero, which is also needed as a data point for graphs)
@@ -248,6 +262,7 @@ class MembersStatsService {
             paid: Math.max(0, paid),
             free: Math.max(0, free),
             comped: Math.max(0, comped),
+            gift: Math.max(0, gift),
 
             // Deltas
             paid_subscribed: 0,
@@ -273,6 +288,7 @@ module.exports = MembersStatsService;
  * @property {number} paid_canceled Paid members that canceled on this day
  * @property {number} comped_delta Total net comped members on this day
  * @property {number} free_delta Total net members on this day
+ * @property {number} gift_delta Total net gift members on this day
  */
 
 /**
@@ -290,6 +306,7 @@ module.exports = MembersStatsService;
  * @property {number} paid Total paid members
  * @property {number} free Total free members
  * @property {number} comped Total comped members
+ * @property {number} gift Total gift members
  * @property {number} paid_subscribed Paid members that subscribed on this day
  * @property {number} paid_canceled Paid members that canceled on this day
  */

--- a/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -53,6 +53,7 @@ Object {
       "comped": 0,
       "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "free": 3,
+      "gift": 0,
       "paid": 5,
       "paid_canceled": 0,
       "paid_subscribed": 0,
@@ -65,7 +66,7 @@ exports[`Stats API Can fetch member count history 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "158",
+  "content-length": "167",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/server/services/stats/members.test.js
+++ b/ghost/core/test/unit/server/services/stats/members.test.js
@@ -120,7 +120,8 @@ describe('MembersStatsService', function () {
                 const paidCanceled = generateEvents('paid', -event.paid_canceled, event.date);
                 const freeSubscribed = generateEvents('free', event.free_delta, event.date);
                 const compedSubscribed = generateEvents('comped', event.comped_delta, event.date);
-                return memo.concat(paidSubscribed, paidCanceled, freeSubscribed, compedSubscribed);
+                const giftSubscribed = generateEvents('gift', event.gift_delta || 0, event.date);
+                return memo.concat(paidSubscribed, paidCanceled, freeSubscribed, compedSubscribed, giftSubscribed);
             }, []);
 
             if (toInsert.length) {
@@ -145,6 +146,7 @@ describe('MembersStatsService', function () {
                 paid: 1,
                 free: 2,
                 comped: 3,
+                gift: 4,
                 paid_subscribed: 0,
                 paid_canceled: 0
             });
@@ -159,7 +161,8 @@ describe('MembersStatsService', function () {
                     paid_subscribed: 4,
                     paid_canceled: 3,
                     free_delta: 2,
-                    comped_delta: 3
+                    comped_delta: 3,
+                    gift_delta: 2
                 }
             ];
 
@@ -167,6 +170,7 @@ describe('MembersStatsService', function () {
             currentCounts.paid = 1;
             currentCounts.free = 2;
             currentCounts.comped = 3;
+            currentCounts.gift = 2;
 
             await setupDB();
 
@@ -177,6 +181,7 @@ describe('MembersStatsService', function () {
                     paid: 0,
                     free: 0,
                     comped: 0,
+                    gift: 0,
                     paid_subscribed: 0,
                     paid_canceled: 0
                 },
@@ -185,6 +190,7 @@ describe('MembersStatsService', function () {
                     paid: 1,
                     free: 2,
                     comped: 3,
+                    gift: 2,
                     paid_subscribed: 4,
                     paid_canceled: 3
                 }
@@ -200,14 +206,16 @@ describe('MembersStatsService', function () {
                     paid_subscribed: 2,
                     paid_canceled: 1,
                     free_delta: 0,
-                    comped_delta: 0
+                    comped_delta: 0,
+                    gift_delta: 1
                 },
                 {
                     date: todayDate,
                     paid_subscribed: 4,
                     paid_canceled: 3,
                     free_delta: 2,
-                    comped_delta: 3
+                    comped_delta: 3,
+                    gift_delta: 2
                 }
             ];
 
@@ -215,6 +223,7 @@ describe('MembersStatsService', function () {
             currentCounts.paid = 2;
             currentCounts.free = 3;
             currentCounts.comped = 4;
+            currentCounts.gift = 3;
 
             await setupDB();
 
@@ -225,6 +234,7 @@ describe('MembersStatsService', function () {
                     paid: 0,
                     free: 1,
                     comped: 1,
+                    gift: 0,
                     paid_subscribed: 0,
                     paid_canceled: 0
                 },
@@ -233,6 +243,7 @@ describe('MembersStatsService', function () {
                     paid: 1,
                     free: 1,
                     comped: 1,
+                    gift: 1,
                     paid_subscribed: 2,
                     paid_canceled: 1
                 },
@@ -241,6 +252,7 @@ describe('MembersStatsService', function () {
                     paid: 2,
                     free: 3,
                     comped: 4,
+                    gift: 3,
                     paid_subscribed: 4,
                     paid_canceled: 3
                 }
@@ -256,21 +268,24 @@ describe('MembersStatsService', function () {
                     paid_subscribed: 2,
                     paid_canceled: 1,
                     free_delta: 2,
-                    comped_delta: 10
+                    comped_delta: 10,
+                    gift_delta: 0
                 },
                 {
                     date: yesterdayDate,
                     paid_subscribed: 2,
                     paid_canceled: 1,
                     free_delta: -100,
-                    comped_delta: 0
+                    comped_delta: 0,
+                    gift_delta: 0
                 },
                 {
                     date: todayDate,
                     paid_subscribed: 4,
                     paid_canceled: 3,
                     free_delta: 100,
-                    comped_delta: 3
+                    comped_delta: 3,
+                    gift_delta: 0
                 }
             ];
 
@@ -278,6 +293,7 @@ describe('MembersStatsService', function () {
             currentCounts.paid = 2;
             currentCounts.free = 3;
             currentCounts.comped = 4;
+            currentCounts.gift = 0;
 
             await setupDB();
 
@@ -288,6 +304,7 @@ describe('MembersStatsService', function () {
                     paid: 0,
                     free: 1,
                     comped: 0,
+                    gift: 0,
                     paid_subscribed: 0,
                     paid_canceled: 0
                 },
@@ -297,6 +314,7 @@ describe('MembersStatsService', function () {
                     // note that this shouldn't be 100 (which is also what we test here):
                     free: 3,
                     comped: 1,
+                    gift: 0,
                     paid_subscribed: 2,
                     paid_canceled: 1
                 },
@@ -306,6 +324,7 @@ describe('MembersStatsService', function () {
                     // never return negative numbers, this is in fact -997:
                     free: 0,
                     comped: 1,
+                    gift: 0,
                     paid_subscribed: 2,
                     paid_canceled: 1
                 },
@@ -314,6 +333,7 @@ describe('MembersStatsService', function () {
                     paid: 2,
                     free: 3,
                     comped: 4,
+                    gift: 0,
                     paid_subscribed: 4,
                     paid_canceled: 3
                 }
@@ -329,21 +349,24 @@ describe('MembersStatsService', function () {
                     paid_subscribed: 1,
                     paid_canceled: 0,
                     free_delta: 1,
-                    comped_delta: 0
+                    comped_delta: 0,
+                    gift_delta: 0
                 },
                 {
                     date: todayDate,
                     paid_subscribed: 4,
                     paid_canceled: 3,
                     free_delta: 2,
-                    comped_delta: 3
+                    comped_delta: 3,
+                    gift_delta: 1
                 },
                 {
                     date: tomorrowDate,
                     paid_subscribed: 10,
                     paid_canceled: 5,
                     free_delta: 8,
-                    comped_delta: 9
+                    comped_delta: 9,
+                    gift_delta: 7
                 }
             ];
 
@@ -351,6 +374,7 @@ describe('MembersStatsService', function () {
             currentCounts.paid = 1;
             currentCounts.free = 2;
             currentCounts.comped = 3;
+            currentCounts.gift = 1;
 
             await setupDB();
 
@@ -361,6 +385,7 @@ describe('MembersStatsService', function () {
                     paid: 0,
                     free: 0,
                     comped: 0,
+                    gift: 0,
                     paid_subscribed: 0,
                     paid_canceled: 0
                 },
@@ -369,6 +394,7 @@ describe('MembersStatsService', function () {
                     paid: 0,
                     free: 0,
                     comped: 0,
+                    gift: 0,
                     paid_subscribed: 1,
                     paid_canceled: 0
                 },
@@ -377,6 +403,7 @@ describe('MembersStatsService', function () {
                     paid: 1,
                     free: 2,
                     comped: 3,
+                    gift: 1,
                     paid_subscribed: 4,
                     paid_canceled: 3
                 }
@@ -392,21 +419,24 @@ describe('MembersStatsService', function () {
                     paid_subscribed: 2,
                     paid_canceled: 1,
                     free_delta: 2,
-                    comped_delta: 1
+                    comped_delta: 1,
+                    gift_delta: 1
                 },
                 {
                     date: yesterdayDate,
                     paid_subscribed: 1,
                     paid_canceled: 0,
                     free_delta: 1,
-                    comped_delta: 0
+                    comped_delta: 0,
+                    gift_delta: 2
                 },
                 {
                     date: todayDate,
                     paid_subscribed: 4,
                     paid_canceled: 3,
                     free_delta: 2,
-                    comped_delta: 3
+                    comped_delta: 3,
+                    gift_delta: 0
                 }
             ];
 
@@ -414,6 +444,7 @@ describe('MembersStatsService', function () {
             currentCounts.paid = 3;
             currentCounts.free = 5;
             currentCounts.comped = 4;
+            currentCounts.gift = 3;
 
             await setupDB();
 
@@ -431,6 +462,7 @@ describe('MembersStatsService', function () {
                     paid: 2,
                     free: 3,
                     comped: 1,
+                    gift: 3,
                     paid_subscribed: 1,
                     paid_canceled: 0
                 },
@@ -439,6 +471,7 @@ describe('MembersStatsService', function () {
                     paid: 3,
                     free: 5,
                     comped: 4,
+                    gift: 3,
                     paid_subscribed: 4,
                     paid_canceled: 3
                 }
@@ -457,14 +490,16 @@ describe('MembersStatsService', function () {
                     paid_subscribed: 1,
                     paid_canceled: 0,
                     free_delta: 1,
-                    comped_delta: 0
+                    comped_delta: 0,
+                    gift_delta: 0
                 },
                 {
                     date: oneDayAgoDate,
                     paid_subscribed: 1,
                     paid_canceled: 0,
                     free_delta: 1,
-                    comped_delta: 0
+                    comped_delta: 0,
+                    gift_delta: 1
                 }
                 // Note: No events on 2 days ago - should be forward-filled
             ];
@@ -472,6 +507,7 @@ describe('MembersStatsService', function () {
             currentCounts.paid = 2;
             currentCounts.free = 2;
             currentCounts.comped = 0;
+            currentCounts.gift = 1;
 
             await setupDB();
 
@@ -499,6 +535,56 @@ describe('MembersStatsService', function () {
             assert.equal(gapDay.paid_subscribed, 0); // No events on this day
             assert.equal(gapDay.paid_canceled, 0); // No events on this day
             assert.ok(typeof gapDay.paid === 'number'); // But has member counts (forward-filled)
+            // Gift count is forward-filled from the most recent prior day (three days ago: 0)
+            assert.equal(gapDay.gift, 0);
+        });
+
+        it('Replays gift_delta to build per-day gift counts', async function () {
+            events = [
+                {
+                    date: dayBeforeYesterdayDate,
+                    paid_subscribed: 0,
+                    paid_canceled: 0,
+                    free_delta: 0,
+                    comped_delta: 0,
+                    gift_delta: 2
+                },
+                {
+                    date: yesterdayDate,
+                    paid_subscribed: 0,
+                    paid_canceled: 0,
+                    free_delta: 0,
+                    comped_delta: 0,
+                    gift_delta: 3
+                },
+                {
+                    date: todayDate,
+                    paid_subscribed: 0,
+                    paid_canceled: 0,
+                    free_delta: 0,
+                    comped_delta: 0,
+                    gift_delta: -1
+                }
+            ];
+
+            currentCounts.paid = 0;
+            currentCounts.free = 0;
+            currentCounts.comped = 0;
+            currentCounts.gift = 4; // 2 + 3 - 1
+
+            await setupDB();
+
+            const {data: results, meta} = await membersStatsService.getCountHistory();
+
+            // Should have 4 rows: baseline (one day before oldest event) + 3 event days
+            assert.equal(results.length, 4);
+
+            const byDate = Object.fromEntries(results.map(r => [r.date, r]));
+            assert.equal(byDate[twoDaysBeforeYesterday].gift, 0); // Baseline before first event
+            assert.equal(byDate[dayBeforeYesterday].gift, 2);
+            assert.equal(byDate[yesterday].gift, 5);
+            assert.equal(byDate[today].gift, 4);
+            assert.equal(meta.totals.gift, 4);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3491

- the stats app segmented members as `paid`/`free`/`comped` and ignored the new `gift` status, so `gift` members weren't reflected in analytics KPIs, tooltips, or breakdowns
- `gift` is now counted in the `Total Members` and `Paid Members` KPIs, following the same treatment as `comped` (both grant access to paid content)
- the `Paid Members` tooltip gets a new `Gift` breakdown row, and the `Paid Subscription` Breakdown pie gets a new `Gift` slice - both gated behind the `giftSubscriptions` labs flag so sites not using the feature see no UI change
- also added per-day `gift_delta` to the backend `members-stats` service so the time-series is complete end-to-end - the frontend relies on this for accurate tooltip values and cadence-pie deltas over the selected range