### PR TITLE
Restored auto-trigger on devcontainer image workflow and added arm64

### DIFF
--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -3,21 +3,29 @@ name: Devcontainer image
 # Builds the dev container base image used by .devcontainer/devcontainer.json
 # (VS Code Dev Containers + GitHub Codespaces) and publishes it to GHCR.
 #
-# Currently triggered only by manual dispatch — auto-triggers on
-# pull_request and push were removed pending a one-time TryGhost org-admin
-# bootstrap of the ghost-devcontainer package on GHCR. Until then,
-# GITHUB_TOKEN can't create the package on first push (`denied:
-# permission_denied: write_package`), and we don't want every PR's CI to
-# show a noisy failed check.
-#
-# Once the package shell exists at github.com/orgs/TryGhost/packages and
-# is linked to this repo with Actions write access, restore the
-# `pull_request:` and `push:` triggers in a tiny follow-up PR so the
-# image rebuilds automatically on changes to docker/ghost-dev/** and
-# pnpm-install inputs.
+# Triggers only on push to main (path-filtered) and manual dispatch. PRs
+# don't trigger this workflow — devcontainer.json references the :latest
+# tag, so pre-publishing per-PR images would just produce unused tags.
+# A broken Dockerfile change in a PR will surface when the merge to main
+# fires this workflow; the previously-good :latest stays in place until
+# the next successful run.
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/ghost-dev/**'
+      - '.github/workflows/devcontainer-build.yml'
+      - '.github/scripts/**'
+      - '.github/hooks/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.npmrc'
+      - 'ghost/core/package.json'
+      - 'ghost/i18n/package.json'
+      - 'ghost/parse-email-address/package.json'
 
 permissions:
   contents: read
@@ -27,13 +35,16 @@ jobs:
   publish:
     name: Build & push
     runs-on: ubuntu-latest
-    if: github.repository == 'TryGhost/Ghost'
+    if: github.repository == 'TryGhost/Ghost' && github.ref == 'refs/heads/main'
     concurrency:
       group: devcontainer-image-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -50,6 +61,7 @@ jobs:
         with:
           context: .
           file: docker/ghost-dev/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/tryghost/ghost-devcontainer:latest


### PR DESCRIPTION
## Summary

Two changes to `.github/workflows/devcontainer-build.yml`:

1. **Restores push-to-main auto-trigger** that #27553 stripped. The TryGhost org bootstrap is done — the manual dispatch from #27553 successfully published `ghcr.io/tryghost/ghost-devcontainer:latest`, confirming `GITHUB_TOKEN` can push from this repo.
2. **Adds `linux/arm64` alongside `linux/amd64`** via `docker/setup-qemu-action` so M-series Mac developers pull a native arm64 layer from the manifest list instead of needing `--platform linux/amd64` every time.

## When the workflow runs

**Only on push to main** with one of these paths in the merge, plus manual dispatch from main. PRs do **not** trigger it.

```
docker/ghost-dev/**
.github/workflows/devcontainer-build.yml
package.json
pnpm-lock.yaml
pnpm-workspace.yaml
.npmrc
ghost/core/package.json
ghost/i18n/package.json
ghost/parse-email-address/package.json
```

A merge that only touches `apps/**` or `ghost/core/core/**` does NOT rebuild the image. In practice this fires roughly when lockfile bumps land.

A broken Dockerfile change in a PR surfaces when the merge to main fires this workflow; the previously-good `:latest` stays in place until the next successful run.

## Trade-off

Workflow runtime roughly triples (~2 min → ~5-8 min) because arm64 builds under QEMU emulation on the amd64 runner. Acceptable for a workflow that fires on a small set of paths.

## Test plan

- [ ] **After merge**: workflow auto-fires on the merge commit (touches `.github/workflows/devcontainer-build.yml`), publishes `:latest` as a multi-arch manifest list and `:<sha>`.
- [ ] M-series Mac: `docker pull ghcr.io/tryghost/ghost-devcontainer:latest` (no `--platform` flag) succeeds and pulls arm64 layers.
- [ ] amd64 host: `docker pull --platform linux/amd64 ghcr.io/tryghost/ghost-devcontainer:latest` continues to work.
- [ ] **Path-filter regression check**: the next merge to main that doesn't touch any path in the filter should NOT fire this workflow.