### PR TITLE
Fixed gift members unable to redeem or continue when tier is archived

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.17",
+  "version": "2.68.18",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/continue-gift-subscription-banner.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/continue-gift-subscription-banner.js
@@ -1,12 +1,12 @@
 import AppContext from '../../../../app-context';
 import ActionButton from '../../../common/action-button';
-import {getSubscriptionExpiry, isGiftMember} from '../../../../utils/helpers';
+import {getSubscriptionExpiry, isArchivedTier, isGiftMember} from '../../../../utils/helpers';
 import {useContext} from 'react';
 
 const ContinueGiftSubscriptionBanner = () => {
-    const {member, doAction, action, brandColor} = useContext(AppContext);
+    const {member, site, doAction, action, brandColor} = useContext(AppContext);
 
-    if (!isGiftMember({member})) {
+    if (!isGiftMember({member}) || isArchivedTier({member, site})) {
         return null;
     }
 

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -97,10 +97,21 @@ const PaidAccountActions = () => {
     };
 
     const PlanUpdateButton = ({isPaid}) => {
-        if (hasOnlyFreePlan({site}) && !isPaid) {
+        const hasGiftSubscription = isGiftMember({member});
+        const canContinueGiftSubscription = hasGiftSubscription && !isArchivedTier({member, site});
+
+        // If no paid tiers are available, hide the plan update button for:
+        // - Free members, as they have no paid plans to upgrade to
+        // - Gift members on archived tiers, as they have no paid plans to upgrade to
+        //
+        // In constrast, still render the button for:
+        // - Paid members so that they can adjust the cadence on their existing sub
+        // - Comped members so that they can contact publishers to make changes to their complimentary access
+        if (hasOnlyFreePlan({site}) && (!isPaid || (hasGiftSubscription && !canContinueGiftSubscription))) {
             return null;
         }
-        if (isGiftMember({member}) && !isArchivedTier({member, site})) {
+
+        if (canContinueGiftSubscription) {
             return (
                 <button
                     className='gh-portal-btn gh-portal-btn-list' onClick={() => doAction('continueGiftSubscription')}

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isGiftMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isArchivedTier, isComplimentaryMember, isGiftMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as GiftIcon} from '../../../../images/icons/gift.svg';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
@@ -100,7 +100,7 @@ const PaidAccountActions = () => {
         if (hasOnlyFreePlan({site}) && !isPaid) {
             return null;
         }
-        if (isGiftMember({member})) {
+        if (isGiftMember({member}) && !isArchivedTier({member, site})) {
             return (
                 <button
                     className='gh-portal-btn gh-portal-btn-list' onClick={() => doAction('continueGiftSubscription')}

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -105,6 +105,18 @@ export function getSubscriptionExpiry({member}) {
     return '';
 }
 
+export function isArchivedTier({member, site}) {
+    const subscription = getMemberSubscription({member});
+    const tierId = subscription?.tier?.id;
+
+    if (!tierId) {
+        return false;
+    }
+
+    // Archived tiers are filtered out of site.products
+    return !getProductFromId({site, productId: tierId});
+}
+
 export function getUpgradeProducts({site, member}) {
     const activePrice = getMemberActivePrice({member});
     const activePriceCurrency = activePrice?.currency;

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -1,6 +1,6 @@
 import {render} from '../../../../utils/test-utils';
 import PaidAccountActions from '../../../../../src/components/pages/AccountHomePage/components/paid-account-actions';
-import {getDiscountData, getMemberData, getNextPaymentData, getSubscriptionData, getSiteData, getProductsData} from '../../../../../src/utils/fixtures-generator';
+import {getDiscountData, getMemberData, getNextPaymentData, getSubscriptionData, getSiteData, getProductsData, getProductData} from '../../../../../src/utils/fixtures-generator';
 
 const setup = (overrides) => {
     const {mockDoActionFn, ...utils} = render(
@@ -504,6 +504,173 @@ describe('PaidAccountActions', () => {
             expect(queryByTestId('offer-label')).toBeInTheDocument();
             // Should show the discounted yearly price
             expect(queryByText('$45.00/year — Forever')).toBeInTheDocument();
+        });
+    });
+
+    describe('PlanUpdateButton', () => {
+        const buildPaidSite = () => {
+            const products = getProductsData({numOfProducts: 1});
+            return {
+                site: getSiteData({products, portalProducts: products.map(p => p.id)}),
+                products
+            };
+        };
+
+        const buildFreeOnlySite = () => {
+            const products = getProductsData({numOfProducts: 1});
+            return getSiteData({
+                products,
+                portalProducts: products.map(p => p.id),
+                portalPlans: ['free']
+            });
+        };
+
+        const buildGiftMember = ({tierId}) => getMemberData({
+            paid: true,
+            status: 'gift',
+            subscriptions: [
+                getSubscriptionData({
+                    status: 'active',
+                    amount: 0,
+                    currency: 'USD',
+                    interval: 'month',
+                    tier: {id: tierId, expiry_at: new Date('2099-01-01T12:00:00.000Z')}
+                })
+            ]
+        });
+
+        test('renders "Continue" for a gift member whose tier is still active', () => {
+            const {site, products} = buildPaidSite();
+            const member = buildGiftMember({tierId: products[0].id});
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="continue-gift-subscription"]')).toBeInTheDocument();
+            expect(container.querySelector('[data-test-button="change-plan"]')).not.toBeInTheDocument();
+        });
+
+        test('renders "Change" for a gift member when the tier has been archived', () => {
+            // Archived tier = tier id absent from site.products
+            const {site} = buildPaidSite();
+            const archivedTier = getProductData({name: 'Archived'});
+            const member = buildGiftMember({tierId: archivedTier.id});
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="change-plan"]')).toBeInTheDocument();
+            expect(container.querySelector('[data-test-button="continue-gift-subscription"]')).not.toBeInTheDocument();
+        });
+
+        test('renders nothing for a gift on an archived tier when no paid plans are available', () => {
+            const site = buildFreeOnlySite();
+            const archivedTier = getProductData({name: 'Archived'});
+            const member = buildGiftMember({tierId: archivedTier.id});
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="continue-gift-subscription"]')).not.toBeInTheDocument();
+            expect(container.querySelector('[data-test-button="change-plan"]')).not.toBeInTheDocument();
+        });
+
+        test('renders "Change" for a regular paid member when paid plans are available', () => {
+            const {site} = buildPaidSite();
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 500,
+                        currency: 'USD',
+                        interval: 'month'
+                    })
+                ]
+            });
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="change-plan"]')).toBeInTheDocument();
+        });
+
+        test('still renders "Change" for a regular paid member on a free-only site', () => {
+            // Paid members keep the Change button even when no paid plans are
+            // exposed in Portal — the upgrade page is the only place they can
+            // see the contact-publisher message.
+            const site = buildFreeOnlySite();
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 500,
+                        currency: 'USD',
+                        interval: 'month'
+                    })
+                ]
+            });
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="change-plan"]')).toBeInTheDocument();
+        });
+
+        test('renders "Change" for a comped member when paid plans are available', () => {
+            const {site} = buildPaidSite();
+            const member = getMemberData({
+                paid: true,
+                status: 'comped',
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 0,
+                        currency: 'USD',
+                        interval: 'month'
+                    })
+                ]
+            });
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="change-plan"]')).toBeInTheDocument();
+            expect(container.querySelector('[data-test-button="continue-gift-subscription"]')).not.toBeInTheDocument();
+        });
+
+        test('still renders "Change" for a comped member on a free-only site', () => {
+            // Comped members keep the Change button so they can reach the
+            // upgrade page and see the contact-publisher message.
+            const site = buildFreeOnlySite();
+            const member = getMemberData({
+                paid: true,
+                status: 'comped',
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 0,
+                        currency: 'USD',
+                        interval: 'month'
+                    })
+                ]
+            });
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="change-plan"]')).toBeInTheDocument();
+        });
+
+        test('renders nothing for a free member', () => {
+            // Free members have no subscription and aren't complimentary, so
+            // PaidAccountActions short-circuits before PlanUpdateButton is reached.
+            const {site} = buildPaidSite();
+            const member = getMemberData({
+                paid: false,
+                status: 'free',
+                subscriptions: []
+            });
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="change-plan"]')).not.toBeInTheDocument();
+            expect(container.querySelector('[data-test-button="continue-gift-subscription"]')).not.toBeInTheDocument();
+            expect(container.querySelector('[data-test-button="manage-billing"]')).not.toBeInTheDocument();
         });
     });
 

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -18,6 +18,7 @@ import {
     isActiveOffer,
     isRetentionOffer,
     isInviteOnly,
+    isArchivedTier,
     isGiftMember,
     isPaidMember,
     isPaidMembersOnly,
@@ -757,6 +758,37 @@ describe('Helpers - ', () => {
             delete member.subscriptions[0].tier.expiry_at;
 
             expect(getSubscriptionExpiry({member})).toEqual('');
+        });
+    });
+
+    describe('isArchivedTier', () => {
+        const site = FixturesSite.singleTier.basic;
+        const activeTierId = site.products.find(p => p.type === 'paid').id;
+
+        const buildMemberWithTierId = tierId => ({
+            paid: true,
+            status: 'gift',
+            subscriptions: [
+                {
+                    status: 'active',
+                    price: {amount: 0},
+                    tier: tierId === undefined ? {} : {id: tierId}
+                }
+            ]
+        });
+
+        test('returns false when the member has no subscription', () => {
+            expect(isArchivedTier({member: FixtureMember.free, site})).toBe(false);
+        });
+
+        test('returns false when the subscription tier id is in site.products', () => {
+            const member = buildMemberWithTierId(activeTierId);
+            expect(isArchivedTier({member, site})).toBe(false);
+        });
+
+        test('returns true when the subscription tier id is not in site.products', () => {
+            const member = buildMemberWithTierId('archived_tier_id');
+            expect(isArchivedTier({member, site})).toBe(true);
         });
     });
 

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -330,19 +330,6 @@ module.exports = class MemberRepository {
 
         memberData.email_disabled = !!memberData.email_disabled;
 
-        if (memberData.products && memberData.products.length > 1) {
-            throw new errors.BadRequestError({message: tpl(messages.moreThanOneProduct)});
-        }
-
-        if (memberData.products) {
-            for (const productData of memberData.products) {
-                const product = await this._productRepository.get(productData);
-                if (product.get('active') !== true) {
-                    throw new errors.BadRequestError({message: tpl(messages.tierArchived)});
-                }
-            }
-        }
-
         if (memberData.status && !MEMBER_STATUSES.includes(memberData.status)) {
             throw new errors.ValidationError({
                 message: tpl(messages.invalidMemberStatus, {statuses: MEMBER_STATUSES.join(', ')}),
@@ -355,6 +342,21 @@ module.exports = class MemberRepository {
                 memberData.status = 'comped';
             } else {
                 memberData.status = 'free';
+            }
+        }
+
+        if (memberData.products && memberData.products.length > 1) {
+            throw new errors.BadRequestError({message: tpl(messages.moreThanOneProduct)});
+        }
+
+        // Don't allow to use archived tiers
+        // Exception: Gifts remain redeemable even if the tier is later archived, since the entitlement has already been paid for
+        if (memberData.products && memberData.status !== 'gift') {
+            for (const productData of memberData.products) {
+                const product = await this._productRepository.get(productData);
+                if (product.get('active') !== true) {
+                    throw new errors.BadRequestError({message: tpl(messages.tierArchived)});
+                }
             }
         }
 
@@ -674,7 +676,9 @@ module.exports = class MemberRepository {
                 });
             }
 
-            if (product.get('active') !== true) {
+            // Don't allow to use archived tiers
+            // Exception: Gifts remain redeemable even if the tier is later archived, since the entitlement has already been paid for
+            if (product.get('active') !== true && memberStatusData.status !== 'gift') {
                 throw new errors.BadRequestError({message: tpl(messages.tierArchived)});
             }
         }

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -2137,6 +2137,45 @@ describe('MemberRepository', function () {
             sinon.assert.notCalled(Member.add);
             sinon.assert.notCalled(Member.transaction);
         });
+
+        it('allows gift members to be created on an archived tier (gift was valid at purchase time)', async function () {
+            productRepository.get = sinon.stub().resolves({
+                id: 'tier_1',
+                get: sinon.stub().withArgs('active').returns(false)
+            });
+
+            await buildRepo().create({
+                email: 'test@example.com',
+                name: 'Test Member',
+                status: 'gift',
+                products: [{id: 'tier_1'}]
+            }, {});
+
+            sinon.assert.calledOnce(memberAdd);
+            assert.equal(memberAdd.firstCall.args[0].status, 'gift');
+        });
+
+        it('rejects non-gift members being created on an archived tier', async function () {
+            productRepository.get = sinon.stub().resolves({
+                id: 'tier_1',
+                get: sinon.stub().withArgs('active').returns(false)
+            });
+
+            try {
+                await buildRepo().create({
+                    email: 'test@example.com',
+                    name: 'Test Member',
+                    products: [{id: 'tier_1'}]
+                }, {});
+
+                assert.fail('Expected create to reject archived tier for non-gift member');
+            } catch (err) {
+                assert.equal(err instanceof errors.BadRequestError, true);
+                assert.equal(err.message, 'Cannot use archived Tiers');
+            }
+
+            sinon.assert.notCalled(memberAdd);
+        });
     });
 
     describe('update - member status', function () {
@@ -2308,6 +2347,47 @@ describe('MemberRepository', function () {
 
             sinon.assert.calledOnce(memberEdit);
             assert.equal(memberEdit.firstCall.args[0].status, 'free');
+        });
+
+        it('allows gift redemption on an archived tier (gift was valid at purchase time)', async function () {
+            productRepository.get = sinon.stub().resolves({
+                id: 'tier_1',
+                get: sinon.stub().withArgs('active').returns(false)
+            });
+            stripeAPIService.configured = true;
+
+            await buildRepo().update({
+                status: 'gift',
+                products: [{id: 'tier_1'}]
+            }, {
+                id: 'member_id_123'
+            });
+
+            sinon.assert.calledOnce(memberEdit);
+            assert.equal(memberEdit.firstCall.args[0].status, 'gift');
+        });
+
+        it('rejects adding an archived tier to a non-gift member', async function () {
+            productRepository.get = sinon.stub().resolves({
+                id: 'tier_1',
+                get: sinon.stub().withArgs('active').returns(false)
+            });
+            stripeAPIService.configured = true;
+
+            try {
+                await buildRepo().update({
+                    products: [{id: 'tier_1'}]
+                }, {
+                    id: 'member_id_123'
+                });
+
+                assert.fail('Expected update to reject archived tier for non-gift member');
+            } catch (err) {
+                assert.equal(err instanceof errors.BadRequestError, true);
+                assert.equal(err.message, 'Cannot use archived Tiers');
+            }
+
+            sinon.assert.notCalled(memberEdit);
         });
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3566

We validate that a tier is active at the time a gift is purchased. After purchase, gifts should remain redeemable even if the tier is later archived, since they have already been paid for already. This change allows gifts to be redeemed on an archived tier.

Additionally, gift members can currently only continue their subscription on the same tier/cadence so remaining gift time can be carried over as trial days. If that tier has since been archived, this results in a checkout error, as we don't allow paid subscriptions on archived tiers. With this change, the UI renders the standard upgrade flow when the gifted tier is no longer available, letting the member pick from current active tiers. The trade-off is that the remaining gift days can't be preserved in that case; archived tiers are expected to be an edge case in practice.

## What changed

Portal:
- New `isArchivedTier({member, site})` helper that follows the existing `isActiveOffer` pattern (a tier id missing from `site.products` means the tier has been archived).
- The gift "Continue subscription" banner and the gift-specific Continue button on the account page are gated on the tier still being available; otherwise the regular Change button takes over and routes the member through the standard upgrade screen.

Backend:
- `MemberRepository.create` / `update` previously rejected any product that wasn't `active` with "Cannot use archived Tiers", which also blocked the gift-redemption path (creating a member on the gifted tier). The check is now skipped when `status === 'gift'`. Non-gift paths (comped, paid) keep the archived-tier block.
- In `create()`, the products validation block was moved below the status defaulting block so the gift carve-out can read the resolved status.


