### PR TITLE
Bumped dompurify to 3.4.1 across ghost/core, activitypub, portal

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -82,7 +82,7 @@
     "@tryghost/admin-x-framework": "workspace:*",
     "@tryghost/shade": "workspace:*",
     "clsx": "2.1.1",
-    "dompurify": "3.3.1",
+    "dompurify": "3.4.1",
     "html2canvas-objectfit-fix": "1.2.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.18",
+  "version": "2.68.19",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -121,7 +121,7 @@
     "@vitest/ui": "3.2.4",
     "concurrently": "8.2.2",
     "cross-fetch": "4.1.0",
-    "dompurify": "3.3.1",
+    "dompurify": "3.4.1",
     "eslint": "catalog:",
     "eslint-plugin-i18next": "6.1.3",
     "jsdom": "28.1.0",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -165,7 +165,7 @@
     "csso": "5.0.5",
     "csv-writer": "1.6.0",
     "date-fns": "2.30.0",
-    "dompurify": "3.3.0",
+    "dompurify": "3.4.1",
     "downsize": "0.0.8",
     "entities": "4.5.0",
     "express": "4.21.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       dompurify:
-        specifier: 3.3.1
-        version: 3.3.1
+        specifier: 3.4.1
+        version: 3.4.1
       html2canvas-objectfit-fix:
         specifier: 1.2.0
         version: 1.2.0
@@ -901,8 +901,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(encoding@0.1.13)
       dompurify:
-        specifier: 3.3.1
-        version: 3.3.1
+        specifier: 3.4.1
+        version: 3.4.1
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -2197,8 +2197,8 @@ importers:
         specifier: 2.30.0
         version: 2.30.0
       dompurify:
-        specifier: 3.3.0
-        version: 3.3.0
+        specifier: 3.4.1
+        version: 3.4.1
       downsize:
         specifier: 0.0.8
         version: 0.0.8
@@ -12618,11 +12618,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.0:
-    resolution: {integrity: sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==}
-
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   domutils@1.5.1:
     resolution: {integrity: sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==}
@@ -30265,7 +30262,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.3.1
+      dompurify: 3.4.1
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -35096,11 +35093,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.0:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
-  dompurify@3.3.1:
+  dompurify@3.4.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Summary

Bumps `dompurify` from a vulnerable `3.3.x` release to `3.4.1` (current latest) in the three workspaces that depend on it directly:

- `ghost/core`: `3.3.0` → `3.4.1`
- `apps/activitypub`: `3.3.1` → `3.4.1`
- `apps/portal`: `3.3.1` → `3.4.1`

Patch and minor versions within the dompurify 3.x line are backward-compatible; the `sanitize()` API and option shape are unchanged.

Workspace `version` fields bumped on the two apps:

- `apps/activitypub`: `3.1.13` → `3.1.14`
- `apps/portal`: `2.68.18` → `2.68.19`

`ghost/core`'s version field is managed by the release pipeline and is intentionally not bumped here.

## Audit delta

`pnpm audit`: 104 → 88 (`−16 moderate`).

8 of those are dompurify advisories clearing directly. The other 8 clear from deduplication when the resolved tree collapses to a single `dompurify@3.4.1` instance.

## Test plan

- [x] `pnpm install` clean
- [x] Single `dompurify@3.4.1` resolved in tree (no duplication)
- [x] Tests pass for the three affected workspaces (`ghost`, `@tryghost/portal`, `@tryghost/activitypub`)
- [ ] CI green