### PR TITLE
🐛 Fixed admin session not rotating on password change and reset

### DIFF
--- a/ghost/core/core/server/api/endpoints/authentication.js
+++ b/ghost/core/core/server/api/endpoints/authentication.js
@@ -179,11 +179,12 @@ const controller = {
                 });
             }
 
-            const origin = auth.session.getOriginOfRequest(frame.original);
-            await auth.session.sessionService.assignVerifiedUserToSession({
-                session: frame.original.session,
+            // Rotate the session_id and mint a fresh verified session so that
+            // any stolen or cloned copy of the pre-reset cookie is rejected
+            // on its next request.
+            await auth.session.sessionService.rotateAndAssignVerifiedUserToSession({
+                req: frame.original.session.req,
                 user: doResetParams.user,
-                origin,
                 ip: frame.options.ip
             });
 

--- a/ghost/core/core/server/api/endpoints/users.js
+++ b/ghost/core/core/server/api/endpoints/users.js
@@ -30,6 +30,27 @@ function getTargetId(frame) {
     return frame.options.id === 'me' ? frame.user.id : frame.options.id;
 }
 
+// When a user changes their own password we destroy all of their sessions in
+// the model, then rotate the session_id here and mint a fresh verified session
+// for the current browser. Rotating invalidates any cloned or stolen copy of
+// the pre-change cookie.
+async function rotateSessionForSelfPasswordChange(frame, user) {
+    const targetUserId = frame.data.password[0].user_id;
+    const currentUserId = frame.options.context && frame.options.context.user;
+    if (targetUserId !== currentUserId) {
+        return;
+    }
+    const req = frame.original.session && frame.original.session.req;
+    if (!req) {
+        return;
+    }
+    await auth.session.sessionService.rotateAndAssignVerifiedUserToSession({
+        req,
+        user,
+        ip: frame.options.ip
+    });
+}
+
 async function fetchOrCreatePersonalToken(userId) {
     const token = await models.ApiKey.findOne({user_id: userId}, {});
 
@@ -217,6 +238,9 @@ const controller = {
         headers: {
             cacheInvalidate: false
         },
+        options: [
+            'ip'
+        ],
         validation: {
             docName: 'password',
             data: {
@@ -232,9 +256,10 @@ const controller = {
                 return frame.data.password[0].user_id;
             }
         },
-        query(frame) {
-            frame.options.skipSessionID = frame.original.session.id;
-            return models.User.changePassword(frame.data.password[0], frame.options);
+        async query(frame) {
+            const result = await models.User.changePassword(frame.data.password[0], frame.options);
+            await rotateSessionForSelfPasswordChange(frame, result);
+            return result;
         }
     },
 

--- a/ghost/core/core/server/models/session.js
+++ b/ghost/core/core/server/models/session.js
@@ -40,12 +40,13 @@ const Session = ghostBookshelf.Model.extend({
         }
         const options = this.filterOptions(unfilteredOptions, 'destroy');
 
-        // Fetch the object before destroying it, so that the changed data is available to events
+        // Fetch the object before destroying it, so that the changed data is available to events.
+        // A missing row is treated as success: password-change flows destroy
+        // every session for the user, then call req.session.regenerate(), which
+        // asks the store to destroy the same session_id a second time.
         return this.forge({session_id: options.session_id})
             .fetch(options)
-            .then((obj) => {
-                return obj.destroy(options);
-            });
+            .then(obj => obj?.destroy(options));
     },
 
     destroyAll() {

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -1056,7 +1056,6 @@ User = ghostBookshelf.Model.extend({
         const userId = object.user_id;
         const oldPassword = object.oldPassword;
         const isLoggedInUser = userId === options.context.user;
-        const skipSessionID = unfilteredOptions.skipSessionID;
 
         options.require = true;
         options.withRelated = ['sessions'];
@@ -1072,11 +1071,13 @@ User = ghostBookshelf.Model.extend({
 
         const updatedUser = await user.save({password: newPassword});
 
+        // Destroy every active session for this user. The caller must mint a
+        // fresh session (with a new session_id) for self password-changes so
+        // that stolen or cloned cookies are invalidated alongside distinct
+        // concurrent sessions.
         const sessions = user.related('sessions');
         for (const session of sessions) {
-            if (session.get('session_id') !== skipSessionID) {
-                await session.destroy(options);
-            }
+            await session.destroy(options);
         }
 
         return updatedUser;

--- a/ghost/core/core/server/services/auth/session/session-service.js
+++ b/ghost/core/core/server/services/auth/session/session-service.js
@@ -259,6 +259,34 @@ module.exports = function createSessionService({
     }
 
     /**
+     * rotateAndAssignVerifiedUserToSession
+     * Regenerates the Express session (issuing a new session_id) and then
+     * assigns the verified user to the new session. Used after a password
+     * change or reset so that any cloned or stolen copy of the pre-change
+     * cookie is rejected on its next request.
+     *
+     * @param {{req: Req, user: User, ip?: string}} options
+     * @returns {Promise<void>}
+     */
+    async function rotateAndAssignVerifiedUserToSession({req, user, ip}) {
+        await new Promise((resolve, reject) => {
+            req.session.regenerate((err) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve();
+            });
+        });
+        await assignVerifiedUserToSession({
+            session: req.session,
+            user,
+            origin: getOriginOfRequest(req),
+            ip
+        });
+    }
+
+    /**
      * generateAuthCodeForUser
      *
      * @param {Req} req
@@ -494,6 +522,7 @@ module.exports = function createSessionService({
         createSessionForUser,
         createVerifiedSessionForUser,
         assignVerifiedUserToSession,
+        rotateAndAssignVerifiedUserToSession,
         removeUserForSession,
         verifySession,
         isVerifiedSession,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/users.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/users.test.js.snap
@@ -18,6 +18,9 @@ Object {
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "set-cookie": Array [
+    StringMatching /\\^ghost-admin-api-session=/,
+  ],
   "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-powered-by": "Express",
 }

--- a/ghost/core/test/e2e-api/admin/session-invalidation.test.js
+++ b/ghost/core/test/e2e-api/admin/session-invalidation.test.js
@@ -1,0 +1,249 @@
+const {agentProvider, fixtureManager, resetRateLimits} = require('../../utils/e2e-framework');
+const {mockMail, restore} = require('../../utils/e2e-framework-mock-manager');
+const models = require('../../../core/server/models');
+const security = require('@tryghost/security');
+const settingsCache = require('../../../core/shared/settings-cache');
+const moment = require('moment');
+
+const DEFAULT_PASSWORD = 'Sl1m3rson99';
+
+async function stealCookiesAs(agent, role) {
+    return agent.loginAs(null, null, role);
+}
+
+function injectStolenCookies(agent, setCookieHeaders) {
+    agent.jar.setCookies(setCookieHeaders);
+}
+
+describe('Session invalidation on password change', function () {
+    let agentA;
+    let agentB;
+    let ownerAgent;
+    let ownerId;
+    let adminId;
+
+    before(async function () {
+        agentA = await agentProvider.getAdminAPIAgent();
+        agentB = await agentProvider.getAdminAPIAgent();
+        ownerAgent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+        ownerId = fixtureManager.get('users', 0).id;
+        adminId = fixtureManager.get('users', 1).id;
+    });
+
+    beforeEach(async function () {
+        await resetRateLimits();
+        agentA.resetAuthentication();
+        agentB.resetAuthentication();
+        ownerAgent.resetAuthentication();
+
+        await models.User.edit(
+            {password: DEFAULT_PASSWORD},
+            {id: ownerId, context: {internal: true}}
+        );
+        await models.User.edit(
+            {password: DEFAULT_PASSWORD},
+            {id: adminId, context: {internal: true}}
+        );
+    });
+
+    afterEach(function () {
+        restore();
+    });
+
+    it('Changing password invalidates other concurrent sessions for the same user', async function () {
+        await agentA.loginAsOwner();
+        await agentB.loginAsOwner();
+
+        await agentA.get('users/me/').expectStatus(200);
+        await agentB.get('users/me/').expectStatus(200);
+
+        const newPassword = 'Sl1m3rson99-rotated!';
+
+        await agentA.put('users/password/')
+            .body({
+                password: [{
+                    newPassword,
+                    ne2Password: newPassword,
+                    oldPassword: DEFAULT_PASSWORD,
+                    user_id: ownerId
+                }]
+            })
+            .expectStatus(200);
+
+        await agentA.get('users/me/').expectStatus(200);
+        await agentB.get('users/me/').expectStatus(403);
+    });
+
+    it('Stolen-cookie scenario: a cloned session cookie is invalidated by password change', async function () {
+        const victim = agentA;
+        const attacker = agentB;
+
+        const stolenCookies = await stealCookiesAs(victim, 'owner');
+        injectStolenCookies(attacker, stolenCookies);
+
+        await victim.get('users/me/').expectStatus(200);
+        await attacker.get('users/me/').expectStatus(200);
+
+        const newPassword = 'Sl1m3rson99-after-theft!';
+
+        await victim.put('users/password/')
+            .body({
+                password: [{
+                    newPassword,
+                    ne2Password: newPassword,
+                    oldPassword: DEFAULT_PASSWORD,
+                    user_id: ownerId
+                }]
+            })
+            .expectStatus(200);
+
+        await victim.get('users/me/').expectStatus(200);
+        await attacker.get('users/me/').expectStatus(403);
+    });
+
+    it('Owner changing another user\'s password invalidates all of that user\'s sessions', async function () {
+        await ownerAgent.loginAsOwner();
+        await agentA.loginAsAdmin();
+        await agentB.loginAsAdmin();
+
+        await agentA.get('users/me/').expectStatus(200);
+        await agentB.get('users/me/').expectStatus(200);
+
+        const newPassword = 'Sl1m3rson99-by-owner!';
+
+        await ownerAgent.put('users/password/')
+            .body({
+                password: [{
+                    newPassword,
+                    ne2Password: newPassword,
+                    user_id: adminId
+                }]
+            })
+            .expectStatus(200);
+
+        await ownerAgent.get('users/me/').expectStatus(200);
+        await agentA.get('users/me/').expectStatus(403);
+        await agentB.get('users/me/').expectStatus(403);
+    });
+
+    it('Password reset invalidates all prior sessions including stolen cookies', async function () {
+        const victimCookies = await stealCookiesAs(agentA, 'owner');
+        await agentB.loginAsOwner();
+
+        await agentA.get('users/me/').expectStatus(200);
+        await agentB.get('users/me/').expectStatus(200);
+
+        mockMail();
+
+        const ownerFixture = fixtureManager.get('users', 0);
+        const dbHash = settingsCache.get('db_hash');
+        const user = await models.User.getByEmail(ownerFixture.email, {context: {internal: true}});
+
+        const resetToken = security.tokens.resetToken.generateHash({
+            expires: moment().add(1, 'days').valueOf(),
+            email: ownerFixture.email,
+            dbHash,
+            password: user.get('password')
+        });
+        const encodedToken = security.url.encodeBase64(resetToken);
+        const newPassword = 'Sl1m3rson99-reset!';
+
+        agentA.clearCookies();
+
+        await agentA.put('authentication/password_reset')
+            .body({
+                password_reset: [{
+                    token: encodedToken,
+                    newPassword,
+                    ne2Password: newPassword
+                }]
+            })
+            .expectStatus(200);
+
+        await agentA.get('users/me/').expectStatus(200);
+        await agentB.get('users/me/').expectStatus(403);
+
+        ownerAgent.resetAuthentication();
+        injectStolenCookies(ownerAgent, victimCookies);
+        await ownerAgent.get('users/me/').expectStatus(403);
+    });
+
+    it('PUT /users/:id strips password from the request body and does not affect sessions', async function () {
+        await agentA.loginAsAdmin();
+
+        await agentA.get('users/me/').expectStatus(200);
+
+        await agentA.put(`users/${adminId}/`)
+            .body({
+                users: [{
+                    id: adminId,
+                    password: 'attempt-to-change-via-edit'
+                }]
+            })
+            .expectStatus(200);
+
+        await agentA.get('users/me/').expectStatus(200);
+
+        await agentB.resetAuthentication();
+        await agentB.loginAsAdmin();
+        await agentB.get('users/me/').expectStatus(200);
+    });
+
+    describe('Failed attempts leave sessions untouched', function () {
+        it('Wrong old password: sessions are not destroyed', async function () {
+            await agentA.loginAsOwner();
+            await agentB.loginAsOwner();
+
+            await agentA.put('users/password/')
+                .body({
+                    password: [{
+                        newPassword: 'Sl1m3rson99-wrong-old!',
+                        ne2Password: 'Sl1m3rson99-wrong-old!',
+                        oldPassword: 'not-the-right-password',
+                        user_id: ownerId
+                    }]
+                })
+                .expectStatus(422);
+
+            await agentA.get('users/me/').expectStatus(200);
+            await agentB.get('users/me/').expectStatus(200);
+        });
+
+        it('Unauthorized caller (author changing owner): sessions are not destroyed', async function () {
+            await ownerAgent.loginAsOwner();
+            await agentA.loginAs(null, null, 'author');
+
+            await agentA.put('users/password/')
+                .body({
+                    password: [{
+                        newPassword: 'Sl1m3rson99-nope!',
+                        ne2Password: 'Sl1m3rson99-nope!',
+                        user_id: ownerId
+                    }]
+                })
+                .expectStatus(403);
+
+            await ownerAgent.get('users/me/').expectStatus(200);
+            await agentA.get('users/me/').expectStatus(200);
+        });
+
+        it('Invalid password reset token: sessions are not destroyed', async function () {
+            await agentA.loginAsOwner();
+            await agentB.loginAsOwner();
+
+            await ownerAgent.put('authentication/password_reset')
+                .body({
+                    password_reset: [{
+                        token: 'this-is-not-a-valid-token',
+                        newPassword: 'Sl1m3rson99-nope!',
+                        ne2Password: 'Sl1m3rson99-nope!'
+                    }]
+                })
+                .expectStatus(401);
+
+            await agentA.get('users/me/').expectStatus(200);
+            await agentB.get('users/me/').expectStatus(200);
+        });
+    });
+});

--- a/ghost/core/test/e2e-api/admin/users.test.js
+++ b/ghost/core/test/e2e-api/admin/users.test.js
@@ -3,7 +3,7 @@ const config = require('../../../core/shared/config');
 const models = require('../../../core/server/models');
 const db = require('../../../core/server/data/db');
 const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
-const {anyContentVersion, anyEtag, anyObject, anyObjectId, anyArray, anyISODateTime, anyString, nullable} = matchers;
+const {anyContentVersion, anyEtag, anyObject, anyObjectId, anyArray, anyISODateTime, anyString, nullable, stringMatching} = matchers;
 const {cacheInvalidateHeaderNotSet, cacheInvalidateHeaderSetToWildcard} = assertions;
 const localUtils = require('./utils');
 
@@ -549,7 +549,10 @@ describe('User API', function () {
             .expectStatus(200)
             .matchHeaderSnapshot({
                 'content-version': anyContentVersion,
-                etag: anyEtag
+                etag: anyEtag,
+                'set-cookie': [
+                    stringMatching(/^ghost-admin-api-session=/)
+                ]
             })
             .matchBodySnapshot()
             .expect(({body}) => {


### PR DESCRIPTION
Password change and password reset destroyed every other active
session for the user, but the originating session was preserved
unchanged — including its session_id. The originating browser stayed
logged in (intended), but the cookie value didn't refresh.

Both endpoints now call req.session.regenerate() and re-assign the
verified user to the new session, so the originating browser keeps its
login with a fresh session_id. Extracted as
rotateAndAssignVerifiedUserToSession to share the logic across the two
endpoints.

Session.destroy is now idempotent: a missing row is treated as
success. Needed because req.session.regenerate() calls store.destroy()
on a row the model-layer destroy loop has already removed.
