### PR TITLE
Bumped multer 2.0.2 -> 2.1.1 in ghost/core

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -217,7 +217,7 @@
     "mingo": "2.5.3",
     "moment": "2.24.0",
     "moment-timezone": "0.5.45",
-    "multer": "2.0.2",
+    "multer": "2.1.1",
     "mysql2": "3.18.1",
     "nconf": "0.13.0",
     "node-fetch": "2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,8 +2350,8 @@ importers:
         specifier: 0.5.45
         version: 0.5.45
       multer:
-        specifier: 2.0.2
-        version: 2.0.2
+        specifier: 2.1.1
+        version: 2.1.1
       mysql2:
         specifier: 3.18.1
         version: 3.18.1(@types/node@22.19.17)
@@ -17321,10 +17321,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  multer@2.0.2:
-    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
-    engines: {node: '>= 10.16.0'}
 
   multer@2.1.1:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
@@ -42145,16 +42141,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
-
-  multer@2.0.2:
-    dependencies:
-      append-field: 1.0.0
-      busboy: 1.6.0
-      concat-stream: 2.0.0
-      mkdirp: 0.5.6
-      object-assign: 4.1.1
-      type-is: 1.6.18
-      xtend: 4.0.2
 
   multer@2.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

Bumps `multer` in `ghost/core` from `2.0.2` to `2.1.1` to clear three high-severity advisories. Minor version within the 2.x major — no API changes; `multer()`, `upload.single()`, `upload.fields()`, and `multer.MulterError` behave identically.

## Advisories cleared

| CVE | severity | fixed in |
|---|---|---|
| CVE-2026-3304 | high | 2.1.0 |
| CVE-2026-2359 | high | 2.1.0 |
| CVE-2026-3520 | high | 2.1.1 |

`pnpm audit` total: 123 → 120 (`−3 high`).

## Test plan

- [x] Upload middleware unit tests (`test/unit/server/web/api/middleware/upload.test.js`) — 14 / 14 passing
- [x] `ghost/core` full unit suite — 6200 / 6200 passing
- [ ] CI green (covers integration + e2e API)