### PR TITLE
Published ghost-devcontainer image to GHCR on main merges

### DIFF
--- a/.devcontainer/compose.devcontainer.yaml
+++ b/.devcontainer/compose.devcontainer.yaml
@@ -1,4 +1,19 @@
 services:
+  mysql:
+    # Smaller InnoDB buffer pool than the baseline compose.dev.yaml (1G).
+    # Lets the dev stack stay within a 2-core / 8 GB Codespace's budget
+    # after Ghost + 6 Vite dev servers are running. 256 MB is plenty for
+    # dev data volumes.
+    command: --innodb-buffer-pool-size=256M --innodb-log-buffer-size=64M --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
+    mem_limit: 512m
+    restart: unless-stopped
+
+  redis:
+    restart: unless-stopped
+
+  mailpit:
+    restart: unless-stopped
+
   ghost-dev:
     # Mount the full repo so VS Code can edit apps/, e2e/, and root config files.
     # The original ./ghost:/home/ghost/ghost mount from compose.dev.yaml is

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,16 @@
     "shutdownAction": "stopCompose",
     "remoteUser": "root",
 
+    // Installs docker CLI and mounts the host docker socket into ghost-dev so
+    // developers can run `docker ps / logs / inspect / exec` against peer
+    // compose services (mysql, redis, mailpit, gateway) from inside the dev
+    // container. Without this, diagnosing any compose-peer failure requires
+    // SSHing to the Codespaces host, which our image doesn't support out of
+    // the box.
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    },
+
     // Codespaces prebuild step — runs once when the image is built.
     // Primes the pnpm store so first-open is fast.
     "onCreateCommand": "corepack enable && corepack prepare --activate && cd /workspaces/Ghost && pnpm install --prefer-offline || true",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,14 @@
     // container. Without this, diagnosing any compose-peer failure requires
     // SSHing to the Codespaces host, which our image doesn't support out of
     // the box.
+    //
+    // Security note: mounting the host's docker socket combined with
+    // `remoteUser: "root"` effectively gives the dev container root-equivalent
+    // control over the host Docker daemon (spawn privileged containers, mount
+    // host paths, etc.). This is the standard pattern for local / Codespaces
+    // dev containers where the host is the developer's own machine, but do
+    // NOT replicate this pattern in shared build agents, CI runners, or
+    // environments where untrusted code runs in the container.
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,12 @@
     // Runs after the workspace mount is ready on every container create.
     "postCreateCommand": ".devcontainer/postCreate.sh",
 
+    // Runs whenever VS Code attaches to the container. Fires only inside the
+    // container, so this is safe (unlike a tasks.json runOn: folderOpen which
+    // also fires on host VS Code where node_modules doesn't exist yet).
+    // The script guards against double-starting if the stack is already up.
+    "postAttachCommand": "bash .devcontainer/start-dev-stack.sh",
+
     "forwardPorts": [
         2368,
         3306,

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -9,3 +9,9 @@ corepack prepare --activate
 git submodule update --init --recursive
 
 pnpm install --prefer-offline
+
+# Build internal @tryghost/* workspace packages that ghost/core imports at
+# runtime (e.g. @tryghost/parse-email-address's "main": "build/index.js").
+# On host, `pnpm dev` triggers these via Nx dependsOn cascades; inside the
+# devcontainer we invoke workspace dev scripts directly, so we pre-build.
+pnpm build

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -10,8 +10,14 @@ git submodule update --init --recursive
 
 pnpm install --prefer-offline
 
-# Build internal @tryghost/* workspace packages that ghost/core imports at
-# runtime (e.g. @tryghost/parse-email-address's "main": "build/index.js").
-# On host, `pnpm dev` triggers these via Nx dependsOn cascades; inside the
-# devcontainer we invoke workspace dev scripts directly, so we pre-build.
-pnpm build
+# Build workspace packages that ghost/core imports at runtime with build
+# outputs (not source). @tryghost/parse-email-address is the only one today
+# — its package.json "main" points at build/index.js, so the backend can't
+# import it on a fresh clone until it's compiled.
+# On host, `pnpm dev` triggers this via Nx dependsOn cascades; inside the
+# devcontainer we invoke `pnpm --filter ghost dev` directly, which bypasses
+# those cascades.
+# Frontend apps (admin, posts, stats, activitypub, etc.) do NOT need
+# pre-building here — their own dev targets handle it when start-dev-stack.sh
+# runs `nx run-many -t dev`.
+pnpm --filter @tryghost/parse-email-address build

--- a/.devcontainer/start-dev-stack.sh
+++ b/.devcontainer/start-dev-stack.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspaces/Ghost
+
+# Skip if backend is already bound to port 2368 — avoids double-starting on
+# VS Code reload/re-attach. The subshell isolates bash's noisy
+# "connection refused" message on first run when nothing's listening yet.
+if (exec 3<>/dev/tcp/127.0.0.1/2368) 2>/dev/null; then
+    echo "Ghost dev stack already running on :2368, skipping start."
+    exit 0
+fi
+
+echo "Starting Ghost dev stack..."
+
+nohup pnpm --filter ghost dev > /tmp/ghost-backend.log 2>&1 &
+disown
+
+nohup pnpm nx run-many -t dev \
+    --projects=@tryghost/admin,@tryghost/portal,@tryghost/comments-ui,@tryghost/signup-form,@tryghost/sodo-search,@tryghost/announcement-bar \
+    > /tmp/ghost-frontends.log 2>&1 &
+disown
+
+cat <<'MSG'
+Ghost dev stack starting in the background.
+
+  Backend log:  tail -f /tmp/ghost-backend.log
+  Frontend log: tail -f /tmp/ghost-frontends.log
+  Gateway:      http://localhost:2368/
+
+Give it ~30-60s, then open http://localhost:2368/ghost/ for admin.
+MSG

--- a/.devcontainer/start-dev-stack.sh
+++ b/.devcontainer/start-dev-stack.sh
@@ -13,12 +13,16 @@ fi
 
 echo "Starting Ghost dev stack..."
 
-nohup pnpm --filter ghost dev > /tmp/ghost-backend.log 2>&1 &
+# Append to log files (don't truncate) so previous crash tails survive a
+# restart and the user can still tail them for context.
+{ echo "=== $(date -Is) starting backend ==="; } >> /tmp/ghost-backend.log
+nohup pnpm --filter ghost dev >> /tmp/ghost-backend.log 2>&1 &
 disown
 
+{ echo "=== $(date -Is) starting frontends ==="; } >> /tmp/ghost-frontends.log
 nohup pnpm nx run-many -t dev \
     --projects=@tryghost/admin,@tryghost/portal,@tryghost/comments-ui,@tryghost/signup-form,@tryghost/sodo-search,@tryghost/announcement-bar \
-    > /tmp/ghost-frontends.log 2>&1 &
+    >> /tmp/ghost-frontends.log 2>&1 &
 disown
 
 cat <<'MSG'

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -1,0 +1,74 @@
+name: Publish ghost-devcontainer Image
+
+# Builds the dev container base image used by .devcontainer/devcontainer.json
+# (VS Code Dev Containers + GitHub Codespaces) and publishes it to GHCR on
+# merges to main. Publishing means a new Codespace or `Reopen in Container`
+# can pull the pre-built image (with pnpm already installed) instead of
+# building the Dockerfile from scratch — saving ~3–5 min of cold-start time.
+
+on:
+  workflow_dispatch: # manual trigger from the Actions UI / gh CLI
+  pull_request:
+    paths:
+      - 'docker/ghost-dev/**'
+      - '.github/workflows/devcontainer-build.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.npmrc'
+      - 'ghost/core/package.json'
+      - 'ghost/i18n/package.json'
+      - 'ghost/parse-email-address/package.json'
+  push:
+    branches: [main]
+    paths:
+      - 'docker/ghost-dev/**'
+      - '.github/workflows/devcontainer-build.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.npmrc'
+      - 'ghost/core/package.json'
+      - 'ghost/i18n/package.json'
+      - 'ghost/parse-email-address/package.json'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and push ghost-devcontainer to GHCR
+    runs-on: ubuntu-latest
+    if: github.repository == 'TryGhost/Ghost'
+    concurrency:
+      group: publish-ghost-devcontainer-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Login to GHCR
+        # Only log in when we're going to push, i.e. on push-to-main and
+        # workflow_dispatch. PR builds are validation-only.
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (PR) / Build and push (main)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: docker/ghost-dev/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/tryghost/ghost-devcontainer:latest
+            ghcr.io/tryghost/ghost-devcontainer:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,7 @@
+# Paths Nx should exclude from the project graph and `nx --affected`
+# computation. Without this, Nx's default "unknown files affect everything"
+# behaviour makes Lint, Unit tests, and per-app Build jobs run on PRs that
+# only touch dev-tooling files. Pairs with the `any-code` path filter in
+# .github/workflows/ci.yml, which also excludes these paths.
+.devcontainer/
+.vscode/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,8 +27,7 @@
             ],
             "dependsOrder": "parallel",
             "problemMatcher": [],
-            "group": {"kind": "build", "isDefault": true},
-            "runOptions": {"runOn": "folderOpen"}
+            "group": {"kind": "build", "isDefault": true}
         },
         {
             "label": "Ghost: Reset data (empty)",


### PR DESCRIPTION
## Summary

Stacks on **#27547** (pending merge). First piece of the Codespaces cold-start optimisation work from `DEVCONTAINER-FOLLOWUPS.md` (F1).

Adds `.github/workflows/devcontainer-build.yml` — a GHA workflow that builds `docker/ghost-dev/Dockerfile` and publishes the result to `ghcr.io/tryghost/ghost-devcontainer:{latest,<sha>}` on merges to `main`. The published image is the prerequisite for switching `.devcontainer/devcontainer.json` to an `image:` reference, which would drop a fresh Codespace's cold start from the current ~5–10 min (image build + pnpm install) to ~30–60 s (image pull).

### What's here

- **`.github/workflows/devcontainer-build.yml`** — new workflow, patterned exactly on the existing `.github/workflows/publish-tb-cli.yml`:
  - Buildx with the same pinned SHA
  - GHCR login via `GITHUB_TOKEN`
  - Tags: `:latest` and `:${{ github.sha }}`
  - GHA cache backend so successive builds are incremental
  - `if: github.repository == 'TryGhost/Ghost'` to skip on forks / mirrors
  - Concurrency group to avoid overlapping pushes

### What's NOT here (deliberate)

- **No change to `.devcontainer/devcontainer.json`.** Switching that file to `image: ghcr.io/tryghost/ghost-devcontainer:latest` only makes sense once the image actually exists in the registry. A small follow-up PR will flip it after the first successful main push runs this workflow.
- **Single-arch (linux/amd64).** Matches `publish-tb-cli.yml`'s convention and covers GitHub Codespaces (x86). Multi-arch (`linux/arm64` for native M-series Mac Docker) is a deliberate follow-up once this pipeline proves stable — introducing `docker/setup-qemu-action` is a new-to-repo action and worth its own review.
- **No baked `pnpm build` for `@tryghost/parse-email-address`.** Turns out it wouldn't help: the build output would live at `/home/ghost/ghost/parse-email-address/build` inside the image, but the compose bind-mount `./ghost:/home/ghost/ghost` shadows that at runtime with the host's directory. Keeping the build step in `postCreate.sh` (where it writes to the bind-mounted location).

### Path triggers

The workflow fires on changes to:

- `docker/ghost-dev/**` — the Dockerfile and its entrypoint
- `.github/workflows/devcontainer-build.yml` — this workflow itself
- `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc` — anything `pnpm install` cares about
- `ghost/core/package.json`, `ghost/i18n/package.json`, `ghost/parse-email-address/package.json` — the three workspace manifests the Dockerfile COPYs at build time

Changes outside those paths leave the image alone. `postCreate.sh`'s `pnpm install --prefer-offline` reconciles any lockfile drift at first-attach time, so a slightly-stale image is still correct — just slower.

## Test plan

- [ ] **PR run**: this PR's own CI should exercise the build path (no push). Workflow shows green with a `Build (PR)` step log.
- [ ] **After #27547 + this PR merge to main**: the workflow triggers on the merge commit and the `:latest` + `:<sha>` tags appear at `https://github.com/TryGhost/Ghost/pkgs/container/ghost-devcontainer`.
- [ ] **Pull test from a fresh machine**: `docker pull ghcr.io/tryghost/ghost-devcontainer:latest` succeeds.
- [ ] **Follow-up PR** switches `.devcontainer/devcontainer.json` to reference the image; Codespace cold-start time measurably drops (target: <60 s).
- [ ] **No unintended triggers**: change an unrelated file (e.g., `apps/admin/src/App.tsx`) in a test PR and verify this workflow does NOT run.

## After this merges

Next two follow-ups in sequence from the followups doc:

- **Switch `devcontainer.json` to `image:` reference** — the PR that actually cashes the cold-start saving.
- **Enable Codespaces prebuilds** on `main` in repo Settings → Codespaces → Prebuild configurations. No code change required; it's a GitHub toggle that caches the post-postCreate VM state for snapshot-on-clone. Pairs with this workflow to get cold start to ~30 s.