### PR TITLE
Added scheduler-triggered gift reminder flush

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -398,7 +398,11 @@ async function initServices() {
         recommendationsService.init(),
         statsService.init(),
         explorePingService.init(),
-        giftService.init(),
+        giftService.init({
+            apiUrl,
+            schedulerAdapter,
+            schedulerIntegration
+        }),
         new WelcomeEmailAutomationsService().init({
             domainEvents,
             apiUrl,

--- a/ghost/core/core/server/api/endpoints/gift-reminders.js
+++ b/ghost/core/core/server/api/endpoints/gift-reminders.js
@@ -1,0 +1,23 @@
+const domainEvents = require('@tryghost/domain-events');
+const StartGiftReminderFlushEvent = require('../../services/gifts/events/start-gift-reminder-flush-event');
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'gifts',
+
+    flushReminders: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: {
+            docName: 'gifts',
+            method: 'flushReminders'
+        },
+        query() {
+            domainEvents.dispatch(StartGiftReminderFlushEvent.create());
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -297,6 +297,10 @@ module.exports = {
         return apiFramework.pipeline(require('./gifts-members'), localUtils, 'members');
     },
 
+    get giftReminders() {
+        return apiFramework.pipeline(require('./gift-reminders'), localUtils);
+    },
+
     get recommendationsPublic() {
         return apiFramework.pipeline(require('./recommendations-public'), localUtils, 'content');
     },

--- a/ghost/core/core/server/services/gifts/events/start-gift-reminder-flush-event.js
+++ b/ghost/core/core/server/services/gifts/events/start-gift-reminder-flush-event.js
@@ -1,0 +1,16 @@
+module.exports = class StartGiftReminderFlushEvent {
+    /**
+     * @param {Date} timestamp
+     */
+    constructor(timestamp) {
+        this.data = null;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @returns {StartGiftReminderFlushEvent}
+     */
+    static create() {
+        return new StartGiftReminderFlushEvent(new Date());
+    }
+};

--- a/ghost/core/core/server/services/gifts/gift-service-wrapper.js
+++ b/ghost/core/core/server/services/gifts/gift-service-wrapper.js
@@ -1,9 +1,30 @@
+/**
+ * @typedef {object} SchedulerAdapter
+ * @prop {(job: {time: number; url: string; extra: {httpMethod: string}}) => void} schedule
+ */
+
+/**
+ * @typedef {object} SchedulerIntegration
+ * @prop {Array<{id: string; secret: string}>} api_keys
+ */
+
+/**
+ * @typedef {object} InitOptions
+ * @prop {string} [apiUrl]
+ * @prop {SchedulerAdapter} [schedulerAdapter]
+ * @prop {SchedulerIntegration} [schedulerIntegration]
+ */
+
 class GiftServiceWrapper {
     controller;
     service;
+    #initialized = false;
 
-    async init() {
-        if (this.service) {
+    /**
+     * @param {InitOptions} [options]
+     */
+    async init(options = {}) {
+        if (this.#initialized) {
             return;
         }
 
@@ -19,6 +40,7 @@ class GiftServiceWrapper {
         const DomainEvents = require('@tryghost/domain-events');
         const logging = require('@tryghost/logging');
         const {SubscriptionActivatedEvent} = require('../../../shared/events');
+        const StartGiftReminderFlushEvent = require('./events/start-gift-reminder-flush-event');
 
         const {GhostMailer} = require('../mail');
         const settingsCache = require('../../../shared/settings-cache');
@@ -26,6 +48,7 @@ class GiftServiceWrapper {
         const settingsHelpers = require('../settings-helpers');
         const EmailAddressParser = require('../email-address/email-address-parser');
         const {blogIcon} = require('../../../server/lib/image');
+        const {getSignedAdminToken} = require('../../adapters/scheduling/utils');
 
         const repository = new GiftBookshelfRepository({
             GiftModel
@@ -48,7 +71,12 @@ class GiftServiceWrapper {
             giftEmailService,
             get staffServiceEmails() {
                 return staffService.api.emails;
-            }
+            },
+            schedulerAdapter: options.schedulerAdapter ?? null,
+            schedulerIntegration: options.schedulerIntegration ?? null,
+            getSignedAdminToken,
+            urlJoin: urlUtils.urlJoin.bind(urlUtils),
+            apiUrl: options.apiUrl ?? null
         });
 
         this.controller = new GiftController({
@@ -70,6 +98,16 @@ class GiftServiceWrapper {
                 logging.error(err, 'Failed to consume gift on paid subscription activation');
             }
         });
+
+        DomainEvents.subscribe(StartGiftReminderFlushEvent, async () => {
+            try {
+                await this.service.processReminders();
+            } catch (err) {
+                logging.error(err, 'Failed to flush gift reminders');
+            }
+        });
+
+        this.#initialized = true;
     }
 }
 

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -7,6 +7,8 @@ import tpl from '@tryghost/tpl';
 import {GIFT_REMINDER_FLOOR_DAYS, GIFT_REMINDER_LEAD_DAYS} from './constants';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const GIFT_REMINDER_LEAD_MS = GIFT_REMINDER_LEAD_DAYS * MS_PER_DAY;
+const GIFT_REMINDER_FLOOR_MS = GIFT_REMINDER_FLOOR_DAYS * MS_PER_DAY;
 
 const errorMessages = {
     giftSubscriptionsNotEnabled: 'Gift subscriptions are not enabled on this site.',
@@ -107,12 +109,33 @@ export interface GiftPurchaseData {
     stripePaymentIntentId: string;
 }
 
+interface SchedulerAdapter {
+    schedule(job: {time: number; url: string; extra: {httpMethod: string}}): void;
+}
+
+interface SchedulerIntegration {
+    api_keys: Array<{id: string; secret: string}>;
+}
+
+type GetSignedAdminToken = (options: {
+    publishedAt: string;
+    apiUrl: string;
+    integration: SchedulerIntegration;
+}) => string;
+
+type UrlJoin = (...parts: string[]) => string;
+
 interface GiftServiceDeps {
     giftRepository: GiftRepository;
     memberRepository: MemberRepository;
     tiersService: TiersService;
     giftEmailService: GiftEmailService;
     staffServiceEmails: StaffServiceEmails;
+    schedulerAdapter: SchedulerAdapter | null;
+    schedulerIntegration: SchedulerIntegration | null;
+    getSignedAdminToken: GetSignedAdminToken | null;
+    urlJoin: UrlJoin | null;
+    apiUrl: string | null;
 }
 
 interface ReminderSend {
@@ -323,6 +346,8 @@ export class GiftService {
             } catch (err) {
                 logging.error('Failed to notify staff of gift redemption', err);
             }
+
+            this.scheduleReminder(redeemed);
         };
 
         if (options.transacting) {
@@ -477,12 +502,49 @@ export class GiftService {
         return {expiredCount};
     }
 
+    private scheduleReminder(gift: Gift): void {
+        const {schedulerAdapter, schedulerIntegration, getSignedAdminToken, urlJoin, apiUrl} = this.deps;
+
+        if (!schedulerAdapter || !schedulerIntegration || !getSignedAdminToken || !urlJoin || !apiUrl) {
+            return;
+        }
+
+        if (!gift.consumesAt) {
+            return;
+        }
+
+        const time = gift.consumesAt.getTime() - GIFT_REMINDER_LEAD_MS;
+
+        if (time <= Date.now()) {
+            return;
+        }
+
+        try {
+            const signedAdminToken = getSignedAdminToken({
+                publishedAt: new Date(time).toISOString(),
+                apiUrl,
+                integration: schedulerIntegration
+            });
+
+            const url = new URL(urlJoin(apiUrl, 'gifts', 'flush_reminders'));
+            url.searchParams.set('token', signedAdminToken);
+
+            schedulerAdapter.schedule({
+                time,
+                url: url.toString(),
+                extra: {httpMethod: 'PUT'}
+            });
+        } catch (err) {
+            logging.error('Failed to schedule gift reminder', err);
+        }
+    }
+
     async processReminders(): Promise<{remindedCount: number; skippedCount: number; failedCount: number}> {
         const now = new Date();
         const toRemind = await this.deps.giftRepository.findPendingReminder({
             now,
-            reminderLeadMs: GIFT_REMINDER_LEAD_DAYS * MS_PER_DAY,
-            reminderFloorMs: GIFT_REMINDER_FLOOR_DAYS * MS_PER_DAY
+            reminderLeadMs: GIFT_REMINDER_LEAD_MS,
+            reminderFloorMs: GIFT_REMINDER_FLOOR_MS
         });
 
         if (toRemind.length === 0) {

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -64,6 +64,7 @@ const tokenPermissionCheck = function tokenPermissionCheck(req, res, next) {
         config: ['GET'],
         explore: ['GET'],
         schedules: ['PUT'],
+        gifts: ['PUT'],
         files: ['POST'],
         media: ['POST'],
         db: ['GET', 'POST'],

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -73,6 +73,9 @@ module.exports = function apiRoutes() {
     // ## Schedules
     router.put('/schedules/:resource/:id', mw.authAdminApiWithUrl, http(api.schedules.publish));
 
+    // ## Gift Reminders
+    router.put('/gifts/flush_reminders', mw.authAdminApiWithUrl, http(api.giftReminders.flushReminders));
+
     // ## Settings
     router.get('/settings/routes/yaml', mw.authAdminApi, http(api.settings.download));
     router.post('/settings/routes/yaml',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/gift-reminders.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/gift-reminders.test.js.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Gift Reminders API flushReminders dispatches a flush event with a valid scheduler integration token 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Gift Reminders API flushReminders does not flush when request lacks a token 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": "INVALID_JWT",
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Invalid token: No token found in URL",
+      "property": null,
+      "type": "UnauthorizedError",
+    },
+  ],
+}
+`;
+
+exports[`Gift Reminders API flushReminders does not flush when request lacks a token 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "235",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Gift Reminders API flushReminders does not flush when request token is invalid 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": "INVALID_JWT",
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Invalid token: jwt audience invalid. expected: /\\\\/?admin\\\\/?$/",
+      "property": null,
+      "type": "UnauthorizedError",
+    },
+  ],
+}
+`;
+
+exports[`Gift Reminders API flushReminders does not flush when request token is invalid 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "262",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/gift-reminders.test.js
+++ b/ghost/core/test/e2e-api/admin/gift-reminders.test.js
@@ -1,0 +1,104 @@
+const sinon = require('sinon');
+const domainEvents = require('@tryghost/domain-events');
+const models = require('../../../core/server/models');
+const {getSignedAdminToken} = require('../../../core/server/adapters/scheduling/utils');
+const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
+const StartGiftReminderFlushEvent = require('../../../core/server/services/gifts/events/start-gift-reminder-flush-event');
+
+const {anyContentVersion, anyEtag, anyErrorId} = matchers;
+const {cacheInvalidateHeaderNotSet} = assertions;
+
+describe('Gift Reminders API', function () {
+    let agent;
+    let schedulerIntegration;
+    let schedulerToken;
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('integrations', 'api_keys');
+
+        schedulerIntegration = await models.Integration.findOne(
+            {slug: 'ghost-scheduler'},
+            {withRelated: 'api_keys'}
+        );
+
+        schedulerToken = getSignedAdminToken({
+            publishedAt: new Date().toISOString(),
+            apiUrl: '/admin/',
+            integration: schedulerIntegration.toJSON()
+        });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('flushReminders', function () {
+        /** @type {sinon.SinonStub} */
+        let dispatchStub;
+
+        beforeEach(function () {
+            dispatchStub = sinon.stub(domainEvents, 'dispatch');
+        });
+
+        it('does not flush when request lacks a token', async function () {
+            await agent
+                .put('gifts/flush_reminders/')
+                .expectStatus(401)
+                .expect(cacheInvalidateHeaderNotSet())
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId,
+                        message: 'Invalid token: No token found in URL'
+                    }]
+                });
+
+            sinon.assert.notCalled(dispatchStub);
+        });
+
+        it('does not flush when request token is invalid', async function () {
+            const invalidSchedulerToken = getSignedAdminToken({
+                publishedAt: new Date().toISOString(),
+                apiUrl: '/members/',
+                integration: schedulerIntegration.toJSON()
+            });
+
+            await agent
+                .put(`gifts/flush_reminders/?token=${invalidSchedulerToken}`)
+                .expectStatus(401)
+                .expect(cacheInvalidateHeaderNotSet())
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                });
+
+            sinon.assert.notCalled(dispatchStub);
+        });
+
+        it('dispatches a flush event with a valid scheduler integration token', async function () {
+            await agent
+                .put(`gifts/flush_reminders/?token=${schedulerToken}`)
+                .expectStatus(204)
+                .expectEmptyBody()
+                .expect(cacheInvalidateHeaderNotSet())
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+
+            sinon.assert.calledOnceWithExactly(
+                dispatchStub,
+                sinon.match.instanceOf(StartGiftReminderFlushEvent)
+            );
+        });
+    });
+});

--- a/ghost/core/test/unit/api/endpoints/gift-reminders.test.js
+++ b/ghost/core/test/unit/api/endpoints/gift-reminders.test.js
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const domainEvents = require('@tryghost/domain-events');
+const giftRemindersController = require('../../../../core/server/api/endpoints/gift-reminders');
+const StartGiftReminderFlushEvent = require('../../../../core/server/services/gifts/events/start-gift-reminder-flush-event');
+
+describe('Gift Reminders controller', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('flushReminders', function () {
+        it('dispatches a StartGiftReminderFlushEvent', function () {
+            const dispatchStub = sinon.stub(domainEvents, 'dispatch');
+
+            const result = giftRemindersController.flushReminders.query({});
+
+            sinon.assert.calledOnceWithExactly(
+                dispatchStub,
+                sinon.match.instanceOf(StartGiftReminderFlushEvent)
+            );
+            assert.equal(result, undefined);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -118,13 +118,24 @@ describe('GiftService', function () {
         sinon.restore();
     });
 
-    function createService() {
+    function createService(overrides: {
+        schedulerAdapter?: {schedule: sinon.SinonStub} | null;
+        schedulerIntegration?: {api_keys: Array<{id: string; secret: string}>} | null;
+        getSignedAdminToken?: sinon.SinonStub | null;
+        urlJoin?: sinon.SinonStub | null;
+        apiUrl?: string | null;
+    } = {}) {
         return new GiftService({
             giftRepository: giftRepository as any,
             memberRepository,
             tiersService,
             giftEmailService,
-            staffServiceEmails
+            staffServiceEmails,
+            schedulerAdapter: overrides.schedulerAdapter ?? null,
+            schedulerIntegration: overrides.schedulerIntegration ?? null,
+            getSignedAdminToken: overrides.getSignedAdminToken ?? null,
+            urlJoin: overrides.urlJoin ?? null,
+            apiUrl: overrides.apiUrl ?? null
         });
     }
 
@@ -1265,6 +1276,177 @@ describe('GiftService', function () {
             sinon.assert.notCalled(memberRepository.update);
             sinon.assert.notCalled(giftRepository.update);
             sinon.assert.notCalled(staffServiceEmails.notifyGiftSubscriptionStarted);
+        });
+    });
+
+    describe('scheduleReminder (via redeem)', function () {
+        const apiUrl = 'https://example.com/ghost/api/admin';
+
+        function buildSchedulerDeps() {
+            const schedule = sinon.stub();
+            const getSignedAdminToken = sinon.stub().returns('signed-token');
+            const urlJoin = sinon.stub().callsFake((...parts: string[]) => parts.join('/'));
+
+            return {
+                schedulerAdapter: {schedule},
+                schedulerIntegration: {api_keys: [{id: 'key-id', secret: '00'.repeat(32)}]},
+                getSignedAdminToken,
+                urlJoin,
+                apiUrl
+            };
+        }
+
+        function stubRedeemer() {
+            const memberGet = sinon.stub();
+
+            memberGet.withArgs('status').returns('free');
+            memberGet.withArgs('name').returns('Member Name');
+            memberGet.withArgs('email').returns('member@example.com');
+
+            memberRepository.get.resolves({id: 'member_1', get: memberGet});
+        }
+
+        it('schedules a reminder 7 days before consumes_at after redeem commits', async function () {
+            stubRedeemer();
+
+            const gift = buildGift();
+            giftRepository.getByToken.resolves(gift);
+
+            const deps = buildSchedulerDeps();
+            const service = createService(deps);
+
+            const redeemed = await service.redeem('gift-token', 'member_1');
+
+            assert.ok(redeemed.consumesAt);
+            const expectedTime = redeemed.consumesAt.getTime() - 7 * 24 * 60 * 60 * 1000;
+
+            sinon.assert.calledOnce(deps.schedulerAdapter.schedule);
+            const [job] = deps.schedulerAdapter.schedule.getCall(0).args;
+            assert.equal(job.time, expectedTime);
+            assert.equal(job.extra.httpMethod, 'PUT');
+            assert.equal(job.url, `${apiUrl}/gifts/flush_reminders?token=signed-token`);
+
+            sinon.assert.calledOnceWithExactly(deps.getSignedAdminToken, {
+                publishedAt: new Date(expectedTime).toISOString(),
+                apiUrl,
+                integration: deps.schedulerIntegration
+            });
+        });
+
+        it('does NOT schedule a reminder when scheduler deps are absent', async function () {
+            stubRedeemer();
+
+            const gift = buildGift();
+            giftRepository.getByToken.resolves(gift);
+
+            // No scheduler deps at all
+            const service = createService();
+            await service.redeem('gift-token', 'member_1');
+
+            // If we got here without throwing, the no-op path worked.
+            // Explicit assertion: staff notification still ran.
+            sinon.assert.calledOnce(staffServiceEmails.notifyGiftSubscriptionStarted);
+        });
+
+        it('does NOT schedule a reminder when only some scheduler deps are present', async function () {
+            stubRedeemer();
+
+            const gift = buildGift();
+            giftRepository.getByToken.resolves(gift);
+
+            const schedule = sinon.stub();
+            // schedulerAdapter provided but apiUrl missing
+            const service = createService({
+                schedulerAdapter: {schedule},
+                schedulerIntegration: null,
+                getSignedAdminToken: sinon.stub(),
+                urlJoin: sinon.stub(),
+                apiUrl: null
+            });
+
+            await service.redeem('gift-token', 'member_1');
+
+            sinon.assert.notCalled(schedule);
+        });
+
+        it('logs but does not throw when getSignedAdminToken throws', async function () {
+            stubRedeemer();
+
+            const gift = buildGift();
+            giftRepository.getByToken.resolves(gift);
+
+            const deps = buildSchedulerDeps();
+            deps.getSignedAdminToken.throws(new Error('JWT signing failed'));
+
+            const service = createService(deps);
+
+            // Should not throw — error is caught and logged.
+            const redeemed = await service.redeem('gift-token', 'member_1');
+
+            assert.equal(redeemed.status, 'redeemed');
+            sinon.assert.notCalled(deps.schedulerAdapter.schedule);
+        });
+
+        it('schedules the reminder even when staff notification fails', async function () {
+            stubRedeemer();
+
+            const gift = buildGift();
+            giftRepository.getByToken.resolves(gift);
+
+            staffServiceEmails.notifyGiftSubscriptionStarted.rejects(new Error('SMTP error'));
+
+            const deps = buildSchedulerDeps();
+            const service = createService(deps);
+
+            await service.redeem('gift-token', 'member_1');
+
+            sinon.assert.calledOnce(deps.schedulerAdapter.schedule);
+        });
+
+        it('schedules a reminder when redeem uses an external transaction (after commit)', async function () {
+            stubRedeemer();
+
+            const gift = buildGift();
+            giftRepository.getByToken.resolves(gift);
+
+            const deps = buildSchedulerDeps();
+            const service = createService(deps);
+
+            const externalTrx = {executionPromise: Promise.resolve()};
+            await service.redeem('gift-token', 'member_1', {transacting: externalTrx});
+
+            // Wait for the post-commit notify callback to run.
+            await externalTrx.executionPromise;
+            // One more microtask flush for the .then chain.
+            await new Promise((resolve) => {
+                setImmediate(resolve);
+            });
+
+            sinon.assert.calledOnce(deps.schedulerAdapter.schedule);
+        });
+
+        it('does NOT schedule a reminder when an external transaction rolls back', async function () {
+            stubRedeemer();
+
+            const gift = buildGift();
+            giftRepository.getByToken.resolves(gift);
+
+            const deps = buildSchedulerDeps();
+            const service = createService(deps);
+
+            const rejection = Promise.reject(new Error('rolled back'));
+            // Suppress unhandled rejection warning
+            rejection.catch(() => {});
+            const externalTrx = {executionPromise: rejection};
+
+            await service.redeem('gift-token', 'member_1', {transacting: externalTrx});
+
+            // Wait for the .then(notify, () => {}) reject branch.
+            await new Promise((resolve) => {
+                setImmediate(resolve);
+            });
+
+            sinon.assert.notCalled(deps.schedulerAdapter.schedule);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3525

The daily `send-gift-reminders` cron sends gift-expiry reminders, but because it only runs once a day, a reminder can fire up to ~24 hours after it first becomes eligible. More importantly, on Ghost Pro a site can sleep between redemption and reminder time, so the daily cron can't reliably fire at all — the site needs an external wakeup at the right moment.

- at redeem time, `GiftService.scheduleReminder` registers a one-off scheduler wakeup for `consumes_at - 7d` pointing at a shared URL
- scheduler fires → `PUT /schedules/gifts/reminders` dispatches `StartGiftReminderFlushEvent` and returns 204 without blocking on email sending
- subscriber in `GiftServiceWrapper` runs `processReminders()` in the background via `oneAtATime` to coalesce overlapping pings
- every gift's registration points at the same URL: the wakeup is just "the site should flush now", not a per-gift instruction. Wakeups for already-stamped gifts no-op via the row-level idempotency stamp on `consumes_soon_reminder_sent_at`
- no unschedule on refund/consume — the scheduler fires harmlessly, the SQL window in `processReminders` excludes non-redeemed gifts
- no boot rescan on self-hosted: a restart loses in-memory scheduler entries, and the daily cron picks them up on its next run. Matches the welcome-email-automations precedent (#27437)
- mirrors the welcome-email-automations pattern: inline `schedulerAdapter.schedule(...)` from the service, event dispatch from the HTTP handler, `oneAtATime` subscriber
