### PR TITLE
Added Gifts toggle to member activity event filter

### DIFF
--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -3,6 +3,7 @@ export const ALL_EVENT_TYPES = [
     {event: 'login_event', icon: 'filter-dropdown-logins', name: 'Logins', group: 'auth'},
     {event: 'subscription_event', icon: 'filter-dropdown-paid-subscriptions', name: 'Paid subscriptions', group: 'payments'},
     {event: 'payment_event', icon: 'filter-dropdown-payments', name: 'Payments', group: 'payments'},
+    {event: 'gift_purchase_event', icon: 'filter-dropdown-gifts', name: 'Gifts', group: 'payments'},
     {event: 'newsletter_event', icon: 'filter-dropdown-email-subscriptions', name: 'Email subscriptions', group: 'emails'},
     {event: 'email_opened_event', icon: 'filter-dropdown-email-opened', name: 'Email opened', group: 'emails'},
     {event: 'email_delivered_event', icon: 'filter-dropdown-email-received', name: 'Email received', group: 'emails'},
@@ -33,11 +34,15 @@ export function toggleEventType(eventType, eventTypes) {
         if (excludedEvents.has('payment_event')) {
             excludedEvents.delete('payment_event');
             excludedEvents.delete('donation_event');
-            excludedEvents.delete('gift_purchase_event');
-            excludedEvents.delete('gift_redemption_event');
         } else {
             excludedEvents.add('payment_event');
             excludedEvents.add('donation_event');
+        }
+    } else if (eventType === 'gift_purchase_event') {
+        if (excludedEvents.has('gift_purchase_event')) {
+            excludedEvents.delete('gift_purchase_event');
+            excludedEvents.delete('gift_redemption_event');
+        } else {
             excludedEvents.add('gift_purchase_event');
             excludedEvents.add('gift_redemption_event');
         }

--- a/ghost/admin/public/assets/icons/filter-dropdown-gifts.svg
+++ b/ghost/admin/public/assets/icons/filter-dropdown-gifts.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16">
+    <path d="M2.5 7v6.5a.5.5 0 0 0 .5.5h10a.5.5 0 0 0 .5-.5V7M1.5 5h13v2h-13V5zM8 5v9M8 5c-.6-1.85-1.85-3.3-3.3-3.3a1.65 1.65 0 0 0 0 3.3H8zM8 5c.6-1.85 1.85-3.3 3.3-3.3a1.65 1.65 0 0 1 0 3.3H8z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -24,7 +24,7 @@ describe('Unit | Utility | event-type-utils', function () {
 
         const newExcludedEvents = toggleEventType('payment_event', eventTypes);
 
-        expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event,gift_redemption_event');
+        expect(newExcludedEvents).to.equal('payment_event,donation_event');
     });
 
     it('should toggle both payment_event and donation_event off when toggling payment_event off', function () {
@@ -33,6 +33,26 @@ describe('Unit | Utility | event-type-utils', function () {
         ];
 
         const newExcludedEvents = toggleEventType('payment_event', eventTypes);
+
+        expect(newExcludedEvents).to.equal('');
+    });
+
+    it('should toggle both gift_purchase_event and gift_redemption_event when toggling gift_purchase_event', function () {
+        const eventTypes = [
+            {event: 'gift_purchase_event', isSelected: true}
+        ];
+
+        const newExcludedEvents = toggleEventType('gift_purchase_event', eventTypes);
+
+        expect(newExcludedEvents).to.equal('gift_purchase_event,gift_redemption_event');
+    });
+
+    it('should toggle both gift_purchase_event and gift_redemption_event off when toggling gift_purchase_event off', function () {
+        const eventTypes = [
+            {event: 'gift_purchase_event', isSelected: false}
+        ];
+
+        const newExcludedEvents = toggleEventType('gift_purchase_event', eventTypes);
 
         expect(newExcludedEvents).to.equal('');
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3526/ghost-admin-add-filtering-for-gift-member-events

- `gift_purchase_event` and `gift_redemption_event` were previously bundled under the Payments toggle, leaving no way to filter gift activity on its own
- new Gifts toggle owns both events together so admins can investigate purchases and redemptions in one view
- placed alongside other transactional toggles (Paid subscriptions, Payments) in the same group

