### PR TITLE
Prototype threaded comments rendering

### DIFF
--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -2,6 +2,7 @@ import {AddComment, Comment, CommentsOptions, DispatchActionType, EditableAppCon
 import {AdminApi} from './utils/admin-api';
 import {GhostApi} from './utils/api';
 import {Page} from './pages';
+import {hydrateVisibleReplies} from './utils/reply-hydration';
 
 async function loadMoreComments({state, api, options, order}: {state: EditableAppContext, api: GhostApi, options: CommentsOptions, order?:string}): Promise<Partial<EditableAppContext>> {
     let page = 1;
@@ -15,7 +16,13 @@ async function loadMoreComments({state, api, options, order}: {state: EditableAp
         data = await api.comments.browse({page, postId: options.postId, order: order || state.order});
     }
 
-    const updatedComments = [...state.comments, ...data.comments];
+    const hydratedComments = await hydrateVisibleReplies({
+        comments: data.comments,
+        api,
+        adminApi: state.admin ? state.adminApi : null,
+        memberUuid: state.member?.uuid
+    });
+    const updatedComments = [...state.comments, ...hydratedComments];
     const dedupedComments = updatedComments.filter((comment, index, self) => self.findIndex(c => c.id === comment.id) === index);
 
     // Note: we store the comments from new to old, and show them in reverse order
@@ -42,8 +49,15 @@ async function setOrder({state, data: {order}, options, api, dispatchAction}: {s
             data = await api.comments.browse({page: 1, postId: options.postId, order});
         }
 
+        const hydratedComments = await hydrateVisibleReplies({
+            comments: data.comments,
+            api,
+            adminApi: state.admin ? state.adminApi : null,
+            memberUuid: state.member?.uuid
+        });
+
         return {
-            comments: [...data.comments],
+            comments: hydratedComments,
             pagination: data.meta.pagination,
             order,
             commentsIsLoading: false

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -9,6 +9,7 @@ import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
 import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
 import {CommentsFrame} from './components/frame';
+import {hydrateVisibleReplies} from './utils/reply-hydration';
 import {setupAdminAPI} from './utils/admin-api';
 import {useOptions} from './utils/options';
 
@@ -141,6 +142,11 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
                 if (admin) {
                     // this is a bit of a hack, but we need to fetch the comments fully populated if the user is an admin
                     const adminComments = await adminApi.browse({page: 1, postId: options.postId, order: state.order, memberUuid: state.member?.uuid});
+                    const hydratedAdminComments = await hydrateVisibleReplies({
+                        comments: adminComments.comments,
+                        adminApi,
+                        memberUuid: state.member?.uuid
+                    });
                     setState((currentState) => {
                         // Don't overwrite comments when initSetup loaded extra data
                         // for permalink scrolling (multiple pages or expanded replies)
@@ -155,7 +161,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
                             adminApi,
                             admin,
                             isAdmin: true,
-                            comments: adminComments.comments,
+                            comments: hydratedAdminComments,
                             pagination: adminComments.meta.pagination
                         };
                     });
@@ -183,9 +189,13 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         const countPromise = api.comments.count({postId: options.postId});
 
         const [data, count] = await Promise.all([dataPromise, countPromise]);
+        const comments = await hydrateVisibleReplies({
+            comments: data.comments,
+            api
+        });
 
         return {
-            comments: data.comments,
+            comments,
             pagination: data.meta.pagination,
             count: count
         };
@@ -227,7 +237,11 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
                 postId: options.postId,
                 order: state.order
             });
-            comments = [...comments, ...nextPage.comments];
+            const nextComments = await hydrateVisibleReplies({
+                comments: nextPage.comments,
+                api
+            });
+            comments = [...comments, ...nextComments];
             pagination = nextPage.meta.pagination;
         }
 

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -2,7 +2,7 @@ import EditForm from './forms/edit-form';
 import LikeButton from './buttons/like-button';
 import LikeCount from './buttons/like-count';
 import MoreButton from './buttons/more-button';
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import Replies, {RepliesProps} from './replies';
 import ReplyButton from './buttons/reply-button';
 import ReplyForm from './forms/reply-form';
@@ -15,9 +15,16 @@ import {useRelativeTime} from '../../utils/hooks';
 type AnimatedCommentProps = {
     comment: Comment;
     parent?: Comment;
+    hideConnectedReplySnippet?: boolean;
+    hasThreadChildren?: boolean;
+    renderReplies?: boolean;
+    layoutVariant?: CommentLayoutVariant;
+    showRepliesLine?: boolean;
 };
 
-const AnimatedComment: React.FC<AnimatedCommentProps> = ({comment, parent}) => {
+export type CommentLayoutVariant = 'default' | 'compact-thread';
+
+const AnimatedComment: React.FC<AnimatedCommentProps> = ({comment, parent, hideConnectedReplySnippet, hasThreadChildren, renderReplies, layoutVariant, showRepliesLine}) => {
     const {commentsIsLoading} = useAppContext();
 
     return (
@@ -34,14 +41,23 @@ const AnimatedComment: React.FC<AnimatedCommentProps> = ({comment, parent}) => {
             show={true}
             appear
         >
-            <CommentComponent comment={comment} parent={parent} />
+            <CommentComponent
+                comment={comment}
+                hasThreadChildren={hasThreadChildren}
+                hideConnectedReplySnippet={hideConnectedReplySnippet}
+                layoutVariant={layoutVariant}
+                parent={parent}
+                renderReplies={renderReplies}
+                showRepliesLine={showRepliesLine}
+            />
         </Transition>
     );
 };
 
-export const CommentComponent: React.FC<CommentProps> = ({comment, parent}) => {
+export const CommentComponent: React.FC<CommentProps> = ({comment, parent, hideConnectedReplySnippet, hasThreadChildren, renderReplies, layoutVariant, showRepliesLine}) => {
     const {dispatchAction, isAdmin} = useAppContext();
     const {showDeletedMessage, showHiddenMessage, showCommentContent} = useCommentVisibility(comment, isAdmin);
+    const effectiveShowRepliesLine = showRepliesLine ?? Boolean(parent || !renderReplies);
 
     const openEditMode = useCallback(() => {
         const newForm: OpenCommentForm = {
@@ -55,9 +71,20 @@ export const CommentComponent: React.FC<CommentProps> = ({comment, parent}) => {
     }, [comment.id, dispatchAction]);
 
     if (showDeletedMessage || showHiddenMessage) {
-        return <UnpublishedComment comment={comment} openEditMode={openEditMode} />;
+        return <UnpublishedComment comment={comment} hasThreadChildren={hasThreadChildren} layoutVariant={layoutVariant} openEditMode={openEditMode} renderReplies={renderReplies} showRepliesLine={effectiveShowRepliesLine} />;
     } else if (showCommentContent && !showHiddenMessage) {
-        return <PublishedComment comment={comment} openEditMode={openEditMode} parent={parent} />;
+        return (
+            <PublishedComment
+                comment={comment}
+                hasThreadChildren={hasThreadChildren}
+                hideConnectedReplySnippet={hideConnectedReplySnippet}
+                layoutVariant={layoutVariant}
+                openEditMode={openEditMode}
+                parent={parent}
+                renderReplies={renderReplies}
+                showRepliesLine={effectiveShowRepliesLine}
+            />
+        );
     }
 
     return null;
@@ -82,7 +109,7 @@ const useCommentVisibility = (comment: Comment, admin: boolean) => {
 type PublishedCommentProps = CommentProps & {
     openEditMode: () => void;
 }
-const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, openEditMode}) => {
+const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, openEditMode, hideConnectedReplySnippet = false, hasThreadChildren = false, renderReplies = true, layoutVariant = 'default', showRepliesLine}) => {
     const {dispatchAction, openCommentForms, isAdmin, commentIdToHighlight} = useAppContext();
 
     // Determine if the comment should be displayed with reduced opacity
@@ -124,20 +151,20 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, ope
         }
     }, [comment, parent, openForm, dispatchAction]);
 
-    const hasReplies = displayReplyForm || (comment.replies && comment.replies.length > 0);
+    const hasReplies = displayReplyForm || hasThreadChildren || (renderReplies && comment.replies && comment.replies.length > 0);
     const avatar = (<Avatar member={comment.member} />);
 
     return (
-        <CommentLayout avatar={avatar} className={hiddenClass} hasReplies={hasReplies} memberUuid={comment.member?.uuid}>
+        <CommentLayout avatar={avatar} className={hiddenClass} hasReplies={hasReplies} layoutVariant={layoutVariant} memberUuid={comment.member?.uuid} showRepliesLine={showRepliesLine}>
             <div>
                 {isInEditMode ? (
                     <>
-                        <CommentHeader className={hiddenClass} comment={comment} />
+                        <CommentHeader className={hiddenClass} comment={comment} hideConnectedReplySnippet={hideConnectedReplySnippet} />
                         <EditForm comment={comment} openForm={editForm} parent={parent} />
                     </>
                 ) : (
                     <>
-                        <CommentHeader className={hiddenClass} comment={comment} />
+                        <CommentHeader className={hiddenClass} comment={comment} hideConnectedReplySnippet={hideConnectedReplySnippet} />
                         <CommentBody className={hiddenClass} html={comment.html} isHighlighted={comment.id === commentIdToHighlight} />
                         <CommentMenu
                             comment={comment}
@@ -149,7 +176,7 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, ope
                     </>
                 )}
             </div>
-            <RepliesContainer comment={comment} />
+            {renderReplies && <RepliesContainer comment={comment} connectToParentAvatar={showRepliesLine === false && layoutVariant === 'default'} layoutVariant={layoutVariant} />}
             {displayReplyForm && <ReplyFormBox comment={comment} openForm={openForm} />}
         </CommentLayout>
     );
@@ -157,15 +184,19 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, ope
 
 type UnpublishedCommentProps = {
     comment: Comment;
+    hasThreadChildren?: boolean;
     openEditMode: () => void;
+    renderReplies?: boolean;
+    layoutVariant?: CommentLayoutVariant;
+    showRepliesLine?: boolean;
 }
-const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, openEditMode}) => {
+const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, hasThreadChildren = false, openEditMode, renderReplies = true, layoutVariant = 'default', showRepliesLine}) => {
     const {isAdmin, openCommentForms, t} = useAppContext();
 
     const avatar = (isAdmin && comment.status !== 'deleted')
         ? <Avatar member={comment.member} />
         : <BlankAvatar />;
-    const hasReplies = comment.replies && comment.replies.length > 0;
+    const hasReplies = hasThreadChildren || (renderReplies && comment.replies && comment.replies.length > 0);
 
     const notPublishedMessage = comment.status === 'hidden' ?
         t('This comment has been hidden.') :
@@ -183,7 +214,7 @@ const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, openEdi
     const showMoreButton = isAdmin && comment.status === 'hidden';
 
     return (
-        <CommentLayout avatar={avatar} hasReplies={hasReplies}>
+        <CommentLayout avatar={avatar} hasReplies={hasReplies} layoutVariant={layoutVariant} showRepliesLine={showRepliesLine}>
             <div className="mt-[-3px] flex items-start">
                 <div className="flex h-10 flex-row items-center gap-4 pb-[8px] pr-4">
                     <p className="text-md mt-[4px] font-sans leading-normal text-neutral-900/40 sm:text-lg dark:text-white/60">
@@ -196,7 +227,7 @@ const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, openEdi
                     )}
                 </div>
             </div>
-            <RepliesContainer comment={comment} />
+            {renderReplies && <RepliesContainer comment={comment} connectToParentAvatar={showRepliesLine === false && layoutVariant === 'default'} layoutVariant={layoutVariant} />}
             {displayReplyForm && <ReplyFormBox comment={comment} openForm={openForm} />}
         </CommentLayout>
     );
@@ -228,16 +259,82 @@ const EditedInfo: React.FC<{comment: Comment}> = ({comment}) => {
         </span>
     );
 };
-const RepliesContainer: React.FC<RepliesProps & {className?: string}> = ({comment, className = ''}) => {
+const RepliesContainer: React.FC<RepliesProps & {className?: string; connectToParentAvatar?: boolean; layoutVariant?: CommentLayoutVariant}> = ({comment, className = '', connectToParentAvatar = false, layoutVariant = 'default'}) => {
     const hasReplies = comment.replies && comment.replies.length > 0;
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [rootConnectorLineStyle, setRootConnectorLineStyle] = useState<React.CSSProperties | undefined>();
+
+    useEffect(() => {
+        if (!connectToParentAvatar) {
+            setRootConnectorLineStyle(undefined);
+            return;
+        }
+
+        const container = containerRef.current;
+        if (!container) {
+            return;
+        }
+
+        const updateRootConnector = () => {
+            const rootComment = container.closest<HTMLElement>('[data-testid="comment-component"]');
+            const rootAvatarColumn = rootComment?.firstElementChild as HTMLElement | null;
+            const rootAvatar = rootAvatarColumn?.querySelector<HTMLElement>('[data-testid="avatar"], [data-testid="blank-avatar"]');
+            const firstReply = container.querySelector<HTMLElement>('[data-testid="thread-primary-connector"]');
+            const firstReplyAvatar = firstReply?.querySelector<HTMLElement>('[data-testid="avatar"], [data-testid="blank-avatar"]');
+
+            if (!rootAvatar || !firstReplyAvatar) {
+                setRootConnectorLineStyle(undefined);
+                return;
+            }
+
+            const containerRect = container.getBoundingClientRect();
+            const rootAvatarRect = rootAvatar.getBoundingClientRect();
+            const firstReplyAvatarRect = firstReplyAvatar.getBoundingClientRect();
+            const top = rootAvatarRect.bottom - containerRect.top;
+            const height = firstReplyAvatarRect.top - rootAvatarRect.bottom;
+
+            if (height <= 0) {
+                setRootConnectorLineStyle(undefined);
+                return;
+            }
+
+            setRootConnectorLineStyle({
+                height: `${Math.round(height)}px`,
+                top: `${Math.round(top)}px`
+            });
+        };
+
+        updateRootConnector();
+
+        const frame = window.requestAnimationFrame(updateRootConnector);
+        const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateRootConnector);
+        resizeObserver?.observe(container);
+
+        const rootComment = container.closest<HTMLElement>('[data-testid="comment-component"]');
+        if (rootComment) {
+            resizeObserver?.observe(rootComment);
+        }
+
+        window.addEventListener('resize', updateRootConnector);
+
+        return () => {
+            window.cancelAnimationFrame(frame);
+            resizeObserver?.disconnect();
+            window.removeEventListener('resize', updateRootConnector);
+        };
+    }, [comment.id, comment.replies.length, connectToParentAvatar]);
 
     if (!hasReplies) {
         return null;
     }
 
+    const spacingClassName = layoutVariant === 'compact-thread'
+        ? 'mb-2 mt-5 sm:mb-1 sm:mt-6'
+        : '-ml-11 mb-4 mt-7 sm:mb-0 sm:mt-8';
+
     return (
-        <div className={`-ml-2 mb-4 mt-7 sm:mb-0 sm:mt-8 ${className}`}>
-            <Replies comment={comment} />
+        <div ref={containerRef} className={`${spacingClassName} ${className}`}>
+            <Replies comment={comment} rootConnectorLineStyle={rootConnectorLineStyle} />
         </div>
     );
 };
@@ -295,13 +392,15 @@ export const RepliedToSnippet: React.FC<{comment: Comment}> = ({comment}) => {
 type CommentHeaderProps = {
     comment: Comment;
     className?: string;
+    hideConnectedReplySnippet?: boolean;
 }
 
-const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = ''}) => {
+const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = '', hideConnectedReplySnippet = false}) => {
     const {member, t, pageUrl} = useAppContext();
     const createdAtRelative = useRelativeTime(comment.created_at);
     const memberExpertise = member && comment.member && comment.member.uuid === member.uuid ? member.expertise : comment?.member?.expertise;
     const isReplyToReply = comment.in_reply_to_id && comment.in_reply_to_snippet;
+    const showReplyToSnippet = isReplyToReply && !hideConnectedReplySnippet;
 
     const timestampElement = (
         <a
@@ -316,7 +415,7 @@ const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = ''}) 
 
     return (
         <>
-            <div className={`mt-0.5 flex flex-wrap items-start sm:flex-row ${memberExpertise ? 'flex-col' : 'flex-row'} ${isReplyToReply ? 'mb-0.5' : 'mb-2'} ${className}`}>
+            <div className={`mt-0.5 flex flex-wrap items-start sm:flex-row ${memberExpertise ? 'flex-col' : 'flex-row'} ${showReplyToSnippet ? 'mb-0.5' : 'mb-2'} ${className}`}>
                 <AuthorName comment={comment} />
                 <div className="flex items-baseline pr-4 font-sans text-base leading-snug text-neutral-900/50 sm:text-sm dark:text-white/60">
                     <span>
@@ -326,7 +425,7 @@ const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = ''}) 
                     </span>
                 </div>
             </div>
-            {(isReplyToReply &&
+            {(showReplyToSnippet &&
                 <div className="mb-2 line-clamp-1 font-sans text-base leading-snug text-neutral-900/50 sm:text-sm dark:text-white/60">
                     <span>{t('Replied to')}</span>:&nbsp;<RepliedToSnippet comment={comment} />
                 </div>
@@ -433,15 +532,23 @@ type CommentLayoutProps = {
     hasReplies: boolean;
     className?: string;
     memberUuid?: string;
+    layoutVariant?: CommentLayoutVariant;
+    showRepliesLine?: boolean;
 }
-const CommentLayout: React.FC<CommentLayoutProps> = ({children, avatar, hasReplies, className = '', memberUuid = ''}) => {
+const CommentLayout: React.FC<CommentLayoutProps> = ({children, avatar, hasReplies, className = '', memberUuid = '', layoutVariant = 'default', showRepliesLine}) => {
+    const compactThread = layoutVariant === 'compact-thread';
+    const bottomMarginClassName = hasReplies ? 'mb-0' : compactThread ? 'mb-6' : 'mb-7';
+    const avatarColumnClassName = compactThread ? 'mr-2 flex flex-col items-center justify-start sm:mr-2.5' : 'mr-2 flex flex-col items-center justify-start sm:mr-3';
+    const avatarSpacingClassName = 'flex-0';
+    const displayRepliesLine = showRepliesLine ?? hasReplies;
+
     return (
-        <div className={`flex w-full flex-row ${hasReplies === true ? 'mb-0' : 'mb-7'}`} data-member-uuid={memberUuid} data-testid="comment-component">
-            <div className="mr-2 flex flex-col items-center justify-start sm:mr-3">
-                <div className={`flex-0 mb-3 sm:mb-4 ${className}`}>
+        <div className={`flex w-full flex-row ${bottomMarginClassName}`} data-member-uuid={memberUuid} data-testid="comment-component">
+            <div className={avatarColumnClassName}>
+                <div className={`${avatarSpacingClassName} ${className}`}>
                     {avatar}
                 </div>
-                <RepliesLine hasReplies={hasReplies} />
+                <RepliesLine hasReplies={displayRepliesLine} />
             </div>
             <div className="grow">
                 {children}

--- a/apps/comments-ui/src/components/content/content.tsx
+++ b/apps/comments-ui/src/components/content/content.tsx
@@ -4,11 +4,11 @@ import CommentingDisabledBox from './commenting-disabled-box';
 import ContentTitle from './content-title';
 import MainForm from './forms/main-form';
 import Pagination from './pagination';
+import {Fragment, useCallback, useEffect, useRef} from 'react';
 import {ROOT_DIV_ID} from '../../utils/constants';
 import {SortingForm} from './forms/sorting-form';
 import {parseCommentIdFromHash, scrollToElement} from '../../utils/helpers';
 import {useAppContext, useLabs} from '../../app-context';
-import {useCallback, useEffect, useRef} from 'react';
 
 /**
  * Find the iframe element that contains the current window, if any.
@@ -174,7 +174,14 @@ const Content = () => {
     const showDisabledBox = !canComment && isCommentingDisabled;
     const showCtaBox = !canComment && !isCommentingDisabled;
 
-    const commentsComponents = comments.map(comment => <Comment key={comment.id} comment={comment} />);
+    const commentsComponents = comments.map((comment, index) => (
+        <Fragment key={comment.id}>
+            <Comment comment={comment} showRepliesLine={false} />
+            {index < comments.length - 1 && (
+                <hr className="mb-7 mt-8 border-0 border-t border-neutral-900/10 dark:border-white/10" data-testid="top-level-comment-separator" />
+            )}
+        </Fragment>
+    ));
 
     return (
         <>

--- a/apps/comments-ui/src/components/content/replies.tsx
+++ b/apps/comments-ui/src/components/content/replies.tsx
@@ -1,33 +1,208 @@
-import CommentComponent from './comment';
+import CommentComponent, {CommentLayoutVariant} from './comment';
 import RepliesPagination from './replies-pagination';
+import {type CSSProperties, Fragment, useEffect, useMemo, useRef, useState} from 'react';
+import {ReactComponent as ChevronIcon} from '../../images/icons/chevron-down.svg';
 import {Comment, useAppContext} from '../../app-context';
-import {useRef, useState} from 'react';
+import {CommentThreadNode, buildCommentThreadTree} from '../../utils/comment-thread';
+import {formatNumber} from '../../utils/helpers';
 
 const INITIAL_REPLIES_SHOWN = 3;
 
 export type RepliesProps = {
-    comment: Comment
+    comment: Comment;
+    rootConnectorLineStyle?: CSSProperties;
 };
-const Replies: React.FC<RepliesProps> = ({comment}) => {
+
+type ThreadedReplyProps = {
+    node: CommentThreadNode;
+    rootComment: Comment;
+    layoutVariant: CommentLayoutVariant;
+    showBranchStub: boolean;
+};
+
+const ThreadedReply: React.FC<ThreadedReplyProps> = ({node, rootComment, layoutVariant, showBranchStub}) => {
+    const showRepliesLine = node.children.length > 0;
+    const branchLineClassName = 'absolute -left-3 top-4 h-px w-2.5 rounded bg-neutral-900/15 dark:bg-white/20 sm:-left-4 sm:w-3';
+
+    return (
+        <div
+            className="relative"
+            data-testid={`thread-${showBranchStub ? 'branch' : 'primary'}-connector`}
+            data-thread-depth={node.depth}
+            data-thread-parent-id={node.parentId}
+        >
+            {showBranchStub && (
+                <div
+                    className={branchLineClassName}
+                    data-testid="thread-branch-line"
+                />
+            )}
+            <CommentComponent
+                comment={node.comment}
+                hasThreadChildren={node.children.length > 0}
+                hideConnectedReplySnippet={node.parentId !== rootComment.id}
+                layoutVariant={layoutVariant}
+                parent={rootComment}
+                renderReplies={false}
+                showRepliesLine={showRepliesLine}
+            />
+        </div>
+    );
+};
+
+type BranchToggleButtonProps = {
+    count: number;
+    expanded: boolean;
+    onToggle: () => void;
+};
+
+const BranchToggleButton: React.FC<BranchToggleButtonProps> = ({count, expanded, onToggle}) => {
+    const {t} = useAppContext();
+    const label = expanded
+        ? t('Hide')
+        : count === 1
+            ? t('1 other reply')
+            : t('{amount} other replies', {amount: formatNumber(count)});
+
+    return (
+        <button
+            aria-expanded={expanded}
+            className="inline-flex max-w-full items-center gap-2 rounded-full border border-neutral-900/10 bg-transparent px-3 py-1 text-left font-sans text-sm font-medium leading-snug text-neutral-500 transition-colors hover:border-neutral-900/20 hover:text-neutral-800 dark:border-white/15 dark:text-neutral-300 dark:hover:border-white/25 dark:hover:text-white"
+            data-testid="thread-branch-toggle"
+            type="button"
+            onClick={onToggle}
+        >
+            <ChevronIcon className={`size-3 shrink-0 transition-transform ${expanded ? '' : '-rotate-90'}`} />
+            <span className="truncate">{label}</span>
+        </button>
+    );
+};
+
+type HiddenThreadGroupProps = {
+    anchorNode: CommentThreadNode;
+    nodes: CommentThreadNode[];
+    expandedNodes: CommentThreadNode[];
+    onCollapse: (branchIds: string[]) => void;
+    onExpand: (branchIds: string[]) => void;
+    renderNode: (node: CommentThreadNode, options: RenderNodeOptions) => React.ReactNode;
+    showMainlineContinuation: boolean;
+};
+
+const HiddenThreadGroup: React.FC<HiddenThreadGroupProps> = ({anchorNode, nodes, expandedNodes, onCollapse, onExpand, renderNode, showMainlineContinuation}) => {
+    const branchIds = nodes.map(node => node.comment.id);
+    const expanded = expandedNodes.length > 0;
+    const toggleBranches = () => {
+        if (expanded) {
+            onCollapse(branchIds);
+        } else {
+            onExpand(branchIds);
+        }
+    };
+
+    return (
+        <div
+            className="relative mb-5 mt-1"
+            data-testid="thread-hidden-group"
+            data-thread-depth={anchorNode.depth + 1}
+            data-thread-parent-id={anchorNode.comment.id}
+        >
+            {showMainlineContinuation && (
+                <div
+                    className="absolute -top-5 bottom-[-0.75rem] left-4 w-px rounded bg-neutral-900/15 dark:bg-white/20"
+                    data-testid="thread-mainline-continuation"
+                />
+            )}
+            <div
+                className="absolute left-4 top-4 h-px w-9 rounded bg-neutral-900/15 dark:bg-white/20"
+                data-testid="thread-branch-line"
+            />
+            {expandedNodes.length > 0 && (
+                <div
+                    className="absolute bottom-8 left-12 top-4 w-px rounded bg-gradient-to-b from-neutral-900/15 from-80% to-transparent dark:from-white/20 dark:from-80%"
+                    data-testid="thread-hidden-group-line"
+                />
+            )}
+            <div className="relative z-[1] ml-[52px]">
+                <BranchToggleButton count={nodes.length} expanded={expanded} onToggle={toggleBranches} />
+            </div>
+            {expanded && (
+                <div className="ml-8 mt-4">
+                    {expandedNodes.map(node => renderNode(node, {
+                        collapseSideBranches: false,
+                        showBranchStub: false
+                    }))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+function collectExpandedBranchIds(rootNode: CommentThreadNode, targetId: string): Set<string> {
+    const expandedIds = new Set<string>();
+
+    const visit = (node: CommentThreadNode) => {
+        for (const [index, child] of node.children.entries()) {
+            if (child.comment.id === targetId || visit(child)) {
+                if (index > 0) {
+                    expandedIds.add(child.comment.id);
+                }
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    visit(rootNode);
+
+    return expandedIds;
+}
+
+function getVisibleReplyCount(nodes: CommentThreadNode[]) {
+    return nodes.reduce((total, node) => total + 1 + node.descendantCount, 0);
+}
+
+type RenderNodeOptions = {
+    collapseSideBranches?: boolean;
+    showBranchStub: boolean;
+};
+
+const Replies: React.FC<RepliesProps> = ({comment, rootConnectorLineStyle}) => {
     const {dispatchAction, commentIdToScrollTo} = useAppContext();
     const initialReplyIds = useRef(new Set(comment.replies.map(reply => reply.id)));
+    const threadRoot = useMemo(() => buildCommentThreadTree(comment), [comment]);
 
     const [showAll, setShowAll] = useState(() => {
         return !!commentIdToScrollTo
             && comment.replies.slice(INITIAL_REPLIES_SHOWN).some(reply => reply.id === commentIdToScrollTo);
     });
+    const [expandedBranchIds, setExpandedBranchIds] = useState<Set<string>>(new Set());
 
     const hasNewReplies = comment.replies.some(reply => !initialReplyIds.current.has(reply.id));
     const expanded = showAll || hasNewReplies;
 
+    useEffect(() => {
+        if (!commentIdToScrollTo) {
+            return;
+        }
+
+        const nextExpandedIds = collectExpandedBranchIds(threadRoot, commentIdToScrollTo);
+        if (nextExpandedIds.size === 0) {
+            return;
+        }
+
+        setExpandedBranchIds((currentExpandedIds) => {
+            const mergedExpandedIds = new Set(currentExpandedIds);
+            nextExpandedIds.forEach(id => mergedExpandedIds.add(id));
+            return mergedExpandedIds;
+        });
+    }, [commentIdToScrollTo, threadRoot]);
+
     // The API may return fewer replies than count.replies (e.g. old API with LIMIT 3).
     // When that happens, "Show more" fetches the rest from the server first.
     const serverHasMore = comment.count.replies > comment.replies.length;
-    const visibleReplies = expanded ? comment.replies : comment.replies.slice(0, INITIAL_REPLIES_SHOWN);
-    const clientHiddenCount = comment.replies.length - visibleReplies.length;
-    const totalHiddenCount = serverHasMore
-        ? comment.count.replies - visibleReplies.length
-        : clientHiddenCount;
+    const visibleRootBranches = expanded ? threadRoot.children : threadRoot.children.slice(0, INITIAL_REPLIES_SHOWN);
+    const totalHiddenCount = Math.max(comment.count.replies - getVisibleReplyCount(visibleRootBranches), 0);
 
     const loadMore = () => {
         if (serverHasMore) {
@@ -36,9 +211,88 @@ const Replies: React.FC<RepliesProps> = ({comment}) => {
         setShowAll(true);
     };
 
+    const expandBranches = (branchIds: string[]) => {
+        setExpandedBranchIds((currentExpandedIds) => {
+            const nextExpandedIds = new Set(currentExpandedIds);
+            branchIds.forEach(id => nextExpandedIds.add(id));
+            return nextExpandedIds;
+        });
+    };
+
+    const collapseBranches = (branchIds: string[]) => {
+        setExpandedBranchIds((currentExpandedIds) => {
+            const nextExpandedIds = new Set(currentExpandedIds);
+            branchIds.forEach(id => nextExpandedIds.delete(id));
+            return nextExpandedIds;
+        });
+    };
+
+    const renderNode = (node: CommentThreadNode, options: RenderNodeOptions): React.ReactNode => {
+        const {showBranchStub} = options;
+        const collapseSideBranches = options.collapseSideBranches ?? true;
+        const isNestedBranch = showBranchStub && node.depth > 1;
+        const isCollapsedBranch = collapseSideBranches && isNestedBranch && !expandedBranchIds.has(node.comment.id);
+        const layoutVariant: CommentLayoutVariant = node.depth > 1 ? 'compact-thread' : 'default';
+        const primaryChild = node.children[0];
+        const branchChildren = node.children.slice(1);
+        const hiddenBranchChildren = branchChildren.filter(branchChild => branchChild.depth > 1);
+        const expandedHiddenBranchChildren = hiddenBranchChildren.filter(branchChild => expandedBranchIds.has(branchChild.comment.id));
+        const visibleBranchChildren = branchChildren.filter(branchChild => !hiddenBranchChildren.includes(branchChild));
+        const childOptions = {
+            collapseSideBranches
+        };
+
+        if (isCollapsedBranch) {
+            return (
+                <BranchToggleButton
+                    key={node.comment.id}
+                    count={1}
+                    expanded={false}
+                    onToggle={() => expandBranches([node.comment.id])}
+                />
+            );
+        }
+
+        const nodeContent = (
+            <>
+                <ThreadedReply layoutVariant={layoutVariant} node={node} rootComment={comment} showBranchStub={showBranchStub} />
+                {hiddenBranchChildren.length > 0 && (
+                    <HiddenThreadGroup
+                        anchorNode={node}
+                        expandedNodes={expandedHiddenBranchChildren}
+                        nodes={hiddenBranchChildren}
+                        renderNode={renderNode}
+                        showMainlineContinuation={Boolean(primaryChild || visibleBranchChildren.length > 0)}
+                        onCollapse={collapseBranches}
+                        onExpand={expandBranches}
+                    />
+                )}
+                {primaryChild ? renderNode(primaryChild, {...childOptions, showBranchStub: false}) : null}
+                {visibleBranchChildren.map(branchChild => renderNode(branchChild, {...childOptions, showBranchStub: true}))}
+            </>
+        );
+
+        return (
+            <Fragment key={node.comment.id}>
+                {nodeContent}
+            </Fragment>
+        );
+    };
+
+    const renderNodes = (nodes: CommentThreadNode[]) => {
+        return nodes.map((node, index) => renderNode(node, {showBranchStub: index > 0}));
+    };
+
     return (
-        <div>
-            {visibleReplies.map((reply => <CommentComponent key={reply.id} comment={reply} parent={comment} />))}
+        <div className="relative">
+            {visibleRootBranches.length > 0 && (
+                <div
+                    className={`absolute left-4 w-px rounded bg-neutral-900/15 dark:bg-white/20 ${rootConnectorLineStyle ? '' : '-top-6 h-6'}`}
+                    data-testid="thread-root-start-line"
+                    style={rootConnectorLineStyle}
+                />
+            )}
+            {renderNodes(visibleRootBranches)}
             {totalHiddenCount > 0 && <RepliesPagination count={totalHiddenCount} loadMore={loadMore}/>}
         </div>
     );

--- a/apps/comments-ui/src/utils/comment-thread.ts
+++ b/apps/comments-ui/src/utils/comment-thread.ts
@@ -1,0 +1,140 @@
+import {Comment} from '../app-context';
+
+export type ThreadConnectorType = 'primary' | 'branch';
+
+export type ThreadRenderItem = {
+    comment: Comment;
+    parentId: string;
+    depth: number;
+    isPrimary: boolean;
+    isBranch: boolean;
+    connector: {
+        type: ThreadConnectorType;
+        continues: boolean;
+    };
+};
+
+export type CommentThreadNode = {
+    comment: Comment;
+    parentId: string;
+    children: CommentThreadNode[];
+    depth: number;
+    descendantCount: number;
+};
+
+function getLikes(comment: Comment) {
+    return comment.count?.likes || 0;
+}
+
+function getCreatedAt(comment: Comment) {
+    const time = new Date(comment.created_at).getTime();
+    return Number.isNaN(time) ? 0 : time;
+}
+
+function compareNodes(a: CommentThreadNode, b: CommentThreadNode) {
+    const likesDifference = getLikes(b.comment) - getLikes(a.comment);
+    if (likesDifference !== 0) {
+        return likesDifference;
+    }
+
+    const descendantDifference = b.descendantCount - a.descendantCount;
+    if (descendantDifference !== 0) {
+        return descendantDifference;
+    }
+
+    const createdAtDifference = getCreatedAt(a.comment) - getCreatedAt(b.comment);
+    if (createdAtDifference !== 0) {
+        return createdAtDifference;
+    }
+
+    return a.comment.id.localeCompare(b.comment.id);
+}
+
+function updateDescendantCounts(node: CommentThreadNode): number {
+    node.descendantCount = node.children.reduce((total, child) => {
+        return total + 1 + updateDescendantCounts(child);
+    }, 0);
+
+    return node.descendantCount;
+}
+
+function sortChildren(node: CommentThreadNode) {
+    node.children.sort(compareNodes);
+    node.children.forEach((child) => {
+        child.depth = node.depth + 1;
+        sortChildren(child);
+    });
+}
+
+function canAttachToReply(node: CommentThreadNode | undefined) {
+    return node?.comment.status === 'published';
+}
+
+function appendRenderItems(node: CommentThreadNode, parentIsPrimary: boolean, renderItems: ThreadRenderItem[]) {
+    node.children.forEach((child, index) => {
+        const isPrimary = parentIsPrimary && index === 0;
+
+        renderItems.push({
+            comment: child.comment,
+            parentId: child.parentId,
+            depth: child.depth,
+            isPrimary,
+            isBranch: !isPrimary,
+            connector: {
+                type: isPrimary ? 'primary' : 'branch',
+                continues: child.children.length > 0
+            }
+        });
+
+        appendRenderItems(child, isPrimary, renderItems);
+    });
+}
+
+export function buildCommentThreadTree(rootComment: Comment): CommentThreadNode {
+    const rootNode: CommentThreadNode = {
+        comment: rootComment,
+        parentId: rootComment.id,
+        children: [],
+        depth: 0,
+        descendantCount: 0
+    };
+    const nodesById = new Map<string, CommentThreadNode>();
+
+    (rootComment.replies || []).forEach((reply) => {
+        nodesById.set(reply.id, {
+            comment: reply,
+            parentId: rootComment.id,
+            children: [],
+            depth: 1,
+            descendantCount: 0
+        });
+    });
+
+    nodesById.forEach((node) => {
+        const parentNode = node.comment.in_reply_to_id
+            ? nodesById.get(node.comment.in_reply_to_id)
+            : undefined;
+
+        if (canAttachToReply(parentNode)) {
+            node.parentId = parentNode!.comment.id;
+            parentNode!.children.push(node);
+        } else {
+            node.parentId = rootComment.id;
+            rootNode.children.push(node);
+        }
+    });
+
+    updateDescendantCounts(rootNode);
+    sortChildren(rootNode);
+
+    return rootNode;
+}
+
+export function buildCommentThread(rootComment: Comment): ThreadRenderItem[] {
+    const rootNode = buildCommentThreadTree(rootComment);
+
+    const renderItems: ThreadRenderItem[] = [];
+    appendRenderItems(rootNode, true, renderItems);
+
+    return renderItems;
+}

--- a/apps/comments-ui/src/utils/reply-hydration.ts
+++ b/apps/comments-ui/src/utils/reply-hydration.ts
@@ -1,0 +1,68 @@
+import {Comment} from '../app-context';
+
+type PublicRepliesApi = {
+    comments: {
+        replies: ({commentId, limit}: {commentId: string; limit: 'all'}) => Promise<{comments: Comment[]}>;
+    };
+};
+
+type AdminRepliesApi = {
+    replies: ({commentId, afterReplyId, limit, memberUuid}: {commentId: string; afterReplyId?: string; limit?: number; memberUuid?: string}) => Promise<{comments: Comment[]; meta?: {pagination?: {next?: number | false | null}}}>;
+};
+
+type HydrateVisibleRepliesOptions = {
+    comments: Comment[];
+    api?: PublicRepliesApi;
+    adminApi?: AdminRepliesApi | null;
+    memberUuid?: string;
+};
+
+async function fetchAdminReplies(adminApi: AdminRepliesApi, commentId: string, memberUuid?: string) {
+    const replies: Comment[] = [];
+    let afterReplyId: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+        const data = await adminApi.replies({
+            commentId,
+            afterReplyId,
+            limit: 100,
+            memberUuid
+        });
+
+        replies.push(...data.comments);
+        hasMore = !!data.meta?.pagination?.next && data.comments.length > 0;
+
+        if (data.comments.length > 0) {
+            afterReplyId = data.comments[data.comments.length - 1]?.id;
+        }
+    }
+
+    return replies;
+}
+
+export async function hydrateVisibleReplies({comments, api, adminApi, memberUuid}: HydrateVisibleRepliesOptions) {
+    return Promise.all(comments.map(async (comment) => {
+        if (!comment.count?.replies) {
+            return comment;
+        }
+
+        try {
+            const replies = adminApi
+                ? await fetchAdminReplies(adminApi, comment.id, memberUuid)
+                : (await api!.comments.replies({commentId: comment.id, limit: 'all'})).comments;
+
+            return {
+                ...comment,
+                replies,
+                count: {
+                    ...comment.count,
+                    replies: replies.length
+                }
+            };
+        } catch (error) {
+            console.warn('[Comments] Failed to hydrate replies:', error); // eslint-disable-line no-console
+            return comment;
+        }
+    }));
+}


### PR DESCRIPTION
## Summary

This is a proof-of-concept for conversation-preserving rendering in `comments-ui`.

- Keeps top-level comment sorting intact while rendering replies as a reply graph.
- Hydrates replies for visible top-level comments so hidden branches can participate in branch selection.
- Promotes a primary branch and renders side branches behind compact inline toggles.
- Removes the confusing outer top-level rail, adds top-level separators, and adjusts connector geometry for root-to-first-reply and expanded branch islands.

## Notes

This intentionally avoids backend/API changes. Network efficiency and production-grade ranking can be revisited after the UI direction is evaluated.

Test file changes from the prototype iteration were left out of this commit because this pass is focused on the proof of concept UI behavior.

## Validation

- `pnpm --filter @tryghost/comments-ui build`
- Browser checked `http://localhost:2368/tangle-comments/`
- Browser checked `http://localhost:2368/nested-comments/`

Unit/e2e suites were not run for this prototype pass.