### PR TITLE
Removed unnecessary `done`s from several tests

### DIFF
--- a/ghost/core/test/legacy/site/dynamic-routing.test.js
+++ b/ghost/core/test/legacy/site/dynamic-routing.test.js
@@ -16,19 +16,14 @@ const themeEngine = require('../../../core/frontend/services/theme-engine');
 let request;
 
 describe('Dynamic Routing', function () {
-    function doEnd(done) {
-        return function (err, res) {
-            if (err) {
-                return done(err);
-            }
-
-            assert.equal(res.headers['x-cache-invalidate'], undefined);
-            assert.equal(res.headers['X-CSRF-Token'], undefined);
-            assert.equal(res.headers['set-cookie'], undefined);
-            assertExists(res.headers.date);
-
-            done();
-        };
+    /**
+     * @param {Readonly<Record<string, string>>} headers
+     */
+    function assertCorrectHeaders(headers) {
+        assert.equal(headers['x-cache-invalidate'], undefined);
+        assert.equal(headers['X-CSRF-Token'], undefined);
+        assert.equal(headers['set-cookie'], undefined);
+        assertExists(headers.date);
     }
 
     before(async function () {
@@ -47,37 +42,26 @@ describe('Dynamic Routing', function () {
     });
 
     describe('Collection Index', function () {
-        it('should respond with html', function (done) {
-            request.get('/')
+        it('should respond with html', async function () {
+            const res = await request.get('/')
                 .expect('Content-Type', /html/)
                 .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+                .expect(200);
 
-                    const $ = cheerio.load(res.text);
+            assertCorrectHeaders(res.headers);
 
-                    assert.equal(res.headers['x-cache-invalidate'], undefined);
-                    assert.equal(res.headers['X-CSRF-Token'], undefined);
-                    assert.equal(res.headers['set-cookie'], undefined);
-                    assertExists(res.headers.date);
-
-                    assert.equal($('title').text(), 'Ghost');
-                    assert.equal($('body.home-template').length, 1);
-                    assert.equal($('article.post').length, 7);
-
-                    done();
-                });
+            const $ = cheerio.load(res.text);
+            assert.equal($('title').text(), 'Ghost');
+            assert.equal($('body.home-template').length, 1);
+            assert.equal($('article.post').length, 7);
         });
 
-        it('should not have a third page', function (done) {
-            request.get('/page/3/')
+        it('should not have a third page', async function () {
+            const res = await request.get('/page/3/')
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
-                .expect(/Page not found/)
-                .end(doEnd(done));
+                .expect(/Page not found/);
+            assertCorrectHeaders(res.headers);
         });
     });
 
@@ -90,22 +74,22 @@ describe('Dynamic Routing', function () {
             });
         });
 
-        it('should render page with slug permalink', function (done) {
-            request.get('/static-page-test/')
+        it('should render page with slug permalink', async function () {
+            const res = await request.get('/static-page-test/')
                 .expect('Content-Type', /html/)
                 .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect(200)
-                .end(doEnd(done));
+                .expect(200);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('should not render page with dated permalink', function (done) {
+        it('should not render page with dated permalink', async function () {
             const date = moment().format('YYYY/MM/DD');
 
-            request.get('/' + date + '/static-page-test/')
+            const res = await request.get('/' + date + '/static-page-test/')
                 .expect('Content-Type', /html/)
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
-                .expect(404)
-                .end(doEnd(done));
+                .expect(404);
+            assertCorrectHeaders(res.headers);
         });
     });
 
@@ -118,97 +102,86 @@ describe('Dynamic Routing', function () {
 
         after(testUtils.teardownDb);
 
-        it('should return HTML for valid route', function (done) {
-            request.get('/tag/getting-started/')
+        it('should return HTML for valid route', async function () {
+            const res = await request.get('/tag/getting-started/')
                 .expect(200)
                 .expect('Content-Type', /html/)
                 .expect('Content-Type', /html/)
                 .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+                .expect(200);
 
-                    const $ = cheerio.load(res.text);
+            assertCorrectHeaders(res.headers);
 
-                    assert.equal(res.headers['x-cache-invalidate'], undefined);
-                    assert.equal(res.headers['X-CSRF-Token'], undefined);
-                    assert.equal(res.headers['set-cookie'], undefined);
-                    assertExists(res.headers.date);
-
-                    assert.equal($('body').attr('class'), 'tag-template tag-getting-started has-sans-title has-sans-body');
-                    assert.equal($('article.post').length, 5);
-
-                    done();
-                });
+            const $ = cheerio.load(res.text);
+            assert.equal($('body').attr('class'), 'tag-template tag-getting-started has-sans-title has-sans-body');
+            assert.equal($('article.post').length, 5);
         });
 
-        it('should 404 for /tag/ route', function (done) {
-            request.get('/tag/')
+        it('should 404 for /tag/ route', async function () {
+            const res = await request.get('/tag/')
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
-                .expect(/Page not found/)
-                .end(doEnd(done));
+                .expect(/Page not found/);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('should 404 for unknown tag', function (done) {
-            request.get('/tag/spectacular/')
+        it('should 404 for unknown tag', async function () {
+            const res = await request.get('/tag/spectacular/')
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
-                .expect(/Page not found/)
-                .end(doEnd(done));
+                .expect(/Page not found/);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('should 404 for unknown tag with invalid characters', function (done) {
-            request.get('/tag/~$pectacular~/')
+        it('should 404 for unknown tag with invalid characters', async function () {
+            const res = await request.get('/tag/~$pectacular~/')
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
-                .expect(/Page not found/)
-                .end(doEnd(done));
+                .expect(/Page not found/);
+            assertCorrectHeaders(res.headers);
         });
 
         describe('RSS', function () {
-            it('should redirect without slash', function (done) {
-                request.get('/tag/getting-started/rss')
+            it('should redirect without slash', async function () {
+                const res = await request.get('/tag/getting-started/rss')
                     .expect('Location', '/tag/getting-started/rss/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
+                    .expect(301);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should respond with xml', function (done) {
-                request.get('/tag/getting-started/rss/')
+            it('should respond with xml', async function () {
+                const res = await request.get('/tag/getting-started/rss/')
                     .expect('Content-Type', /xml/)
                     .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(200)
-                    .end(doEnd(done));
+                    .expect(200);
+                assertCorrectHeaders(res.headers);
             });
         });
 
         describe('Edit', function () {
-            it('should redirect without slash', function (done) {
-                request.get('/tag/getting-started/edit')
+            it('should redirect without slash', async function () {
+                const res = await request.get('/tag/getting-started/edit')
                     .expect('Location', '/tag/getting-started/edit/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
+                    .expect(301);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should redirect to tag settings', function (done) {
-                request.get('/tag/getting-started/edit/')
+            it('should redirect to tag settings', async function () {
+                const res = await request.get('/tag/getting-started/edit/')
                     .expect('Location', /\/ghost\/#\/tags\/getting-started\//)
                     .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(302)
-                    .end(doEnd(done));
+                    .expect(302);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should 404 for non-edit parameter', function (done) {
-                request.get('/tag/getting-started/notedit/')
+            it('should 404 for non-edit parameter', async function () {
+                const res = await request.get('/tag/getting-started/notedit/')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
+                    .expect(/Page not found/);
+                assertCorrectHeaders(res.headers);
             });
         });
 
@@ -231,19 +204,19 @@ describe('Dynamic Routing', function () {
                 request = supertest.agent(config.get('url'));
             });
 
-            it('should redirect without slash', function (done) {
-                request.get('/tag/getting-started/edit')
+            it('should redirect without slash', async function () {
+                const res = await request.get('/tag/getting-started/edit')
                     .expect('Location', '/tag/getting-started/edit/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
+                    .expect(301);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should not redirect to admin', function (done) {
-                request.get('/tag/getting-started/edit/')
+            it('should not redirect to admin', async function () {
+                const res = await request.get('/tag/getting-started/edit/')
                     .expect(404)
-                    .expect('Cache-Control', testUtils.cacheRules.noCache)
-                    .end(doEnd(done));
+                    .expect('Cache-Control', testUtils.cacheRules.noCache);
+                assertCorrectHeaders(res.headers);
             });
         });
     });
@@ -265,150 +238,148 @@ describe('Dynamic Routing', function () {
 
         const ownerSlug = 'ghost-owner';
 
-        before(function (done) {
-            testUtils.teardownDb().then(function () {
-                // we initialise data, but not a user. No user should be required for navigating the frontend
-                return testUtils.initData();
-            }).then(function () {
-                return testUtils.fixtures.overrideOwnerUser(ownerSlug);
-            }).then(function (insertedUser) {
-                return testUtils.fixtures.insertPosts([
+        before(async function () {
+            await testUtils.teardownDb();
+            // we initialise data, but not a user. No user should be required for navigating the frontend
+            await testUtils.initData();
+
+            {
+                const insertedUser = await testUtils.fixtures.overrideOwnerUser(ownerSlug);
+                await testUtils.fixtures.insertPosts([
                     testUtils.DataGenerator.forKnex.createPost({
                         authors: [{
                             id: insertedUser.id
                         }]
                     })
                 ]);
-            }).then(function () {
-                return testUtils.fixtures.insertOneUser(lockedUser);
-            }).then(function (insertedUser) {
-                return testUtils.fixtures.insertPosts([
+            }
+
+            {
+                const insertedUser = await testUtils.fixtures.insertOneUser(lockedUser);
+                await testUtils.fixtures.insertPosts([
                     testUtils.DataGenerator.forKnex.createPost({
                         authors: [{
                             id: insertedUser.id
                         }]
                     })
                 ]);
-            }).then(() => {
-                return testUtils.fixtures.insertOneUser(suspendedUser);
-            }).then(function (insertedUser) {
-                return testUtils.fixtures.insertPosts([
+            }
+
+            {
+                const insertedUser = await testUtils.fixtures.insertOneUser(suspendedUser);
+                await testUtils.fixtures.insertPosts([
                     testUtils.DataGenerator.forKnex.createPost({
                         authors: [{
                             id: insertedUser.id
                         }]
                     })
                 ]);
-            }).then(function () {
-                done();
-            }).catch(done);
+            }
         });
 
         after(testUtils.teardownDb);
 
-        it('should 404 for /author/ route', function (done) {
-            request.get('/author/')
+        it('should 404 for /author/ route', async function () {
+            const res = await request.get('/author/')
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
-                .expect(/Page not found/)
-                .end(doEnd(done));
+                .expect(/Page not found/);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('should 404 for unknown author', function (done) {
-            request.get('/author/spectacular/')
+        it('should 404 for unknown author', async function () {
+            const res = await request.get('/author/spectacular/')
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
-                .expect(/Page not found/)
-                .end(doEnd(done));
+                .expect(/Page not found/);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('should 404 for unknown author with invalid characters', function (done) {
-            request.get('/author/ghost!user^/')
+        it('should 404 for unknown author with invalid characters', async function () {
+            const res = await request.get('/author/ghost!user^/')
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
-                .expect(/Page not found/)
-                .end(doEnd(done));
+                .expect(/Page not found/);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('[success] author is locked', function (done) {
-            request.get('/author/' + lockedUser.slug + '/')
+        it('[success] author is locked', async function () {
+            const res = await request.get('/author/' + lockedUser.slug + '/')
                 .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect(200)
-                .end(doEnd(done));
+                .expect(200);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('[success] author is suspended', function (done) {
-            request.get('/author/' + suspendedUser.slug + '/')
+        it('[success] author is suspended', async function () {
+            const res = await request.get('/author/' + suspendedUser.slug + '/')
                 .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect(200)
-                .end(doEnd(done));
+                .expect(200);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('[failure] ghost owner before blog setup', function (done) {
-            testUtils.fixtures.changeOwnerUserStatus({
+        it('[failure] ghost owner before blog setup', async function () {
+            await testUtils.fixtures.changeOwnerUserStatus({
                 slug: ownerSlug,
                 status: 'inactive'
-            }).then(function () {
-                request.get('/author/ghost-owner/')
-                    .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(200)
-                    .end(doEnd(done));
-            }).catch(done);
+            });
+            const res = await request.get('/author/ghost-owner/')
+                .expect('Cache-Control', testUtils.cacheRules.public)
+                .expect(200);
+            assertCorrectHeaders(res.headers);
         });
 
-        it('[success] ghost owner after blog setup', function (done) {
-            testUtils.fixtures.changeOwnerUserStatus({
+        it('[success] ghost owner after blog setup', async function () {
+            await testUtils.fixtures.changeOwnerUserStatus({
                 slug: ownerSlug,
                 status: 'active'
-            }).then(function () {
-                request.get('/author/ghost-owner/')
-                    .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(200)
-                    .end(doEnd(done));
             });
+            const res = await request.get('/author/ghost-owner/')
+                .expect('Cache-Control', testUtils.cacheRules.public)
+                .expect(200);
+            assertCorrectHeaders(res.headers);
         });
 
         describe('RSS', function () {
-            it('should redirect without slash', function (done) {
-                request.get('/author/ghost-owner/rss')
+            it('should redirect without slash', async function () {
+                const res = await request.get('/author/ghost-owner/rss')
                     .expect('Location', '/author/ghost-owner/rss/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
+                    .expect(301);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should respond with xml', function (done) {
-                request.get('/author/ghost-owner/rss/')
+            it('should respond with xml', async function () {
+                const res = await request.get('/author/ghost-owner/rss/')
                     .expect('Content-Type', /xml/)
                     .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(200)
-                    .end(doEnd(done));
+                    .expect(200);
+                assertCorrectHeaders(res.headers);
             });
         });
 
         describe('Edit', function () {
-            it('should redirect without slash', function (done) {
-                request.get('/author/ghost-owner/edit')
+            it('should redirect without slash', async function () {
+                const res = await request.get('/author/ghost-owner/edit')
                     .expect('Location', '/author/ghost-owner/edit/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
+                    .expect(301);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should redirect to editor', function (done) {
-                request.get('/author/ghost-owner/edit/')
+            it('should redirect to editor', async function () {
+                const res = await request.get('/author/ghost-owner/edit/')
                     .expect('Location', /\/ghost\/#\/settings\/staff\/ghost-owner\//)
                     .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(302)
-                    .end(doEnd(done));
+                    .expect(302);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should 404 for something that isn\'t edit', function (done) {
-                request.get('/author/ghost-owner/notedit/')
+            it('should 404 for something that isn\'t edit', async function () {
+                const res = await request.get('/author/ghost-owner/notedit/')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
+                    .expect(/Page not found/);
+                assertCorrectHeaders(res.headers);
             });
         });
 
@@ -431,104 +402,98 @@ describe('Dynamic Routing', function () {
                 request = supertest.agent(config.get('url'));
             });
 
-            it('should redirect without slash', function (done) {
-                request.get('/author/ghost-owner/edit')
+            it('should redirect without slash', async function () {
+                const res = await request.get('/author/ghost-owner/edit')
                     .expect('Location', '/author/ghost-owner/edit/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
+                    .expect(301);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should not redirect to admin', function (done) {
-                request.get('/author/ghost-owner/edit/')
+            it('should not redirect to admin', async function () {
+                const res = await request.get('/author/ghost-owner/edit/')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
-                    .expect(404)
-                    .end(doEnd(done));
+                    .expect(404);
+                assertCorrectHeaders(res.headers);
             });
         });
 
         describe('Paged', function () {
             // Add enough posts to trigger pages
-            before(function (done) {
-                testUtils.teardownDb().then(function () {
-                    // we initialize data, but not a user. No user should be required for navigating the frontend
-                    return testUtils.initData();
-                }).then(function () {
-                    return testUtils.fixtures.insertPostsAndTags();
-                }).then(function () {
-                    return testUtils.fixtures.insertExtraPosts(9);
-                }).then(function () {
-                    return testUtils.fixtures.overrideOwnerUser('ghost-owner');
-                }).then(function () {
-                    done();
-                }).catch(done);
+            before(async function () {
+                await testUtils.teardownDb();
+                // we initialize data, but not a user. No user should be required for navigating the frontend
+                await testUtils.initData();
+                await testUtils.fixtures.insertPostsAndTags();
+                await testUtils.fixtures.insertExtraPosts(9);
+                await testUtils.fixtures.overrideOwnerUser('ghost-owner');
             });
 
             after(testUtils.teardownDb);
 
-            it('should redirect without slash', function (done) {
-                request.get('/author/ghost-owner/page/2')
+            it('should redirect without slash', async function () {
+                const res = await request.get('/author/ghost-owner/page/2')
                     .expect('Location', '/author/ghost-owner/page/2/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
+                    .expect(301);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should respond with html', function (done) {
-                request.get('/author/ghost-owner/page/2/')
+            it('should respond with html', async function () {
+                const res = await request.get('/author/ghost-owner/page/2/')
                     .expect('Content-Type', /html/)
                     .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(200)
-                    .end(doEnd(done));
+                    .expect(200);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should redirect page 1', function (done) {
-                request.get('/author/ghost-owner/page/1/')
+            it('should redirect page 1', async function () {
+                const res = await request.get('/author/ghost-owner/page/1/')
                     .expect('Location', '/author/ghost-owner/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
+                    .expect(301);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should 404 if page too high', function (done) {
-                request.get('/author/ghost-owner/page/6/')
+            it('should 404 if page too high', async function () {
+                const res = await request.get('/author/ghost-owner/page/6/')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
+                    .expect(/Page not found/);
+                assertCorrectHeaders(res.headers);
             });
 
-            it('should 404 if page too low', function (done) {
-                request.get('/author/ghost-owner/page/0/')
+            it('should 404 if page too low', async function () {
+                const res = await request.get('/author/ghost-owner/page/0/')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
+                    .expect(/Page not found/);
+                assertCorrectHeaders(res.headers);
             });
 
             describe('RSS', function () {
-                it('should 404 if index attempted with 0', function (done) {
-                    request.get('/author/ghost-owner/rss/0/')
+                it('should 404 if index attempted with 0', async function () {
+                    const res = await request.get('/author/ghost-owner/rss/0/')
                         .expect('Cache-Control', testUtils.cacheRules.noCache)
                         .expect(404)
-                        .expect(/Page not found/)
-                        .end(doEnd(done));
+                        .expect(/Page not found/);
+                    assertCorrectHeaders(res.headers);
                 });
 
-                it('should 404 if index attempted with 1', function (done) {
-                    request.get('/author/ghost-owner/rss/1/')
+                it('should 404 if index attempted with 1', async function () {
+                    const res = await request.get('/author/ghost-owner/rss/1/')
                         .expect('Cache-Control', testUtils.cacheRules.noCache)
                         .expect(404)
-                        .expect(/Page not found/)
-                        .end(doEnd(done));
+                        .expect(/Page not found/);
+                    assertCorrectHeaders(res.headers);
                 });
 
-                it('should 404 for other pages', function (done) {
-                    request.get('/author/ghost-owner/rss/2/')
+                it('should 404 for other pages', async function () {
+                    const res = await request.get('/author/ghost-owner/rss/2/')
                         .expect('Cache-Control', testUtils.cacheRules.noCache)
                         .expect(404)
-                        .expect(/Page not found/)
-                        .end(doEnd(done));
+                        .expect(/Page not found/);
+                    assertCorrectHeaders(res.headers);
                 });
             });
         });

--- a/ghost/core/test/unit/frontend/helpers/comments.test.js
+++ b/ghost/core/test/unit/frontend/helpers/comments.test.js
@@ -32,14 +32,12 @@ describe('{{comments}} helper', function () {
         await configUtils.restore();
     });
 
-    it('returns undefined if not used withing post context', function (done) {
+    it('returns undefined if not used withing post context', async function () {
         settingsCacheGetStub.withArgs('members_enabled').returns(true);
         settingsCacheGetStub.withArgs('comments_enabled').returns('all');
 
-        comments({}).then(function (rendered) {
-            assert.equal(rendered, undefined);
-            done();
-        }).catch(done);
+        const rendered = await comments({});
+        assert.equal(rendered, undefined);
     });
 
     it('returns a script tag', async function () {

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -91,21 +91,18 @@ describe('{{#get}} helper', function () {
             });
         });
 
-        it('converts html strings to SafeString', function (done) {
-            get.call(
+        it('converts html strings to SafeString', async function () {
+            await get.call(
                 {},
                 'posts',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                sinon.assert.called(fn);
-                const args = fn.firstCall.args[0];
-                assert(args && typeof args === 'object');
-                assert('posts' in args);
+            );
+            sinon.assert.called(fn);
+            const args = fn.firstCall.args[0];
+            assert(args && typeof args === 'object');
+            assert('posts' in args);
 
-                assert(fn.firstCall.args[0].posts[0].feature_image_caption instanceof SafeString);
-
-                done();
-            }).catch(done);
+            assert(fn.firstCall.args[0].posts[0].feature_image_caption instanceof SafeString);
         });
     });
 
@@ -122,21 +119,18 @@ describe('{{#get}} helper', function () {
             });
         });
 
-        it('browse authors', function (done) {
-            get.call(
+        it('browse authors', async function () {
+            await get.call(
                 {},
                 'authors',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                sinon.assert.called(fn);
-                const args = fn.firstCall.args[0];
-                assert(args && typeof args === 'object');
-                assert('authors' in args);
-                assert.deepEqual(fn.firstCall.args[0].authors, []);
-                sinon.assert.notCalled(inverse);
-
-                done();
-            }).catch(done);
+            );
+            sinon.assert.called(fn);
+            const args = fn.firstCall.args[0];
+            assert(args && typeof args === 'object');
+            assert('authors' in args);
+            assert.deepEqual(fn.firstCall.args[0].authors, []);
+            sinon.assert.notCalled(inverse);
         });
     });
 
@@ -153,76 +147,64 @@ describe('{{#get}} helper', function () {
             });
         });
 
-        it('browse newsletters', function (done) {
-            get.call(
+        it('browse newsletters', async function () {
+            await get.call(
                 {},
                 'newsletters',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                sinon.assert.called(fn);
-                const args = fn.firstCall.args[0];
-                assert(args && typeof args === 'object');
-                assert('newsletters' in args);
-                assert.deepEqual(fn.firstCall.args[0].newsletters, []);
-                sinon.assert.notCalled(inverse);
-
-                done();
-            }).catch(done);
+            );
+            sinon.assert.called(fn);
+            const args = fn.firstCall.args[0];
+            assert(args && typeof args === 'object');
+            assert('newsletters' in args);
+            assert.deepEqual(fn.firstCall.args[0].newsletters, []);
+            sinon.assert.notCalled(inverse);
         });
     });
 
     describe('general error handling', function () {
-        it('should return an error for an unknown resource', function (done) {
-            get.call(
+        it('should return an error for an unknown resource', async function () {
+            await get.call(
                 {},
                 'magic',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                sinon.assert.notCalled(fn);
-                sinon.assert.calledOnce(inverse);
-                const args = inverse.firstCall.args[1];
-                assert(args && typeof args === 'object');
-                assert('data' in args);
-                const data = args.data;
-                assert(data && typeof data === 'object');
-                assert('error' in data);
-                assert.equal(data.error, 'Invalid "magic" resource given to get helper');
-
-                done();
-            }).catch(done);
+            );
+            sinon.assert.notCalled(fn);
+            sinon.assert.calledOnce(inverse);
+            const args = inverse.firstCall.args[1];
+            assert(args && typeof args === 'object');
+            assert('data' in args);
+            const data = args.data;
+            assert(data && typeof data === 'object');
+            assert('error' in data);
+            assert.equal(data.error, 'Invalid "magic" resource given to get helper');
         });
 
-        it('should handle error from the API', function (done) {
-            get.call(
+        it('should handle error from the API', async function () {
+            await get.call(
                 {},
                 'posts',
                 {hash: {slug: 'thing!'}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                sinon.assert.notCalled(fn);
-                sinon.assert.calledOnce(inverse);
-                const args = inverse.firstCall.args[1];
-                assert(args && typeof args === 'object');
-                assert('data' in args);
-                const data = args.data;
-                assert(data && typeof data === 'object');
-                assert('error' in data);
-                assert.match(data.error, /^Validation/);
-
-                done();
-            }).catch(done);
+            );
+            sinon.assert.notCalled(fn);
+            sinon.assert.calledOnce(inverse);
+            const args = inverse.firstCall.args[1];
+            assert(args && typeof args === 'object');
+            assert('data' in args);
+            const data = args.data;
+            assert(data && typeof data === 'object');
+            assert('error' in data);
+            assert.match(data.error, /^Validation/);
         });
 
-        it('should show warning for call without any options', function (done) {
-            get.call(
+        it('should show warning for call without any options', async function () {
+            await get.call(
                 {},
                 'posts',
                 {data: locals}
-            ).then(function () {
-                sinon.assert.notCalled(fn);
-                sinon.assert.notCalled(inverse);
-
-                done();
-            }).catch(done);
+            );
+            sinon.assert.notCalled(fn);
+            sinon.assert.notCalled(inverse);
         });
     });
 
@@ -246,123 +228,102 @@ describe('{{#get}} helper', function () {
             });
         });
 
-        it('should resolve post.tags alias', function (done) {
-            get.call(
+        it('should resolve post.tags alias', async function () {
+            await get.call(
                 resource,
                 'posts',
                 {hash: {filter: 'tags:[{{post.tags}}]'}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                assert(Array.isArray(browseStub.firstCall.args));
-                assert.equal(browseStub.firstCall.args.length, 1);
-                const options = browseStub.firstCall.args[0];
-                assert(options && typeof options === 'object');
-                assert('filter' in options);
-                assert.equal(options.filter, 'tags:[test,magic]');
-
-                done();
-            }).catch(done);
+            );
+            assert(Array.isArray(browseStub.firstCall.args));
+            assert.equal(browseStub.firstCall.args.length, 1);
+            const options = browseStub.firstCall.args[0];
+            assert(options && typeof options === 'object');
+            assert('filter' in options);
+            assert.equal(options.filter, 'tags:[test,magic]');
         });
 
-        it('should resolve post.author alias', function (done) {
-            get.call(
+        it('should resolve post.author alias', async function () {
+            await get.call(
                 resource,
                 'posts',
                 {hash: {filter: 'author:{{post.author}}'}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                assert(Array.isArray(browseStub.firstCall.args));
-                assert.equal(browseStub.firstCall.args.length, 1);
-                const options = browseStub.firstCall.args[0];
-                assert(options && typeof options === 'object');
-                assert('filter' in options);
-                assert.equal(options.filter, 'author:cameron');
-
-                done();
-            }).catch(done);
+            );
+            assert(Array.isArray(browseStub.firstCall.args));
+            assert.equal(browseStub.firstCall.args.length, 1);
+            const options = browseStub.firstCall.args[0];
+            assert(options && typeof options === 'object');
+            assert('filter' in options);
+            assert.equal(options.filter, 'author:cameron');
         });
 
-        it('should resolve basic path', function (done) {
-            get.call(
+        it('should resolve basic path', async function () {
+            await get.call(
                 resource,
                 'posts',
                 {hash: {filter: 'id:-{{post.id}}'}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                assert(Array.isArray(browseStub.firstCall.args));
-                assert.equal(browseStub.firstCall.args.length, 1);
-                const options = browseStub.firstCall.args[0];
-                assert(options && typeof options === 'object');
-                assert('filter' in options);
-                assert.equal(options.filter, 'id:-3');
-
-                done();
-            }).catch(done);
+            );
+            assert(Array.isArray(browseStub.firstCall.args));
+            assert.equal(browseStub.firstCall.args.length, 1);
+            const options = browseStub.firstCall.args[0];
+            assert(options && typeof options === 'object');
+            assert('filter' in options);
+            assert.equal(options.filter, 'id:-3');
         });
 
-        it('should handle arrays the same as handlebars', function (done) {
-            get.call(
+        it('should handle arrays the same as handlebars', async function () {
+            await get.call(
                 resource,
                 'posts',
                 {hash: {filter: 'tags:{{post.tags.[0].slug}}'}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                assert(Array.isArray(browseStub.firstCall.args));
-                assert.equal(browseStub.firstCall.args.length, 1);
-                const options = browseStub.firstCall.args[0];
-                assert(options && typeof options === 'object');
-                assert('filter' in options);
-                assert.equal(options.filter, 'tags:test');
-
-                done();
-            }).catch(done);
+            );
+            assert(Array.isArray(browseStub.firstCall.args));
+            assert.equal(browseStub.firstCall.args.length, 1);
+            const options = browseStub.firstCall.args[0];
+            assert(options && typeof options === 'object');
+            assert('filter' in options);
+            assert.equal(options.filter, 'tags:test');
         });
 
-        it('should handle dates', function (done) {
-            get.call(
+        it('should handle dates', async function () {
+            await get.call(
                 resource,
                 'posts',
                 {hash: {filter: 'published_at:<=\'{{post.published_at}}\''}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                assert(Array.isArray(browseStub.firstCall.args));
-                assert.equal(browseStub.firstCall.args.length, 1);
-                const options = browseStub.firstCall.args[0];
-                assert(options && typeof options === 'object');
-                assert('filter' in options);
-                assert.equal(options.filter, `published_at:<='${pubDate.toISOString()}'`);
-
-                done();
-            }).catch(done);
+            );
+            assert(Array.isArray(browseStub.firstCall.args));
+            assert.equal(browseStub.firstCall.args.length, 1);
+            const options = browseStub.firstCall.args[0];
+            assert(options && typeof options === 'object');
+            assert('filter' in options);
+            assert.equal(options.filter, `published_at:<='${pubDate.toISOString()}'`);
         });
 
-        it('should output nothing if path does not resolve', function (done) {
-            get.call(
+        it('should output nothing if path does not resolve', async function () {
+            await get.call(
                 resource,
                 'posts',
                 {hash: {filter: 'id:{{post.thing}}'}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                assert(Array.isArray(browseStub.firstCall.args));
-                assert.equal(browseStub.firstCall.args.length, 1);
-                const options = browseStub.firstCall.args[0];
-                assert(options && typeof options === 'object');
-                assert('filter' in options);
-                assert.equal(options.filter, 'id:');
-
-                done();
-            }).catch(done);
+            );
+            assert(Array.isArray(browseStub.firstCall.args));
+            assert.equal(browseStub.firstCall.args.length, 1);
+            const options = browseStub.firstCall.args[0];
+            assert(options && typeof options === 'object');
+            assert('filter' in options);
+            assert.equal(options.filter, 'id:');
         });
 
-        it('should resolve global props', function (done) {
-            get.call(
+        it('should resolve global props', async function () {
+            await get.call(
                 resource,
                 'posts',
                 {hash: {filter: 'slug:{{@globalProp.foo}}'}, data: locals, fn: fn, inverse: inverse}
-            ).then(function () {
-                assert(Array.isArray(browseStub.firstCall.args));
-                assert.equal(browseStub.firstCall.args.length, 1);
-                const options = browseStub.firstCall.args[0];
-                assert(options && typeof options === 'object');
-                assert('filter' in options);
-                assert.equal(options.filter, 'slug:bar');
-
-                done();
-            }).catch(done);
+            );
+            assert(Array.isArray(browseStub.firstCall.args));
+            assert.equal(browseStub.firstCall.args.length, 1);
+            const options = browseStub.firstCall.args[0];
+            assert(options && typeof options === 'object');
+            assert('filter' in options);
+            assert.equal(options.filter, 'slug:bar');
         });
     });
 

--- a/ghost/core/test/unit/frontend/meta/schema.test.js
+++ b/ghost/core/test/unit/frontend/meta/schema.test.js
@@ -40,7 +40,7 @@ const BASE_METADATA = {
 };
 
 describe('getSchema', function () {
-    it('should return post schema if context starts with post', function (done) {
+    it('should return post schema if context starts with post', function () {
         const metadata = {
             site: {
                 title: 'Site Title',
@@ -138,10 +138,9 @@ describe('getSchema', function () {
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
-        done();
     });
 
-    it('should return page schema if context starts with page', function (done) {
+    it('should return page schema if context starts with page', function () {
         const metadata = {
             site: {
                 title: 'Site Title',
@@ -239,10 +238,9 @@ describe('getSchema', function () {
             },
             url: 'http://mysite.com/post/my-page-slug/'
         });
-        done();
     });
 
-    it('should return post schema removing null or undefined values', function (done) {
+    it('should return post schema removing null or undefined values', function () {
         const metadata = {
             site: {
                 title: 'Site Title'
@@ -298,10 +296,9 @@ describe('getSchema', function () {
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
-        done();
     });
 
-    it('should return image url instead of ImageObjects if no dimensions supplied', function (done) {
+    it('should return image url instead of ImageObjects if no dimensions supplied', function () {
         const metadata = {
             site: {
                 title: 'Site Title',
@@ -383,7 +380,6 @@ describe('getSchema', function () {
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
-        done();
     });
 
     it('should return home schema if context starts with home', function () {

--- a/ghost/core/test/unit/frontend/meta/structured-data.test.js
+++ b/ghost/core/test/unit/frontend/meta/structured-data.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const getStructuredData = require('../../../../core/frontend/meta/structured-data');
 
 describe('getStructuredData', function () {
-    it('should return structured data from metadata per post', function (done) {
+    it('should return structured data from metadata per post', function () {
         const metadata = {
             site: {
                 title: 'Site Title',
@@ -64,10 +64,9 @@ describe('getStructuredData', function () {
             'twitter:site': '@testuser',
             'twitter:creator': '@twitterpage'
         });
-        done();
     });
 
-    it('should return structured data from metadata with provided og and twitter images only per post', function (done) {
+    it('should return structured data from metadata with provided og and twitter images only per post', function () {
         const metadata = {
             site: {
                 title: 'Site Title',
@@ -126,10 +125,9 @@ describe('getStructuredData', function () {
             'twitter:site': '@testuser',
             'twitter:creator': '@twitterpage'
         });
-        done();
     });
 
-    it('should return structured data from metadata with no nulls', function (done) {
+    it('should return structured data from metadata with no nulls', function () {
         const metadata = {
             site: {
                 title: 'Site Title',
@@ -172,6 +170,5 @@ describe('getStructuredData', function () {
             'twitter:title': 'Post Title',
             'twitter:url': 'http://mysite.com/post/my-post-slug/'
         });
-        done();
     });
 });

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -57,44 +57,38 @@ describe('Unit - frontend/data/fetch-data', function () {
         sinon.restore();
     });
 
-    it('should handle no options', function (done) {
-        data.fetchData(null, null, locals).then(function (result) {
-            assertExists(result);
-            assert(result && typeof result === 'object');
-            assert('posts' in result);
-            assert('meta' in result);
-            assert(!('data' in result));
+    it('should handle no options', async function () {
+        const result = await data.fetchData(null, null, locals);
+        assertExists(result);
+        assert(result && typeof result === 'object');
+        assert('posts' in result);
+        assert('meta' in result);
+        assert(!('data' in result));
 
-            sinon.assert.calledOnce(browsePostsStub);
-            assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
-            assert('include' in browsePostsStub.firstCall.args[0]);
-            assert(!('filter' in browsePostsStub.firstCall.args[0]));
-
-            done();
-        }).catch(done);
+        sinon.assert.calledOnce(browsePostsStub);
+        assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
+        assert('include' in browsePostsStub.firstCall.args[0]);
+        assert(!('filter' in browsePostsStub.firstCall.args[0]));
     });
 
-    it('should handle path options with page/limit', function (done) {
-        data.fetchData({page: 2, limit: 10}, null, locals).then(function (result) {
-            assertExists(result);
-            assert(result && typeof result === 'object');
-            assert('posts' in result);
-            assert('meta' in result);
-            assert(!('data' in result));
+    it('should handle page and limit options', async function () {
+        const result = await data.fetchData({page: 2, limit: 10}, null, locals);
+        assertExists(result);
+        assert(result && typeof result === 'object');
+        assert('posts' in result);
+        assert('meta' in result);
+        assert(!('data' in result));
 
-            assert.equal(result.posts.length, posts.length);
+        assert.equal(result.posts.length, posts.length);
 
-            sinon.assert.calledOnce(browsePostsStub);
-            assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
-            assert('include' in browsePostsStub.firstCall.args[0]);
-            assert.equal(browsePostsStub.firstCall.args[0].limit, 10);
-            assert.equal(browsePostsStub.firstCall.args[0].page, 2);
-
-            done();
-        }).catch(done);
+        sinon.assert.calledOnce(browsePostsStub);
+        assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
+        assert('include' in browsePostsStub.firstCall.args[0]);
+        assert.equal(browsePostsStub.firstCall.args[0].limit, 10);
+        assert.equal(browsePostsStub.firstCall.args[0].page, 2);
     });
 
-    it('should handle multiple queries', function (done) {
+    it('should handle multiple queries', async function () {
         const pathOptions = {};
 
         const routerOptions = {
@@ -110,27 +104,25 @@ describe('Unit - frontend/data/fetch-data', function () {
             }
         };
 
-        data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
-            assertExists(result);
-            assert(result && typeof result === 'object');
-            assert('posts' in result);
-            assert('meta' in result);
-            assert('data' in result);
-            assert(result.data && typeof result.data === 'object');
-            assert('featured' in result.data);
+        const result = await data.fetchData(pathOptions, routerOptions, locals);
+        assertExists(result);
+        assert(result && typeof result === 'object');
+        assert('posts' in result);
+        assert('meta' in result);
+        assert('data' in result);
+        assert(result.data && typeof result.data === 'object');
+        assert('featured' in result.data);
 
-            assert.equal(result.posts.length, posts.length);
-            assert.equal(result.data.featured.length, posts.length);
+        assert.equal(result.posts.length, posts.length);
+        assert.equal(result.data.featured.length, posts.length);
 
-            sinon.assert.calledTwice(browsePostsStub);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'authors,tags,tiers');
-            assert.equal(browsePostsStub.secondCall.args[0].filter, 'featured:true');
-            assert.equal(browsePostsStub.secondCall.args[0].limit, 3);
-            done();
-        }).catch(done);
+        sinon.assert.calledTwice(browsePostsStub);
+        assert.equal(browsePostsStub.firstCall.args[0].include, 'authors,tags,tiers');
+        assert.equal(browsePostsStub.secondCall.args[0].filter, 'featured:true');
+        assert.equal(browsePostsStub.secondCall.args[0].limit, 3);
     });
 
-    it('should handle multiple queries with page param', function (done) {
+    it('should handle multiple queries with page param', async function () {
         const pathOptions = {
             page: 2
         };
@@ -145,29 +137,27 @@ describe('Unit - frontend/data/fetch-data', function () {
             }
         };
 
-        data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
-            assertExists(result);
+        const result = await data.fetchData(pathOptions, routerOptions, locals);
+        assertExists(result);
 
-            assert(result && typeof result === 'object');
-            assert('posts' in result);
-            assert('meta' in result);
-            assert('data' in result);
-            assert(result.data && typeof result.data === 'object');
-            assert('featured' in result.data);
+        assert(result && typeof result === 'object');
+        assert('posts' in result);
+        assert('meta' in result);
+        assert('data' in result);
+        assert(result.data && typeof result.data === 'object');
+        assert('featured' in result.data);
 
-            assert.equal(result.posts.length, posts.length);
-            assert.equal(result.data.featured.length, posts.length);
+        assert.equal(result.posts.length, posts.length);
+        assert.equal(result.data.featured.length, posts.length);
 
-            sinon.assert.calledTwice(browsePostsStub);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'authors,tags,tiers');
-            assert.equal(browsePostsStub.firstCall.args[0].page, 2);
-            assert.equal(browsePostsStub.secondCall.args[0].filter, 'featured:true');
-            assert.equal(browsePostsStub.secondCall.args[0].limit, 3);
-            done();
-        }).catch(done);
+        sinon.assert.calledTwice(browsePostsStub);
+        assert.equal(browsePostsStub.firstCall.args[0].include, 'authors,tags,tiers');
+        assert.equal(browsePostsStub.firstCall.args[0].page, 2);
+        assert.equal(browsePostsStub.secondCall.args[0].filter, 'featured:true');
+        assert.equal(browsePostsStub.secondCall.args[0].limit, 3);
     });
 
-    it('should handle queries with slug replacements', function (done) {
+    it('should handle queries with slug replacements', async function () {
         const pathOptions = {
             slug: 'testing'
         };
@@ -184,24 +174,22 @@ describe('Unit - frontend/data/fetch-data', function () {
             }
         };
 
-        data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
-            assertExists(result);
-            assert(result && typeof result === 'object');
-            assert('posts' in result);
-            assert('meta' in result);
-            assert('data' in result);
-            assert(result.data && typeof result.data === 'object');
-            assert('tag' in result.data);
+        const result = await data.fetchData(pathOptions, routerOptions, locals);
+        assertExists(result);
+        assert(result && typeof result === 'object');
+        assert('posts' in result);
+        assert('meta' in result);
+        assert('data' in result);
+        assert(result.data && typeof result.data === 'object');
+        assert('tag' in result.data);
 
-            assert.equal(result.posts.length, posts.length);
-            assert.equal(result.data.tag.length, tags.length);
+        assert.equal(result.posts.length, posts.length);
+        assert.equal(result.data.tag.length, tags.length);
 
-            sinon.assert.calledOnce(browsePostsStub);
-            assert('include' in browsePostsStub.firstCall.args[0]);
-            assert.equal(browsePostsStub.firstCall.args[0].filter, 'tags:testing');
-            assert(!('slug' in browsePostsStub.firstCall.args[0]));
-            assert.equal(readTagsStub.firstCall.args[0].slug, 'testing');
-            done();
-        }).catch(done);
+        sinon.assert.calledOnce(browsePostsStub);
+        assert('include' in browsePostsStub.firstCall.args[0]);
+        assert.equal(browsePostsStub.firstCall.args[0].filter, 'tags:testing');
+        assert(!('slug' in browsePostsStub.firstCall.args[0]));
+        assert.equal(readTagsStub.firstCall.args[0].slug, 'testing');
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
@@ -8,13 +7,6 @@ const themeEngine = require('../../../../../../core/frontend/services/theme-engi
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
 const renderer = require('../../../../../../core/frontend/services/rendering');
 const dataService = require('../../../../../../core/frontend/services/data');
-
-function failTest(done) {
-    return function (err) {
-        assertExists(err);
-        done(err);
-    };
-}
 
 describe('Unit - services/routing/controllers/channel', function () {
     let req;
@@ -67,7 +59,9 @@ describe('Unit - services/routing/controllers/channel', function () {
         sinon.restore();
     });
 
-    it('no params', function (done) {
+    it('no params', async function () {
+        let next = sinon.stub();
+
         fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
@@ -78,15 +72,15 @@ describe('Unit - services/routing/controllers/channel', function () {
                 }
             });
 
-        controllers.channel(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            done();
-        }).catch(done);
+        await controllers.channel(req, res, next);
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.notCalled(next);
     });
 
-    it('pass page param', function (done) {
+    it('pass page param', async function () {
+        let next = sinon.stub();
         req.params.page = 2;
 
         fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.routerOptions)
@@ -99,15 +93,15 @@ describe('Unit - services/routing/controllers/channel', function () {
                 }
             });
 
-        controllers.channel(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            done();
-        }).catch(done);
+        await controllers.channel(req, res, next);
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.notCalled(next);
     });
 
-    it('update hbs engine: router defines limit', function (done) {
+    it('update hbs engine: router defines limit', async function () {
+        let next = sinon.stub();
         res.routerOptions.limit = 3;
         req.params.page = 2;
 
@@ -121,16 +115,16 @@ describe('Unit - services/routing/controllers/channel', function () {
                 }
             });
 
-        controllers.channel(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            done();
-        }).catch(done);
+        await controllers.channel(req, res, next);
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.notCalled(next);
     });
 
-    it('page param too big', function (done) {
+    it('page param too big', async function () {
+        let next = sinon.stub();
         req.params.page = 6;
 
         fetchDataStub.withArgs({page: 6, slug: undefined, limit: postsPerPage}, res.routerOptions)
@@ -143,18 +137,15 @@ describe('Unit - services/routing/controllers/channel', function () {
                 }
             });
 
-        controllers.channel(req, res, function (err) {
-            assert.equal((err instanceof errors.NotFoundError), true);
-
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            sinon.assert.notCalled(renderStub);
-            done();
-        });
+        await controllers.channel(req, res, next);
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.calledWith(next, sinon.match.instanceOf(errors.NotFoundError));
     });
 
-    it('slug param', function (done) {
+    it('slug param', async function () {
+        let next = sinon.stub();
         req.params.slug = 'unsafe';
 
         fetchDataStub.withArgs({page: 1, slug: 'safe', limit: postsPerPage}, res.routerOptions)
@@ -167,15 +158,15 @@ describe('Unit - services/routing/controllers/channel', function () {
                 }
             });
 
-        controllers.channel(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.calledOnce(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            done();
-        }).catch(done);
+        await controllers.channel(req, res, next);
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.calledOnce(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.notCalled(next);
     });
 
-    it('invalid posts per page', function (done) {
+    it('invalid posts per page', async function () {
+        let next = sinon.stub();
         postsPerPage = -1;
 
         fetchDataStub.withArgs({page: 1, slug: undefined}, res.routerOptions)
@@ -188,11 +179,10 @@ describe('Unit - services/routing/controllers/channel', function () {
                 }
             });
 
-        controllers.channel(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            done();
-        }).catch(done);
+        await controllers.channel(req, res, next);
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.notCalled(next);
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
@@ -9,13 +8,6 @@ const routerManager = require('../../../../../../core/frontend/services/routing/
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
 const renderer = require('../../../../../../core/frontend/services/rendering');
 const dataService = require('../../../../../../core/frontend/services/data');
-
-function failTest(done) {
-    return function (err) {
-        assertExists(err);
-        done(err);
-    };
-}
 
 describe('Unit - services/routing/controllers/collection', function () {
     let req;
@@ -74,7 +66,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.restore();
     });
 
-    it('no params', function (done) {
+    it('no params', async function () {
         fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
@@ -85,16 +77,14 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        controllers.collection(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            sinon.assert.calledOnce(ownsStub);
-            done();
-        }).catch(done);
+        await controllers.collection(req, res, function () {});
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.calledOnce(ownsStub);
     });
 
-    it('pass page param', function (done) {
+    it('pass page param', async function () {
         req.params.page = 2;
 
         fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.routerOptions)
@@ -107,16 +97,14 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        controllers.collection(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            sinon.assert.calledOnce(ownsStub);
-            done();
-        }).catch(done);
+        await controllers.collection(req, res, function () {});
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.calledOnce(ownsStub);
     });
 
-    it('update hbs engine: router defines limit', function (done) {
+    it('update hbs engine: router defines limit', async function () {
         res.routerOptions.limit = 3;
         req.params.page = 2;
 
@@ -130,17 +118,15 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        controllers.collection(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            sinon.assert.calledOnce(ownsStub);
-            done();
-        }).catch(done);
+        await controllers.collection(req, res, function () {});
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.calledOnce(ownsStub);
     });
 
-    it('page param too big', function (done) {
+    it('page param too big', async function () {
         req.params.page = 6;
 
         fetchDataStub.withArgs({page: 6, slug: undefined, limit: postsPerPage}, res.routerOptions)
@@ -153,19 +139,45 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        controllers.collection(req, res, function (err) {
-            assert.equal((err instanceof errors.NotFoundError), true);
+        let called = false;
 
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            sinon.assert.notCalled(renderStub);
-            sinon.assert.notCalled(ownsStub);
-            done();
+        await new Promise((resolve, reject) => {
+            const next = (err) => {
+                if (called) {
+                    return;
+                }
+
+                called = true;
+
+                try {
+                    assert.equal((err instanceof errors.NotFoundError), true);
+                    sinon.assert.calledOnce(themeEngine.getActive);
+                    sinon.assert.notCalled(security.string.safe);
+                    sinon.assert.calledOnce(fetchDataStub);
+                    sinon.assert.notCalled(renderStub);
+                    sinon.assert.notCalled(ownsStub);
+                    resolve();
+                } catch (error) {
+                    reject(error);
+                }
+            };
+
+            controllers.collection(req, res, next)
+                .then(() => {
+                    if (!called) {
+                        reject(new Error('Expected callback to be called with NotFoundError.'));
+                    }
+                })
+                .catch((error) => {
+                    if (!called) {
+                        reject(error);
+                    }
+                });
         });
+        assert.equal(called, true);
     });
 
-    it('slug param', function (done) {
+    it('slug param', async function () {
         req.params.slug = 'unsafe';
 
         fetchDataStub.withArgs({page: 1, slug: 'safe', limit: postsPerPage}, res.routerOptions)
@@ -178,16 +190,14 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        controllers.collection(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.calledOnce(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            sinon.assert.calledOnce(ownsStub);
-            done();
-        }).catch(done);
+        await controllers.collection(req, res, function () {});
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.calledOnce(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.calledOnce(ownsStub);
     });
 
-    it('invalid posts per page', function (done) {
+    it('invalid posts per page', async function () {
         postsPerPage = -1;
 
         fetchDataStub.withArgs({page: 1, slug: undefined}, res.routerOptions)
@@ -200,16 +210,14 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        controllers.collection(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            sinon.assert.calledOnce(ownsStub);
-            done();
-        }).catch(done);
+        await controllers.collection(req, res, function () {});
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.calledOnce(ownsStub);
     });
 
-    it('should verify if post belongs to collection', function (done) {
+    it('should verify if post belongs to collection', async function () {
         posts = [
             testUtils.DataGenerator.forKnex.createPost({url: '/a/'}),
             testUtils.DataGenerator.forKnex.createPost({url: '/b/'}),
@@ -238,12 +246,10 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        controllers.collection(req, res, failTest(done)).then(function () {
-            sinon.assert.calledOnce(themeEngine.getActive);
-            sinon.assert.notCalled(security.string.safe);
-            sinon.assert.calledOnce(fetchDataStub);
-            sinon.assert.callCount(ownsStub, 4);
-            done();
-        }).catch(done);
+        await controllers.collection(req, res, function () {});
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.callCount(ownsStub, 4);
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -17,6 +17,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     let posts;
     let postsPerPage;
     let ownsStub;
+    let next;
 
     beforeEach(function () {
         postsPerPage = 5;
@@ -27,6 +28,7 @@ describe('Unit - services/routing/controllers/collection', function () {
 
         fetchDataStub = sinon.stub();
         renderStub = sinon.stub();
+        next = sinon.stub();
 
         sinon.stub(dataService, 'fetchData').get(function () {
             return fetchDataStub;
@@ -77,11 +79,12 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        await controllers.collection(req, res, function () {});
+        await controllers.collection(req, res, next);
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
         sinon.assert.calledOnce(ownsStub);
+        sinon.assert.notCalled(next);
     });
 
     it('pass page param', async function () {
@@ -97,11 +100,12 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        await controllers.collection(req, res, function () {});
+        await controllers.collection(req, res, next);
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
         sinon.assert.calledOnce(ownsStub);
+        sinon.assert.notCalled(next);
     });
 
     it('update hbs engine: router defines limit', async function () {
@@ -118,12 +122,13 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        await controllers.collection(req, res, function () {});
+        await controllers.collection(req, res, next);
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
         sinon.assert.calledOnce(ownsStub);
+        sinon.assert.notCalled(next);
     });
 
     it('page param too big', async function () {
@@ -139,42 +144,13 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        let called = false;
-
-        await new Promise((resolve, reject) => {
-            const next = (err) => {
-                if (called) {
-                    return;
-                }
-
-                called = true;
-
-                try {
-                    assert.equal((err instanceof errors.NotFoundError), true);
-                    sinon.assert.calledOnce(themeEngine.getActive);
-                    sinon.assert.notCalled(security.string.safe);
-                    sinon.assert.calledOnce(fetchDataStub);
-                    sinon.assert.notCalled(renderStub);
-                    sinon.assert.notCalled(ownsStub);
-                    resolve();
-                } catch (error) {
-                    reject(error);
-                }
-            };
-
-            controllers.collection(req, res, next)
-                .then(() => {
-                    if (!called) {
-                        reject(new Error('Expected callback to be called with NotFoundError.'));
-                    }
-                })
-                .catch((error) => {
-                    if (!called) {
-                        reject(error);
-                    }
-                });
-        });
-        assert.equal(called, true);
+        await controllers.collection(req, res, next);
+        sinon.assert.calledWith(next, sinon.match.instanceOf(errors.NotFoundError));
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.notCalled(renderStub);
+        sinon.assert.notCalled(ownsStub);
     });
 
     it('slug param', async function () {
@@ -190,11 +166,12 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        await controllers.collection(req, res, function () {});
+        await controllers.collection(req, res, next);
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.calledOnce(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
         sinon.assert.calledOnce(ownsStub);
+        sinon.assert.notCalled(next);
     });
 
     it('invalid posts per page', async function () {
@@ -210,11 +187,12 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        await controllers.collection(req, res, function () {});
+        await controllers.collection(req, res, next);
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
         sinon.assert.calledOnce(ownsStub);
+        sinon.assert.notCalled(next);
     });
 
     it('should verify if post belongs to collection', async function () {
@@ -246,10 +224,11 @@ describe('Unit - services/routing/controllers/collection', function () {
                 }
             });
 
-        await controllers.collection(req, res, function () {});
+        await controllers.collection(req, res, next);
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
         sinon.assert.callCount(ownsStub, 4);
+        sinon.assert.notCalled(next);
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
@@ -1,4 +1,3 @@
-const {assertExists} = require('../../../../../utils/assertions');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
 const configUtils = require('../../../../../utils/config-utils');
@@ -14,13 +13,6 @@ describe('Unit - services/routing/controllers/previews', function () {
     let res;
     let post;
     let apiResponse;
-
-    function failTest(done) {
-        return function (err) {
-            assertExists(err);
-            done(err);
-        };
-    }
 
     afterEach(async function () {
         sinon.restore();
@@ -80,10 +72,10 @@ describe('Unit - services/routing/controllers/previews', function () {
         });
     });
 
-    it('should render post', function (done) {
-        controllers.previews(req, res, failTest(done)).then(function () {
-            sinon.assert.called(renderStub);
-            done();
-        }).catch(done);
+    it('should render post', async function () {
+        const next = sinon.stub();
+        await controllers.previews(req, res, next);
+        sinon.assert.called(renderStub);
+        sinon.assert.notCalled(next);
     });
 });

--- a/ghost/core/test/unit/frontend/services/rss/cache.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/cache.test.js
@@ -21,7 +21,7 @@ describe('RSS: Cache', function () {
         generateFeedReset = rssCache.__set__('generateFeed', generateSpy);
     });
 
-    it('should not rebuild xml for same data and url', function (done) {
+    it('should not rebuild xml for same data and url', async function () {
         const data = {
             title: 'Test Title',
             description: 'Testing Desc',
@@ -30,27 +30,22 @@ describe('RSS: Cache', function () {
         };
         let xmlData1;
 
-        rssCache.getXML('/rss/', data)
-            .then(function (_xmlData) {
-                xmlData1 = _xmlData;
+        const _xmlData = await rssCache.getXML('/rss/', data);
 
-                // We should have called generateFeed
-                sinon.assert.calledOnce(generateSpy);
+        xmlData1 = _xmlData;
 
-                // Call RSS again to check that we didn't rebuild
-                return rssCache.getXML('/rss/', data);
-            })
-            .then(function (xmlData2) {
-                // Assertions
+        // We should have called generateFeed
+        sinon.assert.calledOnce(generateSpy);
 
-                // We should not have called generateFeed again
-                sinon.assert.calledOnce(generateSpy);
+        // Call RSS again to check that we didn't rebuild
+        const xmlData2 = await rssCache.getXML('/rss/', data);
 
-                // The data should be identical, no changing lastBuildDate
-                assert.equal(xmlData1, xmlData2);
+        // Assertions
 
-                done();
-            })
-            .catch(done);
+        // We should not have called generateFeed again
+        sinon.assert.calledOnce(generateSpy);
+
+        // The data should be identical, no changing lastBuildDate
+        assert.equal(xmlData1, xmlData2);
     });
 });

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -60,72 +60,66 @@ describe('RSS: Generate Feed', function () {
             configUtils.set({url: 'http://my-ghost-blog.com'});
         });
 
-        it('should get the RSS tags correct', function (done) {
+        it('should get the RSS tags correct', async function () {
             data.posts = [];
 
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                assertExists(xmlData);
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
 
-                // xml & rss tags
-                assert.match(xmlData, /^<\?xml version="1.0" encoding="UTF-8"\?>/);
-                assert.match(xmlData, /<rss/);
-                assert.match(xmlData, /xmlns:dc="http:\/\/purl.org\/dc\/elements\/1.1\/"/);
-                assert.match(xmlData, /xmlns:content="http:\/\/purl.org\/rss\/1.0\/modules\/content\/"/);
-                assert.match(xmlData, /xmlns:atom="http:\/\/www.w3.org\/2005\/Atom"/);
-                assert.match(xmlData, /version="2.0"/);
-                assert.match(xmlData, /xmlns:media="http:\/\/search.yahoo.com\/mrss\/"/);
+            // xml & rss tags
+            assert.match(xmlData, /^<\?xml version="1.0" encoding="UTF-8"\?>/);
+            assert.match(xmlData, /<rss/);
+            assert.match(xmlData, /xmlns:dc="http:\/\/purl.org\/dc\/elements\/1.1\/"/);
+            assert.match(xmlData, /xmlns:content="http:\/\/purl.org\/rss\/1.0\/modules\/content\/"/);
+            assert.match(xmlData, /xmlns:atom="http:\/\/www.w3.org\/2005\/Atom"/);
+            assert.match(xmlData, /version="2.0"/);
+            assert.match(xmlData, /xmlns:media="http:\/\/search.yahoo.com\/mrss\/"/);
 
-                // channel tags
-                assert.match(xmlData, /<channel><title><!\[CDATA\[Test Title\]\]><\/title>/);
-                assert.match(xmlData, /<description><!\[CDATA\[Testing Desc\]\]><\/description>/);
-                assert.match(xmlData, /<link>http:\/\/my-ghost-blog.com\/<\/link>/);
-                assert.match(xmlData, /<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
-                assert.match(xmlData, /<generator>Ghost 0.6<\/generator>/);
-                assert.match(xmlData, /<lastBuildDate>.*?<\/lastBuildDate>/);
-                assert.match(xmlData, /<atom:link href="http:\/\/my-ghost-blog.com\/rss\/" rel="self"/);
-                assert.match(xmlData, /type="application\/rss\+xml"\/><ttl>60<\/ttl>/);
-                assert.match(xmlData, /<\/channel><\/rss>$/);
-
-                done();
-            }).catch(done);
+            // channel tags
+            assert.match(xmlData, /<channel><title><!\[CDATA\[Test Title\]\]><\/title>/);
+            assert.match(xmlData, /<description><!\[CDATA\[Testing Desc\]\]><\/description>/);
+            assert.match(xmlData, /<link>http:\/\/my-ghost-blog.com\/<\/link>/);
+            assert.match(xmlData, /<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
+            assert.match(xmlData, /<generator>Ghost 0.6<\/generator>/);
+            assert.match(xmlData, /<lastBuildDate>.*?<\/lastBuildDate>/);
+            assert.match(xmlData, /<atom:link href="http:\/\/my-ghost-blog.com\/rss\/" rel="self"/);
+            assert.match(xmlData, /type="application\/rss\+xml"\/><ttl>60<\/ttl>/);
+            assert.match(xmlData, /<\/channel><\/rss>$/);
         });
 
-        it('should get the item tags correct', function (done) {
+        it('should get the item tags correct', async function () {
             data.posts = posts;
 
             _.each(data.posts, function (post) {
                 routerManagerGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
             });
 
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                assertExists(xmlData);
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
 
-                // item tags
-                assert.match(xmlData, /<item><title><!\[CDATA\[HTML Ipsum\]\]><\/title>/);
-                assert.match(xmlData, /<description><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
-                assert.match(xmlData, /<link>http:\/\/my-ghost-blog.com\/html-ipsum\/<\/link>/);
-                assert.match(xmlData, /<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
-                assert.match(xmlData, /<guid isPermaLink="false">/);
-                assert.match(xmlData, /<\/guid><dc:creator><!\[CDATA\[Joe Bloggs\]\]><\/dc:creator>/);
-                assert.match(xmlData, /<pubDate>Thu, 01 Jan 2015/);
-                assert.match(xmlData, /<content:encoded><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
-                assert.match(xmlData, /<\/code><\/pre>\]\]><\/content:encoded><\/item>/);
-                assert.doesNotMatch(xmlData, /<author>/);
+            // item tags
+            assert.match(xmlData, /<item><title><!\[CDATA\[HTML Ipsum\]\]><\/title>/);
+            assert.match(xmlData, /<description><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
+            assert.match(xmlData, /<link>http:\/\/my-ghost-blog.com\/html-ipsum\/<\/link>/);
+            assert.match(xmlData, /<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
+            assert.match(xmlData, /<guid isPermaLink="false">/);
+            assert.match(xmlData, /<\/guid><dc:creator><!\[CDATA\[Joe Bloggs\]\]><\/dc:creator>/);
+            assert.match(xmlData, /<pubDate>Thu, 01 Jan 2015/);
+            assert.match(xmlData, /<content:encoded><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
+            assert.match(xmlData, /<\/code><\/pre>\]\]><\/content:encoded><\/item>/);
+            assert.doesNotMatch(xmlData, /<author>/);
 
-                // basic structure check
-                const postEnd = '<\/code><\/pre>\]\]><\/content:encoded>';
-                const firstIndex = xmlData.indexOf(postEnd);
+            // basic structure check
+            const postEnd = '<\/code><\/pre>\]\]><\/content:encoded>';
+            const firstIndex = xmlData.indexOf(postEnd);
 
-                // The first title should be before the first content
-                assert(xmlData.indexOf('HTML Ipsum') < firstIndex);
-                // The second title should be after the first content
-                assert(xmlData.indexOf('Ghostly Kitchen Sink') > firstIndex);
-
-                done();
-            }).catch(done);
+            // The first title should be before the first content
+            assert(xmlData.indexOf('HTML Ipsum') < firstIndex);
+            // The second title should be after the first content
+            assert(xmlData.indexOf('Ghostly Kitchen Sink') > firstIndex);
         });
 
-        it('should only return visible tags', function (done) {
+        it('should only return visible tags', async function () {
             const postWithTags = posts[2];
             postWithTags.tags = [
                 {name: 'public', visibility: 'public'},
@@ -135,111 +129,94 @@ describe('RSS: Generate Feed', function () {
 
             data.posts = [postWithTags];
 
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                assertExists(xmlData);
-                // item tags
-                assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
-                assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
-                assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
-                assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
-                assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
-                assert.match(xmlData, /<category><!\[CDATA\[public\]\]/);
-                assert.match(xmlData, /<category><!\[CDATA\[visibility\]\]/);
-                assert.doesNotMatch(xmlData, /<category><!\[CDATA\[internal\]\]/);
-                done();
-            }).catch(done);
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
+            // item tags
+            assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
+            assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
+            assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
+            assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
+            assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
+            assert.match(xmlData, /<category><!\[CDATA\[public\]\]/);
+            assert.match(xmlData, /<category><!\[CDATA\[visibility\]\]/);
+            assert.doesNotMatch(xmlData, /<category><!\[CDATA\[internal\]\]/);
         });
 
-        it('should not error if author is somehow not present', function (done) {
+        it('should not error if author is somehow not present', async function () {
             data.posts = [_.omit(posts[2], 'primary_author')];
 
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                assertExists(xmlData);
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
 
-                // special/optional tags
-                assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
-                assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
-                assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
-                assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
-                assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
-                assert.doesNotMatch(xmlData, /<dc:creator>/);
-
-                done();
-            }).catch(done);
+            // special/optional tags
+            assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
+            assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
+            assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
+            assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
+            assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
+            assert.doesNotMatch(xmlData, /<dc:creator>/);
         });
 
-        it('should not error if post content is null', function (done) {
+        it('should not error if post content is null', async function () {
             data.posts = [Object.assign({}, posts[2], {html: null})];
 
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                assertExists(xmlData);
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
 
-                // special/optional tags
-                assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
-                assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
-                assert.match(xmlData, /<content:encoded\/>/);
-                assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
-                assert.match(xmlData, /<dc:creator>/);
-
-                done();
-            }).catch(done);
+            // special/optional tags
+            assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
+            assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
+            assert.match(xmlData, /<content:encoded\/>/);
+            assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
+            assert.match(xmlData, /<dc:creator>/);
         });
 
-        it('should use meta_description and image where available', function (done) {
+        it('should use meta_description and image where available', async function () {
             data.posts = [posts[2]];
 
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                assertExists(xmlData);
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
 
-                // special/optional tags
-                assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
-                assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
-                assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
-                assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
-                assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
-
-                done();
-            }).catch(done);
+            // special/optional tags
+            assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
+            assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
+            assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
+            assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
+            assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
         });
 
-        it('should use excerpt when no meta_description is set', function (done) {
+        it('should use excerpt when no meta_description is set', async function () {
             data.posts = [posts[0]];
 
             _.each(data.posts, function (post) {
                 routerManagerGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
             });
 
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                assertExists(xmlData);
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
 
-                // special/optional tags
-                assert.match(xmlData, /<title><!\[CDATA\[HTML Ipsum\]\]>/);
-                assert.match(xmlData, /<description><!\[CDATA\[This is my custom excerpt!/);
-
-                done();
-            }).catch(done);
+            // special/optional tags
+            assert.match(xmlData, /<title><!\[CDATA\[HTML Ipsum\]\]>/);
+            assert.match(xmlData, /<description><!\[CDATA\[This is my custom excerpt!/);
         });
 
-        it('should process urls correctly', function (done) {
+        it('should process urls correctly', async function () {
             data.posts = [posts[3]];
 
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                assertExists(xmlData);
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
 
-                // anchor URL - <a href="#nowhere" title="Anchor URL">
-                assert.match(xmlData, /<a href="#nowhere" title="Anchor URL">/);
+            // anchor URL - <a href="#nowhere" title="Anchor URL">
+            assert.match(xmlData, /<a href="#nowhere" title="Anchor URL">/);
 
-                // relative URL - <a href="/about#nowhere" title="Relative URL">
-                assert.match(xmlData, /<a href="http:\/\/my-ghost-blog.com\/about#nowhere" title="Relative URL">/);
+            // relative URL - <a href="/about#nowhere" title="Relative URL">
+            assert.match(xmlData, /<a href="http:\/\/my-ghost-blog.com\/about#nowhere" title="Relative URL">/);
 
-                // protocol relative URL - <a href="//somewhere.com/link#nowhere" title="Protocol Relative URL">
-                assert.match(xmlData, /<a href="\/\/somewhere.com\/link#nowhere" title="Protocol Relative URL">/);
+            // protocol relative URL - <a href="//somewhere.com\/link#nowhere" title="Protocol Relative URL">
+            assert.match(xmlData, /<a href="\/\/somewhere.com\/link#nowhere" title="Protocol Relative URL">/);
 
-                // absolute URL - <a href="http://somewhere.com/link#nowhere" title="Absolute URL">
-                assert.match(xmlData, /<a href="http:\/\/somewhere.com\/link#nowhere" title="Absolute URL">/);
-
-                done();
-            }).catch(done);
+            // absolute URL - <a href="http:\/\/somewhere.com\/link#nowhere" title="Absolute URL">
+            assert.match(xmlData, /<a href="http:\/\/somewhere.com\/link#nowhere" title="Absolute URL">/);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/rss/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/renderer.test.js
@@ -24,77 +24,64 @@ describe('RSS: Renderer', function () {
         sinon.restore();
     });
 
-    it('calls the cache and attempts to render, even without data', function (done) {
+    it('calls the cache and attempts to render, even without data', async function () {
         rssCacheStub.returns(Promise.resolve('dummyxml'));
 
-        renderer.render(res, baseUrl).then(function () {
-            sinon.assert.calledOnce(rssCacheStub);
-            assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
+        await renderer.render(res, baseUrl);
+        sinon.assert.calledOnce(rssCacheStub);
+        assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
 
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
 
-            sinon.assert.calledOnce(res.send);
-            sinon.assert.calledWith(res.send, 'dummyxml');
-
-            done();
-        }).catch(done);
+        sinon.assert.calledOnce(res.send);
+        sinon.assert.calledWith(res.send, 'dummyxml');
     });
 
-    it('correctly merges locals into empty data before rendering', function (done) {
+    it('correctly merges locals into empty data before rendering', async function () {
         rssCacheStub.returns(Promise.resolve('dummyxml'));
 
         res.locals = {foo: 'bar'};
 
-        renderer.render(res, baseUrl).then(function () {
-            sinon.assert.calledOnce(rssCacheStub);
-            assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'bar'}]);
+        await renderer.render(res, baseUrl);
+        sinon.assert.calledOnce(rssCacheStub);
+        assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'bar'}]);
 
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
 
-            sinon.assert.calledOnce(res.send);
-            sinon.assert.calledWith(res.send, 'dummyxml');
-
-            done();
-        }).catch(done);
+        sinon.assert.calledOnce(res.send);
+        sinon.assert.calledWith(res.send, 'dummyxml');
     });
 
-    it('correctly merges locals into non-empty data before rendering', function (done) {
+    it('correctly merges locals into non-empty data before rendering', async function () {
         rssCacheStub.returns(Promise.resolve('dummyxml'));
 
         res.locals = {foo: 'bar'};
         const data = {foo: 'baz', fizz: 'buzz'};
 
-        renderer.render(res, baseUrl, data).then(function () {
-            sinon.assert.calledOnce(rssCacheStub);
-            assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'baz', fizz: 'buzz'}]);
+        await renderer.render(res, baseUrl, data);
+        sinon.assert.calledOnce(rssCacheStub);
+        assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'baz', fizz: 'buzz'}]);
 
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
 
-            sinon.assert.calledOnce(res.send);
-            sinon.assert.calledWith(res.send, 'dummyxml');
-
-            done();
-        }).catch(done);
+        sinon.assert.calledOnce(res.send);
+        sinon.assert.calledWith(res.send, 'dummyxml');
     });
 
-    it('does nothing if it gets an error', function (done) {
+    it('does nothing if it gets an error', async function () {
         rssCacheStub.returns(Promise.reject(new Error('Fake Error')));
 
-        renderer.render(res, baseUrl).then(function () {
-            done('This should have errored');
-        }).catch(function (err) {
-            assert.equal(err.message, 'Fake Error');
-
-            sinon.assert.calledOnce(rssCacheStub);
-            assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
-
-            sinon.assert.notCalled(res.set);
-            sinon.assert.notCalled(res.send);
-
-            done();
+        await assert.rejects(() => renderer.render(res, baseUrl), {
+            message: 'Fake Error'
         });
+
+        sinon.assert.calledOnce(rssCacheStub);
+        assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
+
+        sinon.assert.notCalled(res.set);
+        sinon.assert.notCalled(res.send);
     });
 });

--- a/ghost/core/test/unit/frontend/web/routers/serve-favicon.test.js
+++ b/ghost/core/test/unit/frontend/web/routers/serve-favicon.test.js
@@ -33,61 +33,56 @@ describe('Serve Favicon', function () {
 
     describe('serveFavicon', function () {
         describe('serves', function () {
-            it('default favicon.ico', function (done) {
+            it('default favicon.ico', async function () {
                 localSettingsCache.icon = '';
 
-                request(blogApp)
+                await request(blogApp)
                     .get('/favicon.ico')
                     .expect(200)
                     .expect('Content-Type', /image\/x-icon/)
-                    .expect('Content-Length', '15406')
-                    .end(done);
+                    .expect('Content-Length', '15406');
             });
         });
 
         describe('redirects', function () {
-            it('custom uploaded favicon.png', function (done) {
+            it('custom uploaded favicon.png', async function () {
                 storage.getStorage().storagePath = path.join(__dirname, '../../../../utils/fixtures/images/');
                 localSettingsCache.icon = '/content/images/favicon.png';
 
-                request(blogApp)
+                await request(blogApp)
                     .get('/favicon.png')
                     .expect(302)
-                    .expect('Location', '/content/images/size/w256h256/favicon.png')
-                    .end(done);
+                    .expect('Location', '/content/images/size/w256h256/favicon.png');
             });
 
-            it('custom uploaded favicon.webp', function (done) {
+            it('custom uploaded favicon.webp', async function () {
                 storage.getStorage().storagePath = path.join(__dirname, '../../../../utils/fixtures/images/');
                 localSettingsCache.icon = '/content/images/favicon.webp';
 
-                request(blogApp)
+                await request(blogApp)
                     .get('/favicon.png')
                     .expect(302)
-                    .expect('Location', '/content/images/size/w256h256/format/png/favicon.webp')
-                    .end(done);
+                    .expect('Location', '/content/images/size/w256h256/format/png/favicon.webp');
             });
 
-            it('custom uploaded favicon.ico', function (done) {
+            it('custom uploaded favicon.ico', async function () {
                 storage.getStorage().storagePath = path.join(__dirname, '../../../../utils/fixtures/images/');
                 localSettingsCache.icon = '/content/images/favicon.ico';
 
-                request(blogApp)
+                await request(blogApp)
                     .get('/favicon.ico')
                     .expect(302)
-                    .expect('Location', '/content/images/favicon.ico')
-                    .end(done);
+                    .expect('Location', '/content/images/favicon.ico');
             });
 
-            it('to favicon.ico when favicon.png is requested', function (done) {
+            it('to favicon.ico when favicon.png is requested', async function () {
                 configUtils.set('paths:publicFilePath', path.join(__dirname, '../../../../test/utils/fixtures/'));
                 localSettingsCache.icon = null;
 
-                request(blogApp)
+                await request(blogApp)
                     .get('/favicon.png')
                     .expect(302)
-                    .expect('Location', '/favicon.ico')
-                    .end(done);
+                    .expect('Location', '/favicon.ico');
             });
         });
     });

--- a/ghost/core/test/unit/server/data/db/backup.test.js
+++ b/ghost/core/test/unit/server/data/db/backup.test.js
@@ -24,25 +24,21 @@ describe('Backup', function () {
         fsStub = sinon.stub(fs, 'writeFile').resolves();
     });
 
-    it('should create a backup JSON file', function (done) {
-        dbBackup.backup().then(function () {
-            sinon.assert.calledOnce(exportStub);
-            sinon.assert.calledOnce(filenameStub);
-            sinon.assert.calledOnce(fsStub);
+    it('should create a backup JSON file', async function () {
+        await dbBackup.backup();
 
-            done();
-        }).catch(done);
+        sinon.assert.calledOnce(exportStub);
+        sinon.assert.calledOnce(filenameStub);
+        sinon.assert.calledOnce(fsStub);
     });
 
-    it('should not create a backup JSON file if disabled', function (done) {
+    it('should not create a backup JSON file if disabled', async function () {
         configUtils.set('disableJSBackups', true);
 
-        dbBackup.backup().then(function () {
-            sinon.assert.notCalled(exportStub);
-            sinon.assert.notCalled(filenameStub);
-            sinon.assert.notCalled(fsStub);
+        await dbBackup.backup();
 
-            done();
-        }).catch(done);
+        sinon.assert.notCalled(exportStub);
+        sinon.assert.notCalled(filenameStub);
+        sinon.assert.notCalled(fsStub);
     });
 });

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -38,116 +38,105 @@ describe('Exporter', function () {
             });
         });
 
-        it('should try to export all the correct tables (without excluded)', function (done) {
-            exporter.doExport().then(function (exportData) {
-                // NOTE: 15 default tables
-                const expectedCallCount = exporter.TABLES_ALLOWLIST.length;
+        it('should try to export all the correct tables (without excluded)', async function () {
+            const exportData = await exporter.doExport();
+            // NOTE: 15 default tables
+            const expectedCallCount = exporter.TABLES_ALLOWLIST.length;
 
-                assertExists(exportData);
+            assertExists(exportData);
 
-                assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
+            assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
 
-                sinon.assert.calledOnce(tablesStub);
-                sinon.assert.called(db.knex);
+            sinon.assert.calledOnce(tablesStub);
+            sinon.assert.called(db.knex);
 
-                sinon.assert.callCount(knexMock, expectedCallCount);
-                sinon.assert.callCount(queryMock.select, expectedCallCount);
+            sinon.assert.callCount(knexMock, expectedCallCount);
+            sinon.assert.callCount(queryMock.select, expectedCallCount);
 
-                const expectedTables = new Set([
-                    'posts',
-                    'posts_authors',
-                    'posts_meta',
-                    'posts_tags',
-                    'roles',
-                    'roles_users',
-                    'settings',
-                    'custom_theme_settings',
-                    'tags',
-                    'users',
-                    'products',
-                    'stripe_products',
-                    'stripe_prices',
-                    'posts_products',
-                    'newsletters',
-                    'benefits',
-                    'products_benefits',
-                    'offers',
-                    'offer_redemptions',
-                    'snippets'
-                ]);
-                const actualTables = new Set(knexMock.getCalls().map(call => call.args[0]));
-                assert.deepEqual(actualTables, expectedTables);
-
-                done();
-            }).catch(done);
+            const expectedTables = new Set([
+                'posts',
+                'posts_authors',
+                'posts_meta',
+                'posts_tags',
+                'roles',
+                'roles_users',
+                'settings',
+                'custom_theme_settings',
+                'tags',
+                'users',
+                'products',
+                'stripe_products',
+                'stripe_prices',
+                'posts_products',
+                'newsletters',
+                'benefits',
+                'products_benefits',
+                'offers',
+                'offer_redemptions',
+                'snippets'
+            ]);
+            const actualTables = new Set(knexMock.getCalls().map(call => call.args[0]));
+            assert.deepEqual(actualTables, expectedTables);
         });
 
-        it('should try to export all the correct tables with extra tables', function (done) {
+        it('should try to export all the correct tables with extra tables', async function () {
             const include = ['mobiledoc_revisions', 'email_recipients'];
 
-            exporter.doExport({include}).then(function (exportData) {
-                // NOTE: 15 default tables + 2 includes
-                const expectedCallCount = exporter.TABLES_ALLOWLIST.length + 2;
+            const exportData = await exporter.doExport({include});
+            // NOTE: 15 default tables + 2 includes
+            const expectedCallCount = exporter.TABLES_ALLOWLIST.length + 2;
 
-                assertExists(exportData);
+            assertExists(exportData);
 
-                assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
+            assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
 
-                sinon.assert.calledOnce(tablesStub);
-                sinon.assert.called(db.knex);
-                sinon.assert.called(queryMock.select);
+            sinon.assert.calledOnce(tablesStub);
+            sinon.assert.called(db.knex);
+            sinon.assert.called(queryMock.select);
 
-                sinon.assert.callCount(knexMock, expectedCallCount);
-                sinon.assert.callCount(queryMock.select, expectedCallCount);
+            sinon.assert.callCount(knexMock, expectedCallCount);
+            sinon.assert.callCount(queryMock.select, expectedCallCount);
 
-                const expectedTables = new Set([
-                    'posts',
-                    'posts_authors',
-                    'posts_meta',
-                    'posts_tags',
-                    'roles',
-                    'roles_users',
-                    'settings',
-                    'custom_theme_settings',
-                    'tags',
-                    'users',
-                    'products',
-                    'stripe_products',
-                    'stripe_prices',
-                    'posts_products',
-                    'newsletters',
-                    'benefits',
-                    'products_benefits',
-                    'offers',
-                    'offer_redemptions',
-                    'snippets',
-                    ...include
-                ]);
-                const actualTables = new Set(knexMock.getCalls().map(call => call.args[0]));
-                assert.deepEqual(actualTables, expectedTables);
-
-                done();
-            }).catch(done);
+            const expectedTables = new Set([
+                'posts',
+                'posts_authors',
+                'posts_meta',
+                'posts_tags',
+                'roles',
+                'roles_users',
+                'settings',
+                'custom_theme_settings',
+                'tags',
+                'users',
+                'products',
+                'stripe_products',
+                'stripe_prices',
+                'posts_products',
+                'newsletters',
+                'benefits',
+                'products_benefits',
+                'offers',
+                'offer_redemptions',
+                'snippets',
+                ...include
+            ]);
+            const actualTables = new Set(knexMock.getCalls().map(call => call.args[0]));
+            assert.deepEqual(actualTables, expectedTables);
         });
 
-        it('should catch and log any errors', function (done) {
+        it('should catch and log any errors', async function () {
             // Setup for failure
             queryMock.select.returns(Promise.reject({}));
 
             // Execute
-            exporter.doExport()
-                .then(function () {
-                    done(new Error('expected error for export'));
-                })
-                .catch(function (err) {
-                    assert.equal((err instanceof errors.DataExportError), true);
-                    done();
-                });
+            await assert.rejects(async () => {
+                await exporter.doExport();
+            }, errors.DataExportError);
         });
     });
 
     describe('exportFileName', function () {
-        it('should return a correctly structured filename', function (done) {
+        it('should return a correctly structured filename', async function () {
             const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
                 Promise.resolve({
                     get: function () {
@@ -156,43 +145,34 @@ describe('Exporter', function () {
                 })
             );
 
-            exporter.fileName().then(function (result) {
-                assertExists(result);
-                sinon.assert.calledOnce(settingsStub);
-                assert.match(result, /^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
-
-                done();
-            }).catch(done);
+            const result = await exporter.fileName();
+            assertExists(result);
+            sinon.assert.calledOnce(settingsStub);
+            assert.match(result, /^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
         });
 
-        it('should return a correctly structured filename if settings is empty', function (done) {
+        it('should return a correctly structured filename if settings is empty', async function () {
             const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
                 Promise.resolve()
             );
 
-            exporter.fileName().then(function (result) {
-                assertExists(result);
-                sinon.assert.calledOnce(settingsStub);
-                assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
-
-                done();
-            }).catch(done);
+            const result = await exporter.fileName();
+            assertExists(result);
+            sinon.assert.calledOnce(settingsStub);
+            assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
         });
 
-        it('should return a correctly structured filename if settings errors', function (done) {
+        it('should return a correctly structured filename if settings errors', async function () {
             const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
                 Promise.reject()
             );
             const loggingStub = sinon.stub(logging, 'error');
 
-            exporter.fileName().then(function (result) {
-                assertExists(result);
-                sinon.assert.calledOnce(settingsStub);
-                sinon.assert.calledOnce(loggingStub);
-                assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
-
-                done();
-            }).catch(done);
+            const result = await exporter.fileName();
+            assertExists(result);
+            sinon.assert.calledOnce(settingsStub);
+            sinon.assert.calledOnce(loggingStub);
+            assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
         });
     });
 

--- a/ghost/core/test/unit/server/data/importer/handlers/image.test.js
+++ b/ghost/core/test/unit/server/data/importer/handlers/image.test.js
@@ -38,7 +38,7 @@ describe('ImageHandler', function () {
         assert.equal(typeof ImageHandler.loadFile, 'function');
     });
 
-    it('can load a single file', function (done) {
+    it('can load a single file', async function () {
         const filename = 'test-image.jpeg';
 
         const file = [{
@@ -49,18 +49,15 @@ describe('ImageHandler', function () {
         const storeSpy = sinon.spy(store, 'getUniqueFileName');
         const storageSpy = sinon.spy(storage, 'getStorage');
 
-        ImageHandler.loadFile(_.clone(file)).then(function () {
-            sinon.assert.calledOnce(storageSpy);
-            sinon.assert.calledOnce(storeSpy);
-            assert.equal(storeSpy.firstCall.args[0].originalPath, 'test-image.jpeg');
-            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
-            assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/test-image.jpeg');
-
-            done();
-        }).catch(done);
+        await ImageHandler.loadFile(_.clone(file));
+        sinon.assert.calledOnce(storageSpy);
+        sinon.assert.calledOnce(storeSpy);
+        assert.equal(storeSpy.firstCall.args[0].originalPath, 'test-image.jpeg');
+        assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+        assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/test-image.jpeg');
     });
 
-    it('can load a single file, maintaining structure', function (done) {
+    it('can load a single file, maintaining structure', async function () {
         const filename = 'photos/my-cat.jpeg';
 
         const file = [{
@@ -71,18 +68,15 @@ describe('ImageHandler', function () {
         const storeSpy = sinon.spy(store, 'getUniqueFileName');
         const storageSpy = sinon.spy(storage, 'getStorage');
 
-        ImageHandler.loadFile(_.clone(file)).then(function () {
-            sinon.assert.calledOnce(storageSpy);
-            sinon.assert.calledOnce(storeSpy);
-            assert.equal(storeSpy.firstCall.args[0].originalPath, 'photos/my-cat.jpeg');
-            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)photos$/);
-            assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/photos/my-cat.jpeg');
-
-            done();
-        }).catch(done);
+        await ImageHandler.loadFile(_.clone(file));
+        sinon.assert.calledOnce(storageSpy);
+        sinon.assert.calledOnce(storeSpy);
+        assert.equal(storeSpy.firstCall.args[0].originalPath, 'photos/my-cat.jpeg');
+        assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)photos$/);
+        assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/photos/my-cat.jpeg');
     });
 
-    it('can load a single file, removing ghost dirs', function (done) {
+    it('can load a single file, removing ghost dirs', async function () {
         const filename = 'content/images/my-cat.jpeg';
 
         const file = [{
@@ -93,18 +87,15 @@ describe('ImageHandler', function () {
         const storeSpy = sinon.spy(store, 'getUniqueFileName');
         const storageSpy = sinon.spy(storage, 'getStorage');
 
-        ImageHandler.loadFile(_.clone(file)).then(function () {
-            sinon.assert.calledOnce(storageSpy);
-            sinon.assert.calledOnce(storeSpy);
-            assert.equal(storeSpy.firstCall.args[0].originalPath, 'content/images/my-cat.jpeg');
-            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
-            assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/my-cat.jpeg');
-
-            done();
-        }).catch(done);
+        await ImageHandler.loadFile(_.clone(file));
+        sinon.assert.calledOnce(storageSpy);
+        sinon.assert.calledOnce(storeSpy);
+        assert.equal(storeSpy.firstCall.args[0].originalPath, 'content/images/my-cat.jpeg');
+        assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+        assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/my-cat.jpeg');
     });
 
-    it('can load a file (subdirectory)', function (done) {
+    it('can load a file (subdirectory)', async function () {
         configUtils.set({url: 'http://localhost:65535/subdir'});
 
         const filename = 'test-image.jpeg';
@@ -117,18 +108,15 @@ describe('ImageHandler', function () {
         const storeSpy = sinon.spy(store, 'getUniqueFileName');
         const storageSpy = sinon.spy(storage, 'getStorage');
 
-        ImageHandler.loadFile(_.clone(file)).then(function () {
-            sinon.assert.calledOnce(storageSpy);
-            sinon.assert.calledOnce(storeSpy);
-            assert.equal(storeSpy.firstCall.args[0].originalPath, 'test-image.jpeg');
-            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
-            assert.equal(storeSpy.firstCall.args[0].newPath, '/subdir/content/images/test-image.jpeg');
-
-            done();
-        }).catch(done);
+        await ImageHandler.loadFile(_.clone(file));
+        sinon.assert.calledOnce(storageSpy);
+        sinon.assert.calledOnce(storeSpy);
+        assert.equal(storeSpy.firstCall.args[0].originalPath, 'test-image.jpeg');
+        assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+        assert.equal(storeSpy.firstCall.args[0].newPath, '/subdir/content/images/test-image.jpeg');
     });
 
-    it('can load multiple files', function (done) {
+    it('can load multiple files', async function () {
         const files = [{
             path: '/my/test/testing.png',
             name: 'testing.png'
@@ -149,23 +137,20 @@ describe('ImageHandler', function () {
         const storeSpy = sinon.spy(store, 'getUniqueFileName');
         const storageSpy = sinon.spy(storage, 'getStorage');
 
-        ImageHandler.loadFile(_.clone(files)).then(function () {
-            sinon.assert.calledOnce(storageSpy);
-            sinon.assert.callCount(storeSpy, 4);
-            assert.equal(storeSpy.firstCall.args[0].originalPath, 'testing.png');
-            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
-            assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/testing.png');
-            assert.equal(storeSpy.secondCall.args[0].originalPath, 'photo/kitten.jpg');
-            assert.match(storeSpy.secondCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)photo$/);
-            assert.equal(storeSpy.secondCall.args[0].newPath, '/content/images/photo/kitten.jpg');
-            assert.equal(storeSpy.thirdCall.args[0].originalPath, 'content/images/animated/bunny.gif');
-            assert.match(storeSpy.thirdCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)animated$/);
-            assert.equal(storeSpy.thirdCall.args[0].newPath, '/content/images/animated/bunny.gif');
-            assert.equal(storeSpy.lastCall.args[0].originalPath, 'images/puppy.jpg');
-            assert.match(storeSpy.lastCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
-            assert.equal(storeSpy.lastCall.args[0].newPath, '/content/images/puppy.jpg');
-
-            done();
-        }).catch(done);
+        await ImageHandler.loadFile(_.clone(files));
+        sinon.assert.calledOnce(storageSpy);
+        sinon.assert.callCount(storeSpy, 4);
+        assert.equal(storeSpy.firstCall.args[0].originalPath, 'testing.png');
+        assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+        assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/testing.png');
+        assert.equal(storeSpy.secondCall.args[0].originalPath, 'photo/kitten.jpg');
+        assert.match(storeSpy.secondCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)photo$/);
+        assert.equal(storeSpy.secondCall.args[0].newPath, '/content/images/photo/kitten.jpg');
+        assert.equal(storeSpy.thirdCall.args[0].originalPath, 'content/images/animated/bunny.gif');
+        assert.match(storeSpy.thirdCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)animated$/);
+        assert.equal(storeSpy.thirdCall.args[0].newPath, '/content/images/animated/bunny.gif');
+        assert.equal(storeSpy.lastCall.args[0].originalPath, 'images/puppy.jpg');
+        assert.match(storeSpy.lastCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+        assert.equal(storeSpy.lastCall.args[0].newPath, '/content/images/puppy.jpg');
     });
 });

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -155,32 +155,28 @@ describe('Importer', function () {
 
         // Step 1 of importing is loadFile
         describe('loadFile', function () {
-            it('knows when to process a file', function (done) {
+            it('knows when to process a file', async function () {
                 const testFile = {name: 'myFile.json', path: '/my/path/myFile.json'};
                 const zipSpy = sinon.stub(ImportManager, 'processZip').returns(Promise.resolve({}));
                 const fileSpy = sinon.stub(ImportManager, 'processFile').returns(Promise.resolve({}));
 
-                ImportManager.loadFile(testFile).then(function () {
-                    sinon.assert.notCalled(zipSpy);
-                    sinon.assert.calledOnce(fileSpy);
-                    done();
-                }).catch(done);
+                await ImportManager.loadFile(testFile);
+                sinon.assert.notCalled(zipSpy);
+                sinon.assert.calledOnce(fileSpy);
             });
 
             // We need to make sure we don't actually extract a zip and leave temporary files everywhere!
-            it('knows when to process a zip', function (done) {
+            it('knows when to process a zip', async function () {
                 const testZip = {name: 'myFile.zip', path: '/my/path/myFile.zip'};
                 const zipSpy = sinon.stub(ImportManager, 'processZip').resolves({});
                 const fileSpy = sinon.stub(ImportManager, 'processFile').resolves({});
 
-                ImportManager.loadFile(testZip).then(function () {
-                    sinon.assert.calledOnce(zipSpy);
-                    sinon.assert.notCalled(fileSpy);
-                    done();
-                }).catch(done);
+                await ImportManager.loadFile(testZip);
+                sinon.assert.calledOnce(zipSpy);
+                sinon.assert.notCalled(fileSpy);
             });
 
-            it('has same result for zips and files', function (done) {
+            it('has same result for zips and files', async function () {
                 const testFile = {name: 'myFile.json', path: '/my/path/myFile.json'};
                 const testZip = {name: 'myFile.zip', path: '/my/path/myFile.zip'};
 
@@ -199,26 +195,24 @@ describe('Importer', function () {
                 getFileSpy.withArgs(JSONHandler, sinon.match.string).returns([{path: '/tmp/dir/myFile.json', name: 'myFile.json'}]);
                 getFileSpy.withArgs(RevueHandler, sinon.match.string).returns([{path: '/tmp/dir/myFile.json', name: 'myFile.json'}]);
 
-                ImportManager.processZip(testZip).then(function (zipResult) {
-                    sinon.assert.calledOnce(extractSpy);
-                    sinon.assert.calledOnce(validSpy);
-                    sinon.assert.calledOnce(baseDirSpy);
-                    sinon.assert.callCount(getFileSpy, 6);
-                    sinon.assert.calledOnce(jsonSpy);
-                    sinon.assert.notCalled(imageSpy);
-                    sinon.assert.notCalled(mdSpy);
-                    sinon.assert.called(revueSpy);
+                const zipResult = await ImportManager.processZip(testZip);
 
-                    ImportManager.processFile(testFile, '.json').then(function (fileResult) {
-                        sinon.assert.calledTwice(jsonSpy);
+                sinon.assert.calledOnce(extractSpy);
+                sinon.assert.calledOnce(validSpy);
+                sinon.assert.calledOnce(baseDirSpy);
+                sinon.assert.callCount(getFileSpy, 6);
+                sinon.assert.calledOnce(jsonSpy);
+                sinon.assert.notCalled(imageSpy);
+                sinon.assert.notCalled(mdSpy);
+                sinon.assert.called(revueSpy);
 
-                        // They should both have data keys, and they should be equivalent
-                        assert('data' in zipResult);
-                        assert('data' in fileResult);
-                        assert.deepEqual(zipResult, fileResult);
-                        done();
-                    });
-                }).catch(done);
+                const fileResult = await ImportManager.processFile(testFile, '.json');
+                sinon.assert.calledTwice(jsonSpy);
+
+                // They should both have data keys, and they should be equivalent
+                assert('data' in zipResult);
+                assert('data' in fileResult);
+                assert.deepEqual(zipResult, fileResult);
             });
 
             describe('Validate Zip', function () {
@@ -383,17 +377,16 @@ describe('Importer', function () {
             });
 
             describe('Zip behavior', function () {
-                it('can call extract and error correctly', function () {
-                    return ImportManager
-                        // Deliberately pass something that can't be extracted just to check this method signature is working
-                        .extractZip('test/utils/fixtures/import/zips/zip-with-base-dir')
-                        .then(() => {
-                            throw new Error('should have failed');
-                        })
-                        .catch((err) => {
+                it('can call extract and error correctly', async function () {
+                    // Deliberately pass something that can't be extracted just to check this method signature is working
+                    await assert.rejects(
+                        ImportManager.extractZip('test/utils/fixtures/import/zips/zip-with-base-dir'),
+                        (err) => {
                             assert.match(err.message, /EISDIR/);
                             assert.match(err.code, /EISDIR/);
-                        });
+                            return true;
+                        }
+                    );
                 });
             });
         });
@@ -401,7 +394,7 @@ describe('Importer', function () {
         // Step 2 of importing is preProcess
         describe('preProcess', function () {
             // preProcess can modify the data prior to importing
-            it('calls the DataImporter preProcess method', function (done) {
+            it('calls the DataImporter preProcess method', async function () {
                 const input = {
                     data: {},
                     images: [],
@@ -416,22 +409,20 @@ describe('Importer', function () {
                 const imageSpy = sinon.spy(ImportManager.importers[0], 'preProcess');
                 const revueSpy = sinon.spy(RevueImporter, 'preProcess');
 
-                ImportManager.preProcess(inputCopy).then(function (output) {
-                    sinon.assert.calledOnce(revueSpy);
-                    sinon.assert.calledWith(revueSpy, inputCopy);
-                    sinon.assert.calledOnce(dataSpy);
-                    sinon.assert.calledWith(dataSpy, inputCopy);
-                    sinon.assert.calledOnce(imageSpy);
-                    sinon.assert.calledWith(imageSpy, inputCopy);
-                    // eql checks for equality
-                    // equal checks the references are for the same object
-                    assert.notEqual(output, input);
-                    assert.equal(output.preProcessedByData, true);
-                    assert.equal(output.preProcessedByImage, true);
-                    assert.equal(output.preProcessedByMedia, true);
-                    assert.equal(output.preProcessedByFiles, true);
-                    done();
-                }).catch(done);
+                const output = await ImportManager.preProcess(inputCopy);
+                sinon.assert.calledOnce(revueSpy);
+                sinon.assert.calledWith(revueSpy, inputCopy);
+                sinon.assert.calledOnce(dataSpy);
+                sinon.assert.calledWith(dataSpy, inputCopy);
+                sinon.assert.calledOnce(imageSpy);
+                sinon.assert.calledWith(imageSpy, inputCopy);
+                // eql checks for equality
+                // equal checks the references are for the same object
+                assert.notEqual(output, input);
+                assert.equal(output.preProcessedByData, true);
+                assert.equal(output.preProcessedByImage, true);
+                assert.equal(output.preProcessedByMedia, true);
+                assert.equal(output.preProcessedByFiles, true);
             });
         });
 
@@ -439,7 +430,7 @@ describe('Importer', function () {
         describe('doImport', function () {
             // doImport calls the real importers and has an effect on the DB. We don't want any of those calls to be made,
             // but to test that the right calls would be made
-            it('calls the DataImporter doImport method with the data object', function (done) {
+            it('calls the DataImporter doImport method with the data object', async function () {
                 const input = {data: {posts: []}, images: []};
 
                 // pass a copy so that input doesn't get modified
@@ -458,18 +449,16 @@ describe('Importer', function () {
 
                 const expectedImages = input.images;
 
-                ImportManager.doImport(inputCopy).then(function (output) {
-                    // eql checks for equality
-                    // equal checks the references are for the same object
-                    sinon.assert.calledOnce(dataSpy);
-                    sinon.assert.calledOnce(imageSpy);
-                    assert.deepEqual(dataSpy.getCall(0).args[0], expectedData);
-                    assert.deepEqual(imageSpy.getCall(0).args[0], expectedImages);
+                const output = await ImportManager.doImport(inputCopy);
+                // eql checks for equality
+                // equal checks the references are for the same object
+                sinon.assert.calledOnce(dataSpy);
+                sinon.assert.calledOnce(imageSpy);
+                assert.deepEqual(dataSpy.getCall(0).args[0], expectedData);
+                assert.deepEqual(imageSpy.getCall(0).args[0], expectedImages);
 
-                    // we stubbed this as a noop but ImportManager calls with sequence, so we should get an array
-                    assert.deepEqual(output, {images: expectedImages, data: expectedData});
-                    done();
-                }).catch(done);
+                // we stubbed this as a noop but ImportManager calls with sequence, so we should get an array
+                assert.deepEqual(output, {images: expectedImages, data: expectedData});
             });
         });
 
@@ -477,33 +466,28 @@ describe('Importer', function () {
         describe('generateReport', function () {
             // generateReport is intended to create a message to show to the user about what has been imported
             // it is currently a noop
-            it('is currently a noop', function (done) {
+            it('is currently a noop', async function () {
                 const input = [{data: {}, images: []}];
-                ImportManager.generateReport(input).then(function (output) {
-                    assert.equal(output, input);
-                    done();
-                }).catch(done);
+                const output = await ImportManager.generateReport(input);
+                assert.equal(output, input);
             });
         });
 
         describe('importFromFile', function () {
-            it('does the import steps in order', function (done) {
+            it('does the import steps in order', async function () {
                 const loadFileSpy = sinon.stub(ImportManager, 'loadFile').returns(Promise.resolve({}));
                 const preProcessSpy = sinon.stub(ImportManager, 'preProcess').returns(Promise.resolve({}));
                 const doImportSpy = sinon.stub(ImportManager, 'doImport').returns(Promise.resolve([]));
                 const generateReportSpy = sinon.spy(ImportManager, 'generateReport');
                 const cleanupSpy = sinon.stub(ImportManager, 'cleanUp').returns(Promise.resolve());
 
-                ImportManager.importFromFile({name: 'test.json', path: '/test.json'}).then(function () {
-                    sinon.assert.calledOnce(loadFileSpy);
-                    sinon.assert.calledOnce(preProcessSpy);
-                    sinon.assert.calledOnce(doImportSpy);
-                    sinon.assert.calledOnce(generateReportSpy);
-                    sinon.assert.calledOnce(cleanupSpy);
-                    sinon.assert.callOrder(loadFileSpy, preProcessSpy, doImportSpy, generateReportSpy, cleanupSpy);
-
-                    done();
-                }).catch(done);
+                await ImportManager.importFromFile({name: 'test.json', path: '/test.json'});
+                sinon.assert.calledOnce(loadFileSpy);
+                sinon.assert.calledOnce(preProcessSpy);
+                sinon.assert.calledOnce(doImportSpy);
+                sinon.assert.calledOnce(generateReportSpy);
+                sinon.assert.calledOnce(cleanupSpy);
+                sinon.assert.callOrder(loadFileSpy, preProcessSpy, doImportSpy, generateReportSpy, cleanupSpy);
             });
         });
     });
@@ -519,30 +503,29 @@ describe('Importer', function () {
             assert.equal(typeof JSONHandler.loadFile, 'function');
         });
 
-        it('correctly handles a valid db api wrapper', function (done) {
+        it('correctly handles a valid db api wrapper', async function () {
             const file = [{
                 path: testUtils.fixtures.getExportFixturePath('valid'),
                 name: 'valid.json'
             }];
-            JSONHandler.loadFile(file).then(function (result) {
-                assert(_.keys(result).includes('meta'));
-                assert(_.keys(result).includes('data'));
-                done();
-            }).catch(done);
+            const result = await JSONHandler.loadFile(file);
+            assert(_.keys(result).includes('meta'));
+            assert(_.keys(result).includes('data'));
         });
 
-        it('correctly errors when given a bad db api wrapper', function (done) {
+        it('correctly errors when given a bad db api wrapper', async function () {
             const file = [{
                 path: testUtils.fixtures.getExportFixturePath('broken'),
                 name: 'broken.json'
             }];
 
-            JSONHandler.loadFile(file).then(function () {
-                done(new Error('Didn\'t error for bad db api wrapper'));
-            }).catch(function (response) {
-                assert.equal(response.errorType, 'BadRequestError');
-                done();
-            }).catch(done);
+            await assert.rejects(
+                JSONHandler.loadFile(file),
+                (response) => {
+                    assert.equal(response.errorType, 'BadRequestError');
+                    return true;
+                }
+            );
         });
     });
 
@@ -560,7 +543,7 @@ describe('Importer', function () {
             assert.equal(typeof MarkdownHandler.loadFile, 'function');
         });
 
-        it('does convert a markdown file into a post object', function (done) {
+        it('does convert a markdown file into a post object', async function () {
             const filename = 'draft-2014-12-19-test-1.md';
 
             const file = [{
@@ -568,20 +551,17 @@ describe('Importer', function () {
                 name: filename
             }];
 
-            MarkdownHandler.loadFile(file).then(function (result) {
-                assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
-                assert.equal(result.data.posts[0].status, 'draft');
-                assert.equal(result.data.posts[0].slug, 'test-1');
-                assert.equal(result.data.posts[0].title, 'test-1');
-                assert.equal(result.data.posts[0].created_at, 1418990400000);
-                assert.equal(moment.utc(result.data.posts[0].created_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
-                assert(!('image' in result.data.posts[0]));
-
-                done();
-            }).catch(done);
+            const result = await MarkdownHandler.loadFile(file);
+            assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
+            assert.equal(result.data.posts[0].status, 'draft');
+            assert.equal(result.data.posts[0].slug, 'test-1');
+            assert.equal(result.data.posts[0].title, 'test-1');
+            assert.equal(result.data.posts[0].created_at, 1418990400000);
+            assert.equal(moment.utc(result.data.posts[0].created_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
+            assert(!('image' in result.data.posts[0]));
         });
 
-        it('can parse a title from a markdown file', function (done) {
+        it('can parse a title from a markdown file', async function () {
             const filename = 'draft-2014-12-19-test-2.md';
 
             const file = [{
@@ -589,19 +569,16 @@ describe('Importer', function () {
                 name: filename
             }];
 
-            MarkdownHandler.loadFile(file).then(function (result) {
-                assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
-                assert.equal(result.data.posts[0].status, 'draft');
-                assert.equal(result.data.posts[0].slug, 'test-2');
-                assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
-                assert.equal(result.data.posts[0].created_at, 1418990400000);
-                assert(!('image' in result.data.posts[0]));
-
-                done();
-            }).catch(done);
+            const result = await MarkdownHandler.loadFile(file);
+            assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
+            assert.equal(result.data.posts[0].status, 'draft');
+            assert.equal(result.data.posts[0].slug, 'test-2');
+            assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
+            assert.equal(result.data.posts[0].created_at, 1418990400000);
+            assert(!('image' in result.data.posts[0]));
         });
 
-        it('can parse a featured image from a markdown file if there is a title', function (done) {
+        it('can parse a featured image from a markdown file if there is a title', async function () {
             const filename = 'draft-2014-12-19-test-3.md';
 
             const file = [{
@@ -609,19 +586,16 @@ describe('Importer', function () {
                 name: filename
             }];
 
-            MarkdownHandler.loadFile(file).then(function (result) {
-                assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
-                assert.equal(result.data.posts[0].status, 'draft');
-                assert.equal(result.data.posts[0].slug, 'test-3');
-                assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
-                assert.equal(result.data.posts[0].created_at, 1418990400000);
-                assert.equal(result.data.posts[0].image, '/images/kitten.jpg');
-
-                done();
-            }).catch(done);
+            const result = await MarkdownHandler.loadFile(file);
+            assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
+            assert.equal(result.data.posts[0].status, 'draft');
+            assert.equal(result.data.posts[0].slug, 'test-3');
+            assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
+            assert.equal(result.data.posts[0].created_at, 1418990400000);
+            assert.equal(result.data.posts[0].image, '/images/kitten.jpg');
         });
 
-        it('can import a published post', function (done) {
+        it('can import a published post', async function () {
             const filename = 'published-2014-12-19-test-1.md';
 
             const file = [{
@@ -629,20 +603,17 @@ describe('Importer', function () {
                 name: filename
             }];
 
-            MarkdownHandler.loadFile(file).then(function (result) {
-                assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
-                assert.equal(result.data.posts[0].status, 'published');
-                assert.equal(result.data.posts[0].slug, 'test-1');
-                assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
-                assert.equal(result.data.posts[0].published_at, 1418990400000);
-                assert.equal(moment.utc(result.data.posts[0].published_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
-                assert(!('image' in result.data.posts[0]));
-
-                done();
-            }).catch(done);
+            const result = await MarkdownHandler.loadFile(file);
+            assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
+            assert.equal(result.data.posts[0].status, 'published');
+            assert.equal(result.data.posts[0].slug, 'test-1');
+            assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
+            assert.equal(result.data.posts[0].published_at, 1418990400000);
+            assert.equal(moment.utc(result.data.posts[0].published_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
+            assert(!('image' in result.data.posts[0]));
         });
 
-        it('does not import deleted posts', function (done) {
+        it('does not import deleted posts', async function () {
             const filename = 'deleted-2014-12-19-test-1.md';
 
             const file = [{
@@ -650,14 +621,11 @@ describe('Importer', function () {
                 name: filename
             }];
 
-            MarkdownHandler.loadFile(file).then(function (result) {
-                assert.equal(result.data.posts.length, 0);
-
-                done();
-            }).catch(done);
+            const result = await MarkdownHandler.loadFile(file);
+            assert.equal(result.data.posts.length, 0);
         });
 
-        it('can import multiple files', function (done) {
+        it('can import multiple files', async function () {
             const files = [{
                 path: testUtils.fixtures.getImportFixturePath('deleted-2014-12-19-test-1.md'),
                 name: 'deleted-2014-12-19-test-1.md'
@@ -669,34 +637,31 @@ describe('Importer', function () {
                 name: 'draft-2014-12-19-test-3.md'
             }];
 
-            MarkdownHandler.loadFile(files).then(function (result) {
-                // deleted-2014-12-19-test-1.md
-                // doesn't get imported ;)
+            const result = await MarkdownHandler.loadFile(files);
+            // deleted-2014-12-19-test-1.md
+            // doesn't get imported ;)
 
-                // loadFile doesn't guarantee order of results
-                const one = result.data.posts[0].status === 'published' ? 0 : 1;
+            // loadFile doesn't guarantee order of results
+            const one = result.data.posts[0].status === 'published' ? 0 : 1;
 
-                const two = one === 0 ? 1 : 0;
+            const two = one === 0 ? 1 : 0;
 
-                // published-2014-12-19-test-1.md
-                assert.equal(result.data.posts[one].markdown, 'You\'re live! Nice.');
-                assert.equal(result.data.posts[one].status, 'published');
-                assert.equal(result.data.posts[one].slug, 'test-1');
-                assert.equal(result.data.posts[one].title, 'Welcome to Ghost');
-                assert.equal(result.data.posts[one].published_at, 1418990400000);
-                assert.equal(moment.utc(result.data.posts[one].published_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
-                assert(!('image' in result.data.posts[one]));
+            // published-2014-12-19-test-1.md
+            assert.equal(result.data.posts[one].markdown, 'You\'re live! Nice.');
+            assert.equal(result.data.posts[one].status, 'published');
+            assert.equal(result.data.posts[one].slug, 'test-1');
+            assert.equal(result.data.posts[one].title, 'Welcome to Ghost');
+            assert.equal(result.data.posts[one].published_at, 1418990400000);
+            assert.equal(moment.utc(result.data.posts[one].published_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
+            assert(!('image' in result.data.posts[one]));
 
-                // draft-2014-12-19-test-3.md
-                assert.equal(result.data.posts[two].markdown, 'You\'re live! Nice.');
-                assert.equal(result.data.posts[two].status, 'draft');
-                assert.equal(result.data.posts[two].slug, 'test-3');
-                assert.equal(result.data.posts[two].title, 'Welcome to Ghost');
-                assert.equal(result.data.posts[two].created_at, 1418990400000);
-                assert.equal(result.data.posts[two].image, '/images/kitten.jpg');
-
-                done();
-            }).catch(done);
+            // draft-2014-12-19-test-3.md
+            assert.equal(result.data.posts[two].markdown, 'You\'re live! Nice.');
+            assert.equal(result.data.posts[two].status, 'draft');
+            assert.equal(result.data.posts[two].slug, 'test-3');
+            assert.equal(result.data.posts[two].title, 'Welcome to Ghost');
+            assert.equal(result.data.posts[two].created_at, 1418990400000);
+            assert.equal(result.data.posts[two].image, '/images/kitten.jpg');
         });
     });
 

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -328,7 +328,7 @@ describe('Migration Fixture Utils', function () {
     });
 
     describe('Add Fixtures For Model', function () {
-        it('should call add for main post fixture', function (done) {
+        it('should call add for main post fixture', async function () {
             const postOneStub = sinon.stub(models.Post, 'findOne').returns(Promise.resolve());
             const postAddStub = sinon.stub(models.Post, 'add').returns(Promise.resolve({}));
 
@@ -336,20 +336,17 @@ describe('Migration Fixture Utils', function () {
                 return modelFixture.name === 'Post';
             });
 
-            fixtureManager.addFixturesForModel(postFixtures).then(function (result) {
-                assertExists(result);
-                assert(_.isPlainObject(result));
-                assert.equal(result.expected, 11);
-                assert.equal(result.done, 11);
+            const result = await fixtureManager.addFixturesForModel(postFixtures);
+            assertExists(result);
+            assert(_.isPlainObject(result));
+            assert.equal(result.expected, 11);
+            assert.equal(result.done, 11);
 
-                sinon.assert.callCount(postOneStub, 11);
-                sinon.assert.callCount(postAddStub, 11);
-
-                done();
-            }).catch(done);
+            sinon.assert.callCount(postOneStub, 11);
+            sinon.assert.callCount(postAddStub, 11);
         });
 
-        it('should call add for main newsletter fixture', function (done) {
+        it('should call add for main newsletter fixture', async function () {
             const newsletterOneStub = sinon.stub(models.Newsletter, 'findOne').returns(Promise.resolve());
             const newsletterAddStub = sinon.stub(models.Newsletter, 'add').returns(Promise.resolve({}));
 
@@ -357,20 +354,17 @@ describe('Migration Fixture Utils', function () {
                 return modelFixture.name === 'Newsletter';
             });
 
-            fixtureManager.addFixturesForModel(newsletterFixtures).then(function (result) {
-                assertExists(result);
-                assert(_.isPlainObject(result));
-                assert.equal(result.expected, 1);
-                assert.equal(result.done, 1);
+            const result = await fixtureManager.addFixturesForModel(newsletterFixtures);
+            assertExists(result);
+            assert(_.isPlainObject(result));
+            assert.equal(result.expected, 1);
+            assert.equal(result.done, 1);
 
-                sinon.assert.calledOnce(newsletterOneStub);
-                sinon.assert.calledOnce(newsletterAddStub);
-
-                done();
-            }).catch(done);
+            sinon.assert.calledOnce(newsletterOneStub);
+            sinon.assert.calledOnce(newsletterAddStub);
         });
 
-        it('should not call add for main post fixture if it is already found', function (done) {
+        it('should not call add for main post fixture if it is already found', async function () {
             const postOneStub = sinon.stub(models.Post, 'findOne').returns(Promise.resolve({}));
             const postAddStub = sinon.stub(models.Post, 'add').returns(Promise.resolve({}));
 
@@ -378,22 +372,19 @@ describe('Migration Fixture Utils', function () {
                 return modelFixture.name === 'Post';
             });
 
-            fixtureManager.addFixturesForModel(postFixtures).then(function (result) {
-                assertExists(result);
-                assert(_.isPlainObject(result));
-                assert.equal(result.expected, 11);
-                assert.equal(result.done, 0);
+            const result = await fixtureManager.addFixturesForModel(postFixtures);
+            assertExists(result);
+            assert(_.isPlainObject(result));
+            assert.equal(result.expected, 11);
+            assert.equal(result.done, 0);
 
-                sinon.assert.callCount(postOneStub, 11);
-                sinon.assert.notCalled(postAddStub);
-
-                done();
-            }).catch(done);
+            sinon.assert.callCount(postOneStub, 11);
+            sinon.assert.notCalled(postAddStub);
         });
     });
 
     describe('Add Fixtures For Relation', function () {
-        it('should call attach for permissions-roles', function (done) {
+        it('should call attach for permissions-roles', async function () {
             const fromItem = {
                 related: sinon.stub().returnsThis(),
                 find: sinon.stub().returns()
@@ -410,28 +401,25 @@ describe('Migration Fixture Utils', function () {
             const permsAllStub = sinon.stub(models.Permission, 'findAll').returns(Promise.resolve(dataMethodStub));
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
-            fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
-                const FIXTURE_COUNT = 140;
-                assertExists(result);
-                assert(_.isPlainObject(result));
-                assert.equal(result.expected, FIXTURE_COUNT);
-                assert.equal(result.done, FIXTURE_COUNT);
+            const result = await fixtureManager.addFixturesForRelation(fixtures.relations[0]);
+            const FIXTURE_COUNT = 140;
+            assertExists(result);
+            assert(_.isPlainObject(result));
+            assert.equal(result.expected, FIXTURE_COUNT);
+            assert.equal(result.done, FIXTURE_COUNT);
 
-                // Permissions & Roles
-                sinon.assert.calledOnce(permsAllStub);
-                sinon.assert.calledOnce(rolesAllStub);
-                sinon.assert.callCount(dataMethodStub.filter, FIXTURE_COUNT);
-                sinon.assert.callCount(dataMethodStub.find, 10);
-                sinon.assert.callCount(baseUtilAttachStub, FIXTURE_COUNT);
+            // Permissions & Roles
+            sinon.assert.calledOnce(permsAllStub);
+            sinon.assert.calledOnce(rolesAllStub);
+            sinon.assert.callCount(dataMethodStub.filter, FIXTURE_COUNT);
+            sinon.assert.callCount(dataMethodStub.find, 10);
+            sinon.assert.callCount(baseUtilAttachStub, FIXTURE_COUNT);
 
-                sinon.assert.callCount(fromItem.related, FIXTURE_COUNT);
-                sinon.assert.callCount(fromItem.find, FIXTURE_COUNT);
-
-                done();
-            }).catch(done);
+            sinon.assert.callCount(fromItem.related, FIXTURE_COUNT);
+            sinon.assert.callCount(fromItem.find, FIXTURE_COUNT);
         });
 
-        it('should call attach for posts-tags', function (done) {
+        it('should call attach for posts-tags', async function () {
             const fromItem = {
                 related: sinon.stub().returnsThis(),
                 find: sinon.stub().returns()
@@ -448,26 +436,23 @@ describe('Migration Fixture Utils', function () {
             const postsAllStub = sinon.stub(models.Post, 'findAll').returns(Promise.resolve(dataMethodStub));
             const tagsAllStub = sinon.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
 
-            fixtureManager.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
-                assertExists(result);
-                assert(_.isPlainObject(result));
-                assert.equal(result.expected, 7);
-                assert.equal(result.done, 7);
+            const result = await fixtureManager.addFixturesForRelation(fixtures.relations[1]);
+            assertExists(result);
+            assert(_.isPlainObject(result));
+            assert.equal(result.expected, 7);
+            assert.equal(result.done, 7);
 
-                // Posts & Tags
-                sinon.assert.calledOnce(postsAllStub);
-                sinon.assert.calledOnce(tagsAllStub);
-                sinon.assert.callCount(dataMethodStub.filter, 7);
-                sinon.assert.callCount(dataMethodStub.find, 7);
-                sinon.assert.callCount(fromItem.related, 7);
-                sinon.assert.callCount(fromItem.find, 7);
-                sinon.assert.callCount(baseUtilAttachStub, 7);
-
-                done();
-            }).catch(done);
+            // Posts & Tags
+            sinon.assert.calledOnce(postsAllStub);
+            sinon.assert.calledOnce(tagsAllStub);
+            sinon.assert.callCount(dataMethodStub.filter, 7);
+            sinon.assert.callCount(dataMethodStub.find, 7);
+            sinon.assert.callCount(fromItem.related, 7);
+            sinon.assert.callCount(fromItem.find, 7);
+            sinon.assert.callCount(baseUtilAttachStub, 7);
         });
 
-        it('will not call attach for posts-tags if already present', function (done) {
+        it('will not call attach for posts-tags if already present', async function () {
             const fromItem = {
                 related: sinon.stub().returnsThis(),
                 find: sinon.stub().returns({}),
@@ -485,26 +470,23 @@ describe('Migration Fixture Utils', function () {
             const postsAllStub = sinon.stub(models.Post, 'findAll').returns(Promise.resolve(dataMethodStub));
             const tagsAllStub = sinon.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
 
-            fixtureManager.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
-                assertExists(result);
-                assert(_.isPlainObject(result));
-                assert.equal(result.expected, 7);
-                assert.equal(result.done, 0);
+            const result = await fixtureManager.addFixturesForRelation(fixtures.relations[1]);
+            assertExists(result);
+            assert(_.isPlainObject(result));
+            assert.equal(result.expected, 7);
+            assert.equal(result.done, 0);
 
-                // Posts & Tags
-                sinon.assert.calledOnce(postsAllStub);
-                sinon.assert.calledOnce(tagsAllStub);
-                sinon.assert.callCount(dataMethodStub.filter, 7);
-                sinon.assert.callCount(dataMethodStub.find, 7);
+            // Posts & Tags
+            sinon.assert.calledOnce(postsAllStub);
+            sinon.assert.calledOnce(tagsAllStub);
+            sinon.assert.callCount(dataMethodStub.filter, 7);
+            sinon.assert.callCount(dataMethodStub.find, 7);
 
-                sinon.assert.callCount(fromItem.related, 7);
-                sinon.assert.callCount(fromItem.find, 7);
+            sinon.assert.callCount(fromItem.related, 7);
+            sinon.assert.callCount(fromItem.find, 7);
 
-                sinon.assert.notCalled(fromItem.tags);
-                sinon.assert.notCalled(fromItem.attach);
-
-                done();
-            }).catch(done);
+            sinon.assert.notCalled(fromItem.tags);
+            sinon.assert.notCalled(fromItem.attach);
         });
     });
 

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -461,7 +461,7 @@ describe('lib/image: image size', function () {
             assert.equal(requestMock.isDone(), true);
         });
 
-        it('[failure] returns error if \`probe-image-size`\ module throws error', async function () {
+        it('[failure] returns error if `probe-image-size` module throws error', async function () {
             const url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg';
 
             const requestMock = nock('https://static.wixstatic.com')
@@ -478,7 +478,7 @@ describe('lib/image: image size', function () {
             assert.equal(requestMock.isDone(), true);
         });
 
-        it('[failure] returns error if \`image-size`\ module throws error', async function () {
+        it('[failure] returns error if `image-size` module throws error', async function () {
             const url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.cur';
 
             const requestMock = nock('https://static.wixstatic.com')
@@ -637,15 +637,9 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: createFixtureStorageUtils(), urlUtils: createLocalUrlUtils('http://myblog.com/content/images/not-existing-image.png'), request: () => Promise.reject(new Error('request should not be used'))});
 
-            let thrownError;
-            try {
+            await assert.rejects(async () => {
                 await imageSize.getImageSizeFromStoragePath(url);
-            } catch (err) {
-                thrownError = err;
-                assertExists(err);
-                assert.equal((err instanceof errors.NotFoundError), true);
-            }
-            assert(thrownError);
+            }, errors.NotFoundError);
         });
 
         it('[failure] rejects traversal outside the image storage root', async function () {
@@ -674,7 +668,7 @@ describe('lib/image: image size', function () {
             );
         });
 
-        it('[failure] returns error if \`image-size`\ module throws error', async function () {
+        it('[failure] returns error if `image-size` module throws error', async function () {
             const url = '/content/images/malformed.svg';
 
             const imageSize = createImageSize({storage: {

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -86,7 +86,7 @@ describe('lib/image: image size', function () {
     });
 
     describe('getImageSizeFromUrl', function () {
-        it('[success] should return image dimensions from probe request for probe-supported extension', function (done) {
+        it('[success] should return image dimensions from probe request for probe-supported extension', async function () {
             const url = 'http://img.stockfresh.com/files/f/feedough/x/11/1540353_20925115.jpg';
             const expectedImageObject = {
                 height: 1,
@@ -100,17 +100,15 @@ describe('lib/image: image size', function () {
 
             const imageSize = createImageSize();
 
-            imageSize.getImageSizeFromUrl(url).then(function (res) {
-                assert.equal(requestMock.isDone(), true);
-                assertExists(res);
-                assert.equal(res.width, expectedImageObject.width);
-                assert.equal(res.height, expectedImageObject.height);
-                assert.equal(res.url, expectedImageObject.url);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromUrl(url);
+            assert.equal(requestMock.isDone(), true);
+            assertExists(res);
+            assert.equal(res.width, expectedImageObject.width);
+            assert.equal(res.height, expectedImageObject.height);
+            assert.equal(res.url, expectedImageObject.url);
         });
 
-        it('[success] should return image dimensions from fetch request for non-probe-supported extension', function (done) {
+        it('[success] should return image dimensions from fetch request for non-probe-supported extension', async function () {
             const url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.cur';
             const expectedImageObject = {
                 height: 1,
@@ -129,17 +127,15 @@ describe('lib/image: image size', function () {
                 }
             });
 
-            imageSize.getImageSizeFromUrl(url).then(function (res) {
-                assert.equal(requestMock.isDone(), false);
-                assertExists(res);
-                assert.equal(res.width, expectedImageObject.width);
-                assert.equal(res.height, expectedImageObject.height);
-                assert.equal(res.url, expectedImageObject.url);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromUrl(url);
+            assert.equal(requestMock.isDone(), false);
+            assertExists(res);
+            assert.equal(res.width, expectedImageObject.width);
+            assert.equal(res.height, expectedImageObject.height);
+            assert.equal(res.url, expectedImageObject.url);
         });
 
-        it('[success] should return image dimensions when no image extension given', function (done) {
+        it('[success] should return image dimensions when no image extension given', async function () {
             const url = 'https://www.zomato.com/logo/18163505/minilogo';
             const expectedImageObject = {
                 height: 1,
@@ -153,17 +149,15 @@ describe('lib/image: image size', function () {
 
             const imageSize = createImageSize();
 
-            imageSize.getImageSizeFromUrl(url).then(function (res) {
-                assert.equal(requestMock.isDone(), true);
-                assertExists(res);
-                assert.equal(res.width, expectedImageObject.width);
-                assert.equal(res.height, expectedImageObject.height);
-                assert.equal(res.url, expectedImageObject.url);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromUrl(url);
+            assert.equal(requestMock.isDone(), true);
+            assertExists(res);
+            assert.equal(res.width, expectedImageObject.width);
+            assert.equal(res.height, expectedImageObject.height);
+            assert.equal(res.url, expectedImageObject.url);
         });
 
-        it('[success] should returns largest image value for .ico files', function (done) {
+        it('[success] should returns largest image value for .ico files', async function () {
             const url = 'https://super-website.com/media/icon.ico';
             const expectedImageObject = {
                 height: 64,
@@ -178,18 +172,16 @@ describe('lib/image: image size', function () {
 
             const imageSize = createImageSize();
 
-            imageSize.getImageSizeFromUrl(url).then(function (res) {
-                assert.equal(requestMockNotFound.isDone(), false);
-                assert.equal(requestMock.isDone(), true);
-                assertExists(res);
-                assert.equal(res.width, expectedImageObject.width);
-                assert.equal(res.height, expectedImageObject.height);
-                assert.equal(res.url, expectedImageObject.url);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromUrl(url);
+            assert.equal(requestMockNotFound.isDone(), false);
+            assert.equal(requestMock.isDone(), true);
+            assertExists(res);
+            assert.equal(res.width, expectedImageObject.width);
+            assert.equal(res.height, expectedImageObject.height);
+            assert.equal(res.url, expectedImageObject.url);
         });
 
-        it('[success] should return image dimensions asset path images', function (done) {
+        it('[success] should return image dimensions asset path images', async function () {
             const url = '/assets/img/logo.png?v=d30c3d1e41';
             const expectedImageObject = {
                 height: 1,
@@ -223,17 +215,15 @@ describe('lib/image: image size', function () {
                 }
             });
 
-            imageSize.getImageSizeFromUrl(url).then(function (res) {
-                assert.equal(requestMock.isDone(), true);
-                assertExists(res);
-                assert.equal(res.width, expectedImageObject.width);
-                assert.equal(res.height, expectedImageObject.height);
-                assert.equal(res.url, expectedImageObject.url);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromUrl(url);
+            assert.equal(requestMock.isDone(), true);
+            assertExists(res);
+            assert.equal(res.width, expectedImageObject.width);
+            assert.equal(res.height, expectedImageObject.height);
+            assert.equal(res.url, expectedImageObject.url);
         });
 
-        it('[success] should return image dimensions for gravatar images request', function (done) {
+        it('[success] should return image dimensions for gravatar images request', async function () {
             const url = '//www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&d=mm&r=x';
             const expectedImageObject = {
                 height: 1,
@@ -247,17 +237,15 @@ describe('lib/image: image size', function () {
 
             const imageSize = createImageSize();
 
-            imageSize.getImageSizeFromUrl(url).then(function (res) {
-                assert.equal(requestMock.isDone(), true);
-                assertExists(res);
-                assert.equal(res.width, expectedImageObject.width);
-                assert.equal(res.height, expectedImageObject.height);
-                assert.equal(res.url, expectedImageObject.url);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromUrl(url);
+            assert.equal(requestMock.isDone(), true);
+            assertExists(res);
+            assert.equal(res.width, expectedImageObject.width);
+            assert.equal(res.height, expectedImageObject.height);
+            assert.equal(res.url, expectedImageObject.url);
         });
 
-        it('[success] can handle redirect (probe-image-size)', function (done) {
+        it('[success] can handle redirect (probe-image-size)', async function () {
             const url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg';
             const expectedImageObject = {
                 height: 1,
@@ -277,18 +265,16 @@ describe('lib/image: image size', function () {
 
             const imageSize = createImageSize();
 
-            imageSize.getImageSizeFromUrl(url).then(function (res) {
-                assert.equal(requestMock.isDone(), true);
-                assert.equal(secondRequestMock.isDone(), true);
-                assertExists(res);
-                assert.equal(res.width, expectedImageObject.width);
-                assert.equal(res.height, expectedImageObject.height);
-                assert.equal(res.url, expectedImageObject.url);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromUrl(url);
+            assert.equal(requestMock.isDone(), true);
+            assert.equal(secondRequestMock.isDone(), true);
+            assertExists(res);
+            assert.equal(res.width, expectedImageObject.width);
+            assert.equal(res.height, expectedImageObject.height);
+            assert.equal(res.url, expectedImageObject.url);
         });
 
-        it('[success] should switch to local file storage if available', function (done) {
+        it('[success] should switch to local file storage if available', async function () {
             const url = '/content/images/favicon.png';
             const expectedImageObject = {
                 height: 100,
@@ -325,17 +311,15 @@ describe('lib/image: image size', function () {
                 }
             });
 
-            imageSize.getImageSizeFromUrl(url).then(function (res) {
-                assert.equal(requestMock.isDone(), false);
-                assertExists(res);
-                assertExists(res.width);
-                assert.equal(res.width, expectedImageObject.width);
-                assertExists(res.height);
-                assert.equal(res.height, expectedImageObject.height);
-                assertExists(res.url);
-                assert.equal(res.url, expectedImageObject.url);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromUrl(url);
+            assert.equal(requestMock.isDone(), false);
+            assertExists(res);
+            assertExists(res.width);
+            assert.equal(res.width, expectedImageObject.width);
+            assertExists(res.height);
+            assert.equal(res.height, expectedImageObject.height);
+            assertExists(res.url);
+            assert.equal(res.url, expectedImageObject.url);
         });
 
         it('should use storage for local URL and HTTP for CDN URL', async function () {
@@ -380,7 +364,7 @@ describe('lib/image: image size', function () {
             sinon.assert.calledOnce(storageReadSpy);
         });
 
-        it('[failure] can handle an error with statuscode not 200 (probe-image-size)', function (done) {
+        it('[failure] can handle an error with statuscode not 200 (probe-image-size)', async function () {
             const url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg';
 
             const requestMock = nock('http://noimagehere.com')
@@ -389,17 +373,16 @@ describe('lib/image: image size', function () {
 
             const imageSize = createImageSize();
 
-            imageSize.getImageSizeFromUrl(url)
-                .catch(function (err) {
-                    assert.equal(requestMock.isDone(), true);
-                    assertExists(err);
-                    assert.equal(err.errorType, 'NotFoundError');
-                    assert.equal(err.message, 'Image not found.');
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromUrl(url);
+            }, {
+                errorType: 'NotFoundError',
+                message: 'Image not found.'
+            });
+            assert.equal(requestMock.isDone(), true);
         });
 
-        it('[failure] can handle an error with statuscode not 200 (image-size)', function (done) {
+        it('[failure] can handle an error with statuscode not 200 (image-size)', async function () {
             const url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.cur';
 
             const requestMock = nock('http://noimagehere.com')
@@ -423,33 +406,31 @@ describe('lib/image: image size', function () {
                 }
             });
 
-            imageSize.getImageSizeFromUrl(url)
-                .catch(function (err) {
-                    assert.equal(requestMock.isDone(), false);
-                    assertExists(err);
-                    assert.equal(err.errorType, 'NotFoundError');
-                    assert.equal(err.message, 'Image not found.');
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromUrl(url);
+            }, {
+                errorType: 'NotFoundError',
+                message: 'Image not found.'
+            });
+            assert.equal(requestMock.isDone(), false);
         });
 
-        it('[failure] handles invalid URL', function (done) {
+        it('[failure] handles invalid URL', async function () {
             const url = 'Not-a-valid-url';
 
             const imageSize = createImageSize({
                 validator: {isURL: () => false}
             });
 
-            imageSize.getImageSizeFromUrl(url)
-                .catch(function (err) {
-                    assertExists(err);
-                    assert.equal(err.errorType, 'InternalServerError');
-                    assert.equal(err.message, 'URL empty or invalid.');
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromUrl(url);
+            }, {
+                errorType: 'InternalServerError',
+                message: 'URL empty or invalid.'
+            });
         });
 
-        it('[failure] will handle responses timing out', function (done) {
+        it('[failure] will handle responses timing out', async function () {
             const url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256';
 
             const requestMock = nock('https://static.wixstatic.com')
@@ -471,17 +452,16 @@ describe('lib/image: image size', function () {
                 }
             });
 
-            imageSize.getImageSizeFromUrl(url)
-                .catch(function (err) {
-                    assert.equal(requestMock.isDone(), true);
-                    assertExists(err);
-                    assert.equal(err.errorType, 'InternalServerError');
-                    assert.equal(err.message, 'Request timed out.');
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromUrl(url);
+            }, {
+                errorType: 'InternalServerError',
+                message: 'Request timed out.'
+            });
+            assert.equal(requestMock.isDone(), true);
         });
 
-        it('[failure] returns error if \`probe-image-size`\ module throws error', function (done) {
+        it('[failure] returns error if \`probe-image-size`\ module throws error', async function () {
             const url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg';
 
             const requestMock = nock('https://static.wixstatic.com')
@@ -490,19 +470,15 @@ describe('lib/image: image size', function () {
 
             const imageSize = createImageSize();
 
-            imageSize.getImageSizeFromUrl(url)
-                .then(() => {
-                    assert.equal(true, false, 'succeeded when expecting failure');
-                })
-                .catch(function (err) {
-                    assert.equal(requestMock.isDone(), true);
-                    assertExists(err);
-                    assert.equal(err.errorType, 'InternalServerError');
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromUrl(url);
+            }, {
+                errorType: 'InternalServerError'
+            });
+            assert.equal(requestMock.isDone(), true);
         });
 
-        it('[failure] returns error if \`image-size`\ module throws error', function (done) {
+        it('[failure] returns error if \`image-size`\ module throws error', async function () {
             const url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.cur';
 
             const requestMock = nock('https://static.wixstatic.com')
@@ -520,35 +496,30 @@ describe('lib/image: image size', function () {
                 }
             });
 
-            imageSize.getImageSizeFromUrl(url)
-                .then(() => {
-                    assert.equal(true, false, 'succeeded when expecting failure');
-                })
-                .catch(function (err) {
-                    assert.equal(requestMock.isDone(), false);
-                    assertExists(err);
-                    assert.equal(err.errorType, 'InternalServerError');
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromUrl(url);
+            }, {
+                errorType: 'InternalServerError'
+            });
+            assert.equal(requestMock.isDone(), false);
         });
 
-        it('[failure] returns error if request errors', function (done) {
+        it('[failure] returns error if request errors', async function () {
             const url = 'https://notarealwebsite.com/images/notapicture.dds';
 
             const imageSize = createImageSize({
                 request: () => Promise.reject({})
             });
 
-            imageSize.getImageSizeFromUrl(url)
-                .catch(function (err) {
-                    assertExists(err);
-                    assert.equal(err.errorType, 'InternalServerError');
-                    assert.equal(err.message, 'Unknown Request error.');
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromUrl(url);
+            }, {
+                errorType: 'InternalServerError',
+                message: 'Unknown Request error.'
+            });
         });
 
-        it('[failure] handles probe being unresponsive', function (done) {
+        it('[failure] handles probe being unresponsive', async function () {
             const url = 'http://img.stockfresh.com/files/f/feedough/x/11/1540353_20925115.jpg';
             const requestMock = nock('http://img.stockfresh.com')
                 .get('/files/f/feedough/x/11/1540353_20925115.jpg')
@@ -568,19 +539,18 @@ describe('lib/image: image size', function () {
                 }
             });
 
-            imageSize.getImageSizeFromUrl(url)
-                .catch(function (err) {
-                    assert.equal(requestMock.isDone(), true);
-                    assertExists(err);
-                    assert.equal(err.errorType, 'InternalServerError');
-                    assert.equal(err.message, 'Probe unresponsive.');
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromUrl(url);
+            }, {
+                errorType: 'InternalServerError',
+                message: 'Probe unresponsive.'
+            });
+            assert.equal(requestMock.isDone(), true);
         });
     });
 
     describe('getImageSizeFromStoragePath', function () {
-        it('[success] should return image dimensions for locally stored images', function (done) {
+        it('[success] should return image dimensions for locally stored images', async function () {
             const url = '/content/images/ghost-logo.png';
             const expectedImageObject = {
                 height: 257,
@@ -595,13 +565,11 @@ describe('lib/image: image size', function () {
                 request: () => Promise.reject(new Error('request should not be used'))
             });
 
-            imageSize.getImageSizeFromStoragePath(url).then(function (res) {
-                assertImageObject(res, expectedImageObject);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromStoragePath(url);
+            assertImageObject(res, expectedImageObject);
         });
 
-        it('[success] should return image dimensions for locally stored images with subdirectory', function (done) {
+        it('[success] should return image dimensions for locally stored images with subdirectory', async function () {
             const url = '/content/images/favicon_too_large.png';
             const expectedImageObject = {
                 height: 1010,
@@ -616,13 +584,11 @@ describe('lib/image: image size', function () {
                 request: () => Promise.reject(new Error('request should not be used'))
             });
 
-            imageSize.getImageSizeFromStoragePath(url).then(function (res) {
-                assertImageObject(res, expectedImageObject);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromStoragePath(url);
+            assertImageObject(res, expectedImageObject);
         });
 
-        it('[success] should return largest image dimensions for locally stored .ico image', function (done) {
+        it('[success] should return largest image dimensions for locally stored .ico image', async function () {
             const url = 'http://myblog.com/content/images/favicon_multi_sizes.ico';
             const expectedImageObject = {
                 height: 64,
@@ -637,13 +603,11 @@ describe('lib/image: image size', function () {
                 request: () => Promise.reject(new Error('request should not be used'))
             });
 
-            imageSize.getImageSizeFromStoragePath(url).then(function (res) {
-                assertImageObject(res, expectedImageObject);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromStoragePath(url);
+            assertImageObject(res, expectedImageObject);
         });
 
-        it('[success] should return image dimensions for locally stored .webp image', function (done) {
+        it('[success] should return image dimensions for locally stored .webp image', async function () {
             const url = 'http://myblog.com/content/images/ghosticon.webp';
             const expectedImageObject = {
                 height: 249,
@@ -658,13 +622,11 @@ describe('lib/image: image size', function () {
                 request: () => Promise.reject(new Error('request should not be used'))
             });
 
-            imageSize.getImageSizeFromStoragePath(url).then(function (res) {
-                assertImageObject(res, expectedImageObject);
-                done();
-            }).catch(done);
+            const res = await imageSize.getImageSizeFromStoragePath(url);
+            assertImageObject(res, expectedImageObject);
         });
 
-        it('[failure] returns error if storage adapter errors', function (done) {
+        it('[failure] returns error if storage adapter errors', async function () {
             const url = '/content/images/not-existing-image.png';
 
             const imageSize = createImageSize({storage: {
@@ -675,12 +637,15 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: createFixtureStorageUtils(), urlUtils: createLocalUrlUtils('http://myblog.com/content/images/not-existing-image.png'), request: () => Promise.reject(new Error('request should not be used'))});
 
-            imageSize.getImageSizeFromStoragePath(url)
-                .catch(function (err) {
-                    assertExists(err);
-                    assert.equal((err instanceof errors.NotFoundError), true);
-                    done();
-                }).catch(done);
+            let thrownError;
+            try {
+                await imageSize.getImageSizeFromStoragePath(url);
+            } catch (err) {
+                thrownError = err;
+                assertExists(err);
+                assert.equal((err instanceof errors.NotFoundError), true);
+            }
+            assert(thrownError);
         });
 
         it('[failure] rejects traversal outside the image storage root', async function () {
@@ -709,7 +674,7 @@ describe('lib/image: image size', function () {
             );
         });
 
-        it('[failure] returns error if \`image-size`\ module throws error', function (done) {
+        it('[failure] returns error if \`image-size`\ module throws error', async function () {
             const url = '/content/images/malformed.svg';
 
             const imageSize = createImageSize({storage: {
@@ -727,11 +692,9 @@ describe('lib/image: image size', function () {
                 return Promise.reject({});
             }});
 
-            imageSize.getImageSizeFromStoragePath(url)
-                .catch(function (err) {
-                    assertExists(err);
-                    done();
-                }).catch(done);
+            await assert.rejects(async () => {
+                await imageSize.getImageSizeFromStoragePath(url);
+            });
         });
     });
 });

--- a/ghost/core/test/unit/server/lib/package-json/read.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/read.test.js
@@ -7,7 +7,7 @@ const packageJSON = require('../../../../../core/server/lib/package-json');
 
 describe('package-json read', function () {
     describe('readPackages', function () {
-        it('should read directory and ignore unneeded items', function (done) {
+        it('should read directory and ignore unneeded items', async function () {
             const packagePath = tmp.dirSync({unsafeCleanup: true});
 
             // create example theme
@@ -20,23 +20,21 @@ describe('package-json read', function () {
             fs.mkdirSync(join(packagePath.name, '.git'));
             fs.writeFileSync(join(packagePath.name, '.DS_Store'), '');
 
-            packageJSON.readPackages(packagePath.name)
-                .then(function (pkgs) {
-                    assert.deepEqual(pkgs, {
-                        casper: {
-                            name: 'casper',
-                            path: join(packagePath.name, 'casper'),
-                            'package.json': null
-                        }
-                    });
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+            try {
+                const pkgs = await packageJSON.readPackages(packagePath.name);
+                assert.deepEqual(pkgs, {
+                    casper: {
+                        name: 'casper',
+                        path: join(packagePath.name, 'casper'),
+                        'package.json': null
+                    }
+                });
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
 
-        it('should read directory and parse package.json files', function (done) {
+        it('should read directory and parse package.json files', async function () {
             let packagePath;
             let pkgJson;
 
@@ -51,26 +49,24 @@ describe('package-json read', function () {
             fs.writeFileSync(join(packagePath.name, 'testtheme', 'package.json'), pkgJson);
             fs.writeFileSync(join(packagePath.name, 'testtheme', 'index.hbs'), '');
 
-            packageJSON.readPackages(packagePath.name)
-                .then(function (pkgs) {
-                    assert.deepEqual(pkgs, {
-                        testtheme: {
-                            name: 'testtheme',
-                            path: join(packagePath.name, 'testtheme'),
-                            'package.json': {
-                                name: 'test',
-                                version: '0.0.0'
-                            }
+            try {
+                const pkgs = await packageJSON.readPackages(packagePath.name);
+                assert.deepEqual(pkgs, {
+                    testtheme: {
+                        name: 'testtheme',
+                        path: join(packagePath.name, 'testtheme'),
+                        'package.json': {
+                            name: 'test',
+                            version: '0.0.0'
                         }
-                    });
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+                    }
+                });
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
 
-        it('should read directory and ignore invalid package.json files', function (done) {
+        it('should read directory and ignore invalid package.json files', async function () {
             let packagePath;
             let pkgJson;
 
@@ -84,23 +80,21 @@ describe('package-json read', function () {
             fs.writeFileSync(join(packagePath.name, 'testtheme', 'package.json'), pkgJson);
             fs.writeFileSync(join(packagePath.name, 'testtheme', 'index.hbs'), '');
 
-            packageJSON.readPackages(packagePath.name)
-                .then(function (pkgs) {
-                    assert.deepEqual(pkgs, {
-                        testtheme: {
-                            name: 'testtheme',
-                            path: join(packagePath.name, 'testtheme'),
-                            'package.json': null
-                        }
-                    });
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+            try {
+                const pkgs = await packageJSON.readPackages(packagePath.name);
+                assert.deepEqual(pkgs, {
+                    testtheme: {
+                        name: 'testtheme',
+                        path: join(packagePath.name, 'testtheme'),
+                        'package.json': null
+                    }
+                });
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
 
-        it('should read directory and include symlinked directories', function (done) {
+        it('should read directory and include symlinked directories', async function () {
             let packagePath;
             let pkgJson;
 
@@ -117,25 +111,23 @@ describe('package-json read', function () {
             // Symlink one theme to the other so we should have 2 themes
             fs.symlinkSync(join(packagePath.name, 'testtheme'), join(packagePath.name, 'testtheme2'));
 
-            packageJSON.readPackages(packagePath.name)
-                .then(function (pkgs) {
-                    assert.deepEqual(pkgs, {
-                        testtheme: {
-                            name: 'testtheme',
-                            path: join(packagePath.name, 'testtheme'),
-                            'package.json': null
-                        },
-                        testtheme2: {
-                            name: 'testtheme2',
-                            path: join(packagePath.name, 'testtheme2'),
-                            'package.json': null
-                        }
-                    });
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+            try {
+                const pkgs = await packageJSON.readPackages(packagePath.name);
+                assert.deepEqual(pkgs, {
+                    testtheme: {
+                        name: 'testtheme',
+                        path: join(packagePath.name, 'testtheme'),
+                        'package.json': null
+                    },
+                    testtheme2: {
+                        name: 'testtheme2',
+                        path: join(packagePath.name, 'testtheme2'),
+                        'package.json': null
+                    }
+                });
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
 
         it('should read directory and ignore invalid symlinks', async function () {
@@ -168,7 +160,7 @@ describe('package-json read', function () {
     });
 
     describe('readPackage', function () {
-        it('should read directory and ignore unneeded items', function (done) {
+        it('should read directory and ignore unneeded items', async function () {
             const packagePath = tmp.dirSync({unsafeCleanup: true});
 
             // create example theme
@@ -181,23 +173,21 @@ describe('package-json read', function () {
             fs.mkdirSync(join(packagePath.name, '.git'));
             fs.writeFileSync(join(packagePath.name, '.DS_Store'), '');
 
-            packageJSON.readPackage(packagePath.name, 'casper')
-                .then(function (pkgs) {
-                    assert.deepEqual(pkgs, {
-                        casper: {
-                            name: 'casper',
-                            path: join(packagePath.name, 'casper'),
-                            'package.json': null
-                        }
-                    });
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+            try {
+                const pkgs = await packageJSON.readPackage(packagePath.name, 'casper');
+                assert.deepEqual(pkgs, {
+                    casper: {
+                        name: 'casper',
+                        path: join(packagePath.name, 'casper'),
+                        'package.json': null
+                    }
+                });
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
 
-        it('should read directory and parse package.json files', function (done) {
+        it('should read directory and parse package.json files', async function () {
             let packagePath;
             let pkgJson;
 
@@ -212,26 +202,24 @@ describe('package-json read', function () {
             fs.writeFileSync(join(packagePath.name, 'testtheme', 'package.json'), pkgJson);
             fs.writeFileSync(join(packagePath.name, 'testtheme', 'index.hbs'), '');
 
-            packageJSON.readPackage(packagePath.name, 'testtheme')
-                .then(function (pkgs) {
-                    assert.deepEqual(pkgs, {
-                        testtheme: {
-                            name: 'testtheme',
-                            path: join(packagePath.name, 'testtheme'),
-                            'package.json': {
-                                name: 'test',
-                                version: '0.0.0'
-                            }
+            try {
+                const pkgs = await packageJSON.readPackage(packagePath.name, 'testtheme');
+                assert.deepEqual(pkgs, {
+                    testtheme: {
+                        name: 'testtheme',
+                        path: join(packagePath.name, 'testtheme'),
+                        'package.json': {
+                            name: 'test',
+                            version: '0.0.0'
                         }
-                    });
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+                    }
+                });
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
 
-        it('should read directory and ignore invalid package.json files', function (done) {
+        it('should read directory and ignore invalid package.json files', async function () {
             let packagePath;
             let pkgJson;
 
@@ -245,23 +233,21 @@ describe('package-json read', function () {
             fs.writeFileSync(join(packagePath.name, 'testtheme', 'package.json'), pkgJson);
             fs.writeFileSync(join(packagePath.name, 'testtheme', 'index.hbs'), '');
 
-            packageJSON.readPackage(packagePath.name, 'testtheme')
-                .then(function (pkgs) {
-                    assert.deepEqual(pkgs, {
-                        testtheme: {
-                            name: 'testtheme',
-                            path: join(packagePath.name, 'testtheme'),
-                            'package.json': null
-                        }
-                    });
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+            try {
+                const pkgs = await packageJSON.readPackage(packagePath.name, 'testtheme');
+                assert.deepEqual(pkgs, {
+                    testtheme: {
+                        name: 'testtheme',
+                        path: join(packagePath.name, 'testtheme'),
+                        'package.json': null
+                    }
+                });
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
 
-        it('should read directory and include only single requested package', function (done) {
+        it('should read directory and include only single requested package', async function () {
             const packagePath = tmp.dirSync({unsafeCleanup: true});
 
             // create trash
@@ -276,55 +262,46 @@ describe('package-json read', function () {
             fs.mkdirSync(join(packagePath.name, 'not-casper'));
             fs.writeFileSync(join(packagePath.name, 'not-casper', 'index.hbs'), '');
 
-            packageJSON.readPackage(packagePath.name, 'casper')
-                .then(function (pkgs) {
-                    assert.deepEqual(pkgs, {
-                        casper: {
-                            name: 'casper',
-                            path: join(packagePath.name, 'casper'),
-                            'package.json': null
-                        }
-                    });
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+            try {
+                const pkgs = await packageJSON.readPackage(packagePath.name, 'casper');
+                assert.deepEqual(pkgs, {
+                    casper: {
+                        name: 'casper',
+                        path: join(packagePath.name, 'casper'),
+                        'package.json': null
+                    }
+                });
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
 
-        it('should return an error if package cannot be found', function (done) {
+        it('should return an error if package cannot be found', async function () {
             const packagePath = tmp.dirSync({unsafeCleanup: true});
 
             // create trash
             fs.writeFileSync(join(packagePath.name, 'casper.zip'), '');
             fs.writeFileSync(join(packagePath.name, '.DS_Store'), '');
 
-            packageJSON.readPackage(packagePath.name, 'casper')
-                .then(function () {
-                    done('Should have thrown an error');
-                })
-                .catch(function (err) {
-                    assert.equal(err.message, 'Package not found');
-                    done();
-                })
-                .finally(packagePath.removeCallback);
+            await assert.rejects(async () => {
+                await packageJSON.readPackage(packagePath.name, 'casper');
+            }, /Package not found/);
+            await packagePath.removeCallback();
         });
 
-        it('should return empty object if package is not a directory', function (done) {
+        it('should return empty object if package is not a directory', async function () {
             const packagePath = tmp.dirSync({unsafeCleanup: true});
 
             // create trash
             fs.writeFileSync(join(packagePath.name, 'casper.zip'), '');
             fs.writeFileSync(join(packagePath.name, '.DS_Store'), '');
 
-            packageJSON.readPackage(packagePath.name, 'casper.zip')
-                .then(function (pkg) {
-                    assert.deepEqual(pkg, {});
-
-                    done();
-                })
-                .catch(done)
-                .finally(packagePath.removeCallback);
+            try {
+                const pkgs = await packageJSON.readPackage(packagePath.name, 'casper.zip');
+                assert.deepEqual(pkgs, {});
+            } finally {
+                await packagePath.removeCallback();
+            }
         });
     });
 });

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -431,7 +431,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
     describe('Permissible', function () {
         describe('As Contributor', function () {
             describe('Editing', function () {
-                it('rejects if changing status', function (done) {
+                it('rejects if changing status', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -442,7 +442,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.get.withArgs('status').returns('draft');
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
+                    await assert.rejects(() => models.Post.permissible(
                         mockPostObj,
                         'edit',
                         context,
@@ -451,15 +451,13 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         true,
                         false
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
+                    ), (error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        done();
-                    }).catch(done);
+                        return true;
+                    });
                 });
 
-                it('rejects if changing visibility', function (done) {
+                it('rejects if changing visibility', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -470,24 +468,25 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.get.withArgs('visibility').returns('paid');
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        false
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        done();
-                    }).catch(done);
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'edit',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            false
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            return true;
+                        }
+                    );
                 });
 
-                it('rejects if changing authors.0', function (done) {
+                it('rejects if changing authors.0', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -497,26 +496,27 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        false
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        assert.equal(mockPostObj.related.calledTwice, false);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'edit',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            false
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            assert.equal(mockPostObj.related.calledTwice, false);
+                            return true;
+                        }
+                    );
                 });
 
-                it('ignores if changes authors.1', function (done) {
+                it('ignores if changes authors.1', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -527,7 +527,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
                     mockPostObj.get.withArgs('status').returns('draft');
 
-                    models.Post.permissible(
+                    const result = await models.Post.permissible(
                         mockPostObj,
                         'edit',
                         context,
@@ -536,16 +536,14 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         true,
                         false
-                    ).then((result) => {
-                        assertExists(result);
-                        assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
-                        sinon.assert.calledTwice(mockPostObj.get);
-                        sinon.assert.calledTwice(mockPostObj.related);
-                        done();
-                    }).catch(done);
+                    );
+                    assertExists(result);
+                    assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
+                    sinon.assert.calledTwice(mockPostObj.get);
+                    sinon.assert.calledTwice(mockPostObj.related);
                 });
 
-                it('rejects if post is not draft', function (done) {
+                it('rejects if post is not draft', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -556,26 +554,27 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.get.withArgs('status').returns('published');
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        false
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.calledTwice(mockPostObj.get);
-                        sinon.assert.calledOnce(mockPostObj.related);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'edit',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            false
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.calledTwice(mockPostObj.get);
+                            sinon.assert.calledOnce(mockPostObj.related);
+                            return true;
+                        }
+                    );
                 });
 
-                it('rejects if contributor is not author of post', function (done) {
+                it('rejects if contributor is not author of post', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -585,22 +584,23 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        false
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.calledOnce(mockPostObj.related);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'edit',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            false
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.calledOnce(mockPostObj.related);
+                            return true;
+                        }
+                    );
                 });
 
                 it('resolves if none of the above cases are true', function () {
@@ -633,89 +633,92 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
             });
 
             describe('Adding', function () {
-                it('rejects if "published" status', function (done) {
+                it('rejects if "published" status', async function () {
                     const mockPostObj = {
                         get: sinon.stub()
                     };
                     const context = {user: 1};
                     const unsafeAttrs = {status: 'published', authors: [{id: 1}]};
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'add',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'add',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            return true;
+                        }
+                    );
                 });
 
-                it('rejects if different author id', function (done) {
+                it('rejects if different author id', async function () {
                     const mockPostObj = {
                         get: sinon.stub()
                     };
                     const context = {user: 1};
                     const unsafeAttrs = {status: 'draft', authors: [{id: 2}]};
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'add',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'add',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            return true;
+                        }
+                    );
                 });
 
-                it('rejects if different logged in user and `authors.0`', function (done) {
+                it('rejects if different logged in user and `authors.0`', async function () {
                     const mockPostObj = {
                         get: sinon.stub()
                     };
                     const context = {user: 1};
                     const unsafeAttrs = {status: 'draft', authors: [{id: 2}]};
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'add',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'add',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            return true;
+                        }
+                    );
                 });
 
-                it('resolves if same logged in user and `authors.0`', function (done) {
+                it('resolves if same logged in user and `authors.0`', async function () {
                     const mockPostObj = {
                         get: sinon.stub()
                     };
                     const context = {user: 1};
                     const unsafeAttrs = {status: 'draft', authors: [{id: 1}]};
 
-                    models.Post.permissible(
+                    const result = await models.Post.permissible(
                         mockPostObj,
                         'add',
                         context,
@@ -724,45 +727,13 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         true,
                         true
-                    ).then((result) => {
-                        assertExists(result);
-                        assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        done();
-                    }).catch(done);
-                });
-            });
-
-            describe('Destroying', function () {
-                it('rejects if destroying another author\'s post', function (done) {
-                    const mockPostObj = {
-                        get: sinon.stub(),
-                        related: sinon.stub()
-                    };
-                    const context = {user: 1};
-
-                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
-
-                    models.Post.permissible(
-                        mockPostObj,
-                        'destroy',
-                        context,
-                        {},
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.calledOnce(mockPostObj.get);
-                        sinon.assert.calledOnce(mockPostObj.related);
-                        done();
-                    });
+                    );
+                    assertExists(result);
+                    assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
+                    sinon.assert.notCalled(mockPostObj.get);
                 });
 
-                it('rejects if destroying a published post', function (done) {
+                it('rejects if destroying a published post', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -772,23 +743,24 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
                     mockPostObj.get.withArgs('status').returns('published');
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'destroy',
-                        context,
-                        {},
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.calledOnce(mockPostObj.get);
-                        sinon.assert.calledOnce(mockPostObj.related);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'destroy',
+                            context,
+                            {},
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.calledOnce(mockPostObj.get);
+                            sinon.assert.calledOnce(mockPostObj.related);
+                            return true;
+                        }
+                    );
                 });
 
                 it('resolves if none of the above cases are true', function () {
@@ -822,7 +794,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
         describe('As Author', function () {
             describe('Editing', function () {
-                it('rejects if editing another\'s post', function (done) {
+                it('rejects if editing another\'s post', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -832,26 +804,27 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 2}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.author,
-                        false,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        sinon.assert.calledOnce(mockPostObj.related);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'edit',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.author,
+                            false,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            sinon.assert.calledOnce(mockPostObj.related);
+                            return true;
+                        }
+                    );
                 });
 
-                it('rejects if changing visibility', function (done) {
+                it('rejects if changing visibility', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -862,26 +835,27 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.get.withArgs('visibility').returns('paid');
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.author,
-                        false,
-                        false,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        sinon.assert.calledOnce(mockPostObj.related);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'edit',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.author,
+                            false,
+                            false,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            sinon.assert.calledOnce(mockPostObj.related);
+                            return true;
+                        }
+                    );
                 });
 
-                it('rejects if editing another\'s post (using `authors`)', function (done) {
+                it('rejects if editing another\'s post (using `authors`)', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -891,26 +865,27 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.author,
-                        false,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        sinon.assert.calledTwice(mockPostObj.related);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'edit',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.author,
+                            false,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            sinon.assert.calledTwice(mockPostObj.related);
+                            return true;
+                        }
+                    );
                 });
 
-                it('rejects if changing authors', function (done) {
+                it('rejects if changing authors', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -920,23 +895,24 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.author,
-                        false,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        sinon.assert.calledTwice(mockPostObj.related);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'edit',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.author,
+                            false,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            sinon.assert.calledTwice(mockPostObj.related);
+                            return true;
+                        }
+                    );
                 });
 
                 it('resolves if none of the above cases are true', function () {
@@ -964,32 +940,33 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
             });
 
             describe('Adding', function () {
-                it('rejects if different author id', function (done) {
+                it('rejects if different author id', async function () {
                     const mockPostObj = {
                         get: sinon.stub()
                     };
                     const context = {user: 1};
                     const unsafeAttrs = {authors: [{id: 2}]};
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'add',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.author,
-                        false,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'add',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.author,
+                            false,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            return true;
+                        }
+                    );
                 });
 
-                it('rejects if different authors', function (done) {
+                it('rejects if different authors', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -999,28 +976,29 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    models.Post.permissible(
-                        mockPostObj,
-                        'add',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.author,
-                        false,
-                        true,
-                        true
-                    ).then(() => {
-                        done(new Error('Permissible function should have rejected.'));
-                    }).catch((error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        done();
-                    });
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'add',
+                            context,
+                            unsafeAttrs,
+                            testUtils.permissions.author,
+                            false,
+                            true,
+                            true
+                        ),
+                        (error) => {
+                            assert(error instanceof errors.NoPermissionError);
+                            sinon.assert.notCalled(mockPostObj.get);
+                            return true;
+                        }
+                    );
                 });
             });
         });
 
         describe('Everyone Else', function () {
-            it('rejects if hasUserPermissions is false and not current owner', function (done) {
+            it('rejects if hasUserPermissions is false and not current owner', async function () {
                 const mockPostObj = {
                     get: sinon.stub(),
                     related: sinon.stub()
@@ -1030,23 +1008,24 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 mockPostObj.related.withArgs('authors').returns({models: [{id: 2}]});
 
-                models.Post.permissible(
-                    mockPostObj,
-                    'edit',
-                    context,
-                    unsafeAttrs,
-                    testUtils.permissions.editor,
-                    false,
-                    true,
-                    true
-                ).then(() => {
-                    done(new Error('Permissible function should have rejected.'));
-                }).catch((error) => {
-                    assert(error instanceof errors.NoPermissionError);
-                    sinon.assert.notCalled(mockPostObj.get);
-                    sinon.assert.calledOnce(mockPostObj.related);
-                    done();
-                });
+                await assert.rejects(
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.editor,
+                        false,
+                        true,
+                        true
+                    ),
+                    (error) => {
+                        assert(error instanceof errors.NoPermissionError);
+                        sinon.assert.notCalled(mockPostObj.get);
+                        sinon.assert.calledOnce(mockPostObj.related);
+                        return true;
+                    }
+                );
             });
 
             it('resolves if hasUserPermission is true', function () {
@@ -1070,7 +1049,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 });
             });
 
-            it('resolves if changing visibility as owner', function (done) {
+            it('resolves if changing visibility as owner', async function () {
                 const mockPostObj = {
                     get: sinon.stub(),
                     related: sinon.stub()
@@ -1081,7 +1060,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 mockPostObj.get.withArgs('visibility').returns('paid');
                 mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                models.Post.permissible(
+                await models.Post.permissible(
                     mockPostObj,
                     'edit',
                     context,
@@ -1090,16 +1069,12 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     false,
                     true,
                     true
-                ).then(() => {
-                    sinon.assert.notCalled(mockPostObj.get);
-                    sinon.assert.calledOnce(mockPostObj.related);
-                    done();
-                }).catch(() => {
-                    done(new Error('Permissible function should have passed for owner.'));
-                });
+                );
+                sinon.assert.notCalled(mockPostObj.get);
+                sinon.assert.calledOnce(mockPostObj.related);
             });
 
-            it('resolves if changing visibility as administrator', function (done) {
+            it('resolves if changing visibility as administrator', async function () {
                 const mockPostObj = {
                     get: sinon.stub(),
                     related: sinon.stub()
@@ -1110,7 +1085,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 mockPostObj.get.withArgs('visibility').returns('paid');
                 mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                models.Post.permissible(
+                await models.Post.permissible(
                     mockPostObj,
                     'edit',
                     context,
@@ -1119,13 +1094,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     false,
                     true,
                     true
-                ).then(() => {
-                    sinon.assert.notCalled(mockPostObj.get);
-                    sinon.assert.calledOnce(mockPostObj.related);
-                    done();
-                }).catch(() => {
-                    done(new Error('Permissible function should have passed for administrator.'));
-                });
+                );
+                sinon.assert.notCalled(mockPostObj.get);
+                sinon.assert.calledOnce(mockPostObj.related);
             });
         });
     });

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -733,6 +733,32 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     sinon.assert.notCalled(mockPostObj.get);
                 });
 
+                it('rejects if destroying another author\'s post', async function () {
+                    const mockPostObj = {
+                        get: sinon.stub(),
+                        related: sinon.stub()
+                    };
+                    const context = {user: 1};
+
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    await assert.rejects(
+                        models.Post.permissible(
+                            mockPostObj,
+                            'destroy',
+                            context,
+                            {},
+                            testUtils.permissions.contributor,
+                            true,
+                            true,
+                            true
+                        ),
+                        errors.NoPermissionError
+                    );
+                    sinon.assert.calledOnce(mockPostObj.get);
+                    sinon.assert.calledOnce(mockPostObj.related);
+                });
+
                 it('rejects if destroying a published post', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -442,19 +442,21 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.get.withArgs('status').returns('draft');
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    await assert.rejects(() => models.Post.permissible(
-                        mockPostObj,
-                        'edit',
-                        context,
-                        unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
-                        true,
-                        false
-                    ), (error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        return true;
-                    });
+                    await assert.rejects(
+                        async () => {
+                            await models.Post.permissible(
+                                mockPostObj,
+                                'edit',
+                                context,
+                                unsafeAttrs,
+                                testUtils.permissions.contributor,
+                                true,
+                                true,
+                                false
+                            );
+                        },
+                        errors.NoPermissionError
+                    );
                 });
 
                 it('rejects if changing visibility', async function () {
@@ -479,10 +481,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             false
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
                 });
 
@@ -507,13 +506,10 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             false
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            assert.equal(mockPostObj.related.calledTwice, false);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
+                    assert.equal(mockPostObj.related.calledTwice, false);
                 });
 
                 it('ignores if changes authors.1', async function () {
@@ -565,13 +561,10 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             false
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.calledTwice(mockPostObj.get);
-                            sinon.assert.calledOnce(mockPostObj.related);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.calledTwice(mockPostObj.get);
+                    sinon.assert.calledOnce(mockPostObj.related);
                 });
 
                 it('rejects if contributor is not author of post', async function () {
@@ -595,12 +588,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             false
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.calledOnce(mockPostObj.related);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.calledOnce(mockPostObj.related);
                 });
 
                 it('resolves if none of the above cases are true', function () {
@@ -651,12 +641,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
                 });
 
                 it('rejects if different author id', async function () {
@@ -677,12 +664,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
                 });
 
                 it('rejects if different logged in user and `authors.0`', async function () {
@@ -703,12 +687,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
                 });
 
                 it('resolves if same logged in user and `authors.0`', async function () {
@@ -732,7 +713,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
                     sinon.assert.notCalled(mockPostObj.get);
                 });
+            });
 
+            describe('Destroying', function () {
                 it('rejects if destroying another author\'s post', async function () {
                     const mockPostObj = {
                         get: sinon.stub(),
@@ -780,13 +763,10 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.calledOnce(mockPostObj.get);
-                            sinon.assert.calledOnce(mockPostObj.related);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.calledOnce(mockPostObj.get);
+                    sinon.assert.calledOnce(mockPostObj.related);
                 });
 
                 it('resolves if none of the above cases are true', function () {
@@ -841,13 +821,10 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            sinon.assert.calledOnce(mockPostObj.related);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
+                    sinon.assert.calledOnce(mockPostObj.related);
                 });
 
                 it('rejects if changing visibility', async function () {
@@ -872,13 +849,10 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             false,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            sinon.assert.calledOnce(mockPostObj.related);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
+                    sinon.assert.calledOnce(mockPostObj.related);
                 });
 
                 it('rejects if editing another\'s post (using `authors`)', async function () {
@@ -902,13 +876,10 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            sinon.assert.calledTwice(mockPostObj.related);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
+                    sinon.assert.calledTwice(mockPostObj.related);
                 });
 
                 it('rejects if changing authors', async function () {
@@ -932,13 +903,10 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            sinon.assert.calledTwice(mockPostObj.related);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
+                    sinon.assert.calledTwice(mockPostObj.related);
                 });
 
                 it('resolves if none of the above cases are true', function () {
@@ -984,12 +952,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
                 });
 
                 it('rejects if different authors', async function () {
@@ -1013,12 +978,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                             true,
                             true
                         ),
-                        (error) => {
-                            assert(error instanceof errors.NoPermissionError);
-                            sinon.assert.notCalled(mockPostObj.get);
-                            return true;
-                        }
+                        errors.NoPermissionError
                     );
+                    sinon.assert.notCalled(mockPostObj.get);
                 });
             });
         });
@@ -1045,13 +1007,10 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         true
                     ),
-                    (error) => {
-                        assert(error instanceof errors.NoPermissionError);
-                        sinon.assert.notCalled(mockPostObj.get);
-                        sinon.assert.calledOnce(mockPostObj.related);
-                        return true;
-                    }
+                    errors.NoPermissionError
                 );
+                sinon.assert.notCalled(mockPostObj.get);
+                sinon.assert.calledOnce(mockPostObj.related);
             });
 
             it('resolves if hasUserPermission is true', function () {

--- a/ghost/core/test/unit/server/models/session.test.js
+++ b/ghost/core/test/unit/server/models/session.test.js
@@ -117,7 +117,7 @@ describe('Unit: models/session', function () {
             assert.equal(returnVal, baseDestroyReturnVal);
         });
 
-        it('calls forge with the session_id, fetchs with the filtered options and then destroys with the options', function (done) {
+        it('calls forge with the session_id, fetchs with the filtered options and then destroys with the options', async function () {
             const model = models.Session.forge({});
             const session_id = 23;
             const unfilteredOptions = {session_id};
@@ -132,22 +132,20 @@ describe('Unit: models/session', function () {
             const destroyStub = sinon.stub(model, 'destroy')
                 .resolves();
 
-            models.Session.destroy(unfilteredOptions).then(() => {
-                assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
-                assert.equal(filterOptionsStub.args[0][1], 'destroy');
+            await models.Session.destroy(unfilteredOptions);
 
-                assert.deepEqual(forgeStub.args[0][0], {session_id});
+            assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
+            assert.equal(filterOptionsStub.args[0][1], 'destroy');
 
-                assert.equal(fetchStub.args[0][0], filteredOptions);
-                assert.equal(destroyStub.args[0][0], filteredOptions);
+            assert.deepEqual(forgeStub.args[0][0], {session_id});
 
-                done();
-            });
+            assert.equal(fetchStub.args[0][0], filteredOptions);
+            assert.equal(destroyStub.args[0][0], filteredOptions);
         });
     });
 
     describe('upsert', function () {
-        it('calls findOne and then add if findOne results in nothing', function (done) {
+        it('calls findOne and then add if findOne results in nothing', async function () {
             const session_id = 314;
             const unfilteredOptions = {session_id};
             const filteredOptions = {session_id};
@@ -165,27 +163,26 @@ describe('Unit: models/session', function () {
 
             const addStub = sinon.stub(models.Session, 'add');
 
-            models.Session.upsert(data, unfilteredOptions).then(() => {
-                assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
-                assert.equal(filterOptionsStub.args[0][1], 'upsert');
+            await models.Session.upsert(data, unfilteredOptions);
 
-                assert.deepEqual(findOneStub.args[0][0], {
-                    session_id
-                });
-                assert.equal(findOneStub.args[0][1], filteredOptions);
+            assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
+            assert.equal(filterOptionsStub.args[0][1], 'upsert');
 
-                assert.deepEqual(addStub.args[0][0], {
-                    session_id: filteredOptions.session_id,
-                    session_data: data.session_data,
-                    user_id: data.session_data.user_id
-                });
-
-                assert.equal(addStub.args[0][1], filteredOptions);
-                done();
+            assert.deepEqual(findOneStub.args[0][0], {
+                session_id
             });
+            assert.equal(findOneStub.args[0][1], filteredOptions);
+
+            assert.deepEqual(addStub.args[0][0], {
+                session_id: filteredOptions.session_id,
+                session_data: data.session_data,
+                user_id: data.session_data.user_id
+            });
+
+            assert.equal(addStub.args[0][1], filteredOptions);
         });
 
-        it('calls findOne and then edit if findOne results in nothing', function (done) {
+        it('calls findOne and then edit if findOne results in nothing', async function () {
             const model = models.Session.forge({id: 2});
             const session_id = 314;
             const unfilteredOptions = {session_id};
@@ -204,27 +201,26 @@ describe('Unit: models/session', function () {
 
             const editStub = sinon.stub(models.Session, 'edit');
 
-            models.Session.upsert(data, unfilteredOptions).then(() => {
-                assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
-                assert.equal(filterOptionsStub.args[0][1], 'upsert');
+            await models.Session.upsert(data, unfilteredOptions);
 
-                assert.deepEqual(findOneStub.args[0][0], {
-                    session_id
-                });
-                assert.equal(findOneStub.args[0][1], filteredOptions);
+            assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
+            assert.equal(filterOptionsStub.args[0][1], 'upsert');
 
-                assert.deepEqual(editStub.args[0][0], {
-                    session_data: data.session_data
-                });
-
-                assert.deepEqual(editStub.args[0][1], {
-                    session_id,
-                    id: model.id
-                });
-
-                assert.equal(editStub.args[0][1], filteredOptions);
-                done();
+            assert.deepEqual(findOneStub.args[0][0], {
+                session_id
             });
+            assert.equal(findOneStub.args[0][1], filteredOptions);
+
+            assert.deepEqual(editStub.args[0][0], {
+                session_data: data.session_data
+            });
+
+            assert.deepEqual(editStub.args[0][1], {
+                session_id,
+                id: model.id
+            });
+
+            assert.equal(editStub.args[0][1], filteredOptions);
         });
     });
 });

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -161,17 +161,14 @@ describe('Unit: models/user', function () {
             };
         }
 
-        it('cannot delete owner', function (done) {
+        it('cannot delete owner', async function () {
             const mockUser = getUserModel(1, 'Owner');
             const context = {user: 1};
 
-            models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.owner, true, true, true).then(() => {
-                done(new Error('Permissible function should have errored'));
-            }).catch((error) => {
-                assert(error instanceof errors.NoPermissionError);
-                sinon.assert.calledOnce(mockUser.hasRole);
-                done();
-            });
+            await assert.rejects(async () => {
+                await models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.owner, true, true, true);
+            }, errors.NoPermissionError);
+            sinon.assert.calledOnce(mockUser.hasRole);
         });
 
         it('can always edit self', function () {
@@ -312,46 +309,37 @@ describe('Unit: models/user', function () {
         });
 
         describe('as editor', function () {
-            it('can\'t edit another editor', function (done) {
+            it('can\'t edit another editor', async function () {
                 const mockUser = getUserModel(3, 'Editor');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    done(new Error('Permissible function should have errored'));
-                }).catch((error) => {
-                    assert(error instanceof errors.NoPermissionError);
-                    sinon.assert.called(mockUser.hasRole);
-                    sinon.assert.calledOnce(mockUser.get);
-                    done();
-                });
+                await assert.rejects(async () => {
+                    await models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true);
+                }, errors.NoPermissionError);
+                sinon.assert.called(mockUser.hasRole);
+                sinon.assert.calledOnce(mockUser.get);
             });
 
-            it('can\'t edit owner', function (done) {
+            it('can\'t edit owner', async function () {
                 const mockUser = getUserModel(3, 'Owner');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    done(new Error('Permissible function should have errored'));
-                }).catch((error) => {
-                    assert(error instanceof errors.NoPermissionError);
-                    sinon.assert.called(mockUser.hasRole);
-                    sinon.assert.calledOnce(mockUser.get);
-                    done();
-                });
+                await assert.rejects(async () => {
+                    await models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true);
+                }, errors.NoPermissionError);
+                sinon.assert.called(mockUser.hasRole);
+                sinon.assert.calledOnce(mockUser.get);
             });
 
-            it('can\'t edit an admin', function (done) {
+            it('can\'t edit an admin', async function () {
                 const mockUser = getUserModel(3, 'Administrator');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    done(new Error('Permissible function should have errored'));
-                }).catch((error) => {
-                    assert(error instanceof errors.NoPermissionError);
-                    sinon.assert.called(mockUser.hasRole);
-                    sinon.assert.calledOnce(mockUser.get);
-                    done();
-                });
+                await assert.rejects(async () => {
+                    await models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true);
+                }, errors.NoPermissionError);
+                sinon.assert.called(mockUser.hasRole);
+                sinon.assert.calledOnce(mockUser.get);
             });
 
             it('can edit author', function () {
@@ -384,32 +372,26 @@ describe('Unit: models/user', function () {
                 });
             });
 
-            it('can\'t destroy another editor', function (done) {
+            it('can\'t destroy another editor', async function () {
                 const mockUser = getUserModel(3, 'Editor');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    done(new Error('Permissible function should have errored'));
-                }).catch((error) => {
-                    assert(error instanceof errors.NoPermissionError);
-                    sinon.assert.called(mockUser.hasRole);
-                    sinon.assert.calledOnce(mockUser.get);
-                    done();
-                });
+                await assert.rejects(async () => {
+                    await models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true);
+                }, errors.NoPermissionError);
+                sinon.assert.called(mockUser.hasRole);
+                sinon.assert.calledOnce(mockUser.get);
             });
 
-            it('can\'t destroy an admin', function (done) {
+            it('can\'t destroy an admin', async function () {
                 const mockUser = getUserModel(3, 'Administrator');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    done(new Error('Permissible function should have errored'));
-                }).catch((error) => {
-                    assert(error instanceof errors.NoPermissionError);
-                    sinon.assert.called(mockUser.hasRole);
-                    sinon.assert.calledOnce(mockUser.get);
-                    done();
-                });
+                await assert.rejects(async () => {
+                    await models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true);
+                }, errors.NoPermissionError);
+                sinon.assert.called(mockUser.hasRole);
+                sinon.assert.calledOnce(mockUser.get);
             });
 
             it('can destroy an author', function () {

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -104,136 +104,114 @@ describe('Permissions', function () {
             // Permissions need to be NOT fundamentally baked into Ghost, but a separate module, at some point
             // It can depend on bookshelf, but should NOT use hard coded model knowledge.
             describe('with permissible calls (post model)', function () {
-                it('No context: does not allow edit post (no model)', function (done) {
-                    permissions
+                it('No context: does not allow edit post (no model)', async function () {
+                    await assert.rejects(permissions
                         .canThis() // no context
                         .edit
-                        .post() // post id
-                        .then(function () {
-                            done(new Error('was able to edit post without permission'));
-                        })
-                        .catch(function (err) {
-                            assert.equal(err.errorType, 'NoPermissionError');
+                        .post(), // post id
+                    function (err) {
+                        assert.equal(err.errorType, 'NoPermissionError');
+                        return true;
+                    }
+                    );
 
-                            sinon.assert.notCalled(findPostSpy);
-                            done();
-                        });
+                    sinon.assert.notCalled(findPostSpy);
                 });
 
-                it('No context: does not allow edit post (model syntax)', function (done) {
-                    permissions
+                it('No context: does not allow edit post (model syntax)', async function () {
+                    await assert.rejects(permissions
                         .canThis() // no context
                         .edit
-                        .post({id: 1}) // post id in model syntax
-                        .then(function () {
-                            done(new Error('was able to edit post without permission'));
-                        })
-                        .catch(function (err) {
-                            assert.equal(err.errorType, 'NoPermissionError');
+                        .post({id: 1}), // post id in model syntax
+                    function (err) {
+                        assert.equal(err.errorType, 'NoPermissionError');
+                        return true;
+                    }
+                    );
 
-                            sinon.assert.calledOnce(findPostSpy);
-                            assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
-                            done();
-                        });
+                    sinon.assert.calledOnce(findPostSpy);
+                    assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                 });
 
-                it('No context: does not allow edit post (model ID syntax)', function (done) {
-                    permissions
+                it('No context: does not allow edit post (model ID syntax)', async function () {
+                    await assert.rejects(permissions
                         .canThis({}) // no context
                         .edit
-                        .post(1) // post id using number syntax
-                        .then(function () {
-                            done(new Error('was able to edit post without permission'));
-                        })
-                        .catch(function (err) {
-                            assert.equal(err.errorType, 'NoPermissionError');
+                        .post(1), // post id using number syntax
+                    function (err) {
+                        assert.equal(err.errorType, 'NoPermissionError');
+                        return true;
+                    }
+                    );
 
-                            sinon.assert.calledOnce(findPostSpy);
-                            assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
-                            done();
-                        });
+                    sinon.assert.calledOnce(findPostSpy);
+                    assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                 });
 
-                it('Internal context: instantly grants permissions', function (done) {
-                    permissions
+                it('Internal context: instantly grants permissions', async function () {
+                    await permissions
                         .canThis({internal: true}) // internal context
                         .edit
-                        .post({id: 1}) // post id
-                        .then(function () {
-                            // We don't get this far, permissions are instantly granted for internal
-                            sinon.assert.notCalled(findPostSpy);
-                            done();
-                        })
-                        .catch(function () {
-                            done(new Error('Should allow editing post with { internal: true }'));
-                        });
+                        .post({id: 1}); // post id
+
+                    // We don't get this far, permissions are instantly granted for internal
+                    sinon.assert.notCalled(findPostSpy);
                 });
 
-                it('External context: does not grant permissions', function (done) {
-                    permissions
+                it('External context: does not grant permissions', async function () {
+                    await assert.rejects(permissions
                         .canThis({external: true}) // internal context
                         .edit
-                        .post({id: 1}) // post id
-                        .then(function () {
-                            done(new Error('was able to edit post without permission'));
-                        })
-                        .catch(function (err) {
-                            assert.equal(err.errorType, 'NoPermissionError');
+                        .post({id: 1}), // post id
+                    function (err) {
+                        assert.equal(err.errorType, 'NoPermissionError');
+                        return true;
+                    }
+                    );
 
-                            sinon.assert.calledOnce(findPostSpy);
-                            assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
-                            done();
-                        });
+                    sinon.assert.calledOnce(findPostSpy);
+                    assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                 });
             });
 
             describe('without permissible (tag model)', function () {
-                it('No context: does not allow edit tag (model syntax)', function (done) {
-                    permissions
+                it('No context: does not allow edit tag (model syntax)', async function () {
+                    await assert.rejects(permissions
                         .canThis() // no context
                         .edit
-                        .tag({id: 1}) // tag id in model syntax
-                        .then(function () {
-                            done(new Error('was able to edit tag without permission'));
-                        })
-                        .catch(function (err) {
-                            assert.equal(err.errorType, 'NoPermissionError');
+                        .tag({id: 1}), // tag id in model syntax
+                    function (err) {
+                        assert.equal(err.errorType, 'NoPermissionError');
+                        return true;
+                    }
+                    );
 
-                            // We don't look up tags
-                            sinon.assert.notCalled(findTagSpy);
-                            done();
-                        });
+                    // We don't look up tags
+                    sinon.assert.notCalled(findTagSpy);
                 });
 
-                it('Internal context: instantly grants permissions', function (done) {
-                    permissions
+                it('Internal context: instantly grants permissions', async function () {
+                    await permissions
                         .canThis({internal: true}) // internal context
                         .edit
-                        .tag({id: 1}) // tag id
-                        .then(function () {
-                            // We don't look up tags
-                            sinon.assert.notCalled(findTagSpy);
-                            done();
-                        })
-                        .catch(function () {
-                            done(new Error('Should allow editing post with { internal: true }'));
-                        });
+                        .tag({id: 1}); // tag id
+
+                    // We don't look up tags
+                    sinon.assert.notCalled(findTagSpy);
                 });
 
-                it('External context: does not grant permissions', function (done) {
-                    permissions
+                it('External context: does not grant permissions', async function () {
+                    await assert.rejects(permissions
                         .canThis({external: true}) // external context
                         .edit
-                        .tag({id: 1}) // tag id
-                        .then(function () {
-                            done(new Error('was able to edit tag without permission'));
-                        })
-                        .catch(function (err) {
-                            assert.equal(err.errorType, 'NoPermissionError');
+                        .tag({id: 1}), // tag id
+                    function (err) {
+                        assert.equal(err.errorType, 'NoPermissionError');
+                        return true;
+                    }
+                    );
 
-                            sinon.assert.notCalled(findTagSpy);
-                            done();
-                        });
+                    sinon.assert.notCalled(findTagSpy);
                 });
             });
         });
@@ -243,7 +221,7 @@ describe('Permissions', function () {
             // Permissions need to be NOT fundamentally baked into Ghost, but a separate module, at some point
             // It can depend on bookshelf, but should NOT use hard coded model knowledge.
             // We use the tag model here because it doesn't have permissible, once that changes, these tests must also change
-            it('No permissions: cannot edit tag (no permissible function on model)', function (done) {
+            it('No permissions: cannot edit tag (no permissible function on model)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
@@ -252,21 +230,19 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                await assert.rejects(permissions
                     .canThis({user: {}}) // user context
                     .edit
-                    .tag({id: 1}) // tag id in model syntax
-                    .then(function () {
-                        done(new Error('was able to edit tag without permission'));
-                    })
-                    .catch(function (err) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        assert.equal(err.errorType, 'NoPermissionError');
-                        done();
-                    });
+                    .tag({id: 1}), // tag id in model syntax
+                function (err) {
+                    sinon.assert.calledOnce(userProviderStub);
+                    assert.equal(err.errorType, 'NoPermissionError');
+                    return true;
+                }
+                );
             });
 
-            it('With permissions: can edit specific tag (no permissible function on model)', function (done) {
+            it('With permissions: can edit specific tag (no permissible function on model)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
@@ -275,19 +251,16 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                const res = await permissions
                     .canThis({user: {}}) // user context
                     .edit
-                    .tag({id: 1}) // tag id in model syntax
-                    .then(function (res) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        assert.equal(res, undefined);
-                        done();
-                    })
-                    .catch(done);
+                    .tag({id: 1}); // tag id in model syntax
+
+                sinon.assert.calledOnce(userProviderStub);
+                assert.equal(res, undefined);
             });
 
-            it('With permissions: can edit non-specific tag (no permissible function on model)', function (done) {
+            it('With permissions: can edit non-specific tag (no permissible function on model)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
@@ -296,19 +269,16 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                const res = await permissions
                     .canThis({user: {}}) // user context
                     .edit
-                    .tag() // tag id in model syntax
-                    .then(function (res) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        assert.equal(res, undefined);
-                        done();
-                    })
-                    .catch(done);
+                    .tag(); // tag id in model syntax
+
+                sinon.assert.calledOnce(userProviderStub);
+                assert.equal(res, undefined);
             });
 
-            it('With owner role: can edit tag (no permissible function on model)', function (done) {
+            it('With owner role: can edit tag (no permissible function on model)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
@@ -318,16 +288,13 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                const res = await permissions
                     .canThis({user: {}}) // user context
                     .edit
-                    .tag({id: 1}) // tag id in model syntax
-                    .then(function (res) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        assert.equal(res, undefined);
-                        done();
-                    })
-                    .catch(done);
+                    .tag({id: 1}); // tag id in model syntax
+
+                sinon.assert.calledOnce(userProviderStub);
+                assert.equal(res, undefined);
             });
         });
 
@@ -336,7 +303,7 @@ describe('Permissions', function () {
             // Permissions need to be NOT fundamentally baked into Ghost, but a separate module, at some point
             // It can depend on bookshelf, but should NOT use hard coded model knowledge.
             // We use the tag model here because it doesn't have permissible, once that changes, these tests must also change
-            it('With permissions: can edit non-specific tag (no permissible function on model)', function (done) {
+            it('With permissions: can edit non-specific tag (no permissible function on model)', async function () {
                 const apiKeyProviderStub = sinon.stub(providers, 'apiKey').callsFake(() => {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
@@ -345,17 +312,14 @@ describe('Permissions', function () {
                         roles: [testUtils.DataGenerator.Content.roles[5]]
                     });
                 });
-                permissions.canThis({api_key: {
+                const res = await permissions.canThis({api_key: {
                     id: 123
                 }}) // api key context
                     .edit
-                    .tag({id: 1}) // tag id in model syntax
-                    .then(function (res) {
-                        sinon.assert.calledOnce(apiKeyProviderStub);
-                        assert.equal(res, undefined);
-                        done();
-                    })
-                    .catch(done);
+                    .tag({id: 1}); // tag id in model syntax
+
+                sinon.assert.calledOnce(apiKeyProviderStub);
+                assert.equal(res, undefined);
             });
         });
 
@@ -363,7 +327,7 @@ describe('Permissions', function () {
             // Tests for when both user and API key are present in context
             // This is the scenario introduced by staff API keys where a user can have an associated API key
 
-            it('Current behavior: User with permission + API key with permission (should pass with current logic)', function (done) {
+            it('Current behavior: User with permission + API key with permission (should pass with current logic)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -378,23 +342,20 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                const res = await permissions
                     .canThis({
                         user: {id: 1},
                         api_key: {id: 123, type: 'admin'}
                     })
                     .edit
-                    .tag({id: 1})
-                    .then(function (res) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        sinon.assert.calledOnce(apiKeyProviderStub);
-                        assert.equal(res, undefined);
-                        done();
-                    })
-                    .catch(done);
+                    .tag({id: 1});
+
+                sinon.assert.calledOnce(userProviderStub);
+                sinon.assert.calledOnce(apiKeyProviderStub);
+                assert.equal(res, undefined);
             });
 
-            it('Fixed behavior: User with permission + API key without permission (now uses USER permission and passes)', function (done) {
+            it('Fixed behavior: User with permission + API key without permission (now uses USER permission and passes)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -409,26 +370,21 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                const res = await permissions
                     .canThis({
                         user: {id: 1},
                         api_key: {id: 123, type: 'admin'}
                     })
                     .edit
-                    .tag({id: 1})
-                    .then(function (res) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        sinon.assert.calledOnce(apiKeyProviderStub);
-                        assert.equal(res, undefined);
-                        // Fixed: Now uses USER permission instead of API key logic
-                        done();
-                    })
-                    .catch(function (err) {
-                        done(new Error(`Should have passed using USER permissions, but failed with: ${err.message}`));
-                    });
+                    .tag({id: 1});
+
+                sinon.assert.calledOnce(userProviderStub);
+                sinon.assert.calledOnce(apiKeyProviderStub);
+                assert.equal(res, undefined);
+                // Fixed: Now uses USER permission instead of API key logic
             });
 
-            it('Fixed behavior: User without permission + API key with permission (now uses USER permission and fails)', function (done) {
+            it('Fixed behavior: User without permission + API key with permission (now uses USER permission and fails)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     return Promise.resolve({
                         permissions: [], // User has no permissions
@@ -443,26 +399,24 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                await assert.rejects(permissions
                     .canThis({
                         user: {id: 1},
                         api_key: {id: 123, type: 'admin'}
                     })
                     .edit
-                    .tag({id: 1})
-                    .then(function () {
-                        done(new Error('Should have failed using USER permissions (ignoring API key permissions)'));
-                    })
-                    .catch(function (err) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        sinon.assert.calledOnce(apiKeyProviderStub);
-                        assert.equal(err.errorType, 'NoPermissionError');
-                        // Fixed: Now uses USER permission instead of API key logic
-                        done();
-                    });
+                    .tag({id: 1}),
+                function (err) {
+                    sinon.assert.calledOnce(userProviderStub);
+                    sinon.assert.calledOnce(apiKeyProviderStub);
+                    assert.equal(err.errorType, 'NoPermissionError');
+                    // Fixed: Now uses USER permission instead of API key logic
+                    return true;
+                }
+                );
             });
 
-            it('Current behavior: User without permission + API key without permission (should fail)', function (done) {
+            it('Current behavior: User without permission + API key without permission (should fail)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     return Promise.resolve({
                         permissions: [],
@@ -477,25 +431,23 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                await assert.rejects(permissions
                     .canThis({
                         user: {id: 1},
                         api_key: {id: 123, type: 'admin'}
                     })
                     .edit
-                    .tag({id: 1})
-                    .then(function () {
-                        done(new Error('Should have failed due to no permissions'));
-                    })
-                    .catch(function (err) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        sinon.assert.calledOnce(apiKeyProviderStub);
-                        assert.equal(err.errorType, 'NoPermissionError');
-                        done();
-                    });
+                    .tag({id: 1}),
+                function (err) {
+                    sinon.assert.calledOnce(userProviderStub);
+                    sinon.assert.calledOnce(apiKeyProviderStub);
+                    assert.equal(err.errorType, 'NoPermissionError');
+                    return true;
+                }
+                );
             });
 
-            it('Current behavior: Owner user + API key without permission (owner should override)', function (done) {
+            it('Current behavior: Owner user + API key without permission (owner should override)', async function () {
                 const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     return Promise.resolve({
                         permissions: [],
@@ -510,25 +462,22 @@ describe('Permissions', function () {
                     });
                 });
 
-                permissions
+                const res = await permissions
                     .canThis({
                         user: {id: 1},
                         api_key: {id: 123, type: 'admin'}
                     })
                     .edit
-                    .tag({id: 1})
-                    .then(function (res) {
-                        sinon.assert.calledOnce(userProviderStub);
-                        sinon.assert.calledOnce(apiKeyProviderStub);
-                        assert.equal(res, undefined);
-                        done();
-                    })
-                    .catch(done);
+                    .tag({id: 1});
+
+                sinon.assert.calledOnce(userProviderStub);
+                sinon.assert.calledOnce(apiKeyProviderStub);
+                assert.equal(res, undefined);
             });
 
             // Tests for NEW expected behavior after fix
             describe('Expected behavior after fix: User permissions should take precedence', function () {
-                it('Expected: User with permission + API key without permission (should use USER permission and pass)', function (done) {
+                it('Expected: User with permission + API key without permission (should use USER permission and pass)', async function () {
                     const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -543,25 +492,20 @@ describe('Permissions', function () {
                         });
                     });
 
-                    permissions
+                    const res = await permissions
                         .canThis({
                             user: {id: 1},
                             api_key: {id: 123, type: 'admin'}
                         })
                         .edit
-                        .tag({id: 1})
-                        .then(function (res) {
-                            sinon.assert.calledOnce(userProviderStub);
-                            sinon.assert.calledOnce(apiKeyProviderStub);
-                            assert.equal(res, undefined);
-                            done();
-                        })
-                        .catch(function (err) {
-                            done(new Error(`Should have passed using USER permissions, but failed with: ${err.message}`));
-                        });
+                        .tag({id: 1});
+
+                    sinon.assert.calledOnce(userProviderStub);
+                    sinon.assert.calledOnce(apiKeyProviderStub);
+                    assert.equal(res, undefined);
                 });
 
-                it('Expected: User without permission + API key with permission (should use USER permission and fail)', function (done) {
+                it('Expected: User without permission + API key with permission (should use USER permission and fail)', async function () {
                     const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                         return Promise.resolve({
                             permissions: [], // User has no permissions
@@ -576,25 +520,23 @@ describe('Permissions', function () {
                         });
                     });
 
-                    permissions
+                    await assert.rejects(permissions
                         .canThis({
                             user: {id: 1},
                             api_key: {id: 123, type: 'admin'}
                         })
                         .edit
-                        .tag({id: 1})
-                        .then(function () {
-                            done(new Error('Should have failed using USER permissions (ignoring API key permissions)'));
-                        })
-                        .catch(function (err) {
-                            sinon.assert.calledOnce(userProviderStub);
-                            sinon.assert.calledOnce(apiKeyProviderStub);
-                            assert.equal(err.errorType, 'NoPermissionError');
-                            done();
-                        });
+                        .tag({id: 1}),
+                    function (err) {
+                        sinon.assert.calledOnce(userProviderStub);
+                        sinon.assert.calledOnce(apiKeyProviderStub);
+                        assert.equal(err.errorType, 'NoPermissionError');
+                        return true;
+                    }
+                    );
                 });
 
-                it('Expected: Owner user + API key without permission (should use USER permission and pass)', function (done) {
+                it('Expected: Owner user + API key without permission (should use USER permission and pass)', async function () {
                     const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                         return Promise.resolve({
                             permissions: [],
@@ -609,29 +551,24 @@ describe('Permissions', function () {
                         });
                     });
 
-                    permissions
+                    const res = await permissions
                         .canThis({
                             user: {id: 1},
                             api_key: {id: 123, type: 'admin'}
                         })
                         .edit
-                        .tag({id: 1})
-                        .then(function (res) {
-                            sinon.assert.calledOnce(userProviderStub);
-                            sinon.assert.calledOnce(apiKeyProviderStub);
-                            assert.equal(res, undefined);
-                            done();
-                        })
-                        .catch(function (err) {
-                            done(new Error(`Owner user should have permission regardless of API key, but failed with: ${err.message}`));
-                        });
+                        .tag({id: 1});
+
+                    sinon.assert.calledOnce(userProviderStub);
+                    sinon.assert.calledOnce(apiKeyProviderStub);
+                    assert.equal(res, undefined);
                 });
             });
         });
     });
 
     describe('permissible (overridden)', function () {
-        it('can use permissible function on model to forbid something (post model)', function (done) {
+        it('can use permissible function on model to forbid something (post model)', async function () {
             const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                 // Fake the response from providers.user, which contains permissions and roles
                 return Promise.resolve({
@@ -644,26 +581,24 @@ describe('Permissions', function () {
                 return Promise.reject({message: 'Hello World!'});
             });
 
-            permissions
+            await assert.rejects(permissions
                 .canThis({user: {}}) // user context
                 .edit
-                .post({id: 1}) // tag id in model syntax
-                .then(function () {
-                    done(new Error('was able to edit post without permission'));
-                })
-                .catch(function (err) {
-                    sinon.assert.calledOnce(permissibleStub);
-                    sinon.assert.calledWith(permissibleStub,
-                        1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
-                    );
+                .post({id: 1}), // tag id in model syntax
+            function (err) {
+                sinon.assert.calledOnce(permissibleStub);
+                sinon.assert.calledWith(permissibleStub,
+                    1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
+                );
 
-                    sinon.assert.calledOnce(userProviderStub);
-                    assert.equal(err.message, 'Hello World!');
-                    done();
-                });
+                sinon.assert.calledOnce(userProviderStub);
+                assert.equal(err.message, 'Hello World!');
+                return true;
+            }
+            );
         });
 
-        it('can use permissible function on model to allow something (post model)', function (done) {
+        it('can use permissible function on model to allow something (post model)', async function () {
             const userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                 // Fake the response from providers.user, which contains permissions and roles
                 return Promise.resolve({
@@ -676,21 +611,18 @@ describe('Permissions', function () {
                 return Promise.resolve();
             });
 
-            permissions
+            const res = await permissions
                 .canThis({user: {}}) // user context
                 .edit
-                .post({id: 1}) // tag id in model syntax
-                .then(function (res) {
-                    sinon.assert.calledOnce(permissibleStub);
-                    sinon.assert.calledWith(permissibleStub,
-                        1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
-                    );
+                .post({id: 1}); // tag id in model syntax
 
-                    sinon.assert.calledOnce(userProviderStub);
-                    assert.equal(res, undefined);
-                    done();
-                })
-                .catch(done);
+            sinon.assert.calledOnce(permissibleStub);
+            sinon.assert.calledWith(permissibleStub,
+                1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
+            );
+
+            sinon.assert.calledOnce(userProviderStub);
+            assert.equal(res, undefined);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/permissions/index.test.js
+++ b/ghost/core/test/unit/server/services/permissions/index.test.js
@@ -73,42 +73,38 @@ describe('Permissions', function () {
     });
 
     describe('Init (build actions map)', function () {
-        it('can load an actions map from existing permissions', function (done) {
+        it('can load an actions map from existing permissions', async function () {
             fakePermissions = loadFakePermissions();
 
-            permissions.init().then(function (actions) {
-                assertExists(actions);
+            const actions = await permissions.init();
 
-                assert.doesNotThrow(permissions.canThis);
+            assertExists(actions);
 
-                assert.deepEqual(_.keys(actions), ['browse', 'edit', 'add', 'destroy']);
+            assert.doesNotThrow(permissions.canThis);
 
-                assert.deepEqual(actions.browse, ['post']);
-                assert.deepEqual(actions.edit, ['post', 'tag', 'user', 'page']);
-                assert.deepEqual(actions.add, ['post', 'user', 'page']);
-                assert.deepEqual(actions.destroy, ['post', 'user']);
+            assert.deepEqual(_.keys(actions), ['browse', 'edit', 'add', 'destroy']);
 
-                done();
-            }).catch(done);
+            assert.deepEqual(actions.browse, ['post']);
+            assert.deepEqual(actions.edit, ['post', 'tag', 'user', 'page']);
+            assert.deepEqual(actions.add, ['post', 'user', 'page']);
+            assert.deepEqual(actions.destroy, ['post', 'user']);
         });
 
-        it('can load an actions map from existing permissions, and deduplicate', function (done) {
+        it('can load an actions map from existing permissions, and deduplicate', async function () {
             fakePermissions = loadFakePermissions({extra: true});
 
-            permissions.init().then(function (actions) {
-                assertExists(actions);
+            const actions = await permissions.init();
 
-                assert.doesNotThrow(permissions.canThis);
+            assertExists(actions);
 
-                assert.deepEqual(_.keys(actions), ['browse', 'edit', 'add', 'destroy']);
+            assert.doesNotThrow(permissions.canThis);
 
-                assert.deepEqual(actions.browse, ['post']);
-                assert.deepEqual(actions.edit, ['post', 'tag', 'user', 'page']);
-                assert.deepEqual(actions.add, ['post', 'user', 'page']);
-                assert.deepEqual(actions.destroy, ['post', 'user']);
+            assert.deepEqual(_.keys(actions), ['browse', 'edit', 'add', 'destroy']);
 
-                done();
-            }).catch(done);
+            assert.deepEqual(actions.browse, ['post']);
+            assert.deepEqual(actions.edit, ['post', 'tag', 'user', 'page']);
+            assert.deepEqual(actions.add, ['post', 'user', 'page']);
+            assert.deepEqual(actions.destroy, ['post', 'user']);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/permissions/providers.test.js
+++ b/ghost/core/test/unit/server/services/permissions/providers.test.js
@@ -14,23 +14,20 @@ describe('Permission Providers', function () {
     });
 
     describe('User', function () {
-        it('errors if user cannot be found', function (done) {
+        it('errors if user cannot be found', async function () {
             const findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 return Promise.resolve();
             });
 
-            providers.user(1)
-                .then(function () {
-                    done(new Error('Should have thrown a user not found error'));
-                })
-                .catch(function (err) {
-                    sinon.assert.calledOnce(findUserSpy);
-                    assert.equal(err.errorType, 'NotFoundError');
-                    done();
-                });
+            await assert.rejects(async () => {
+                await providers.user(1);
+            }, {
+                errorType: 'NotFoundError'
+            });
+            sinon.assert.calledOnce(findUserSpy);
         });
 
-        it('can load user with role, and permissions', function (done) {
+        it('can load user with role, and permissions', async function () {
             // This test requires quite a lot of unique setup work
             const findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
@@ -56,38 +53,33 @@ describe('Permission Providers', function () {
             });
 
             // Get permissions for the user
-            providers.user(1)
-                .then(function (res) {
-                    sinon.assert.calledOnce(findUserSpy);
+            const res = await providers.user(1);
+            sinon.assert.calledOnce(findUserSpy);
 
-                    assert(res && typeof res === 'object');
-                    assert('permissions' in res);
-                    assert('roles' in res);
+            assert(res && typeof res === 'object');
+            assert('permissions' in res);
+            assert('roles' in res);
 
-                    assert(Array.isArray(res.permissions));
-                    assert.equal(res.permissions.length, 10);
-                    assert(Array.isArray(res.roles));
-                    assert.equal(res.roles.length, 1);
+            assert(Array.isArray(res.permissions));
+            assert.equal(res.permissions.length, 10);
+            assert(Array.isArray(res.roles));
+            assert.equal(res.roles.length, 1);
 
-                    // @TODO fix this!
-                    // Permissions is an array of models
-                    // Roles is a JSON array
-                    assert(res.permissions[0] && typeof res.permissions[0] === 'object');
-                    assert('attributes' in res.permissions[0]);
-                    assert('id' in res.permissions[0]);
-                    assert(res.roles[0] && typeof res.roles[0] === 'object');
-                    assert('id' in res.roles[0]);
-                    assert('name' in res.roles[0]);
-                    assert('description' in res.roles[0]);
-                    assert(res.permissions[0] instanceof models.Base.Model);
-                    assert(!(res.roles[0] instanceof models.Base.Model));
-
-                    done();
-                })
-                .catch(done);
+            // @TODO fix this!
+            // Permissions is an array of models
+            // Roles is a JSON array
+            assert(res.permissions[0] && typeof res.permissions[0] === 'object');
+            assert('attributes' in res.permissions[0]);
+            assert('id' in res.permissions[0]);
+            assert(res.roles[0] && typeof res.roles[0] === 'object');
+            assert('id' in res.roles[0]);
+            assert('name' in res.roles[0]);
+            assert('description' in res.roles[0]);
+            assert(res.permissions[0] instanceof models.Base.Model);
+            assert(!(res.roles[0] instanceof models.Base.Model));
         });
 
-        it('can load user with role, and role.permissions', function (done) {
+        it('can load user with role, and role.permissions', async function () {
             // This test requires quite a lot of unique setup work
             const findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
@@ -115,38 +107,33 @@ describe('Permission Providers', function () {
             });
 
             // Get permissions for the user
-            providers.user(1)
-                .then(function (res) {
-                    sinon.assert.calledOnce(findUserSpy);
+            const res = await providers.user(1);
+            sinon.assert.calledOnce(findUserSpy);
 
-                    assert(res && typeof res === 'object');
-                    assert('permissions' in res);
-                    assert('roles' in res);
+            assert(res && typeof res === 'object');
+            assert('permissions' in res);
+            assert('roles' in res);
 
-                    assert(Array.isArray(res.permissions));
-                    assert.equal(res.permissions.length, 10);
-                    assert(Array.isArray(res.roles));
-                    assert.equal(res.roles.length, 1);
+            assert(Array.isArray(res.permissions));
+            assert.equal(res.permissions.length, 10);
+            assert(Array.isArray(res.roles));
+            assert.equal(res.roles.length, 1);
 
-                    // @TODO fix this!
-                    // Permissions is an array of models
-                    // Roles is a JSON array
-                    assert(res.permissions[0] && typeof res.permissions[0] === 'object');
-                    assert('attributes' in res.permissions[0]);
-                    assert('id' in res.permissions[0]);
-                    assert(res.roles[0] && typeof res.roles[0] === 'object');
-                    assert('id' in res.roles[0]);
-                    assert('name' in res.roles[0]);
-                    assert('description' in res.roles[0]);
-                    assert(res.permissions[0] instanceof models.Base.Model);
-                    assert(!(res.roles[0] instanceof models.Base.Model));
-
-                    done();
-                })
-                .catch(done);
+            // @TODO fix this!
+            // Permissions is an array of models
+            // Roles is a JSON array
+            assert(res.permissions[0] && typeof res.permissions[0] === 'object');
+            assert('attributes' in res.permissions[0]);
+            assert('id' in res.permissions[0]);
+            assert(res.roles[0] && typeof res.roles[0] === 'object');
+            assert('id' in res.roles[0]);
+            assert('name' in res.roles[0]);
+            assert('description' in res.roles[0]);
+            assert(res.permissions[0] instanceof models.Base.Model);
+            assert(!(res.roles[0] instanceof models.Base.Model));
         });
 
-        it('can load user with role, permissions and role.permissions and deduplicate them', function (done) {
+        it('can load user with role, permissions and role.permissions and deduplicate them', async function () {
             // This test requires quite a lot of unique setup work
             const findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
@@ -175,38 +162,33 @@ describe('Permission Providers', function () {
             });
 
             // Get permissions for the user
-            providers.user(1)
-                .then(function (res) {
-                    sinon.assert.calledOnce(findUserSpy);
+            const res = await providers.user(1);
+            sinon.assert.calledOnce(findUserSpy);
 
-                    assert(res && typeof res === 'object');
-                    assert('permissions' in res);
-                    assert('roles' in res);
+            assert(res && typeof res === 'object');
+            assert('permissions' in res);
+            assert('roles' in res);
 
-                    assert(Array.isArray(res.permissions));
-                    assert.equal(res.permissions.length, 10);
-                    assert(Array.isArray(res.roles));
-                    assert.equal(res.roles.length, 1);
+            assert(Array.isArray(res.permissions));
+            assert.equal(res.permissions.length, 10);
+            assert(Array.isArray(res.roles));
+            assert.equal(res.roles.length, 1);
 
-                    // @TODO fix this!
-                    // Permissions is an array of models
-                    // Roles is a JSON array
-                    assert(res.permissions[0] && typeof res.permissions[0] === 'object');
-                    assert('attributes' in res.permissions[0]);
-                    assert('id' in res.permissions[0]);
-                    assert(res.roles[0] && typeof res.roles[0] === 'object');
-                    assert('id' in res.roles[0]);
-                    assert('name' in res.roles[0]);
-                    assert('description' in res.roles[0]);
-                    assert(res.permissions[0] instanceof models.Base.Model);
-                    assert(!(res.roles[0] instanceof models.Base.Model));
-
-                    done();
-                })
-                .catch(done);
+            // @TODO fix this!
+            // Permissions is an array of models
+            // Roles is a JSON array
+            assert(res.permissions[0] && typeof res.permissions[0] === 'object');
+            assert('attributes' in res.permissions[0]);
+            assert('id' in res.permissions[0]);
+            assert(res.roles[0] && typeof res.roles[0] === 'object');
+            assert('id' in res.roles[0]);
+            assert('name' in res.roles[0]);
+            assert('description' in res.roles[0]);
+            assert(res.permissions[0] instanceof models.Base.Model);
+            assert(!(res.roles[0] instanceof models.Base.Model));
         });
 
-        it('throws when user with non-active status is loaded', function (done) {
+        it('throws when user with non-active status is loaded', async function () {
             // This test requires quite a lot of unique setup work
             const findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
@@ -217,33 +199,28 @@ describe('Permission Providers', function () {
             });
 
             // Get permissions for the user
-            providers.user(1)
-                .then(function () {
-                    done(new Error('Locked user should should throw an error'));
-                })
-                .catch((err) => {
-                    assert.equal(err.errorType, 'UnauthorizedError');
-                    sinon.assert.calledOnce(findUserSpy);
-                    done();
-                });
+            await assert.rejects(async () => {
+                await providers.user(1);
+            }, {
+                errorType: 'UnauthorizedError'
+            });
+            sinon.assert.calledOnce(findUserSpy);
         });
     });
 
     describe('API Key', function () {
-        it('errors if api_key cannot be found', function (done) {
+        it('errors if api_key cannot be found', async function () {
             let findApiKeySpy = sinon.stub(models.ApiKey, 'findOne');
             findApiKeySpy.returns(Promise.resolve());
-            providers.apiKey(1)
-                .then(() => {
-                    done(new Error('Should have thrown an api key not found error'));
-                })
-                .catch((err) => {
-                    sinon.assert.calledOnce(findApiKeySpy);
-                    assert.equal(err.errorType, 'NotFoundError');
-                    done();
-                });
+
+            await assert.rejects(async () => {
+                await providers.apiKey(1);
+            }, {
+                errorType: 'NotFoundError'
+            });
+            sinon.assert.calledOnce(findApiKeySpy);
         });
-        it('can load api_key with role, and role.permissions', function (done) {
+        it('can load api_key with role, and role.permissions', async function () {
             const findApiKeySpy = sinon.stub(models.ApiKey, 'findOne').callsFake(function () {
                 const fakeApiKey = models.ApiKey.forge(testUtils.DataGenerator.Content.api_keys[0]);
                 const fakeAdminRole = models.Role.forge(testUtils.DataGenerator.Content.roles[0]);
@@ -257,24 +234,22 @@ describe('Permission Providers', function () {
                 fakeApiKey.withRelated = ['role', 'role.permissions'];
                 return Promise.resolve(fakeApiKey);
             });
-            providers.apiKey(1).then((res) => {
-                sinon.assert.calledOnce(findApiKeySpy);
-                assert(res && typeof res === 'object');
-                assert('permissions' in res);
-                assert('roles' in res);
-                assert(Array.isArray(res.roles));
-                assert.equal(res.roles.length, 1);
-                assert(res.permissions[0] && typeof res.permissions[0] === 'object');
-                assert('attributes' in res.permissions[0]);
-                assert('id' in res.permissions[0]);
-                assert(res.roles[0] && typeof res.roles[0] === 'object');
-                assert('id' in res.roles[0]);
-                assert('name' in res.roles[0]);
-                assert('description' in res.roles[0]);
-                assert(res.permissions[0] instanceof models.Base.Model);
-                assert(!(res.roles[0] instanceof models.Base.Model));
-                done();
-            }).catch(done);
+            const res = await providers.apiKey(1);
+            sinon.assert.calledOnce(findApiKeySpy);
+            assert(res && typeof res === 'object');
+            assert('permissions' in res);
+            assert('roles' in res);
+            assert(Array.isArray(res.roles));
+            assert.equal(res.roles.length, 1);
+            assert(res.permissions[0] && typeof res.permissions[0] === 'object');
+            assert('attributes' in res.permissions[0]);
+            assert('id' in res.permissions[0]);
+            assert(res.roles[0] && typeof res.roles[0] === 'object');
+            assert('id' in res.roles[0]);
+            assert('name' in res.roles[0]);
+            assert('description' in res.roles[0]);
+            assert(res.permissions[0] instanceof models.Base.Model);
+            assert(!(res.roles[0] instanceof models.Base.Model));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -70,20 +70,17 @@ describe('Unit: services/url/UrlService', function () {
         assert.equal(urlService.urlGenerators.length, 1);
     });
 
-    it('fn: getResourceById', function (done) {
+    it('fn: getResourceById', function () {
         urlService.urls.getByResourceId.withArgs('id123').returns({resource: true});
         assert.equal(urlService.getResourceById('id123'), true);
 
         urlService.urls.getByResourceId.withArgs('id12345').returns(null);
 
-        try {
-            assert.equal(urlService.getResourceById('id12345'), true);
-            done(new Error('expected error'));
-        } catch (err) {
-            assertExists(err);
-            assert.equal(err.code, 'URLSERVICE_RESOURCE_NOT_FOUND');
-            done();
-        }
+        assert.throws(() => {
+            urlService.getResourceById('id12345');
+        }, {
+            code: 'URLSERVICE_RESOURCE_NOT_FOUND'
+        });
     });
 
     describe('fn: getResource', function () {


### PR DESCRIPTION
no ref

This is a test-only change. I think it's useful on its own, but will make upcoming changes (like migrating to Vitest) a bit easier.
