### PR TITLE
Added cache hit/miss/error/reset metrics

### DIFF
--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const BaseCacheAdapter = require('@tryghost/adapter-base-cache');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+const metrics = require('@tryghost/metrics');
 const debug = require('@tryghost/debug')('redis-cache');
 const cacheManager = require('cache-manager');
 const redisStoreFactory = require('./redis-store-factory');
@@ -22,6 +23,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * @param {number} [config.getTimeoutMilliseconds] - default timeout for cache get operations in *milliseconds*
      * @param {number} [config.refreshAheadFactor] - 0-1 number to use to determine how old (as a percentage of ttl) an entry should be before refreshing it
      * @param {string} [config.keyPrefix] - prefix to use when building a unique cache key, e.g.: 'some_id:image-sizes:'
+     * @param {string} [config.featureName] - name of the cache feature (e.g. 'postsPublic') used for dashboard filtering
      * @param {boolean} [config.reuseConnection] - specifies if the redis store/connection should be reused within the process
      */
     constructor(config) {
@@ -67,8 +69,22 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         this.currentlyExecutingBackgroundRefreshes = new Set();
         this.currentlyExecutingReads = new Map();
         this._keyPrefix = config.keyPrefix || '';
+        this._featureName = config.featureName;
         this._prefixHashInitInFlight = null;
         this.redisClient.on('error', this.handleRedisError);
+    }
+
+    /**
+     * Underscore-private to survive api-framework's `_.cloneDeep` on the
+     * controller (and this adapter). See the "survives deep cloning"
+     * suite — `#`-private methods break on clones.
+     */
+    _metric(name, extra = {}) {
+        const value = {...extra};
+        if (this._featureName !== undefined) {
+            value.feature = this._featureName;
+        }
+        metrics.metric(name, value);
     }
 
     /**
@@ -192,16 +208,35 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         }
 
         return new Promise((resolve) => {
+            // `lookup` keeps running after the timer fires, so without a
+            // single-settlement guard a slow failing redis read would emit
+            // both `cache-timeout` and `cache-error` for the same request.
+            let settled = false;
             const timer = setTimeout(() => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
                 debug('get', key, 'timeout');
+                this._metric('cache-timeout');
                 resolve({internalKey: null, result: null});
             }, this.getTimeoutMilliseconds);
             lookup.then((value) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
                 clearTimeout(timer);
                 resolve(value);
-            }, () => {
-                // redis failure during lookup - treat as MISS, same as the timeout path
+            }, (err) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
                 clearTimeout(timer);
+                // redis failure during lookup - treat as MISS, same as the timeout path
+                this._metric('cache-error', {operation: 'get'});
+                logging.error(err);
                 resolve({internalKey: null, result: null});
             });
         });
@@ -216,6 +251,13 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         try {
             const {internalKey, result} = await this._lookupWithTimeout(key);
             debug(`get ${key}: Cache ${result ? 'HIT' : 'MISS'}`);
+            if (result) {
+                this._metric('cache-hit');
+            } else if (internalKey !== null) {
+                // A real miss; timeouts and lookup errors (internalKey === null)
+                // already emitted their own metric in `_lookupWithTimeout`.
+                this._metric('cache-miss');
+            }
             if (!fetchData) {
                 return result;
             }
@@ -228,11 +270,15 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 if (!isRefreshing && shouldRefresh) {
                     debug(`Doing background refresh for ${key}`);
                     this.currentlyExecutingBackgroundRefreshes.add(internalKey);
+                    this._metric('cache-background-refresh-triggered');
+                    const refreshStart = performance.now();
                     fetchData().then(async (data) => {
-                        await this.set(key, data); // We don't use `internalKey` here because `set` handles it
+                        await this.set(key, data, {throwOnError: true}); // We don't use `internalKey` here because `set` handles it
                         this.currentlyExecutingBackgroundRefreshes.delete(internalKey);
+                        this._metric('cache-background-refresh-succeeded', {value: performance.now() - refreshStart});
                     }).catch((error) => {
                         this.currentlyExecutingBackgroundRefreshes.delete(internalKey);
+                        this._metric('cache-background-refresh-failed');
                         logging.error({
                             message: 'There was an error refreshing cache data in the background',
                             error: error
@@ -256,6 +302,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                         debug('set', internalKey);
                         await this.cache.set(internalKey, data);
                     } catch (err) {
+                        this._metric('cache-error', {operation: 'set'});
                         logging.error(err);
                     }
                 }).catch(() => {
@@ -267,6 +314,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 return resultPromise;
             }
         } catch (err) {
+            this._metric('cache-error', {operation: 'get'});
             logging.error(err);
         }
     }
@@ -275,14 +323,20 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      *
      * @param {string} key
      * @param {*} value
+     * @param {Object} [options]
+     * @param {boolean} [options.throwOnError] - if true, rethrow write errors after logging. Used by the background refresh path so success is only emitted after a write that actually succeeded.
      */
-    async set(key, value) {
+    async set(key, value, {throwOnError = false} = {}) {
         try {
             const internalKey = await this._buildKey(key);
             debug('set', internalKey);
             return await this.cache.set(internalKey, value);
         } catch (err) {
+            this._metric('cache-error', {operation: 'set'});
             logging.error(err);
+            if (throwOnError) {
+                throw err;
+            }
         }
     }
 
@@ -295,9 +349,12 @@ class AdapterCacheRedis extends BaseCacheAdapter {
 
     async reset() {
         debug('reset');
+        const t0 = performance.now();
         try {
             await this.cyclePrefixHash();
+            this._metric('cache-reset', {value: performance.now() - t0});
         } catch (err) {
+            this._metric('cache-error', {operation: 'reset'});
             logging.error(err);
         }
     }

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+const metrics = require('@tryghost/metrics');
 const RedisCache = require('../../../../../../core/server/adapters/lib/redis/AdapterCacheRedis');
 
 const PREFIX_HASH = 'mock-prefix-hash';
@@ -33,13 +34,26 @@ function createCacheStub({keyPrefix = ''} = {}) {
 }
 
 describe('Adapter Cache Redis', function () {
+    let metricStub;
+
     beforeEach(function () {
         sinon.stub(logging, 'error');
+        metricStub = sinon.stub(metrics, 'metric');
     });
 
     afterEach(function () {
         sinon.restore();
     });
+
+    function metricCall(name) {
+        return metricStub.getCalls().find(c => c.args[0] === name);
+    }
+
+    function flushMicrotasks() {
+        return new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+    }
 
     it('can initialize Redis cache instance directly', async function () {
         const cache = new RedisCache({cache: createCacheStub()});
@@ -497,6 +511,251 @@ describe('Adapter Cache Redis', function () {
                 () => cache.keys(),
                 err => err instanceof errors.IncorrectUsageError
             );
+        });
+    });
+
+    describe('metrics', function () {
+        it('emits cache-hit with feature on a hit', async function () {
+            const cacheStub = createCacheStub();
+            cacheStub.get.resolves('v');
+            const cache = new RedisCache({cache: cacheStub, featureName: 'postsPublic'});
+
+            await cache.get('k');
+
+            const call = metricCall('cache-hit');
+            assert.ok(call, 'cache-hit was emitted');
+            assert.equal(call.args[1].feature, 'postsPublic');
+            assert.equal(metricCall('cache-miss'), undefined);
+        });
+
+        it('emits cache-miss with feature on a genuine miss', async function () {
+            const cacheStub = createCacheStub();
+            cacheStub.get.resolves(null);
+            const cache = new RedisCache({cache: cacheStub, featureName: 'postsPublic'});
+
+            await cache.get('k');
+
+            const call = metricCall('cache-miss');
+            assert.ok(call, 'cache-miss was emitted');
+            assert.equal(call.args[1].feature, 'postsPublic');
+            assert.equal(metricCall('cache-hit'), undefined);
+        });
+
+        it('omits feature when featureName is not set', async function () {
+            const cacheStub = createCacheStub({keyPrefix: 'postsPublic:'});
+            cacheStub.get.resolves('v');
+            const cache = new RedisCache({cache: cacheStub, keyPrefix: 'postsPublic:'});
+
+            await cache.get('k');
+
+            assert.equal('feature' in metricCall('cache-hit').args[1], false);
+        });
+
+        it('emits cache-timeout (but not cache-miss) when the get exceeds the timeout', async function () {
+            const cacheStub = createCacheStub();
+            cacheStub.get.callsFake(() => new Promise((resolve) => {
+                setTimeout(() => resolve('v'), 200);
+            }));
+            const cache = new RedisCache({
+                cache: cacheStub,
+                featureName: 'postsPublic',
+                getTimeoutMilliseconds: 10
+            });
+
+            await cache.get('k');
+
+            const timeoutCall = metricCall('cache-timeout');
+            assert.ok(timeoutCall, 'cache-timeout was emitted');
+            assert.equal(timeoutCall.args[1].feature, 'postsPublic');
+            assert.equal(metricCall('cache-miss'), undefined, 'timeout is not also counted as a miss');
+        });
+
+        it('does not double-emit when a timed-out lookup rejects later', async function () {
+            // If the timer fires first and the underlying redis read rejects
+            // afterwards, we should count the request once (as a timeout),
+            // not both as a timeout and as an error.
+            let rejectLookup;
+            const cacheStub = createCacheStub();
+            cacheStub.get.callsFake(() => new Promise((_resolve, reject) => {
+                rejectLookup = reject;
+            }));
+            const cache = new RedisCache({
+                cache: cacheStub,
+                featureName: 'postsPublic',
+                getTimeoutMilliseconds: 10
+            });
+
+            await cache.get('k');
+            rejectLookup(new Error('late failure'));
+            await new Promise((resolve) => {
+                setTimeout(resolve, 20);
+            });
+
+            assert.ok(metricCall('cache-timeout'));
+            assert.equal(metricCall('cache-error'), undefined, 'no cache-error emitted after timeout');
+        });
+
+        it('emits cache-error (but not cache-miss) when a redis get rejects in timeout mode', async function () {
+            const cacheStub = createCacheStub();
+            cacheStub.get.rejects(new Error('redis down'));
+            const cache = new RedisCache({
+                cache: cacheStub,
+                featureName: 'postsPublic',
+                getTimeoutMilliseconds: 1000
+            });
+
+            await cache.get('k');
+
+            const errorCall = metricCall('cache-error');
+            assert.ok(errorCall, 'cache-error was emitted');
+            assert.equal(errorCall.args[1].operation, 'get');
+            assert.equal(errorCall.args[1].feature, 'postsPublic');
+            assert.equal(metricCall('cache-miss'), undefined, 'redis error is not also counted as a miss');
+        });
+
+        it('emits cache-error on a set failure', async function () {
+            const cacheStub = createCacheStub();
+            cacheStub.set = sinon.stub().rejects(new Error('write failed'));
+            const cache = new RedisCache({cache: cacheStub, featureName: 'postsPublic'});
+
+            await cache.set('k', 'v');
+
+            const call = metricCall('cache-error');
+            assert.ok(call);
+            assert.equal(call.args[1].operation, 'set');
+            assert.equal(call.args[1].feature, 'postsPublic');
+        });
+
+        it('emits cache-reset on successful reset', async function () {
+            const cacheStub = createCacheStub();
+            const cache = new RedisCache({cache: cacheStub, featureName: 'postsPublic'});
+
+            await cache.reset();
+
+            const call = metricCall('cache-reset');
+            assert.ok(call);
+            assert.equal(call.args[1].feature, 'postsPublic');
+            assert.equal(typeof call.args[1].value, 'number');
+            assert.equal(metricCall('cache-error'), undefined);
+        });
+
+        it('emits cache-error on a reset failure', async function () {
+            const cacheStub = createCacheStub();
+            cacheStub.store.getClient().set.rejects(new Error('cycle failed'));
+            const cache = new RedisCache({cache: cacheStub, featureName: 'postsPublic'});
+
+            await cache.reset();
+
+            const errorCalls = metricStub.getCalls().filter(c => c.args[0] === 'cache-error');
+            assert.equal(errorCalls.length, 1);
+            assert.equal(errorCalls[0].args[1].operation, 'reset');
+            assert.equal(metricCall('cache-reset'), undefined);
+        });
+
+        it('emits background refresh triggered + succeeded on a successful refresh', async function () {
+            const KEY = 'bg-success';
+            let cachedValue = 'Original';
+            const cacheStub = createCacheStub();
+            cacheStub.get.callsFake(async (key) => {
+                if (key === PREFIX_HASH + KEY) {
+                    return cachedValue;
+                }
+            });
+            cacheStub.set.callsFake(async (key, value) => {
+                if (key === PREFIX_HASH + KEY) {
+                    cachedValue = value;
+                }
+            });
+            cacheStub.ttl.resolves(5);
+            const cache = new RedisCache({
+                cache: cacheStub,
+                featureName: 'postsPublic',
+                ttl: 100,
+                refreshAheadFactor: 0.2
+            });
+
+            const fetchData = sinon.stub().resolves('Fresh');
+            await cache.get(KEY, fetchData);
+            await flushMicrotasks();
+            await flushMicrotasks();
+
+            assert.ok(metricCall('cache-background-refresh-triggered'));
+            assert.ok(metricCall('cache-background-refresh-succeeded'));
+            assert.equal(metricCall('cache-background-refresh-triggered').args[1].feature, 'postsPublic');
+            assert.equal(typeof metricCall('cache-background-refresh-succeeded').args[1].value, 'number');
+            assert.equal(metricCall('cache-background-refresh-failed'), undefined);
+        });
+
+        it('emits cache-background-refresh-failed when the refresh fetch rejects', async function () {
+            const KEY = 'bg-fetch-fail';
+            const cachedValue = 'Original';
+            const cacheStub = createCacheStub();
+            cacheStub.get.callsFake(async (key) => {
+                if (key === PREFIX_HASH + KEY) {
+                    return cachedValue;
+                }
+            });
+            cacheStub.ttl.resolves(5);
+            const cache = new RedisCache({
+                cache: cacheStub,
+                featureName: 'postsPublic',
+                ttl: 100,
+                refreshAheadFactor: 0.2
+            });
+
+            const fetchData = sinon.stub().rejects(new Error('upstream down'));
+            await cache.get(KEY, fetchData);
+            await flushMicrotasks();
+            await flushMicrotasks();
+
+            assert.ok(metricCall('cache-background-refresh-triggered'));
+            assert.ok(metricCall('cache-background-refresh-failed'));
+            assert.equal(metricCall('cache-background-refresh-succeeded'), undefined);
+        });
+
+        it('emits cache-background-refresh-failed when the cache write fails', async function () {
+            const KEY = 'bg-write-fail';
+            const cachedValue = 'Original';
+            const cacheStub = createCacheStub();
+            cacheStub.get.callsFake(async (key) => {
+                if (key === PREFIX_HASH + KEY) {
+                    return cachedValue;
+                }
+            });
+            cacheStub.set = sinon.stub().rejects(new Error('write failed'));
+            cacheStub.ttl.resolves(5);
+            const cache = new RedisCache({
+                cache: cacheStub,
+                featureName: 'postsPublic',
+                ttl: 100,
+                refreshAheadFactor: 0.2
+            });
+
+            const fetchData = sinon.stub().resolves('Fresh');
+            await cache.get(KEY, fetchData);
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 10);
+            });
+
+            assert.ok(metricCall('cache-background-refresh-triggered'));
+            assert.ok(metricCall('cache-background-refresh-failed'));
+            assert.equal(metricCall('cache-background-refresh-succeeded'), undefined);
+        });
+
+        it('emits metrics correctly on a cloned adapter', async function () {
+            // Regression: `_metric` is underscore-private (not `#`-private) so
+            // that api-framework's _.cloneDeep doesn't turn metric emissions
+            // into "Receiver must be an instance of..." errors.
+            const cacheStub = createCacheStub();
+            cacheStub.get.resolves('v');
+            const cache = new RedisCache({cache: cacheStub, featureName: 'postsPublic'});
+
+            const cloned = _.cloneDeep(cache);
+            await cloned.get('k');
+
+            assert.ok(metricCall('cache-hit'), 'cache-hit was emitted on clone');
+            assert.equal(metricCall('cache-hit').args[1].feature, 'postsPublic');
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1712

## Why

There's no way to answer basic questions about the redis cache in
production today: hit rate, reset frequency, error counts, whether
background refresh is working. The adapter only emits `debug()` logs,
which only help when investigating a single request.

## What

Emits metrics via `@tryghost/metrics` at every instrumentation point
in `AdapterCacheRedis`:

- `cache-hit`, `cache-miss` — on every `get`
- `cache-timeout` — when `getTimeoutMilliseconds` fires
- `cache-error` — failures in `get`, `set`, `reset` (with `operation` field)
- `cache-background-refresh-triggered` — when a refresh starts
- `cache-background-refresh-succeeded` — with duration in ms
- `cache-background-refresh-failed` — when the fetch or the cache write throws
- `cache-reset` — with duration