### PR TITLE
🐛 Added bookmark card fallback for non-allowlisted oEmbed responses

### DIFF
--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -444,6 +444,18 @@ class OEmbedService {
                     return;
                 }
 
+                // `rich` and `video` responses ship provider-supplied HTML that gets
+                // stored in the post's Lexical payload and rendered into the admin
+                // editor preview (via srcdoc) and into public themes (via innerHTML).
+                // Known providers (YouTube, Twitter, etc.) go through `knownProvider`
+                // with @extractus/oembed-extractor's allowlist — anything reaching
+                // here is an arbitrary site's self-declared oEmbed endpoint, which we
+                // must not trust. Drop the response and let the caller fall back to
+                // a bookmark card.
+                if (oembed.type === 'video' || oembed.type === 'rich') {
+                    return;
+                }
+
                 // return the extracted object, don't pass through the response body
                 return oembed;
             }

--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -536,6 +536,10 @@ describe('Oembed API', function () {
         });
 
         it('strips unknown response fields', async function () {
+            // Uses `photo` because unknown providers returning rich/video are
+            // rejected outright as a security measure (ONC-1648); see the next
+            // test. `photo` still passes through so we can verify the legacy
+            // field-stripping behaviour.
             const pageMock = nock('http://test.com')
                 .get('/')
                 .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://test.com/oembed"></head></html>');
@@ -544,8 +548,8 @@ describe('Oembed API', function () {
                 .get('/oembed')
                 .reply(200, {
                     version: '1.0',
-                    type: 'video',
-                    html: '<p>Test</p>',
+                    type: 'photo',
+                    url: 'http://test.com/photo.jpg',
                     width: 200,
                     height: 100,
                     unknown: 'test'
@@ -563,12 +567,43 @@ describe('Oembed API', function () {
 
             assert.deepEqual(res.body, {
                 version: '1.0',
-                type: 'video',
-                html: '<p>Test</p>',
+                type: 'photo',
+                url: 'http://test.com/photo.jpg',
                 width: 200,
                 height: 100
             });
             assert.equal(res.body.unknown, undefined);
+        });
+
+        it('rejects rich/video responses from non-allowlisted providers (ONC-1648)', async function () {
+            // Self-declared oEmbed endpoints cannot return safe HTML for
+            // embedding in the admin preview or on the public site. Known
+            // providers (YouTube, Twitter, …) go through `knownProvider` with
+            // @extractus's allowlist; anything reaching this fallback path is
+            // an arbitrary site and must not propagate its html.
+            const pageMock = nock('http://test.com')
+                .get('/')
+                .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://test.com/oembed"></head></html>');
+
+            const oembedMock = nock('http://test.com')
+                .get('/oembed')
+                .reply(200, {
+                    version: '1.0',
+                    type: 'video',
+                    html: '<img src=x onerror="alert(1)">',
+                    width: 200,
+                    height: 100
+                });
+
+            const url = encodeURIComponent('http://test.com');
+            await request.get(localUtils.API.getApiQuery(`oembed/?url=${url}`))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(422);
+
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), true);
         });
 
         it('skips fetching IPv4 addresses', async function () {

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -104,35 +104,69 @@ describe('oembed-service', function () {
         });
     });
 
-    describe('fetchOembedDataFromUrl', function () {
-        it('allows rich embeds to skip height field', async function () {
-            nock('https://www.example.com')
-                .get('/')
-                .query(true)
-                .reply(200, `<html><head><link type="application/json+oembed" href="https://www.example.com/oembed"></head></html>`);
+    describe('fetchOembedData', function () {
+        const pageHtml = `<html><head><link type="application/json+oembed" href="https://www.example.com/oembed"></head></html>`;
 
+        it('drops rich-type responses from non-allowlisted providers (ONC-1648)', async function () {
+            // Self-declared oEmbed endpoints for arbitrary sites cannot be trusted
+            // to return safe HTML — known providers (Twitter, YouTube, …) go through
+            // `knownProvider` which uses an allowlist. Rich/video responses reaching
+            // this fallback path must not propagate their html into post content.
             nock('https://www.example.com')
                 .get('/oembed')
-                .query(true)
                 .reply(200, {
                     type: 'rich',
                     version: '1.0',
                     title: 'Test Title',
-                    author_name: 'Test Author',
-                    author_url: 'https://example.com/user/testauthor',
-                    html: '<iframe src="https://www.example.com/embed"></iframe>',
+                    html: '<img src=x onerror="alert(1)">',
                     width: 640,
-                    height: null
+                    height: 480
                 });
 
-            const response = await oembedService.fetchOembedDataFromUrl('https://www.example.com');
+            const response = await oembedService.fetchOembedData('https://www.example.com', pageHtml);
 
-            assert.equal(response.title, 'Test Title');
-            assert.equal(response.author_name, 'Test Author');
-            assert.equal(response.author_url, 'https://example.com/user/testauthor');
-            assert.equal(response.html, '<iframe src="https://www.example.com/embed"></iframe>');
+            // Returning undefined signals the caller to fall back to a bookmark
+            // card instead of storing the attacker-controlled html.
+            assert.equal(response, undefined);
         });
 
+        it('drops video-type responses from non-allowlisted providers (ONC-1648)', async function () {
+            nock('https://www.example.com')
+                .get('/oembed')
+                .reply(200, {
+                    type: 'video',
+                    version: '1.0',
+                    title: 'Test Title',
+                    html: '<iframe src="javascript:alert(1)"></iframe>',
+                    width: 640,
+                    height: 480
+                });
+
+            const response = await oembedService.fetchOembedData('https://www.example.com', pageHtml);
+
+            assert.equal(response, undefined);
+        });
+
+        it('still returns photo-type responses from non-allowlisted providers', async function () {
+            nock('https://www.example.com')
+                .get('/oembed')
+                .reply(200, {
+                    type: 'photo',
+                    version: '1.0',
+                    title: 'Test Title',
+                    url: 'https://www.example.com/photo.jpg',
+                    width: 640,
+                    height: 480
+                });
+
+            const response = await oembedService.fetchOembedData('https://www.example.com', pageHtml);
+
+            assert.equal(response.type, 'photo');
+            assert.equal(response.url, 'https://www.example.com/photo.jpg');
+        });
+    });
+
+    describe('fetchOembedDataFromUrl', function () {
         it('uses a known user-agent for bookmark requests', async function () {
             nock('https://www.example.com')
                 .get('/')


### PR DESCRIPTION
fetchOembedData returns provider-supplied embed html for rich and
video oEmbed response types. The fallback path — used when the source
isn't on the known-provider allowlist — now drops that html and
treats the response as a bookmark candidate, so the caller falls back
to a bookmark card.

Allowlisted providers (YouTube, Vimeo, Twitter, Spotify, SoundCloud,
etc.) continue to use @extractus/oembed-extractor's allowlist via
knownProvider, unchanged. photo-type responses are unchanged.

Credit: Jorian Woltjer
