### PR TITLE
Handled gift subscriptions in member CSV import / export

### DIFF
--- a/apps/posts/src/views/members/components/bulk-action-modals/import-members-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/import-members-modal.tsx
@@ -28,7 +28,8 @@ export function ImportMembersModal({
     const errorCsvUrlRef = useRef<string | null>(null);
     const {data: configData} = useBrowseConfig();
     const importMemberTier = configData?.config?.labs?.importMemberTier === true;
-    const fieldMappings = useMemo(() => getFieldMappings({importMemberTier}), [importMemberTier]);
+    const giftSubscriptionsEnabled = configData?.config?.labs?.giftSubscriptions === true;
+    const fieldMappings = useMemo(() => getFieldMappings({importMemberTier, giftSubscriptionsEnabled}), [importMemberTier, giftSubscriptionsEnabled]);
 
     const labelPicker = useLabelPicker({
         selectedSlugs: state.selectedLabelSlugs,
@@ -83,7 +84,7 @@ export function ImportMembersModal({
                 const data = parseCSV(text);
 
                 if (data.length > 0) {
-                    const detectedMapping = detectFieldTypes(data, {importMemberTier});
+                    const detectedMapping = detectFieldTypes(data, {importMemberTier, giftSubscriptionsEnabled});
                     const fieldMapping = new MembersFieldMapping(detectedMapping);
 
                     dispatch({
@@ -135,7 +136,7 @@ export function ImportMembersModal({
                 reader.abort();
             }
         };
-    }, [importMemberTier, state.file]);
+    }, [importMemberTier, giftSubscriptionsEnabled, state.file]);
 
     const validateFile = useCallback((file: File): boolean => {
         const match = /(?:\.([^.]+))?$/.exec(file.name);

--- a/apps/posts/src/views/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/posts/src/views/members/components/bulk-action-modals/import-members/mapping.ts
@@ -1,5 +1,6 @@
 type FieldMappingOptions = {
     importMemberTier?: boolean;
+    giftSubscriptionsEnabled?: boolean;
 };
 
 export const FIELD_MAPPINGS = [
@@ -14,6 +15,7 @@ export const FIELD_MAPPINGS = [
 ];
 
 const IMPORT_TIER_FIELD_MAPPING = {label: 'Tier', value: 'import_tier'};
+const GIFT_ID_FIELD_MAPPING = {label: 'Gift ID', value: 'gift_id'};
 
 const SUPPORTED_TYPES = [
     'email',
@@ -26,17 +28,19 @@ const SUPPORTED_TYPES = [
     'created_at'
 ];
 
-function getSupportedTypes({importMemberTier = false}: FieldMappingOptions = {}): string[] {
+function getSupportedTypes({importMemberTier = false, giftSubscriptionsEnabled = false}: FieldMappingOptions = {}): string[] {
     return [
         ...SUPPORTED_TYPES,
-        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING.value] : [])
+        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING.value] : []),
+        ...(giftSubscriptionsEnabled ? [GIFT_ID_FIELD_MAPPING.value] : [])
     ];
 }
 
-export function getFieldMappings({importMemberTier = false}: FieldMappingOptions = {}) {
+export function getFieldMappings({importMemberTier = false, giftSubscriptionsEnabled = false}: FieldMappingOptions = {}) {
     return [
         ...FIELD_MAPPINGS,
-        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : [])
+        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : []),
+        ...(giftSubscriptionsEnabled ? [GIFT_ID_FIELD_MAPPING] : [])
     ];
 }
 

--- a/apps/posts/test/unit/views/members/import-members/mapping.test.ts
+++ b/apps/posts/test/unit/views/members/import-members/mapping.test.ts
@@ -74,4 +74,33 @@ describe('mapping helpers', () => {
 
         expect(formatted).toContain('Note is too long');
     });
+
+    it('omits Gift ID from field mappings when giftSubscriptions is disabled', () => {
+        const mappings = getFieldMappings({giftSubscriptionsEnabled: false});
+
+        expect(mappings.find(m => m.value === 'gift_id')).toBeUndefined();
+    });
+
+    it('includes Gift ID in field mappings when giftSubscriptions is enabled', () => {
+        const mappings = getFieldMappings({giftSubscriptionsEnabled: true});
+
+        expect(mappings.find(m => m.value === 'gift_id')).toEqual({label: 'Gift ID', value: 'gift_id'});
+    });
+
+    it('does not auto-detect gift_id when giftSubscriptions is disabled', () => {
+        const mapping = detectFieldTypes([
+            {email: 'user@example.com', gift_id: 'some-gift-uuid'}
+        ]);
+
+        expect(mapping.gift_id).toBeUndefined();
+    });
+
+    it('auto-detects gift_id when giftSubscriptions is enabled', () => {
+        const mapping = detectFieldTypes(
+            [{email: 'user@example.com', gift_id: 'some-gift-uuid'}],
+            {giftSubscriptionsEnabled: true}
+        );
+
+        expect(mapping.gift_id).toBe('gift_id');
+    });
 });

--- a/apps/posts/test/unit/views/members/import-members/modal.test.tsx
+++ b/apps/posts/test/unit/views/members/import-members/modal.test.tsx
@@ -7,7 +7,8 @@ vi.mock('@tryghost/admin-x-framework/api/config', () => ({
         data: {
             config: {
                 labs: {
-                    importMemberTier: true
+                    importMemberTier: true,
+                    giftSubscriptions: true
                 }
             }
         }

--- a/e2e/tests/admin/members/export.test.ts
+++ b/e2e/tests/admin/members/export.test.ts
@@ -16,7 +16,8 @@ const DOWNLOADED_CONTENT_FIELDS = [
     'created_at,',
     'deleted_at,',
     'labels,',
-    'tiers'
+    'tiers,',
+    'gift_subscription'
 ];
 
 const MEMBERS_FIXTURE = [

--- a/e2e/tests/admin/members/export.test.ts
+++ b/e2e/tests/admin/members/export.test.ts
@@ -17,7 +17,7 @@ const DOWNLOADED_CONTENT_FIELDS = [
     'deleted_at,',
     'labels,',
     'tiers,',
-    'gift_subscription'
+    'gift_id'
 ];
 
 const MEMBERS_FIXTURE = [

--- a/ghost/admin/app/components/gh-members-import-mapping-input.js
+++ b/ghost/admin/app/components/gh-members-import-mapping-input.js
@@ -20,6 +20,9 @@ export default class extends Component {
         ...FIELD_MAPPINGS,
         ...(
             this.feature.importMemberTier ? [{label: 'Tier', value: 'import_tier'}] : []
+        ),
+        ...(
+            this.feature.giftSubscriptions ? [{label: 'Gift ID', value: 'gift_id'}] : []
         )
     ];
 

--- a/ghost/admin/app/services/member-import-validator.js
+++ b/ghost/admin/app/services/member-import-validator.js
@@ -92,6 +92,10 @@ export default class MemberImportValidatorService extends Service {
             supportedTypes.push('import_tier');
         }
 
+        if (this.feature.giftSubscriptions) {
+            supportedTypes.push('gift_id');
+        }
+
         const autoDetectedTypes = [
             'email'
         ];

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -37,7 +37,7 @@ const CSV_HEADERS = [
     'deleted_at',
     'labels',
     'tiers',
-    'gift_subscription'
+    'gift_id'
 ];
 
 /**
@@ -64,9 +64,9 @@ function formatMemberForCSV(member) {
     // Only comped = true should result in 'true', otherwise empty string
     const complimentaryPlan = member.comped === true ? 'true' : '';
 
-    // Convert boolean 'false' to empty string for tests to pass
-    // Only gift_subscription = true should result in 'true', otherwise empty string
-    const giftSubscription = member.gift_subscription === true ? 'true' : '';
+    // Gift members carry the gift id so an exported CSV can be re-imported and reassigned
+    // back to a (possibly new) member record via the gifts table
+    const giftId = member.gift_id || '';
 
     // Convert subscribed boolean to string representation
     const subscribedToEmails = member.subscribed === true ? 'true' : 'false';
@@ -83,7 +83,7 @@ function formatMemberForCSV(member) {
         deleted_at: member.deleted_at || null,
         labels: labels,
         tiers: tiers,
-        gift_subscription: giftSubscription
+        gift_id: giftId
     };
 }
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -36,7 +36,8 @@ const CSV_HEADERS = [
     'created_at',
     'deleted_at',
     'labels',
-    'tiers'
+    'tiers',
+    'gift_subscription'
 ];
 
 /**
@@ -62,7 +63,11 @@ function formatMemberForCSV(member) {
     // Convert boolean 'false' to empty string for tests to pass
     // Only comped = true should result in 'true', otherwise empty string
     const complimentaryPlan = member.comped === true ? 'true' : '';
-    
+
+    // Convert boolean 'false' to empty string for tests to pass
+    // Only gift_subscription = true should result in 'true', otherwise empty string
+    const giftSubscription = member.gift_subscription === true ? 'true' : '';
+
     // Convert subscribed boolean to string representation
     const subscribedToEmails = member.subscribed === true ? 'true' : 'false';
 
@@ -77,7 +82,8 @@ function formatMemberForCSV(member) {
         created_at: member.created_at,
         deleted_at: member.deleted_at || null,
         labels: labels,
-        tiers: tiers
+        tiers: tiers,
+        gift_subscription: giftSubscription
     };
 }
 

--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -60,6 +60,14 @@ export class GiftBookshelfRepository implements GiftRepository {
         return !!existing;
     }
 
+    async getById(id: string, options: RepositoryTransactionOptions = {}): Promise<Gift | null> {
+        const model = await this.model.findOne({
+            id
+        }, {require: false, ...options});
+
+        return model ? this.toGift(model) : null;
+    }
+
     async getByToken(token: string, options: RepositoryTransactionOptions = {}): Promise<Gift | null> {
         const model = await this.model.findOne({
             token

--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -84,11 +84,11 @@ export class GiftBookshelfRepository implements GiftRepository {
         return model ? this.toGift(model) : null;
     }
 
-    async getActiveByMember(memberId: string): Promise<Gift | null> {
+    async getActiveByMember(memberId: string, options: RepositoryTransactionOptions = {}): Promise<Gift | null> {
         const model = await this.model.findOne({
             redeemer_member_id: memberId,
             status: 'redeemed'
-        }, {require: false});
+        }, {require: false, ...options});
 
         return model ? this.toGift(model) : null;
     }

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -14,6 +14,7 @@ export interface FindPendingReminderOptions {
 
 export interface GiftRepository {
     existsByCheckoutSessionId(checkoutSessionId: string): Promise<boolean>;
+    getById(id: string, options?: RepositoryTransactionOptions): Promise<Gift | null>;
     getByToken(token: string, options?: RepositoryTransactionOptions): Promise<Gift | null>;
     getByPaymentIntentId(paymentIntentId: string): Promise<Gift | null>;
     findPendingConsumption(): Promise<Gift[]>;

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -20,7 +20,7 @@ export interface GiftRepository {
     findPendingConsumption(): Promise<Gift[]>;
     findPendingExpiration(): Promise<Gift[]>;
     findPendingReminder(options: FindPendingReminderOptions): Promise<Gift[]>;
-    getActiveByMember(memberId: string): Promise<Gift | null>;
+    getActiveByMember(memberId: string, options?: RepositoryTransactionOptions): Promise<Gift | null>;
     create(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     update(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -393,6 +393,10 @@ export class GiftService {
                 throw new errors.NotFoundError({message: tpl(errorMessages.giftNotFound)});
             }
 
+            if (gift.redeemerMemberId === memberId) {
+                return gift;
+            }
+
             const check = gift.checkReassignable();
 
             if (!check.reassignable) {

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -19,6 +19,7 @@ const errorMessages = {
     giftRefunded: 'This gift has been refunded.',
     paidMember: 'You already have an active subscription.',
     giftInvalidReassignStatus: 'This gift does not have a reassignable status.',
+    giftInvalidReassignMember: 'Member already has an active subscription.',
     giftAlreadyAssigned: 'This gift is already assigned to another member.',
     giftMissingConsumesAt: 'This gift is missing a "consumes at" date.'
 };
@@ -426,7 +427,7 @@ export class GiftService {
 
             const memberStatus = member.get('status');
             if (memberStatus !== 'free' && memberStatus !== 'gift') {
-                throw new errors.BadRequestError({message: tpl(errorMessages.paidMember)});
+                throw new errors.BadRequestError({message: tpl(errorMessages.giftInvalidReassignMember)});
             }
 
             const reassignedGift = gift.reassignRedeemer(memberId);

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -17,7 +17,10 @@ const errorMessages = {
     giftConsumed: 'This gift has already been consumed.',
     giftExpired: 'This gift has expired.',
     giftRefunded: 'This gift has been refunded.',
-    paidMember: 'You already have an active subscription.'
+    paidMember: 'You already have an active subscription.',
+    giftInvalidReassignStatus: 'This gift does not have a reassignable status.',
+    giftAlreadyAssigned: 'This gift is already assigned to another member.',
+    giftMissingConsumesAt: 'This gift is missing a "consumes at" date.'
 };
 
 interface MemberModel {
@@ -375,6 +378,74 @@ export class GiftService {
         const diffDays = Math.ceil((gift.consumesAt.getTime() - now.getTime()) / MS_PER_DAY);
 
         return Math.max(0, diffDays);
+    }
+
+    async reassignRedeemer(
+        giftId: string,
+        memberId: string,
+        options: {transacting?: unknown} = {}
+    ): Promise<Gift> {
+        const run = async (transacting: unknown): Promise<Gift> => {
+            const gift = await this.deps.giftRepository.getById(giftId, {transacting, forUpdate: true});
+
+            if (!gift) {
+                throw new errors.NotFoundError({message: tpl(errorMessages.giftNotFound)});
+            }
+
+            const check = gift.checkReassignable();
+
+            if (!check.reassignable) {
+                switch (check.reason) {
+                case 'assigned':
+                    throw new errors.BadRequestError({message: tpl(errorMessages.giftAlreadyAssigned)});
+                case 'unredeemed':
+                case 'consumed':
+                case 'expired':
+                case 'refunded':
+                    throw new errors.BadRequestError({message: tpl(errorMessages.giftInvalidReassignStatus)});
+                case 'missing-consumes-at':
+                    throw new errors.BadRequestError({message: tpl(errorMessages.giftMissingConsumesAt)});
+                default: {
+                    const exhaustiveCheck: never = check.reason;
+
+                    throw new errors.InternalServerError({
+                        message: `Unhandled reassign failure reason: ${exhaustiveCheck}`
+                    });
+                }
+                }
+            }
+
+            const member = await this.deps.memberRepository.get(
+                {id: memberId},
+                {transacting, forUpdate: true}
+            );
+
+            if (!member) {
+                throw new errors.NotFoundError({message: `Member not found: ${memberId}`});
+            }
+
+            if (member.get('status') === 'paid') {
+                throw new errors.BadRequestError({message: tpl(errorMessages.paidMember)});
+            }
+
+            const reassignedGift = gift.reassignRedeemer(memberId);
+
+            await this.deps.memberRepository.update({
+                products: [{
+                    id: reassignedGift.tierId,
+                    expiry_at: reassignedGift.consumesAt
+                }],
+                status: 'gift'
+            }, {id: memberId, transacting});
+
+            await this.deps.giftRepository.update(reassignedGift, {transacting});
+
+            return reassignedGift;
+        };
+
+        return options.transacting
+            ? run(options.transacting)
+            : this.deps.giftRepository.transaction(run);
     }
 
     async refund(paymentIntentId: string): Promise<boolean> {

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -424,7 +424,8 @@ export class GiftService {
                 throw new errors.NotFoundError({message: `Member not found: ${memberId}`});
             }
 
-            if (member.get('status') === 'paid') {
+            const memberStatus = member.get('status');
+            if (memberStatus !== 'free' && memberStatus !== 'gift') {
                 throw new errors.BadRequestError({message: tpl(errorMessages.paidMember)});
             }
 

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -21,7 +21,8 @@ const errorMessages = {
     giftInvalidReassignStatus: 'This gift does not have a reassignable status.',
     giftInvalidReassignMember: 'Member already has an active subscription.',
     giftAlreadyAssigned: 'This gift is already assigned to another member.',
-    giftMissingConsumesAt: 'This gift is missing a "consumes at" date.'
+    giftMissingConsumesAt: 'This gift is missing a "consumes at" date.',
+    giftMemberAlreadyHasGift: 'Member already has a different active gift attached.'
 };
 
 interface MemberModel {
@@ -364,11 +365,11 @@ export class GiftService {
         return redeemed;
     }
 
-    async getActiveByMember(memberId: string): Promise<Gift | null> {
+    async getActiveByMember(memberId: string, options: {transacting?: unknown} = {}): Promise<Gift | null> {
         if (!memberId) {
             return null;
         }
-        return this.deps.giftRepository.getActiveByMember(memberId);
+        return this.deps.giftRepository.getActiveByMember(memberId, options);
     }
 
     getRemainingActiveDays(gift: Gift, now: Date = new Date()): number {
@@ -432,6 +433,11 @@ export class GiftService {
             const memberStatus = member.get('status');
             if (memberStatus !== 'free' && memberStatus !== 'gift') {
                 throw new errors.BadRequestError({message: tpl(errorMessages.giftInvalidReassignMember)});
+            }
+
+            const existingActiveGift = await this.deps.giftRepository.getActiveByMember(memberId, {transacting});
+            if (existingActiveGift && existingActiveGift.token !== gift.token) {
+                throw new errors.BadRequestError({message: tpl(errorMessages.giftMemberAlreadyHasGift)});
             }
 
             const reassignedGift = gift.reassignRedeemer(memberId);

--- a/ghost/core/core/server/services/gifts/gift.ts
+++ b/ghost/core/core/server/services/gifts/gift.ts
@@ -8,6 +8,11 @@ export type RedeemableCheckResult =
     | {redeemable: true}
     | {redeemable: false; reason: RedeemableCheckFailureReason};
 
+export type ReassignableCheckFailureReason = 'unredeemed' | 'assigned' | 'consumed' | 'expired' | 'refunded' | 'missing-consumes-at';
+export type ReassignableCheckResult =
+    | {reassignable: true}
+    | {reassignable: false; reason: ReassignableCheckFailureReason};
+
 interface GiftData {
     token: string;
     buyerEmail: string;
@@ -165,6 +170,41 @@ export class Gift {
             redeemedAt,
             consumesAt,
             status: 'redeemed'
+        });
+    }
+
+    checkReassignable(): ReassignableCheckResult {
+        if (this.isRefunded()) {
+            return {reassignable: false, reason: 'refunded'};
+        }
+
+        if (this.isConsumed()) {
+            return {reassignable: false, reason: 'consumed'};
+        }
+
+        if (this.isExpired()) {
+            return {reassignable: false, reason: 'expired'};
+        }
+
+        if (this.status !== 'redeemed' || this.redeemedAt === null) {
+            return {reassignable: false, reason: 'unredeemed'};
+        }
+
+        if (this.consumesAt === null) {
+            return {reassignable: false, reason: 'missing-consumes-at'};
+        }
+
+        if (this.redeemerMemberId !== null) {
+            return {reassignable: false, reason: 'assigned'};
+        }
+
+        return {reassignable: true};
+    }
+
+    reassignRedeemer(newMemberId: string): Gift {
+        return new Gift({
+            ...this,
+            redeemerMemberId: newMemberId
         });
     }
 

--- a/ghost/core/core/server/services/members/exporter/query.js
+++ b/ghost/core/core/server/services/members/exporter/query.js
@@ -114,6 +114,7 @@ async function createExportStream(options) {
 
                     knex('gifts')
                         .select('id', 'redeemer_member_id')
+                        .where('status', 'redeemed')
                         .whereIn('redeemer_member_id', memberIds)
                 ]);
 

--- a/ghost/core/core/server/services/members/exporter/query.js
+++ b/ghost/core/core/server/services/members/exporter/query.js
@@ -36,6 +36,7 @@ function processMembersData(members, tiersMap, labelsMap, stripeCustomerMap, sub
         row.subscribed = subscribedSet.has(row.id);
         row.comped = row.status === 'comped';
         row.complimentary_plan = row.status === 'complimentary';
+        row.gift_subscription = row.status === 'gift';
         row.stripe_customer_id = stripeCustomerMap.get(row.id) || null;
         row.created_at = moment(row.created_at).toISOString();
     }

--- a/ghost/core/core/server/services/members/exporter/query.js
+++ b/ghost/core/core/server/services/members/exporter/query.js
@@ -11,11 +11,12 @@ const {Transform} = require('stream');
  * @param {Object} labelsMap - Map of member_id to labels
  * @param {Object} stripeCustomerMap - Map of member_id to stripe customer IDs
  * @param {Set} subscribedSet - Set of subscribed member IDs
+ * @param {Map} giftIdMap - Map of member_id to gift id (for gift members only)
  * @param {Object} allProducts - Map of product IDs to product names
  * @param {Object} allLabels - Map of label IDs to label names
  * @returns {Array} Processed member records
  */
-function processMembersData(members, tiersMap, labelsMap, stripeCustomerMap, subscribedSet, allProducts, allLabels) {
+function processMembersData(members, tiersMap, labelsMap, stripeCustomerMap, subscribedSet, giftIdMap, allProducts, allLabels) {
     for (const row of members) {
         const tierIds = tiersMap.get(row.id) ? tiersMap.get(row.id).split(',') : [];
         const tierDetails = tierIds.map((id) => {
@@ -36,7 +37,7 @@ function processMembersData(members, tiersMap, labelsMap, stripeCustomerMap, sub
         row.subscribed = subscribedSet.has(row.id);
         row.comped = row.status === 'comped';
         row.complimentary_plan = row.status === 'complimentary';
-        row.gift_subscription = row.status === 'gift';
+        row.gift_id = giftIdMap.get(row.id) || null;
         row.stripe_customer_id = stripeCustomerMap.get(row.id) || null;
         row.created_at = moment(row.created_at).toISOString();
     }
@@ -91,7 +92,7 @@ async function createExportStream(options) {
                 const memberIds = batch.map(member => member.id);
                 
                 // Fetch related data for this batch
-                const [tiers, labels, stripeCustomers, subscriptions] = await Promise.all([
+                const [tiers, labels, stripeCustomers, subscriptions, gifts] = await Promise.all([
                     knex('members_products')
                         .select('member_id', knex.raw('GROUP_CONCAT(product_id) as tiers'))
                         .whereIn('member_id', memberIds)
@@ -109,7 +110,11 @@ async function createExportStream(options) {
                     
                     knex('members_newsletters')
                         .distinct('member_id')
-                        .whereIn('member_id', memberIds)
+                        .whereIn('member_id', memberIds),
+
+                    knex('gifts')
+                        .select('id', 'redeemer_member_id')
+                        .whereIn('redeemer_member_id', memberIds)
                 ]);
 
                 // Create maps for quick lookups
@@ -117,6 +122,7 @@ async function createExportStream(options) {
                 const labelsMap = new Map(labels.map(row => [row.member_id, row.labels]));
                 const stripeCustomerMap = new Map(stripeCustomers.map(row => [row.member_id, row.stripe_customer_id]));
                 const subscribedSet = new Set(subscriptions.map(row => row.member_id));
+                const giftIdMap = new Map(gifts.map(row => [row.redeemer_member_id, row.id]));
 
                 // Process the batch
                 const processedMembers = processMembersData(
@@ -125,6 +131,7 @@ async function createExportStream(options) {
                     labelsMap, 
                     stripeCustomerMap, 
                     subscribedSet, 
+                    giftIdMap,
                     allProducts, 
                     allLabels
                 );

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -11,7 +11,8 @@ const logging = require('@tryghost/logging');
 const messages = {
     filenameCollision: 'Filename already exists, please try again.',
     freeMemberNotAllowedImportTier: 'You cannot import a free member with a specified tier.',
-    invalidImportTier: '"{tier}" is not a valid tier.'
+    invalidImportTier: '"{tier}" is not a valid tier.',
+    giftMemberNotAllowedImport: 'Gift subscriptions cannot be imported.'
 };
 
 // The key should correspond to a member model field (unless it's a special purpose field like 'complimentary_plan')
@@ -62,6 +63,8 @@ module.exports = class MembersCSVImporter {
         this._context = context;
         this._stripeUtils = stripeUtils;
         this._tierIdCache = new Map();
+        // Rows rejected during `prepare()`, keyed by output file path and drained by `perform()`.
+        this._rejectedRowsByFile = new Map();
     }
 
     /**
@@ -79,6 +82,12 @@ module.exports = class MembersCSVImporter {
      */
     async prepare(inputFilePath, headerMapping, defaultLabels) {
         headerMapping = headerMapping || DEFAULT_CSV_HEADER_MAPPING;
+        // Force-recognise `gift_subscription` so the rejection below fires even when the
+        // user-supplied mapping doesn't include it (the column is not exposed in the UI).
+        headerMapping = {
+            ...headerMapping,
+            gift_subscription: 'gift_subscription'
+        };
         // @NOTE: investigate why is it "1" and do we even need this concept anymore?
         const batchSize = 1;
 
@@ -94,9 +103,29 @@ module.exports = class MembersCSVImporter {
         }
 
         // completely rely on explicit user input for header mappings
-        const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
-        const columns = Object.keys(rows[0]);
-        const numberOfBatches = Math.ceil(rows.length / batchSize);
+        const allRows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
+
+        // Reject gift rows here rather than in `perform()`: `membersCSV.unparse()` below
+        // strips unknown columns, so `gift_subscription` wouldn't survive that round-trip.
+        const rejectedGiftRows = [];
+        const rows = [];
+        for (const row of allRows) {
+            if (row.gift_subscription === true) {
+                rejectedGiftRows.push({
+                    ...row,
+                    error: tpl(messages.giftMemberNotAllowedImport)
+                });
+            } else {
+                rows.push(row);
+            }
+        }
+        this._rejectedRowsByFile.set(outputFilePath, rejectedGiftRows);
+
+        const columns = Object.keys(rows[0] || allRows[0] || {});
+        // Batch count reflects the original CSV size (including pre-rejected rows) so
+        // meta.originalImportSize matches what the user uploaded. The intermediate CSV
+        // still only contains non-rejected rows — gifts must never reach `perform()`.
+        const numberOfBatches = Math.ceil(allRows.length / batchSize);
         const mappedCSV = membersCSV.unparse(rows, columns);
 
         const hasStripeData = !!(rows.find(function rowHasStripeData(row) {
@@ -121,6 +150,11 @@ module.exports = class MembersCSVImporter {
      */
     async perform(filePath) {
         const performStart = Date.now();
+        // Drain rows pre-rejected by `prepare()` up front and delete the map entry
+        // immediately, so state does not leak if anything below throws.
+        const preRejected = this._rejectedRowsByFile.get(filePath) || [];
+        this._rejectedRowsByFile.delete(filePath);
+
         const rows = await membersCSV.parse(filePath, DEFAULT_CSV_HEADER_MAPPING);
 
         const defaultTier = await this._getDefaultTier();
@@ -283,15 +317,18 @@ module.exports = class MembersCSVImporter {
             archivableStripePriceIds.map(stripePriceId => this._stripeUtils.archivePrice(stripePriceId))
         );
 
+        const combinedErrors = [...preRejected, ...result.errors];
+
         metrics.metric({
             imported: result.imported,
-            errors: result.errors.length,
+            errors: combinedErrors.length,
             value: Date.now() - performStart
         });
 
         return {
-            total: result.imported + result.errors.length,
-            ...result
+            total: result.imported + combinedErrors.length,
+            imported: result.imported,
+            errors: combinedErrors
         };
     }
 

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -12,42 +12,19 @@ const messages = {
     filenameCollision: 'Filename already exists, please try again.',
     freeMemberNotAllowedImportTier: 'You cannot import a free member with a specified tier.',
     invalidImportTier: '"{tier}" is not a valid tier.',
-    giftNotFound: 'Gift record not found.',
-    giftAlreadyAssigned: 'Gift is already assigned to another member.',
-    giftNotReassignable: 'Gift cannot be reassigned to a member in its current state.',
+    giftServiceUnavailable: 'Gift service is not available.',
     giftCannotCombineWithImportTier: 'Cannot specify both gift_id and import_tier.',
     giftCannotCombineWithComplimentary: 'Cannot specify both gift_id and complimentary_plan.',
-    giftMemberAlreadyHasGift: 'Cannot reassign gift to a member with an existing gift.',
-    giftCannotReassignToPaidMember: 'Cannot reassign gift to a member with an active paid subscription.',
-    giftMissingExpiry: 'Cannot compute expiry for gift; gift cannot be reassigned.'
+    giftMemberAlreadyHasGift: 'Cannot reassign gift to a member with an existing gift.'
 };
 
-function translateGiftError(error) {
+function wrapGiftError(error) {
     if (error instanceof errors.DataImportError) {
         return error;
     }
-
-    const isNotFound = error && error.errorType === 'NotFoundError';
-    if (isNotFound) {
-        return new errors.DataImportError({message: tpl(messages.giftNotFound)});
-    }
-
-    const message = error && typeof error.message === 'string' ? error.message : '';
-    if (message.includes('already assigned')) {
-        return new errors.DataImportError({message: tpl(messages.giftAlreadyAssigned)});
-    }
-    if (message.includes('reassignable status')) {
-        return new errors.DataImportError({message: tpl(messages.giftNotReassignable)});
-    }
-    if (message.includes('active subscription')) {
-        return new errors.DataImportError({message: tpl(messages.giftCannotReassignToPaidMember)});
-    }
-    if (message.includes('"consumes at" date')) {
-        return new errors.DataImportError({message: tpl(messages.giftMissingExpiry)});
-    }
-
-    // Unknown/unexpected error — surface the raw message so the user can see what failed.
-    return new errors.DataImportError({message: message || tpl(messages.giftNotReassignable)});
+    return new errors.DataImportError({
+        message: (error && typeof error.message === 'string' && error.message) || ''
+    });
 }
 
 // The key should correspond to a member model field (unless it's a special purpose field like 'complimentary_plan')
@@ -315,7 +292,7 @@ module.exports = class MembersCSVImporter {
 
                 if (row.gift_id) {
                     if (!giftService) {
-                        throw new errors.DataImportError({message: tpl(messages.giftNotFound)});
+                        throw new errors.DataImportError({message: tpl(messages.giftServiceUnavailable)});
                     }
 
                     // Reject if the member already has a different gift attached; we don't
@@ -328,7 +305,7 @@ module.exports = class MembersCSVImporter {
                     try {
                         await giftService.reassignRedeemer(row.gift_id, member.id, {transacting: trx});
                     } catch (giftError) {
-                        throw translateGiftError(giftError);
+                        throw wrapGiftError(giftError);
                     }
                 }
 

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -12,8 +12,43 @@ const messages = {
     filenameCollision: 'Filename already exists, please try again.',
     freeMemberNotAllowedImportTier: 'You cannot import a free member with a specified tier.',
     invalidImportTier: '"{tier}" is not a valid tier.',
-    giftMemberNotAllowedImport: 'Gift subscriptions cannot be imported.'
+    giftNotFound: 'Gift record not found.',
+    giftAlreadyAssigned: 'Gift is already assigned to another member.',
+    giftNotReassignable: 'Gift cannot be reassigned to a member in its current state.',
+    giftCannotCombineWithImportTier: 'Cannot specify both gift_id and import_tier.',
+    giftCannotCombineWithComplimentary: 'Cannot specify both gift_id and complimentary_plan.',
+    giftMemberAlreadyHasGift: 'Cannot reassign gift to a member with an existing gift.',
+    giftCannotReassignToPaidMember: 'Cannot reassign gift to a member with an active paid subscription.',
+    giftMissingExpiry: 'Cannot compute expiry for gift; gift cannot be reassigned.'
 };
+
+function translateGiftError(error) {
+    if (error instanceof errors.DataImportError) {
+        return error;
+    }
+
+    const isNotFound = error && error.errorType === 'NotFoundError';
+    if (isNotFound) {
+        return new errors.DataImportError({message: tpl(messages.giftNotFound)});
+    }
+
+    const message = error && typeof error.message === 'string' ? error.message : '';
+    if (message.includes('already assigned')) {
+        return new errors.DataImportError({message: tpl(messages.giftAlreadyAssigned)});
+    }
+    if (message.includes('reassignable status')) {
+        return new errors.DataImportError({message: tpl(messages.giftNotReassignable)});
+    }
+    if (message.includes('active subscription')) {
+        return new errors.DataImportError({message: tpl(messages.giftCannotReassignToPaidMember)});
+    }
+    if (message.includes('"consumes at" date')) {
+        return new errors.DataImportError({message: tpl(messages.giftMissingExpiry)});
+    }
+
+    // Unknown/unexpected error — surface the raw message so the user can see what failed.
+    return new errors.DataImportError({message: message || tpl(messages.giftNotReassignable)});
+}
 
 // The key should correspond to a member model field (unless it's a special purpose field like 'complimentary_plan')
 // the value should represent an allowed field name coming from user input
@@ -26,7 +61,8 @@ const DEFAULT_CSV_HEADER_MAPPING = {
     complimentary_plan: 'complimentary_plan',
     stripe_customer_id: 'stripe_customer_id',
     labels: 'labels',
-    import_tier: 'import_tier'
+    import_tier: 'import_tier',
+    gift_id: 'gift_id'
 };
 
 /**
@@ -36,6 +72,7 @@ const DEFAULT_CSV_HEADER_MAPPING = {
  * @property {() => Object} getMembersRepository - member model access instance for data access and manipulation
  * @property {() => Promise<import('../../tiers/tier')>} getDefaultTier - async function returning default Member Tier
  * @property {(string) => Promise<import('../../tiers/tier')>} getTierByName - async function returning Member Tier by name
+ * @property {() => Promise<import('../../gifts/gift-service').GiftService>} getGiftService - async function returning the GiftService instance
  * @property {Function} sendEmail - function sending an email
  * @property {(string) => boolean} isSet - Method checking if specific feature is enabled
  * @property {({job, offloaded, name}) => void} addJob - Method registering an async job
@@ -49,12 +86,13 @@ module.exports = class MembersCSVImporter {
     /**
      * @param {MembersCSVImporterOptions} options
      */
-    constructor({storagePath, getTimezone, getMembersRepository, getDefaultTier, getTierByName, sendEmail, isSet, addJob, knex, urlFor, context, stripeUtils}) {
+    constructor({storagePath, getTimezone, getMembersRepository, getDefaultTier, getTierByName, getGiftService, sendEmail, isSet, addJob, knex, urlFor, context, stripeUtils}) {
         this._storagePath = storagePath;
         this._getTimezone = getTimezone;
         this._getMembersRepository = getMembersRepository;
         this._getDefaultTier = getDefaultTier;
         this._getTierByName = getTierByName;
+        this._getGiftService = getGiftService;
         this._sendEmail = sendEmail;
         this._isSet = isSet;
         this._addJob = addJob;
@@ -63,8 +101,6 @@ module.exports = class MembersCSVImporter {
         this._context = context;
         this._stripeUtils = stripeUtils;
         this._tierIdCache = new Map();
-        // Rows rejected during `prepare()`, keyed by output file path and drained by `perform()`.
-        this._rejectedRowsByFile = new Map();
     }
 
     /**
@@ -82,11 +118,11 @@ module.exports = class MembersCSVImporter {
      */
     async prepare(inputFilePath, headerMapping, defaultLabels) {
         headerMapping = headerMapping || DEFAULT_CSV_HEADER_MAPPING;
-        // Force-recognise `gift_subscription` so the rejection below fires even when the
+        // Force-recognise `gift_id` so the importer can reassign gift rows even when the
         // user-supplied mapping doesn't include it (the column is not exposed in the UI).
         headerMapping = {
             ...headerMapping,
-            gift_subscription: 'gift_subscription'
+            gift_id: 'gift_id'
         };
         // @NOTE: investigate why is it "1" and do we even need this concept anymore?
         const batchSize = 1;
@@ -103,29 +139,9 @@ module.exports = class MembersCSVImporter {
         }
 
         // completely rely on explicit user input for header mappings
-        const allRows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
-
-        // Reject gift rows here rather than in `perform()`: `membersCSV.unparse()` below
-        // strips unknown columns, so `gift_subscription` wouldn't survive that round-trip.
-        const rejectedGiftRows = [];
-        const rows = [];
-        for (const row of allRows) {
-            if (row.gift_subscription === true) {
-                rejectedGiftRows.push({
-                    ...row,
-                    error: tpl(messages.giftMemberNotAllowedImport)
-                });
-            } else {
-                rows.push(row);
-            }
-        }
-        this._rejectedRowsByFile.set(outputFilePath, rejectedGiftRows);
-
-        const columns = Object.keys(rows[0] || allRows[0] || {});
-        // Batch count reflects the original CSV size (including pre-rejected rows) so
-        // meta.originalImportSize matches what the user uploaded. The intermediate CSV
-        // still only contains non-rejected rows — gifts must never reach `perform()`.
-        const numberOfBatches = Math.ceil(allRows.length / batchSize);
+        const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
+        const columns = Object.keys(rows[0]);
+        const numberOfBatches = Math.ceil(rows.length / batchSize);
         const mappedCSV = membersCSV.unparse(rows, columns);
 
         const hasStripeData = !!(rows.find(function rowHasStripeData(row) {
@@ -150,15 +166,11 @@ module.exports = class MembersCSVImporter {
      */
     async perform(filePath) {
         const performStart = Date.now();
-        // Drain rows pre-rejected by `prepare()` up front and delete the map entry
-        // immediately, so state does not leak if anything below throws.
-        const preRejected = this._rejectedRowsByFile.get(filePath) || [];
-        this._rejectedRowsByFile.delete(filePath);
-
         const rows = await membersCSV.parse(filePath, DEFAULT_CSV_HEADER_MAPPING);
 
         const defaultTier = await this._getDefaultTier();
         const membersRepository = await this._getMembersRepository();
+        const giftService = this._getGiftService ? await this._getGiftService() : null;
 
         // Clear tier ID cache before each import in-case tiers have been updated since last import
         this._tierIdCache.clear();
@@ -180,6 +192,17 @@ module.exports = class MembersCSVImporter {
             };
 
             try {
+                // Early validation of mutually exclusive columns so we fail the row before
+                // any member/tier work.
+                if (row.gift_id) {
+                    if (row.import_tier) {
+                        throw new errors.DataImportError({message: tpl(messages.giftCannotCombineWithImportTier)});
+                    }
+                    if (row.complimentary_plan) {
+                        throw new errors.DataImportError({message: tpl(messages.giftCannotCombineWithComplimentary)});
+                    }
+                }
+
                 // If the member is created in the future, set created_at to now
                 // Members created in the future will not appear in admin members list
                 // Refs https://github.com/TryGhost/Team/issues/2793
@@ -290,6 +313,25 @@ module.exports = class MembersCSVImporter {
                     throw new errors.DataImportError({message: tpl(messages.freeMemberNotAllowedImportTier)});
                 }
 
+                if (row.gift_id) {
+                    if (!giftService) {
+                        throw new errors.DataImportError({message: tpl(messages.giftNotFound)});
+                    }
+
+                    // Reject if the member already has a different gift attached; we don't
+                    // want to silently orphan or overwrite the existing one.
+                    const conflictingGift = await this.#findConflictingGift(member.id, row.gift_id, trx);
+                    if (conflictingGift) {
+                        throw new errors.DataImportError({message: tpl(messages.giftMemberAlreadyHasGift)});
+                    }
+
+                    try {
+                        await giftService.reassignRedeemer(row.gift_id, member.id, {transacting: trx});
+                    } catch (giftError) {
+                        throw translateGiftError(giftError);
+                    }
+                }
+
                 await trx.commit();
                 return {
                     ...resultAccumulator,
@@ -317,18 +359,15 @@ module.exports = class MembersCSVImporter {
             archivableStripePriceIds.map(stripePriceId => this._stripeUtils.archivePrice(stripePriceId))
         );
 
-        const combinedErrors = [...preRejected, ...result.errors];
-
         metrics.metric({
             imported: result.imported,
-            errors: combinedErrors.length,
+            errors: result.errors.length,
             value: Date.now() - performStart
         });
 
         return {
-            total: result.imported + combinedErrors.length,
-            imported: result.imported,
-            errors: combinedErrors
+            total: result.imported + result.errors.length,
+            ...result
         };
     }
 
@@ -497,5 +536,25 @@ module.exports = class MembersCSVImporter {
         }
 
         return this._tierIdCache.get(name);
+    }
+
+    /**
+     * Returns the id of any gift already attached to `memberId` that is not `incomingGiftId`,
+     * or null if no conflict exists. Uses the caller-supplied transaction so the check is
+     * part of the same atomic unit as the subsequent reassignment.
+     *
+     * @param {string} memberId
+     * @param {string} incomingGiftId
+     * @param {import('knex').Knex.Transaction} trx
+     * @returns {Promise<string|null>}
+     */
+    async #findConflictingGift(memberId, incomingGiftId, trx) {
+        const row = await trx('gifts')
+            .where({redeemer_member_id: memberId})
+            .whereNot({id: incomingGiftId})
+            .select('id')
+            .first();
+
+        return row ? row.id : null;
     }
 };

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -15,7 +15,6 @@ const messages = {
     giftServiceUnavailable: 'Gift service is not available.',
     giftCannotCombineWithImportTier: 'Cannot specify both gift_id and import_tier.',
     giftCannotCombineWithComplimentary: 'Cannot specify both gift_id and complimentary_plan.',
-    giftMemberAlreadyHasGift: 'Cannot reassign gift to a member with an existing gift.',
     giftReassignFailed: 'Failed to reassign gift to member.'
 };
 
@@ -295,13 +294,6 @@ module.exports = class MembersCSVImporter {
                         throw new errors.DataImportError({message: tpl(messages.giftServiceUnavailable)});
                     }
 
-                    // Reject if the member already has a different gift attached; we don't
-                    // want to silently orphan or overwrite the existing one.
-                    const conflictingGift = await this.#findConflictingGift(member.id, row.gift_id, trx);
-                    if (conflictingGift) {
-                        throw new errors.DataImportError({message: tpl(messages.giftMemberAlreadyHasGift)});
-                    }
-
                     try {
                         await giftService.reassignRedeemer(row.gift_id, member.id, {transacting: trx});
                     } catch (giftError) {
@@ -513,25 +505,5 @@ module.exports = class MembersCSVImporter {
         }
 
         return this._tierIdCache.get(name);
-    }
-
-    /**
-     * Returns the id of any gift already attached to `memberId` that is not `incomingGiftId`,
-     * or null if no conflict exists. Uses the caller-supplied transaction so the check is
-     * part of the same atomic unit as the subsequent reassignment.
-     *
-     * @param {string} memberId
-     * @param {string} incomingGiftId
-     * @param {import('knex').Knex.Transaction} trx
-     * @returns {Promise<string|null>}
-     */
-    async #findConflictingGift(memberId, incomingGiftId, trx) {
-        const row = await trx('gifts')
-            .where({redeemer_member_id: memberId})
-            .whereNot({id: incomingGiftId})
-            .select('id')
-            .first();
-
-        return row ? row.id : null;
     }
 };

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -93,12 +93,6 @@ module.exports = class MembersCSVImporter {
      */
     async prepare(inputFilePath, headerMapping, defaultLabels) {
         headerMapping = headerMapping || DEFAULT_CSV_HEADER_MAPPING;
-        // Force-recognise `gift_id` so the importer can reassign gift rows even when the
-        // user-supplied mapping doesn't include it (the column is not exposed in the UI).
-        headerMapping = {
-            ...headerMapping,
-            gift_id: 'gift_id'
-        };
         // @NOTE: investigate why is it "1" and do we even need this concept anymore?
         const batchSize = 1;
 

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -19,11 +19,10 @@ const messages = {
 };
 
 function wrapGiftError(error) {
-    if (error instanceof errors.DataImportError) {
-        return error;
-    }
     const message = (error && typeof error.message === 'string' && error.message) || tpl(messages.giftReassignFailed);
-    return new errors.DataImportError({message});
+    return new errors.DataImportError({
+        message: `Member cannot be assigned to a gift: ${message}`
+    });
 }
 
 // The key should correspond to a member model field (unless it's a special purpose field like 'complimentary_plan')
@@ -172,10 +171,10 @@ module.exports = class MembersCSVImporter {
                 // any member/tier work.
                 if (row.gift_id) {
                     if (row.import_tier) {
-                        throw new errors.DataImportError({message: tpl(messages.giftCannotCombineWithImportTier)});
+                        throw wrapGiftError(new errors.DataImportError({message: tpl(messages.giftCannotCombineWithImportTier)}));
                     }
                     if (row.complimentary_plan) {
-                        throw new errors.DataImportError({message: tpl(messages.giftCannotCombineWithComplimentary)});
+                        throw wrapGiftError(new errors.DataImportError({message: tpl(messages.giftCannotCombineWithComplimentary)}));
                     }
                 }
 
@@ -291,7 +290,7 @@ module.exports = class MembersCSVImporter {
 
                 if (row.gift_id) {
                     if (!giftService) {
-                        throw new errors.DataImportError({message: tpl(messages.giftServiceUnavailable)});
+                        throw wrapGiftError(new errors.DataImportError({message: tpl(messages.giftServiceUnavailable)}));
                     }
 
                     try {

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -15,16 +15,16 @@ const messages = {
     giftServiceUnavailable: 'Gift service is not available.',
     giftCannotCombineWithImportTier: 'Cannot specify both gift_id and import_tier.',
     giftCannotCombineWithComplimentary: 'Cannot specify both gift_id and complimentary_plan.',
-    giftMemberAlreadyHasGift: 'Cannot reassign gift to a member with an existing gift.'
+    giftMemberAlreadyHasGift: 'Cannot reassign gift to a member with an existing gift.',
+    giftReassignFailed: 'Failed to reassign gift to member.'
 };
 
 function wrapGiftError(error) {
     if (error instanceof errors.DataImportError) {
         return error;
     }
-    return new errors.DataImportError({
-        message: (error && typeof error.message === 'string' && error.message) || ''
-    });
+    const message = (error && typeof error.message === 'string' && error.message) || tpl(messages.giftReassignFailed);
+    return new errors.DataImportError({message});
 }
 
 // The key should correspond to a member model field (unless it's a special purpose field like 'complimentary_plan')

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -16,6 +16,7 @@ const models = require('../../models');
 const {GhostMailer} = require('../mail');
 const jobsService = require('../jobs');
 const tiersService = require('../tiers');
+const giftService = require('../gifts');
 const VerificationTrigger = require('../verification-trigger');
 const {verificationWebhookService} = require('../verification/verification-webhook-service');
 const DatabaseInfo = require('@tryghost/database-info');
@@ -71,6 +72,10 @@ const initMembersCSVImporter = ({stripeAPIService}) => {
             }
 
             return null;
+        },
+        getGiftService: async () => {
+            await giftService.init();
+            return giftService.service;
         },
         sendEmail: ghostMailer.send.bind(ghostMailer),
         isSet: flag => labsService.isSet(flag),

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -73,10 +73,7 @@ const initMembersCSVImporter = ({stripeAPIService}) => {
 
             return null;
         },
-        getGiftService: async () => {
-            await giftService.init();
-            return giftService.service;
-        },
+        getGiftService: () => giftService.service,
         sendEmail: ghostMailer.send.bind(ghostMailer),
         isSet: flag => labsService.isSet(flag),
         addJob: jobsService.addJob.bind(jobsService),

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -120,7 +120,7 @@
     "@tryghost/kg-mobiledoc-html-renderer": "7.2.1",
     "@tryghost/limit-service": "1.5.2",
     "@tryghost/logging": "4.1.0",
-    "@tryghost/members-csv": "2.0.5",
+    "@tryghost/members-csv": "2.0.7",
     "@tryghost/metrics": "1.0.43",
     "@tryghost/mongo-utils": "0.6.3",
     "@tryghost/mw-error-handler": "1.0.13",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-exporter.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-exporter.test.js.snap
@@ -132,7 +132,7 @@ Object {
 }
 `;
 
-exports[`Members API — exportCSV Can export gift subscription 1: [headers] 1`] = `
+exports[`Members API — exportCSV Can export gift_id for gift members 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -144,7 +144,7 @@ Object {
 }
 `;
 
-exports[`Members API — exportCSV Can export gift subscription 2: [headers] 1`] = `
+exports[`Members API — exportCSV Can export gift_id for gift members 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -156,7 +156,7 @@ Object {
 }
 `;
 
-exports[`Members API — exportCSV Can export gift subscription 3: [headers] 1`] = `
+exports[`Members API — exportCSV Can export gift_id for gift members 3: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -168,7 +168,7 @@ Object {
 }
 `;
 
-exports[`Members API — exportCSV Can export gift subscription 4: [headers] 1`] = `
+exports[`Members API — exportCSV Can export gift_id for gift members 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-exporter.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-exporter.test.js.snap
@@ -132,6 +132,54 @@ Object {
 }
 `;
 
+exports[`Members API — exportCSV Can export gift subscription 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API — exportCSV Can export gift subscription 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API — exportCSV Can export gift subscription 3: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API — exportCSV Can export gift subscription 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API — exportCSV Can export labels 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-exporter.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-exporter.test.js.snap
@@ -311,3 +311,51 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Members API — exportCSV Does not export gift_id for members whose gift is consumed 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API — exportCSV Does not export gift_id for members whose gift is consumed 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API — exportCSV Does not export gift_id for members whose gift is consumed 3: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API — exportCSV Does not export gift_id for members whose gift is consumed 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/backup.test.js
+++ b/ghost/core/test/e2e-api/admin/backup.test.js
@@ -85,7 +85,7 @@ describe('Backup Integration', function () {
                         'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
                     .expect(({text}) => {
-                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
                     });
             });
         });
@@ -136,7 +136,7 @@ describe('Backup Integration', function () {
                         'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
                     .expect(({text}) => {
-                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
                     });
             });
         });
@@ -181,7 +181,7 @@ describe('Backup Integration', function () {
                         'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
                     .expect(({text}) => {
-                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
                     });
             });
         });
@@ -226,7 +226,7 @@ describe('Backup Integration', function () {
                         'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
                     .expect(({text}) => {
-                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
                     });
             });
         });

--- a/ghost/core/test/e2e-api/admin/backup.test.js
+++ b/ghost/core/test/e2e-api/admin/backup.test.js
@@ -85,7 +85,7 @@ describe('Backup Integration', function () {
                         'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
                     .expect(({text}) => {
-                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
                     });
             });
         });
@@ -136,7 +136,7 @@ describe('Backup Integration', function () {
                         'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
                     .expect(({text}) => {
-                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
                     });
             });
         });
@@ -181,7 +181,7 @@ describe('Backup Integration', function () {
                         'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
                     .expect(({text}) => {
-                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
                     });
             });
         });
@@ -226,7 +226,7 @@ describe('Backup Integration', function () {
                         'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
                     .expect(({text}) => {
-                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
                     });
             });
         });

--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -220,6 +220,44 @@ describe('Members API — exportCSV', function () {
         }, ['filter=status:gift', 'filter=subscribed:false']);
     });
 
+    it('Does not export gift_id for members whose gift is consumed', async function () {
+        const tier = tiers[0];
+        const member = await createMember({
+            name: 'Test ex-gift member',
+            note: 'Gift was consumed',
+            status: 'paid',
+            products: [{id: tier.id}]
+        });
+
+        const now = new Date();
+        await models.Gift.add({
+            token: `exporter-consumed-token-${Date.now()}`,
+            buyer_email: 'buyer@example.com',
+            buyer_member_id: null,
+            redeemer_member_id: member.id,
+            tier_id: tier.id,
+            cadence: 'year',
+            duration: 1,
+            currency: 'usd',
+            amount: 5000,
+            stripe_checkout_session_id: `cs_exporter_consumed_${Date.now()}`,
+            stripe_payment_intent_id: `pi_exporter_consumed_${Date.now()}`,
+            consumes_at: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+            expires_at: new Date(now.getTime() + 10 * 365 * 24 * 60 * 60 * 1000),
+            status: 'consumed',
+            purchased_at: now,
+            redeemed_at: now,
+            consumed_at: now,
+            expired_at: null,
+            refunded_at: null
+        });
+
+        await testOutput(member, (row) => {
+            basicAsserts(member, row);
+            assert.equal(row.gift_id, '');
+        }, [`filter=email:'${member.get('email')}'`, 'filter=subscribed:false']);
+    });
+
     it('Can export newsletters', async function () {
         // Create a new member with a product
         const member = await createMember({

--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -52,7 +52,7 @@ async function testOutput(member, asserts, filters = []) {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
 
         let csv = Papa.parse(res.text, {header: true});
         let row = csv.data.find(r => r.id === member.id);
@@ -175,11 +175,11 @@ describe('Members API — exportCSV', function () {
             assert.equal(row.complimentary_plan, 'true');
             assert.equal(row.labels, '');
             assert.equal(row.tiers, '');
-            assert.equal(row.gift_subscription, '');
+            assert.equal(row.gift_id, '');
         }, ['filter=status:comped', 'filter=subscribed:false']);
     });
 
-    it('Can export gift subscription', async function () {
+    it('Can export gift_id for gift members', async function () {
         const tier = tiers[0];
         const member = await createMember({
             name: 'Test gift member',
@@ -188,11 +188,34 @@ describe('Members API — exportCSV', function () {
             products: [{id: tier.id}]
         });
 
+        const now = new Date();
+        const gift = await models.Gift.add({
+            token: `exporter-test-token-${Date.now()}`,
+            buyer_email: 'buyer@example.com',
+            buyer_member_id: null,
+            redeemer_member_id: member.id,
+            tier_id: tier.id,
+            cadence: 'year',
+            duration: 1,
+            currency: 'usd',
+            amount: 5000,
+            stripe_checkout_session_id: `cs_exporter_${Date.now()}`,
+            stripe_payment_intent_id: `pi_exporter_${Date.now()}`,
+            consumes_at: new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000),
+            expires_at: new Date(now.getTime() + 10 * 365 * 24 * 60 * 60 * 1000),
+            status: 'redeemed',
+            purchased_at: now,
+            redeemed_at: now,
+            consumed_at: null,
+            expired_at: null,
+            refunded_at: null
+        });
+
         await testOutput(member, (row) => {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'false');
             assert.equal(row.complimentary_plan, '');
-            assert.equal(row.gift_subscription, 'true');
+            assert.equal(row.gift_id, gift.id);
             assert.equal(row.tiers, tier.get('name'));
         }, ['filter=status:gift', 'filter=subscribed:false']);
     });

--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -52,7 +52,7 @@ async function testOutput(member, asserts, filters = []) {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
 
         let csv = Papa.parse(res.text, {header: true});
         let row = csv.data.find(r => r.id === member.id);
@@ -175,7 +175,26 @@ describe('Members API — exportCSV', function () {
             assert.equal(row.complimentary_plan, 'true');
             assert.equal(row.labels, '');
             assert.equal(row.tiers, '');
+            assert.equal(row.gift_subscription, '');
         }, ['filter=status:comped', 'filter=subscribed:false']);
+    });
+
+    it('Can export gift subscription', async function () {
+        const tier = tiers[0];
+        const member = await createMember({
+            name: 'Test gift member',
+            note: 'A gift',
+            status: 'gift',
+            products: [{id: tier.id}]
+        });
+
+        await testOutput(member, (row) => {
+            basicAsserts(member, row);
+            assert.equal(row.subscribed_to_emails, 'false');
+            assert.equal(row.complimentary_plan, '');
+            assert.equal(row.gift_subscription, 'true');
+            assert.equal(row.tiers, tier.get('name'));
+        }, ['filter=status:gift', 'filter=subscribed:false']);
     });
 
     it('Can export newsletters', async function () {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2658,7 +2658,7 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
 
         const csv = Papa.parse(res.text, {header: true});
         assertExists(csv.data.find(row => row.name === 'Mr Egg'));
@@ -2679,7 +2679,7 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
 
         const csv = Papa.parse(res.text, {header: true});
         assertExists(csv.data.find(row => row.name === 'Mr Egg'));

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2658,7 +2658,7 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
 
         const csv = Papa.parse(res.text, {header: true});
         assertExists(csv.data.find(row => row.name === 'Mr Egg'));
@@ -2679,7 +2679,7 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription/);
 
         const csv = Papa.parse(res.text, {header: true});
         assertExists(csv.data.find(row => row.name === 'Mr Egg'));

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -1757,6 +1757,24 @@ describe('GiftService', function () {
             sinon.assert.notCalled(staffServiceEmails.notifyGiftSubscriptionStarted);
         });
 
+        it('is a no-op when the gift is already assigned to the same member', async function () {
+            const existingGift = buildGift({
+                status: 'redeemed',
+                redeemerMemberId: 'member_existing',
+                redeemedAt: new Date('2025-04-01T00:00:00.000Z'),
+                consumesAt: new Date('2026-04-01T00:00:00.000Z')
+            });
+            giftRepository.getById.resolves(existingGift);
+
+            const service = createService();
+            const result = await service.reassignRedeemer('gift_id_1', 'member_existing');
+
+            assert.equal(result.redeemerMemberId, 'member_existing');
+            sinon.assert.notCalled(memberRepository.get);
+            sinon.assert.notCalled(memberRepository.update);
+            sinon.assert.notCalled(giftRepository.update);
+        });
+
         it('throws NotFoundError when the gift id does not exist', async function () {
             giftRepository.getById.resolves(null);
 

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -30,6 +30,7 @@ function buildRedeemer(id: string = 'member_1') {
 describe('GiftService', function () {
     type GiftRepositoryStub = {
         existsByCheckoutSessionId: sinon.SinonStub<[string], Promise<boolean>>;
+        getById: sinon.SinonStub<Parameters<GiftRepository['getById']>, ReturnType<GiftRepository['getById']>>;
         getByToken: sinon.SinonStub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>;
         getByPaymentIntentId: sinon.SinonStub<[string], Promise<Gift | null>>;
         getActiveByMember: sinon.SinonStub<[string], Promise<Gift | null>>;
@@ -75,6 +76,7 @@ describe('GiftService', function () {
     beforeEach(function () {
         giftRepository = {
             existsByCheckoutSessionId: sinon.stub<[string], Promise<boolean>>().resolves(false),
+            getById: sinon.stub<Parameters<GiftRepository['getById']>, ReturnType<GiftRepository['getById']>>().resolves(null),
             getByToken: sinon.stub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>().resolves(null),
             getByPaymentIntentId: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
             getActiveByMember: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
@@ -1712,6 +1714,172 @@ describe('GiftService', function () {
             const result = service.getRemainingActiveDays(gift);
 
             assert.ok(result === 5 || result === 4, `expected 4 or 5, got ${result}`);
+        });
+    });
+
+    describe('reassignRedeemer', function () {
+        function buildOrphanedGift() {
+            return buildGift({
+                status: 'redeemed',
+                redeemerMemberId: null,
+                redeemedAt: new Date('2025-04-01T00:00:00.000Z'),
+                consumesAt: new Date('2026-04-01T00:00:00.000Z')
+            });
+        }
+
+        it('updates the member and the gift when the gift is reassignable', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+
+            const service = createService();
+            const result = await service.reassignRedeemer('gift_id_1', 'member_new');
+
+            assert.equal(result.redeemerMemberId, 'member_new');
+            sinon.assert.calledOnce(giftRepository.update);
+            sinon.assert.calledOnce(memberRepository.update);
+
+            const [memberUpdateData, memberUpdateOptions] = memberRepository.update.getCall(0).args;
+            assert.equal(memberUpdateData.status, 'gift');
+            assert.equal(memberUpdateData.products[0].id, 'tier_1');
+            assert.deepEqual(memberUpdateData.products[0].expiry_at, new Date('2026-04-01T00:00:00.000Z'));
+            assert.equal(memberUpdateOptions.id, 'member_new');
+        });
+
+        it('does not send a staff notification (only on original redemption)', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+
+            const service = createService();
+            await service.reassignRedeemer('gift_id_1', 'member_new');
+
+            sinon.assert.notCalled(staffServiceEmails.notifyGiftSubscriptionStarted);
+        });
+
+        it('throws NotFoundError when the gift id does not exist', async function () {
+            giftRepository.getById.resolves(null);
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('missing_gift_id', 'member_new'),
+                errors.NotFoundError
+            );
+            sinon.assert.notCalled(memberRepository.update);
+            sinon.assert.notCalled(giftRepository.update);
+        });
+
+        it('throws BadRequestError with already-assigned message when the redeemer is set', async function () {
+            giftRepository.getById.resolves(buildGift({
+                status: 'redeemed',
+                redeemerMemberId: 'member_existing',
+                redeemedAt: new Date('2025-04-01T00:00:00.000Z'),
+                consumesAt: new Date('2026-04-01T00:00:00.000Z')
+            }));
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('gift_id_1', 'member_new'),
+                (err: Error) => err instanceof errors.BadRequestError && /already assigned/.test(err.message)
+            );
+            sinon.assert.notCalled(memberRepository.update);
+        });
+
+        it('throws BadRequestError with not-reassignable message for a consumed gift', async function () {
+            giftRepository.getById.resolves(buildGift({
+                status: 'consumed',
+                redeemerMemberId: null,
+                consumedAt: new Date('2026-04-01T00:00:00.000Z')
+            }));
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('gift_id_1', 'member_new'),
+                (err: Error) => err instanceof errors.BadRequestError && /reassignable status/.test(err.message)
+            );
+        });
+
+        it('throws BadRequestError for a purchased (never redeemed) gift', async function () {
+            giftRepository.getById.resolves(buildGift({status: 'purchased'}));
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('gift_id_1', 'member_new'),
+                (err: Error) => err instanceof errors.BadRequestError && /reassignable status/.test(err.message)
+            );
+        });
+
+        it('throws InternalServerError when a redeemed gift has no consumesAt', async function () {
+            giftRepository.getById.resolves(buildGift({
+                status: 'redeemed',
+                redeemerMemberId: null,
+                redeemedAt: new Date('2025-04-01T00:00:00.000Z'),
+                consumesAt: null
+            }));
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('gift_id_1', 'member_new'),
+                (err: Error) => err instanceof errors.BadRequestError && /"consumes at" date/.test(err.message)
+            );
+            sinon.assert.notCalled(memberRepository.update);
+            sinon.assert.notCalled(giftRepository.update);
+        });
+
+        it('uses the caller-supplied transaction if provided and skips opening a new one', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+
+            const service = createService();
+            await service.reassignRedeemer('gift_id_1', 'member_new', {transacting: 'outer_trx'});
+
+            sinon.assert.notCalled(giftRepository.transaction);
+            const getByIdOptions = giftRepository.getById.getCall(0).args[1];
+            assert.equal(getByIdOptions?.transacting, 'outer_trx');
+        });
+
+        it('locks the destination member with forUpdate before reassigning', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+
+            const service = createService();
+            await service.reassignRedeemer('gift_id_1', 'member_new');
+
+            sinon.assert.calledWith(
+                memberRepository.get,
+                {id: 'member_new'},
+                sinon.match({forUpdate: true})
+            );
+        });
+
+        it('throws BadRequestError when the destination member already has an active paid subscription', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+
+            const memberGet = sinon.stub();
+            memberGet.withArgs('status').returns('paid');
+            memberRepository.get.resolves({id: 'member_new', get: memberGet});
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('gift_id_1', 'member_new'),
+                (err: Error) => err instanceof errors.BadRequestError && /active subscription/.test(err.message)
+            );
+            sinon.assert.notCalled(memberRepository.update);
+            sinon.assert.notCalled(giftRepository.update);
+        });
+
+        it('throws NotFoundError when the destination member does not exist', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+            memberRepository.get.resolves(null);
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('gift_id_1', 'member_new'),
+                errors.NotFoundError
+            );
+            sinon.assert.notCalled(memberRepository.update);
+            sinon.assert.notCalled(giftRepository.update);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -33,7 +33,7 @@ describe('GiftService', function () {
         getById: sinon.SinonStub<Parameters<GiftRepository['getById']>, ReturnType<GiftRepository['getById']>>;
         getByToken: sinon.SinonStub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>;
         getByPaymentIntentId: sinon.SinonStub<[string], Promise<Gift | null>>;
-        getActiveByMember: sinon.SinonStub<[string], Promise<Gift | null>>;
+        getActiveByMember: sinon.SinonStub<Parameters<GiftRepository['getActiveByMember']>, ReturnType<GiftRepository['getActiveByMember']>>;
         findPendingConsumption: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingExpiration: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingReminder: sinon.SinonStub<[FindPendingReminderOptions], Promise<Gift[]>>;
@@ -79,7 +79,7 @@ describe('GiftService', function () {
             getById: sinon.stub<Parameters<GiftRepository['getById']>, ReturnType<GiftRepository['getById']>>().resolves(null),
             getByToken: sinon.stub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>().resolves(null),
             getByPaymentIntentId: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
-            getActiveByMember: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
+            getActiveByMember: sinon.stub<Parameters<GiftRepository['getActiveByMember']>, ReturnType<GiftRepository['getActiveByMember']>>().resolves(null),
             findPendingConsumption: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingExpiration: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingReminder: sinon.stub<[FindPendingReminderOptions], Promise<Gift[]>>().resolves([]),
@@ -1605,7 +1605,7 @@ describe('GiftService', function () {
             const result = await service.getActiveByMember('member_1');
 
             assert.equal(result, gift);
-            sinon.assert.calledOnceWithExactly(giftRepository.getActiveByMember, 'member_1');
+            sinon.assert.calledOnceWithExactly(giftRepository.getActiveByMember, 'member_1', {});
         });
 
         it('returns null when the repository has no redeemed gift for the member', async function () {
@@ -1931,6 +1931,32 @@ describe('GiftService', function () {
             await assert.rejects(
                 service.reassignRedeemer('gift_id_1', 'member_new'),
                 errors.NotFoundError
+            );
+            sinon.assert.notCalled(memberRepository.update);
+            sinon.assert.notCalled(giftRepository.update);
+        });
+
+        it('throws BadRequestError when the destination member already has a different active gift attached', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+
+            const memberGet = sinon.stub();
+            memberGet.withArgs('status').returns('gift');
+            memberRepository.get.resolves({id: 'member_new', get: memberGet});
+
+            // The member already has a different active gift (different token)
+            giftRepository.getActiveByMember.resolves(buildGift({
+                token: 'different-gift-token',
+                status: 'redeemed',
+                redeemerMemberId: 'member_new',
+                redeemedAt: new Date('2025-01-01T00:00:00.000Z'),
+                consumesAt: new Date('2026-01-01T00:00:00.000Z')
+            }));
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('gift_id_1', 'member_new'),
+                (err: Error) => err instanceof errors.BadRequestError && /different active gift/.test(err.message)
             );
             sinon.assert.notCalled(memberRepository.update);
             sinon.assert.notCalled(giftRepository.update);

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -90,7 +90,11 @@ describe('GiftService', function () {
             })
         };
         memberRepository = {
-            get: sinon.stub().resolves({id: 'member_1', get: sinon.stub().returns(null)}),
+            get: sinon.stub().callsFake(() => {
+                const memberGet = sinon.stub().returns(null);
+                memberGet.withArgs('status').returns('free');
+                return Promise.resolve({id: 'member_1', get: memberGet});
+            }),
             update: sinon.stub().resolves(undefined)
         };
         staffServiceEmails = {
@@ -1866,6 +1870,38 @@ describe('GiftService', function () {
             );
             sinon.assert.notCalled(memberRepository.update);
             sinon.assert.notCalled(giftRepository.update);
+        });
+
+        it('throws BadRequestError when the destination member has a comped subscription', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+
+            const memberGet = sinon.stub();
+            memberGet.withArgs('status').returns('comped');
+            memberRepository.get.resolves({id: 'member_new', get: memberGet});
+
+            const service = createService();
+
+            await assert.rejects(
+                service.reassignRedeemer('gift_id_1', 'member_new'),
+                (err: Error) => err instanceof errors.BadRequestError && /active subscription/.test(err.message)
+            );
+            sinon.assert.notCalled(memberRepository.update);
+            sinon.assert.notCalled(giftRepository.update);
+        });
+
+        it('allows reassignment when the destination member already has gift status', async function () {
+            giftRepository.getById.resolves(buildOrphanedGift());
+
+            const memberGet = sinon.stub();
+            memberGet.withArgs('status').returns('gift');
+            memberRepository.get.resolves({id: 'member_new', get: memberGet});
+
+            const service = createService();
+            const result = await service.reassignRedeemer('gift_id_1', 'member_new');
+
+            assert.equal(result.redeemerMemberId, 'member_new');
+            sinon.assert.calledOnce(memberRepository.update);
+            sinon.assert.calledOnce(giftRepository.update);
         });
 
         it('throws NotFoundError when the destination member does not exist', async function () {

--- a/ghost/core/test/unit/server/services/gifts/gift.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift.test.ts
@@ -348,4 +348,102 @@ describe('Gift', function () {
             assert.equal(result, null);
         });
     });
+
+    describe('checkReassignable', function () {
+        // An orphaned gift is one that was redeemed but whose redeemer member was later
+        // deleted (the FK is SET NULL on delete). These should be reassignable on re-import.
+        function orphanedGift() {
+            return buildGift({
+                status: 'redeemed',
+                redeemerMemberId: null,
+                redeemedAt: new Date('2026-04-11T12:00:00.000Z'),
+                consumesAt: new Date('2027-04-11T12:00:00.000Z')
+            });
+        }
+
+        it('returns reassignable=true for a redeemed gift whose redeemer is null', function () {
+            const gift = orphanedGift();
+
+            assert.deepEqual(gift.checkReassignable(), {reassignable: true});
+        });
+
+        it('returns unredeemed for a purchased (never redeemed) gift', function () {
+            const gift = buildGift({status: 'purchased'});
+
+            assert.deepEqual(gift.checkReassignable(), {reassignable: false, reason: 'unredeemed'});
+        });
+
+        it('returns assigned when redeemer is set', function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemerMemberId: 'member_2',
+                redeemedAt: new Date('2026-04-11T12:00:00.000Z'),
+                consumesAt: new Date('2027-04-11T12:00:00.000Z')
+            });
+
+            assert.deepEqual(gift.checkReassignable(), {reassignable: false, reason: 'assigned'});
+        });
+
+        it('returns consumed when consumedAt is set', function () {
+            const gift = buildGift({
+                status: 'consumed',
+                redeemerMemberId: null,
+                redeemedAt: new Date('2026-04-11T12:00:00.000Z'),
+                consumesAt: new Date('2027-04-11T12:00:00.000Z'),
+                consumedAt: new Date('2027-04-11T12:00:00.000Z')
+            });
+
+            assert.deepEqual(gift.checkReassignable(), {reassignable: false, reason: 'consumed'});
+        });
+
+        it('returns expired when expiredAt is set', function () {
+            const gift = buildGift({
+                status: 'expired',
+                redeemerMemberId: null,
+                expiredAt: new Date('2027-04-11T12:00:00.000Z')
+            });
+
+            assert.deepEqual(gift.checkReassignable(), {reassignable: false, reason: 'expired'});
+        });
+
+        it('returns refunded when refundedAt is set', function () {
+            const gift = buildGift({
+                status: 'refunded',
+                redeemerMemberId: null,
+                refundedAt: new Date('2027-04-11T12:00:00.000Z')
+            });
+
+            assert.deepEqual(gift.checkReassignable(), {reassignable: false, reason: 'refunded'});
+        });
+
+        it('returns missing-consumes-at when consumesAt is null on a redeemed gift', function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemerMemberId: null,
+                redeemedAt: new Date('2026-04-11T12:00:00.000Z'),
+                consumesAt: null
+            });
+
+            assert.deepEqual(gift.checkReassignable(), {reassignable: false, reason: 'missing-consumes-at'});
+        });
+    });
+
+    describe('reassignRedeemer', function () {
+        it('returns a new Gift with the supplied redeemer id', function () {
+            const gift = buildGift({
+                status: 'redeemed',
+                redeemerMemberId: null,
+                redeemedAt: new Date('2026-04-11T12:00:00.000Z'),
+                consumesAt: new Date('2027-04-11T12:00:00.000Z')
+            });
+
+            const reassigned = gift.reassignRedeemer('member_new');
+
+            assert.equal(reassigned.redeemerMemberId, 'member_new');
+            // Other lifecycle fields should be untouched
+            assert.equal(reassigned.status, 'redeemed');
+            assert.deepEqual(reassigned.redeemedAt, gift.redeemedAt);
+            assert.deepEqual(reassigned.consumesAt, gift.consumesAt);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-import.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-import.csv
@@ -1,2 +1,0 @@
-id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription
-634e48e056ef99c6a7af5851,giftmember@example.com,Some Gift Member,This is a gift member,true,,,2023-07-26T11:50:00.000Z,,,Premium Tier,true

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-import.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-import.csv
@@ -1,0 +1,2 @@
+id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_subscription
+634e48e056ef99c6a7af5851,giftmember@example.com,Some Gift Member,This is a gift member,true,,,2023-07-26T11:50:00.000Z,,,Premium Tier,true

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-reassign-with-complimentary.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-reassign-with-complimentary.csv
@@ -1,0 +1,2 @@
+id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id
+634e48e056ef99c6a7af5853,giftmember3@example.com,Gift And Comp,Has both gift_id and complimentary_plan,true,true,,2023-07-26T11:50:00.000Z,,,Premium Tier,abc123abc123abc123abc123

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-reassign-with-tier.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-reassign-with-tier.csv
@@ -1,0 +1,2 @@
+id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id,import_tier
+634e48e056ef99c6a7af5852,giftmember2@example.com,Gift And Tier,Has both gift_id and import_tier,true,,,2023-07-26T11:50:00.000Z,,,Premium Tier,abc123abc123abc123abc123,Premium Tier

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-reassign.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/gift-member-reassign.csv
@@ -1,0 +1,2 @@
+id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id
+634e48e056ef99c6a7af5851,giftmember@example.com,Some Gift Member,A reassignable gift member,true,,,2023-07-26T11:50:00.000Z,,,Premium Tier,abc123abc123abc123abc123

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -62,11 +62,22 @@ describe('MembersCSVImporter', function () {
             linkStripeCustomer: sinon.stub().resolves(null),
             getCustomerIdByEmail: sinon.stub().resolves('cus_mock_123456')
         };
+        // The `trx` returned by knex.transaction() is used both as a commit/rollback handle
+        // AND as a callable knex query builder (e.g. trx('gifts').where(...)). The stubbed
+        // callable returns a minimal chainable query builder whose terminators resolve to
+        // `null`, simulating "no rows found". Tests that care about a specific result can
+        // override via deps.knex.
+        const trxStub = sinon.stub().callsFake(() => ({
+            where: sinon.stub().returnsThis(),
+            whereNot: sinon.stub().returnsThis(),
+            select: sinon.stub().returnsThis(),
+            first: sinon.stub().resolves(null)
+        }));
+        trxStub.rollback = () => {};
+        trxStub.commit = () => {};
+
         knexStub = {
-            transaction: sinon.stub().resolves({
-                rollback: () => {},
-                commit: () => {}
-            })
+            transaction: sinon.stub().resolves(trxStub)
         };
         sendEmailStub = sinon.stub();
         stripeUtilsStub = {
@@ -758,37 +769,138 @@ describe('MembersCSVImporter', function () {
             assert.equal(result.errors[0].error, '"Invalid Tier" is not a valid tier.');
         });
 
-        it('rejects gift_subscription rows during the full process() flow even when the UI omits gift_subscription from the mapping', async function () {
-            // Simulates a user importing an exported CSV via the UI: the mapping UI does
-            // not include gift_subscription, so without server-side handling the column
-            // would be stripped by the parser and never reach `perform()`.
-            const LabelModelStub = {
-                findOne: sinon.stub().resolves(null)
+        it('reassigns an orphaned gift to the imported member', async function () {
+            const giftServiceStub = {
+                reassignRedeemer: sinon.stub().resolves({})
             };
-            const importer = buildMockImporterInstance();
-
-            const result = await importer.process({
-                pathToCSV: `${csvPath}/gift-member-import.csv`,
-                headerMapping: defaultAllowedFields,
-                importLabel: {name: 'Test Import'},
-                user: {email: 'test@example.com'},
-                LabelModel: LabelModelStub,
-                forceInline: true,
-                verificationTrigger: {
-                    testImportThreshold: () => {}
-                }
+            const importer = buildMockImporterInstance({
+                getGiftService: async () => giftServiceStub
             });
 
-            assert.equal(result.meta.stats.imported, 0);
-            assert.equal(result.meta.stats.invalid.length, 1);
-            assert.equal(
-                result.meta.stats.invalid[0].error,
-                'Gift subscriptions cannot be imported.'
-            );
-            // originalImportSize should reflect what the user uploaded, not what survived
-            // the gift filter. The CSV had 1 row; the user sees 1 row accounted for.
-            assert.equal(result.meta.originalImportSize, 1);
-            sinon.assert.notCalled(membersRepositoryStub.create);
+            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+
+            assert.equal(result.total, 1);
+            assert.equal(result.imported, 1);
+            assert.equal(result.errors.length, 0);
+            sinon.assert.calledOnce(giftServiceStub.reassignRedeemer);
+            const [giftId, memberId] = giftServiceStub.reassignRedeemer.getCall(0).args;
+            assert.equal(giftId, 'abc123abc123abc123abc123');
+            assert.equal(memberId, 'test_member_id');
+        });
+
+        it('rejects a row that specifies both gift_id and import_tier', async function () {
+            const giftServiceStub = {
+                reassignRedeemer: sinon.stub().resolves({})
+            };
+            const importer = buildMockImporterInstance({
+                getGiftService: async () => giftServiceStub
+            });
+
+            const result = await importer.perform(`${csvPath}/gift-member-reassign-with-tier.csv`);
+
+            assert.equal(result.imported, 0);
+            assert.equal(result.errors.length, 1);
+            assert.equal(result.errors[0].error, 'Cannot specify both gift_id and import_tier.');
+            sinon.assert.notCalled(giftServiceStub.reassignRedeemer);
+        });
+
+        it('rejects a row that specifies both gift_id and complimentary_plan', async function () {
+            const giftServiceStub = {
+                reassignRedeemer: sinon.stub().resolves({})
+            };
+            const importer = buildMockImporterInstance({
+                getGiftService: async () => giftServiceStub
+            });
+
+            const result = await importer.perform(`${csvPath}/gift-member-reassign-with-complimentary.csv`);
+
+            assert.equal(result.imported, 0);
+            assert.equal(result.errors.length, 1);
+            assert.equal(result.errors[0].error, 'Cannot specify both gift_id and complimentary_plan.');
+            sinon.assert.notCalled(giftServiceStub.reassignRedeemer);
+        });
+
+        it('translates NotFoundError from GiftService into a user-facing gift-not-found error', async function () {
+            const NotFoundError = class extends Error {
+                constructor(message) {
+                    super(message);
+                    this.errorType = 'NotFoundError';
+                }
+            };
+            const giftServiceStub = {
+                reassignRedeemer: sinon.stub().rejects(new NotFoundError('This gift does not exist.'))
+            };
+            const importer = buildMockImporterInstance({
+                getGiftService: async () => giftServiceStub
+            });
+
+            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+
+            assert.equal(result.imported, 0);
+            assert.equal(result.errors.length, 1);
+            assert.equal(result.errors[0].error, 'Gift record not found.');
+        });
+
+        it('translates already-assigned error from GiftService into a user-facing message', async function () {
+            const giftServiceStub = {
+                reassignRedeemer: sinon.stub().rejects(new Error('This gift is already assigned to another member.'))
+            };
+            const importer = buildMockImporterInstance({
+                getGiftService: async () => giftServiceStub
+            });
+
+            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+
+            assert.equal(result.imported, 0);
+            assert.equal(result.errors.length, 1);
+            assert.equal(result.errors[0].error, 'Gift is already assigned to another member.');
+        });
+
+        it('translates not-reassignable error from GiftService into a user-facing message', async function () {
+            const giftServiceStub = {
+                reassignRedeemer: sinon.stub().rejects(new Error('This gift does not have a reassignable status.'))
+            };
+            const importer = buildMockImporterInstance({
+                getGiftService: async () => giftServiceStub
+            });
+
+            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+
+            assert.equal(result.imported, 0);
+            assert.equal(result.errors.length, 1);
+            assert.equal(result.errors[0].error, 'Gift cannot be reassigned to a member in its current state.');
+        });
+
+        it('rejects when the matched member already has a different gift attached', async function () {
+            const giftServiceStub = {
+                reassignRedeemer: sinon.stub().resolves({})
+            };
+
+            // Simulate a conflicting gift already attached to the existing member.
+            const conflictingTrx = sinon.stub().callsFake(() => ({
+                where: sinon.stub().returnsThis(),
+                whereNot: sinon.stub().returnsThis(),
+                select: sinon.stub().returnsThis(),
+                first: sinon.stub().resolves({id: 'other_gift_id'})
+            }));
+            conflictingTrx.rollback = () => {};
+            conflictingTrx.commit = () => {};
+
+            const knexWithConflict = {
+                transaction: sinon.stub().resolves(conflictingTrx)
+            };
+
+            const importer = buildMockImporterInstance({
+                getGiftService: async () => giftServiceStub,
+                knex: knexWithConflict
+            });
+
+            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+
+            assert.equal(result.imported, 0);
+            assert.equal(result.errors.length, 1);
+            assert.equal(result.errors[0].error, 'Cannot reassign gift to a member with an existing gift.');
+            sinon.assert.notCalled(giftServiceStub.reassignRedeemer);
         });
 
         it('imports a paid member with an import tier', async function () {

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -758,6 +758,39 @@ describe('MembersCSVImporter', function () {
             assert.equal(result.errors[0].error, '"Invalid Tier" is not a valid tier.');
         });
 
+        it('rejects gift_subscription rows during the full process() flow even when the UI omits gift_subscription from the mapping', async function () {
+            // Simulates a user importing an exported CSV via the UI: the mapping UI does
+            // not include gift_subscription, so without server-side handling the column
+            // would be stripped by the parser and never reach `perform()`.
+            const LabelModelStub = {
+                findOne: sinon.stub().resolves(null)
+            };
+            const importer = buildMockImporterInstance();
+
+            const result = await importer.process({
+                pathToCSV: `${csvPath}/gift-member-import.csv`,
+                headerMapping: defaultAllowedFields,
+                importLabel: {name: 'Test Import'},
+                user: {email: 'test@example.com'},
+                LabelModel: LabelModelStub,
+                forceInline: true,
+                verificationTrigger: {
+                    testImportThreshold: () => {}
+                }
+            });
+
+            assert.equal(result.meta.stats.imported, 0);
+            assert.equal(result.meta.stats.invalid.length, 1);
+            assert.equal(
+                result.meta.stats.invalid[0].error,
+                'Gift subscriptions cannot be imported.'
+            );
+            // originalImportSize should reflect what the user uploaded, not what survived
+            // the gift filter. The CSV had 1 row; the user sees 1 row accounted for.
+            assert.equal(result.meta.originalImportSize, 1);
+            sinon.assert.notCalled(membersRepositoryStub.create);
+        });
+
         it('imports a paid member with an import tier', async function () {
             const tier = {
                 id: {

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -820,7 +820,7 @@ describe('MembersCSVImporter', function () {
             sinon.assert.notCalled(giftServiceStub.reassignRedeemer);
         });
 
-        it('translates NotFoundError from GiftService into a user-facing gift-not-found error', async function () {
+        it('surfaces NotFoundError from GiftService as a row error', async function () {
             const NotFoundError = class extends Error {
                 constructor(message) {
                     super(message);
@@ -838,10 +838,10 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'Gift record not found.');
+            assert.equal(result.errors[0].error, 'This gift does not exist.');
         });
 
-        it('translates already-assigned error from GiftService into a user-facing message', async function () {
+        it('surfaces already-assigned error from GiftService as a row error', async function () {
             const giftServiceStub = {
                 reassignRedeemer: sinon.stub().rejects(new Error('This gift is already assigned to another member.'))
             };
@@ -853,10 +853,10 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'Gift is already assigned to another member.');
+            assert.equal(result.errors[0].error, 'This gift is already assigned to another member.');
         });
 
-        it('translates not-reassignable error from GiftService into a user-facing message', async function () {
+        it('surfaces not-reassignable error from GiftService as a row error', async function () {
             const giftServiceStub = {
                 reassignRedeemer: sinon.stub().rejects(new Error('This gift does not have a reassignable status.'))
             };
@@ -868,7 +868,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'Gift cannot be reassigned to a member in its current state.');
+            assert.equal(result.errors[0].error, 'This gift does not have a reassignable status.');
         });
 
         it('rejects when the matched member already has a different gift attached', async function () {

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -62,17 +62,7 @@ describe('MembersCSVImporter', function () {
             linkStripeCustomer: sinon.stub().resolves(null),
             getCustomerIdByEmail: sinon.stub().resolves('cus_mock_123456')
         };
-        // The `trx` returned by knex.transaction() is used both as a commit/rollback handle
-        // AND as a callable knex query builder (e.g. trx('gifts').where(...)). The stubbed
-        // callable returns a minimal chainable query builder whose terminators resolve to
-        // `null`, simulating "no rows found". Tests that care about a specific result can
-        // override via deps.knex.
-        const trxStub = sinon.stub().callsFake(() => ({
-            where: sinon.stub().returnsThis(),
-            whereNot: sinon.stub().returnsThis(),
-            select: sinon.stub().returnsThis(),
-            first: sinon.stub().resolves(null)
-        }));
+        const trxStub = sinon.stub();
         trxStub.rollback = () => {};
         trxStub.commit = () => {};
 
@@ -871,36 +861,19 @@ describe('MembersCSVImporter', function () {
             assert.equal(result.errors[0].error, 'This gift does not have a reassignable status.');
         });
 
-        it('rejects when the matched member already has a different gift attached', async function () {
+        it('surfaces existing-gift conflict from GiftService as a row error', async function () {
             const giftServiceStub = {
-                reassignRedeemer: sinon.stub().resolves({})
+                reassignRedeemer: sinon.stub().rejects(new Error('Member already has a different active gift attached.'))
             };
-
-            // Simulate a conflicting gift already attached to the existing member.
-            const conflictingTrx = sinon.stub().callsFake(() => ({
-                where: sinon.stub().returnsThis(),
-                whereNot: sinon.stub().returnsThis(),
-                select: sinon.stub().returnsThis(),
-                first: sinon.stub().resolves({id: 'other_gift_id'})
-            }));
-            conflictingTrx.rollback = () => {};
-            conflictingTrx.commit = () => {};
-
-            const knexWithConflict = {
-                transaction: sinon.stub().resolves(conflictingTrx)
-            };
-
             const importer = buildMockImporterInstance({
-                getGiftService: async () => giftServiceStub,
-                knex: knexWithConflict
+                getGiftService: async () => giftServiceStub
             });
 
             const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'Cannot reassign gift to a member with an existing gift.');
-            sinon.assert.notCalled(giftServiceStub.reassignRedeemer);
+            assert.equal(result.errors[0].error, 'Member already has a different active gift attached.');
         });
 
         it('imports a paid member with an import tier', async function () {

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -790,7 +790,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'Cannot specify both gift_id and import_tier.');
+            assert.equal(result.errors[0].error, 'Member cannot be assigned to a gift: Cannot specify both gift_id and import_tier.');
             sinon.assert.notCalled(giftServiceStub.reassignRedeemer);
         });
 
@@ -806,7 +806,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'Cannot specify both gift_id and complimentary_plan.');
+            assert.equal(result.errors[0].error, 'Member cannot be assigned to a gift: Cannot specify both gift_id and complimentary_plan.');
             sinon.assert.notCalled(giftServiceStub.reassignRedeemer);
         });
 
@@ -828,7 +828,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'This gift does not exist.');
+            assert.equal(result.errors[0].error, 'Member cannot be assigned to a gift: This gift does not exist.');
         });
 
         it('surfaces already-assigned error from GiftService as a row error', async function () {
@@ -843,7 +843,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'This gift is already assigned to another member.');
+            assert.equal(result.errors[0].error, 'Member cannot be assigned to a gift: This gift is already assigned to another member.');
         });
 
         it('surfaces not-reassignable error from GiftService as a row error', async function () {
@@ -858,7 +858,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'This gift does not have a reassignable status.');
+            assert.equal(result.errors[0].error, 'Member cannot be assigned to a gift: This gift does not have a reassignable status.');
         });
 
         it('surfaces existing-gift conflict from GiftService as a row error', async function () {
@@ -873,7 +873,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
-            assert.equal(result.errors[0].error, 'Member already has a different active gift attached.');
+            assert.equal(result.errors[0].error, 'Member cannot be assigned to a gift: Member already has a different active gift attached.');
         });
 
         it('imports a paid member with an import tier', async function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29809,7 +29809,7 @@ snapshots:
   '@tryghost/members-csv@2.0.7':
     dependencies:
       fs-extra: 11.3.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       papaparse: 5.3.2
       pump: 3.0.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2075,8 +2075,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       '@tryghost/members-csv':
-        specifier: 2.0.5
-        version: 2.0.5
+        specifier: 2.0.7
+        version: 2.0.7
       '@tryghost/metrics':
         specifier: 1.0.43
         version: 1.0.43
@@ -8559,6 +8559,9 @@ packages:
 
   '@tryghost/members-csv@2.0.5':
     resolution: {integrity: sha512-5BMzhWSoJg+pOQuXdO8ygHDxLFcwZLob903NX7lprWQtooLPD8FAWwdFql/ZA7gPG5Bq9lV7TyUFK3hWVtvIlw==}
+
+  '@tryghost/members-csv@2.0.7':
+    resolution: {integrity: sha512-RnpaY2jKXC2waJTH4tI34vW541YBoDu7rX3NPZeHIdzoRP1102NCrzhPrFB/edmcyJ9fMMj5XpcvoQWw7FR/5A==}
 
   '@tryghost/metrics@1.0.43':
     resolution: {integrity: sha512-zTpO/VWhhsDgT/NPeXTa2UNO6KRoMVroo5oHpvKCB29eSE2td6uSarxZCzoxZ9c6rgA2TW0tiGuNu7sB3bMY7g==}
@@ -29800,6 +29803,13 @@ snapshots:
     dependencies:
       fs-extra: 11.3.0
       lodash: 4.18.1
+      papaparse: 5.3.2
+      pump: 3.0.2
+
+  '@tryghost/members-csv@2.0.7':
+    dependencies:
+      fs-extra: 11.3.0
+      lodash: 4.17.21
       papaparse: 5.3.2
       pump: 3.0.2
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3483

- Gift members previously exported as `free` members (`status` = `gift` was not mapped to any CSV column), so a round-trip silently converted them
- Added a `gift_id` column to the members CSV export, populated for members with an active (redeemed, non-consumed, non-refunded) gift attached
- On import, `gift_id` reassigns the gift to the row's member via `GiftService.reassignRedeemer()`: locks the gift, sets the member's `status` to `gift`, and applies the gift's tier with `expiry_at` = `consumes_at`
- Did not expose `gift_id` as a user-mappable field in the import UI; the importer force-recognises the column so exported CSVs round-trip regardless of the user's mapping
- `gift_id` is mutually exclusive with `import_tier` and `complimentary_plan` - combining them produces a row-level error
- `reassignRedeemer()` locks the destination member with `forUpdate` and rejects rows where `status` === `'paid'`, so a CSV row can't silently change a paying member onto the gift tier
- Added a `'missing-consumes-at'` guard in `Gift.checkReassignable()` to refuse reassignment when a redeemed gift has no `consumes_at` (would propagate `expiry_at: null`)
- Intentionally kept the CSV surface minimal (`gift_id only`, no buyer/cadence/duration metadata) — lifecycle data remains queryable via the gifts table