### PR TITLE
Added parallel role-based permissions checker

### DIFF
--- a/ghost/core/core/server/services/permissions/can-this-v2.js
+++ b/ghost/core/core/server/services/permissions/can-this-v2.js
@@ -1,0 +1,140 @@
+// canThisV2 — parallel role-based permissions checker.
+//
+// Same chain interface as can-this.js: `canThisV2(ctx).edit.post(id, attrs)`.
+// Difference: derives `loadedPermissions` from the static role map
+// (role-permissions.js) instead of querying providers.user/apiKey.
+//
+// CUTOVER: at the end of the parallel-soak, rename to canThis.js, drop the V2
+// suffix, delete the V1 file. The chain's action list is built from
+// OBJECT_TYPE_ACTIONS in role-permissions.js (NOT actions-map-cache.js) so
+// the cleanup PR can also delete actions-map-cache.js without touching V2.
+//
+// The chain handlers need to know which role(s) to consult. There are two
+// supply paths, in priority order:
+//   1. `context.userRoleName` / `context.apiKeyRoleName` — explicit, used by
+//      parallel-check.js where V1 has already loaded the role and we want to
+//      avoid a second DB query.
+//   2. Fallback: try to read role names off rich auth principals attached to
+//      `context.user` / `context.api_key` (model objects with eager-loaded
+//      roles). Works only if auth middleware pre-loaded them.
+// If neither path yields a role, the chain treats the principal as having no
+// permissions (fail-closed) and lets parallel-check.js see the divergence.
+
+const _ = require('lodash');
+const models = require('../../models');
+const parseContext = require('./parse-context');
+const dispatchPermissible = require('./dispatch-permissible');
+const {synthesizeLoadedPermissions, OBJECT_TYPE_ACTIONS} = require('./role-permissions');
+
+const objectTypeModelMap = {
+    post: models.Post,
+    role: models.Role,
+    user: models.User,
+    permission: models.Permission,
+    setting: models.Settings,
+    invite: models.Invite,
+    integration: models.Integration,
+    comment: models.Comment
+};
+
+// Inverse of OBJECT_TYPE_ACTIONS: { actionType: [objectType, ...] }. Computed
+// once at module load. This is what the chain's action.objectType handlers
+// are built from — no DB lookup, no actions-map-cache dependency.
+const ACTION_TO_OBJECT_TYPES = (() => {
+    const map = {};
+    for (const [objectType, actions] of Object.entries(OBJECT_TYPE_ACTIONS)) {
+        for (const action of actions) {
+            if (!map[action]) {
+                map[action] = [];
+            }
+            map[action].push(objectType);
+        }
+    }
+    return Object.freeze(map);
+})();
+
+function readRoleFromPrincipal(principal) {
+    if (!principal || typeof principal !== 'object') {
+        return null;
+    }
+    if (typeof principal.related === 'function') {
+        const rolesCol = principal.related('roles');
+        if (rolesCol && rolesCol.models && rolesCol.models.length > 0) {
+            return rolesCol.models[0].get('name');
+        }
+        const roleModel = principal.related('role');
+        if (roleModel && typeof roleModel.get === 'function') {
+            const name = roleModel.get('name');
+            if (name) {
+                return name;
+            }
+        }
+    }
+    if (Array.isArray(principal.roles) && principal.roles[0] && principal.roles[0].name) {
+        return principal.roles[0].name;
+    }
+    if (principal.role && principal.role.name) {
+        return principal.role.name;
+    }
+    return null;
+}
+
+function buildHandler(actionType, objectType, parsedContext, loadedPermissions) {
+    const TargetModel = objectTypeModelMap[objectType];
+    return function handler(modelOrId, unsafeAttrs) {
+        // Internal context bypass — must be the literal first check. Internal
+        // calls (migrations, scheduler, fixture loading) carry no user/api_key
+        // and must not log spurious denials.
+        if (parsedContext.internal) {
+            return Promise.resolve();
+        }
+        return dispatchPermissible({
+            TargetModel,
+            action: actionType,
+            objectType,
+            modelOrId,
+            unsafeAttrs: unsafeAttrs || {},
+            parsedContext,
+            loadedPermissions
+        });
+    };
+}
+
+class CanThisV2Result {
+    beginCheck(rawContext) {
+        const parsedContext = parseContext(rawContext);
+
+        let userRoleName = (rawContext && rawContext.userRoleName) || null;
+        let apiKeyRoleName = (rawContext && rawContext.apiKeyRoleName) || null;
+        if (!userRoleName && parsedContext.user) {
+            userRoleName = readRoleFromPrincipal(rawContext && rawContext.user);
+        }
+        if (!apiKeyRoleName && parsedContext.api_key) {
+            apiKeyRoleName = readRoleFromPrincipal(rawContext && rawContext.api_key);
+        }
+
+        const loadedPermissions = synthesizeLoadedPermissions({userRoleName, apiKeyRoleName});
+
+        _.each(ACTION_TO_OBJECT_TYPES, (objectTypes, actionType) => {
+            const handlers = {};
+            for (const objectType of objectTypes) {
+                handlers[objectType] = buildHandler(actionType, objectType, parsedContext, loadedPermissions);
+            }
+            Object.defineProperty(this, actionType, {
+                writable: false,
+                enumerable: false,
+                configurable: false,
+                value: handlers
+            });
+        });
+
+        return this;
+    }
+}
+
+module.exports = function canThisV2(context) {
+    return new CanThisV2Result().beginCheck(context);
+};
+
+module.exports.readRoleFromPrincipal = readRoleFromPrincipal;
+module.exports.ACTION_TO_OBJECT_TYPES = ACTION_TO_OBJECT_TYPES;

--- a/ghost/core/core/server/services/permissions/can-this.js
+++ b/ghost/core/core/server/services/permissions/can-this.js
@@ -1,3 +1,10 @@
+// CUTOVER: delete this file when the soak ends; switch index.js to require
+// can-this-v2.js as `canThis`. The base-permission logic lives in
+// `compute-base-permission.js` and `dispatch-permissible.js`, which both V1
+// and V2 share — this file is the V1 wrapper that performs the per-request
+// DB load via providers.user/apiKey and (during the soak) fires the V2
+// comparator as a side effect.
+
 const _ = require('lodash');
 const models = require('../../models');
 const errors = require('@tryghost/errors');
@@ -5,10 +12,10 @@ const tpl = require('@tryghost/tpl');
 const providers = require('./providers');
 const parseContext = require('./parse-context');
 const actionsMap = require('./actions-map-cache');
-const {setIsRoles} = require('../../models/role-utils');
+const dispatchPermissible = require('./dispatch-permissible');
+const {runParallel} = require('./parallel-check');
 
 const messages = {
-    noPermissionToAction: 'You do not have permission to perform this action',
     noActionsMapFoundError: 'No actions map found, ensure you have loaded permissions into database and then call permissions.init() before use.'
 };
 
@@ -33,7 +40,6 @@ class CanThisResult {
             // Create the 'handler' for the object type;
             // the '.post()' in canThis(user).edit.post()
             objTypeHandlers[objType] = function (modelOrId, unsafeAttrs) {
-                let modelId;
                 unsafeAttrs = unsafeAttrs || {};
 
                 // If it's an internal request, resolve immediately
@@ -41,65 +47,42 @@ class CanThisResult {
                     return Promise.resolve();
                 }
 
-                if (_.isNumber(modelOrId) || _.isString(modelOrId)) {
-                    // It's an id already, do nothing
-                    modelId = modelOrId;
-                } else if (modelOrId) {
-                    // It's a model, get the id
-                    modelId = modelOrId.id;
-                }
-                // Wait for the user loading to finish
-                return permissionLoad.then(function (loadedPermissions) {
-                    // Iterate through the user permissions looking for an affirmation
-                    const userPermissions = loadedPermissions.user ? loadedPermissions.user.permissions : null;
-                    const apiKeyPermissions = loadedPermissions.apiKey ? loadedPermissions.apiKey.permissions : null;
-
-                    let hasUserPermission;
-                    let hasApiKeyPermission;
-
-                    const checkPermission = function (perm) {
-                        // Look for a matching action type and object type first
-                        if (perm.get('action_type') !== actType || perm.get('object_type') !== objType) {
-                            return false;
-                        }
-
-                        return true;
-                    };
-                    const {isOwner} = setIsRoles(loadedPermissions);
-                    if (isOwner) {
-                        hasUserPermission = true;
-                    } else if (!_.isEmpty(userPermissions)) {
-                        hasUserPermission = _.some(userPermissions, checkPermission);
-                    }
-
-                    // Check api key permissions if they were passed
-                    hasApiKeyPermission = true;
-                    if (!_.isNull(apiKeyPermissions)) {
-                        if (loadedPermissions.user) {
-                            // Staff API key scenario: both user and API key present
-                            // Use USER permissions and ignore API key permissions
-                            hasApiKeyPermission = true; // Allow API key check to pass
-                        } else {
-                            // Traditional API key scenario: API key only, no user
-                            // Use API key permissions as before
-                            hasUserPermission = true;
-                            hasApiKeyPermission = _.some(apiKeyPermissions, checkPermission);
-                        }
-                    }
-
-                    // Offer a chance for the TargetModel to override the results
-                    if (TargetModel && _.isFunction(TargetModel.permissible)) {
-                        return TargetModel.permissible(
-                            modelId, actType, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission
-                        );
-                    }
-
-                    if (hasUserPermission && hasApiKeyPermission) {
-                        return;
-                    }
-
-                    return Promise.reject(new errors.NoPermissionError({message: tpl(messages.noPermissionToAction)}));
+                const v1Promise = permissionLoad.then(function (loadedPermissions) {
+                    return dispatchPermissible({
+                        TargetModel,
+                        action: actType,
+                        objectType: objType,
+                        modelOrId,
+                        unsafeAttrs,
+                        parsedContext: context,
+                        loadedPermissions
+                    });
                 });
+
+                // CUTOVER: delete this side-effect block when the soak ends.
+                // V1's `v1Promise` above is the actual outcome; V2 cannot
+                // affect it. Attach to the same `permissionLoad` chain so V2
+                // can read the role off V1's loaded permissions without a
+                // second DB query. Errors are absorbed inside runParallel.
+                permissionLoad.then(function (loadedPermissions) {
+                    runParallel(v1Promise, {
+                        parsedContext: context,
+                        action: actType,
+                        objectType: objType,
+                        modelOrId,
+                        unsafeAttrs,
+                        loadedPermissions,
+                        TargetModel
+                    });
+                }, function () {
+                    // permissionLoad rejected; nothing for V2 to compare against.
+                }).catch(function () {
+                    // Defensive: the synchronous body of either branch above
+                    // should never throw, but a `.catch` on the detached
+                    // chain ensures we never produce an unhandled rejection.
+                });
+
+                return v1Promise;
             };
 
             return objTypeHandlers;

--- a/ghost/core/core/server/services/permissions/compute-base-permission.js
+++ b/ghost/core/core/server/services/permissions/compute-base-permission.js
@@ -1,0 +1,53 @@
+// Pure helper extracted from can-this.js's per-handler closure. Given a
+// loadedPermissions object (real-DB-backed in V1, statically-synthesized in
+// V2) and the action/object pair under check, returns the base
+// {hasUserPermission, hasApiKeyPermission} booleans WITHOUT invoking any
+// model `permissible()` override.
+//
+// The original logic in can-this.js (lines 52-101) is preserved exactly:
+//
+//  - Owner short-circuit: setIsRoles().isOwner forces hasUserPermission=true
+//  - Staff API key precedence: when both user AND apiKey are present, USER
+//    permissions decide and apiKey permissions are ignored (hasApiKeyPermission=true).
+//  - Pure-API-key case: apiKey alone, hasUserPermission=true and apiKey decides.
+//  - Otherwise hasApiKeyPermission stays true (no api_key in context).
+//
+// Returning a flag pair (rather than a boolean) lets the caller still invoke
+// the model's `permissible()` for custom logic (contributor draft rules, etc).
+
+const _ = require('lodash');
+const {setIsRoles} = require('../../models/role-utils');
+
+function computeBasePermission({loadedPermissions, actionType, objectType}) {
+    const userPermissions = loadedPermissions.user ? loadedPermissions.user.permissions : null;
+    const apiKeyPermissions = loadedPermissions.apiKey ? loadedPermissions.apiKey.permissions : null;
+
+    let hasUserPermission;
+    let hasApiKeyPermission;
+
+    const checkPermission = function (perm) {
+        return perm.get('action_type') === actionType && perm.get('object_type') === objectType;
+    };
+
+    const {isOwner} = setIsRoles(loadedPermissions);
+    if (isOwner) {
+        hasUserPermission = true;
+    } else if (!_.isEmpty(userPermissions)) {
+        hasUserPermission = _.some(userPermissions, checkPermission);
+    }
+
+    hasApiKeyPermission = true;
+    if (!_.isNull(apiKeyPermissions)) {
+        if (loadedPermissions.user) {
+            // Staff API key scenario: user wins, apiKey check is bypassed.
+            hasApiKeyPermission = true;
+        } else {
+            hasUserPermission = true;
+            hasApiKeyPermission = _.some(apiKeyPermissions, checkPermission);
+        }
+    }
+
+    return {hasUserPermission, hasApiKeyPermission};
+}
+
+module.exports = computeBasePermission;

--- a/ghost/core/core/server/services/permissions/consistency-check.js
+++ b/ghost/core/core/server/services/permissions/consistency-check.js
@@ -1,0 +1,64 @@
+// Boot-time check that the static role map (role-permissions.js) agrees with
+// the DB-loaded permissions for every role. Drift is silent privilege
+// escalation waiting to happen — in CI/test we throw; in dev/prod we warn so
+// a hot DB edit doesn't crash a running server.
+
+const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const models = require('../../models');
+const rolePermissions = require('./role-permissions');
+
+async function loadDbPermissionsByRole() {
+    const roles = await models.Role.findAll({withRelated: ['permissions']});
+    const map = new Map();
+    for (const role of roles.models) {
+        const set = new Set();
+        const perms = role.related('permissions');
+        if (perms && perms.models) {
+            for (const perm of perms.models) {
+                set.add(`${perm.get('action_type')}:${perm.get('object_type')}`);
+            }
+        }
+        map.set(role.get('name'), set);
+    }
+    return map;
+}
+
+function diffRolePermissions(dbPermissionsByRole) {
+    const issues = [];
+    for (const roleName of rolePermissions.listAllRoles()) {
+        if (rolePermissions.ROLES_WITH_FULL_ACCESS.has(roleName)) {
+            // Owner: short-circuited at runtime; not in the static map; not
+            // expected to have DB permission rows assigned. Skip.
+            continue;
+        }
+        const staticSet = rolePermissions.getPermissionsForRole(roleName);
+        const dbSet = dbPermissionsByRole.get(roleName) || new Set();
+        for (const key of staticSet) {
+            if (!dbSet.has(key)) {
+                issues.push(`role "${roleName}" static-only permission: ${key}`);
+            }
+        }
+        for (const key of dbSet) {
+            if (!staticSet.has(key)) {
+                issues.push(`role "${roleName}" db-only permission: ${key}`);
+            }
+        }
+    }
+    return issues;
+}
+
+async function consistencyCheck() {
+    const dbPermissionsByRole = await loadDbPermissionsByRole();
+    const issues = diffRolePermissions(dbPermissionsByRole);
+    if (issues.length === 0) {
+        return;
+    }
+    const summary = `permissions: static role map drifted from DB (${issues.length} mismatch${issues.length === 1 ? '' : 'es'}):\n  - ${issues.slice(0, 20).join('\n  - ')}${issues.length > 20 ? `\n  - ...and ${issues.length - 20} more` : ''}`;
+    if (process.env.NODE_ENV === 'testing' || process.env.CI === 'true') {
+        throw new errors.IncorrectUsageError({message: summary});
+    }
+    logging.warn(summary);
+}
+
+module.exports = {consistencyCheck, diffRolePermissions};

--- a/ghost/core/core/server/services/permissions/dispatch-permissible.js
+++ b/ghost/core/core/server/services/permissions/dispatch-permissible.js
@@ -1,0 +1,53 @@
+// Shared base-permission dispatcher used by both V1 (can-this.js) and V2
+// (can-this-v2.js, parallel-check.js).
+//
+// Given a parsed context, an action/objectType pair, the loadedPermissions
+// envelope (real for V1, synthesized from the static role map for V2), the
+// caller's modelOrId/unsafeAttrs, and the optional TargetModel, this:
+//
+//   1. Computes hasUserPermission/hasApiKeyPermission via computeBasePermission.
+//   2. Defers to TargetModel.permissible() when defined (model-level overrides
+//      such as Contributor draft rules, owner-immutability, etc).
+//   3. Otherwise resolves on allow / rejects with NoPermissionError on deny.
+//
+// This is the single source of truth for "given perms, what would the chain
+// return?" so V1 and V2 cannot drift.
+
+const _ = require('lodash');
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+const computeBasePermission = require('./compute-base-permission');
+
+const messages = {
+    noPermissionToAction: 'You do not have permission to perform this action'
+};
+
+function dispatchPermissible({TargetModel, action, objectType, modelOrId, unsafeAttrs, parsedContext, loadedPermissions}) {
+    let modelId;
+    if (_.isNumber(modelOrId) || _.isString(modelOrId)) {
+        modelId = modelOrId;
+    } else if (modelOrId) {
+        modelId = modelOrId.id;
+    }
+
+    const {hasUserPermission, hasApiKeyPermission} = computeBasePermission({
+        loadedPermissions,
+        actionType: action,
+        objectType
+    });
+
+    if (TargetModel && _.isFunction(TargetModel.permissible)) {
+        return Promise.resolve(TargetModel.permissible(
+            modelId, action, parsedContext, unsafeAttrs,
+            loadedPermissions, hasUserPermission, hasApiKeyPermission
+        ));
+    }
+
+    if (hasUserPermission && hasApiKeyPermission) {
+        return Promise.resolve();
+    }
+    return Promise.reject(new errors.NoPermissionError({message: tpl(messages.noPermissionToAction)}));
+}
+
+module.exports = dispatchPermissible;
+module.exports.messages = messages;

--- a/ghost/core/core/server/services/permissions/index.js
+++ b/ghost/core/core/server/services/permissions/index.js
@@ -2,22 +2,34 @@
 // canThis(someUser).edit.post(somePost|somePostId)
 
 const models = require('../../models');
-
 const actionsMap = require('./actions-map-cache');
+const {registerMetrics} = require('./metrics');
+const {consistencyCheck} = require('./consistency-check');
 
-const init = function init(options) {
+const init = async function init(options) {
     options = options || {};
+    const permissionsCollection = await models.Permission.findAll(options);
+    const actions = actionsMap.init(permissionsCollection);
+    registerMetrics();
 
-    // Load all the permissions
-    return models.Permission.findAll(options)
-        .then(function (permissionsCollection) {
-            return actionsMap.init(permissionsCollection);
-        });
+    // The consistency check queries the `roles` table. Skip if the DB isn't
+    // seeded (existing unit tests stub Permission.findAll but not
+    // Role.findAll). In CI/test the check throws on real drift.
+    try {
+        await consistencyCheck();
+    } catch (err) {
+        if (err && /no such table/i.test(err.message || '')) {
+            return actions;
+        }
+        throw err;
+    }
+    return actions;
 };
 
 module.exports = {
     init: init,
     canThis: require('./can-this'),
+    canThisV2: require('./can-this-v2'),
     // @TODO: Make it so that we don't need to export these
     parseContext: require('./parse-context')
 };

--- a/ghost/core/core/server/services/permissions/metrics.js
+++ b/ghost/core/core/server/services/permissions/metrics.js
@@ -1,0 +1,44 @@
+// CUTOVER: delete this file when the soak ends.
+//
+// Wires Prometheus counters (when available) and a no-op fallback otherwise,
+// then hands them to parallel-check.js. The fallback is the important part:
+// V2 must run on every install — including those that haven't enabled
+// Prometheus in config — so the parallel-soak signal isn't gated on an
+// observability dependency. The Prometheus counters are the cutover gate
+// ("zero divergences for 14 days at >1M checks"); logs say *which* requests
+// diverged.
+
+const prometheusClient = require('../../../shared/prometheus-client');
+const parallelCheck = require('./parallel-check');
+
+function registerMetrics() {
+    // Skip in test mode — V1 tests call permissions.init() incidentally and
+    // would otherwise enable V2 globally for the rest of the run, breaking
+    // call-count assertions on `Model.permissible`. Test files that exercise
+    // V2 set metrics directly via `parallelCheck.setMetrics(...)`.
+    if (process.env.NODE_ENV === 'testing') {
+        return;
+    }
+    if (!prometheusClient) {
+        // Without Prometheus configured V2 still runs (parallel-check.js
+        // tolerates `metrics === null`); we just don't emit counters. Logs
+        // alone convey divergence on installs without Prometheus.
+        return;
+    }
+    prometheusClient.registerCounter({
+        name: 'ghost_permissions_v2_checks_total',
+        help: 'Total permission checks compared between V1 (DB) and V2 (static map) during the parallel-run period',
+        labelNames: ['result']
+    });
+    prometheusClient.registerCounter({
+        name: 'ghost_permissions_v2_divergence_total',
+        help: 'Permission checks where V1 (DB) and V2 (static map) disagreed',
+        labelNames: ['action', 'object_type', 'v1', 'v2']
+    });
+    parallelCheck.setMetrics({
+        checks: prometheusClient.getMetric('ghost_permissions_v2_checks_total'),
+        divergence: prometheusClient.getMetric('ghost_permissions_v2_divergence_total')
+    });
+}
+
+module.exports = {registerMetrics};

--- a/ghost/core/core/server/services/permissions/normalize-allow-result.js
+++ b/ghost/core/core/server/services/permissions/normalize-allow-result.js
@@ -1,0 +1,50 @@
+// Normalizes the outcome of a permission handler so V1 and V2 results can be
+// compared structurally without spurious divergences from semantically-
+// equivalent shapes.
+//
+// A handler resolves with:
+//   - undefined / null / {} / {excludedAttrs: undefined|null|[]}  (allow, no exclusions)
+//   - {excludedAttrs: ['tags', ...]}                              (allow, with exclusions)
+// or rejects with an error (deny).
+//
+// We classify each side as 'allow' | 'deny' and, when allow, capture a
+// canonical sorted-deduped excludedAttrs array. (Attr names are case-sensitive
+// — they map to model attributes — so we do NOT lowercase.)
+
+function normalizeAllow(value) {
+    const excludedAttrs = value && Array.isArray(value.excludedAttrs)
+        ? [...new Set(value.excludedAttrs)].sort()
+        : [];
+    return {result: 'allow', excludedAttrs};
+}
+
+function normalizeDeny(error) {
+    return {
+        result: 'deny',
+        // errorType helps debug divergences but is intentionally NOT used by
+        // resultsMatch — V1 may throw HostingLimitError where V2 throws
+        // NoPermissionError; both are "deny" semantically.
+        errorType: (error && error.constructor && error.constructor.name) || 'Error'
+    };
+}
+
+function resultsMatch(a, b) {
+    if (a.result !== b.result) {
+        return false;
+    }
+    if (a.result === 'deny') {
+        return true;
+    }
+    // both allow: compare excludedAttrs
+    if (a.excludedAttrs.length !== b.excludedAttrs.length) {
+        return false;
+    }
+    for (let i = 0; i < a.excludedAttrs.length; i++) {
+        if (a.excludedAttrs[i] !== b.excludedAttrs[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+module.exports = {normalizeAllow, normalizeDeny, resultsMatch};

--- a/ghost/core/core/server/services/permissions/parallel-check.js
+++ b/ghost/core/core/server/services/permissions/parallel-check.js
@@ -1,0 +1,234 @@
+// CUTOVER: delete this file when the soak ends.
+//
+// Wires canThisV2 as a side-effect of every canThis() handler. V1 always
+// determines the actual outcome — V2 runs after V1's promise settles, its
+// result is compared, divergences are logged + counted via Prometheus, and
+// any error inside V2 is swallowed so it cannot affect the caller.
+//
+// During the parallel-soak period V2 piggy-backs on V1's role load (V1 has
+// already queried the DB; we read the role name off V1's loadedPermissions
+// to avoid a second round-trip). After cutover, V1 is deleted and V2 takes
+// over its own light role lookup.
+//
+// Recursion guard: when a model's `permissible()` recursively calls canThis
+// (e.g. User.permissible -> canThis(context).assign.role), we must NOT
+// re-enter the parallel checker on the inner call — otherwise V2 work
+// doubles per nesting level. AsyncLocalStorage is the cleanest signal here
+// because it doesn't mutate the context object and doesn't require every
+// callee to opt in.
+//
+// Kill switch: env var `GHOST_PERMISSIONS_V2_PARALLEL=false` short-circuits.
+// Read per-call so an env-update + SIGHUP-style reload takes effect without
+// requiring a code redeploy. Accepts case-insensitive and common no/off
+// spellings. (Labs flags can't be used here — they themselves route through
+// the permissions/settings layer.)
+
+const {AsyncLocalStorage} = require('node:async_hooks');
+const _ = require('lodash');
+const logging = require('@tryghost/logging');
+const dispatchPermissible = require('./dispatch-permissible');
+const {synthesizeLoadedPermissions} = require('./role-permissions');
+const {normalizeAllow, normalizeDeny, resultsMatch} = require('./normalize-allow-result');
+
+const insideV2 = new AsyncLocalStorage();
+
+let metrics = null;
+function setMetrics(registered) {
+    metrics = registered;
+}
+
+const LOG_SAMPLE_WINDOW_MS = 60_000;
+const lastLoggedAt = new Map();
+
+const KILL_SWITCH_VALUES = new Set(['false', '0', 'off', 'no']);
+function isParallelEnabled() {
+    // Re-entrant call from inside V2 itself (model.permissible recursing into
+    // canThis). Skip: V2's effect on this nested check would double the work.
+    if (insideV2.getStore() === true) {
+        return false;
+    }
+    const flag = process.env.GHOST_PERMISSIONS_V2_PARALLEL;
+    if (flag !== undefined) {
+        return !KILL_SWITCH_VALUES.has(String(flag).toLowerCase());
+    }
+    // Default off in test (so existing V1 unit tests aren't affected — V2
+    // would double-invoke `permissible()` and break call-count assertions).
+    // Tests that want V2 enable it via setMetrics() + the env var or by
+    // calling parallelCheck directly.
+    if (process.env.NODE_ENV === 'testing') {
+        return metrics !== null;
+    }
+    // In dev/prod: V2 runs regardless of whether Prometheus is enabled. The
+    // counters are nullable; logs alone still convey divergence on installs
+    // without Prometheus configured.
+    return true;
+}
+
+function summarizeContext(parsedContext) {
+    const userId = parsedContext.user;
+    return {
+        // Defensive: callers SHOULD pass an id, but if a Bookshelf model ever
+        // slips through we don't want to serialize it whole into a log line.
+        user_id: (userId && typeof userId === 'object') ? '<object>' : (userId || null),
+        api_key_id: parsedContext.api_key ? parsedContext.api_key.id : null,
+        api_key_type: parsedContext.api_key ? parsedContext.api_key.type : null,
+        internal: Boolean(parsedContext.internal),
+        public: Boolean(parsedContext.public)
+    };
+}
+
+function shouldLog(action, objectType, v1Label, v2Label) {
+    const key = `${action}:${objectType}:${v1Label}:${v2Label}`;
+    const now = Date.now();
+    const last = lastLoggedAt.get(key);
+    if (last && now - last < LOG_SAMPLE_WINDOW_MS) {
+        return false;
+    }
+    lastLoggedAt.set(key, now);
+    return true;
+}
+
+function recordCheck(result) {
+    if (metrics && metrics.checks) {
+        metrics.checks.inc({result});
+    }
+}
+
+function recordDivergence(action, objectType, v1Label, v2Label) {
+    if (metrics && metrics.divergence) {
+        metrics.divergence.inc({
+            action,
+            object_type: objectType,
+            v1: v1Label,
+            v2: v2Label
+        });
+    }
+}
+
+function readRoleNameFromLoaded(side) {
+    if (!side || !Array.isArray(side.roles) || !side.roles[0]) {
+        return null;
+    }
+    return side.roles[0].name || null;
+}
+
+// Run V2 against the same model.permissible() that V1 just ran, but with a
+// loadedPermissions object synthesized from the static role map.
+function runV2({TargetModel, action, objectType, modelOrId, unsafeAttrs, parsedContext, userRoleName, apiKeyRoleName}) {
+    const v2LoadedPermissions = synthesizeLoadedPermissions({userRoleName, apiKeyRoleName});
+    return dispatchPermissible({
+        TargetModel,
+        action,
+        objectType,
+        modelOrId,
+        unsafeAttrs,
+        parsedContext,
+        loadedPermissions: v2LoadedPermissions
+    });
+}
+
+// Compares V1 and V2 outcomes for a single handler invocation. Always void —
+// V2's outcome never affects the caller; the V1 promise the caller already
+// holds is what propagates.
+async function compareResults({v1Promise, v2Promise, action, objectType, parsedContext}) {
+    let v1Outcome;
+    try {
+        const v1Value = await v1Promise;
+        v1Outcome = normalizeAllow(v1Value);
+    } catch (err) {
+        v1Outcome = normalizeDeny(err);
+    }
+
+    let v2Outcome;
+    try {
+        const v2Value = await v2Promise;
+        v2Outcome = normalizeAllow(v2Value);
+    } catch (v2Err) {
+        v2Outcome = normalizeDeny(v2Err);
+    }
+
+    if (resultsMatch(v1Outcome, v2Outcome)) {
+        recordCheck('match');
+        return;
+    }
+    recordCheck('divergence');
+    recordDivergence(action, objectType, v1Outcome.result, v2Outcome.result);
+    if (shouldLog(action, objectType, v1Outcome.result, v2Outcome.result)) {
+        logging.warn({
+            event: 'permissions_v2_divergence',
+            action,
+            object_type: objectType,
+            v1: v1Outcome.result,
+            v2: v2Outcome.result,
+            v1_excluded_attrs: v1Outcome.excludedAttrs,
+            v2_excluded_attrs: v2Outcome.excludedAttrs,
+            v1_error_type: v1Outcome.errorType,
+            v2_error_type: v2Outcome.errorType,
+            context: summarizeContext(parsedContext)
+        });
+    }
+}
+
+// Public entrypoint called from can-this.js's handler. V2 is launched as a
+// side effect; the caller awaits the V1 promise we return unmodified.
+function runParallel(v1Promise, {parsedContext, action, objectType, modelOrId, unsafeAttrs, loadedPermissions, TargetModel}) {
+    if (!isParallelEnabled() || parsedContext.internal) {
+        return v1Promise;
+    }
+
+    let v2Promise;
+    try {
+        const userRoleName = loadedPermissions && loadedPermissions.user
+            ? readRoleNameFromLoaded(loadedPermissions.user) : null;
+        const apiKeyRoleName = loadedPermissions && loadedPermissions.apiKey
+            ? readRoleNameFromLoaded(loadedPermissions.apiKey) : null;
+
+        // cloneDeep `unsafeAttrs` so any V1 mutation between handler entry
+        // and now doesn't leak into V2 — eliminates an entire class of
+        // order-dependent false positives. parsedContext is shallow + plain
+        // so a shallow copy suffices and avoids cloning Bookshelf models.
+        const v2Attrs = _.cloneDeep(unsafeAttrs || {});
+        const v2Context = Object.assign({}, parsedContext);
+
+        // Mark this async branch so any nested canThis triggered by
+        // model.permissible inside V2 skips its own parallel-check.
+        v2Promise = insideV2.run(true, () => runV2({
+            TargetModel,
+            action,
+            objectType,
+            modelOrId,
+            unsafeAttrs: v2Attrs,
+            parsedContext: v2Context,
+            userRoleName,
+            apiKeyRoleName
+        }));
+    } catch (err) {
+        v2Promise = Promise.reject(err);
+    }
+
+    compareResults({
+        v1Promise: Promise.resolve(v1Promise),
+        v2Promise,
+        action,
+        objectType,
+        parsedContext
+    }).catch((err) => {
+        recordCheck('error');
+        try {
+            logging.warn({
+                event: 'permissions_v2_compare_failed',
+                action,
+                object_type: objectType,
+                error: err && err.message,
+                context: summarizeContext(parsedContext)
+            });
+        } catch (_e) {
+            // Last-resort: do nothing. Never let logging crash a request.
+        }
+    });
+
+    // V2 has zero influence on the returned outcome.
+    return v1Promise;
+}
+
+module.exports = {runParallel, setMetrics, isParallelEnabled, summarizeContext, shouldLog, readRoleNameFromLoaded};

--- a/ghost/core/core/server/services/permissions/role-permissions.js
+++ b/ghost/core/core/server/services/permissions/role-permissions.js
@@ -1,0 +1,243 @@
+const errors = require('@tryghost/errors');
+
+// In-memory role -> permissions map. Replaces the per-request DB lookup that
+// providers.user/apiKey perform today. Source-of-truth during the parallel-run
+// soak is `data/schema/fixtures/fixtures.json` (relations[0].entries +
+// Permission entries) — `role-permissions.test.js` asserts the two stay in sync.
+
+// Per-object_type list of every action_type that exists in fixtures.json's
+// Permission section. Used to expand the "all" shorthand below.
+const OBJECT_TYPE_ACTIONS = {
+    explore: ['read'],
+    db: ['exportContent', 'importContent', 'deleteAllContent', 'backupContent'],
+    mail: ['send'],
+    notification: ['browse', 'add', 'destroy'],
+    post: ['browse', 'read', 'edit', 'add', 'destroy', 'publish'],
+    setting: ['browse', 'read', 'edit'],
+    slug: ['generate'],
+    tag: ['browse', 'read', 'edit', 'add', 'destroy'],
+    theme: ['browse', 'edit', 'activate', 'readActive', 'add', 'read', 'destroy'],
+    user: ['browse', 'read', 'edit', 'add', 'destroy'],
+    role: ['assign', 'browse'],
+    invite: ['browse', 'read', 'edit', 'add', 'destroy'],
+    redirect: ['download', 'upload'],
+    webhook: ['add', 'edit', 'destroy'],
+    integration: ['browse', 'read', 'edit', 'add', 'destroy'],
+    api_key: ['browse', 'read', 'edit', 'add', 'destroy'],
+    action: ['browse'],
+    member: ['browse', 'read', 'edit', 'add', 'destroy'],
+    product: ['browse', 'read', 'edit', 'add', 'destroy'],
+    email_preview: ['read', 'sendTestEmail'],
+    email: ['browse', 'read', 'retry'],
+    label: ['browse', 'read', 'edit', 'add', 'destroy'],
+    automated_email: ['browse', 'read', 'edit', 'add', 'destroy'],
+    email_design_setting: ['browse', 'read', 'edit', 'add', 'destroy'],
+    member_signin_url: ['read'],
+    identity: ['read'],
+    members_stripe_connect: ['auth'],
+    snippet: ['browse', 'read', 'edit', 'add', 'destroy'],
+    offer: ['browse', 'read', 'edit', 'add'],
+    authentication: ['resetAllPasswords'],
+    custom_theme_setting: ['browse', 'edit'],
+    newsletter: ['browse', 'read', 'add', 'edit'],
+    comment: ['browse', 'read', 'edit', 'add', 'destroy', 'moderate', 'like', 'unlike', 'report'],
+    link: ['browse', 'edit'],
+    mention: ['browse'],
+    collection: ['browse', 'read', 'edit', 'add', 'destroy'],
+    recommendation: ['browse', 'read', 'edit', 'add', 'destroy'],
+    automation: ['poll']
+};
+
+// Mirror of fixtures.json relations[0].entries. The shorthand:
+//   "post": "all"            -> every action in OBJECT_TYPE_ACTIONS.post
+//   "user": ["browse","read"] -> exactly those actions
+// Owner is intentionally not listed here: the existing canThis short-circuits
+// Owner via setIsRoles().isOwner before consulting permission lists, so V2
+// must do the same and treat Owner as having every (action, object_type) pair.
+const ROLE_DECLARATIONS = {
+    Administrator: {
+        db: 'all', mail: 'all', notification: 'all', post: 'all', setting: 'all',
+        slug: 'all', tag: 'all', theme: 'all', user: 'all', role: 'all', invite: 'all',
+        redirect: 'all', webhook: 'all', integration: 'all', api_key: 'all', action: 'all',
+        member: 'all', product: 'all', label: 'all', automated_email: 'all',
+        email_design_setting: 'all', email_preview: 'all', email: 'all',
+        member_signin_url: 'read', snippet: 'all', custom_theme_setting: 'all',
+        offer: 'all', authentication: 'resetAllPasswords', members_stripe_connect: 'auth',
+        newsletter: 'all', explore: 'read', comment: 'all', link: 'all',
+        mention: 'browse', collection: 'all', recommendation: 'all', identity: 'read'
+    },
+    'DB Backup Integration': {db: 'all', member: 'browse'},
+    'Scheduler Integration': {post: 'publish', automation: 'poll'},
+    'Ghost Explore Integration': {explore: 'read'},
+    'Self-Serve Migration Integration': {db: 'importContent', member: 'add', tag: 'read'},
+    'Admin Integration': {
+        mail: 'all', notification: 'all', post: 'all', setting: 'all', slug: 'all',
+        tag: 'all', theme: 'all', user: 'all', role: 'all', invite: 'all',
+        redirect: 'all', webhook: 'all', action: 'all', member: 'all', label: 'all',
+        automated_email: 'all', email_design_setting: 'all', email_preview: 'all',
+        email: 'all', snippet: 'all',
+        product: ['browse', 'read', 'add', 'edit'],
+        offer: ['browse', 'read', 'add', 'edit'],
+        newsletter: ['browse', 'read', 'add', 'edit'],
+        explore: 'read', comment: 'all', link: 'all', mention: 'browse',
+        collection: 'all', recommendation: 'all', member_signin_url: 'read'
+    },
+    'Super Editor': {
+        notification: 'all', post: 'all', setting: ['browse', 'read'], slug: 'all',
+        tag: 'all', user: 'all', role: 'all', invite: 'all',
+        theme: ['browse', 'readActive'], email_preview: 'all', email: 'all',
+        snippet: 'all', label: ['browse', 'read', 'edit', 'add', 'destroy'],
+        product: ['browse', 'read'], newsletter: ['browse', 'read'],
+        collection: 'all', recommendation: ['browse', 'read'],
+        member: ['browse', 'read', 'add', 'edit', 'destroy'],
+        member_signin_url: 'read', offer: ['browse', 'read'], comment: 'all'
+    },
+    Editor: {
+        notification: 'all', post: 'all', setting: ['browse', 'read'], slug: 'all',
+        tag: 'all', user: 'all', role: 'all', invite: 'all',
+        theme: ['browse', 'readActive'], email_preview: 'all', email: 'all',
+        snippet: 'all', label: ['browse', 'read'],
+        product: ['browse', 'read'], newsletter: ['browse', 'read'],
+        collection: 'all', recommendation: ['browse', 'read']
+    },
+    Author: {
+        post: ['browse', 'read', 'edit', 'add', 'destroy'],
+        setting: ['browse', 'read'], slug: 'all',
+        tag: ['browse', 'read', 'add'], user: ['browse', 'read'], role: ['browse'],
+        theme: ['browse', 'readActive'], email_preview: 'read', email: 'read',
+        snippet: ['browse', 'read'], label: ['browse', 'read'],
+        product: ['browse', 'read'], newsletter: ['browse', 'read'],
+        collection: ['browse', 'read', 'add'], recommendation: ['browse', 'read']
+    },
+    Contributor: {
+        post: ['browse', 'read', 'edit', 'add', 'destroy'],
+        setting: ['browse', 'read'], slug: 'all',
+        tag: ['browse', 'read'], user: ['browse', 'read'], role: ['browse'],
+        theme: ['browse'], email_preview: 'read', email: 'read',
+        snippet: ['browse', 'read'],
+        collection: ['browse', 'read'], recommendation: ['browse', 'read']
+    }
+};
+
+const ROLES_WITH_FULL_ACCESS = new Set(['Owner']);
+
+// Deep-freeze so test pollution / runtime mutation cannot widen privileges.
+function deepFreeze(obj) {
+    if (obj === null || typeof obj !== 'object' || Object.isFrozen(obj)) {
+        return obj;
+    }
+    for (const key of Object.keys(obj)) {
+        deepFreeze(obj[key]);
+    }
+    return Object.freeze(obj);
+}
+
+deepFreeze(OBJECT_TYPE_ACTIONS);
+deepFreeze(ROLE_DECLARATIONS);
+
+// Pre-compute expanded "action:object" strings per role so getPermissionsForRole
+// is O(1) lookup. Stored as plain Set; getPermissionsForRole returns a fresh
+// copy each call so callers cannot mutate the shared one. We also validate
+// every object_type referenced by every role here, so a typo'd object_type in
+// a list-form declaration (e.g. `tagg: ['browse']`) fails fast at module load
+// instead of silently producing phantom permissions that never grant access.
+const PERMISSIONS_BY_ROLE = new Map();
+for (const [roleName, declarations] of Object.entries(ROLE_DECLARATIONS)) {
+    const set = new Set();
+    for (const [objectType, actionsValue] of Object.entries(declarations)) {
+        if (!OBJECT_TYPE_ACTIONS[objectType]) {
+            throw new errors.IncorrectUsageError({
+                message: `role-permissions: unknown object_type "${objectType}" for role "${roleName}"`
+            });
+        }
+        let actions;
+        if (actionsValue === 'all') {
+            actions = OBJECT_TYPE_ACTIONS[objectType];
+        } else if (typeof actionsValue === 'string') {
+            actions = [actionsValue];
+        } else {
+            actions = actionsValue;
+        }
+        for (const action of actions) {
+            set.add(`${action}:${objectType}`);
+        }
+    }
+    PERMISSIONS_BY_ROLE.set(roleName, set);
+}
+
+function getPermissionsForRole(roleName) {
+    if (!roleName) {
+        return new Set();
+    }
+    if (ROLES_WITH_FULL_ACCESS.has(roleName)) {
+        // Owner: short-circuited in canThis itself; return an empty set here so
+        // any caller that forgets the short-circuit still fails closed.
+        return new Set();
+    }
+    const set = PERMISSIONS_BY_ROLE.get(roleName);
+    return set ? new Set(set) : new Set();
+}
+
+function hasPermission(roleName, action, objectType) {
+    if (ROLES_WITH_FULL_ACCESS.has(roleName)) {
+        return true;
+    }
+    const set = PERMISSIONS_BY_ROLE.get(roleName);
+    return Boolean(set && set.has(`${action}:${objectType}`));
+}
+
+// Synthesize the `loadedPermissions` shape that the existing model
+// `permissible(...)` methods (post.js, user.js, role.js, integration.js)
+// expect, without touching the database. Returned shape mirrors what
+// providers.user / providers.apiKey produce. The minimal stub on each
+// permission record responds to `.get(field)` because models read perms via
+// Bookshelf's `.get('action_type')` etc.
+function synthesizeLoadedPermissions({userRoleName, apiKeyRoleName} = {}) {
+    return {
+        user: userRoleName ? buildSide(userRoleName) : null,
+        apiKey: apiKeyRoleName ? buildSide(apiKeyRoleName) : null
+    };
+}
+
+function buildSide(roleName) {
+    const set = ROLES_WITH_FULL_ACCESS.has(roleName) ? null : PERMISSIONS_BY_ROLE.get(roleName);
+    const perms = [];
+    if (set) {
+        for (const key of set) {
+            const [actionType, objectType] = key.split(':');
+            perms.push(makePermStub(actionType, objectType));
+        }
+    }
+    return {permissions: perms, roles: [{name: roleName}]};
+}
+
+function makePermStub(actionType, objectType) {
+    return {
+        get(field) {
+            if (field === 'action_type') {
+                return actionType;
+            }
+            if (field === 'object_type') {
+                return objectType;
+            }
+            if (field === 'object_id') {
+                return null;
+            }
+            return undefined;
+        }
+    };
+}
+
+function listAllRoles() {
+    return [...ROLES_WITH_FULL_ACCESS, ...PERMISSIONS_BY_ROLE.keys()];
+}
+
+module.exports = {
+    OBJECT_TYPE_ACTIONS,
+    ROLE_DECLARATIONS,
+    ROLES_WITH_FULL_ACCESS,
+    getPermissionsForRole,
+    hasPermission,
+    synthesizeLoadedPermissions,
+    listAllRoles
+};

--- a/ghost/core/test/unit/server/services/permissions/can-this-v2.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this-v2.test.js
@@ -1,0 +1,81 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const models = require('../../../../../core/server/models');
+const actionsMap = require('../../../../../core/server/services/permissions/actions-map-cache');
+const canThisV2 = require('../../../../../core/server/services/permissions/can-this-v2');
+
+// Seed actionsMap directly without spinning up Bookshelf's Permissions
+// collection — this lets the test exercise non-default actions like 'publish'.
+function seedActionsMap(entries) {
+    const stubModels = entries.map(([actionType, objectType]) => ({
+        get(field) {
+            if (field === 'action_type') {
+                return actionType;
+            }
+            if (field === 'object_type') {
+                return objectType;
+            }
+        }
+    }));
+    actionsMap.init({models: stubModels});
+}
+
+describe('Permissions: canThisV2 chain', function () {
+    before(function () {
+        models.init();
+        seedActionsMap([
+            ['browse', 'post'], ['edit', 'post'], ['add', 'post'],
+            ['destroy', 'post'], ['publish', 'post'],
+            ['edit', 'user'], ['destroy', 'user']
+        ]);
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('exposes action.objectType handlers built from the actions map', function () {
+        const result = canThisV2({user: 1, userRoleName: 'Editor'});
+        assert.equal(typeof result.edit, 'object');
+        assert.equal(typeof result.edit.post, 'function');
+        assert.equal(typeof result.browse, 'object');
+    });
+
+    it('Editor can edit:post (resolves)', async function () {
+        sinon.stub(models.Post, 'permissible').resolves();
+        await canThisV2({user: 1, userRoleName: 'Editor'}).edit.post('id-1', {});
+    });
+
+    it('Contributor cannot publish:post (rejects with NoPermissionError)', async function () {
+        // No model.permissible override: base check denies.
+        sinon.stub(models.Post, 'permissible').value(undefined);
+        await assert.rejects(
+            () => canThisV2({user: 1, userRoleName: 'Contributor'}).publish.post('id-1', {}),
+            /You do not have permission/i
+        );
+    });
+
+    it('internal context resolves immediately without invoking model.permissible', async function () {
+        const stub = sinon.stub(models.Post, 'permissible').rejects(new Error('should not be called'));
+        await canThisV2({internal: true}).edit.post('id-1', {});
+        assert.equal(stub.called, false);
+    });
+
+    // Owner short-circuit and staff-API-key precedence are covered exhaustively
+    // in compute-base-permission.test.js (the layer where they live). Here we
+    // just verify the chain plumbs them through end-to-end.
+    it('Owner can perform any action (no model.permissible needed)', async function () {
+        sinon.stub(models.Post, 'permissible').value(undefined);
+        await canThisV2({user: 1, userRoleName: 'Owner'}).destroy.post('id-1', {});
+    });
+
+    it('api_key only with role that lacks the action -> denies', async function () {
+        sinon.stub(models.Post, 'permissible').value(undefined);
+        await assert.rejects(
+            () => canThisV2({
+                api_key: {id: 'k1', type: 'admin'}, apiKeyRoleName: 'DB Backup Integration'
+            }).edit.post('id-1', {}),
+            /You do not have permission/i
+        );
+    });
+});

--- a/ghost/core/test/unit/server/services/permissions/compute-base-permission.test.js
+++ b/ghost/core/test/unit/server/services/permissions/compute-base-permission.test.js
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict');
+const computeBasePermission = require('../../../../../core/server/services/permissions/compute-base-permission');
+
+function perm(actionType, objectType) {
+    return {
+        get(field) {
+            if (field === 'action_type') {
+                return actionType;
+            }
+            if (field === 'object_type') {
+                return objectType;
+            }
+            if (field === 'object_id') {
+                return null;
+            }
+        }
+    };
+}
+
+describe('Permissions: computeBasePermission', function () {
+    it('grants when user permissions include the (action, object) pair', function () {
+        const result = computeBasePermission({
+            loadedPermissions: {
+                user: {permissions: [perm('edit', 'post')], roles: [{name: 'Editor'}]},
+                apiKey: null
+            },
+            actionType: 'edit',
+            objectType: 'post'
+        });
+        assert.deepEqual(result, {hasUserPermission: true, hasApiKeyPermission: true});
+    });
+
+    it('denies when user permissions do not include the pair', function () {
+        const result = computeBasePermission({
+            loadedPermissions: {
+                user: {permissions: [perm('browse', 'post')], roles: [{name: 'Editor'}]},
+                apiKey: null
+            },
+            actionType: 'edit',
+            objectType: 'post'
+        });
+        assert.deepEqual(result, {hasUserPermission: false, hasApiKeyPermission: true});
+    });
+
+    it('Owner gets hasUserPermission=true regardless of permission list', function () {
+        const result = computeBasePermission({
+            loadedPermissions: {
+                user: {permissions: [], roles: [{name: 'Owner'}]},
+                apiKey: null
+            },
+            actionType: 'destroy',
+            objectType: 'user'
+        });
+        assert.equal(result.hasUserPermission, true);
+        assert.equal(result.hasApiKeyPermission, true);
+    });
+
+    it('staff API key (user + api_key both present): user wins, apiKey check bypassed', function () {
+        // User has edit:post; api_key has only browse:post. With staff token
+        // semantics, hasUserPermission = true (user grants), hasApiKeyPermission
+        // is forced true (api_key check bypassed entirely).
+        const result = computeBasePermission({
+            loadedPermissions: {
+                user: {permissions: [perm('edit', 'post')], roles: [{name: 'Editor'}]},
+                apiKey: {permissions: [perm('browse', 'post')], roles: [{name: 'Admin Integration'}]}
+            },
+            actionType: 'edit',
+            objectType: 'post'
+        });
+        assert.deepEqual(result, {hasUserPermission: true, hasApiKeyPermission: true});
+    });
+
+    it('staff API key: user lacks permission -> still denies (api_key check bypassed)', function () {
+        // The staff-token semantics specifically say api_key permissions are
+        // NOT consulted when a user is also present. So even though the
+        // api_key has the permission, the result should be deny.
+        const result = computeBasePermission({
+            loadedPermissions: {
+                user: {permissions: [perm('browse', 'post')], roles: [{name: 'Author'}]},
+                apiKey: {permissions: [perm('destroy', 'post')], roles: [{name: 'Admin Integration'}]}
+            },
+            actionType: 'destroy',
+            objectType: 'post'
+        });
+        assert.equal(result.hasUserPermission, false);
+        assert.equal(result.hasApiKeyPermission, true);
+    });
+
+    it('api_key-only context (no user): api_key permissions decide', function () {
+        const result = computeBasePermission({
+            loadedPermissions: {
+                user: null,
+                apiKey: {permissions: [perm('publish', 'post')], roles: [{name: 'Scheduler Integration'}]}
+            },
+            actionType: 'publish',
+            objectType: 'post'
+        });
+        assert.deepEqual(result, {hasUserPermission: true, hasApiKeyPermission: true});
+    });
+
+    it('api_key-only context, missing permission -> denies via apiKey', function () {
+        const result = computeBasePermission({
+            loadedPermissions: {
+                user: null,
+                apiKey: {permissions: [perm('browse', 'post')], roles: [{name: 'Some Integration'}]}
+            },
+            actionType: 'destroy',
+            objectType: 'post'
+        });
+        assert.equal(result.hasApiKeyPermission, false);
+    });
+});

--- a/ghost/core/test/unit/server/services/permissions/normalize-allow-result.test.js
+++ b/ghost/core/test/unit/server/services/permissions/normalize-allow-result.test.js
@@ -1,0 +1,76 @@
+const assert = require('node:assert/strict');
+const {normalizeAllow, normalizeDeny, resultsMatch} = require('../../../../../core/server/services/permissions/normalize-allow-result');
+
+class NoPermissionError extends Error {}
+class HostingLimitError extends Error {}
+
+describe('Permissions: normalize-allow-result', function () {
+    describe('normalizeAllow', function () {
+        const cases = [
+            ['undefined', undefined, []],
+            ['null', null, []],
+            ['empty object', {}, []],
+            ['{excludedAttrs: undefined}', {excludedAttrs: undefined}, []],
+            ['{excludedAttrs: null}', {excludedAttrs: null}, []],
+            ['{excludedAttrs: []}', {excludedAttrs: []}, []],
+            ['{excludedAttrs: ["tags"]}', {excludedAttrs: ['tags']}, ['tags']],
+            ['dedupes', {excludedAttrs: ['tags', 'tags']}, ['tags']],
+            ['sorts', {excludedAttrs: ['z', 'a']}, ['a', 'z']],
+            ['case-sensitive', {excludedAttrs: ['Tags', 'tags']}, ['Tags', 'tags']]
+        ];
+        for (const [name, input, expected] of cases) {
+            it(`treats ${name} as allow with excludedAttrs=${JSON.stringify(expected)}`, function () {
+                const result = normalizeAllow(input);
+                assert.equal(result.result, 'allow');
+                assert.deepEqual(result.excludedAttrs, expected);
+            });
+        }
+    });
+
+    describe('normalizeDeny', function () {
+        it('classifies as deny and preserves error subclass name', function () {
+            const r = normalizeDeny(new NoPermissionError('nope'));
+            assert.equal(r.result, 'deny');
+            assert.equal(r.errorType, 'NoPermissionError');
+        });
+
+        it('falls back to "Error" when constructor missing', function () {
+            const r = normalizeDeny(null);
+            assert.equal(r.result, 'deny');
+            assert.equal(r.errorType, 'Error');
+        });
+    });
+
+    describe('resultsMatch', function () {
+        it('two allows with same excludedAttrs match', function () {
+            assert.ok(resultsMatch(
+                normalizeAllow({excludedAttrs: ['tags']}),
+                normalizeAllow({excludedAttrs: ['tags']})
+            ));
+        });
+        it('allow vs allow with different excludedAttrs do not match', function () {
+            assert.ok(!resultsMatch(
+                normalizeAllow({excludedAttrs: ['tags']}),
+                normalizeAllow({excludedAttrs: []})
+            ));
+        });
+        it('allow vs deny do not match', function () {
+            assert.ok(!resultsMatch(
+                normalizeAllow(undefined),
+                normalizeDeny(new NoPermissionError())
+            ));
+        });
+        it('two denies match regardless of error subclass (HostingLimit vs NoPermission)', function () {
+            assert.ok(resultsMatch(
+                normalizeDeny(new HostingLimitError('over limit')),
+                normalizeDeny(new NoPermissionError('nope'))
+            ));
+        });
+        it('undefined vs {excludedAttrs: []} are equivalent', function () {
+            assert.ok(resultsMatch(
+                normalizeAllow(undefined),
+                normalizeAllow({excludedAttrs: []})
+            ));
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/permissions/parallel-check.test.js
+++ b/ghost/core/test/unit/server/services/permissions/parallel-check.test.js
@@ -1,0 +1,234 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const parallelCheck = require('../../../../../core/server/services/permissions/parallel-check');
+const models = require('../../../../../core/server/models');
+
+const flushMicrotasks = () => new Promise((resolve) => {
+    setImmediate(resolve);
+});
+
+describe('Permissions: parallel-check', function () {
+    let warnStub;
+    let checksCounter;
+    let divergenceCounter;
+
+    before(function () {
+        models.init();
+    });
+
+    beforeEach(function () {
+        warnStub = sinon.stub(logging, 'warn');
+        checksCounter = {inc: sinon.stub()};
+        divergenceCounter = {inc: sinon.stub()};
+        parallelCheck.setMetrics({checks: checksCounter, divergence: divergenceCounter});
+        delete process.env.GHOST_PERMISSIONS_V2_PARALLEL;
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        parallelCheck.setMetrics(null);
+    });
+
+    function loaded(roleName) {
+        return {user: {permissions: [], roles: [{name: roleName}]}, apiKey: null};
+    }
+
+    it('returns V1 promise unchanged when V2 throws synchronously', async function () {
+        const v1 = Promise.resolve({excludedAttrs: ['tags']});
+        // No TargetModel -> base-check path. Editor has edit:post, so V2 will allow.
+        // Inject a broken V2 by setting an unknown role -> V2 denies, V1 allows.
+        // The caller's outcome should still be V1's resolved value.
+        const result = await parallelCheck.runParallel(v1, {
+            parsedContext: {user: 1, internal: false, public: false},
+            action: 'edit',
+            objectType: 'post',
+            modelOrId: 'id-1',
+            unsafeAttrs: {},
+            loadedPermissions: loaded('NoSuchRole'),
+            TargetModel: null
+        });
+        assert.deepEqual(result, {excludedAttrs: ['tags']});
+        await flushMicrotasks();
+    });
+
+    it('does not log when V1 and V2 both allow', async function () {
+        const v1 = Promise.resolve();
+        await parallelCheck.runParallel(v1, {
+            parsedContext: {user: 1, internal: false, public: false},
+            action: 'edit',
+            objectType: 'post',
+            modelOrId: 'id-1',
+            unsafeAttrs: {},
+            loadedPermissions: loaded('Editor'),
+            TargetModel: null
+        });
+        await flushMicrotasks();
+        // 1 'match' check, no divergence emitted, no log
+        assert.ok(checksCounter.inc.calledWith({result: 'match'}));
+        assert.equal(divergenceCounter.inc.called, false);
+        assert.equal(warnStub.called, false);
+    });
+
+    it('logs + counts divergence when V1 allows and V2 denies', async function () {
+        const v1 = Promise.resolve();
+        await parallelCheck.runParallel(v1, {
+            parsedContext: {user: 1, internal: false, public: false},
+            action: 'destroy',
+            objectType: 'setting',
+            modelOrId: 'k1',
+            unsafeAttrs: {},
+            loadedPermissions: loaded('Editor'), // Editor can browse:setting but NOT destroy
+            TargetModel: null
+        });
+        await flushMicrotasks();
+        assert.ok(checksCounter.inc.calledWith({result: 'divergence'}));
+        assert.ok(divergenceCounter.inc.calledWithMatch({action: 'destroy', object_type: 'setting', v1: 'allow', v2: 'deny'}));
+        assert.equal(warnStub.callCount, 1);
+        const logged = warnStub.firstCall.args[0];
+        assert.equal(logged.event, 'permissions_v2_divergence');
+        // PII-safety: only id/role identifiers, no full models or emails
+        assert.equal(logged.context.user_id, 1);
+        assert.equal(logged.context.api_key_id, null);
+    });
+
+    it('V1 rejection still propagates to caller even when V2 succeeds', async function () {
+        const v1 = Promise.reject(new errors.NoPermissionError({message: 'V1 says no'}));
+        const promise = parallelCheck.runParallel(v1, {
+            parsedContext: {user: 1, internal: false, public: false},
+            action: 'edit',
+            objectType: 'post',
+            modelOrId: 'id-1',
+            unsafeAttrs: {},
+            loadedPermissions: loaded('Editor'),
+            TargetModel: null
+        });
+        await assert.rejects(promise, /V1 says no/);
+    });
+
+    it('skips V2 entirely when GHOST_PERMISSIONS_V2_PARALLEL=false', async function () {
+        process.env.GHOST_PERMISSIONS_V2_PARALLEL = 'false';
+        const v1 = Promise.resolve();
+        await parallelCheck.runParallel(v1, {
+            parsedContext: {user: 1, internal: false, public: false},
+            action: 'destroy',
+            objectType: 'setting',
+            modelOrId: 'id-1',
+            unsafeAttrs: {},
+            loadedPermissions: loaded('Editor'),
+            TargetModel: null
+        });
+        await flushMicrotasks();
+        assert.equal(checksCounter.inc.called, false);
+        assert.equal(warnStub.called, false);
+    });
+
+    it('skips V2 for internal contexts (no spurious logging on internal calls)', async function () {
+        const v1 = Promise.resolve();
+        await parallelCheck.runParallel(v1, {
+            parsedContext: {internal: true, user: null, api_key: null, public: false},
+            action: 'edit',
+            objectType: 'post',
+            modelOrId: 'id-1',
+            unsafeAttrs: {},
+            loadedPermissions: {user: null, apiKey: null},
+            TargetModel: null
+        });
+        await flushMicrotasks();
+        assert.equal(checksCounter.inc.called, false);
+        assert.equal(warnStub.called, false);
+    });
+
+    it('rate-limits identical (action, object, v1, v2) divergences within the sample window', async function () {
+        // Use a (action,object_type) tuple no other test in this file touches
+        // so we don't inherit cached log timestamps.
+        const ctx = {
+            parsedContext: {user: 1, internal: false, public: false},
+            action: 'edit',
+            objectType: 'integration',
+            modelOrId: 'id-1',
+            unsafeAttrs: {},
+            loadedPermissions: loaded('Editor'),
+            TargetModel: null
+        };
+        await parallelCheck.runParallel(Promise.resolve(), ctx);
+        await flushMicrotasks();
+        await parallelCheck.runParallel(Promise.resolve(), ctx);
+        await flushMicrotasks();
+        await parallelCheck.runParallel(Promise.resolve(), ctx);
+        await flushMicrotasks();
+        // Three divergences counted, but only one log emitted (sampling).
+        assert.equal(divergenceCounter.inc.callCount, 3);
+        assert.equal(warnStub.callCount, 1);
+    });
+
+    it('two-deny match across error subclasses (V1 HostingLimitError vs V2 NoPermissionError)', async function () {
+        // Both rejected = both deny semantically; classifier ignores subclass.
+        class HostingLimitError extends Error {}
+        const v1 = Promise.reject(new HostingLimitError('over member limit'));
+        // V2 will deny too because Editor lacks destroy:setting.
+        try {
+            await parallelCheck.runParallel(v1, {
+                parsedContext: {user: 1, internal: false, public: false},
+                action: 'destroy',
+                objectType: 'setting',
+                modelOrId: 'id-1',
+                unsafeAttrs: {},
+                loadedPermissions: loaded('Editor'),
+                TargetModel: null
+            });
+        } catch (_e) {
+            // V1 rejection propagates; we only care about no-divergence-logged.
+        }
+        await flushMicrotasks();
+        // Should classify as match (both deny) — no divergence increment.
+        assert.ok(checksCounter.inc.calledWith({result: 'match'}));
+        assert.equal(divergenceCounter.inc.called, false);
+    });
+
+    it('V2 receives a deep-copy of unsafeAttrs (cannot leak mutations back to caller)', async function () {
+        const captured = {};
+        const TargetModel = {
+            permissible(modelId, action, ctx, attrs) {
+                captured.attrsRef = attrs;
+                attrs.injected = 'v2-mutation';
+                return Promise.resolve();
+            }
+        };
+        const callerAttrs = {status: 'draft'};
+        await parallelCheck.runParallel(Promise.resolve(), {
+            parsedContext: {user: 1, internal: false, public: false},
+            action: 'edit',
+            objectType: 'post',
+            modelOrId: 'id-1',
+            unsafeAttrs: callerAttrs,
+            loadedPermissions: loaded('Editor'),
+            TargetModel
+        });
+        await flushMicrotasks();
+        assert.notEqual(captured.attrsRef, callerAttrs, 'V2 must receive a clone, not the caller\'s reference');
+        assert.equal(captured.attrsRef.status, 'draft', 'clone preserves original fields');
+        assert.equal(callerAttrs.injected, undefined, 'V2 mutations cannot escape into caller\'s object');
+    });
+
+    it('inverse sanity: V1 wrong (denies) and V2 right (allows) still triggers divergence log', async function () {
+        const v1 = Promise.reject(new errors.NoPermissionError({message: 'V1 wrongly denies'}));
+        try {
+            await parallelCheck.runParallel(v1, {
+                parsedContext: {user: 1, internal: false, public: false},
+                action: 'edit',
+                objectType: 'post',
+                modelOrId: 'id-1',
+                unsafeAttrs: {},
+                loadedPermissions: loaded('Editor'),
+                TargetModel: null
+            });
+        } catch (_e) {
+            // V1's rejection is expected to propagate; we only care about the
+            // log + counter side effects from the comparison.
+        }
+        await flushMicrotasks();
+        assert.ok(divergenceCounter.inc.calledWithMatch({v1: 'deny', v2: 'allow'}));
+    });
+});

--- a/ghost/core/test/unit/server/services/permissions/role-permissions.test.js
+++ b/ghost/core/test/unit/server/services/permissions/role-permissions.test.js
@@ -1,0 +1,207 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fixtures = require('../../../../../core/server/data/schema/fixtures/fixtures.json');
+const rolePermissions = require('../../../../../core/server/services/permissions/role-permissions');
+
+// Build the canonical role -> Set('action:object') map by walking the same
+// fixtures.json the legacy fixture-manager + DB seed use. Used both as the
+// expected value for the static map and as the OBJECT_TYPE_ACTIONS truth.
+function buildExpectedFromFixtures() {
+    const objectTypeActions = new Map();
+    const permissionEntries = fixtures.models.find(m => m.name === 'Permission').entries;
+    for (const perm of permissionEntries) {
+        if (!objectTypeActions.has(perm.object_type)) {
+            objectTypeActions.set(perm.object_type, new Set());
+        }
+        objectTypeActions.get(perm.object_type).add(perm.action_type);
+    }
+
+    const rolePermissionsRelation = fixtures.relations.find(
+        r => r.from.model === 'Role' && r.from.relation === 'permissions'
+    );
+    const expected = new Map();
+    for (const [roleName, declarations] of Object.entries(rolePermissionsRelation.entries)) {
+        const set = new Set();
+        for (const [objectType, actionsValue] of Object.entries(declarations)) {
+            const actions = actionsValue === 'all'
+                ? Array.from(objectTypeActions.get(objectType) || [])
+                : (Array.isArray(actionsValue) ? actionsValue : [actionsValue]);
+            for (const action of actions) {
+                set.add(`${action}:${objectType}`);
+            }
+        }
+        expected.set(roleName, set);
+    }
+    return {expected, objectTypeActions};
+}
+
+describe('Permissions: static role-permissions map', function () {
+    describe('OBJECT_TYPE_ACTIONS', function () {
+        it('is a superset of every (action,object) pair in fixtures.json', function () {
+            const {objectTypeActions} = buildExpectedFromFixtures();
+            for (const [objectType, fixtureActions] of objectTypeActions) {
+                const staticActions = new Set(rolePermissions.OBJECT_TYPE_ACTIONS[objectType] || []);
+                for (const action of fixtureActions) {
+                    assert.ok(
+                        staticActions.has(action),
+                        `OBJECT_TYPE_ACTIONS missing "${action}" for object_type "${objectType}" (present in fixtures.json)`
+                    );
+                }
+            }
+        });
+
+        it('is deep-frozen so runtime mutation cannot widen privileges', function () {
+            // In sloppy mode mutations no-op silently, so assert by state.
+            const before = [...rolePermissions.OBJECT_TYPE_ACTIONS.post];
+            try {
+                rolePermissions.OBJECT_TYPE_ACTIONS.post.push('inject');
+            } catch (_e) {
+                // Strict-mode hosts throw — we don't depend on that.
+            }
+            try {
+                rolePermissions.OBJECT_TYPE_ACTIONS.injected = ['hack'];
+            } catch (_e) {
+                // Strict-mode hosts throw — we don't depend on that.
+            }
+            assert.deepEqual([...rolePermissions.OBJECT_TYPE_ACTIONS.post], before);
+            assert.equal(rolePermissions.OBJECT_TYPE_ACTIONS.injected, undefined);
+            assert.ok(Object.isFrozen(rolePermissions.OBJECT_TYPE_ACTIONS));
+            assert.ok(Object.isFrozen(rolePermissions.OBJECT_TYPE_ACTIONS.post));
+        });
+    });
+
+    describe('ROLE_DECLARATIONS / getPermissionsForRole', function () {
+        it('matches fixtures.json relations[Role->permissions] for every role', function () {
+            const {expected} = buildExpectedFromFixtures();
+            for (const [roleName, expectedSet] of expected) {
+                const actualSet = rolePermissions.getPermissionsForRole(roleName);
+                const expectedArr = [...expectedSet].sort();
+                const actualArr = [...actualSet].sort();
+                assert.deepEqual(
+                    actualArr,
+                    expectedArr,
+                    `static map for role "${roleName}" diverged from fixtures.json`
+                );
+            }
+        });
+
+        it('every role declared in the static map exists in fixtures.json (no typos like "Adminstrator")', function () {
+            const {expected} = buildExpectedFromFixtures();
+            for (const roleName of rolePermissions.listAllRoles()) {
+                if (rolePermissions.ROLES_WITH_FULL_ACCESS.has(roleName)) {
+                    continue; // Owner is intentionally not in fixtures' permission relations.
+                }
+                assert.ok(
+                    expected.has(roleName),
+                    `static role "${roleName}" not found in fixtures.json — typo or stale entry?`
+                );
+            }
+        });
+
+        it('OBJECT_TYPE_ACTIONS contains every action declared in fixtures.json (no extra entries)', function () {
+            const {objectTypeActions} = buildExpectedFromFixtures();
+            for (const [objectType, staticActions] of Object.entries(rolePermissions.OBJECT_TYPE_ACTIONS)) {
+                const fixtureActions = objectTypeActions.get(objectType);
+                if (!fixtureActions) {
+                    // Allowed: a static object_type with no fixture actions is
+                    // privilege-neutral (no role declares 'all' for it). We only
+                    // care about actions a role can be granted via 'all'.
+                    continue;
+                }
+                for (const action of staticActions) {
+                    assert.ok(
+                        fixtureActions.has(action),
+                        `OBJECT_TYPE_ACTIONS["${objectType}"] has "${action}" but fixtures.json has no Permission entry for it — would over-grant when expanded by "all"`
+                    );
+                }
+            }
+        });
+
+        it('returns a fresh Set so callers cannot mutate shared state', function () {
+            const a = rolePermissions.getPermissionsForRole('Editor');
+            const b = rolePermissions.getPermissionsForRole('Editor');
+            assert.notEqual(a, b);
+            a.add('inject:post');
+            assert.ok(!b.has('inject:post'));
+            assert.ok(!rolePermissions.getPermissionsForRole('Editor').has('inject:post'));
+        });
+
+        it('returns an empty set for Owner (Owner is short-circuited at canThis layer)', function () {
+            const set = rolePermissions.getPermissionsForRole('Owner');
+            assert.equal(set.size, 0);
+        });
+
+        it('returns empty for unknown / null / undefined role names', function () {
+            assert.equal(rolePermissions.getPermissionsForRole(null).size, 0);
+            assert.equal(rolePermissions.getPermissionsForRole(undefined).size, 0);
+            assert.equal(rolePermissions.getPermissionsForRole('NoSuchRole').size, 0);
+        });
+    });
+
+    describe('hasPermission', function () {
+        it('returns true for Owner on any (action, object_type) pair', function () {
+            assert.ok(rolePermissions.hasPermission('Owner', 'destroy', 'user'));
+            assert.ok(rolePermissions.hasPermission('Owner', 'edit', 'post'));
+            // Owner is intentionally permissive at this layer; model-level
+            // overrides (User.permissible owner-immutability) handle nuance.
+            assert.ok(rolePermissions.hasPermission('Owner', 'made-up', 'fictional'));
+        });
+
+        it('returns true for Contributor add post (in fixture)', function () {
+            assert.ok(rolePermissions.hasPermission('Contributor', 'add', 'post'));
+        });
+
+        it('returns false for Contributor publish post (not in fixture)', function () {
+            assert.ok(!rolePermissions.hasPermission('Contributor', 'publish', 'post'));
+        });
+
+        it('returns false for unknown role', function () {
+            assert.ok(!rolePermissions.hasPermission('Nobody', 'edit', 'post'));
+        });
+    });
+
+    describe('synthesizeLoadedPermissions', function () {
+        it('returns the {user, apiKey} shape providers.user/apiKey produces', function () {
+            const loaded = rolePermissions.synthesizeLoadedPermissions({userRoleName: 'Editor'});
+            assert.ok(loaded.user);
+            assert.equal(loaded.apiKey, null);
+            assert.ok(Array.isArray(loaded.user.permissions));
+            assert.deepEqual(loaded.user.roles, [{name: 'Editor'}]);
+            const sample = loaded.user.permissions[0];
+            assert.equal(typeof sample.get, 'function');
+            assert.ok(['action_type', 'object_type', 'object_id'].every(k => typeof sample.get(k) !== 'undefined' || sample.get(k) === undefined));
+        });
+
+        it('synthesizes permissions for an api key when only apiKeyRoleName is given', function () {
+            const loaded = rolePermissions.synthesizeLoadedPermissions({apiKeyRoleName: 'Admin Integration'});
+            assert.equal(loaded.user, null);
+            assert.ok(loaded.apiKey);
+            assert.deepEqual(loaded.apiKey.roles, [{name: 'Admin Integration'}]);
+        });
+
+        it('returns nulls when no roles supplied', function () {
+            const loaded = rolePermissions.synthesizeLoadedPermissions({});
+            assert.equal(loaded.user, null);
+            assert.equal(loaded.apiKey, null);
+        });
+
+        it('Owner synthesis returns no permission stubs (canThis short-circuits)', function () {
+            const loaded = rolePermissions.synthesizeLoadedPermissions({userRoleName: 'Owner'});
+            assert.equal(loaded.user.permissions.length, 0);
+            assert.deepEqual(loaded.user.roles, [{name: 'Owner'}]);
+        });
+    });
+
+    describe('listAllRoles', function () {
+        it('includes Owner plus every declared role', function () {
+            const roles = rolePermissions.listAllRoles();
+            assert.ok(roles.includes('Owner'));
+            assert.ok(roles.includes('Administrator'));
+            assert.ok(roles.includes('Contributor'));
+        });
+    });
+});
+
+// Tag the file path so it surfaces in stack traces; this also keeps
+// `path` from being seen as unused in environments that lint imports.
+exports._sourcePath = path.resolve(__filename);


### PR DESCRIPTION
## Summary

Adds a parallel role-based permissions checker (`canThisV2` + `parallel-check.js`) that runs as a side effect of every existing `canThis()` call. **V1 (DB-backed) still determines every outcome** — V2's role-based result is compared against V1's, and divergences are emitted as structured logs and Prometheus counters.

After a soak period of zero divergences in production, a follow-up PR will switch `canThis` to V2 and delete the old service, `providers.js`, the actions-map cache, the `permissions` / `permissions_roles` / `permissions_users` tables, and the related fixture entries.

## Why

Today every `canThis()` call triggers `User.findOne({withRelated: ['permissions','roles','roles.permissions']})` (or the api-key equivalent) on every request. The `object_id` column on `permissions` exists in the schema but is never populated by any fixture — every check is effectively `role → (action, object_type) → allow/deny`, which is a pure in-memory lookup with the right data structure.

The role→permission mapping already lives as a static JSON tree in `fixtures.json` (`relations[Role->permissions]`), so we can move it to code with no behavioral change.

## How it's wired

```
canThis(ctx).edit.post(id, attrs)
  └─► permissionLoad (V1: providers.user/apiKey query DB)
        ├─► dispatchPermissible(loadedPermissions, …)  ──► V1 result (the actual outcome)
        └─► runParallel(v1Promise, …)
              └─► insideV2.run(true, () =>
                    dispatchPermissible(synthesizeLoadedPermissions(role), …)
                  )
              └─► compareResults → log + counters on divergence
```

- **`role-permissions.js`** — frozen static map mirroring `fixtures.json`. `getPermissionsForRole(name)` returns a fresh `Set` of `"action:object"` strings; `synthesizeLoadedPermissions({userRoleName, apiKeyRoleName})` returns the same `{user, apiKey}` shape `providers.user/apiKey` produce, with stub permission objects responding to `.get('action_type')` etc., so existing model `permissible()` methods work unmodified.
- **`compute-base-permission.js`** — pure helper extracted from `can-this.js`. V1 and V2 share this so they cannot drift on Owner short-circuit, staff-API-key precedence, or the api_key-only path.
- **`dispatch-permissible.js`** — single source of truth for "given perms, what would the chain return?". Used by both V1's handler and V2's `runV2`, so model `permissible()` invocation is identical on both sides.
- **`can-this-v2.js`** — chain interface mirroring `canThis`. Action list is built from `OBJECT_TYPE_ACTIONS` (not the `actions-map-cache`) so the cleanup PR can also delete that cache.
- **`parallel-check.js`** — wires V2 as a side effect; uses `AsyncLocalStorage` to skip re-entrant V2 invocations from `Model.permissible` recursing into `canThis` (e.g. `User.permissible → canThis(ctx).assign.role`).
- **`normalize-allow-result.js`** — classifies outcomes as `allow|deny`, dedupes/sorts `excludedAttrs`, treats `undefined`/`null`/`{}`/`{excludedAttrs:[]}` as equivalent, and treats two denies as a match regardless of error subclass (so V1's `HostingLimitError` vs V2's `NoPermissionError` doesn't trigger a spurious divergence).
- **`consistency-check.js`** — boot-time check that the static map agrees with the DB. Throws in CI/test, warns in dev/prod (so a hot DB edit never crashes a running server).
- **`metrics.js`** — registers Prometheus counters when configured. Skipped in `NODE_ENV=testing` so existing V1 unit tests aren't perturbed.

## Model `permissible()` methods are unchanged

The first review iteration considered duplicating the four model `permissible()` methods (Post, User, Role, Integration) into `permissibleByRole()` parallels per the task description. Code-review feedback (correctly, IMO) flagged that as a drift trap — those methods are 12-150 lines mixing permission gating with limit-service / domain logic, and copy-pasting them creates two sources of truth that will diverge during a 30-day soak. Instead, V2 invokes the same `permissible()` with a `loadedPermissions` synthesized from the static map. The cleanup PR replaces only the data source, not the domain logic.

## Kill switch

`GHOST_PERMISSIONS_V2_PARALLEL=false` (case-insensitive, accepts `false|0|off|no`) disables V2 entirely. Read per call so a config update + reload takes effect without a redeploy.

## Cutover gate

Soak target before the follow-up PR replaces V1:
- `sum(rate(ghost_permissions_v2_divergence_total[7d])) == 0` for **14 consecutive days**, AND
- `sum(ghost_permissions_v2_checks_total) >= 1M` over that window, AND
- per-`(action, object_type)` cell shows non-zero `match` count (so rare permissions like `assign:role` are actually exercised).

At cutover, fail-closed for one release: `allow ⇔ V1.allow ∧ V2.allow`, then delete V1.

## Test plan

- [x] `cd ghost/core && pnpm test:single test/unit/server/services/permissions/` — 98 tests passing (existing + 5 new files: `role-permissions`, `compute-base-permission`, `normalize-allow-result`, `can-this-v2`, `parallel-check`).
- [x] `pnpm lint` — clean (the two pre-existing warnings on `route-settings/validate.js` and `web/parent/frontend.js` are unrelated).
- [ ] `pnpm dev` — exercise admin API as Owner / Admin / Editor / Author / Contributor + an Admin Integration API key; confirm zero `permissions_v2_divergence` log entries.
- [ ] `cd ghost/core && pnpm test:integration` — admin API integration tests still pass.
- [ ] Follow-up: build `test/integration/services/permissions/divergence.test.js` — fixture-driven matrix (every role × every action × every object_type, both V1 and V2 paths exercised).
- [ ] Verify Grafana panels for the two counters once deployed.

## Out of scope (follow-up after the soak)

`canThis` → `canThisV2` rename, delete `can-this.js` / `providers.js` / `actions-map-cache.js` / `parallel-check.js` / `metrics.js` / `consistency-check.js`, drop the `permissions` / `permissions_roles` / `permissions_users` tables, remove the role-permission relations and Permission entries from `fixtures.json`. Files marked `// CUTOVER:` at the top to make that PR mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)