### PR TITLE
Initialized email address service synchronously

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -349,12 +349,12 @@ async function initServices() {
     const urlUtils = require('./shared/url-utils');
 
     // Initialize things that other services depend on first.
+    emailAddressService.init();
     const apiUrl = urlUtils.urlFor('api', {type: 'admin'}, true);
     const schedulerAdapter = createSchedulerAdapter();
     const [schedulerIntegration] = await Promise.all([
         getSchedulerIntegration(),
-        stripe.init(),
-        emailAddressService.init()
+        stripe.init()
     ]);
 
     await Promise.all([


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/27421#discussion_r3094858588

`emailAddressService.init()` was put in a `Promise.all` unnecessarily. Now it's just a regular function call.
