### PR TITLE
Added devcontainer config for VS Code and Codespaces

### DIFF
--- a/.devcontainer/compose.devcontainer.yaml
+++ b/.devcontainer/compose.devcontainer.yaml
@@ -1,0 +1,36 @@
+services:
+  ghost-dev:
+    # Mount the full repo so VS Code can edit apps/, e2e/, and root config files.
+    # The original ./ghost:/home/ghost/ghost mount from compose.dev.yaml is
+    # preserved via merge semantics so nodemon hot-reload still works for anyone
+    # running the backend the original way.
+    volumes:
+      - ./:/workspaces/Ghost:cached
+    # Override the default `pnpm dev` command. VS Code controls startup and the
+    # user runs backend/frontend dev servers as tasks (see .vscode/tasks.json).
+    command: ["sleep", "infinity"]
+    working_dir: /workspaces/Ghost
+    # The baseline healthcheck in compose.dev.yaml hits Ghost on :2368, but in
+    # the devcontainer Ghost isn't running until the user starts the dev task.
+    # Replace with a trivial check so the gateway's depends_on doesn't time out.
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 5s
+      timeout: 2s
+      retries: 1
+      start_period: 0s
+
+  ghost-dev-gateway:
+    # Point Caddy at the dev servers running inside the ghost-dev container
+    # instead of host.docker.internal (which is the default for the hybrid
+    # host/container dev setup).
+    environment:
+      GHOST_BACKEND: ghost-dev:2368
+      ADMIN_DEV_SERVER: ghost-dev:5174
+      ADMIN_LIVE_RELOAD_SERVER: ghost-dev:4200
+      PORTAL_DEV_SERVER: ghost-dev:4175
+      COMMENTS_DEV_SERVER: ghost-dev:7173
+      SIGNUP_DEV_SERVER: ghost-dev:6174
+      SEARCH_DEV_SERVER: ghost-dev:4178
+      ANNOUNCEMENT_DEV_SERVER: ghost-dev:4177
+      LEXICAL_DEV_SERVER: ghost-dev:4173

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,60 @@
+{
+    "name": "Ghost",
+    "dockerComposeFile": [
+        "../compose.dev.yaml",
+        "compose.devcontainer.yaml"
+    ],
+    "service": "ghost-dev",
+    "workspaceFolder": "/workspaces/Ghost",
+    "shutdownAction": "stopCompose",
+    "remoteUser": "root",
+
+    // Codespaces prebuild step — runs once when the image is built.
+    // Primes the pnpm store so first-open is fast.
+    "onCreateCommand": "corepack enable && corepack prepare --activate && cd /workspaces/Ghost && pnpm install --prefer-offline || true",
+
+    // Runs after the workspace mount is ready on every container create.
+    "postCreateCommand": ".devcontainer/postCreate.sh",
+
+    "forwardPorts": [
+        2368,
+        3306,
+        6379,
+        1025,
+        8025,
+        5174,
+        4200,
+        4175,
+        7173,
+        6174,
+        4178,
+        4177,
+        4173
+    ],
+    "portsAttributes": {
+        "2368": {"label": "Ghost (via gateway)", "onAutoForward": "notify"},
+        "3306": {"label": "MySQL"},
+        "6379": {"label": "Redis"},
+        "1025": {"label": "Mailpit SMTP"},
+        "8025": {"label": "Mailpit Web"},
+        "5174": {"label": "Admin (Vite)"},
+        "4200": {"label": "Ember live-reload"},
+        "4175": {"label": "Portal"},
+        "7173": {"label": "Comments UI"},
+        "6174": {"label": "Signup Form"},
+        "4178": {"label": "Sodo Search"},
+        "4177": {"label": "Announcement Bar"},
+        "4173": {"label": "Koenig Lexical"}
+    },
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "bradlc.vscode-tailwindcss",
+                "ms-playwright.playwright",
+                "editorconfig.editorconfig"
+            ]
+        }
+    }
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspaces/Ghost
+
+corepack enable
+corepack prepare --activate
+
+git submodule update --init --recursive
+
+pnpm install --prefer-offline


### PR DESCRIPTION
## Summary

First of a planned series of PRs adding VS Code Dev Containers + Codespaces support to Ghost. This PR is the minimum viable spike: with the Dev Containers extension installed, contributors can **Reopen in Container** locally, or open the repo in a **Codespace**, and get a working Ghost dev environment without touching host Node/pnpm/MySQL.

**Baseline behaviour is unchanged.** The existing `pnpm dev` host-hybrid workflow is not affected — the devcontainer is purely additive.

### What's here

- `.devcontainer/devcontainer.json` — compose-based config attaching to the existing `ghost-dev` service, workspace at `/workspaces/Ghost`, Codespaces prebuild hook, forwarded ports for Ghost + all Vite dev servers, recommended extensions pared down to the four the repo actually uses (eslint, tailwindcss, playwright, editorconfig).
- `.devcontainer/compose.devcontainer.yaml` — overlay on top of `compose.dev.yaml` that:
  - Mounts the full repo at `/workspaces/Ghost` (alongside the preserved `./ghost:/home/ghost/ghost` mount so nodemon hot-reload still works).
  - Points Caddy's `*_DEV_SERVER` env vars at `ghost-dev:<port>` instead of `host.docker.internal:<port>`, collapsing the host/container split so frontend Vite servers can run inside the container.
  - Overrides the `ghost-dev` command to `sleep infinity` and the healthcheck to a trivial pass, so VS Code controls startup (the user starts backend + frontends manually for now — auto-start arrives in PR 2, and dropping the `sleep infinity` override in favour of the baseline command arrives in PR 3).
- `.devcontainer/postCreate.sh` — enables corepack, initialises submodules, runs `pnpm install`.

### Known limitations of this PR (addressed in follow-ups)

- **Auto-start is not yet shareable.** `.vscode/tasks.json` and `.vscode/extensions.json` are blocked by `.gitignore:72` (`.vscode/*`); next PR un-ignores them, adds a `runOn: folderOpen` Full dev stack task, and recommends the Dev Containers extension on host.
- Backend and frontends must be started manually after attach (`pnpm --filter ghost dev` + the Nx run-many for frontends).
- `sleep infinity` override will be removed in PR 3 in favour of the baseline image's auto-start command, once PR 2 makes the companion task shareable.
- No Codespaces prebuild image yet — first attach on a Codespace runs a full `docker build` + `pnpm install` (~5–8 min). Prebuilt `ghcr.io` image lands in PR 5.
- No CI validation of the devcontainer itself — smoke test lands in PR 6.

## Test plan

- [ ] **macOS / OrbStack**: `Reopen in Container` succeeds; all 5 compose services (mysql, redis, mailpit, ghost-dev, gateway) report healthy.
- [ ] Inside the container: `pnpm --filter ghost dev &` + the Nx frontend run-many → `curl http://localhost:2368/ghost/api/admin/site/` returns 200 within 60s.
- [ ] Host browser: `http://localhost:2368/ghost/` loads admin after the manual start.
- [ ] `http://localhost:8025` reaches Mailpit through the forwarded port.
- [ ] **Codespaces on this branch**: create a codespace → `pnpm install` completes → manual dev stack start works end-to-end.
- [ ] Baseline `pnpm dev` on host still works unchanged when run from a fresh clone (overlay is opt-in via devcontainer attach).