### PR TITLE
🐛 Fixed Gmail inbox links 404 for Workspace and signed-out users

### DIFF
--- a/ghost/core/core/server/lib/get-inbox-links.ts
+++ b/ghost/core/core/server/lib/get-inbox-links.ts
@@ -61,18 +61,19 @@ const buildUrl = (baseHref: string, key: string, value: string): string => {
     return result.toString();
 };
 
-const encodeRecipientForGmailUrl = (recipient: string) => (
-    encodeURIComponent(recipient).replaceAll('%40', '@')
-);
-
 const PROVIDERS: ReadonlyArray<Provider> = [
     {
         name: 'gmail',
         domains: ['gmail.com', 'googlemail.com', 'google.com'],
+        // Gmail's `/mail/u/<X>/` path expects a numeric account index. Passing a
+        // raw email only resolves when that account happens to be signed in at
+        // that slot; Workspace accounts and signed-out users hit a 404 before
+        // the `#search` fragment runs. `authuser` is Gmail's own account
+        // resolver and falls through to sign-in instead of erroring.
         getDesktopLink: ({recipient, sender}) => (
-            `https://mail.google.com/mail/u/${encodeRecipientForGmailUrl(
+            `https://mail.google.com/mail/u/0/?authuser=${encodeURIComponent(
                 recipient
-            )}/#search/from%3A(${encodeURIComponent(
+            )}#search/from%3A(${encodeURIComponent(
                 sender
             )})+in%3Aanywhere+newer_than%3A1h`
         ),

--- a/ghost/core/test/unit/server/lib/get-inbox-links.test.ts
+++ b/ghost/core/test/unit/server/lib/get-inbox-links.test.ts
@@ -41,8 +41,8 @@ describe('getInboxLinks', function () {
                 dnsResolver: resolverThatShouldNeverBeUsed
             });
             assert.equal(result?.provider, 'gmail');
-            assert(result?.desktop.startsWith('https://mail.google.com/'));
-            assert(result?.desktop.includes(recipient));
+            assert(result?.desktop.startsWith('https://mail.google.com/mail/u/0/'));
+            assert(result?.desktop.includes(`authuser=${encodeURIComponent(recipient)}`));
             assert(result?.desktop.includes(encodeURIComponent('sender@example.com')));
             assert(result?.android.startsWith('intent:'));
             assert(result?.android.includes('com.google.android.gm'));
@@ -54,7 +54,7 @@ describe('getInboxLinks', function () {
             sender: 'sendér@example.com',
             dnsResolver: resolverThatShouldNeverBeUsed
         });
-        assert(nonAsciiResult?.desktop.includes('exampl%C3%A9@gmail.com'));
+        assert(nonAsciiResult?.desktop.includes(`authuser=${encodeURIComponent('examplé@gmail.com')}`));
         assert(nonAsciiResult?.desktop.includes(encodeURIComponent('sendér@example.com')));
     });
 


### PR DESCRIPTION
## Problem

The "Open in Gmail" link we show to members right after signup is returning an error page platform-wide. It's been working for years, but Gmail appears to have tightened the URL format it accepts, and the pattern we'd been using now dead-ends for Google Workspace accounts and for anyone who isn't already signed into the right Gmail account at the moment they click — which is most new subscribers. The result is a broken first impression right when the reader is trying to confirm their email, and measurably worse conversion across every Ghost site.

## Solution

Switch to Gmail's currently-supported deep-link shape, which routes the reader through sign-in when needed and then lands them on the search for the confirmation email. Behaviour for already-signed-in readers is unchanged.