### PR TITLE
Fixed hoisted devDependency

### DIFF
--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/announcement-bar",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -82,6 +82,7 @@
   "devDependencies": {
     "@vitejs/plugin-react": "4.7.0",
     "@vitest/coverage-v8": "~3.2.4",
+    "concurrently": "8.2.2",
     "cross-fetch": "4.1.0",
     "jsdom": "28.1.0",
     "vite": "5.4.21",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/sodo-search",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -99,6 +99,7 @@
     "@testing-library/react": "12.1.5",
     "@vitejs/plugin-react": "4.7.0",
     "@vitest/coverage-v8": "~3.2.4",
+    "concurrently": "8.2.2",
     "cross-fetch": "4.1.0",
     "jsdom": "28.1.0",
     "nock": "13.5.6",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@playwright/test": "1.59.1",
     "chalk": "4.1.2",
     "chokidar": "3.6.0",
-    "concurrently": "8.2.2",
     "eslint": "catalog:",
     "eslint-plugin-ghost": "3.5.0",
     "eslint-plugin-react": "7.37.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       chokidar:
         specifier: 3.6.0
         version: 3.6.0
-      concurrently:
-        specifier: 8.2.2
-        version: 8.2.2
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -717,6 +714,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ~3.2.4
         version: 3.2.4(vitest@3.2.4)
+      concurrently:
+        specifier: 8.2.2
+        version: 8.2.2
       cross-fetch:
         specifier: 4.1.0
         version: 4.1.0(encoding@0.1.13)
@@ -1386,6 +1386,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ~3.2.4
         version: 3.2.4(vitest@3.2.4)
+      concurrently:
+        specifier: 8.2.2
+        version: 8.2.2
       cross-fetch:
         specifier: 4.1.0
         version: 4.1.0(encoding@0.1.13)
@@ -24526,7 +24529,7 @@ snapshots:
       js-string-escape: 1.0.1
       jsdom: 16.7.0
       json-stable-stringify: 1.3.0
-      lodash: 4.18.1
+      lodash: 4.17.23
       pkg-up: 2.0.0
       resolve: 1.22.11
       resolve-package-path: 1.2.7
@@ -24589,7 +24592,7 @@ snapshots:
       babel-import-util: 3.0.1
       ember-cli-babel: 7.26.11
       find-up: 5.0.0
-      lodash: 4.18.1
+      lodash: 4.17.23
       resolve: 1.22.11
       semver: 7.7.4
     transitivePeerDependencies:
@@ -24599,7 +24602,7 @@ snapshots:
     dependencies:
       ember-rfc176-data: 0.3.18
       fs-extra: 7.0.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       pkg-up: 3.1.0
       resolve-package-path: 1.2.7
       semver: 7.7.4
@@ -24611,7 +24614,7 @@ snapshots:
       ember-rfc176-data: 0.3.18
       fs-extra: 9.1.0
       js-string-escape: 1.0.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       resolve-package-path: 4.0.3
       semver: 7.7.4
       typescript-memoize: 1.1.1
@@ -24658,7 +24661,7 @@ snapshots:
       fs-extra: 9.1.0
       is-subdir: 1.2.0
       js-string-escape: 1.0.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       minimatch: 3.1.5
       pkg-entry-points: 1.1.1
       resolve-package-path: 4.0.3
@@ -31770,7 +31773,7 @@ snapshots:
 
   async@2.6.4:
     dependencies:
-      lodash: 4.18.1
+      lodash: 4.17.23
 
   async@3.2.3: {}
 
@@ -31855,7 +31858,7 @@ snapshots:
       convert-source-map: 1.9.0
       debug: 2.6.9(supports-color@1.2.0)
       json5: 0.5.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       minimatch: 3.1.5
       path-is-absolute: 1.0.1
       private: 0.1.8
@@ -31871,7 +31874,7 @@ snapshots:
       babel-types: 6.26.0
       detect-indent: 4.0.0
       jsesc: 1.3.0
-      lodash: 4.18.1
+      lodash: 4.17.23
       source-map: 0.5.7
       trim-right: 1.0.1
 
@@ -31903,7 +31906,7 @@ snapshots:
       babel-helper-function-name: 6.24.1
       babel-runtime: 6.26.0
       babel-types: 6.26.0
-      lodash: 4.18.1
+      lodash: 4.17.23
     transitivePeerDependencies:
       - supports-color
 
@@ -31944,7 +31947,7 @@ snapshots:
     dependencies:
       babel-runtime: 6.26.0
       babel-types: 6.26.0
-      lodash: 4.18.1
+      lodash: 4.17.23
 
   babel-helper-remap-async-to-generator@6.24.1:
     dependencies:
@@ -32197,7 +32200,7 @@ snapshots:
       babel-template: 6.26.0
       babel-traverse: 6.26.0
       babel-types: 6.26.0
-      lodash: 4.18.1
+      lodash: 4.17.23
     transitivePeerDependencies:
       - supports-color
 
@@ -32422,7 +32425,7 @@ snapshots:
       babel-runtime: 6.26.0
       core-js: 2.6.12
       home-or-tmp: 2.0.0
-      lodash: 4.18.1
+      lodash: 4.17.23
       mkdirp: 0.5.6
       source-map-support: 0.4.18
     transitivePeerDependencies:
@@ -32453,7 +32456,7 @@ snapshots:
       debug: 2.6.9(supports-color@1.2.0)
       globals: 9.18.0
       invariant: 2.2.4
-      lodash: 4.18.1
+      lodash: 4.17.23
     transitivePeerDependencies:
       - supports-color
 
@@ -32461,7 +32464,7 @@ snapshots:
     dependencies:
       babel-runtime: 6.26.0
       esutils: 2.0.3
-      lodash: 4.18.1
+      lodash: 4.17.23
       to-fast-properties: 1.0.3
 
   babel6-plugin-strip-class-callcheck@6.0.0: {}
@@ -34149,7 +34152,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       date-fns: 2.30.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       rxjs: 7.8.2
       shell-quote: 1.8.3
       spawn-command: 0.0.2
@@ -37196,7 +37199,7 @@ snapshots:
       esquery: 1.7.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       pluralize: 8.0.0
       read-pkg-up: 7.0.1
       regexp-tree: 0.1.27
@@ -39244,7 +39247,7 @@ snapshots:
       cli-width: 2.2.1
       external-editor: 3.1.0
       figures: 2.0.0
-      lodash: 4.18.1
+      lodash: 4.17.23
       mute-stream: 0.0.7
       run-async: 2.4.1
       rxjs: 6.6.7
@@ -48083,7 +48086,7 @@ snapshots:
 
   whatwg-url@8.7.0:
     dependencies:
-      lodash: 4.18.1
+      lodash: 4.17.23
       tr46: 2.1.0
       webidl-conversions: 6.1.0
 
@@ -48152,7 +48155,7 @@ snapshots:
 
   wide-align@1.1.5:
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
no ref

Two apps (`apps/announcement-bar`, `apps/sodo-search`) reference `concurrently` in their own `dev` scripts but never declared it as a `devDependency`.