### PR TITLE
Fixed member activity events for gift members

### DIFF
--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -183,6 +183,9 @@ export default class ParseMemberEventHelper extends Helper {
 
         if (event.type === 'subscription_event') {
             if (event.data.type === 'created') {
+                if (event.data.previous_status === 'gift') {
+                    return 'continued paid subscription after gift';
+                }
                 return 'started paid subscription';
             }
             if (event.data.type === 'updated') {
@@ -348,6 +351,9 @@ export default class ParseMemberEventHelper extends Helper {
         }
 
         if (event.type === 'signup_event' && this.membersUtils.paidMembersEnabled) {
+            if (event.data.created_with_status && event.data.created_with_status !== 'free') {
+                return null;
+            }
             return 'Free';
         }
 

--- a/ghost/admin/tests/unit/helpers/parse-member-event-test.js
+++ b/ghost/admin/tests/unit/helpers/parse-member-event-test.js
@@ -1,0 +1,116 @@
+import Service from '@ember/service';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit: Helper: parse-member-event', function () {
+    setupTest();
+
+    let helper;
+
+    function buildEvent({type, data = {}} = {}) {
+        return {
+            type,
+            data: {
+                created_at: '2026-04-29T12:00:00Z',
+                member: {id: 'member-1', name: 'Alice', email: 'alice@example.com'},
+                ...data
+            }
+        };
+    }
+
+    beforeEach(function () {
+        const MembersUtilsStub = Service.extend({
+            paidMembersEnabled: true,
+            hasMultipleTiers: false
+        });
+        this.owner.register('service:members-utils', MembersUtilsStub);
+
+        helper = this.owner.factoryFor('helper:parse-member-event').create();
+    });
+
+    describe('subscription_event action', function () {
+        it('returns "continued paid subscription after gift" when previous_status is "gift"', function () {
+            const event = buildEvent({
+                type: 'subscription_event',
+                data: {type: 'created', previous_status: 'gift'}
+            });
+            const result = helper.compute([event]);
+            expect(result.action).to.equal('continued paid subscription after gift');
+        });
+
+        it('returns "started paid subscription" when previous_status is null', function () {
+            const event = buildEvent({
+                type: 'subscription_event',
+                data: {type: 'created', previous_status: null}
+            });
+            const result = helper.compute([event]);
+            expect(result.action).to.equal('started paid subscription');
+        });
+
+        it('returns "started paid subscription" when previous_status is "free"', function () {
+            const event = buildEvent({
+                type: 'subscription_event',
+                data: {type: 'created', previous_status: 'free'}
+            });
+            const result = helper.compute([event]);
+            expect(result.action).to.equal('started paid subscription');
+        });
+
+        it('returns "started paid subscription" when previous_status is missing', function () {
+            const event = buildEvent({
+                type: 'subscription_event',
+                data: {type: 'created'}
+            });
+            const result = helper.compute([event]);
+            expect(result.action).to.equal('started paid subscription');
+        });
+    });
+
+    describe('signup_event info', function () {
+        it('returns null when created_with_status is "paid"', function () {
+            const event = buildEvent({
+                type: 'signup_event',
+                data: {created_with_status: 'paid'}
+            });
+            const result = helper.compute([event]);
+            expect(result.info).to.equal(null);
+        });
+
+        it('returns null when created_with_status is "comped"', function () {
+            const event = buildEvent({
+                type: 'signup_event',
+                data: {created_with_status: 'comped'}
+            });
+            const result = helper.compute([event]);
+            expect(result.info).to.equal(null);
+        });
+
+        it('returns "Free" when created_with_status is "free"', function () {
+            const event = buildEvent({
+                type: 'signup_event',
+                data: {created_with_status: 'free'}
+            });
+            const result = helper.compute([event]);
+            expect(result.info).to.equal('Free');
+        });
+
+        it('returns "Free" when created_with_status is null', function () {
+            const event = buildEvent({
+                type: 'signup_event',
+                data: {created_with_status: null}
+            });
+            const result = helper.compute([event]);
+            expect(result.info).to.equal('Free');
+        });
+
+        it('returns "Free" when created_with_status is missing', function () {
+            const event = buildEvent({
+                type: 'signup_event',
+                data: {}
+            });
+            const result = helper.compute([event]);
+            expect(result.info).to.equal('Free');
+        });
+    });
+});

--- a/ghost/core/core/server/models/member-created-event.js
+++ b/ghost/core/core/server/models/member-created-event.js
@@ -16,11 +16,12 @@ const MemberCreatedEvent = ghostBookshelf.Model.extend({
     },
 
     /**
-     * The status event recorded at member creation time (if any)
+     * The status event recorded at member creation time (if any).
+     * Should only ever match one row per batch_id today; orderBy makes the choice deterministic if not.
      */
     signupStatusEvent() {
         return this.belongsTo('MemberStatusEvent', 'batch_id', 'batch_id')
-            .query(qb => qb.whereNull('from_status'));
+            .query(qb => qb.whereNull('from_status').orderBy('created_at', 'desc'));
     },
 
     postAttribution() {

--- a/ghost/core/core/server/models/member-created-event.js
+++ b/ghost/core/core/server/models/member-created-event.js
@@ -15,18 +15,26 @@ const MemberCreatedEvent = ghostBookshelf.Model.extend({
         return this.belongsTo('SubscriptionCreatedEvent', 'batch_id', 'batch_id');
     },
 
+    /**
+     * The status event recorded at member creation time (if any)
+     */
+    signupStatusEvent() {
+        return this.belongsTo('MemberStatusEvent', 'batch_id', 'batch_id')
+            .query(qb => qb.whereNull('from_status'));
+    },
+
     postAttribution() {
-        return this.belongsTo('Post', 'attribution_id', 'id');   
+        return this.belongsTo('Post', 'attribution_id', 'id');
     },
 
     userAttribution() {
-        return this.belongsTo('User', 'attribution_id', 'id');   
+        return this.belongsTo('User', 'attribution_id', 'id');
     },
 
     tagAttribution() {
-        return this.belongsTo('Tag', 'attribution_id', 'id');   
+        return this.belongsTo('Tag', 'attribution_id', 'id');
     },
-    
+
     filterRelations() {
         return {
             subscriptionCreatedEvent: {

--- a/ghost/core/core/server/models/subscription-created-event.js
+++ b/ghost/core/core/server/models/subscription-created-event.js
@@ -15,20 +15,29 @@ const SubscriptionCreatedEvent = ghostBookshelf.Model.extend({
         return this.belongsTo('MemberCreatedEvent', 'batch_id', 'batch_id');
     },
 
+    /**
+     * The status transition recorded at subscription creation time (if any)
+     * (e.g. free -> paid, or gift -> paid)
+     */
+    paidStatusEvent() {
+        return this.belongsTo('MemberStatusEvent', 'batch_id', 'batch_id')
+            .query(qb => qb.where('to_status', 'paid'));
+    },
+
     subscription() {
         return this.belongsTo('StripeCustomerSubscription', 'subscription_id', 'id');
     },
 
     postAttribution() {
-        return this.belongsTo('Post', 'attribution_id', 'id');   
+        return this.belongsTo('Post', 'attribution_id', 'id');
     },
 
     userAttribution() {
-        return this.belongsTo('User', 'attribution_id', 'id');   
+        return this.belongsTo('User', 'attribution_id', 'id');
     },
 
     tagAttribution() {
-        return this.belongsTo('Tag', 'attribution_id', 'id');   
+        return this.belongsTo('Tag', 'attribution_id', 'id');
     }
 }, {
     async edit() {

--- a/ghost/core/core/server/models/subscription-created-event.js
+++ b/ghost/core/core/server/models/subscription-created-event.js
@@ -17,11 +17,12 @@ const SubscriptionCreatedEvent = ghostBookshelf.Model.extend({
 
     /**
      * The status transition recorded at subscription creation time (if any)
-     * (e.g. free -> paid, or gift -> paid)
+     * (e.g. free -> paid, or gift -> paid).
+     * Should only ever match one row per batch_id today; orderBy makes the choice deterministic if not.
      */
     paidStatusEvent() {
         return this.belongsTo('MemberStatusEvent', 'batch_id', 'batch_id')
-            .query(qb => qb.where('to_status', 'paid'));
+            .query(qb => qb.where('to_status', 'paid').orderBy('created_at', 'desc'));
     },
 
     subscription() {

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -130,9 +130,8 @@ module.exports = class EventRepository {
                     if (diff !== 0) {
                         return diff;
                     }
-                    // Tiebreaker for events sharing the same created_at. Lower number = higher in
-                    // the (newest-first) feed. Display order top → bottom:
-                    // login → subscription / gift redemption → newsletter → signup.
+                    // Tiebreaker for events sharing the same created_at:
+                    // Signup > Newsletter subscription > Subscription / gift redemption event > Login
                     const tieOrder = {
                         login_event: 0,
                         subscription_event: 1,
@@ -140,9 +139,9 @@ module.exports = class EventRepository {
                         newsletter_event: 2,
                         signup_event: 3
                     };
-                    const orderA = tieOrder[a.type] ?? Infinity;
-                    const orderB = tieOrder[b.type] ?? Infinity;
-                    if (orderA !== orderB) {
+                    const orderA = tieOrder[a.type];
+                    const orderB = tieOrder[b.type];
+                    if (orderA !== undefined && orderB !== undefined && orderA !== orderB) {
                         return orderA - orderB;
                     }
                     return b.data.id.localeCompare(a.data.id);
@@ -254,6 +253,10 @@ module.exports = class EventRepository {
 
             // Prevent toJSON on stripeSubscription (we don't have everything loaded)
             delete model.relations.stripeSubscription;
+            // paidStatusEvent is a helper relation only used to derive previous_status above
+            if (subscriptionCreatedEvent && subscriptionCreatedEvent.id) {
+                delete subscriptionCreatedEvent.relations.paidStatusEvent;
+            }
             const d = {
                 ...model.toJSON(options),
                 attribution: model.get('type') === 'created' && subscriptionCreatedEvent && subscriptionCreatedEvent.id ? this._memberAttributionService.getEventAttribution(subscriptionCreatedEvent) : null,

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -130,6 +130,21 @@ module.exports = class EventRepository {
                     if (diff !== 0) {
                         return diff;
                     }
+                    // Tiebreaker for events sharing the same created_at. Lower number = higher in
+                    // the (newest-first) feed. Display order top → bottom:
+                    // login → subscription / gift redemption → newsletter → signup.
+                    const tieOrder = {
+                        login_event: 0,
+                        subscription_event: 1,
+                        gift_redemption_event: 1,
+                        newsletter_event: 2,
+                        signup_event: 3
+                    };
+                    const orderA = tieOrder[a.type] ?? Infinity;
+                    const orderB = tieOrder[b.type] ?? Infinity;
+                    if (orderA !== orderB) {
+                        return orderA - orderB;
+                    }
                     return b.data.id.localeCompare(a.data.id);
                 }
             ).slice(0, options.limit),
@@ -198,6 +213,7 @@ module.exports = class EventRepository {
                 'subscriptionCreatedEvent.userAttribution',
                 'subscriptionCreatedEvent.tagAttribution',
                 'subscriptionCreatedEvent.memberCreatedEvent',
+                'subscriptionCreatedEvent.paidStatusEvent',
 
                 // This is rediculous, but we need the tier name (we'll be able to shorten this later when we switch to the subscriptions table)
                 'stripeSubscription.stripePrice.stripeProduct.product'
@@ -230,12 +246,19 @@ module.exports = class EventRepository {
         const data = models.map((model) => {
             const tierName = model.related('stripeSubscription') && model.related('stripeSubscription').related('stripePrice') && model.related('stripeSubscription').related('stripePrice').related('stripeProduct') && model.related('stripeSubscription').related('stripePrice').related('stripeProduct').related('product') ? model.related('stripeSubscription').related('stripePrice').related('stripeProduct').related('product').get('name') : null;
 
+            const subscriptionCreatedEvent = model.related('subscriptionCreatedEvent');
+            const paidStatusEvent = subscriptionCreatedEvent && subscriptionCreatedEvent.id
+                ? subscriptionCreatedEvent.related('paidStatusEvent')
+                : null;
+            const previousStatus = paidStatusEvent && paidStatusEvent.id ? paidStatusEvent.get('from_status') : null;
+
             // Prevent toJSON on stripeSubscription (we don't have everything loaded)
             delete model.relations.stripeSubscription;
             const d = {
                 ...model.toJSON(options),
-                attribution: model.get('type') === 'created' && model.related('subscriptionCreatedEvent') && model.related('subscriptionCreatedEvent').id ? this._memberAttributionService.getEventAttribution(model.related('subscriptionCreatedEvent')) : null,
-                signup: model.get('type') === 'created' && model.related('subscriptionCreatedEvent') && model.related('subscriptionCreatedEvent').id && model.related('subscriptionCreatedEvent').related('memberCreatedEvent') && model.related('subscriptionCreatedEvent').related('memberCreatedEvent').id ? true : false,
+                attribution: model.get('type') === 'created' && subscriptionCreatedEvent && subscriptionCreatedEvent.id ? this._memberAttributionService.getEventAttribution(subscriptionCreatedEvent) : null,
+                signup: model.get('type') === 'created' && subscriptionCreatedEvent && subscriptionCreatedEvent.id && subscriptionCreatedEvent.related('memberCreatedEvent') && subscriptionCreatedEvent.related('memberCreatedEvent').id ? true : false,
+                previous_status: previousStatus,
                 tierName
             };
             delete d.stripeSubscription;
@@ -324,7 +347,8 @@ module.exports = class EventRepository {
                 'member',
                 'postAttribution',
                 'userAttribution',
-                'tagAttribution'
+                'tagAttribution',
+                'signupStatusEvent'
             ],
             filter: 'subscriptionCreatedEvent.id:null+custom:true',
             useBasicCount: true,
@@ -357,10 +381,13 @@ module.exports = class EventRepository {
             delete json.postAttribution?.mobiledoc;
             delete json.postAttribution?.lexical;
             delete json.postAttribution?.plaintext;
+            const createdWithStatus = json.signupStatusEvent?.to_status ?? null;
+            delete json.signupStatusEvent;
             return {
                 type: 'signup_event',
                 data: {
                     ...json,
+                    created_with_status: createdWithStatus,
                     attribution: this._memberAttributionService.getEventAttribution(model)
                 }
             };

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -451,7 +451,7 @@ module.exports = class MemberRepository {
             member_id: member.id,
             from_status: null,
             to_status: member.get('status'),
-            batch_id: options.batch_id,
+            batch_id: options.batch_id ?? null,
             ...eventData
         }, options);
 

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -451,6 +451,7 @@ module.exports = class MemberRepository {
             member_id: member.id,
             from_status: null,
             to_status: member.get('status'),
+            batch_id: options.batch_id,
             ...eventData
         }, options);
 
@@ -784,7 +785,8 @@ module.exports = class MemberRepository {
             await this._MemberStatusEvent.add({
                 member_id: member.id,
                 from_status: member._previousAttributes.status,
-                to_status: member.get('status')
+                to_status: member.get('status'),
+                batch_id: options.batch_id ?? null
             }, sharedOptions);
         }
 
@@ -1499,6 +1501,7 @@ module.exports = class MemberRepository {
                 member_id: data.id,
                 from_status: updatedMember._previousAttributes.status,
                 to_status: updatedMember.get('status'),
+                batch_id: options.batch_id ?? null,
                 ...eventData
             }, options);
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
@@ -22699,7 +22699,7 @@ exports[`Activity Feed API Can filter events by post id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "18572",
+  "content-length": "18676",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -24415,7 +24415,7 @@ exports[`Activity Feed API Returns signup events in activity feed 2: [headers] 1
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "21855",
+  "content-length": "22071",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -416,7 +416,7 @@ exports[`Members API - member attribution Returns sign up attributions of all ty
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8732",
+  "content-length": "8877",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -6808,7 +6808,7 @@ exports[`Members API Can subscribe to a newsletter 5: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5505",
+  "content-length": "5534",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -8357,7 +8357,7 @@ exports[`Members API can change the email address 5: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1209",
+  "content-length": "1238",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/members/__snapshots__/webhooks.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/webhooks.test.js.snap
@@ -490,7 +490,7 @@ exports[`Members API Member attribution Returns subscription created attribution
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "7037",
+  "content-length": "7287",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3542
closes https://linear.app/ghost/issue/BER-3565

## Summary

Fixes how member activity events are surfaced for gift redemptions and gift-to-paid upgrades, addressing two related issues:

- When a new member redeemed a gift, the activity feed showed `Signed up (Free)` followed by the gift subscription event, which was both inaccurate (they aren't a free member) and ordered confusingly.
- When a gift member converted to paid, the feed showed two separate `Started paid subscription` entries, making it look like the member started two distinct subscriptions.

## Changes

### Differentiate gift vs free signup 
- The `MemberCreatedEvent` model now joins to its sibling `MemberStatusEvent` via `batch_id` to expose the status the member was created with (`signupStatusEvent`).
- The signup event API payload now includes `created_with_status`, so the client can tell whether a signup was Free, Paid, or Gift.
- In `parse-member-event`, signup events with a non-`free` `created_with_status` no longer render the `(Free)` badge on the signup line — the accompanying gift/subscription event already conveys the member type.

### Fix event ordering in the activity feed 
- Added a tiebreaker for events sharing the same `created_at` timestamp in `EventRepository`:
  `login → subscription / gift redemption → newsletter → signup`.
- This ensures the feed reads naturally for new gift members: *signed up → subscribed to newsletter → started paid subscription via gift*.

### Distinguish gift → paid continuation from a fresh paid sub 
- The `SubscriptionCreatedEvent` model exposes a `paidStatusEvent` relation (the `MemberStatusEvent` whose `to_status = paid` for the same `batch_id`), letting us read the `previous_status` at subscription creation time.
- The subscription-created API payload now includes `previous_status`.
- When `previous_status === 'gift'`, `parse-member-event` renders **"continued paid subscription after gift"** instead of **"started paid subscription"**.

### Backend wiring
- `MemberRepository` now propagates `batch_id` into all `MemberStatusEvent` writes (signup, status updates, and subscription-driven status transitions), which is what makes the relation joins above work end-to-end.


## Test plan

- [x] Free signup still shows `Signed up (Free)` in member activity
- [x] Paid signup still shows `Signed up (<Tier>)` in member activity
- [x] New member redeeming a gift shows: `Signed up` → `Subscribed to newsletter` → `Started paid subscription via gift (<Tier>)` in correct order, with no spurious `(Free)` badge
- [x] Existing free member redeeming a gift is unchanged
- [x] Gift member who converts to paid sees `Continued paid subscription after gift (<Tier>)` instead of a second `Started paid subscription`
- [x] `pnpm test:e2e` in `ghost/core` passes with updated snapshots