### PR TITLE
Added audit:overrides script for validating pnpm.overrides hygiene

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "data:analytics:generate": "node ghost/core/core/server/data/tinybird/scripts/docker-analytics-manager.js generate",
     "data:analytics:clear": "node ghost/core/core/server/data/tinybird/scripts/docker-analytics-manager.js clear",
     "release": "node scripts/release.js",
-    "test:release": "node --test 'scripts/test/*.js'"
+    "test:release": "node --test 'scripts/test/*.js'",
+    "audit:overrides": "node scripts/audit-overrides.js"
   },
   "pnpm": {
     "overrides": {

--- a/scripts/audit-overrides.js
+++ b/scripts/audit-overrides.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+'use strict';
+
+// Validates root pnpm.overrides entries by toggling each one off in turn,
+// re-resolving the lockfile, and re-running pnpm audit. An override is
+// "moot" if removing it does not increase the audit count — meaning the
+// dependency tree no longer depends on it (parents have caught up, or the
+// vulnerable version is no longer reachable). Run periodically and after
+// any major direct-dep bump to find overrides that can be retired.
+//
+// Usage: node scripts/audit-overrides.js [--only <name>]
+//
+// Refuses to run if package.json or pnpm-lock.yaml has uncommitted changes.
+// Restores both files on exit (including SIGINT/SIGTERM).
+
+const path = require('node:path');
+const fs = require('node:fs');
+const {execSync, spawnSync} = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const pkgPath = path.join(repoRoot, 'package.json');
+const lockPath = path.join(repoRoot, 'pnpm-lock.yaml');
+
+const args = process.argv.slice(2);
+const onlyIdx = args.indexOf('--only');
+const onlyKey = onlyIdx >= 0 ? args[onlyIdx + 1] : null;
+
+function readPkgRaw() {
+    return fs.readFileSync(pkgPath, 'utf8');
+}
+
+function readLockRaw() {
+    return fs.readFileSync(lockPath, 'utf8');
+}
+
+function detectIndent(raw) {
+    const match = raw.match(/^\{\n([ \t]+)"/);
+    return match ? match[1] : '  ';
+}
+
+function writePkg(pkg, originalRaw) {
+    const indent = detectIndent(originalRaw);
+    const trailingNewline = originalRaw.endsWith('\n') ? '\n' : '';
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, indent) + trailingNewline);
+}
+
+function ensureCleanWorkingTree() {
+    const status = execSync('git status --porcelain package.json pnpm-lock.yaml', {
+        cwd: repoRoot,
+        encoding: 'utf8'
+    }).trim();
+    if (status) {
+        console.error('Refusing to run: package.json or pnpm-lock.yaml has uncommitted changes.');
+        console.error('Commit or stash first.');
+        process.exit(1);
+    }
+}
+
+function pnpmInstall() {
+    const result = spawnSync('pnpm', ['install', '--silent'], {
+        cwd: repoRoot,
+        stdio: ['ignore', 'ignore', 'pipe'],
+        encoding: 'utf8'
+    });
+    if (result.status !== 0) {
+        const stderr = result.stderr || '';
+        throw new Error(`pnpm install failed (exit ${result.status})\n${stderr.split('\n').slice(0, 20).join('\n')}`);
+    }
+}
+
+function pnpmAudit() {
+    const result = spawnSync('pnpm', ['audit', '--json'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        maxBuffer: 50 * 1024 * 1024
+    });
+    if (!result.stdout) {
+        throw new Error(`pnpm audit produced no output (exit ${result.status})\n${result.stderr || ''}`);
+    }
+    return JSON.parse(result.stdout);
+}
+
+function summarize(audit) {
+    const v = audit.metadata && audit.metadata.vulnerabilities ? audit.metadata.vulnerabilities : {};
+    return {
+        critical: v.critical || 0,
+        high: v.high || 0,
+        moderate: v.moderate || 0,
+        low: v.low || 0,
+        total: (v.critical || 0) + (v.high || 0) + (v.moderate || 0) + (v.low || 0)
+    };
+}
+
+function advisoryFingerprint(audit) {
+    const set = new Set();
+    const advisories = audit.advisories || {};
+    for (const adv of Object.values(advisories)) {
+        const findings = adv.findings || [];
+        for (const finding of findings) {
+            for (const path of finding.paths || []) {
+                set.add(`${adv.module_name}@${adv.vulnerable_versions}|${path}`);
+            }
+        }
+    }
+    return set;
+}
+
+function diffSets(baseline, probe) {
+    const introduced = [];
+    for (const k of probe) {
+        if (!baseline.has(k)) {
+            introduced.push(k);
+        }
+    }
+    return introduced;
+}
+
+function formatRow(key, status, before, after, extra) {
+    const delta = after.total - before.total;
+    const sign = delta >= 0 ? '+' : '';
+    return `${status.padEnd(7)} ${key.padEnd(45)} total ${before.total} → ${after.total} (${sign}${delta})${extra ? '  ' + extra : ''}`;
+}
+
+function main() {
+    ensureCleanWorkingTree();
+
+    const originalPkgRaw = readPkgRaw();
+    const originalLockRaw = readLockRaw();
+    const originalPkg = JSON.parse(originalPkgRaw);
+    const overrides = (originalPkg.pnpm && originalPkg.pnpm.overrides) || {};
+    let keys = Object.keys(overrides);
+
+    if (onlyKey) {
+        if (!keys.includes(onlyKey)) {
+            console.error(`Override key not found: ${onlyKey}`);
+            console.error(`Available: ${keys.join(', ')}`);
+            process.exit(1);
+        }
+        keys = [onlyKey];
+    }
+
+    if (keys.length === 0) {
+        console.log('No pnpm.overrides entries to validate.');
+        return;
+    }
+
+    let restoring = false;
+    function restore() {
+        if (restoring) return;
+        restoring = true;
+        try {
+            fs.writeFileSync(pkgPath, originalPkgRaw);
+            fs.writeFileSync(lockPath, originalLockRaw);
+            console.log('\nRestoring lockfile (pnpm install)...');
+            pnpmInstall();
+            console.log('Restored.');
+        } catch (e) {
+            console.error('Failed to restore cleanly:', e.message);
+            console.error('Run `git checkout -- package.json pnpm-lock.yaml && pnpm install` manually.');
+        }
+    }
+
+    process.on('SIGINT', () => {
+        console.log('\nInterrupted.');
+        restore();
+        process.exit(130);
+    });
+    process.on('SIGTERM', () => {
+        restore();
+        process.exit(143);
+    });
+
+    console.log(`Validating ${keys.length} pnpm.overrides entr${keys.length === 1 ? 'y' : 'ies'}\n`);
+
+    console.log('Capturing baseline audit...');
+    const baselineAudit = pnpmAudit();
+    const baselineSummary = summarize(baselineAudit);
+    const baselineFingerprint = advisoryFingerprint(baselineAudit);
+    console.log(`Baseline: total=${baselineSummary.total} (crit=${baselineSummary.critical} high=${baselineSummary.high} mod=${baselineSummary.moderate} low=${baselineSummary.low})\n`);
+
+    const results = [];
+
+    try {
+        for (const key of keys) {
+            const replacement = overrides[key];
+            process.stdout.write(`Probing ${key} → ${replacement} ... `);
+
+            const modified = JSON.parse(originalPkgRaw);
+            delete modified.pnpm.overrides[key];
+            writePkg(modified, originalPkgRaw);
+
+            try {
+                pnpmInstall();
+            } catch (e) {
+                console.log('install failed → ACTIVE (cannot resolve without override)');
+                results.push({key, replacement, status: 'ACTIVE_BLOCKING', before: baselineSummary, after: baselineSummary, introduced: []});
+                fs.writeFileSync(pkgPath, originalPkgRaw);
+                fs.writeFileSync(lockPath, originalLockRaw);
+                continue;
+            }
+
+            const probeAudit = pnpmAudit();
+            const probeSummary = summarize(probeAudit);
+            const probeFingerprint = advisoryFingerprint(probeAudit);
+            const introduced = diffSets(baselineFingerprint, probeFingerprint);
+
+            const totalDelta = probeSummary.total - baselineSummary.total;
+            let status;
+            if (totalDelta <= 0 && introduced.length === 0) {
+                status = 'MOOT';
+            } else if (introduced.length > 0) {
+                status = 'ACTIVE';
+            } else {
+                status = 'NEUTRAL';
+            }
+
+            console.log(`${status} (Δ${totalDelta >= 0 ? '+' : ''}${totalDelta}, +${introduced.length} advisories reintroduced)`);
+            results.push({key, replacement, status, before: baselineSummary, after: probeSummary, introduced});
+
+            fs.writeFileSync(pkgPath, originalPkgRaw);
+            fs.writeFileSync(lockPath, originalLockRaw);
+        }
+    } finally {
+        restore();
+    }
+
+    console.log('\n=== Summary ===');
+    const moot = results.filter(r => r.status === 'MOOT');
+    const active = results.filter(r => r.status === 'ACTIVE');
+    const blocking = results.filter(r => r.status === 'ACTIVE_BLOCKING');
+    const neutral = results.filter(r => r.status === 'NEUTRAL');
+
+    console.log(`MOOT:    ${moot.length}  (override is dead weight; safe to remove)`);
+    console.log(`ACTIVE:  ${active.length}  (removal reintroduces advisories; keep)`);
+    console.log(`ACTIVE_BLOCKING: ${blocking.length}  (install fails without override; keep)`);
+    console.log(`NEUTRAL: ${neutral.length}  (no advisory delta but resolution differs; possibly removable)`);
+
+    if (moot.length > 0) {
+        console.log('\nCandidates to remove from pnpm.overrides:');
+        for (const r of moot) {
+            console.log(`  - "${r.key}": "${r.replacement}"`);
+        }
+    }
+    if (active.length > 0) {
+        console.log('\nActive overrides (keep):');
+        for (const r of active) {
+            const sample = r.introduced.slice(0, 2).map(s => s.split('|')[0]).join(', ');
+            console.log(`  - ${r.key}  (reintroduces ${r.introduced.length} paths, e.g. ${sample})`);
+        }
+    }
+
+    process.exitCode = moot.length > 0 ? 0 : 0;
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a small Node script (`scripts/audit-overrides.js`) that validates each entry in the root `pnpm.overrides` block by toggling it off, re-resolving the lockfile, and re-running `pnpm audit`. Reports each entry as one of:

- **MOOT** — removing the override has no audit impact. Candidate for removal.
- **ACTIVE** — removal reintroduces specific advisories. Keep.
- **ACTIVE_BLOCKING** — `pnpm install` fails without the override. Keep.
- **NEUTRAL** — no advisory delta but resolution differs (likely a dedup pin).

The script always restores `package.json` and `pnpm-lock.yaml` to their committed state on exit, including SIGINT/SIGTERM. Refuses to run if either file is dirty at start.

## Why

`pnpm.overrides` is an effective tool for forcing vulnerable transitive deps forward when their parents are stuck or unmaintained. But override entries silently decay — once the parent catches up (or its consumer is removed entirely), the override stops binding but stays in the file forever, hiding the fact that it's no longer needed and occasionally blocking legitimate upgrades.

This script is the "is any override unnecessary?" check we can run periodically (e.g., after each major direct-dep bump) to keep the overrides block honest.

## Smoke test

Run on `main`'s current overrides found a real finding:

```
$ pnpm audit:overrides --only nwsapi
Baseline: total=153 (crit=8 high=65 mod=67 low=13)
Probing nwsapi → 2.2.23 ... MOOT (Δ+0, +0 advisories reintroduced)
```

`nwsapi: 2.2.23` has been in the overrides block for a while and currently has no audit impact — a candidate for removal in a follow-up cleanup PR.

## Usage

```bash
pnpm audit:overrides                          # validate all overrides
pnpm audit:overrides --only "nwsapi"          # validate one entry by key
```

Each probe runs `pnpm install` + `pnpm audit`, so on this monorepo expect ~1–2 min per entry. The full run on ~25 overrides is ~25–40 min.

## Test plan

- [x] Syntax check (`node -c`)
- [x] Single-override smoke test (`--only nwsapi`) — clean restore, correct MOOT classification
- [x] Clean-tree precondition refuses dirty state
- [ ] CI green
- [ ] Full-run on `main` (out of band; will surface other moot/neutral entries for cleanup)

## Notes

- Independent of the Batch A overrides PR (#27569) — touches different files, can merge in either order.