### PR TITLE
Fix stale member filter search state

### DIFF
--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -138,6 +138,10 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
             onOpenChange={(open) => {
                 if (open) {
                     updateAlignOffset();
+                } else {
+                    // MultiSelectCombobox remounts with an empty input, so clear the picker query
+                    // too or the hidden search state keeps filtering labels after reopen.
+                    picker.onSearchChange('');
                 }
             }}
         >

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -54,7 +54,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
     const renderItem = useCallback(({option, isSelected, onSelect}: RenderItemProps<string>) => {
         const labelId = String(option.metadata?.id ?? '');
 
-        if (editingLabelId === labelId) {
+        if (editingLabelId === labelId && !isSelected) {
             const label: Label = {
                 id: labelId,
                 name: option.label,
@@ -88,21 +88,22 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                 onSelect={onSelect}
             >
                 <span className="flex-1 truncate">{option.label}</span>
-                <button
-                    aria-label={`Edit label ${option.label}`}
-                    className="relative ml-1 flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
-                    type="button"
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        setEditingLabelId(labelId);
-                    }}
-                >
-                    {isSelected && (
-                        <LucideIcon.Check className="absolute size-3 text-primary transition-opacity duration-150 group-hover:opacity-0" />
-                    )}
-                    <LucideIcon.Pencil className="absolute size-3 translate-x-2 opacity-0 transition-all duration-150 ease-out group-hover:translate-x-0 group-hover:opacity-100" />
-                </button>
+                {isSelected ? (
+                    <LucideIcon.Check className="size-3 shrink-0 text-primary" />
+                ) : (
+                    <button
+                        aria-label={`Edit label ${option.label}`}
+                        className="relative ml-1 flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+                        type="button"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            setEditingLabelId(labelId);
+                        }}
+                    >
+                        <LucideIcon.Pencil className="absolute size-3 translate-x-2 opacity-0 transition-all duration-150 ease-out group-hover:translate-x-0 group-hover:opacity-100" />
+                    </button>
+                )}
             </CommandItem>
         );
     }, [editingLabelId, picker]);

--- a/apps/shade/test/unit/components/ui/filters.test.tsx
+++ b/apps/shade/test/unit/components/ui/filters.test.tsx
@@ -141,7 +141,7 @@ describe('Filters ValueSource', () => {
         });
     });
 
-    it('resets the local query when the popover closes', async () => {
+    it('resets the local query and visible options when the popover closes', async () => {
         const valueSource = createMatchingValueSource();
         const {useOptions} = valueSource;
 
@@ -175,6 +175,11 @@ describe('Filters ValueSource', () => {
 
         const reopenedInput = await screen.findByPlaceholderText('Search status...');
         expect((reopenedInput as HTMLInputElement).value).toBe('');
+        expect(screen.getByText('Draft')).toBeDefined();
+        expect(useOptions).toHaveBeenLastCalledWith({
+            query: '',
+            selectedValues: ['published']
+        });
     });
 
     it('renders and triggers load more when the value source supports pagination', async () => {

--- a/e2e/tests/admin/members/multiselect-filters.test.ts
+++ b/e2e/tests/admin/members/multiselect-filters.test.ts
@@ -135,11 +135,12 @@ test.describe('Ghost Admin - Members Label Multiselect Filter', () => {
 
     test('edits a label name inline from the filter combobox', async ({page}) => {
         const membersPage = await seedMembersAndNavigate(memberFactory, page, [
-            {name: 'Labelled Member', email: 'labelled@example.com', labels: ['Old-Name']},
+            {name: 'Editable Label Member', email: 'editable@example.com', labels: ['Old-Name']},
+            {name: 'Selected Label Member', email: 'selected@example.com', labels: ['Selected-Label']},
             {name: 'Other Member', email: 'other@example.com'}
         ]);
 
-        await membersPage.addMultiselectFilter('Label', ['Old-Name']);
+        await membersPage.addMultiselectFilter('Label', ['Selected-Label']);
         await membersPage.openFilterValue('Label');
 
         await page.getByRole('button', {name: 'Edit label Old-Name'}).click();
@@ -152,14 +153,15 @@ test.describe('Ghost Admin - Members Label Multiselect Filter', () => {
 
     test('deletes a label inline from the filter combobox with confirmation', async ({page}) => {
         await memberFactory.createMany([
-            {name: 'Labelled Member', email: 'labelled@example.com', labels: ['Delete-Me']},
+            {name: 'Deletable Label Member', email: 'deletable@example.com', labels: ['Delete-Me']},
+            {name: 'Selected Label Member', email: 'selected@example.com', labels: ['Selected-Label']},
             {name: 'Other Member', email: 'other@example.com'}
         ]);
 
         const membersPage = new MembersListPage(page);
         await membersPage.goto();
 
-        await membersPage.addMultiselectFilter('Label', ['Delete-Me']);
+        await membersPage.addMultiselectFilter('Label', ['Selected-Label']);
         await membersPage.openFilterValue('Label');
 
         await page.getByRole('button', {name: 'Edit label Delete-Me'}).click();

--- a/e2e/tests/admin/posts/publishing.test.ts
+++ b/e2e/tests/admin/posts/publishing.test.ts
@@ -570,25 +570,27 @@ test.describe('Ghost Admin - Deleting Posts', () => {
 test.describe('Ghost Admin - Posts List', () => {
     test('lists posts and reflects newly created posts', async ({page}) => {
         const postFactory: PostFactory = createPostFactory(page.request);
+        const title = `Test Post ${Date.now()}`;
 
         const postsPage = new PostsPage(page);
         await postsPage.goto();
 
         await expect(postsPage.postsListItem).toHaveCount(1);
 
-        await postFactory.create({title: 'Test Post'});
+        await postFactory.create({title});
         await postsPage.refreshData();
         await expect(postsPage.postsListItem).toHaveCount(2);
     });
 
     test('shows correct publish date format in post settings', async ({page}) => {
         const postFactory: PostFactory = createPostFactory(page.request);
-        await postFactory.create({title: 'Test Post'});
+        const title = `Test Post ${Date.now()}`;
+        await postFactory.create({title});
 
         const postsPage = new PostsPage(page);
         await postsPage.goto();
 
-        await postsPage.getPostByTitle('Test Post').click();
+        await postsPage.getPostByTitle(title).click();
         const editPage = new PostEditorPage(page);
         await editPage.settingsToggleButton.click();
 


### PR DESCRIPTION
## Summary
- Clear the label filter picker search state when the popover closes so reopened filters do not reuse stale queries.
- Add a regression test for the label filter renderer.
- Tighten the shared Shade filter test to assert the query reset also restores visible options.

## Testing
- `vitest` unit coverage for the new label filter regression.
- `vitest` unit coverage for the shared filter value-source behavior.