### PR TITLE
Defaulted release script to next patch RC

### DIFF
--- a/ghost/core/bin/create-migration.js
+++ b/ghost/core/bin/create-migration.js
@@ -3,6 +3,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const {execSync} = require('child_process');
 const semver = require('semver');
 
 const MIGRATION_TEMPLATE = `const logging = require('@tryghost/logging');
@@ -21,40 +22,62 @@ module.exports = /**/;
 
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
-/**
- * Validates that a slug is kebab-case (lowercase alphanumeric with single hyphens).
- */
 function isValidSlug(slug) {
     return typeof slug === 'string' && SLUG_PATTERN.test(slug);
 }
 
 /**
- * Returns the migration version folder name for the given package version.
- *
- * semver.inc(v, 'minor') handles both cases:
- *   - Stable 6.18.0 → 6.19.0 (increments minor)
- *   - Prerelease 6.19.0-rc.0 → 6.19.0 (strips prerelease, keeps minor)
- *
- * Key invariant: 6.18.0 and 6.19.0-rc.0 both produce folder "6.19".
+ * Resolves the most recent stable tag (e.g. v6.34.0) from git.
+ * Excludes prerelease tags so the answer reflects what's actually shipped.
  */
-function getNextMigrationVersion(version) {
-    const next = semver.inc(version, 'minor');
-    if (!next) {
-        throw new Error(`Invalid version: ${version}`);
-    }
-    return `${semver.major(next)}.${semver.minor(next)}`;
+function readLastPublishedVersion(cwd) {
+    const tag = execSync(
+        `git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude 'v*-*'`,
+        {cwd, encoding: 'utf8'}
+    ).trim();
+    return tag.replace(/^v/, '');
+}
+
+function minorOf(version) {
+    return `${semver.major(version)}.${semver.minor(version)}`;
 }
 
 /**
- * Creates a migration file and optionally bumps package versions to RC.
+ * Returns the migration version folder for a new migration.
+ *
+ * The folder is always the minor *after* the last published version. If the
+ * package version is already promoted to that minor (or beyond — second
+ * migration of a cycle), we stay there; otherwise the folder is the next
+ * minor and the package version needs to be promoted to match.
+ *
+ * Examples (last published = 6.34.0):
+ *   package 6.34.1-rc.0 → folder 6.35   (needs promote)
+ *   package 6.35.0-rc.0 → folder 6.35   (already promoted)
+ *   package 6.34.0      → folder 6.35   (needs promote, e.g. fresh checkout)
+ */
+function getTargetMigrationFolder(packageVersion, lastPublishedVersion) {
+    const packageMinor = minorOf(packageVersion);
+    const nextAfterPublished = minorOf(semver.inc(lastPublishedVersion, 'minor'));
+
+    return semver.gte(`${packageMinor}.0`, `${nextAfterPublished}.0`)
+        ? packageMinor
+        : nextAfterPublished;
+}
+
+/**
+ * Creates a migration file and promotes package.json to the target minor RC
+ * if needed. Promotion is required because knex-migrator filters out folders
+ * whose version > package.json's major.minor — without it, the new migration
+ * would be silently skipped on dev installs.
  *
  * @param {object} options
  * @param {string} options.slug - The migration name in kebab-case
  * @param {string} options.coreDir - Path to ghost/core directory
  * @param {Date}   [options.date] - Override the timestamp (for testing)
+ * @param {string} [options.lastPublishedVersion] - Override the last published version (for testing)
  * @returns {{migrationPath: string, rcVersion: string|null}}
  */
-function createMigration({slug, coreDir, date}) {
+function createMigration({slug, coreDir, date, lastPublishedVersion}) {
     if (!isValidSlug(slug)) {
         throw new Error(`Invalid slug: "${slug}". Use kebab-case (e.g. add-column-to-posts)`);
     }
@@ -65,8 +88,9 @@ function createMigration({slug, coreDir, date}) {
     const corePackage = JSON.parse(fs.readFileSync(corePackagePath, 'utf8'));
     const currentVersion = corePackage.version;
 
-    const nextVersion = getNextMigrationVersion(currentVersion);
-    const versionDir = path.join(migrationsDir, nextVersion);
+    const resolvedLastPublished = lastPublishedVersion || readLastPublishedVersion(coreDir);
+    const targetFolder = getTargetMigrationFolder(currentVersion, resolvedLastPublished);
+    const versionDir = path.join(migrationsDir, targetFolder);
 
     const timestamp = (date || new Date()).toISOString().slice(0, 19).replace('T', '-').replaceAll(':', '-');
     const filename = `${timestamp}-${slug}.js`;
@@ -82,10 +106,9 @@ function createMigration({slug, coreDir, date}) {
         throw err;
     }
 
-    // Auto-bump to RC if this is a stable version
     let rcVersion = null;
-    if (!semver.prerelease(currentVersion)) {
-        rcVersion = semver.inc(currentVersion, 'preminor', 'rc');
+    if (minorOf(currentVersion) !== targetFolder) {
+        rcVersion = `${targetFolder}.0-rc.0`;
 
         corePackage.version = rcVersion;
         fs.writeFileSync(corePackagePath, JSON.stringify(corePackage, null, 2) + '\n');
@@ -101,7 +124,6 @@ function createMigration({slug, coreDir, date}) {
     return {migrationPath, rcVersion};
 }
 
-// CLI entry point
 if (require.main === module) {
     const slug = process.argv[2];
 
@@ -125,4 +147,4 @@ if (require.main === module) {
     }
 }
 
-module.exports = {isValidSlug, getNextMigrationVersion, createMigration};
+module.exports = {isValidSlug, getTargetMigrationFolder, createMigration};

--- a/ghost/core/test/unit/bin/create-migration.test.js
+++ b/ghost/core/test/unit/bin/create-migration.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
-const {isValidSlug, getNextMigrationVersion, createMigration} = require('../../../bin/create-migration');
+const {isValidSlug, getTargetMigrationFolder, createMigration} = require('../../../bin/create-migration');
 
 describe('bin/create-migration', function () {
     describe('isValidSlug', function () {
@@ -31,28 +31,25 @@ describe('bin/create-migration', function () {
         });
     });
 
-    describe('getNextMigrationVersion', function () {
-        it('increments minor for stable versions', function () {
-            assert.equal(getNextMigrationVersion('6.18.0'), '6.19');
-            assert.equal(getNextMigrationVersion('5.75.0'), '5.76');
-            assert.equal(getNextMigrationVersion('6.0.0'), '6.1');
-            assert.equal(getNextMigrationVersion('7.12.3'), '7.13');
+    describe('getTargetMigrationFolder', function () {
+        it('targets the minor after the last published version when package is on the patch RC', function () {
+            assert.equal(getTargetMigrationFolder('6.34.1-rc.0', '6.34.0'), '6.35');
+            assert.equal(getTargetMigrationFolder('6.34.2-rc.0', '6.34.0'), '6.35');
         });
 
-        it('uses current minor for prerelease versions', function () {
-            assert.equal(getNextMigrationVersion('6.19.0-rc.0'), '6.19');
-            assert.equal(getNextMigrationVersion('6.19.0-rc.1'), '6.19');
-            assert.equal(getNextMigrationVersion('6.0.0-alpha.0'), '6.0');
-            assert.equal(getNextMigrationVersion('5.75.0-beta.1'), '5.75');
+        it('stays on the current minor when package is already promoted to the next minor RC', function () {
+            assert.equal(getTargetMigrationFolder('6.35.0-rc.0', '6.34.0'), '6.35');
+            assert.equal(getTargetMigrationFolder('6.35.0-rc.3', '6.34.0'), '6.35');
         });
 
-        it('stable and its RC target the same folder', function () {
-            assert.equal(getNextMigrationVersion('6.18.0'), '6.19');
-            assert.equal(getNextMigrationVersion('6.19.0-rc.0'), '6.19');
+        it('targets the next minor when package is sitting on a stable version', function () {
+            assert.equal(getTargetMigrationFolder('6.34.0', '6.34.0'), '6.35');
+            assert.equal(getTargetMigrationFolder('5.75.0', '5.75.0'), '5.76');
         });
 
-        it('throws for invalid versions', function () {
-            assert.throws(() => getNextMigrationVersion('not-a-version'), /Invalid version/);
+        it('does not double-bump when package is further ahead than next-of-published', function () {
+            // Hypothetical recovery state — package was manually promoted ahead
+            assert.equal(getTargetMigrationFolder('6.36.0-rc.0', '6.34.0'), '6.36');
         });
     });
 
@@ -61,8 +58,6 @@ describe('bin/create-migration', function () {
         let coreDir;
 
         beforeEach(function () {
-            // Create a parent dir that mirrors the monorepo layout (core/ + admin/)
-            // so path.resolve(coreDir, '..', 'admin') stays inside the sandbox
             tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-migration-test-'));
             coreDir = path.join(tmpDir, 'core');
 
@@ -84,27 +79,29 @@ describe('bin/create-migration', function () {
             return JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).version;
         }
 
-        it('creates a migration file in the correct version folder', function () {
-            writePackageJson(coreDir, '6.18.0');
+        it('creates a migration file in the next-minor folder when on a patch RC', function () {
+            writePackageJson(coreDir, '6.34.1-rc.0');
 
             const result = createMigration({
                 slug: 'add-column',
                 coreDir,
-                date: new Date('2026-02-23T10:30:00Z')
+                date: new Date('2026-02-23T10:30:00Z'),
+                lastPublishedVersion: '6.34.0'
             });
 
             assert.ok(fs.existsSync(result.migrationPath));
-            assert.ok(result.migrationPath.includes(path.join('versions', '6.19')));
+            assert.ok(result.migrationPath.includes(path.join('versions', '6.35')));
             assert.ok(result.migrationPath.endsWith('2026-02-23-10-30-00-add-column.js'));
         });
 
         it('writes the migration template', function () {
-            writePackageJson(coreDir, '6.18.0');
+            writePackageJson(coreDir, '6.34.1-rc.0');
 
             const {migrationPath} = createMigration({
                 slug: 'test-migration',
                 coreDir,
-                date: new Date('2026-01-01T00:00:00Z')
+                date: new Date('2026-01-01T00:00:00Z'),
+                lastPublishedVersion: '6.34.0'
             });
 
             const content = fs.readFileSync(migrationPath, 'utf8');
@@ -115,88 +112,107 @@ describe('bin/create-migration', function () {
         });
 
         it('creates the version directory if it does not exist', function () {
-            writePackageJson(coreDir, '6.18.0');
+            writePackageJson(coreDir, '6.34.1-rc.0');
 
-            const versionDir = path.join(coreDir, 'core', 'server', 'data', 'migrations', 'versions', '6.19');
+            const versionDir = path.join(coreDir, 'core', 'server', 'data', 'migrations', 'versions', '6.35');
             assert.ok(!fs.existsSync(versionDir));
 
             createMigration({
                 slug: 'new-folder',
                 coreDir,
-                date: new Date('2026-01-01T00:00:00Z')
+                date: new Date('2026-01-01T00:00:00Z'),
+                lastPublishedVersion: '6.34.0'
             });
 
             assert.ok(fs.existsSync(versionDir));
         });
 
-        it('bumps to RC when current version is stable', function () {
-            writePackageJson(coreDir, '6.18.0');
+        it('promotes package.json from patch RC to next-minor RC on first migration of the cycle', function () {
+            writePackageJson(coreDir, '6.34.1-rc.0');
 
             const {rcVersion} = createMigration({
                 slug: 'first-migration',
                 coreDir,
-                date: new Date('2026-01-01T00:00:00Z')
+                date: new Date('2026-01-01T00:00:00Z'),
+                lastPublishedVersion: '6.34.0'
             });
 
-            assert.equal(rcVersion, '6.19.0-rc.0');
-            assert.equal(readVersion(coreDir), '6.19.0-rc.0');
+            assert.equal(rcVersion, '6.35.0-rc.0');
+            assert.equal(readVersion(coreDir), '6.35.0-rc.0');
         });
 
-        it('bumps admin package.json when it exists', function () {
-            writePackageJson(coreDir, '6.18.0');
+        it('promotes from a stable version when no RC exists yet', function () {
+            writePackageJson(coreDir, '6.34.0');
+
+            const {rcVersion} = createMigration({
+                slug: 'first-migration',
+                coreDir,
+                date: new Date('2026-01-01T00:00:00Z'),
+                lastPublishedVersion: '6.34.0'
+            });
+
+            assert.equal(rcVersion, '6.35.0-rc.0');
+            assert.equal(readVersion(coreDir), '6.35.0-rc.0');
+        });
+
+        it('promotes admin package.json alongside core', function () {
+            writePackageJson(coreDir, '6.34.1-rc.0');
 
             const adminDir = path.join(tmpDir, 'admin');
             fs.mkdirSync(adminDir, {recursive: true});
-            writePackageJson(adminDir, '6.18.0');
+            writePackageJson(adminDir, '6.34.1-rc.0');
 
             createMigration({
                 slug: 'with-admin',
                 coreDir,
-                date: new Date('2026-01-01T00:00:00Z')
+                date: new Date('2026-01-01T00:00:00Z'),
+                lastPublishedVersion: '6.34.0'
             });
 
-            assert.equal(readVersion(adminDir), '6.19.0-rc.0');
+            assert.equal(readVersion(adminDir), '6.35.0-rc.0');
         });
 
-        it('does not bump when already a prerelease', function () {
-            writePackageJson(coreDir, '6.19.0-rc.0');
+        it('does not bump when already on the target minor RC', function () {
+            writePackageJson(coreDir, '6.35.0-rc.0');
 
             const {rcVersion} = createMigration({
                 slug: 'second-migration',
                 coreDir,
-                date: new Date('2026-01-01T00:00:00Z')
+                date: new Date('2026-01-01T00:00:00Z'),
+                lastPublishedVersion: '6.34.0'
             });
 
             assert.equal(rcVersion, null);
-            assert.equal(readVersion(coreDir), '6.19.0-rc.0');
+            assert.equal(readVersion(coreDir), '6.35.0-rc.0');
         });
 
-        it('places RC migrations in the same folder as stable', function () {
-            writePackageJson(coreDir, '6.19.0-rc.0');
+        it('places subsequent migrations in the same folder as the first', function () {
+            writePackageJson(coreDir, '6.35.0-rc.0');
 
             const result = createMigration({
                 slug: 'rc-migration',
                 coreDir,
-                date: new Date('2026-01-01T00:00:00Z')
+                date: new Date('2026-01-01T00:00:00Z'),
+                lastPublishedVersion: '6.34.0'
             });
 
-            assert.ok(result.migrationPath.includes(path.join('versions', '6.19')));
+            assert.ok(result.migrationPath.includes(path.join('versions', '6.35')));
         });
 
         it('throws for invalid slug', function () {
-            writePackageJson(coreDir, '6.18.0');
+            writePackageJson(coreDir, '6.34.1-rc.0');
 
             assert.throws(
-                () => createMigration({slug: 'INVALID', coreDir}),
+                () => createMigration({slug: 'INVALID', coreDir, lastPublishedVersion: '6.34.0'}),
                 /Invalid slug/
             );
         });
 
         it('throws for missing slug', function () {
-            writePackageJson(coreDir, '6.18.0');
+            writePackageJson(coreDir, '6.34.1-rc.0');
 
             assert.throws(
-                () => createMigration({slug: undefined, coreDir}),
+                () => createMigration({slug: undefined, coreDir, lastPublishedVersion: '6.34.0'}),
                 /Invalid slug/
             );
         });

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -301,9 +301,12 @@ async function main() {
     }
 
     // 10. Advance to next RC
+    // Default to the next patch RC. If a migration lands during the cycle,
+    // ghost/core/bin/create-migration.js promotes this to the next minor RC.
+    // detectBumpType resolves the actual bump (patch vs minor) at the next release.
     logStep('Advancing to next RC');
-    const nextMinor = semver.inc(newVersion, 'minor');
-    const nextRc = `${nextMinor}-rc.0`;
+    const nextPatch = semver.inc(newVersion, 'patch');
+    const nextRc = `${nextPatch}-rc.0`;
     log(`Next RC: ${nextRc}`);
     writePkgVersion(GHOST_CORE_PKG, nextRc);
     writePkgVersion(GHOST_ADMIN_PKG, nextRc);


### PR DESCRIPTION
## Problem

Every Ghost release shipped as a minor version bump, regardless of whether the cycle actually warranted one. The release script's bump-detection logic was effectively dead code: step 10 of the release pre-bumped the working version to the next minor RC, so by the time the next release ran, the patch-vs-minor decision always resolved to minor. Quiet cycles with no migrations or breaking changes still consumed a minor version, inflating the version number and obscuring the signal that minors are supposed to carry.

## Solution

The release script now defaults the post-release bump to the next patch RC instead of the next minor RC. Most cycles stay on the patch track and ship as patches. When a migration lands during a cycle, the migration creation tool promotes the working version up to the next minor RC, so the release that includes it correctly ships as a minor. The target migration folder is now derived from the latest published git tag rather than the in-flight package.json version, which keeps the folder choice stable across the patch-to-minor promotion and avoids the chicken-and-egg problem of asking package.json where the next migration should go while package.json is the thing being promoted.