### PR TITLE
feat(url-service): lazy implementation behind config toggle (spike)

### DIFF
--- a/ghost/core/core/server/services/url/base-url-generator.js
+++ b/ghost/core/core/server/services/url/base-url-generator.js
@@ -1,0 +1,102 @@
+const nql = require('@tryghost/nql');
+const debug = require('@tryghost/debug')('services:url:base-generator');
+
+// @TODO: merge with filter plugin
+const EXPANSIONS = [{
+    key: 'author',
+    replacement: 'authors.slug'
+}, {
+    key: 'tags',
+    replacement: 'tags.slug'
+}, {
+    key: 'tag',
+    replacement: 'tags.slug'
+}, {
+    key: 'authors',
+    replacement: 'authors.slug'
+}, {
+    key: 'primary_tag',
+    replacement: 'primary_tag.slug'
+}, {
+    key: 'primary_author',
+    replacement: 'primary_author.slug'
+}];
+
+const PAGE_TO_TYPE_TRANSFORMER = nql.utils.mapKeyValues({
+    key: {
+        from: 'page',
+        to: 'type'
+    },
+    values: [{
+        from: false,
+        to: 'post'
+    }, {
+        from: true,
+        to: 'page'
+    }]
+});
+
+/**
+ * Shared base for URL generators (eager + lazy).
+ *
+ * Holds the immutable identity of a router's URL contribution: an identifier,
+ * a resource type, a permalink template, an optional NQL filter, and a
+ * registration position. The filter (if provided) is compiled once into an
+ * NQL query and exposed via `matches(resource)`.
+ *
+ * Subclasses add the strategy-specific behavior (queue/Urls integration for
+ * the eager path; on-demand generation + permalink reverse-matching for the
+ * lazy path).
+ */
+class BaseUrlGenerator {
+    /**
+     * @param {Object} options
+     * @param {string} options.identifier router ID reference
+     * @param {string} [options.filter] NQL filter string
+     * @param {string} options.resourceType e.g. 'posts', 'tags'
+     * @param {string} options.permalink permalink template
+     * @param {number} [options.position] position in the parent generator list
+     */
+    constructor({identifier, filter, resourceType, permalink, position}) {
+        this.identifier = identifier;
+        this.resourceType = resourceType;
+        this.permalink = permalink;
+        this.uid = position;
+
+        if (filter) {
+            this.filter = filter;
+            this.nql = nql(filter, {
+                expansions: EXPANSIONS,
+                transformer: PAGE_TO_TYPE_TRANSFORMER
+            });
+            debug('filter', this.filter);
+        }
+    }
+
+    /**
+     * Whether this generator's filter (if any) accepts the resource.
+     *
+     * Returns true when no filter is configured, true when the compiled NQL
+     * query matches, false otherwise. Failures inside `queryJSON` are
+     * swallowed and return false — same behavior the eager generator has
+     * relied on since the filter feature was introduced.
+     *
+     * @param {Object} resourceData
+     * @returns {boolean}
+     */
+    matches(resourceData) {
+        if (!this.nql) {
+            return true;
+        }
+
+        try {
+            return this.nql.queryJSON(resourceData);
+        } catch (err) {
+            debug(`Failed to queryJSON with filter "${this.filter}"`, err);
+            return false;
+        }
+    }
+}
+
+module.exports = BaseUrlGenerator;
+module.exports.EXPANSIONS = EXPANSIONS;

--- a/ghost/core/core/server/services/url/index.js
+++ b/ghost/core/core/server/services/url/index.js
@@ -1,6 +1,8 @@
 const config = require('../../../shared/config');
+const logging = require('@tryghost/logging');
 const LocalFileCache = require('./local-file-cache');
 const UrlService = require('./url-service');
+const LazyUrlService = require('./lazy/service');
 
 // NOTE: instead of a path we could give UrlService a "data-resolver" of some sort
 //       so it doesn't have to contain the logic to read data at all. This would be
@@ -19,8 +21,22 @@ if (process.env.NODE_ENV.startsWith('test')){
     writeDisabled = true;
 }
 
-const cache = new LocalFileCache({storagePath, writeDisabled});
-const urlService = new UrlService({cache});
+const implementationConfig = config.get('urlService:implementation');
+let implementation = implementationConfig || 'eager';
+
+if (implementation !== 'eager' && implementation !== 'lazy') {
+    logging.warn(`URL Service: unknown implementation "${implementationConfig}", falling back to eager`);
+    implementation = 'eager';
+}
+
+let urlService;
+if (implementation === 'lazy') {
+    logging.info('URL Service: lazy implementation active (spike)');
+    urlService = new LazyUrlService();
+} else {
+    const cache = new LocalFileCache({storagePath, writeDisabled});
+    urlService = new UrlService({cache});
+}
 
 // Singleton
 module.exports = urlService;

--- a/ghost/core/core/server/services/url/lazy/lazy-url-generator.js
+++ b/ghost/core/core/server/services/url/lazy/lazy-url-generator.js
@@ -1,0 +1,68 @@
+const localUtils = require('../../../../shared/url-utils');
+const settingsCache = require('../../../../shared/settings-cache');
+const BaseUrlGenerator = require('../base-url-generator');
+const {compilePermalink} = require('./permalink-matcher');
+
+const defaultGetTimezone = () => settingsCache.get('timezone');
+
+/**
+ * URL generator for the lazy URL service.
+ *
+ * Unlike the eager UrlGenerator, this class does not own resources, talk to
+ * the queue, or maintain a Urls map. It exposes two pure operations:
+ *
+ *   - generateUrl(resource): apply this generator's permalink template to a
+ *     resource's data
+ *   - matchUrl(url): reverse a request URL into placeholder values, used for
+ *     forward lookup in LazyUrlService.getResource()
+ *
+ * Filter evaluation is inherited from BaseUrlGenerator.matches().
+ */
+class LazyUrlGenerator extends BaseUrlGenerator {
+    /**
+     * @param {Object} options
+     * @param {string} options.identifier router ID
+     * @param {string} [options.filter] NQL filter from routes.yaml
+     * @param {string} options.resourceType e.g. 'posts'
+     * @param {string} options.permalink permalink template
+     * @param {number} options.position position in the parent generator list
+     * @param {Function} [options.getTimezone] override for tests
+     */
+    constructor({identifier, filter, resourceType, permalink, position, getTimezone}) {
+        super({identifier, filter, resourceType, permalink, position});
+        this.compiledPermalink = compilePermalink(permalink);
+        this.getTimezone = getTimezone || defaultGetTimezone;
+    }
+
+    /**
+     * Substitute placeholders in this generator's permalink with values from
+     * the resource. Delegates to the same `replacePermalink` helper the eager
+     * path uses, so generated URLs are byte-for-byte identical given the
+     * same input.
+     *
+     * @param {Object} resourceData
+     * @returns {string}
+     */
+    generateUrl(resourceData) {
+        return localUtils.replacePermalink(this.permalink, resourceData, this.getTimezone());
+    }
+
+    /**
+     * Reverse a request URL into placeholder values. Returns null when the
+     * URL does not match this generator's permalink shape, or when the
+     * permalink lacks an identifier (`:slug` or `:id`) and so cannot be used
+     * to locate a single resource.
+     *
+     * @param {string} url
+     * @returns {Object|null}
+     */
+    matchUrl(url) {
+        if (!this.compiledPermalink.forwardLookupSafe) {
+            return null;
+        }
+        const m = this.compiledPermalink.regex.exec(url);
+        return m ? m.groups : null;
+    }
+}
+
+module.exports = LazyUrlGenerator;

--- a/ghost/core/core/server/services/url/lazy/permalink-matcher.js
+++ b/ghost/core/core/server/services/url/lazy/permalink-matcher.js
@@ -1,0 +1,104 @@
+/**
+ * Compiles a permalink template (e.g. `/blog/:year/:slug/`) into an anchored,
+ * named-group regex used to reverse a request URL back into the placeholder
+ * values that produced it.
+ *
+ * Only the placeholders supported by `@tryghost/url-utils.replacePermalink`
+ * are accepted, with one exception: `:uuid` is rejected because it is only
+ * used by routers that the URL service deliberately does not back
+ * (PreviewRouter, EmailRouter). Allowing it here would let a forward lookup
+ * resolve a draft post via its preview path.
+ */
+
+const errors = require('@tryghost/errors');
+
+const SLUG_PATTERN = '[^/]+';
+const PLACEHOLDER_PATTERNS = {
+    slug: SLUG_PATTERN,
+    id: SLUG_PATTERN,
+    primary_tag: SLUG_PATTERN,
+    primary_author: SLUG_PATTERN,
+    author: SLUG_PATTERN,
+    year: '\\d{4}',
+    month: '\\d{2}',
+    day: '\\d{2}'
+};
+
+const PLACEHOLDER_RE = /:([a-z_]+)/g;
+const REGEX_META_RE = /[\\^$.*+?()[\]{}|]/g;
+
+/**
+ * @typedef {Object} CompiledPermalink
+ * @property {string} permalink original permalink template
+ * @property {RegExp} regex anchored regex with one named group per placeholder
+ * @property {string[]} fields placeholder names that appear in the template
+ * @property {boolean} forwardLookupSafe whether the template can be reversed into a single resource (must contain :slug or :id)
+ * @property {('slug'|'id'|null)} lookupField which captured group identifies the resource (null when not safe)
+ */
+
+/**
+ * @param {string} permalink
+ * @returns {CompiledPermalink}
+ */
+function compilePermalink(permalink) {
+    if (!permalink.startsWith('/')) {
+        throw new errors.IncorrectUsageError({
+            message: `Permalink "${permalink}" must have a leading slash`
+        });
+    }
+    if (!permalink.endsWith('/')) {
+        throw new errors.IncorrectUsageError({
+            message: `Permalink "${permalink}" must have a trailing slash`
+        });
+    }
+
+    const fields = [];
+    let cursor = 0;
+    let pattern = '';
+
+    for (const match of permalink.matchAll(PLACEHOLDER_RE)) {
+        const literal = permalink.slice(cursor, match.index);
+        pattern += literal.replace(REGEX_META_RE, '\\$&');
+
+        const name = match[1];
+        if (!PLACEHOLDER_PATTERNS[name]) {
+            throw new errors.IncorrectUsageError({
+                message: `Permalink "${permalink}" uses unsupported placeholder ":${name}"`
+            });
+        }
+        if (fields.includes(name)) {
+            throw new errors.IncorrectUsageError({
+                message: `Permalink "${permalink}" repeats placeholder ":${name}"`
+            });
+        }
+        fields.push(name);
+        pattern += `(?<${name}>${PLACEHOLDER_PATTERNS[name]})`;
+
+        cursor = match.index + match[0].length;
+    }
+
+    const trailing = permalink.slice(cursor).replace(REGEX_META_RE, '\\$&');
+    pattern += trailing;
+
+    const regex = new RegExp(`^${pattern}$`);
+
+    let lookupField = null;
+    if (fields.includes('slug')) {
+        lookupField = 'slug';
+    } else if (fields.includes('id')) {
+        lookupField = 'id';
+    }
+
+    return {
+        permalink,
+        regex,
+        fields,
+        forwardLookupSafe: lookupField !== null,
+        lookupField
+    };
+}
+
+module.exports = {
+    compilePermalink,
+    PLACEHOLDER_PATTERNS
+};

--- a/ghost/core/core/server/services/url/lazy/service.js
+++ b/ghost/core/core/server/services/url/lazy/service.js
@@ -1,0 +1,519 @@
+const debug = require('@tryghost/debug')('services:url:lazy:service');
+const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const metrics = require('@tryghost/metrics');
+const urlUtils = require('../../../../shared/url-utils');
+const events = require('../../../lib/common/events');
+const Resources = require('../resources');
+const resourcesConfig = require('../config');
+const LazyUrlGenerator = require('./lazy-url-generator');
+
+const DEFAULT_TOLERANCE_MS = 100;
+
+/**
+ * Drop-in replacement for the eager UrlService.
+ *
+ * Reuses the existing Resources class to load + maintain the in-memory cache
+ * of publishable rows (so RESOURCE_CONFIG visibility filters and model-event
+ * subscriptions are inherited unchanged). Replaces the Queue + Urls + per-
+ * generator ownership machinery with a single ownership map maintained
+ * directly by this class.
+ *
+ * Boot timing:
+ *   1. init() fetches resources (narrow SELECT × 4 tables, identical to eager)
+ *   2. RouterManager registers generators via onRouterAddedType()
+ *   3. After a tolerance window (matches the eager queue's tolerance), one
+ *      pass over (generator × resource) populates the ownership map and
+ *      fires url.added events for the sitemap.
+ *
+ * Runtime:
+ *   - Model events flow through Resources to a queue stub here, which
+ *     recomputes ownership for the affected resource and fires the
+ *     appropriate url.added / url.removed transitions.
+ *   - Reads (getUrlByResourceId / getResource / owns / etc.) are O(1) lookups
+ *     against the ownership map.
+ */
+class LazyUrlService {
+    constructor({cache, resourcesFactory, toleranceMs = DEFAULT_TOLERANCE_MS} = {}) {
+        this.utils = urlUtils;
+        this.cache = cache; // intentionally unused — lazy service does not persist URLs
+        this.urlGenerators = [];
+        this.finished = false;
+        this.lastInitStartTime = null;
+        this.toleranceMs = toleranceMs;
+
+        this._activeUrls = new Map();
+        // Per-type slug → resource index, rebuilt during _recomputeAllUrls and
+        // patched on _onResourceChanged / _onResourceRemoved. Keeps the
+        // forward-lookup (getResource) at O(1) instead of O(n) over
+        // resources.getAllByType, which would dominate any benchmark on a
+        // large database.
+        this._slugIndex = new Map();
+        this._recomputeScheduled = false;
+        this._recomputeTimer = null;
+        this._modelEventListeners = [];
+        this._removeListenersBound = false;
+
+        this.queue = this._createQueueStub();
+        this.resources = resourcesFactory
+            ? resourcesFactory({queue: this.queue})
+            : new Resources({resourcesConfig, queue: this.queue});
+    }
+
+    /**
+     * Stub for the eager Queue. Resources calls `start({event, eventData})`
+     * when a resource is added or its routing-relevant fields change. We
+     * translate that into an ownership recompute for the single affected
+     * resource and fire the corresponding url events.
+     *
+     * INVARIANT: this design relies on Resource.isReserved() always being
+     * false in the lazy service, so that `Resources._onResourceUpdated`
+     * always reaches its `queue.start(...)` call. No code path inside the
+     * lazy service should call `resource.reserve()`. If that invariant is
+     * ever broken — e.g., by a future refactor that shares Resource
+     * instances with code that does reserve them — model updates will
+     * silently stop propagating to the lazy URL service. Either keep this
+     * invariant, or stop reusing Resources and copy the cache logic here.
+     */
+    _createQueueStub() {
+        return {
+            start: ({event, eventData}) => {
+                if (event === 'added' && eventData) {
+                    this._onResourceChanged(eventData.type, eventData.id);
+                }
+            },
+            reset: () => {},
+            softReset: () => {},
+            addListener: () => {},
+            removeListener: () => {}
+        };
+    }
+
+    /**
+     * Fetch all publishable resources and start listening for model events.
+     * Mirrors UrlService.init() minus the queue init event — boot completion
+     * is gated on routers registering, not on the queue draining.
+     */
+    async init() {
+        this.lastInitStartTime = Date.now();
+        this.resources.initEventListeners();
+        await this.resources.fetchResources();
+        this._subscribeToRemoveEvents();
+    }
+
+    /**
+     * Resources's _onResourceRemoved does not fire a queue event (it just
+     * drops the cached entry), so we subscribe to the same model events
+     * directly to learn about removals and emit url.removed accordingly.
+     *
+     * Idempotent: a second call (e.g. init→softReset→init) is a no-op so
+     * remove events do not double-fire.
+     */
+    _subscribeToRemoveEvents() {
+        if (this._removeListenersBound) {
+            return;
+        }
+        for (const rconfig of resourcesConfig) {
+            const removeEvents = Array.isArray(rconfig.events.remove)
+                ? rconfig.events.remove
+                : [rconfig.events.remove];
+
+            for (const eventName of removeEvents) {
+                const listener = (model) => {
+                    const id = model.id || model._previousAttributes?.id;
+                    if (id) {
+                        this._onResourceRemoved(id);
+                    }
+                };
+                events.on(eventName, listener);
+                this._modelEventListeners.push({eventName, listener});
+            }
+        }
+        this._removeListenersBound = true;
+    }
+
+    onRouterAddedType(identifier, filter, resourceType, permalink) {
+        debug('Registering route:', filter, resourceType, permalink);
+
+        const generator = new LazyUrlGenerator({
+            identifier,
+            filter,
+            resourceType,
+            permalink,
+            position: this.urlGenerators.length
+        });
+        this.urlGenerators.push(generator);
+        this._scheduleRecompute();
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    onRouterUpdated(identifier) {
+        // No per-generator ownership to regenerate; a full recompute is sufficient.
+        // The identifier argument is preserved for API compatibility with the eager service.
+        this._scheduleRecompute();
+    }
+
+    /**
+     * Debounce multiple router registrations (or a series of
+     * onRouterUpdated calls) into a single recompute pass once the
+     * tolerance window has elapsed since the LAST trigger. Mirrors the
+     * eager queue's tolerance behavior, including the reset-on-new-
+     * subscriber semantic so registration spread across >tolerance ms
+     * still results in a single recompute with the full generator list.
+     */
+    _scheduleRecompute() {
+        if (this._recomputeTimer) {
+            clearTimeout(this._recomputeTimer);
+        }
+        this._recomputeScheduled = true;
+        this._recomputeTimer = setTimeout(() => {
+            this._recomputeScheduled = false;
+            this._recomputeTimer = null;
+            this._recomputeAllUrls();
+
+            if (!this.finished) {
+                this.finished = true;
+                const elapsed = Date.now() - this.lastInitStartTime;
+                logging.info(`URL Service ready in ${elapsed}ms (lazy)`);
+                metrics.metric('url-service', elapsed);
+            }
+        }, this.toleranceMs);
+    }
+
+    /**
+     * One-pass ownership recomputation. Walks each resource type in
+     * registration order, picks the first matching generator, computes the
+     * URL, and diffs against the previous ownership map to emit transition
+     * events for the sitemap. Also rebuilds the per-type slug index so
+     * forward lookups (getResource) stay O(1).
+     */
+    _recomputeAllUrls() {
+        const newActive = new Map();
+        const newSlugIndex = new Map();
+
+        const generatorsByType = new Map();
+        for (const gen of this.urlGenerators) {
+            if (!generatorsByType.has(gen.resourceType)) {
+                generatorsByType.set(gen.resourceType, []);
+            }
+            generatorsByType.get(gen.resourceType).push(gen);
+        }
+
+        // Build the slug index for ALL resource types we know about, even
+        // those without a registered generator — getResource still needs
+        // to be able to look them up if a generator is added later.
+        for (const type of Object.keys(this.resources.data || {})) {
+            const typeIndex = new Map();
+            for (const resource of this.resources.getAllByType(type) || []) {
+                if (resource.data.slug) {
+                    typeIndex.set(resource.data.slug, resource);
+                }
+            }
+            newSlugIndex.set(type, typeIndex);
+        }
+
+        for (const [type, gens] of generatorsByType) {
+            const resources = this.resources.getAllByType(type) || [];
+            for (const resource of resources) {
+                const owner = this._findOwner(resource, gens);
+                if (owner) {
+                    const url = owner.generateUrl(resource.data);
+                    newActive.set(resource.data.id, {
+                        url,
+                        generatorId: owner.uid,
+                        resource
+                    });
+                }
+            }
+        }
+
+        this._diffAndEmit(this._activeUrls, newActive);
+        this._activeUrls = newActive;
+        this._slugIndex = newSlugIndex;
+    }
+
+    _patchSlugIndex(type, resource) {
+        let typeIndex = this._slugIndex.get(type);
+        if (!typeIndex) {
+            typeIndex = new Map();
+            this._slugIndex.set(type, typeIndex);
+        }
+        if (resource.data.slug) {
+            typeIndex.set(resource.data.slug, resource);
+        }
+    }
+
+    _findOwner(resource, candidateGenerators) {
+        for (const gen of candidateGenerators) {
+            if (gen.matches(resource.data)) {
+                return gen;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Recompute ownership for a single resource (model-event path).
+     */
+    _onResourceChanged(type, id) {
+        const resource = this.resources.getByIdAndType(type, id);
+        if (!resource) {
+            // Resource dropped from cache (e.g. failed RESOURCE_CONFIG filter
+            // post-update). Treat as removal.
+            this._onResourceRemoved(id);
+            return;
+        }
+
+        this._patchSlugIndex(type, resource);
+
+        const candidates = this.urlGenerators.filter(g => g.resourceType === type);
+        const owner = this._findOwner(resource, candidates);
+        const current = this._activeUrls.get(id);
+
+        if (!owner) {
+            if (current) {
+                this._emitRemoved(current);
+                this._activeUrls.delete(id);
+            }
+            return;
+        }
+
+        const url = owner.generateUrl(resource.data);
+        const next = {url, generatorId: owner.uid, resource};
+
+        if (!current) {
+            this._activeUrls.set(id, next);
+            this._emitAdded(next);
+        } else if (current.url !== url || current.generatorId !== owner.uid) {
+            this._emitRemoved(current);
+            this._activeUrls.set(id, next);
+            this._emitAdded(next);
+        }
+    }
+
+    _onResourceRemoved(id) {
+        const current = this._activeUrls.get(id);
+        if (current) {
+            // Drop the slug index entry too — the resource is gone from
+            // Resources.data already by the time this listener fires.
+            const typeIndex = this._slugIndex.get(current.resource.config.type);
+            if (typeIndex && current.resource.data.slug) {
+                typeIndex.delete(current.resource.data.slug);
+            }
+            this._emitRemoved(current);
+            this._activeUrls.delete(id);
+        }
+    }
+
+    _diffAndEmit(prev, next) {
+        for (const [id, prevEntry] of prev) {
+            const nextEntry = next.get(id);
+            if (!nextEntry || nextEntry.url !== prevEntry.url) {
+                this._emitRemoved(prevEntry);
+            }
+        }
+        for (const [id, nextEntry] of next) {
+            const prevEntry = prev.get(id);
+            if (!prevEntry || prevEntry.url !== nextEntry.url) {
+                this._emitAdded(nextEntry);
+            }
+        }
+    }
+
+    _emitAdded(entry) {
+        events.emit('url.added', {
+            url: {
+                relative: entry.url,
+                absolute: urlUtils.createUrl(entry.url, true)
+            },
+            resource: entry.resource
+        });
+    }
+
+    _emitRemoved(entry) {
+        // Match the eager Urls.removeResourceId emit shape (url is a string here).
+        events.emit('url.removed', {
+            url: entry.url,
+            resource: entry.resource
+        });
+    }
+
+    // ---- Public read API ----
+
+    hasFinished() {
+        return this.finished;
+    }
+
+    getUrlByResourceId(id, options = {}) {
+        const entry = this._activeUrls.get(id);
+        const relative = entry ? entry.url : '/404/';
+
+        if (options.absolute) {
+            return this.utils.createUrl(relative, options.absolute);
+        }
+        if (options.withSubdirectory) {
+            return this.utils.createUrl(relative, false, true);
+        }
+        return relative;
+    }
+
+    getResource(url, options = {}) {
+        if (!this.finished) {
+            throw new errors.InternalServerError({
+                message: 'UrlService is processing.',
+                code: 'URLSERVICE_NOT_READY'
+            });
+        }
+
+        // Walk in priority (registration) order; first owner-matching generator wins.
+        for (const gen of this.urlGenerators) {
+            const match = gen.matchUrl(url);
+            if (!match) {
+                continue;
+            }
+
+            const resource = this._lookupResourceForMatch(gen, match);
+            if (!resource) {
+                continue;
+            }
+
+            // Confirm the generator still owns this resource right now —
+            // mirrors the eager getResource semantic where ownership is
+            // reflected by the existence of a Urls entry.
+            const owned = this._activeUrls.get(resource.data.id);
+            if (!owned || owned.generatorId !== gen.uid || owned.url !== url) {
+                continue;
+            }
+
+            if (options.returnEverything) {
+                return {url: owned.url, generatorId: owned.generatorId, resource};
+            }
+            return resource;
+        }
+
+        return null;
+    }
+
+    _lookupResourceForMatch(gen, match) {
+        const lookupField = gen.compiledPermalink.lookupField;
+        const lookupValue = match[lookupField];
+
+        if (lookupField === 'slug') {
+            const typeIndex = this._slugIndex.get(gen.resourceType);
+            return typeIndex ? typeIndex.get(lookupValue) || null : null;
+        }
+
+        if (lookupField === 'id') {
+            // Forward-lookup by id is rare (only for permalinks like /p/:id/);
+            // the id-keyed _activeUrls answers it directly when ownership exists.
+            const entry = this._activeUrls.get(lookupValue);
+            return entry && entry.resource.config.type === gen.resourceType
+                ? entry.resource
+                : null;
+        }
+
+        return null;
+    }
+
+    getResourceById(resourceId) {
+        const entry = this._activeUrls.get(resourceId);
+        if (!entry) {
+            throw new errors.NotFoundError({
+                message: 'Resource not found.',
+                code: 'URLSERVICE_RESOURCE_NOT_FOUND'
+            });
+        }
+        return entry.resource;
+    }
+
+    owns(routerId, id) {
+        const generator = this.urlGenerators.find(g => g.identifier === routerId);
+        if (!generator) {
+            return false;
+        }
+        const entry = this._activeUrls.get(id);
+        return !!entry && entry.generatorId === generator.uid;
+    }
+
+    getPermalinkByUrl(url, options = {}) {
+        const everything = this.getResource(url, {returnEverything: true});
+        if (!everything) {
+            return null;
+        }
+        const gen = this.urlGenerators.find(g => g.uid === everything.generatorId);
+        if (!gen) {
+            return null;
+        }
+        if (options.withUrlOptions) {
+            return urlUtils.urlJoin(gen.permalink, '/:options(edit)?/');
+        }
+        return gen.permalink;
+    }
+
+    // ---- Lifecycle ----
+
+    async shutdown() {
+        // No persistence in the lazy implementation.
+    }
+
+    reset(options = {}) {
+        if (this._recomputeTimer) {
+            clearTimeout(this._recomputeTimer);
+            this._recomputeTimer = null;
+            this._recomputeScheduled = false;
+        }
+        this.urlGenerators = [];
+        this._activeUrls = new Map();
+        this._slugIndex = new Map();
+        this.finished = false;
+        this.resources.reset();
+
+        if (!options.keepListeners) {
+            for (const {eventName, listener} of this._modelEventListeners) {
+                events.removeListener(eventName, listener);
+            }
+            this._modelEventListeners = [];
+            this._removeListenersBound = false;
+        }
+    }
+
+    resetGenerators(options = {}) {
+        if (this._recomputeTimer) {
+            clearTimeout(this._recomputeTimer);
+            this._recomputeTimer = null;
+            this._recomputeScheduled = false;
+        }
+        this.finished = false;
+        this.urlGenerators = [];
+
+        // Emit url.removed for everything so the sitemap clears its state,
+        // mirroring the eager urls.reset() effect (the eager path does not
+        // emit removals on reset, but the sitemap also has its own
+        // routers.reset listener that wipes its state — see
+        // site-map-manager.js:46-51 — so we don't need to over-emit here).
+
+        for (const entry of this._activeUrls.values()) {
+            this._emitRemoved(entry);
+        }
+        this._activeUrls = new Map();
+
+        if (options.releaseResourcesOnly) {
+            this.resources.releaseAll();
+        } else {
+            this.resources.softReset();
+        }
+    }
+
+    softReset() {
+        if (this._recomputeTimer) {
+            clearTimeout(this._recomputeTimer);
+            this._recomputeTimer = null;
+            this._recomputeScheduled = false;
+        }
+        this.finished = false;
+        this._activeUrls = new Map();
+        this.resources.softReset();
+    }
+}
+
+module.exports = LazyUrlService;

--- a/ghost/core/core/server/services/url/url-generator.js
+++ b/ghost/core/core/server/services/url/url-generator.js
@@ -1,27 +1,6 @@
-const nql = require('@tryghost/nql');
 const debug = require('@tryghost/debug')('services:url:generator');
 const localUtils = require('../../../shared/url-utils');
-
-// @TODO: merge with filter plugin
-const EXPANSIONS = [{
-    key: 'author',
-    replacement: 'authors.slug'
-}, {
-    key: 'tags',
-    replacement: 'tags.slug'
-}, {
-    key: 'tag',
-    replacement: 'tags.slug'
-}, {
-    key: 'authors',
-    replacement: 'authors.slug'
-}, {
-    key: 'primary_tag',
-    replacement: 'primary_tag.slug'
-}, {
-    key: 'primary_author',
-    replacement: 'primary_author.slug'
-}];
+const BaseUrlGenerator = require('./base-url-generator');
 
 /**
  * The UrlGenerator class is responsible to generate urls based on a router's conditions.
@@ -31,7 +10,7 @@ const EXPANSIONS = [{
  *
  * Each router is represented by a url generator.
  */
-class UrlGenerator {
+class UrlGenerator extends BaseUrlGenerator {
     /**
      * @param {Object} options
      * @param {string} options.identifier frontend router ID reference
@@ -44,35 +23,10 @@ class UrlGenerator {
      * @param {number} options.position an ID of the generator
      */
     constructor({identifier, filter, resourceType, permalink, queue, resources, urls, position}) {
-        this.identifier = identifier;
-        this.resourceType = resourceType;
-        this.permalink = permalink;
+        super({identifier, filter, resourceType, permalink, position});
         this.queue = queue;
         this.urls = urls;
         this.resources = resources;
-        this.uid = position;
-
-        // CASE: routers can define custom filters, but not required.
-        if (filter) {
-            this.filter = filter;
-            this.nql = nql(this.filter, {
-                expansions: EXPANSIONS,
-                transformer: nql.utils.mapKeyValues({
-                    key: {
-                        from: 'page',
-                        to: 'type'
-                    },
-                    values: [{
-                        from: false,
-                        to: 'post'
-                    }, {
-                        from: true,
-                        to: 'page'
-                    }]
-                })
-            });
-            debug('filter', this.filter);
-        }
 
         this._listeners();
     }
@@ -166,21 +120,7 @@ class UrlGenerator {
             return false;
         }
 
-        // CASE 1: route has no custom filter, it will own the resource for sure
-        let shouldReserve = !this.filter;
-
-        // CASE 2: find out if my filter matches the resource
-        if (!shouldReserve) {
-            try {
-                shouldReserve = this.nql.queryJSON(resource.data);
-            } catch (err) {
-                debug(`Failed to queryJSON with filter "${this.filter}"`, err);
-
-                return false;
-            }
-        }
-
-        if (shouldReserve) {
+        if (this.matches(resource.data)) {
             const url = this._generateUrl(resource);
             this.urls.add({
                 url: url,

--- a/ghost/core/test/integration/services/url/lazy-parity.test.js
+++ b/ghost/core/test/integration/services/url/lazy-parity.test.js
@@ -1,0 +1,250 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const rewire = require('rewire');
+const events = require('../../../../core/server/lib/common/events');
+
+const LazyUrlService = require('../../../../core/server/services/url/lazy/service');
+const EagerUrlService = rewire('../../../../core/server/services/url/url-service');
+
+/**
+ * Build a Resources-shaped mock that both URL service implementations can
+ * consume. The lazy service expects: getAllByType, getByIdAndType,
+ * fetchResources, initEventListeners, reset, softReset, releaseAll. The
+ * eager service expects: data, getAllByType, getByIdAndType, fetchResources,
+ * initEventListeners, reset, softReset, releaseAll.
+ */
+function makeResources(seed) {
+    const data = {};
+    for (const [type, rows] of Object.entries(seed)) {
+        data[type] = rows.map(row => ({
+            data: row,
+            config: {type, reserved: false},
+            reserve() {
+                this.config.reserved = true;
+            },
+            release() {
+                this.config.reserved = false;
+            },
+            isReserved() {
+                return this.config.reserved;
+            },
+            removeAllListeners() {},
+            addListener() {}
+        }));
+    }
+    return {
+        data,
+        getByIdAndType(type, id) {
+            return data[type]?.find(r => r.data.id === id);
+        },
+        getAllByType(type) {
+            return data[type] || [];
+        },
+        getAll() {
+            return data;
+        },
+        fetchResources: sinon.stub().resolves(),
+        initEventListeners: sinon.stub(),
+        reset: sinon.stub(),
+        softReset: sinon.stub(),
+        releaseAll() {
+            for (const rows of Object.values(data)) {
+                for (const r of rows) {
+                    r.release();
+                }
+            }
+        }
+    };
+}
+
+const FIXTURES = {
+    posts: [
+        {id: 'p1', slug: 'first-post', published_at: '2026-01-01T00:00:00Z', featured: false, type: 'post', visibility: 'public', status: 'published'},
+        {id: 'p2', slug: 'featured-post', published_at: '2026-02-01T00:00:00Z', featured: true, type: 'post', visibility: 'public', status: 'published'},
+        {id: 'p3', slug: 'tagged-post', published_at: '2026-03-01T00:00:00Z', featured: false, type: 'post', visibility: 'public', status: 'published', tags: [{slug: 'news'}]}
+    ],
+    pages: [
+        {id: 'pg1', slug: 'about', published_at: '2025-12-01T00:00:00Z', type: 'page', visibility: 'public', status: 'published'}
+    ],
+    tags: [
+        {id: 't1', slug: 'news', visibility: 'public'}
+    ],
+    authors: [
+        {id: 'a1', slug: 'jane-doe', visibility: 'public'}
+    ]
+};
+
+const ROUTES = [
+    // identifier, filter, resourceType, permalink
+    ['static-pages', null, 'pages', '/:slug/'],
+    ['featured', 'featured:true', 'posts', '/featured/:slug/'],
+    ['post-collection', null, 'posts', '/:slug/'],
+    ['tag', null, 'tags', '/tag/:slug/'],
+    ['author', null, 'authors', '/author/:slug/']
+];
+
+async function bootLazy(seed) {
+    const resources = makeResources(seed);
+    const svc = new LazyUrlService({resourcesFactory: () => resources, toleranceMs: 5});
+    await svc.init();
+    for (const [identifier, filter, type, permalink] of ROUTES) {
+        svc.onRouterAddedType(identifier, filter, type, permalink);
+    }
+    // Wait for tolerance window (5ms) to elapse, plus a bit
+    await new Promise((resolve) => {
+        setTimeout(resolve, 30);
+    });
+    return svc;
+}
+
+async function bootEager(seed) {
+    const resources = makeResources(seed);
+    const svc = new EagerUrlService();
+    // Replace internal Resources with our mock; keep the real Queue/Urls so
+    // the queue tolerance + ownership flow runs unchanged.
+    svc.resources = resources;
+    // The Queue triggers an 'init' event when started; UrlGenerators call
+    // resources.getAllByType in their _onInit handler. We don't await
+    // resources.fetchResources because our mock doesn't need it.
+    for (const [identifier, filter, type, permalink] of ROUTES) {
+        svc.onRouterAddedType(identifier, filter, type, permalink);
+    }
+    svc.queue.start({event: 'init', tolerance: 5, requiredSubscriberCount: 1});
+    // Wait for the queue to drain
+    await new Promise((resolve) => {
+        const check = () => {
+            if (svc.hasFinished()) {
+                resolve();
+            } else {
+                setTimeout(check, 5);
+            }
+        };
+        check();
+    });
+    return svc;
+}
+
+describe('Integration: lazy URL service parity with eager', function () {
+    let lazy;
+    let eager;
+
+    beforeEach(async function () {
+        lazy = await bootLazy(FIXTURES);
+        eager = await bootEager(FIXTURES);
+    });
+
+    afterEach(function () {
+        lazy.reset();
+        eager.reset();
+        events.removeAllListeners();
+        sinon.restore();
+    });
+
+    describe('getUrlByResourceId', function () {
+        it('matches eager output for every fixture id', function () {
+            const allIds = Object.values(FIXTURES).flat().map(r => r.id);
+            for (const id of allIds) {
+                assert.equal(
+                    lazy.getUrlByResourceId(id),
+                    eager.getUrlByResourceId(id),
+                    `URL mismatch for resource ${id}`
+                );
+            }
+        });
+
+        it('matches eager /404/ behavior for unknown ids', function () {
+            assert.equal(lazy.getUrlByResourceId('nonexistent'), '/404/');
+            assert.equal(eager.getUrlByResourceId('nonexistent'), '/404/');
+        });
+
+        it('matches eager output with absolute=true', function () {
+            for (const id of ['p1', 'p2', 'pg1', 't1', 'a1']) {
+                assert.equal(
+                    lazy.getUrlByResourceId(id, {absolute: true}),
+                    eager.getUrlByResourceId(id, {absolute: true}),
+                    `Absolute URL mismatch for ${id}`
+                );
+            }
+        });
+    });
+
+    describe('getResource', function () {
+        it('matches eager output for known URLs', function () {
+            const probes = [
+                '/first-post/',
+                '/featured/featured-post/',
+                '/tagged-post/',
+                '/about/',
+                '/tag/news/',
+                '/author/jane-doe/'
+            ];
+            for (const url of probes) {
+                const lazyRes = lazy.getResource(url);
+                const eagerRes = eager.getResource(url);
+                assert.equal(
+                    lazyRes ? lazyRes.data.id : null,
+                    eagerRes ? eagerRes.data.id : null,
+                    `getResource(${url}) id mismatch`
+                );
+                assert.equal(
+                    lazyRes ? lazyRes.config.type : null,
+                    eagerRes ? eagerRes.config.type : null,
+                    `getResource(${url}) type mismatch`
+                );
+            }
+        });
+
+        it('returns null from both for unmatchable URLs', function () {
+            assert.equal(lazy.getResource('/no/such/url/'), null);
+            assert.equal(eager.getResource('/no/such/url/'), null);
+        });
+    });
+
+    describe('owns', function () {
+        it('matches eager ownership for every (router, resource) pair', function () {
+            const allIds = Object.values(FIXTURES).flat().map(r => r.id);
+            for (const [identifier] of ROUTES) {
+                for (const id of allIds) {
+                    assert.equal(
+                        lazy.owns(identifier, id),
+                        eager.owns(identifier, id),
+                        `owns(${identifier}, ${id}) mismatch`
+                    );
+                }
+            }
+        });
+    });
+
+    describe('getPermalinkByUrl', function () {
+        it('returns the same permalink template for known URLs', function () {
+            const probes = ['/first-post/', '/featured/featured-post/', '/tag/news/', '/about/'];
+            for (const url of probes) {
+                assert.equal(
+                    lazy.getPermalinkByUrl(url),
+                    eager.getPermalinkByUrl(url),
+                    `getPermalinkByUrl(${url}) mismatch`
+                );
+            }
+        });
+    });
+
+    describe('round-trip', function () {
+        it('every (id → URL → resource) cycle returns the same id', function () {
+            const allIds = Object.values(FIXTURES).flat().map(r => r.id);
+            for (const id of allIds) {
+                const lazyUrl = lazy.getUrlByResourceId(id);
+                if (lazyUrl === '/404/') {
+                    continue;
+                }
+                const lazyResource = lazy.getResource(lazyUrl);
+                assert.ok(lazyResource, `lazy: getResource(${lazyUrl}) returned null`);
+                assert.equal(lazyResource.data.id, id, `lazy round-trip mismatch for ${id}`);
+
+                const eagerUrl = eager.getUrlByResourceId(id);
+                const eagerResource = eager.getResource(eagerUrl);
+                assert.ok(eagerResource, `eager: getResource(${eagerUrl}) returned null`);
+                assert.equal(eagerResource.data.id, id, `eager round-trip mismatch for ${id}`);
+            }
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/url/base-url-generator.test.js
+++ b/ghost/core/test/unit/server/services/url/base-url-generator.test.js
@@ -1,0 +1,126 @@
+const assert = require('node:assert/strict');
+const BaseUrlGenerator = require('../../../../../core/server/services/url/base-url-generator');
+
+describe('Unit: services/url/BaseUrlGenerator', function () {
+    it('assigns identifier, resourceType, permalink, uid from constructor', function () {
+        const gen = new BaseUrlGenerator({
+            identifier: 'router-1',
+            resourceType: 'posts',
+            permalink: '/:slug/',
+            position: 3
+        });
+
+        assert.equal(gen.identifier, 'router-1');
+        assert.equal(gen.resourceType, 'posts');
+        assert.equal(gen.permalink, '/:slug/');
+        assert.equal(gen.uid, 3);
+    });
+
+    it('leaves filter and nql undefined when no filter is provided', function () {
+        const gen = new BaseUrlGenerator({
+            identifier: 'router-1',
+            resourceType: 'posts',
+            permalink: '/:slug/'
+        });
+
+        assert.equal(gen.filter, undefined);
+        assert.equal(gen.nql, undefined);
+    });
+
+    it('compiles a filter string into an nql query when filter is provided', function () {
+        const gen = new BaseUrlGenerator({
+            identifier: 'router-1',
+            filter: 'featured:true',
+            resourceType: 'posts',
+            permalink: '/:slug/'
+        });
+
+        assert.equal(gen.filter, 'featured:true');
+        assert.ok(gen.nql, 'expected nql to be compiled');
+        assert.equal(typeof gen.nql.queryJSON, 'function');
+    });
+
+    it('expands tag/author/primary_tag/primary_author keys via EXPANSIONS', function () {
+        const gen = new BaseUrlGenerator({
+            identifier: 'router-1',
+            filter: 'tag:news',
+            resourceType: 'posts',
+            permalink: '/:slug/'
+        });
+
+        // tag:news should match a post with tags.slug === 'news'
+        assert.equal(gen.nql.queryJSON({tags: [{slug: 'news'}]}), true);
+        assert.equal(gen.nql.queryJSON({tags: [{slug: 'sports'}]}), false);
+    });
+
+    it('maps page:false → type:post and page:true → type:page', function () {
+        const postsGen = new BaseUrlGenerator({
+            identifier: 'r',
+            filter: 'page:false',
+            resourceType: 'posts',
+            permalink: '/:slug/'
+        });
+
+        assert.equal(postsGen.nql.queryJSON({type: 'post'}), true);
+        assert.equal(postsGen.nql.queryJSON({type: 'page'}), false);
+
+        const pagesGen = new BaseUrlGenerator({
+            identifier: 'r',
+            filter: 'page:true',
+            resourceType: 'pages',
+            permalink: '/:slug/'
+        });
+
+        assert.equal(pagesGen.nql.queryJSON({type: 'page'}), true);
+        assert.equal(pagesGen.nql.queryJSON({type: 'post'}), false);
+    });
+
+    describe('matches()', function () {
+        it('returns true when no filter is set', function () {
+            const gen = new BaseUrlGenerator({
+                identifier: 'r',
+                resourceType: 'posts',
+                permalink: '/:slug/'
+            });
+
+            assert.equal(gen.matches({slug: 'anything'}), true);
+        });
+
+        it('returns true when filter matches the resource', function () {
+            const gen = new BaseUrlGenerator({
+                identifier: 'r',
+                filter: 'featured:true',
+                resourceType: 'posts',
+                permalink: '/:slug/'
+            });
+
+            assert.equal(gen.matches({featured: true}), true);
+        });
+
+        it('returns false when filter does not match the resource', function () {
+            const gen = new BaseUrlGenerator({
+                identifier: 'r',
+                filter: 'featured:true',
+                resourceType: 'posts',
+                permalink: '/:slug/'
+            });
+
+            assert.equal(gen.matches({featured: false}), false);
+        });
+
+        it('returns false (does not throw) when nql evaluation fails', function () {
+            const gen = new BaseUrlGenerator({
+                identifier: 'r',
+                filter: 'featured:true',
+                resourceType: 'posts',
+                permalink: '/:slug/'
+            });
+            // Force a queryJSON that throws
+            gen.nql = {queryJSON: () => {
+                throw new Error('boom');
+            }};
+
+            assert.equal(gen.matches({}), false);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/url/lazy/lazy-url-generator.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy/lazy-url-generator.test.js
@@ -1,0 +1,98 @@
+const assert = require('node:assert/strict');
+const LazyUrlGenerator = require('../../../../../../core/server/services/url/lazy/lazy-url-generator');
+
+describe('Unit: services/url/lazy/LazyUrlGenerator', function () {
+    it('compiles its permalink at construction', function () {
+        const gen = new LazyUrlGenerator({
+            identifier: 'r',
+            resourceType: 'posts',
+            permalink: '/:slug/',
+            position: 0
+        });
+
+        assert.ok(gen.compiledPermalink);
+        assert.equal(gen.compiledPermalink.forwardLookupSafe, true);
+        assert.equal(gen.compiledPermalink.lookupField, 'slug');
+    });
+
+    describe('generateUrl()', function () {
+        it('substitutes :slug with the resource slug', function () {
+            const gen = new LazyUrlGenerator({
+                identifier: 'r',
+                resourceType: 'posts',
+                permalink: '/:slug/',
+                position: 0
+            });
+
+            assert.equal(gen.generateUrl({slug: 'my-post'}), '/my-post/');
+        });
+
+        it('substitutes date placeholders using published_at and timezone', function () {
+            const gen = new LazyUrlGenerator({
+                identifier: 'r',
+                resourceType: 'posts',
+                permalink: '/:year/:month/:day/:slug/',
+                position: 0,
+                getTimezone: () => 'UTC'
+            });
+
+            const url = gen.generateUrl({
+                slug: 'release-notes',
+                published_at: '2026-04-26T10:00:00Z'
+            });
+            assert.equal(url, '/2026/04/26/release-notes/');
+        });
+    });
+
+    describe('matchUrl()', function () {
+        it('returns the captured groups when the URL matches', function () {
+            const gen = new LazyUrlGenerator({
+                identifier: 'r',
+                resourceType: 'posts',
+                permalink: '/blog/:slug/',
+                position: 0
+            });
+
+            const m = gen.matchUrl('/blog/my-post/');
+            assert.ok(m);
+            assert.equal(m.slug, 'my-post');
+        });
+
+        it('returns null when the URL does not match', function () {
+            const gen = new LazyUrlGenerator({
+                identifier: 'r',
+                resourceType: 'posts',
+                permalink: '/blog/:slug/',
+                position: 0
+            });
+
+            assert.equal(gen.matchUrl('/news/my-post/'), null);
+        });
+
+        it('returns null for permalinks that are not forward-lookup safe', function () {
+            const gen = new LazyUrlGenerator({
+                identifier: 'r',
+                resourceType: 'posts',
+                permalink: '/:year/:month/',
+                position: 0
+            });
+
+            assert.equal(gen.matchUrl('/2026/04/'), null);
+        });
+    });
+
+    describe('inherits from BaseUrlGenerator', function () {
+        it('exposes matches() with NQL filter semantics', function () {
+            const gen = new LazyUrlGenerator({
+                identifier: 'r',
+                filter: 'featured:true',
+                resourceType: 'posts',
+                permalink: '/:slug/',
+                position: 0
+            });
+
+            assert.equal(gen.matches({featured: true}), true);
+            assert.equal(gen.matches({featured: false}), false);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/url/lazy/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy/lazy-url-service.test.js
@@ -1,0 +1,377 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const errors = require('@tryghost/errors');
+const events = require('../../../../../../core/server/lib/common/events');
+const LazyUrlService = require('../../../../../../core/server/services/url/lazy/service');
+
+const fixtures = {
+    posts: [
+        {id: 'p1', slug: 'first-post', published_at: '2026-01-01T00:00:00Z', featured: false, type: 'post', visibility: 'public', status: 'published'},
+        {id: 'p2', slug: 'featured-post', published_at: '2026-02-01T00:00:00Z', featured: true, type: 'post', visibility: 'public', status: 'published'}
+    ],
+    pages: [
+        {id: 'pg1', slug: 'about', published_at: '2025-12-01T00:00:00Z', type: 'page', visibility: 'public', status: 'published'}
+    ],
+    tags: [
+        {id: 't1', slug: 'news', visibility: 'public'}
+    ],
+    authors: [
+        {id: 'a1', slug: 'jane-doe', visibility: 'public'}
+    ]
+};
+
+function makeResources(seed = fixtures) {
+    const data = {};
+    for (const [type, rows] of Object.entries(seed)) {
+        data[type] = rows.map(row => ({
+            data: row,
+            config: {type, reserved: false},
+            reserve() {
+                this.config.reserved = true;
+            },
+            release() {
+                this.config.reserved = false;
+            },
+            isReserved() {
+                return this.config.reserved;
+            },
+            removeAllListeners() {},
+            addListener() {}
+        }));
+    }
+    return {
+        data,
+        getByIdAndType(type, id) {
+            return data[type]?.find(r => r.data.id === id);
+        },
+        getAllByType(type) {
+            return data[type] || [];
+        },
+        fetchResources: sinon.stub().resolves(),
+        initEventListeners: sinon.stub(),
+        reset: sinon.stub(),
+        softReset: sinon.stub(),
+        releaseAll() {
+            for (const rows of Object.values(data)) {
+                for (const r of rows) {
+                    r.release();
+                }
+            }
+        }
+    };
+}
+
+describe('Unit: services/url/lazy/LazyUrlService', function () {
+    let resources;
+    let service;
+    let clock;
+
+    beforeEach(async function () {
+        clock = sinon.useFakeTimers();
+        resources = makeResources();
+        service = new LazyUrlService({resourcesFactory: () => resources});
+        await service.init();
+    });
+
+    afterEach(function () {
+        // Drop event listeners installed by init()
+        service.reset();
+        events.removeAllListeners();
+        clock.restore();
+        sinon.restore();
+    });
+
+    function registerDefaults() {
+        service.onRouterAddedType('static-pages', null, 'pages', '/:slug/');
+        service.onRouterAddedType('post-collection', null, 'posts', '/:slug/');
+        service.onRouterAddedType('tag', null, 'tags', '/tag/:slug/');
+        service.onRouterAddedType('author', null, 'authors', '/author/:slug/');
+        // Tolerance window for boot recompute
+        clock.tick(150);
+    }
+
+    describe('hasFinished()', function () {
+        it('starts false until the boot recompute completes', function () {
+            assert.equal(service.hasFinished(), false);
+            registerDefaults();
+            assert.equal(service.hasFinished(), true);
+        });
+    });
+
+    describe('getUrlByResourceId()', function () {
+        beforeEach(registerDefaults);
+
+        it('returns the computed URL for an owned resource', function () {
+            assert.equal(service.getUrlByResourceId('p1'), '/first-post/');
+            assert.equal(service.getUrlByResourceId('pg1'), '/about/');
+            assert.equal(service.getUrlByResourceId('t1'), '/tag/news/');
+        });
+
+        it('returns /404/ for an unknown resource id', function () {
+            assert.equal(service.getUrlByResourceId('nonexistent'), '/404/');
+        });
+
+        it('honors the absolute option via urlUtils.createUrl', function () {
+            const url = service.getUrlByResourceId('p1', {absolute: true});
+            assert.match(url, /^https?:\/\//, `expected absolute URL, got ${url}`);
+            assert.match(url, /\/first-post\/$/);
+        });
+    });
+
+    describe('getResource()', function () {
+        beforeEach(registerDefaults);
+
+        it('returns the resource at a given URL', function () {
+            const r = service.getResource('/first-post/');
+            assert.equal(r.data.id, 'p1');
+        });
+
+        it('returns null when no generator matches the URL', function () {
+            assert.equal(service.getResource('/totally/unknown/path/'), null);
+        });
+
+        it('respects generator priority order on overlapping matches', function () {
+            // Both 'pages' and 'posts' generators have permalink /:slug/
+            // Pages was registered first in registerDefaults, so for slug 'about'
+            // (a page), pages wins.
+            const r = service.getResource('/about/');
+            assert.equal(r.data.id, 'pg1');
+            assert.equal(r.config.type, 'pages');
+        });
+
+        it('throws URLSERVICE_NOT_READY before init+register completes', function () {
+            // Create a fresh service that hasn't been registered yet
+            const fresh = new LazyUrlService({resourcesFactory: () => makeResources()});
+            return fresh.init().then(() => {
+                assert.equal(fresh.hasFinished(), false);
+                try {
+                    fresh.getResource('/anything/');
+                    throw new Error('expected throw');
+                } catch (err) {
+                    assert.equal(errors.utils.isGhostError(err), true);
+                    assert.equal(err.code, 'URLSERVICE_NOT_READY');
+                }
+            });
+        });
+    });
+
+    describe('getResourceById()', function () {
+        beforeEach(registerDefaults);
+
+        it('returns the resource by id', function () {
+            const r = service.getResourceById('p1');
+            assert.equal(r.data.id, 'p1');
+        });
+
+        it('throws URLSERVICE_RESOURCE_NOT_FOUND for unknown ids', function () {
+            try {
+                service.getResourceById('nope');
+                throw new Error('expected throw');
+            } catch (err) {
+                assert.equal(err.code, 'URLSERVICE_RESOURCE_NOT_FOUND');
+            }
+        });
+    });
+
+    describe('owns()', function () {
+        beforeEach(registerDefaults);
+
+        it('returns true when the named router currently owns the resource', function () {
+            assert.equal(service.owns('post-collection', 'p1'), true);
+        });
+
+        it('returns false when a different router owns the resource', function () {
+            assert.equal(service.owns('tag', 'p1'), false);
+        });
+
+        it('returns false for unknown router ids', function () {
+            assert.equal(service.owns('made-up-router', 'p1'), false);
+        });
+    });
+
+    describe('getPermalinkByUrl()', function () {
+        beforeEach(registerDefaults);
+
+        it('returns the permalink template for the matching generator', function () {
+            assert.equal(service.getPermalinkByUrl('/first-post/'), '/:slug/');
+            assert.equal(service.getPermalinkByUrl('/tag/news/'), '/tag/:slug/');
+        });
+
+        it('returns null when no generator matches', function () {
+            assert.equal(service.getPermalinkByUrl('/no/match/'), null);
+        });
+    });
+
+    describe('filter-based ownership', function () {
+        it('routes featured posts to a featured-only generator', function () {
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+            service.onRouterAddedType('post-collection', null, 'posts', '/:slug/');
+            clock.tick(150);
+
+            assert.equal(service.getUrlByResourceId('p2'), '/featured/featured-post/');
+            assert.equal(service.getUrlByResourceId('p1'), '/first-post/');
+        });
+    });
+
+    describe('model-event path (queue stub)', function () {
+        let added;
+        let removed;
+
+        beforeEach(function () {
+            added = [];
+            removed = [];
+            events.on('url.added', obj => added.push(obj));
+            events.on('url.removed', obj => removed.push(obj));
+            registerDefaults();
+            // Drain the boot-recompute events so the per-event assertions
+            // below only see the change we deliberately drive.
+            added.length = 0;
+            removed.length = 0;
+        });
+
+        it('reflects an ownership flip when a resource gains a generator-matching property', async function () {
+            // To get featured-priority routing we need the featured generator
+            // registered BEFORE the catch-all. Build a fresh service so
+            // ordering is under our control.
+            clock.restore();
+            clock = sinon.useFakeTimers();
+            service.reset();
+            events.removeAllListeners();
+            events.on('url.added', obj => added.push(obj));
+            events.on('url.removed', obj => removed.push(obj));
+            added.length = 0;
+            removed.length = 0;
+
+            resources = makeResources();
+            service = new LazyUrlService({resourcesFactory: () => resources});
+            await service.init();
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+            service.onRouterAddedType('post-collection', null, 'posts', '/:slug/');
+            clock.tick(150);
+
+            // Drain the boot events
+            added.length = 0;
+            removed.length = 0;
+
+            // Fire the simulated model event for p1 transitioning to featured
+            const p1 = resources.getByIdAndType('posts', 'p1');
+            p1.data.featured = true;
+            service.queue.start({event: 'added', eventData: {type: 'posts', id: 'p1'}});
+
+            assert.equal(service.getUrlByResourceId('p1'), '/featured/first-post/');
+            assert.deepEqual(removed.map(r => r.url), ['/first-post/']);
+            assert.deepEqual(added.map(a => a.url.relative), ['/featured/first-post/']);
+        });
+
+        it('treats a post leaving the cache (e.g. unpublished) as a removal', function () {
+            // Simulate Resources dropping the row from its cache (this is what
+            // _onResourceRemoved does at resources.js:411 before our listener fires)
+            resources.data.posts = resources.data.posts.filter(r => r.data.id !== 'p1');
+
+            // Fire the model-removal event
+            events.emit('post.unpublished', {id: 'p1', _previousAttributes: {id: 'p1'}});
+
+            assert.equal(service.getUrlByResourceId('p1'), '/404/');
+            assert.equal(removed.length, 1);
+            assert.equal(removed[0].url, '/first-post/');
+        });
+
+        it('emits no events when an update does not change the resource URL', function () {
+            // Simulate an "update" that doesn't change anything routing-relevant
+            service.queue.start({event: 'added', eventData: {type: 'posts', id: 'p1'}});
+
+            assert.equal(added.length, 0);
+            assert.equal(removed.length, 0);
+        });
+
+        it('forwards getResource through the slug index after a model event', function () {
+            // Add a brand new post into Resources directly
+            resources.data.posts.push({
+                data: {id: 'p99', slug: 'fresh-post', published_at: '2026-04-26T00:00:00Z', featured: false, type: 'post', visibility: 'public', status: 'published'},
+                config: {type: 'posts', reserved: false},
+                reserve() {
+                    this.config.reserved = true;
+                },
+                release() {
+                    this.config.reserved = false;
+                },
+                isReserved() {
+                    return this.config.reserved;
+                },
+                removeAllListeners() {},
+                addListener() {}
+            });
+            service.queue.start({event: 'added', eventData: {type: 'posts', id: 'p99'}});
+
+            // Forward lookup via the slug index
+            const r = service.getResource('/fresh-post/');
+            assert.ok(r);
+            assert.equal(r.data.id, 'p99');
+        });
+    });
+
+    describe('listener idempotency', function () {
+        it('does not double-bind remove listeners on a second init()', async function () {
+            // Capture how many post.unpublished listeners exist after one init
+            const baseCount = events.listenerCount('post.unpublished');
+
+            // A second init() is a realistic scenario after softReset()
+            service.softReset();
+            await service.init();
+
+            assert.equal(events.listenerCount('post.unpublished'), baseCount,
+                'expected listener count to stay stable across init cycles');
+        });
+    });
+
+    describe('debounced recompute', function () {
+        it('coalesces a burst of router registrations into one recompute', function () {
+            const recomputeSpy = sinon.spy(service, '_recomputeAllUrls');
+
+            service.onRouterAddedType('a', null, 'posts', '/a/:slug/');
+            clock.tick(50);
+            service.onRouterAddedType('b', null, 'posts', '/b/:slug/');
+            clock.tick(50);
+            service.onRouterAddedType('c', null, 'posts', '/c/:slug/');
+            clock.tick(150);
+
+            // Each onRouterAddedType resets the debounce timer; only the
+            // last one's tolerance expiry actually fires the recompute.
+            assert.equal(recomputeSpy.callCount, 1);
+        });
+    });
+
+    describe('url.added / url.removed event re-emission', function () {
+        let added;
+        let removed;
+
+        beforeEach(function () {
+            added = [];
+            removed = [];
+            events.on('url.added', obj => added.push(obj));
+            events.on('url.removed', obj => removed.push(obj));
+        });
+
+        it('emits url.added for each owned resource on initial recompute', function () {
+            registerDefaults();
+            const urls = added.map(o => o.url.relative).sort();
+            // Every fixture is owned by exactly one generator
+            assert.deepEqual(urls, [
+                '/about/',
+                '/author/jane-doe/',
+                '/featured-post/',
+                '/first-post/',
+                '/tag/news/'
+            ].sort());
+        });
+
+        it('emits url.added with absolute and relative variants', function () {
+            registerDefaults();
+            const first = added.find(o => o.url.relative === '/first-post/');
+            assert.ok(first);
+            assert.match(first.url.absolute, /\/first-post\/$/);
+            assert.equal(first.resource.data.id, 'p1');
+            assert.equal(first.resource.config.type, 'posts');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/url/lazy/permalink-matcher.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy/permalink-matcher.test.js
@@ -1,0 +1,101 @@
+const assert = require('node:assert/strict');
+const {compilePermalink} = require('../../../../../../core/server/services/url/lazy/permalink-matcher');
+
+describe('Unit: services/url/lazy/permalink-matcher', function () {
+    describe('compilePermalink', function () {
+        it('compiles /:slug/ into a regex with a slug capture group', function () {
+            const compiled = compilePermalink('/:slug/');
+            const m = compiled.regex.exec('/my-post/');
+            assert.ok(m, 'expected match');
+            assert.equal(m.groups.slug, 'my-post');
+            assert.deepEqual(compiled.fields.sort(), ['slug']);
+        });
+
+        it('rejects non-slug paths', function () {
+            const compiled = compilePermalink('/:slug/');
+            assert.equal(compiled.regex.exec('/two/segments/'), null);
+            assert.equal(compiled.regex.exec('/my-post'), null, 'missing trailing slash');
+            assert.equal(compiled.regex.exec('my-post/'), null, 'missing leading slash');
+        });
+
+        it('compiles dated permalinks with strict numeric segments', function () {
+            const compiled = compilePermalink('/:year/:month/:day/:slug/');
+            const m = compiled.regex.exec('/2026/04/26/release-notes/');
+            assert.ok(m);
+            assert.equal(m.groups.year, '2026');
+            assert.equal(m.groups.month, '04');
+            assert.equal(m.groups.day, '26');
+            assert.equal(m.groups.slug, 'release-notes');
+            assert.deepEqual(compiled.fields.sort(), ['day', 'month', 'slug', 'year']);
+
+            // Invalid date formats must not match
+            assert.equal(compiled.regex.exec('/26/04/26/release-notes/'), null, '2-digit year rejected');
+            assert.equal(compiled.regex.exec('/2026/4/26/release-notes/'), null, '1-digit month rejected');
+            assert.equal(compiled.regex.exec('/2026/04/abc/release-notes/'), null, 'non-numeric day rejected');
+        });
+
+        it('compiles /tag/:slug/ into an anchored regex', function () {
+            const compiled = compilePermalink('/tag/:slug/');
+            assert.ok(compiled.regex.exec('/tag/news/'));
+            assert.equal(compiled.regex.exec('/tag/news/extra/'), null);
+            assert.equal(compiled.regex.exec('/prefix/tag/news/'), null);
+        });
+
+        it('compiles permalinks with primary_tag and primary_author', function () {
+            const tagged = compilePermalink('/:primary_tag/:slug/');
+            const tm = tagged.regex.exec('/news/release-notes/');
+            assert.ok(tm);
+            assert.equal(tm.groups.primary_tag, 'news');
+            assert.equal(tm.groups.slug, 'release-notes');
+
+            const authored = compilePermalink('/:primary_author/:slug/');
+            const am = authored.regex.exec('/jane-doe/release-notes/');
+            assert.ok(am);
+            assert.equal(am.groups.primary_author, 'jane-doe');
+            assert.equal(am.groups.slug, 'release-notes');
+        });
+
+        it('compiles permalinks with :id', function () {
+            const compiled = compilePermalink('/p/:id/');
+            const m = compiled.regex.exec('/p/507f1f77bcf86cd799439011/');
+            assert.ok(m);
+            assert.equal(m.groups.id, '507f1f77bcf86cd799439011');
+        });
+
+        it('escapes regex metacharacters in literal segments', function () {
+            const compiled = compilePermalink('/blog.archive/:slug/');
+            assert.ok(compiled.regex.exec('/blog.archive/my-post/'));
+            // The literal '.' must not act as a regex wildcard
+            assert.equal(compiled.regex.exec('/blogXarchive/my-post/'), null);
+        });
+
+        it('throws when permalink lacks leading or trailing slash', function () {
+            assert.throws(() => compilePermalink('foo/:slug/'), /leading slash/i);
+            assert.throws(() => compilePermalink('/foo/:slug'), /trailing slash/i);
+        });
+
+        it('throws when permalink uses an unsupported placeholder', function () {
+            assert.throws(() => compilePermalink('/:uuid/'), /unsupported placeholder/i);
+            assert.throws(() => compilePermalink('/:nope/'), /unsupported placeholder/i);
+        });
+    });
+
+    describe('forward lookup safety', function () {
+        it('marks permalinks with :slug as forward-lookup safe', function () {
+            const compiled = compilePermalink('/:year/:slug/');
+            assert.equal(compiled.forwardLookupSafe, true);
+            assert.equal(compiled.lookupField, 'slug');
+        });
+
+        it('marks permalinks with :id as forward-lookup safe', function () {
+            const compiled = compilePermalink('/p/:id/');
+            assert.equal(compiled.forwardLookupSafe, true);
+            assert.equal(compiled.lookupField, 'id');
+        });
+
+        it('marks permalinks without :slug or :id as not forward-lookup safe', function () {
+            const compiled = compilePermalink('/:year/:month/');
+            assert.equal(compiled.forwardLookupSafe, false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

This is a **spike** — a working lazy URL service to A/B benchmark against the eager implementation on a large database. The intent is to validate feasibility, not to land permanently in this PR. Toggle defaults to `eager`; flip via `urlService.implementation: lazy` in config.

- **refactor commit**: extract `BaseUrlGenerator` from `UrlGenerator` so a lazy variant can share filter compilation. Behavior-preserving; existing tests unchanged.
- **feat commit**: add `lazy/{service,permalink-matcher,lazy-url-generator}.js` plus a config toggle in `services/url/index.js`.

## How it works

The lazy service **reuses the existing `Resources` class** (so `RESOURCE_CONFIG.modelOptions.filter` — `status:published`, `visibility:public`, `shouldHavePosts` — is inherited unchanged; drafts/internal-tags/inactive-authors continue to be excluded). It replaces the `Queue + Urls + UrlGenerator._try/reserve/release` machinery with:

- A single `_activeUrls: Map<id, {url, generatorId, resource}>` ownership map maintained directly by `LazyUrlService`.
- A per-type `_slugIndex: Map<type, Map<slug, resource>>` to keep `getResource(url)` at O(1) instead of O(N) over `Resources.getAllByType`.
- A queue stub that translates `Resources`'s update events into ownership recomputations and re-emits `url.added` / `url.removed` so the sitemap manager works unchanged.
- `PermalinkMatcher` compiles permalink templates into anchored, named-group regexes for forward URL → resource lookup. Refuses `:uuid` so preview paths can never resolve to drafts.

## Honest framing

The "lazy" name is somewhat aspirational — it's really a **simplified eager**. Expected wins from benchmarking:

- **Boot**: faster on CPU/GC (no Queue tolerance event orchestration, no per-resource reservation dance) but **not** on I/O — the eager `Resources.fetchResources` already does narrow SELECTs via `raw_knex.fetchAll`.
- **Memory**: marginal at best, possibly net-zero. `Resources` is reused, and the ownership map is similar size to the eager `Urls` map.
- **Reads**: `getUrlByResourceId` stays O(1). `getResource(url)` is also O(1) via the new slug index. No regression.
- **Forward lookup latency**: same — slug index keeps it cheap.

If the benchmark shows the wins are too marginal to justify the architecture change, the lazy implementation can be removed in a follow-up; the toggle isolates the experiment.

## Reviewer-found issues addressed

Three rounds of review (clean-code, security, perf) ran against both the plan and the implementation. Notable findings addressed:

- **Security**: forward lookup respects `RESOURCE_CONFIG` filters via Resources reuse, not naive `findOne({slug})`. Plus `:uuid` rejected in `PermalinkMatcher`.
- **Perf**: per-type slug index added — without it `getResource` would be O(N) and the benchmark would measure the missing index, not the architecture.
- **Correctness**: `_subscribeToRemoveEvents` made idempotent (no leak on `softReset` + re-init); `_scheduleRecompute` properly debounces (resets timer on each registration).
- **Documentation**: queue stub's reliance on \"lazy never calls `Resource.reserve()`\" called out loudly in `service.js`.

## Test plan

- [x] `pnpm test:base 'test/unit/server/services/url/**/*.test.js' 'test/integration/services/url/lazy-parity.test.js'` — 121 passing locally
- [x] `pnpm lint:server` — clean
- [x] `pnpm lint:test` — clean
- [ ] Boot Ghost with `urlService.implementation=lazy` against a large database and benchmark vs eager
- [ ] Spot-check `/sitemap-posts.xml` matches between implementations

### What's tested

- `permalink-matcher` (12) — round-trip, anchoring, escaping, `:uuid` refusal
- `base-url-generator` (9) — filter compilation, `matches()` semantics
- `lazy-url-generator` (7) — `generateUrl` / `matchUrl` / inherited `matches`
- `lazy-url-service` (24) — full public API, event re-emission, model-event recompute via the queue stub, listener idempotency, debounced registration
- `lazy-parity` integration (8) — both implementations against the same fixtures, asserts identical `getUrlByResourceId`, `getResource`, `owns`, `getPermalinkByUrl`, plus round-trip cycles

## Out of scope (deliberately)

- Removing the eager implementation
- Shadow-read mode (toggle is enough for A/B benchmark)
- Sitemap manager refactor to subscribe to model events directly
- Caller migration to a new `getUrlByResource(resource, type)` API
- Permanent landing — that's a follow-up after benchmark results

🤖 Generated with [Claude Code](https://claude.com/claude-code)