### PR TITLE
Bumped jsonwebtoken 8.5.1 -> 9.0.3 in ghost/core

### DIFF
--- a/ghost/core/core/server/services/tinybird/tinybird-service.js
+++ b/ghost/core/core/server/services/tinybird/tinybird-service.js
@@ -171,7 +171,7 @@ class TinybirdService {
      */
     _isJWTExpired(token, bufferSeconds = 300) {
         try {
-            const decoded = jwt.verify(token, this.tinybirdConfig.adminToken);
+            const decoded = jwt.verify(token, this.tinybirdConfig.adminToken, {algorithms: ['HS256']});
             if (typeof decoded !== 'object' || !decoded.exp) {
                 return true;
             }

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -195,7 +195,7 @@
     "js-yaml": "4.1.1",
     "jsdom": "28.1.0",
     "jsonc-parser": "3.3.1",
-    "jsonwebtoken": "8.5.1",
+    "jsonwebtoken": "9.0.3",
     "juice": "9.1.0",
     "keypair": "1.0.4",
     "knex": "2.4.2",

--- a/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const jwt = require('jsonwebtoken');
 const jwkToPem = require('jwk-to-pem');
 const TokenService = require('../../../../../../../core/server/services/members/members-api/services/token-service');
@@ -7,8 +8,11 @@ describe('TokenService', function () {
     let tokenService;
 
     before(function () {
-        const privateKey = '-----BEGIN RSA PRIVATE KEY-----\nMIICWwIBAAKBgQCea7oriNoFgxnY/JgFDpNRlxLMVIapfoMQTCJMWkH9pDYoAq/8GF6q0yTd\nn5+AS7TGasCjgNGW6miEbBDBaQy8hS8hWqhaRKY6Sy8/11KyAC8y5cs+QW4dFY2JvnXO6UpE\nFaTtHR7oAtTSZJ9D9i/FN+2wAoO/4193Leoqqw1dJwIDAQABAoGAeqejo5M4Yi4n9AVV2gx3\n6SLTrhn/jPljllmr8HutPilGuOGjycZAfXguwdyVjKqQ01LRxYW2QGdK9sQIkQa5kXjzTtLa\ndtHYcplk0rTTsdjbvZ31AKNTNYn5s+PhGGb0Gc9n8co18K75ol8VPG8lpXjUUCWsb2xcV7wA\nQuHkOukCQQD7TluL8I4tHXzREIW3OZeLTyRlPEIn5cDdPPEIHrAIu4WJ50zAbkMH7W4HBmWf\ntafxSgWcRsdMIZn//wZV3goLAkEAoWE6/LgKgowSouIjbRdekw7QPZMvN2LUV0a0GZHpSA2K\nzzyvOsW1dU9EO+WhCpdfoikuxWiPtN+byAe2sbBG1QJALuKgm8wmim488jhV6ig5iMkcLjL+\n2Li5sc0D3xLynr51nJPlsuUfZmQ6qd7cqN5YVeEMiOp/lkmSlLs8sFp7nwJAKEkFWKD4vq4I\n2PBqt4jl6v//q99aIhFhwIe93cQ23+3BgQo9FAbWzXoEJo+kK+itzuVI766ycQyA7uY+DQ1c\nIQJAER3D4lsY5wnE+01eqk8NfF7TO+u4ezWs/rmNyn3hapskgV0xqn+FanXeVJ5K7B3AzabR\na4/tLo88gWEfcow6WQ==\n-----END RSA PRIVATE KEY-----\n';
-        const publicKey = '-----BEGIN RSA PUBLIC KEY-----\nMIGJAoGBAJ5ruiuI2gWDGdj8mAUOk1GXEsxUhql+gxBMIkxaQf2kNigCr/wYXqrTJN2fn4BL\ntMZqwKOA0ZbqaIRsEMFpDLyFLyFaqFpEpjpLLz/XUrIALzLlyz5Bbh0VjYm+dc7pSkQVpO0d\nHugC1NJkn0P2L8U37bACg7/jX3ct6iqrDV0nAgMBAAE=\n-----END RSA PUBLIC KEY-----\n';
+        const {privateKey, publicKey} = crypto.generateKeyPairSync('rsa', {
+            modulusLength: 2048,
+            publicKeyEncoding: {type: 'pkcs1', format: 'pem'},
+            privateKeyEncoding: {type: 'pkcs1', format: 'pem'}
+        });
         const issuer = 'http://127.0.0.1:2369/members/api';
 
         tokenService = new TokenService({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2290,8 +2290,8 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
       jsonwebtoken:
-        specifier: 8.5.1
-        version: 8.5.1
+        specifier: 9.0.3
+        version: 9.0.3
       juice:
         specifier: 9.1.0
         version: 9.1.0(encoding@0.1.13)
@@ -16010,10 +16010,6 @@ packages:
     resolution: {integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==}
     hasBin: true
 
-  jsonwebtoken@8.5.1:
-    resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
-    engines: {node: '>=4', npm: '>=1.4.28'}
-
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
@@ -16037,9 +16033,6 @@ packages:
   just-extend@6.2.0:
     resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
 
-  jwa@1.4.2:
-    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
-
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -16049,9 +16042,6 @@ packages:
   jwks-rsa@3.2.0:
     resolution: {integrity: sha512-PwchfHcQK/5PSydeKCs1ylNym0w/SSv8a62DgHJ//7x2ZclCoinlsjAfDxAAbpoTPybOum/Jgy+vkvMmKz89Ww==}
     engines: {node: '>=14'}
-
-  jws@3.2.3:
-    resolution: {integrity: sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==}
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
@@ -40551,19 +40541,6 @@ snapshots:
 
   jsonrepair@3.13.3: {}
 
-  jsonwebtoken@8.5.1:
-    dependencies:
-      jws: 3.2.3
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
-      ms: 2.1.3
-      semver: 5.7.2
-
   jsonwebtoken@9.0.3:
     dependencies:
       jws: 4.0.1
@@ -40605,12 +40582,6 @@ snapshots:
 
   just-extend@6.2.0: {}
 
-  jwa@1.4.2:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -40633,11 +40604,6 @@ snapshots:
       lru-memoizer: 2.3.0
     transitivePeerDependencies:
       - supports-color
-
-  jws@3.2.3:
-    dependencies:
-      jwa: 1.4.2
-      safe-buffer: 5.2.1
 
   jws@4.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Bumps `jsonwebtoken` in `ghost/core` from `8.5.1` to `9.0.3` to clear three advisories (1 high, 2 moderate). The 8 → 9 jump introduces two breaking changes that required follow-up edits in this PR:

### 1. `verify()` requires explicit `algorithms`

v9 no longer falls back to defaults when `verify()` is called without an `algorithms` option. There were three `verify()` call sites in `ghost/core`:

- `services/auth/api-key/admin.js` — already passes `algorithms: ['HS256']` via `JWT_OPTIONS_DEFAULTS`. ✓
- `services/members/members-api/services/token-service.js` — already passes `algorithms: ['RS512']`. ✓
- `services/tinybird/tinybird-service.js#_isJWTExpired` — **was missing**. Added `{algorithms: ['HS256']}` to match the `HS256` secret used in the corresponding `sign()` directly above. Without this fix, v9 would throw on every call, making `_isJWTExpired` always return `true` and forcing tinybird tokens to be re-issued on every request.

### 2. RS-* algorithms require 2048-bit minimum keys

v9 enforces a 2048-bit minimum for RSA keys when signing with RS512 (and other RSA variants). The `token-service` unit test was using hardcoded 1024-bit test keys that worked under v8. Switched the test to generate a fresh 2048-bit RSA key pair in the `before` hook with `crypto.generateKeyPairSync` — self-contained and avoids hardcoding another fixed key.

All `sign()` sites in `ghost/core` already specify an explicit `algorithm` (`HS256` or `RS512`), so they need no changes for v9.

## Audit delta

`pnpm audit`: 104 → 101 (`−1 high`, `−2 moderate`).

## Test plan

- [x] `pnpm install` clean
- [x] `token-service` unit tests — 3/3 passing (the ones that surfaced the breaking change)
- [x] `ghost/core` full unit suite — 6200/6200 passing
- [ ] CI green (covers integration + e2e API auth flows)