### PR TITLE
Added migration for scheduled gift reminders flushing

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.36/2026-04-28-12-03-44-add-gifts-flush-reminders-permission-to-scheduler-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/6.36/2026-04-28-12-03-44-add-gifts-flush-reminders-permission-to-scheduler-integration.js
@@ -1,0 +1,9 @@
+const {addPermissionWithRoles} = require('../../utils');
+
+module.exports = addPermissionWithRoles({
+    name: 'Flush gift reminders',
+    action: 'flushReminders',
+    object: 'gift'
+}, [
+    'Scheduler Integration'
+]);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -778,6 +778,11 @@
                     "name": "Poll automations",
                     "action_type": "poll",
                     "object_type": "automation"
+                },
+                {
+                    "name": "Flush gift reminders",
+                    "action_type": "flushReminders",
+                    "object_type": "gift"
                 }
             ]
         },
@@ -954,7 +959,8 @@
                 },
                 "Scheduler Integration": {
                     "post": "publish",
-                    "automation": "poll"
+                    "automation": "poll",
+                    "gift": "flushReminders"
                 },
                 "Ghost Explore Integration": {
                     "explore": "read"

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -91,7 +91,7 @@ describe('Migrations', function () {
         // Custom assertion to wrap all permissions
         function assertCompletePermissions(permissions) {
             // If you have to change this number, please add the relevant `assertHavePermission` checks below
-            assert.equal(permissions.length, 131);
+            assert.equal(permissions.length, 132);
 
             assertHavePermission(permissions, 'Export database', ['Administrator', 'DB Backup Integration']);
             assertHavePermission(permissions, 'Import database', ['Administrator', 'Self-Serve Migration Integration', 'DB Backup Integration']);
@@ -110,6 +110,7 @@ describe('Migrations', function () {
             assertHavePermission(permissions, 'Add posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Delete posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Publish posts', ['Administrator', 'Editor', 'Admin Integration', 'Scheduler Integration', 'Super Editor']);
+            assertHavePermission(permissions, 'Flush gift reminders', ['Scheduler Integration']);
 
             assertHavePermission(permissions, 'Browse settings', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Read settings', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -402,7 +402,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             const result = await fixtureManager.addFixturesForRelation(fixtures.relations[0]);
-            const FIXTURE_COUNT = 140;
+            const FIXTURE_COUNT = 141;
             assertExists(result);
             assert(_.isPlainObject(result));
             assert.equal(result.expected, FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'db036dfc567b48b78bdd36cd6604909f';
-    const currentFixturesHash = '64a3110da34bdbaa9a6cc78de9680f7e';
+    const currentFixturesHash = '911c57c12a164237078b618c5b63042d';
     const currentSettingsHash = 'a102b80d2ab0cd92325ed007c94d7da6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -779,6 +779,11 @@
                     "name": "Poll automations",
                     "action_type": "poll",
                     "object_type": "automation"
+                },
+                {
+                    "name": "Flush gift reminders",
+                    "action_type": "flushReminders",
+                    "object_type": "gift"
                 }
             ]
         },
@@ -1108,7 +1113,8 @@
                 },
                 "Scheduler Integration": {
                     "post": "publish",
-                    "automation": "poll"
+                    "automation": "poll",
+                    "gift": "flushReminders"
                 },
                 "Ghost Explore Integration": {
                     "explore": "read"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3525

Migration for scheduled gift reminders flushing. Logic that uses this is implemented in https://github.com/TryGhost/Ghost/pull/27527