### PR TITLE
Replaced dark mode toggle with light/dark/system pill selector

### DIFF
--- a/apps/admin/src/hooks/use-theme.ts
+++ b/apps/admin/src/hooks/use-theme.ts
@@ -1,0 +1,32 @@
+import {useEffect, useState} from 'react';
+import {useUserPreferences, useEditUserPreferences} from '@/hooks/user-preferences';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+function getSystemTheme(): 'dark' | 'light' {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function useTheme() {
+    const {data: preferences} = useUserPreferences();
+    const {mutateAsync: editPreferences} = useEditUserPreferences();
+
+    const theme: ThemeMode = preferences?.nightShift ?? 'system';
+
+    const [systemTheme, setSystemTheme] = useState<'dark' | 'light'>(getSystemTheme);
+
+    useEffect(() => {
+        const mq = window.matchMedia('(prefers-color-scheme: dark)');
+        const handler = (e: MediaQueryListEvent) => setSystemTheme(e.matches ? 'dark' : 'light');
+        mq.addEventListener('change', handler);
+        return () => mq.removeEventListener('change', handler);
+    }, []);
+
+    const resolvedTheme: 'dark' | 'light' = theme !== 'system' ? theme : systemTheme;
+
+    const setTheme = (mode: ThemeMode) => {
+        void editPreferences({nightShift: mode});
+    };
+
+    return {theme, resolvedTheme, setTheme} as const;
+}

--- a/apps/admin/src/hooks/use-theme.ts
+++ b/apps/admin/src/hooks/use-theme.ts
@@ -9,7 +9,7 @@ function getSystemTheme(): 'dark' | 'light' {
 
 export function useTheme() {
     const {data: preferences} = useUserPreferences();
-    const {mutateAsync: editPreferences} = useEditUserPreferences();
+    const {mutate: editPreferences} = useEditUserPreferences();
 
     const theme: ThemeMode = preferences?.nightShift ?? 'system';
 
@@ -25,7 +25,7 @@ export function useTheme() {
     const resolvedTheme: 'dark' | 'light' = theme !== 'system' ? theme : systemTheme;
 
     const setTheme = (mode: ThemeMode) => {
-        void editPreferences({nightShift: mode});
+        editPreferences({nightShift: mode});
     };
 
     return {theme, resolvedTheme, setTheme} as const;

--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -29,6 +29,7 @@ const fixtures = {
         setting: "value",
     },
     defaults: {
+        nightShift: 'system',
         navigation: DEFAULT_NAVIGATION_PREFERENCES,
     }
 };
@@ -244,6 +245,64 @@ describe("useUserPreferences", () => {
         });
     });
 
+    describe("nightShift migration", () => {
+        queryTest("migrates legacy boolean true to 'dark'", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({ nightShift: true }),
+            });
+
+            expect(result.current.data?.nightShift).toBe('dark');
+        });
+
+        queryTest("migrates legacy boolean false to 'light'", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({ nightShift: false }),
+            });
+
+            expect(result.current.data?.nightShift).toBe('light');
+        });
+
+        queryTest("defaults to 'system' when nightShift is absent", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({}),
+            });
+
+            expect(result.current.data?.nightShift).toBe('system');
+        });
+
+        queryTest("preserves 'dark' string value", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({ nightShift: 'dark' }),
+            });
+
+            expect(result.current.data?.nightShift).toBe('dark');
+        });
+
+        queryTest("preserves 'light' string value", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({ nightShift: 'light' }),
+            });
+
+            expect(result.current.data?.nightShift).toBe('light');
+        });
+
+        queryTest("preserves 'system' string value", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({ nightShift: 'system' }),
+            });
+
+            expect(result.current.data?.nightShift).toBe('system');
+        });
+
+        queryTest("falls back to 'system' for invalid nightShift value", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({ nightShift: 'invalid' }),
+            });
+
+            expect(result.current.data?.nightShift).toBe('system');
+        });
+    });
+
     describe("query options", () => {
         queryTest("supports select option to transform data", async ({ server, wrapper }) => {
             server.use(
@@ -256,7 +315,7 @@ describe("useUserPreferences", () => {
                                     expanded: { posts: false },
                                     menu: { visible: true },
                                 },
-                                nightShift: true,
+                                nightShift: 'dark',
                             }),
                         }],
                     });
@@ -321,6 +380,7 @@ describe("useUserPreferences", () => {
 
             await waitFor(() => {
                 expect(result.current.query.data).toEqual({
+                    nightShift: 'system',
                     navigation: DEFAULT_NAVIGATION_PREFERENCES,
                     whatsNew: {
                         lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
@@ -342,6 +402,7 @@ describe("useUserPreferences", () => {
 
             await waitFor(() => {
                 expect(result.current.query.data).toEqual({
+                    nightShift: 'system',
                     navigation: {
                         ...DEFAULT_NAVIGATION_PREFERENCES,
                         expanded: {
@@ -423,7 +484,7 @@ describe("useEditUserPreferences", () => {
                         expanded: { posts: false, members: false },
                         menu: { visible: true },
                     },
-                    nightShift: true,
+                    nightShift: 'dark',
                 }),
             });
 
@@ -439,7 +500,7 @@ describe("useEditUserPreferences", () => {
                         expanded: { posts: true, members: false },
                         menu: { visible: true }, // Preserved
                     },
-                    nightShift: true, // Preserved
+                    nightShift: 'dark', // Preserved
                 });
             });
         });

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -51,7 +51,11 @@ export function useUserPreferences<TData = Preferences>(
             }
 
             const raw = user.accessibility || "{}";
-            const parsed = JSON.parse(raw) as Record<string, unknown>;
+            const parsedRaw: unknown = JSON.parse(raw);
+            const parsed: Record<string, unknown> =
+                parsedRaw && typeof parsedRaw === 'object' && !Array.isArray(parsedRaw)
+                    ? parsedRaw as Record<string, unknown>
+                    : {};
 
             if (parsed.nightShift === true) {
                 parsed.nightShift = 'dark';

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -27,7 +27,7 @@ export const NavigationPreferencesSchema = z.looseObject({
 
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
-    nightShift: z.boolean().optional(),
+    nightShift: z.enum(['light', 'dark', 'system']).default('system').catch('system'),
     navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(DEFAULT_NAVIGATION_PREFERENCES),
 });
 
@@ -51,7 +51,13 @@ export function useUserPreferences<TData = Preferences>(
             }
 
             const raw = user.accessibility || "{}";
-            const parsed = JSON.parse(raw) as unknown;
+            const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+            if (parsed.nightShift === true) {
+                parsed.nightShift = 'dark';
+            } else if (parsed.nightShift === false) {
+                parsed.nightShift = 'light';
+            }
 
             return PreferencesSchema.parse(parsed);
         },

--- a/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import {getFeaturebaseToken} from '@tryghost/admin-x-framework';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useFeatureFlag} from '@/hooks/use-feature-flag';
-import {useUserPreferences} from '@/hooks/user-preferences';
+import {useTheme} from '@/hooks/use-theme';
 import {deferred, type Deferred} from '@/utils/deferred';
 
 type FeaturebaseCallback = (err: unknown, data?: unknown) => void;
@@ -56,13 +56,12 @@ interface Featurebase {
  */
 export function useFeaturebase(): Featurebase {
     const {data: config} = useBrowseConfig();
-    const {data: preferences} = useUserPreferences();
+    const {resolvedTheme: theme} = useTheme();
     const featureFlagEnabled = useFeatureFlag('featurebaseFeedback');
     const [shouldLoad, setShouldLoad] = useState(false);
 
     const {organization, enabled} = config?.config.featurebase ?? {};
     const featurebaseEnabled = !!(featureFlagEnabled && enabled);
-    const theme = preferences?.nightShift ? 'dark' : 'light';
 
     // Token is only fetched once shouldLoad becomes true (on user interaction)
     const {data: tokenData} = getFeaturebaseToken({

--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 
-import {DropdownMenu, DropdownMenuContent, DropdownMenuSeparator, DropdownMenuTrigger, Indicator, SidebarMenuButton, Switch} from "@tryghost/shade/components"
-import {LucideIcon} from "@tryghost/shade/utils"
+import {DropdownMenu, DropdownMenuContent, DropdownMenuSeparator, DropdownMenuTrigger, Indicator, SidebarMenuButton} from "@tryghost/shade/components"
+import {cn, LucideIcon} from "@tryghost/shade/utils"
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { getGhostPaths } from "@tryghost/admin-x-framework/helpers";
-import { useUserPreferences, useEditUserPreferences } from "@/hooks/user-preferences";
+import { useTheme, type ThemeMode } from "@/hooks/use-theme";
 import { useWhatsNew } from "@/whats-new/hooks/use-whats-new";
 import { useUpgradeStatus } from "./hooks/use-upgrade-status";
 import { useBrowseSite } from "@tryghost/admin-x-framework/api/site";
@@ -26,33 +26,49 @@ function UserMenuProfile() {
     );
 }
 
-function UserMenuDarkMode() {
-    const {data: preferences} = useUserPreferences();
-    const {mutateAsync: editPreferences, isLoading: isEditingPreferences} = useEditUserPreferences();
+const THEME_OPTIONS: Array<{value: ThemeMode; Icon: typeof LucideIcon.Sun; label: string}> = [
+    {value: 'light', Icon: LucideIcon.Sun, label: 'Light'},
+    {value: 'system', Icon: LucideIcon.Monitor, label: 'System'},
+    {value: 'dark', Icon: LucideIcon.Moon, label: 'Dark'},
+];
 
-    const setNightShift = (nightShift: boolean) => {
-        void editPreferences({nightShift});
-    };
+function UserMenuDarkMode() {
+    const {theme, setTheme} = useTheme();
+
+    const activeIndex = THEME_OPTIONS.findIndex(o => o.value === theme);
 
     return (
-        <UserMenuItem
-            asChild={false}
-            onSelect={(e: Event) => {
-                e.preventDefault();
-                setNightShift(!preferences?.nightShift);
-            }}
-        >
-            <LucideIcon.Moon />
-            <UserMenuItem.Label className="flex-1">Dark mode</UserMenuItem.Label>
-            <Switch
-                size='sm'
-                checked={preferences?.nightShift ?? false}
-                disabled={isEditingPreferences}
-                onCheckedChange={setNightShift}
-                onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
-                tabIndex={-1}
-            />
-        </UserMenuItem>
+        <div className="px-2 py-1.5">
+            <div className="relative flex items-center rounded-full bg-muted p-[3px]">
+                <div
+                    className="absolute top-[3px] bottom-[3px] rounded-full bg-background shadow-xs transition-[left] duration-200"
+                    style={{
+                        width: 'calc((100% - 6px) / 3)',
+                        left: `calc(3px + ${activeIndex} * (100% - 6px) / 3)`,
+                    }}
+                />
+                {THEME_OPTIONS.map(({value, Icon, label}) => (
+                    <button
+                        key={value}
+                        type="button"
+                        className={cn(
+                            'relative z-10 flex flex-1 items-center justify-center gap-1 rounded-full py-[5px] text-xs font-medium transition-colors duration-150',
+                            theme === value
+                                ? 'text-foreground'
+                                : 'text-muted-foreground hover:text-foreground'
+                        )}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            setTheme(value);
+                        }}
+                        aria-label={`${label} theme`}
+                    >
+                        <Icon className="size-3.5 stroke-[1.5px]" />
+                        <span>{label}</span>
+                    </button>
+                ))}
+            </div>
+        </div>
     );
 }
 

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -36,7 +36,9 @@ export class SidebarPage extends AdminPage {
     public readonly sidebar: Locator;
     public readonly postsToggle: Locator;
     public readonly userDropdownTrigger: Locator;
-    public readonly nightShiftToggle: Locator;
+    public readonly themeLightButton: Locator;
+    public readonly themeSystemButton: Locator;
+    public readonly themeDarkButton: Locator;
     public readonly whatsNewButton: Locator;
     public readonly userProfileLink: Locator;
     public readonly signOutLink: Locator;
@@ -51,7 +53,9 @@ export class SidebarPage extends AdminPage {
         this.sidebar = page.getByRole('navigation');
         this.postsToggle = this.sidebar.getByRole('button', {name: /toggle post views/i});
         this.userDropdownTrigger = page.locator('[data-test-nav="arrow-down"]');
-        this.nightShiftToggle = page.getByRole('menuitem', {name: /dark mode/i}).getByRole('switch');
+        this.themeLightButton = page.getByRole('button', {name: /light theme/i});
+        this.themeSystemButton = page.getByRole('button', {name: /system theme/i});
+        this.themeDarkButton = page.getByRole('button', {name: /dark theme/i});
         this.whatsNewButton = page.getByRole('menuitem', {name: /what's new/i});
         this.userProfileLink = page.getByRole('menuitem', {name: /your profile/i});
         this.signOutLink = page.getByRole('menuitem', {name: /sign out/i});
@@ -89,15 +93,11 @@ export class SidebarPage extends AdminPage {
         }
     }
 
-    async isNightShiftEnabled(): Promise<boolean> {
-        const isChecked = await this.nightShiftToggle.getAttribute('aria-checked');
-        return isChecked === 'true';
-    }
-
-    async waitForNightShiftEnabled(enabled: boolean): Promise<void> {
-        const locator = enabled
-            ? this.page.locator('[aria-checked="true"]')
-            : this.page.locator('[aria-checked="false"]');
-        await locator.waitFor();
+    async waitForDarkMode(enabled: boolean): Promise<void> {
+        if (enabled) {
+            await this.page.locator('html.dark').waitFor();
+        } else {
+            await this.page.locator('html:not(.dark)').waitFor();
+        }
     }
 }

--- a/e2e/tests/admin/sidebar/navigation.test.ts
+++ b/e2e/tests/admin/sidebar/navigation.test.ts
@@ -140,6 +140,19 @@ test.describe('Ghost Admin - Sidebar Navigation', () => {
             await sidebar.waitForDarkMode(false);
         });
 
+        test('theme pill - switches to system mode from dark', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost');
+            await sidebar.userDropdownTrigger.click();
+
+            await sidebar.themeDarkButton.click();
+            await sidebar.waitForDarkMode(true);
+
+            await sidebar.themeSystemButton.click();
+            await expect(sidebar.themeSystemButton).toHaveAttribute('aria-label', /system/i);
+        });
+
         test('sign out link - is visible in dropdown', async ({page}) => {
             const sidebar = new SidebarPage(page);
 

--- a/e2e/tests/admin/sidebar/navigation.test.ts
+++ b/e2e/tests/admin/sidebar/navigation.test.ts
@@ -117,21 +117,27 @@ test.describe('Ghost Admin - Sidebar Navigation', () => {
             await expect(page).toHaveURL(/\/ghost\/#\/settings\/staff\//);
         });
 
-        test('night shift toggle - changes state on click', async ({page}) => {
+        test('theme pill - switches to dark mode', async ({page}) => {
             const sidebar = new SidebarPage(page);
 
             await sidebar.goto('/ghost');
             await sidebar.userDropdownTrigger.click();
 
-            const initialState = await sidebar.isNightShiftEnabled();
+            await sidebar.themeDarkButton.click();
+            await sidebar.waitForDarkMode(true);
+        });
 
-            await sidebar.nightShiftToggle.click();
+        test('theme pill - switches to light mode', async ({page}) => {
+            const sidebar = new SidebarPage(page);
 
-            const expectedState = !initialState;
-            await sidebar.waitForNightShiftEnabled(expectedState);
+            await sidebar.goto('/ghost');
+            await sidebar.userDropdownTrigger.click();
 
-            const newState = await sidebar.isNightShiftEnabled();
-            expect(newState).toBe(expectedState);
+            await sidebar.themeDarkButton.click();
+            await sidebar.waitForDarkMode(true);
+
+            await sidebar.themeLightButton.click();
+            await sidebar.waitForDarkMode(false);
         });
 
         test('sign out link - is visible in dropdown', async ({page}) => {

--- a/e2e/tests/admin/sidebar/navigation.test.ts
+++ b/e2e/tests/admin/sidebar/navigation.test.ts
@@ -150,7 +150,7 @@ test.describe('Ghost Admin - Sidebar Navigation', () => {
             await sidebar.waitForDarkMode(true);
 
             await sidebar.themeSystemButton.click();
-            await expect(sidebar.themeSystemButton).toHaveAttribute('aria-label', /system/i);
+            await sidebar.waitForDarkMode(false);
         });
 
         test('sign out link - is visible in dropdown', async ({page}) => {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -25,7 +25,7 @@ export function feature(name, options = {}) {
             return enabled;
         },
         set(key, value) {
-            this.update(key, value, options);
+            this.update(name, value, options);
 
             if (onChange) {
                 // value must be passed here because the value isn't set until
@@ -54,7 +54,18 @@ export default class FeatureService extends Service {
 
     // user-specific flags
     @feature('nightShift', {user: true, onChange: '_setAdminTheme'})
-        nightShift;
+        _nightShiftPref;
+
+    _osPrefersDark = false;
+
+    @computed('_nightShiftPref', '_osPrefersDark')
+    get nightShift() {
+        const pref = this._nightShiftPref;
+        if (pref === 'system' || pref === undefined || pref === null) {
+            return this._osPrefersDark;
+        }
+        return pref === 'dark' || pref === true;
+    }
 
     // user-specific referral invitation
     @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
@@ -137,21 +148,60 @@ export default class FeatureService extends Service {
         });
     }
 
-    _setAdminTheme(enabled) {
-        let nightShift = enabled;
+    _setAdminTheme(value) {
+        let mode = value;
 
-        if (typeof nightShift === 'undefined') {
-            nightShift = enabled || this.nightShift;
+        if (typeof mode === 'undefined') {
+            mode = this._nightShiftPref;
         }
 
-        document.documentElement.classList.toggle('dark', nightShift ?? false);
+        if (this._systemThemeListener) {
+            this._systemThemeMediaQuery?.removeEventListener('change', this._systemThemeListener);
+            this._systemThemeListener = null;
+            this._systemThemeMediaQuery = null;
+        }
+
+        if (mode === true) {
+            mode = 'dark';
+        } else if (mode === false) {
+            mode = 'light';
+        } else if (mode !== 'dark' && mode !== 'light' && mode !== 'system') {
+            mode = 'system';
+        }
+
+        let isDark;
+        if (mode === 'system') {
+            const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+            isDark = mediaQuery.matches;
+            set(this, '_osPrefersDark', isDark);
+
+            this._systemThemeMediaQuery = mediaQuery;
+            this._systemThemeListener = (e) => {
+                document.documentElement.classList.toggle('dark', e.matches);
+                $('link[title=dark]').prop('disabled', !e.matches);
+                set(this, '_osPrefersDark', e.matches);
+            };
+            mediaQuery.addEventListener('change', this._systemThemeListener);
+        } else {
+            isDark = mode === 'dark';
+        }
+
+        document.documentElement.classList.toggle('dark', isDark);
 
         return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
-            $('link[title=dark]').prop('disabled', !nightShift);
+            $('link[title=dark]').prop('disabled', !isDark);
         }).catch(() => {
-            //TODO: Also disable toggle from settings and Labs hover
             $('link[title=dark]').prop('disabled', true);
             document.documentElement.classList.remove('dark');
         });
+    }
+
+    willDestroy() {
+        super.willDestroy(...arguments);
+        if (this._systemThemeListener) {
+            this._systemThemeMediaQuery?.removeEventListener('change', this._systemThemeListener);
+            this._systemThemeListener = null;
+            this._systemThemeMediaQuery = null;
+        }
     }
 }


### PR DESCRIPTION
## Why?

The dark mode toggle only offered on/off. Users on macOS/Windows with scheduled dark mode had to manually switch every time they opened Ghost Admin. A "System" option that follows the OS preference is a standard expectation.

## What does it do?

<img width="286" height="230" alt="Screenshot 2026-04-25 at 01 00 27" src="https://github.com/user-attachments/assets/27ee99d2-d3e5-431d-80cf-3ccadec11bba" />

Replaces the binary dark mode Switch in the user menu with a tri-state segmented pill (Light / System / Dark). System is the default for new users. On the React side, a useTheme() hook (following the next-themes pattern) owns the matchMedia listener and exposes { theme, resolvedTheme, setTheme } — consumers never touch matchMedia themselves. On the Ember side, feature.nightShift continues returning a resolved boolean via a computed getter, so zero Ember consumer changes were needed.

## Why do Ghost users need this?

Every modern app (VS Code, GitHub, Linear) offers light/dark/system. Ghost users currently have to manually toggle dark mode even when their OS handles it automatically. This brings Ghost Admin in line with that expectation.

- [X] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [X] I've explained my change
- [x] I've written an automated test to prove my change works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI + preference-schema change that alters how theme state is stored/resolved and adds OS `matchMedia` listeners in both React and Ember; risk is mainly regressions in theme application/migration for existing users.
> 
> **Overview**
> Replaces the binary *Dark mode* toggle with a tri-state theme selector (Light / System / Dark) and introduces a shared React `useTheme()` hook that resolves `system` via `prefers-color-scheme` and persists changes to user preferences.
> 
> Updates `nightShift` preference storage from boolean to `'light' | 'dark' | 'system'` (defaulting to `'system'`), including migration of legacy boolean values during parsing plus expanded unit coverage. Consumers such as Featurebase now use `resolvedTheme` instead of inferring from a boolean.
> 
> On the Ember side, `feature.nightShift` is preserved as a resolved boolean via a computed getter while `_setAdminTheme` gains `system` handling with OS theme change listeners and proper cleanup; E2E sidebar tests are updated to exercise the new theme pill UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34e2b64912515655c76dfecbd96a1b63a11d4bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->