### PR TITLE
Fixed dark mode fade effect on ActivityPub onboarding cards

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.36",
+  "version": "3.1.37",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/layout/onboarding/step-2.tsx
+++ b/apps/activitypub/src/components/layout/onboarding/step-2.tsx
@@ -83,7 +83,7 @@ const Step2: React.FC = () => {
                 <Button className='min-w-60 bg-gradient-to-r from-purple-500 to-[#6A1AD6] hover:opacity-90 dark:text-white' size='lg' onClick={() => navigate('/welcome/3')}>Next &rarr;</Button>
             </Header>
             <div className='mt-8 flex h-full max-h-[670px] flex-col items-stretch justify-end'>
-                <div className='relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden px-14 pt-8'>
+                <div className='relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden px-14 pt-8' style={{maskImage: 'linear-gradient(to bottom, black 80%, transparent 100%)', WebkitMaskImage: 'linear-gradient(to bottom, black 80%, transparent 100%)'}}>
                     <div className='relative mx-auto h-[694px] w-full max-w-xl rounded-2xl border border-gray-200/70 bg-white shadow-xl dark:border-gray-900 dark:bg-[#101114] dark:shadow-xl dark:shadow-[#1e1b4b]/10'>
                         <div className='animate-onboarding-followers absolute -top-4 -right-8 flex h-8 items-center gap-1.5 rounded-full bg-gradient-to-t from-black to-gray-900 px-3 font-semibold text-white opacity-0'>
                             <LucideIcon.TrendingUp size={18} />
@@ -154,7 +154,6 @@ const Step2: React.FC = () => {
                             </Reaction>
                         </div>
                     </div>
-                    <div className='absolute inset-x-0 bottom-0 h-18 bg-gradient-to-t from-white via-[rgba(255,255,255,0.71)] to-[rgba(255,255,255,0)] dark:from-black dark:via-[rgba(0,0,0,0.71)] dark:to-[rgba(0,0,0,0)]'></div>
                 </div>
             </div>
         </div>

--- a/apps/activitypub/src/components/layout/onboarding/step-2.tsx
+++ b/apps/activitypub/src/components/layout/onboarding/step-2.tsx
@@ -83,7 +83,7 @@ const Step2: React.FC = () => {
                 <Button className='min-w-60 bg-gradient-to-r from-purple-500 to-[#6A1AD6] hover:opacity-90 dark:text-white' size='lg' onClick={() => navigate('/welcome/3')}>Next &rarr;</Button>
             </Header>
             <div className='mt-8 flex h-full max-h-[670px] flex-col items-stretch justify-end'>
-                <div className='relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden px-14 pt-8' style={{maskImage: 'linear-gradient(to bottom, black 80%, transparent 100%)', WebkitMaskImage: 'linear-gradient(to bottom, black 80%, transparent 100%)'}}>
+                <div className='relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden mask-b-from-80% px-14 pt-8'>
                     <div className='relative mx-auto h-[694px] w-full max-w-xl rounded-2xl border border-gray-200/70 bg-white shadow-xl dark:border-gray-900 dark:bg-[#101114] dark:shadow-xl dark:shadow-[#1e1b4b]/10'>
                         <div className='animate-onboarding-followers absolute -top-4 -right-8 flex h-8 items-center gap-1.5 rounded-full bg-gradient-to-t from-black to-gray-900 px-3 font-semibold text-white opacity-0'>
                             <LucideIcon.TrendingUp size={18} />

--- a/apps/activitypub/src/components/layout/onboarding/step-3.tsx
+++ b/apps/activitypub/src/components/layout/onboarding/step-3.tsx
@@ -371,7 +371,7 @@ const Step3: React.FC = () => {
                         Integrated reader
                     </TabButton>
                 </div>
-                <div className='pointer-events-none relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden px-14'>
+                <div className='pointer-events-none relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden px-14' style={{maskImage: 'linear-gradient(to bottom, black 80%, transparent 100%)', WebkitMaskImage: 'linear-gradient(to bottom, black 80%, transparent 100%)'}}>
                     <div className='mx-auto h-[694px] w-full max-w-6xl overflow-hidden rounded-md bg-white shadow-xl dark:bg-[#101114]'>
                         <div className='flex h-5 w-full items-center gap-1.5 bg-gray-100 pl-2 dark:bg-gray-950'>
                             <div className='size-2 rounded-full bg-gray-300'></div>
@@ -384,7 +384,6 @@ const Step3: React.FC = () => {
                             {activeTab === 3 && <Reader />}
                         </div>
                     </div>
-                    <div className='absolute inset-x-0 bottom-0 h-18 bg-gradient-to-t from-white via-[rgba(255,255,255,0.71)] to-[rgba(255,255,255,0)] dark:from-black dark:via-[rgba(0,0,0,0.71)] dark:to-[rgba(0,0,0,0)]'></div>
                 </div>
             </div>
         </div>

--- a/apps/activitypub/src/components/layout/onboarding/step-3.tsx
+++ b/apps/activitypub/src/components/layout/onboarding/step-3.tsx
@@ -371,7 +371,7 @@ const Step3: React.FC = () => {
                         Integrated reader
                     </TabButton>
                 </div>
-                <div className='pointer-events-none relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden px-14' style={{maskImage: 'linear-gradient(to bottom, black 80%, transparent 100%)', WebkitMaskImage: 'linear-gradient(to bottom, black 80%, transparent 100%)'}}>
+                <div className='pointer-events-none relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden mask-b-from-80% px-14'>
                     <div className='mx-auto h-[694px] w-full max-w-6xl overflow-hidden rounded-md bg-white shadow-xl dark:bg-[#101114]'>
                         <div className='flex h-5 w-full items-center gap-1.5 bg-gray-100 pl-2 dark:bg-gray-950'>
                             <div className='size-2 rounded-full bg-gray-300'></div>


### PR DESCRIPTION
## What

Replaced the hardcoded gradient overlay on the ActivityPub onboarding cards (steps 2 and 3) with a CSS `mask-image` on the container.

## Why

In dark mode, the gradient overlay fades from pure `black`, but the card background is `#101114`. This mismatch creates a visible dark band at the bottom of the card instead of a smooth fade.

In light mode the gradient fades from `white` which matches the card background, so the issue is only visible in dark mode.

<img width="2211" height="1383" alt="Screenshot 2026-04-24 at 23 59 46" src="https://github.com/user-attachments/assets/8be97900-e84b-42dc-a86e-84144f30df31" />

## How

Instead of an overlay div with hardcoded colors, the container now uses `mask-image: linear-gradient(to bottom, black 80%, transparent 100%)`. This fades the content itself to transparent, letting the card's own background show through naturally — works correctly in both light and dark modes without any color matching.

- [x] I've read and followed the [Contributor
Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

No automated test added — this is a visual CSS fix. Can be verified by toggling dark mode on the Network onboarding screen (steps 2 and 3).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only CSS change that replaces a gradient overlay with a `mask-image`; main risk is minor cross-browser rendering differences for CSS masking.
> 
> **Overview**
> Fixes the bottom fade on the ActivityPub onboarding preview cards (steps 2 and 3), especially in dark mode.
> 
> Replaces the hardcoded gradient overlay element with a container-level CSS `mask-image`/`-webkit-mask-image` linear gradient so the card content itself fades out smoothly regardless of background color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c3b625640212a7cd2d19fdb506fe05f76255a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->