### PR TITLE
Converted more tests to use promises

### DIFF
--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -20,151 +20,149 @@ describe('Exporter', function () {
 
     assertExists(exporter);
 
-    it('exports expected table data', function (done) {
-        exporter.doExport().then(function (exportData) {
-            const tables = [
-                'actions',
-                'api_keys',
-                'automated_email_recipients',
-                'benefits',
-                'brute',
-                'collections',
-                'collections_posts',
-                'comments',
-                'comment_likes',
-                'comment_reports',
-                'custom_theme_settings',
-                'donation_payment_events',
-                'email_batches',
-                'email_design_settings',
-                'email_recipient_failures',
-                'email_recipients',
-                'email_spam_complaint_events',
-                'emails',
-                'gifts',
-                'integrations',
-                'invites',
-                'jobs',
-                'labels',
-                'members',
-                'members_cancel_events',
-                'members_click_events',
-                'members_created_events',
-                'members_email_change_events',
-                'members_feedback',
-                'members_labels',
-                'members_login_events',
-                'members_newsletters',
-                'members_paid_subscription_events',
-                'members_payment_events',
-                'members_product_events',
-                'members_products',
-                'members_status_events',
-                'members_stripe_customers',
-                'members_stripe_customers_subscriptions',
-                'members_subscribe_events',
-                'members_subscription_created_events',
-                'mentions',
-                'migrations',
-                'migrations_lock',
-                'milestones',
-                'mobiledoc_revisions',
-                'newsletters',
-                'offers',
-                'offer_redemptions',
-                'outbox',
-                'permissions',
-                'permissions_roles',
-                'permissions_users',
-                'post_revisions',
-                'posts',
-                'posts_authors',
-                'posts_meta',
-                'posts_products',
-                'posts_tags',
-                'products',
-                'products_benefits',
-                'recommendation_click_events',
-                'recommendation_subscribe_events',
-                'recommendations',
-                'redirects',
-                'roles',
-                'roles_users',
-                'sessions',
-                'settings',
-                'snippets',
-                'stripe_prices',
-                'stripe_products',
-                'subscriptions',
-                'suppressions',
-                'tags',
-                'tokens',
-                'users',
-                'webhooks',
-                'welcome_email_automated_emails',
-                'welcome_email_automation_runs',
-                'welcome_email_automations'
-            ];
+    it('exports expected table data', async function () {
+        const exportData = await exporter.doExport();
+        const tables = [
+            'actions',
+            'api_keys',
+            'automated_email_recipients',
+            'benefits',
+            'brute',
+            'collections',
+            'collections_posts',
+            'comments',
+            'comment_likes',
+            'comment_reports',
+            'custom_theme_settings',
+            'donation_payment_events',
+            'email_batches',
+            'email_design_settings',
+            'email_recipient_failures',
+            'email_recipients',
+            'email_spam_complaint_events',
+            'emails',
+            'gifts',
+            'integrations',
+            'invites',
+            'jobs',
+            'labels',
+            'members',
+            'members_cancel_events',
+            'members_click_events',
+            'members_created_events',
+            'members_email_change_events',
+            'members_feedback',
+            'members_labels',
+            'members_login_events',
+            'members_newsletters',
+            'members_paid_subscription_events',
+            'members_payment_events',
+            'members_product_events',
+            'members_products',
+            'members_status_events',
+            'members_stripe_customers',
+            'members_stripe_customers_subscriptions',
+            'members_subscribe_events',
+            'members_subscription_created_events',
+            'mentions',
+            'migrations',
+            'migrations_lock',
+            'milestones',
+            'mobiledoc_revisions',
+            'newsletters',
+            'offers',
+            'offer_redemptions',
+            'outbox',
+            'permissions',
+            'permissions_roles',
+            'permissions_users',
+            'post_revisions',
+            'posts',
+            'posts_authors',
+            'posts_meta',
+            'posts_products',
+            'posts_tags',
+            'products',
+            'products_benefits',
+            'recommendation_click_events',
+            'recommendation_subscribe_events',
+            'recommendations',
+            'redirects',
+            'roles',
+            'roles_users',
+            'sessions',
+            'settings',
+            'snippets',
+            'stripe_prices',
+            'stripe_products',
+            'subscriptions',
+            'suppressions',
+            'tags',
+            'tokens',
+            'users',
+            'webhooks',
+            'welcome_email_automated_emails',
+            'welcome_email_automation_runs',
+            'welcome_email_automations'
+        ];
 
-            assertExists(exportData);
-            assertExists(exportData.meta);
-            assertExists(exportData.data);
+        assertExists(exportData);
+        assertExists(exportData.meta);
+        assertExists(exportData.data);
 
-            // NOTE: using `Object.keys` here instead of `should.have.only.keys` assertion
-            //       because when `have.only.keys` fails there's no useful diff
-            assert.deepEqual(Object.keys(exportData.data).sort(), tables.sort());
-            assert(
-                Object.keys(exportedBodyLatest().db[0].data).every(key => (
-                    Object.hasOwnProperty.call(exportData.data, key)
-                ))
-            );
-            assert.equal(exportData.meta.version, ghostVersion.full);
+        // NOTE: using `Object.keys` here instead of `should.have.only.keys` assertion
+        //       because when `have.only.keys` fails there's no useful diff
+        assert.deepEqual(Object.keys(exportData.data).sort(), tables.sort());
+        assert(
+            Object.keys(exportedBodyLatest().db[0].data).every(key => (
+                Object.hasOwnProperty.call(exportData.data, key)
+            ))
+        );
+        assert.equal(exportData.meta.version, ghostVersion.full);
 
-            // excludes table should contain no data
-            const excludedTables = [
-                'sessions',
-                'mobiledoc_revisions',
-                'post_revisions',
-                'email_batches',
-                'email_recipient_failures',
-                'email_recipients',
-                'email_spam_complaint_events',
-                'members_cancel_events',
-                'members_payment_events',
-                'members_login_events',
-                'members_email_change_events',
-                'members_status_events',
-                'members_paid_subscription_events',
-                'members_subscribe_events',
-                'outbox',
-                'gifts'
-            ];
+        // excludes table should contain no data
+        const excludedTables = [
+            'sessions',
+            'mobiledoc_revisions',
+            'post_revisions',
+            'email_batches',
+            'email_recipient_failures',
+            'email_recipients',
+            'email_spam_complaint_events',
+            'members_cancel_events',
+            'members_payment_events',
+            'members_login_events',
+            'members_email_change_events',
+            'members_status_events',
+            'members_paid_subscription_events',
+            'members_subscribe_events',
+            'outbox',
+            'gifts'
+        ];
 
-            excludedTables.forEach((tableName) => {
-                // NOTE: why is this undefined? The key should probably not even be present
-                assert.equal(exportData.data[tableName], undefined);
-            });
+        excludedTables.forEach((tableName) => {
+            // NOTE: why is this undefined? The key should probably not even be present
+            assert.equal(exportData.data[tableName], undefined);
+        });
 
-            // excludes settings with sensitive data
-            const excludedSettings = [
-                'stripe_connect_publishable_key',
-                'stripe_connect_secret_key',
-                'stripe_connect_account_id',
-                'stripe_secret_key',
-                'stripe_publishable_key',
-                'members_stripe_webhook_id',
-                'members_stripe_webhook_secret'
-            ];
+        // excludes settings with sensitive data
+        const excludedSettings = [
+            'stripe_connect_publishable_key',
+            'stripe_connect_secret_key',
+            'stripe_connect_account_id',
+            'stripe_secret_key',
+            'stripe_publishable_key',
+            'members_stripe_webhook_id',
+            'members_stripe_webhook_secret'
+        ];
 
-            excludedSettings.forEach((settingKey) => {
-                assert.equal(_.find(exportData.data.settings, {key: settingKey}), undefined);
-            });
+        excludedSettings.forEach((settingKey) => {
+            assert.equal(_.find(exportData.data.settings, {key: settingKey}), undefined);
+        });
 
-            assert.equal(_.find(exportData.data.settings, {key: 'permalinks'}), undefined);
+        assert.equal(_.find(exportData.data.settings, {key: 'permalinks'}), undefined);
 
-            // should not export sqlite data
-            assert.equal(exportData.data.sqlite_sequence, undefined);
-            done();
-        }).catch(done);
+        // should not export sqlite data
+        assert.equal(exportData.data.sqlite_sequence, undefined);
     });
 });

--- a/ghost/core/test/legacy/api/admin/images.test.js
+++ b/ghost/core/test/legacy/api/admin/images.test.js
@@ -29,50 +29,29 @@ describe('Images API', function () {
             .expect(422);
     });
 
-    it('Can\'t import with unsupported file', function (done) {
-        request.post(localUtils.API.getApiQuery('images/upload'))
+    it('Can\'t import with unsupported file', async function () {
+        await request.post(localUtils.API.getApiQuery('images/upload'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .attach('file', path.join(__dirname, '/../../../utils/fixtures/csv/single-column-with-header.csv'))
-            .expect(415)
-            .end(function (err) {
-                if (err) {
-                    return done(err);
-                }
-
-                done();
-            });
+            .expect(415);
     });
 
-    it('Can\'t upload incorrect extension', function (done) {
-        request.post(localUtils.API.getApiQuery('images/upload'))
+    it('Can\'t upload incorrect extension', async function () {
+        await request.post(localUtils.API.getApiQuery('images/upload'))
             .set('Origin', config.get('url'))
             .set('content-type', 'image/png')
             .expect('Content-Type', /json/)
             .attach('file', path.join(__dirname, '/../../../utils/fixtures/images/ghost-logo.pngx'))
-            .expect(415)
-            .end(function (err) {
-                if (err) {
-                    return done(err);
-                }
-
-                done();
-            });
+            .expect(415);
     });
 
-    it('Can\'t import if profile image is not square', function (done) {
-        request.post(localUtils.API.getApiQuery('images/upload'))
+    it('Can\'t import if profile image is not square', async function () {
+        await request.post(localUtils.API.getApiQuery('images/upload'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .field('purpose', 'profile_image')
             .attach('file', path.join(__dirname, '/../../../utils/fixtures/images/favicon_not_square.png'))
-            .expect(422)
-            .end(function (err) {
-                if (err) {
-                    return done(err);
-                }
-
-                done();
-            });
+            .expect(422);
     });
 });

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -32,17 +32,13 @@ describe('Posts API', function () {
     });
 
     describe('Browse', function () {
-        it('fields & formats combined', function (done) {
-            request.get(localUtils.API.getApiQuery('posts/?formats=mobiledoc,html&fields=id,title'))
+        it('fields & formats combined', async function () {
+            await request.get(localUtils.API.getApiQuery('posts/?formats=mobiledoc,html&fields=id,title'))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
+                .expect(function (res) {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     assertExists(jsonResponse.posts);
@@ -58,22 +54,16 @@ describe('Posts API', function () {
                     );
 
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-
-                    done();
                 });
         });
 
-        it('combined fields, formats, include and non existing', function (done) {
-            request.get(localUtils.API.getApiQuery('posts/?formats=mobiledoc,html,plaintext&fields=id,title,primary_tag,doesnotexist&include=authors,tags,email'))
+        it('combined fields, formats, include and non existing', async function () {
+            await request.get(localUtils.API.getApiQuery('posts/?formats=mobiledoc,html,plaintext&fields=id,title,primary_tag,doesnotexist&include=authors,tags,email'))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
+                .expect(function (res) {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     assertExists(jsonResponse.posts);
@@ -89,22 +79,16 @@ describe('Posts API', function () {
                     );
 
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-
-                    done();
                 });
         });
 
-        it('can filter by fields coming from posts_meta table non null meta_description', function (done) {
-            request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:-null`))
+        it('can filter by fields coming from posts_meta table non null meta_description', async function () {
+            await request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:-null`))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
+                .expect(function (res) {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     assertExists(jsonResponse.posts);
@@ -120,22 +104,16 @@ describe('Posts API', function () {
                     );
 
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-
-                    done();
                 });
         });
 
-        it('can filter by fields coming from posts_meta table by value', function (done) {
-            request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:'meta description for short and sweet'`))
+        it('can filter by fields coming from posts_meta table by value', async function () {
+            await request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:'meta description for short and sweet'`))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
+                .expect(function (res) {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     assertExists(jsonResponse.posts);
@@ -150,22 +128,16 @@ describe('Posts API', function () {
                     );
 
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-
-                    done();
                 });
         });
 
-        it('can order by fields coming from posts_meta table', function (done) {
-            request.get(localUtils.API.getApiQuery('posts/?order=meta_description%20ASC'))
+        it('can order by fields coming from posts_meta table', async function () {
+            await request.get(localUtils.API.getApiQuery('posts/?order=meta_description%20ASC'))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
+                .expect(function (res) {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     assertExists(jsonResponse.posts);
@@ -182,8 +154,6 @@ describe('Posts API', function () {
                     );
 
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-
-                    done();
                 });
         });
 
@@ -257,18 +227,14 @@ describe('Posts API', function () {
     });
 
     describe('Read', function () {
-        it('can\'t retrieve non existent post', function (done) {
-            request.get(localUtils.API.getApiQuery(`posts/${ObjectId().toHexString()}/`))
+        it('can\'t retrieve non existent post', async function () {
+            await request.get(localUtils.API.getApiQuery(`posts/${ObjectId().toHexString()}/`))
                 .set('Origin', config.get('url'))
                 .set('Accept', 'application/json')
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(404)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
+                .expect(function (res) {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     assertExists(jsonResponse);
@@ -284,7 +250,6 @@ describe('Posts API', function () {
                         'id',
                         'ghostErrorCode'
                     ]);
-                    done();
                 });
         });
 

--- a/ghost/core/test/legacy/api/admin/users.test.js
+++ b/ghost/core/test/legacy/api/admin/users.test.js
@@ -27,18 +27,14 @@ describe('User API', function () {
         });
 
         describe('Read', function () {
-            it('can\'t retrieve non existent user by id', function (done) {
-                request.get(localUtils.API.getApiQuery('users/' + ObjectId().toHexString() + '/'))
+            it('can\'t retrieve non existent user by id', async function () {
+                await request.get(localUtils.API.getApiQuery('users/' + ObjectId().toHexString() + '/'))
                     .set('Origin', config.get('url'))
                     .set('Accept', 'application/json')
                     .expect('Content-Type', /json/)
                     .expect('Cache-Control', testUtils.cacheRules.private)
                     .expect(404)
-                    .end(function (err, res) {
-                        if (err) {
-                            return done(err);
-                        }
-
+                    .expect(function (res) {
                         assert.equal(res.headers['x-cache-invalidate'], undefined);
                         const jsonResponse = res.body;
                         assertExists(jsonResponse);
@@ -54,22 +50,17 @@ describe('User API', function () {
                             'id',
                             'ghostErrorCode'
                         ]);
-                        done();
                     });
             });
 
-            it('can\'t retrieve non existent user by slug', function (done) {
-                request.get(localUtils.API.getApiQuery('users/slug/blargh/'))
+            it('can\'t retrieve non existent user by slug', async function () {
+                await request.get(localUtils.API.getApiQuery('users/slug/blargh/'))
                     .set('Origin', config.get('url'))
                     .set('Accept', 'application/json')
                     .expect('Content-Type', /json/)
                     .expect('Cache-Control', testUtils.cacheRules.private)
                     .expect(404)
-                    .end(function (err, res) {
-                        if (err) {
-                            return done(err);
-                        }
-
+                    .expect(function (res) {
                         assert.equal(res.headers['x-cache-invalidate'], undefined);
                         const jsonResponse = res.body;
                         assertExists(jsonResponse);
@@ -85,14 +76,13 @@ describe('User API', function () {
                             'id',
                             'ghostErrorCode'
                         ]);
-                        done();
                     });
             });
         });
 
         describe('Edit', function () {
-            it('can change the other users password', function (done) {
-                request.put(localUtils.API.getApiQuery('users/password/'))
+            it('can change the other users password', async function () {
+                await request.put(localUtils.API.getApiQuery('users/password/'))
                     .set('Origin', config.get('url'))
                     .send({
                         password: [{
@@ -103,14 +93,7 @@ describe('User API', function () {
                     })
                     .expect('Content-Type', /json/)
                     .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(200)
-                    .end(function (err) {
-                        if (err) {
-                            return done(err);
-                        }
-
-                        done();
-                    });
+                    .expect(200);
             });
         });
 
@@ -121,8 +104,8 @@ describe('User API', function () {
                 await localUtils.doAuth(request);
             });
 
-            it('[failure] Destroy unknown user id', function () {
-                return request
+            it('[failure] Destroy unknown user id', async function () {
+                await request
                     .delete(localUtils.API.getApiQuery('users/' + ObjectId().toHexString()))
                     .set('Origin', config.get('url'))
                     .expect(404);
@@ -172,28 +155,21 @@ describe('User API', function () {
         });
 
         describe('success cases', function () {
-            it('can edit himself', function (done) {
-                request.put(localUtils.API.getApiQuery('users/' + editor.id + '/'))
+            it('can edit himself', async function () {
+                await request.put(localUtils.API.getApiQuery('users/' + editor.id + '/'))
                     .set('Origin', config.get('url'))
                     .send({
                         users: [{id: editor.id, name: 'test'}]
                     })
                     .expect('Content-Type', /json/)
                     .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(200)
-                    .end(function (err) {
-                        if (err) {
-                            return done(err);
-                        }
-
-                        done();
-                    });
+                    .expect(200);
             });
         });
 
         describe('error cases', function () {
-            it('can\'t edit the owner', function (done) {
-                request.put(localUtils.API.getApiQuery('users/' + testUtils.DataGenerator.Content.users[0].id + '/'))
+            it('can\'t edit the owner', async function () {
+                await request.put(localUtils.API.getApiQuery('users/' + testUtils.DataGenerator.Content.users[0].id + '/'))
                     .set('Origin', config.get('url'))
                     .send({
                         users: [{
@@ -202,18 +178,11 @@ describe('User API', function () {
                     })
                     .expect('Content-Type', /json/)
                     .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(403)
-                    .end(function (err) {
-                        if (err) {
-                            return done(err);
-                        }
-
-                        done();
-                    });
+                    .expect(403);
             });
 
-            it('Cannot transfer ownership to any other user', function () {
-                return request
+            it('Cannot transfer ownership to any other user', async function () {
+                await request
                     .put(localUtils.API.getApiQuery('users/owner'))
                     .set('Origin', config.get('url'))
                     .send({
@@ -246,28 +215,21 @@ describe('User API', function () {
         });
 
         describe('success cases', function () {
-            it('can edit himself', function (done) {
-                request.put(localUtils.API.getApiQuery('users/' + author.id + '/'))
+            it('can edit himself', async function () {
+                await request.put(localUtils.API.getApiQuery('users/' + author.id + '/'))
                     .set('Origin', config.get('url'))
                     .send({
                         users: [{id: author.id, name: 'test'}]
                     })
                     .expect('Content-Type', /json/)
                     .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(200)
-                    .end(function (err) {
-                        if (err) {
-                            return done(err);
-                        }
-
-                        done();
-                    });
+                    .expect(200);
             });
         });
 
         describe('error cases', function () {
-            it('can\'t edit the owner', function (done) {
-                request.put(localUtils.API.getApiQuery('users/' + testUtils.DataGenerator.Content.users[0].id + '/'))
+            it('can\'t edit the owner', async function () {
+                await request.put(localUtils.API.getApiQuery('users/' + testUtils.DataGenerator.Content.users[0].id + '/'))
                     .set('Origin', config.get('url'))
                     .send({
                         users: [{
@@ -276,14 +238,7 @@ describe('User API', function () {
                     })
                     .expect('Content-Type', /json/)
                     .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(403)
-                    .end(function (err) {
-                        if (err) {
-                            return done(err);
-                        }
-
-                        done();
-                    });
+                    .expect(403);
             });
         });
     });

--- a/ghost/core/test/legacy/api/content/posts.test.js
+++ b/ghost/core/test/legacy/api/content/posts.test.js
@@ -141,17 +141,13 @@ describe('api/endpoints/content/posts', function () {
         }
     });
 
-    it('browse posts', function (done) {
-        request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}`))
+    it('browse posts', async function () {
+        await request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
-
+            .expect(function (res) {
                 assert.equal(res.headers.vary, 'Accept-Version, Accept-Encoding');
                 assertExists(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
@@ -177,22 +173,16 @@ describe('api/endpoints/content/posts', function () {
                 assert.equal(jsonResponse.meta.pagination.hasOwnProperty('prev'), true);
                 assert.equal(jsonResponse.meta.pagination.next, null);
                 assert.equal(jsonResponse.meta.pagination.prev, null);
-
-                done();
             });
     });
 
-    it('browse posts with related authors/tags also returns primary_author/primary_tag', function (done) {
-        request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&include=authors,tags`))
+    it('browse posts with related authors/tags also returns primary_author/primary_tag', async function () {
+        await request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&include=authors,tags`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
-
+            .expect(function (res) {
                 assert.equal(res.headers.vary, 'Accept-Version, Accept-Encoding');
                 assertExists(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
@@ -224,8 +214,6 @@ describe('api/endpoints/content/posts', function () {
                 assert.equal(jsonResponse.meta.pagination.hasOwnProperty('prev'), true);
                 assert.equal(jsonResponse.meta.pagination.next, null);
                 assert.equal(jsonResponse.meta.pagination.prev, null);
-
-                done();
             });
     });
 
@@ -236,21 +224,16 @@ describe('api/endpoints/content/posts', function () {
             .expect(400);
     });
 
-    it('browse posts with published and draft status, should not return drafts', function (done) {
-        request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&filter=status:published,status:draft`))
+    it('browse posts with published and draft status, should not return drafts', async function () {
+        await request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&filter=status:published,status:draft`))
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+            .expect(function (res) {
                 const jsonResponse = res.body;
 
                 assert(Array.isArray(jsonResponse.posts));
                 assert.equal(jsonResponse.posts.length, 13);
-
-                done();
             });
     });
 
@@ -286,26 +269,21 @@ describe('api/endpoints/content/posts', function () {
             });
     });
 
-    it('ensure origin header on redirect is not getting lost', function (done) {
+    it('ensure origin header on redirect is not getting lost', async function () {
         // NOTE: force a redirect to the admin url
         configUtils.set('admin:url', 'http://localhost:9999');
         urlUtils.stubUrlUtilsFromConfig();
 
-        request.get(localUtils.API.getApiQuery(`posts?key=${validKey}`))
+        await request.get(localUtils.API.getApiQuery(`posts?key=${validKey}`))
             .set('Origin', 'https://example.com')
             // 301 Redirects _should_ be cached
             .expect('Cache-Control', testUtils.cacheRules.year)
             .expect(301)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
-
+            .expect(function (res) {
                 assert.equal(res.headers.vary, 'Accept-Version, Accept, Accept-Encoding');
                 assert.equal(res.headers.location, `http://localhost:9999/ghost/api/content/posts/?key=${validKey}`);
                 assertExists(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
-                done();
             });
     });
 

--- a/ghost/core/test/legacy/models/model-members.test.js
+++ b/ghost/core/test/legacy/models/model-members.test.js
@@ -268,12 +268,11 @@ describe('Member Model', function run() {
     describe('findAll', function () {
         beforeEach(testUtils.setup('members'));
 
-        it('can use search query', function (done) {
-            Member.findAll({search: 'egg'}).then(function (queryResult) {
-                assert.equal(queryResult.length, 1);
-                assert.equal(queryResult.models[0].get('name'), 'Mr Egg');
-                done();
-            }).catch(done);
+        it('can use search query', async function () {
+            const queryResult = await Member.findAll({search: 'egg'});
+
+            assert.equal(queryResult.length, 1);
+            assert.equal(queryResult.models[0].get('name'), 'Mr Egg');
         });
     });
 
@@ -587,4 +586,3 @@ describe('Member Model', function run() {
         });
     });
 });
-

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -86,91 +86,74 @@ describe('Post Model', function () {
                             });
                     });
 
-                    it('can findPage, with various options', function (done) {
-                        models.Post.findPage({page: 2})
-                            .then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 2);
-                                assert.equal(paginationResult.meta.pagination.limit, 15);
-                                assert.equal(paginationResult.meta.pagination.pages, 4);
-                                assert.equal(paginationResult.data.length, 15);
+                    it('can findPage, with various options', async function () {
+                        let paginationResult = await models.Post.findPage({page: 2});
+                        assert.equal(paginationResult.meta.pagination.page, 2);
+                        assert.equal(paginationResult.meta.pagination.limit, 15);
+                        assert.equal(paginationResult.meta.pagination.pages, 4);
+                        assert.equal(paginationResult.data.length, 15);
 
-                                return models.Post.findPage({page: 5});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 5);
-                                assert.equal(paginationResult.meta.pagination.limit, 15);
-                                assert.equal(paginationResult.meta.pagination.pages, 4);
-                                assert.equal(paginationResult.data.length, 0);
+                        paginationResult = await models.Post.findPage({page: 5});
+                        assert.equal(paginationResult.meta.pagination.page, 5);
+                        assert.equal(paginationResult.meta.pagination.limit, 15);
+                        assert.equal(paginationResult.meta.pagination.pages, 4);
+                        assert.equal(paginationResult.data.length, 0);
 
-                                return models.Post.findPage({limit: 30});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 1);
-                                assert.equal(paginationResult.meta.pagination.limit, 30);
-                                assert.equal(paginationResult.meta.pagination.pages, 2);
-                                assert.equal(paginationResult.data.length, 30);
+                        paginationResult = await models.Post.findPage({limit: 30});
+                        assert.equal(paginationResult.meta.pagination.page, 1);
+                        assert.equal(paginationResult.meta.pagination.limit, 30);
+                        assert.equal(paginationResult.meta.pagination.pages, 2);
+                        assert.equal(paginationResult.data.length, 30);
 
-                                // Test featured pages
-                                return models.Post.findPage({limit: 10, filter: 'featured:true'});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 1);
-                                assert.equal(paginationResult.meta.pagination.limit, 10);
-                                assert.equal(paginationResult.meta.pagination.pages, 1);
-                                assert.equal(paginationResult.data.length, 2);
+                        // Test featured pages
+                        paginationResult = await models.Post.findPage({limit: 10, filter: 'featured:true'});
+                        assert.equal(paginationResult.meta.pagination.page, 1);
+                        assert.equal(paginationResult.meta.pagination.limit, 10);
+                        assert.equal(paginationResult.meta.pagination.pages, 1);
+                        assert.equal(paginationResult.data.length, 2);
 
-                                // Test both boolean formats for featured pages
-                                return models.Post.findPage({limit: 10, filter: 'featured:1'});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 1);
-                                assert.equal(paginationResult.meta.pagination.limit, 10);
-                                assert.equal(paginationResult.meta.pagination.pages, 1);
-                                assert.equal(paginationResult.data.length, 2);
+                        // Test both boolean formats for featured pages
+                        paginationResult = await models.Post.findPage({limit: 10, filter: 'featured:1'});
+                        assert.equal(paginationResult.meta.pagination.page, 1);
+                        assert.equal(paginationResult.meta.pagination.limit, 10);
+                        assert.equal(paginationResult.meta.pagination.pages, 1);
+                        assert.equal(paginationResult.data.length, 2);
 
-                                return models.Post.findPage({limit: 10, page: 2, status: 'all'});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.pages, 11);
+                        paginationResult = await models.Post.findPage({limit: 10, page: 2, status: 'all'});
+                        assert.equal(paginationResult.meta.pagination.pages, 11);
 
-                                return models.Post.findPage({limit: 'all', status: 'all'});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 1);
-                                assert.equal(paginationResult.meta.pagination.limit, 'all');
-                                assert.equal(paginationResult.meta.pagination.pages, 1);
-                                assert.equal(paginationResult.data.length, 110);
-
-                                done();
-                            }).catch(done);
+                        paginationResult = await models.Post.findPage({limit: 'all', status: 'all'});
+                        assert.equal(paginationResult.meta.pagination.page, 1);
+                        assert.equal(paginationResult.meta.pagination.limit, 'all');
+                        assert.equal(paginationResult.meta.pagination.pages, 1);
+                        assert.equal(paginationResult.data.length, 110);
                     });
 
-                    it('can findPage for tag, with various options', function (done) {
+                    it('can findPage for tag, with various options', async function () {
                         // Test tag filter
-                        models.Post.findPage({page: 1, filter: 'tags:bacon'})
-                            .then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 1);
-                                assert.equal(paginationResult.meta.pagination.limit, 15);
-                                assert.equal(paginationResult.meta.pagination.pages, 1);
-                                assert.equal(paginationResult.data.length, 2);
+                        let paginationResult = await models.Post.findPage({page: 1, filter: 'tags:bacon'});
+                        assert.equal(paginationResult.meta.pagination.page, 1);
+                        assert.equal(paginationResult.meta.pagination.limit, 15);
+                        assert.equal(paginationResult.meta.pagination.pages, 1);
+                        assert.equal(paginationResult.data.length, 2);
 
-                                return models.Post.findPage({page: 1, filter: 'tags:kitchen-sink'});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 1);
-                                assert.equal(paginationResult.meta.pagination.limit, 15);
-                                assert.equal(paginationResult.meta.pagination.pages, 1);
-                                assert.equal(paginationResult.data.length, 2);
+                        paginationResult = await models.Post.findPage({page: 1, filter: 'tags:kitchen-sink'});
+                        assert.equal(paginationResult.meta.pagination.page, 1);
+                        assert.equal(paginationResult.meta.pagination.limit, 15);
+                        assert.equal(paginationResult.meta.pagination.pages, 1);
+                        assert.equal(paginationResult.data.length, 2);
 
-                                return models.Post.findPage({page: 1, filter: 'tags:injection'});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 1);
-                                assert.equal(paginationResult.meta.pagination.limit, 15);
-                                assert.equal(paginationResult.meta.pagination.pages, 2);
-                                assert.equal(paginationResult.data.length, 15);
+                        paginationResult = await models.Post.findPage({page: 1, filter: 'tags:injection'});
+                        assert.equal(paginationResult.meta.pagination.page, 1);
+                        assert.equal(paginationResult.meta.pagination.limit, 15);
+                        assert.equal(paginationResult.meta.pagination.pages, 2);
+                        assert.equal(paginationResult.data.length, 15);
 
-                                return models.Post.findPage({page: 2, filter: 'tags:injection'});
-                            }).then(function (paginationResult) {
-                                assert.equal(paginationResult.meta.pagination.page, 2);
-                                assert.equal(paginationResult.meta.pagination.limit, 15);
-                                assert.equal(paginationResult.meta.pagination.pages, 2);
-                                assert.equal(paginationResult.data.length, 11);
-
-                                done();
-                            }).catch(done);
+                        paginationResult = await models.Post.findPage({page: 2, filter: 'tags:injection'});
+                        assert.equal(paginationResult.meta.pagination.page, 2);
+                        assert.equal(paginationResult.meta.pagination.limit, 15);
+                        assert.equal(paginationResult.meta.pagination.pages, 2);
+                        assert.equal(paginationResult.data.length, 11);
                     });
                 });
             });
@@ -248,454 +231,361 @@ describe('Post Model', function () {
                 });
             });
 
-            it('can change title', function (done) {
+            it('can change title', async function () {
                 const postId = testUtils.DataGenerator.Content.posts[0].id;
+                const results = await models.Post.findOne({id: postId});
 
-                models.Post.findOne({id: postId}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
-                    assert.notEqual(post.title, 'new title');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
+                assert.notEqual(post.title, 'new title');
 
-                    return models.Post.edit({title: 'new title'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.title, 'new title');
+                const edited = await models.Post.edit({title: 'new title'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.title, 'new title');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.published.edited']);
-                    assertExists(eventsTriggered['post.edited']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.published.edited']);
+                assertExists(eventsTriggered['post.edited']);
             });
 
-            it('[failure] custom excerpt soft limit reached', function (done) {
+            it('[failure] custom excerpt soft limit reached', async function () {
                 const postId = testUtils.DataGenerator.Content.posts[0].id;
+                const results = await models.Post.findOne({id: postId});
 
-                models.Post.findOne({id: postId}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
 
-                    return models.Post.edit({
-                        custom_excerpt: new Array(302).join('a')
-                    }, _.extend({}, context, {id: postId}));
-                }).then(function () {
-                    done(new Error('expected validation error'));
-                }).catch(function (err) {
+                await assert.rejects(models.Post.edit({
+                    custom_excerpt: new Array(302).join('a')
+                }, _.extend({}, context, {id: postId})), (err) => {
                     assert.equal(err[0].name, 'ValidationError');
-                    done();
+                    return true;
                 });
             });
 
-            it('can publish draft post', function (done) {
+            it('can publish draft post', async function () {
                 const postId = testUtils.DataGenerator.Content.posts[3].id;
+                const results = await models.Post.findOne({id: postId, status: 'draft'});
 
-                models.Post.findOne({id: postId, status: 'draft'}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
-                    assert.equal(post.status, 'draft');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
+                assert.equal(post.status, 'draft');
 
-                    return models.Post.edit({status: 'published'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'published');
+                const edited = await models.Post.edit({status: 'published'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'published');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 4);
-                    assertExists(eventsTriggered['post.published']);
-                    assertExists(eventsTriggered['post.edited']);
-                    assertExists(eventsTriggered['tag.attached']);
-                    assertExists(eventsTriggered['user.attached']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 4);
+                assertExists(eventsTriggered['post.published']);
+                assertExists(eventsTriggered['post.edited']);
+                assertExists(eventsTriggered['tag.attached']);
+                assertExists(eventsTriggered['user.attached']);
             });
 
-            it('can unpublish published post', function (done) {
+            it('can unpublish published post', async function () {
                 const postId = testUtils.DataGenerator.Content.posts[0].id;
+                const results = await models.Post.findOne({id: postId});
 
-                models.Post.findOne({id: postId}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
-                    assert.equal(post.status, 'published');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
+                assert.equal(post.status, 'published');
 
-                    return models.Post.edit({status: 'draft'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'draft');
+                const edited = await models.Post.edit({status: 'draft'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'draft');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 4);
-                    assertExists(eventsTriggered['post.unpublished']);
-                    assertExists(eventsTriggered['post.edited']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 4);
+                assertExists(eventsTriggered['post.unpublished']);
+                assertExists(eventsTriggered['post.edited']);
             });
 
-            it('draft -> scheduled without published_at update', function (done) {
-                let post;
+            it('draft -> scheduled without published_at update', async function () {
+                const results = await models.Post.findOne({status: 'draft'});
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.status, 'draft');
 
-                models.Post.findOne({status: 'draft'}).then(function (results) {
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.status, 'draft');
+                results.set('published_at', null);
+                await results.save();
 
-                    results.set('published_at', null);
-                    return results.save();
-                }).then(function () {
-                    return models.Post.edit({
-                        status: 'scheduled'
-                    }, _.extend({}, context, {id: post.id}));
-                }).then(function () {
-                    done(new Error('expected error'));
-                }).catch(function (err) {
-                    assertExists(err);
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                await assert.rejects(models.Post.edit({
+                    status: 'scheduled'
+                }, _.extend({}, context, {id: post.id})), errors.ValidationError);
             });
 
-            it('draft -> scheduled: expect update of published_at', function (done) {
+            it('draft -> scheduled: expect update of published_at', async function () {
                 const newPublishedAt = moment().add(1, 'day').toDate();
+                const results = await models.Post.findOne({status: 'draft'});
 
-                models.Post.findOne({status: 'draft'}).then(function (results) {
-                    let post;
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.status, 'draft');
 
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.status, 'draft');
+                const edited = await models.Post.edit({
+                    status: 'scheduled',
+                    published_at: newPublishedAt
+                }, _.extend({}, context, {id: post.id}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'scheduled');
 
-                    return models.Post.edit({
-                        status: 'scheduled',
-                        published_at: newPublishedAt
-                    }, _.extend({}, context, {id: post.id}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'scheduled');
+                // mysql does not store ms
+                assert.equal(moment(edited.attributes.published_at).startOf('seconds').diff(moment(newPublishedAt).startOf('seconds')), 0);
 
-                    // mysql does not store ms
-                    assert.equal(moment(edited.attributes.published_at).startOf('seconds').diff(moment(newPublishedAt).startOf('seconds')), 0);
-
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.scheduled']);
-                    assertExists(eventsTriggered['post.edited']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.scheduled']);
+                assertExists(eventsTriggered['post.edited']);
             });
 
-            it('scheduled -> draft: expect unschedule', function (done) {
-                models.Post.findOne({status: 'scheduled'}).then(function (results) {
-                    let post;
+            it('scheduled -> draft: expect unschedule', async function () {
+                const results = await models.Post.findOne({status: 'scheduled'});
 
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.status, 'scheduled');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.status, 'scheduled');
 
-                    return models.Post.edit({
-                        status: 'draft'
-                    }, _.extend({}, context, {id: post.id}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'draft');
+                const edited = await models.Post.edit({
+                    status: 'draft'
+                }, _.extend({}, context, {id: post.id}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'draft');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.unscheduled']);
-                    assertExists(eventsTriggered['post.edited']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.unscheduled']);
+                assertExists(eventsTriggered['post.edited']);
             });
 
-            it('scheduled -> scheduled with updated published_at', function (done) {
-                models.Post.findOne({status: 'scheduled'}).then(function (results) {
-                    let post;
+            it('scheduled -> scheduled with updated published_at', async function () {
+                const results = await models.Post.findOne({status: 'scheduled'});
 
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.status, 'scheduled');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.status, 'scheduled');
 
-                    return models.Post.edit({
-                        status: 'scheduled',
-                        published_at: moment().add(20, 'days').toDate()
-                    }, _.extend({}, context, {id: post.id}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'scheduled');
+                const edited = await models.Post.edit({
+                    status: 'scheduled',
+                    published_at: moment().add(20, 'days').toDate()
+                }, _.extend({}, context, {id: post.id}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'scheduled');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.rescheduled']);
-                    assertExists(eventsTriggered['post.edited']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.rescheduled']);
+                assertExists(eventsTriggered['post.edited']);
             });
 
-            it('scheduled -> scheduled with unchanged published_at', function (done) {
-                models.Post.findOne({status: 'scheduled'}).then(function (results) {
-                    let post;
+            it('scheduled -> scheduled with unchanged published_at', async function () {
+                const results = await models.Post.findOne({status: 'scheduled'});
 
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.status, 'scheduled');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.status, 'scheduled');
 
-                    return models.Post.edit({
-                        status: 'scheduled'
-                    }, _.extend({}, context, {id: post.id}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'scheduled');
+                const edited = await models.Post.edit({
+                    status: 'scheduled'
+                }, _.extend({}, context, {id: post.id}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'scheduled');
 
-                    // nothing has changed
-                    assert.equal(Object.keys(eventsTriggered).length, 0);
-
-                    done();
-                }).catch(done);
+                // nothing has changed
+                assert.equal(Object.keys(eventsTriggered).length, 0);
             });
 
-            it('scheduled -> scheduled with unchanged published_at (within the 2 minutes window)', function (done) {
-                let post;
+            it('scheduled -> scheduled with unchanged published_at (within the 2 minutes window)', async function () {
+                const results = await models.Post.findOne({status: 'scheduled'});
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.status, 'scheduled');
 
-                models.Post.findOne({status: 'scheduled'}).then(function (results) {
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.status, 'scheduled');
+                results.set('published_at', moment().add(2, 'minutes').add(2, 'seconds').toDate());
+                await results.save();
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.edited']);
+                assertExists(eventsTriggered['post.rescheduled']);
+                eventsTriggered = {};
 
-                    results.set('published_at', moment().add(2, 'minutes').add(2, 'seconds').toDate());
-                    return results.save();
-                }).then(function () {
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.edited']);
-                    assertExists(eventsTriggered['post.rescheduled']);
-                    eventsTriggered = {};
-
-                    return new Promise((resolve) => {
-                        setTimeout(resolve, 3000);
-                    });
-                }).then(function () {
-                    return models.Post.edit({
-                        status: 'scheduled'
-                    }, _.extend({}, context, {id: post.id}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'scheduled');
-
-                    assert.equal(Object.keys(eventsTriggered).length, 1);
-                    assertExists(eventsTriggered['post.edited']);
-
-                    done();
-                }).catch(done);
-            });
-
-            it('published -> scheduled and expect update of published_at', function (done) {
-                const postId = testUtils.DataGenerator.Content.posts[0].id;
-
-                models.Post.findOne({id: postId}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
-                    assert.equal(post.status, 'published');
-
-                    return models.Post.edit({
-                        status: 'scheduled',
-                        published_at: moment().add(1, 'day').toDate()
-                    }, _.extend({}, context, {id: postId}));
-                }).then(function () {
-                    done(new Error('change status from published to scheduled is not allowed right now!'));
-                }).catch(function (err) {
-                    assertExists(err);
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 3000);
                 });
+
+                const edited = await models.Post.edit({
+                    status: 'scheduled'
+                }, _.extend({}, context, {id: post.id}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'scheduled');
+
+                assert.equal(Object.keys(eventsTriggered).length, 1);
+                assertExists(eventsTriggered['post.edited']);
             });
 
-            it('can convert draft post to page and back', function (done) {
-                const postId = testUtils.DataGenerator.Content.posts[3].id;
-
-                models.Post.findOne({id: postId, status: 'draft'}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
-                    assert.equal(post.status, 'draft');
-
-                    return models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'draft');
-                    assert.equal(edited.attributes.type, 'page');
-
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.deleted']);
-                    assertExists(eventsTriggered['page.added']);
-
-                    return models.Post.edit({type: 'post'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'draft');
-                    assert.equal(edited.attributes.type, 'post');
-
-                    assert.equal(Object.keys(eventsTriggered).length, 4);
-                    assertExists(eventsTriggered['post.deleted']);
-                    assertExists(eventsTriggered['page.added']);
-                    assertExists(eventsTriggered['post.deleted']);
-                    assertExists(eventsTriggered['post.added']);
-
-                    done();
-                }).catch(done);
-            });
-
-            it('can convert draft to schedule AND post to page and back', function (done) {
-                models.Post.findOne({status: 'draft'}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.status, 'draft');
-
-                    return models.Post.edit({
-                        type: 'page',
-                        status: 'scheduled',
-                        published_at: moment().add(10, 'days')
-                    }, _.extend({}, context, {id: post.id}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'scheduled');
-                    assert.equal(edited.attributes.type, 'page');
-
-                    assert.equal(Object.keys(eventsTriggered).length, 3);
-                    assertExists(eventsTriggered['post.deleted']);
-                    assertExists(eventsTriggered['page.added']);
-                    assertExists(eventsTriggered['page.scheduled']);
-
-                    return models.Post.edit({type: 'post'}, _.extend({}, context, {id: edited.id}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'scheduled');
-                    assert.equal(edited.attributes.type, 'post');
-
-                    assert.equal(Object.keys(eventsTriggered).length, 7);
-                    assertExists(eventsTriggered['page.unscheduled']);
-                    assertExists(eventsTriggered['page.deleted']);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['post.scheduled']);
-
-                    done();
-                }).catch(done);
-            });
-
-            it('can convert published post to page and back', function (done) {
+            it('published -> scheduled and expect update of published_at', async function () {
                 const postId = testUtils.DataGenerator.Content.posts[0].id;
+                const results = await models.Post.findOne({id: postId});
 
-                models.Post.findOne({id: postId}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
-                    assert.equal(post.status, 'published');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
+                assert.equal(post.status, 'published');
 
-                    return models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'published');
-                    assert.equal(edited.attributes.type, 'page');
-
-                    assert.equal(Object.keys(eventsTriggered).length, 4);
-                    assertExists(eventsTriggered['post.unpublished']);
-                    assertExists(eventsTriggered['post.deleted']);
-                    assertExists(eventsTriggered['page.added']);
-                    assertExists(eventsTriggered['page.published']);
-
-                    return models.Post.edit({type: 'post'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'published');
-                    assert.equal(edited.attributes.type, 'post');
-
-                    assert.equal(Object.keys(eventsTriggered).length, 8);
-                    assertExists(eventsTriggered['page.unpublished']);
-                    assertExists(eventsTriggered['page.deleted']);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['post.published']);
-
-                    done();
-                }).catch(done);
+                await assert.rejects(models.Post.edit({
+                    status: 'scheduled',
+                    published_at: moment().add(1, 'day').toDate()
+                }, _.extend({}, context, {id: postId})), errors.ValidationError);
             });
 
-            it('can change type and status at the same time', function (done) {
+            it('can convert draft post to page and back', async function () {
                 const postId = testUtils.DataGenerator.Content.posts[3].id;
+                const results = await models.Post.findOne({id: postId, status: 'draft'});
 
-                models.Post.findOne({id: postId, status: 'draft'}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
-                    assert.equal(post.status, 'draft');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
+                assert.equal(post.status, 'draft');
 
-                    return models.Post.edit({type: 'page', status: 'published'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'published');
-                    assert.equal(edited.attributes.type, 'page');
+                let edited = await models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'draft');
+                assert.equal(edited.attributes.type, 'page');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 5);
-                    assertExists(eventsTriggered['post.deleted']);
-                    assertExists(eventsTriggered['page.added']);
-                    assertExists(eventsTriggered['page.published']);
-                    assertExists(eventsTriggered['tag.attached']);
-                    assertExists(eventsTriggered['user.attached']);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.deleted']);
+                assertExists(eventsTriggered['page.added']);
 
-                    return models.Post.edit({type: 'post', status: 'draft'}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'draft');
-                    assert.equal(edited.attributes.type, 'post');
+                edited = await models.Post.edit({type: 'post'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'draft');
+                assert.equal(edited.attributes.type, 'post');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 8);
-                    assertExists(eventsTriggered['page.unpublished']);
-                    assertExists(eventsTriggered['page.deleted']);
-                    assertExists(eventsTriggered['post.added']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 4);
+                assertExists(eventsTriggered['post.deleted']);
+                assertExists(eventsTriggered['page.added']);
+                assertExists(eventsTriggered['post.deleted']);
+                assertExists(eventsTriggered['post.added']);
             });
 
-            it('cannot override the published_by setting', function (done) {
+            it('can convert draft to schedule AND post to page and back', async function () {
+                const results = await models.Post.findOne({status: 'draft'});
+
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.status, 'draft');
+
+                let edited = await models.Post.edit({
+                    type: 'page',
+                    status: 'scheduled',
+                    published_at: moment().add(10, 'days')
+                }, _.extend({}, context, {id: post.id}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'scheduled');
+                assert.equal(edited.attributes.type, 'page');
+
+                assert.equal(Object.keys(eventsTriggered).length, 3);
+                assertExists(eventsTriggered['post.deleted']);
+                assertExists(eventsTriggered['page.added']);
+                assertExists(eventsTriggered['page.scheduled']);
+
+                edited = await models.Post.edit({type: 'post'}, _.extend({}, context, {id: edited.id}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'scheduled');
+                assert.equal(edited.attributes.type, 'post');
+
+                assert.equal(Object.keys(eventsTriggered).length, 7);
+                assertExists(eventsTriggered['page.unscheduled']);
+                assertExists(eventsTriggered['page.deleted']);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['post.scheduled']);
+            });
+
+            it('can convert published post to page and back', async function () {
+                const postId = testUtils.DataGenerator.Content.posts[0].id;
+                const results = await models.Post.findOne({id: postId});
+
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
+                assert.equal(post.status, 'published');
+
+                let edited = await models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'published');
+                assert.equal(edited.attributes.type, 'page');
+
+                assert.equal(Object.keys(eventsTriggered).length, 4);
+                assertExists(eventsTriggered['post.unpublished']);
+                assertExists(eventsTriggered['post.deleted']);
+                assertExists(eventsTriggered['page.added']);
+                assertExists(eventsTriggered['page.published']);
+
+                edited = await models.Post.edit({type: 'post'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'published');
+                assert.equal(edited.attributes.type, 'post');
+
+                assert.equal(Object.keys(eventsTriggered).length, 8);
+                assertExists(eventsTriggered['page.unpublished']);
+                assertExists(eventsTriggered['page.deleted']);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['post.published']);
+            });
+
+            it('can change type and status at the same time', async function () {
                 const postId = testUtils.DataGenerator.Content.posts[3].id;
+                const results = await models.Post.findOne({id: postId, status: 'draft'});
 
-                models.Post.findOne({id: postId, status: 'draft'}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, postId);
-                    assert.equal(post.status, 'draft');
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
+                assert.equal(post.status, 'draft');
 
-                    // Test changing status and published_by at the same time
-                    return models.Post.edit({
-                        status: 'published',
-                        published_by: 4
-                    }, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'published');
-                    assert.equal(edited.attributes.published_by, context.context.user);
+                let edited = await models.Post.edit({type: 'page', status: 'published'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'published');
+                assert.equal(edited.attributes.type, 'page');
 
-                    // Test changing status and published_by on its own
-                    return models.Post.edit({published_by: 4}, _.extend({}, context, {id: postId}));
-                }).then(function (edited) {
-                    assertExists(edited);
-                    assert.equal(edited.attributes.status, 'published');
-                    assert.equal(edited.attributes.published_by, context.context.user);
+                assert.equal(Object.keys(eventsTriggered).length, 5);
+                assertExists(eventsTriggered['post.deleted']);
+                assertExists(eventsTriggered['page.added']);
+                assertExists(eventsTriggered['page.published']);
+                assertExists(eventsTriggered['tag.attached']);
+                assertExists(eventsTriggered['user.attached']);
 
-                    done();
-                }).catch(done);
+                edited = await models.Post.edit({type: 'post', status: 'draft'}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'draft');
+                assert.equal(edited.attributes.type, 'post');
+
+                assert.equal(Object.keys(eventsTriggered).length, 8);
+                assertExists(eventsTriggered['page.unpublished']);
+                assertExists(eventsTriggered['page.deleted']);
+                assertExists(eventsTriggered['post.added']);
+            });
+
+            it('cannot override the published_by setting', async function () {
+                const postId = testUtils.DataGenerator.Content.posts[3].id;
+                const results = await models.Post.findOne({id: postId, status: 'draft'});
+
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, postId);
+                assert.equal(post.status, 'draft');
+
+                // Test changing status and published_by at the same time
+                let edited = await models.Post.edit({
+                    status: 'published',
+                    published_by: 4
+                }, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'published');
+                assert.equal(edited.attributes.published_by, context.context.user);
+
+                // Test changing status and published_by on its own
+                edited = await models.Post.edit({published_by: 4}, _.extend({}, context, {id: postId}));
+                assertExists(edited);
+                assert.equal(edited.attributes.status, 'published');
+                assert.equal(edited.attributes.published_by, context.context.user);
             });
         });
 
@@ -727,62 +617,56 @@ describe('Post Model', function () {
                 });
             });
 
-            it('can add, defaults are all correct', function (done) {
-                let createdPostUpdatedDate;
+            it('can add, defaults are all correct', async function () {
                 const newPost = testUtils.DataGenerator.forModel.posts[2];
                 const newPostDB = testUtils.DataGenerator.Content.posts[2];
+                const addedPost = await models.Post.add(newPost, _.merge({withRelated: ['authors']}, context));
+                const createdPost = await models.Post.findOne({id: addedPost.id, status: 'all'}, {withRelated: ['authors']});
 
-                models.Post.add(newPost, _.merge({withRelated: ['authors']}, context)).then(function (createdPost) {
-                    return models.Post.findOne({id: createdPost.id, status: 'all'}, {withRelated: ['authors']});
-                }).then(function (createdPost) {
-                    assertExists(createdPost);
-                    assert.equal(createdPost.has('uuid'), true);
-                    assert.equal(createdPost.get('status'), 'draft');
-                    assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
-                    assert.equal(createdPost.get('mobiledoc'), newPost.mobiledoc, 'mobiledoc is correct');
-                    assert.equal(createdPost.has('html'), true);
-                    assert.equal(createdPost.get('html'), newPostDB.html);
-                    assert.equal(createdPost.has('plaintext'), true);
-                    assert.match(createdPost.get('plaintext'), /^testing/);
-                    assert.equal(createdPost.get('slug'), newPostDB.slug + '-2');
-                    assert.equal((!!createdPost.get('featured')), false);
-                    assert.equal((!!createdPost.get('page')), false);
+                assertExists(createdPost);
+                assert.equal(createdPost.has('uuid'), true);
+                assert.equal(createdPost.get('status'), 'draft');
+                assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
+                assert.equal(createdPost.get('mobiledoc'), newPost.mobiledoc, 'mobiledoc is correct');
+                assert.equal(createdPost.has('html'), true);
+                assert.equal(createdPost.get('html'), newPostDB.html);
+                assert.equal(createdPost.has('plaintext'), true);
+                assert.match(createdPost.get('plaintext'), /^testing/);
+                assert.equal(createdPost.get('slug'), newPostDB.slug + '-2');
+                assert.equal((!!createdPost.get('featured')), false);
+                assert.equal((!!createdPost.get('page')), false);
 
-                    assert.equal(createdPost.get('locale'), null);
-                    assert.equal(createdPost.get('visibility'), 'public');
+                assert.equal(createdPost.get('locale'), null);
+                assert.equal(createdPost.get('visibility'), 'public');
 
-                    // testing for nulls
-                    assert.equal((createdPost.get('feature_image') === null), true);
+                // testing for nulls
+                assert.equal((createdPost.get('feature_image') === null), true);
 
-                    assert(createdPost.get('created_at') > new Date(0).getTime());
-                    assert.equal(createdPost.relations.authors.models[0].id, testUtils.DataGenerator.Content.users[0].id);
-                    assert(createdPost.get('updated_at') > new Date(0).getTime());
-                    assert.equal(createdPost.get('published_at'), null);
-                    assert.equal(createdPost.get('published_by'), null);
+                assert(createdPost.get('created_at') > new Date(0).getTime());
+                assert.equal(createdPost.relations.authors.models[0].id, testUtils.DataGenerator.Content.users[0].id);
+                assert(createdPost.get('updated_at') > new Date(0).getTime());
+                assert.equal(createdPost.get('published_at'), null);
+                assert.equal(createdPost.get('published_by'), null);
 
-                    createdPostUpdatedDate = createdPost.get('updated_at');
+                const createdPostUpdatedDate = createdPost.get('updated_at');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['user.attached']);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['user.attached']);
 
-                    // Set the status to published to check that `published_at` is set.
-                    return createdPost.save({status: 'published'}, context);
-                }).then(function (publishedPost) {
-                    assert(publishedPost.get('published_at') instanceof Date);
-                    assert.equal(publishedPost.get('published_by'), testUtils.DataGenerator.Content.users[0].id);
-                    assert(publishedPost.get('updated_at') instanceof Date);
-                    assert.notEqual(publishedPost.get('updated_at'), createdPostUpdatedDate);
+                // Set the status to published to check that `published_at` is set.
+                const publishedPost = await createdPost.save({status: 'published'}, context);
+                assert(publishedPost.get('published_at') instanceof Date);
+                assert.equal(publishedPost.get('published_by'), testUtils.DataGenerator.Content.users[0].id);
+                assert(publishedPost.get('updated_at') instanceof Date);
+                assert.notEqual(publishedPost.get('updated_at'), createdPostUpdatedDate);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 4);
-                    assertExists(eventsTriggered['post.published']);
-                    assertExists(eventsTriggered['post.edited']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 4);
+                assertExists(eventsTriggered['post.published']);
+                assertExists(eventsTriggered['post.edited']);
             });
 
-            it('can add, default visibility is taken from settings cache', function (done) {
+            it('can add, default visibility is taken from settings cache', async function () {
                 const originalSettingsCacheGetFn = settingsCache.get;
                 sinon.stub(settingsCache, 'get')
                     .callsFake(function (key, options) {
@@ -797,100 +681,90 @@ describe('Post Model', function () {
                         return originalSettingsCacheGetFn(key, options);
                     });
 
-                let createdPostUpdatedDate;
                 const newPost = testUtils.DataGenerator.forModel.posts[2];
                 const newPostDB = testUtils.DataGenerator.Content.posts[2];
+                const addedPost = await models.Post.add(newPost, _.merge({withRelated: ['authors']}, context));
+                const createdPost = await models.Post.findOne({id: addedPost.id, status: 'all'}, {withRelated: ['authors']});
 
-                models.Post.add(newPost, _.merge({withRelated: ['authors']}, context)).then(function (createdPost) {
-                    return models.Post.findOne({id: createdPost.id, status: 'all'}, {withRelated: ['authors']});
-                }).then(function (createdPost) {
-                    assertExists(createdPost);
-                    assert.equal(createdPost.has('uuid'), true);
-                    assert.equal(createdPost.get('status'), 'draft');
-                    assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
-                    assert.equal(createdPost.get('mobiledoc'), newPost.mobiledoc, 'mobiledoc is correct');
-                    assert.equal(createdPost.has('html'), true);
-                    assert.equal(createdPost.get('html'), newPostDB.html);
-                    assert.equal(createdPost.has('plaintext'), true);
-                    assert.match(createdPost.get('plaintext'), /^testing/);
-                    // assert.equal(createdPost.get('slug'), newPostDB.slug + '-3');
-                    assert.equal((!!createdPost.get('featured')), false);
-                    assert.equal((!!createdPost.get('page')), false);
+                assertExists(createdPost);
+                assert.equal(createdPost.has('uuid'), true);
+                assert.equal(createdPost.get('status'), 'draft');
+                assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
+                assert.equal(createdPost.get('mobiledoc'), newPost.mobiledoc, 'mobiledoc is correct');
+                assert.equal(createdPost.has('html'), true);
+                assert.equal(createdPost.get('html'), newPostDB.html);
+                assert.equal(createdPost.has('plaintext'), true);
+                assert.match(createdPost.get('plaintext'), /^testing/);
+                // assert.equal(createdPost.get('slug'), newPostDB.slug + '-3');
+                assert.equal((!!createdPost.get('featured')), false);
+                assert.equal((!!createdPost.get('page')), false);
 
-                    assert.equal(createdPost.get('locale'), null);
-                    assert.equal(createdPost.get('visibility'), 'paid');
+                assert.equal(createdPost.get('locale'), null);
+                assert.equal(createdPost.get('visibility'), 'paid');
 
-                    // testing for nulls
-                    assert.equal((createdPost.get('feature_image') === null), true);
+                // testing for nulls
+                assert.equal((createdPost.get('feature_image') === null), true);
 
-                    assert(createdPost.get('created_at') > new Date(0).getTime());
-                    assert.equal(createdPost.relations.authors.models[0].id, testUtils.DataGenerator.Content.users[0].id);
-                    assert(createdPost.get('updated_at') > new Date(0).getTime());
-                    assert.equal(createdPost.get('published_at'), null);
-                    assert.equal(createdPost.get('published_by'), null);
+                assert(createdPost.get('created_at') > new Date(0).getTime());
+                assert.equal(createdPost.relations.authors.models[0].id, testUtils.DataGenerator.Content.users[0].id);
+                assert(createdPost.get('updated_at') > new Date(0).getTime());
+                assert.equal(createdPost.get('published_at'), null);
+                assert.equal(createdPost.get('published_by'), null);
 
-                    createdPostUpdatedDate = createdPost.get('updated_at');
+                const createdPostUpdatedDate = createdPost.get('updated_at');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['user.attached']);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['user.attached']);
 
-                    // Set the status to published to check that `published_at` is set.
-                    return createdPost.save({status: 'published'}, context);
-                }).then(function (publishedPost) {
-                    assert(publishedPost.get('published_at') instanceof Date);
-                    assert.equal(publishedPost.get('published_by'), testUtils.DataGenerator.Content.users[0].id);
-                    assert(publishedPost.get('updated_at') instanceof Date);
-                    assert.notEqual(publishedPost.get('updated_at'), createdPostUpdatedDate);
+                // Set the status to published to check that `published_at` is set.
+                const publishedPost = await createdPost.save({status: 'published'}, context);
+                assert(publishedPost.get('published_at') instanceof Date);
+                assert.equal(publishedPost.get('published_by'), testUtils.DataGenerator.Content.users[0].id);
+                assert(publishedPost.get('updated_at') instanceof Date);
+                assert.notEqual(publishedPost.get('updated_at'), createdPostUpdatedDate);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 4);
-                    assertExists(eventsTriggered['post.published']);
-                    assertExists(eventsTriggered['post.edited']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 4);
+                assertExists(eventsTriggered['post.published']);
+                assertExists(eventsTriggered['post.edited']);
             });
 
-            it('can add, with previous published_at date', function (done) {
+            it('can add, with previous published_at date', async function () {
                 const previousPublishedAtDate = new Date(2013, 8, 21, 12);
 
-                models.Post.add({
+                const newPost = await models.Post.add({
                     status: 'published',
                     published_at: previousPublishedAtDate,
                     title: 'published_at test',
                     mobiledoc: markdownToMobiledoc('This is some content')
-                }, context).then(function (newPost) {
-                    assertExists(newPost);
-                    assert.equal(new Date(newPost.get('published_at')).getTime(), previousPublishedAtDate.getTime());
+                }, context);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 3);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['post.published']);
-                    assertExists(eventsTriggered['user.attached']);
+                assertExists(newPost);
+                assert.equal(new Date(newPost.get('published_at')).getTime(), previousPublishedAtDate.getTime());
 
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 3);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['post.published']);
+                assertExists(eventsTriggered['user.attached']);
             });
 
-            it('add draft post without published_at -> we expect no auto insert of published_at', function (done) {
-                models.Post.add({
+            it('add draft post without published_at -> we expect no auto insert of published_at', async function () {
+                const newPost = await models.Post.add({
                     status: 'draft',
                     title: 'draft 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
-                }, context).then(function (newPost) {
-                    assertExists(newPost);
-                    assert.equal(newPost.get('published_at'), null);
+                }, context);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['user.attached']);
+                assertExists(newPost);
+                assert.equal(newPost.get('published_at'), null);
 
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['user.attached']);
             });
 
-            it('add multiple authors', function (done) {
-                models.Post.add({
+            it('add multiple authors', async function () {
+                const newPost = await models.Post.add({
                     status: 'draft',
                     title: 'draft 1',
                     mobiledoc: markdownToMobiledoc('This is some content'),
@@ -898,57 +772,54 @@ describe('Post Model', function () {
                         id: testUtils.DataGenerator.forKnex.users[0].id,
                         name: testUtils.DataGenerator.forKnex.users[0].name
                     }]
-                }, _.merge({withRelated: ['authors']}, context)).then(function (newPost) {
-                    assertExists(newPost);
-                    assert.equal(newPost.toJSON().primary_author.id, testUtils.DataGenerator.forKnex.users[0].id);
-                    assert.equal(newPost.toJSON().authors.length, 1);
-                    assert.equal(newPost.toJSON().authors[0].id, testUtils.DataGenerator.forKnex.users[0].id);
-                    done();
-                }).catch(done);
+                }, _.merge({withRelated: ['authors']}, context));
+
+                assertExists(newPost);
+                assert.equal(newPost.toJSON().primary_author.id, testUtils.DataGenerator.forKnex.users[0].id);
+                assert.equal(newPost.toJSON().authors.length, 1);
+                assert.equal(newPost.toJSON().authors[0].id, testUtils.DataGenerator.forKnex.users[0].id);
             });
 
-            it('add draft post with published_at -> we expect published_at to exist', function (done) {
-                models.Post.add({
+            it('add draft post with published_at -> we expect published_at to exist', async function () {
+                const newPost = await models.Post.add({
                     status: 'draft',
                     published_at: moment().toDate(),
                     title: 'draft 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
-                }, context).then(function (newPost) {
-                    assertExists(newPost);
-                    assertExists(newPost.get('published_at'));
+                }, context);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['user.attached']);
+                assertExists(newPost);
+                assertExists(newPost.get('published_at'));
 
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['user.attached']);
             });
 
-            it('add scheduled post without published_at -> we expect an error', function (done) {
-                models.Post.add({
+            it('add scheduled post without published_at -> we expect an error', async function () {
+                await assert.rejects(models.Post.add({
                     status: 'scheduled',
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
-                }, context).catch(function (err) {
+                }, context), (err) => {
                     assertExists(err);
                     assert.equal((err instanceof errors.ValidationError), true);
                     assert.equal(Object.keys(eventsTriggered).length, 0);
-                    done();
+                    return true;
                 });
             });
 
-            it('add scheduled post with published_at more than 2 minutes in the past -> we expect an error', function (done) {
-                models.Post.add({
+            it('add scheduled post with published_at more than 2 minutes in the past -> we expect an error', async function () {
+                await assert.rejects(models.Post.add({
                     status: 'scheduled',
                     published_at: moment().subtract(3, 'minute'),
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
-                }, context).catch(function (err) {
+                }, context), (err) => {
                     assertExists(err);
                     assert.equal((err instanceof errors.ValidationError), true);
                     assert.equal(Object.keys(eventsTriggered).length, 0);
-                    done();
+                    return true;
                 });
             });
 
@@ -967,107 +838,95 @@ describe('Post Model', function () {
                 assertExists(eventsTriggered['user.attached']);
             });
 
-            it('add scheduled post with published_at 10 minutes in future -> we expect success', function (done) {
-                models.Post.add({
+            it('add scheduled post with published_at 10 minutes in future -> we expect success', async function () {
+                const post = await models.Post.add({
                     status: 'scheduled',
                     published_at: moment().add(10, 'minute'),
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
-                }, context).then(function (post) {
-                    assertExists(post);
+                }, context);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 3);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['post.scheduled']);
-                    assertExists(eventsTriggered['user.attached']);
+                assertExists(post);
 
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 3);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['post.scheduled']);
+                assertExists(eventsTriggered['user.attached']);
             });
 
-            it('can generate a non conflicting slug', function (done) {
+            it('can generate a non conflicting slug', async function () {
                 // Create 12 posts with the same title
-                sequence(_.times(12, function (i) {
+                const createdPosts = await sequence(_.times(12, function (i) {
                     return function () {
                         return models.Post.add({
                             title: 'Test Title',
                             mobiledoc: markdownToMobiledoc('Test Content ' + (i + 1))
                         }, context);
                     };
-                })).then(function (createdPosts) {
-                    // Should have created 12 posts
-                    assert.equal(createdPosts.length, 12);
+                }));
 
-                    // Should have unique slugs and contents
-                    _(createdPosts).each(function (post, i) {
-                        const num = i + 1;
+                // Should have created 12 posts
+                assert.equal(createdPosts.length, 12);
 
-                        // First one has normal title
-                        if (num === 1) {
-                            assert.equal(post.get('slug'), 'test-title');
-                            return;
-                        }
+                // Should have unique slugs and contents
+                _(createdPosts).each(function (post, i) {
+                    const num = i + 1;
 
-                        assert.equal(post.get('slug'), 'test-title-' + num);
-                        assert.equal(JSON.parse(post.get('mobiledoc')).cards[0][1].markdown, 'Test Content ' + num);
+                    // First one has normal title
+                    if (num === 1) {
+                        assert.equal(post.get('slug'), 'test-title');
+                        return;
+                    }
 
-                        assert.equal(Object.keys(eventsTriggered).length, 2);
-                        assertExists(eventsTriggered['post.added']);
-                        assertExists(eventsTriggered['user.attached']);
-                        assert.equal(eventsTriggered['post.added'].length, 12);
-                    });
+                    assert.equal(post.get('slug'), 'test-title-' + num);
+                    assert.equal(JSON.parse(post.get('mobiledoc')).cards[0][1].markdown, 'Test Content ' + num);
 
-                    done();
-                }).catch(done);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['user.attached']);
+                    assert.equal(eventsTriggered['post.added'].length, 12);
+                });
             });
 
-            it('can generate slugs without duplicate hyphens', function (done) {
+            it('can generate slugs without duplicate hyphens', async function () {
                 const newPost = {
                     title: 'apprehensive  titles  have  too  many  spaces—and m-dashes  —  –  and also n-dashes  ',
                     mobiledoc: markdownToMobiledoc('Test Content 1')
                 };
 
-                models.Post.add(newPost, context).then(function (createdPost) {
-                    assert.equal(createdPost.get('slug'), 'apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
+                const createdPost = await models.Post.add(newPost, context);
+                assert.equal(createdPost.get('slug'), 'apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['user.attached']);
-
-                    done();
-                }).catch(done);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['user.attached']);
             });
 
-            it('can generate a safe slug when a protected keyword is used', function (done) {
+            it('can generate a safe slug when a protected keyword is used', async function () {
                 const newPost = {
                     title: 'rss',
                     mobiledoc: markdownToMobiledoc('Test Content 1')
                 };
 
-                models.Post.add(newPost, context).then(function (createdPost) {
-                    assert.notEqual(createdPost.get('slug'), 'rss');
+                const createdPost = await models.Post.add(newPost, context);
+                assert.notEqual(createdPost.get('slug'), 'rss');
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['post.added']);
-                    assertExists(eventsTriggered['user.attached']);
-
-                    done();
-                });
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['user.attached']);
             });
 
-            it('can generate slugs without non-ascii characters', function (done) {
+            it('can generate slugs without non-ascii characters', async function () {
                 const newPost = {
                     title: 'भुते धडकी भरवणारा आहेत',
                     mobiledoc: markdownToMobiledoc('Test Content 1')
                 };
 
-                models.Post.add(newPost, context).then(function (createdPost) {
-                    assert.equal(createdPost.get('slug'), 'bhute-dhddkii-bhrvnnaaraa-aahet');
-                    done();
-                }).catch(done);
+                const createdPost = await models.Post.add(newPost, context);
+                assert.equal(createdPost.get('slug'), 'bhute-dhddkii-bhrvnnaaraa-aahet');
             });
 
-            it('detects duplicate slugs before saving', function (done) {
+            it('detects duplicate slugs before saving', async function () {
                 const firstPost = {
                     title: 'First post',
                     mobiledoc: markdownToMobiledoc('First content 1')
@@ -1079,53 +938,46 @@ describe('Post Model', function () {
                 };
 
                 // Create the first post
-                models.Post.add(firstPost, context)
-                    .then(function (createdFirstPost) {
-                        // Store the slug for later
-                        firstPost.slug = createdFirstPost.get('slug');
+                const createdFirstPost = await models.Post.add(firstPost, context);
+                // Store the slug for later
+                firstPost.slug = createdFirstPost.get('slug');
 
-                        assert.equal(Object.keys(eventsTriggered).length, 2);
-                        assertExists(eventsTriggered['post.added']);
-                        assertExists(eventsTriggered['user.attached']);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['user.attached']);
 
-                        // Create the second post
-                        return models.Post.add(secondPost, context);
-                    }).then(function (createdSecondPost) {
-                    // Store the slug for comparison later
-                        secondPost.slug = createdSecondPost.get('slug');
+                // Create the second post
+                const createdSecondPost = await models.Post.add(secondPost, context);
+                // Store the slug for comparison later
+                secondPost.slug = createdSecondPost.get('slug');
 
-                        assert.equal(Object.keys(eventsTriggered).length, 2);
-                        assertExists(eventsTriggered['post.added']);
-                        assertExists(eventsTriggered['user.attached']);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['user.attached']);
 
-                        // Update with a conflicting slug from the first post
-                        return createdSecondPost.save({
-                            slug: firstPost.slug
-                        }, context);
-                    }).then(function (updatedSecondPost) {
-                    // Should have updated from original
-                        assert.notEqual(updatedSecondPost.get('slug'), secondPost.slug);
-                        // Should not have a conflicted slug from the first
-                        assert.notEqual(updatedSecondPost.get('slug'), firstPost.slug);
+                // Update with a conflicting slug from the first post
+                const updatedSecondPost = await createdSecondPost.save({
+                    slug: firstPost.slug
+                }, context);
+                // Should have updated from original
+                assert.notEqual(updatedSecondPost.get('slug'), secondPost.slug);
+                // Should not have a conflicted slug from the first
+                assert.notEqual(updatedSecondPost.get('slug'), firstPost.slug);
 
-                        assert.equal(Object.keys(eventsTriggered).length, 3);
-                        assertExists(eventsTriggered['post.edited']);
+                assert.equal(Object.keys(eventsTriggered).length, 3);
+                assertExists(eventsTriggered['post.edited']);
 
-                        return models.Post.findOne({
-                            id: updatedSecondPost.id,
-                            status: 'all'
-                        });
-                    }).then(function (foundPost) {
-                    // Should have updated from original
-                        assert.notEqual(foundPost.get('slug'), secondPost.slug);
-                        // Should not have a conflicted slug from the first
-                        assert.notEqual(foundPost.get('slug'), firstPost.slug);
-
-                        done();
-                    }).catch(done);
+                const foundPost = await models.Post.findOne({
+                    id: updatedSecondPost.id,
+                    status: 'all'
+                });
+                // Should have updated from original
+                assert.notEqual(foundPost.get('slug'), secondPost.slug);
+                // Should not have a conflicted slug from the first
+                assert.notEqual(foundPost.get('slug'), firstPost.slug);
             });
 
-            it('it stores urls as transform-ready and reads as absolute', function (done) {
+            it('it stores urls as transform-ready and reads as absolute', async function () {
                 const siteUrl = configUtils.config.get('url');
                 const post = {
                     title: 'Absolute->Transform-ready URL Transform Test',
@@ -1141,47 +993,41 @@ describe('Post Model', function () {
                     }
                 };
 
-                models.Post.add(post, context).then((createdPost) => {
-                    assert.equal(createdPost.get('mobiledoc'), `{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"${siteUrl}/content/images/card.jpg"}]],"markups":[["a",["href","${siteUrl}/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}`);
-                    assert.equal(createdPost.get('html'), `<p><a href="${siteUrl}/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="${siteUrl}/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>`);
-                    assert(createdPost.get('plaintext').includes('Testing'));
-                    assert.equal(createdPost.get('custom_excerpt'), `Testing <a href="${siteUrl}/internal">links</a> in custom excerpts`);
-                    assert.equal(createdPost.get('codeinjection_head'), `<script src="${siteUrl}/assets/head.js"></script>`);
-                    assert.equal(createdPost.get('codeinjection_foot'), `<script src="${siteUrl}/assets/foot.js"></script>`);
-                    assert.equal(createdPost.get('feature_image'), `${siteUrl}/content/images/feature.png`);
-                    assert.equal(createdPost.get('canonical_url'), `${siteUrl}/canonical`);
+                const createdPost = await models.Post.add(post, context);
+                assert.equal(createdPost.get('mobiledoc'), `{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"${siteUrl}/content/images/card.jpg"}]],"markups":[["a",["href","${siteUrl}/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}`);
+                assert.equal(createdPost.get('html'), `<p><a href="${siteUrl}/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="${siteUrl}/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>`);
+                assert(createdPost.get('plaintext').includes('Testing'));
+                assert.equal(createdPost.get('custom_excerpt'), `Testing <a href="${siteUrl}/internal">links</a> in custom excerpts`);
+                assert.equal(createdPost.get('codeinjection_head'), `<script src="${siteUrl}/assets/head.js"></script>`);
+                assert.equal(createdPost.get('codeinjection_foot'), `<script src="${siteUrl}/assets/foot.js"></script>`);
+                assert.equal(createdPost.get('feature_image'), `${siteUrl}/content/images/feature.png`);
+                assert.equal(createdPost.get('canonical_url'), `${siteUrl}/canonical`);
 
-                    const postMeta = createdPost.relations.posts_meta;
+                const postMeta = createdPost.relations.posts_meta;
 
-                    assert.equal(postMeta.get('og_image'), `${siteUrl}/content/images/og.png`);
-                    assert.equal(postMeta.get('twitter_image'), `${siteUrl}/content/images/twitter.png`);
+                assert.equal(postMeta.get('og_image'), `${siteUrl}/content/images/og.png`);
+                assert.equal(postMeta.get('twitter_image'), `${siteUrl}/content/images/twitter.png`);
 
-                    // ensure canonical_url is not transformed when protocol does not match
-                    return createdPost.save({
-                        canonical_url: `${siteUrl.replace('http:', 'https:')}/https-internal`,
-                        // sanity check for general absolute->relative transform during edits
-                        feature_image: `${siteUrl}/content/images/updated_feature.png`
-                    });
-                }).then((updatedPost) => {
-                    assert.equal(updatedPost.get('canonical_url'), `${siteUrl.replace('http:', 'https:')}/https-internal`);
-                    assert.equal(updatedPost.get('feature_image'), `${siteUrl}/content/images/updated_feature.png`);
+                // ensure canonical_url is not transformed when protocol does not match
+                const updatedPost = await createdPost.save({
+                    canonical_url: `${siteUrl.replace('http:', 'https:')}/https-internal`,
+                    // sanity check for general absolute->relative transform during edits
+                    feature_image: `${siteUrl}/content/images/updated_feature.png`
+                });
 
-                    return updatedPost;
-                }).then((updatedPost) => {
-                    return db.knex('posts').where({id: updatedPost.id});
-                }).then((knexResult) => {
-                    const [knexPost] = knexResult;
-                    assert.equal(knexPost.mobiledoc, '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/card.jpg"}]],"markups":[["a",["href","__GHOST_URL__/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
-                    assert.equal(knexPost.html, '<p><a href="__GHOST_URL__/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="__GHOST_URL__/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
-                    assert(knexPost.plaintext.includes('Testing'));
-                    assert.equal(knexPost.custom_excerpt, 'Testing <a href="__GHOST_URL__/internal">links</a> in custom excerpts');
-                    assert.equal(knexPost.codeinjection_head, '<script src="__GHOST_URL__/assets/head.js"></script>');
-                    assert.equal(knexPost.codeinjection_foot, '<script src="__GHOST_URL__/assets/foot.js"></script>');
-                    assert.equal(knexPost.feature_image, '__GHOST_URL__/content/images/updated_feature.png');
-                    assert.equal(knexPost.canonical_url, `${siteUrl.replace('http:', 'https:')}/https-internal`);
+                assert.equal(updatedPost.get('canonical_url'), `${siteUrl.replace('http:', 'https:')}/https-internal`);
+                assert.equal(updatedPost.get('feature_image'), `${siteUrl}/content/images/updated_feature.png`);
 
-                    done();
-                }).catch(done);
+                const knexResult = await db.knex('posts').where({id: updatedPost.id});
+                const [knexPost] = knexResult;
+                assert.equal(knexPost.mobiledoc, '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/card.jpg"}]],"markups":[["a",["href","__GHOST_URL__/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
+                assert.equal(knexPost.html, '<p><a href="__GHOST_URL__/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="__GHOST_URL__/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
+                assert(knexPost.plaintext.includes('Testing'));
+                assert.equal(knexPost.custom_excerpt, 'Testing <a href="__GHOST_URL__/internal">links</a> in custom excerpts');
+                assert.equal(knexPost.codeinjection_head, '<script src="__GHOST_URL__/assets/head.js"></script>');
+                assert.equal(knexPost.codeinjection_foot, '<script src="__GHOST_URL__/assets/foot.js"></script>');
+                assert.equal(knexPost.feature_image, '__GHOST_URL__/content/images/updated_feature.png');
+                assert.equal(knexPost.canonical_url, `${siteUrl.replace('http:', 'https:')}/https-internal`);
             });
 
             // NOTE: separate to the test above because mobiledoc+lexical cannot co-exist
@@ -1468,161 +1314,133 @@ describe('Post Model', function () {
                 });
             });
 
-            it('published post', function (done) {
+            it('published post', async function () {
                 // We're going to try deleting post id 1 which has tag id 1
                 const firstItemData = {id: testUtils.DataGenerator.Content.posts[0].id};
 
                 // Test that we have the post we expect, with exactly one tag
-                models.Post.findOne(firstItemData, {withRelated: ['tags']}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, firstItemData.id);
-                    assert.equal(post.status, 'published');
-                    assert.equal(post.tags.length, 2);
-                    assert.equal(post.tags[0].id, testUtils.DataGenerator.Content.tags[0].id);
+                const results = await models.Post.findOne(firstItemData, {withRelated: ['tags']});
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, firstItemData.id);
+                assert.equal(post.status, 'published');
+                assert.equal(post.tags.length, 2);
+                assert.equal(post.tags[0].id, testUtils.DataGenerator.Content.tags[0].id);
 
-                    // Destroy the post
-                    return results.destroy();
-                }).then(function (response) {
-                    const deleted = response.toJSON();
+                // Destroy the post
+                const response = await results.destroy();
+                const deleted = response.toJSON();
 
-                    assert.equal(deleted.author, undefined);
+                assert.equal(deleted.author, undefined);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 5);
-                    assertExists(eventsTriggered['post.unpublished']);
-                    assertExists(eventsTriggered['post.deleted']);
-                    assertExists(eventsTriggered['user.detached']);
-                    assertExists(eventsTriggered['tag.detached']);
-                    assertExists(eventsTriggered['post.tag.detached']);
+                assert.equal(Object.keys(eventsTriggered).length, 5);
+                assertExists(eventsTriggered['post.unpublished']);
+                assertExists(eventsTriggered['post.deleted']);
+                assertExists(eventsTriggered['user.detached']);
+                assertExists(eventsTriggered['tag.detached']);
+                assertExists(eventsTriggered['post.tag.detached']);
 
-                    // Double check we can't find the post again
-                    return models.Post.findOne(firstItemData);
-                }).then(function (newResults) {
-                    assert.equal(newResults, null);
+                // Double check we can't find the post again
+                const newResults = await models.Post.findOne(firstItemData);
+                assert.equal(newResults, null);
 
-                    // Double check we can't find any related tags
-                    return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
-                }).then(function (postsTags) {
-                    assert.deepEqual(postsTags, []);
-
-                    done();
-                }).catch(done);
+                // Double check we can't find any related tags
+                const postsTags = await ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
+                assert.deepEqual(postsTags, []);
             });
 
-            it('draft post', function (done) {
+            it('draft post', async function () {
                 // We're going to try deleting post 4 which also has tag 4
                 const firstItemData = {id: testUtils.DataGenerator.Content.posts[3].id, status: 'draft'};
 
                 // Test that we have the post we expect, with exactly one tag
-                models.Post.findOne(firstItemData, {withRelated: ['tags']}).then(function (results) {
-                    let post;
-                    assertExists(results);
-                    post = results.toJSON();
-                    assert.equal(post.id, firstItemData.id);
-                    assert.equal(post.tags.length, 1);
-                    assert.equal(post.tags[0].id, testUtils.DataGenerator.Content.tags[3].id);
+                const results = await models.Post.findOne(firstItemData, {withRelated: ['tags']});
+                assertExists(results);
+                const post = results.toJSON();
+                assert.equal(post.id, firstItemData.id);
+                assert.equal(post.tags.length, 1);
+                assert.equal(post.tags[0].id, testUtils.DataGenerator.Content.tags[3].id);
 
-                    // Destroy the post
-                    return results.destroy(firstItemData);
-                }).then(function (response) {
-                    const deleted = response.toJSON();
+                // Destroy the post
+                const response = await results.destroy(firstItemData);
+                const deleted = response.toJSON();
 
-                    assert.equal(deleted.author, undefined);
+                assert.equal(deleted.author, undefined);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 4);
-                    assertExists(eventsTriggered['post.deleted']);
-                    assertExists(eventsTriggered['tag.detached']);
-                    assertExists(eventsTriggered['post.tag.detached']);
-                    assertExists(eventsTriggered['user.detached']);
+                assert.equal(Object.keys(eventsTriggered).length, 4);
+                assertExists(eventsTriggered['post.deleted']);
+                assertExists(eventsTriggered['tag.detached']);
+                assertExists(eventsTriggered['post.tag.detached']);
+                assertExists(eventsTriggered['user.detached']);
 
-                    // Double check we can't find the post again
-                    return models.Post.findOne(firstItemData);
-                }).then(function (newResults) {
-                    assert.equal(newResults, null);
+                // Double check we can't find the post again
+                const newResults = await models.Post.findOne(firstItemData);
+                assert.equal(newResults, null);
 
-                    // Double check we can't find any related tags
-                    return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
-                }).then(function (postsTags) {
-                    assert.deepEqual(postsTags, []);
-
-                    done();
-                }).catch(done);
+                // Double check we can't find any related tags
+                const postsTags = await ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
+                assert.deepEqual(postsTags, []);
             });
 
-            it('published page', function (done) {
+            it('published page', async function () {
                 // We're going to try deleting page 6 which has tag 1
                 const firstItemData = {id: testUtils.DataGenerator.Content.posts[5].id};
 
                 // Test that we have the post we expect, with exactly one tag
-                models.Post.findOne(firstItemData, {withRelated: ['tags']}).then(function (results) {
-                    let page;
-                    assertExists(results);
-                    page = results.toJSON();
-                    assert.equal(page.id, firstItemData.id);
-                    assert.equal(page.status, 'published');
-                    assert.equal(page.type, 'page');
+                const results = await models.Post.findOne(firstItemData, {withRelated: ['tags']});
+                assertExists(results);
+                const page = results.toJSON();
+                assert.equal(page.id, firstItemData.id);
+                assert.equal(page.status, 'published');
+                assert.equal(page.type, 'page');
 
-                    // Destroy the page
-                    return results.destroy(firstItemData);
-                }).then(function (response) {
-                    const deleted = response.toJSON();
+                // Destroy the page
+                const response = await results.destroy(firstItemData);
+                const deleted = response.toJSON();
 
-                    assert.equal(deleted.author, undefined);
+                assert.equal(deleted.author, undefined);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 3);
-                    assertExists(eventsTriggered['page.unpublished']);
-                    assertExists(eventsTriggered['page.deleted']);
-                    assertExists(eventsTriggered['user.detached']);
+                assert.equal(Object.keys(eventsTriggered).length, 3);
+                assertExists(eventsTriggered['page.unpublished']);
+                assertExists(eventsTriggered['page.deleted']);
+                assertExists(eventsTriggered['user.detached']);
 
-                    // Double check we can't find the post again
-                    return models.Post.findOne(firstItemData);
-                }).then(function (newResults) {
-                    assert.equal(newResults, null);
+                // Double check we can't find the post again
+                const newResults = await models.Post.findOne(firstItemData);
+                assert.equal(newResults, null);
 
-                    // Double check we can't find any related tags
-                    return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
-                }).then(function (postsTags) {
-                    assert.deepEqual(postsTags, []);
-
-                    done();
-                }).catch(done);
+                // Double check we can't find any related tags
+                const postsTags = await ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
+                assert.deepEqual(postsTags, []);
             });
 
-            it('draft page', function (done) {
+            it('draft page', async function () {
                 // We're going to try deleting post 7 which has tag 4
                 const firstItemData = {id: testUtils.DataGenerator.Content.posts[6].id, status: 'draft'};
 
                 // Test that we have the post we expect, with exactly one tag
-                models.Post.findOne(firstItemData, {withRelated: ['tags']}).then(function (results) {
-                    let page;
-                    assertExists(results);
-                    page = results.toJSON();
-                    assert.equal(page.id, firstItemData.id);
+                const results = await models.Post.findOne(firstItemData, {withRelated: ['tags']});
+                assertExists(results);
+                const page = results.toJSON();
+                assert.equal(page.id, firstItemData.id);
 
-                    // Destroy the page
-                    return results.destroy(firstItemData);
-                }).then(function (response) {
-                    const deleted = response.toJSON();
+                // Destroy the page
+                const response = await results.destroy(firstItemData);
+                const deleted = response.toJSON();
 
-                    assert.equal(deleted.author, undefined);
+                assert.equal(deleted.author, undefined);
 
-                    assert.equal(Object.keys(eventsTriggered).length, 2);
-                    assertExists(eventsTriggered['page.deleted']);
-                    assertExists(eventsTriggered['user.detached']);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
+                assertExists(eventsTriggered['page.deleted']);
+                assertExists(eventsTriggered['user.detached']);
 
-                    // Double check we can't find the post again
-                    return models.Post.findOne(firstItemData);
-                }).then(function (newResults) {
-                    assert.equal(newResults, null);
+                // Double check we can't find the post again
+                const newResults = await models.Post.findOne(firstItemData);
+                assert.equal(newResults, null);
 
-                    // Double check we can't find any related tags
-                    return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
-                }).then(function (postsTags) {
-                    assert.deepEqual(postsTags, []);
-
-                    done();
-                }).catch(done);
+                // Double check we can't find any related tags
+                const postsTags = await ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
+                assert.deepEqual(postsTags, []);
             });
         });
 
@@ -2007,7 +1825,7 @@ describe('Post Model', function () {
             sinon.restore();
         });
 
-        it('should create the test data correctly', function (done) {
+        it('should create the test data correctly', function () {
             // creates a test tag
             assertExists(tagJSON);
             assert(Array.isArray(tagJSON));
@@ -2026,8 +1844,6 @@ describe('Post Model', function () {
             assert.equal(postJSON.tags[0].name, 'tag1');
             assert.equal(postJSON.tags[1].name, 'tag2');
             assert.equal(postJSON.tags[2].name, 'tag3');
-
-            done();
         });
 
         it('can edit slug of existing tag', function () {
@@ -2157,12 +1973,11 @@ describe('Post Model', function () {
     });
 
     // disabling sanitization until we can implement a better version
-    // it('should sanitize the title', function (done) {
+    // it('should sanitize the title', function () {
     //    new models.Post().fetch().then(function (model) {
     //        return model.set({'title': "</title></head><body><script>alert('blogtitle');</script>"}).save();
     //    }).then(function (saved) {
     //        assert.equal(saved.get('title'), "&lt;/title&gt;&lt;/head>&lt;body&gt;[removed]alert&#40;'blogtitle'&#41;;[removed]");
-    //        done();
-    //    }).catch(done);
+    //    });
     // });
 });

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -31,65 +31,54 @@ describe('User Model', function run() {
     describe('Registration', function runRegistration() {
         beforeEach(testUtils.setup('roles'));
 
-        it('can add first', function (done) {
+        it('can add first', async function () {
             const userData = testUtils.DataGenerator.forModel.users[0];
+            const createdUser = await UserModel.add(userData, context);
 
-            UserModel.add(userData, context).then(function (createdUser) {
-                assertExists(createdUser);
-                assert.notEqual(createdUser.attributes.password, userData.password, 'password was hashed');
-                assert.equal(createdUser.attributes.email, userData.email, 'email address correct');
-
-                done();
-            }).catch(done);
+            assertExists(createdUser);
+            assert.notEqual(createdUser.attributes.password, userData.password, 'password was hashed');
+            assert.equal(createdUser.attributes.email, userData.email, 'email address correct');
         });
 
-        it('shortens slug if possible', function (done) {
+        it('shortens slug if possible', async function () {
+            const userData = testUtils.DataGenerator.forModel.users[2];
+            const createdUser = await UserModel.add(userData, context);
+
+            assertExists(createdUser);
+            assert.equal(createdUser.has('slug'), true);
+            assert.equal(createdUser.attributes.slug, 'jimothy');
+        });
+
+        it('does not short slug if not possible', async function () {
             const userData = testUtils.DataGenerator.forModel.users[2];
 
-            UserModel.add(userData, context).then(function (createdUser) {
-                assertExists(createdUser);
-                assert.equal(createdUser.has('slug'), true);
-                assert.equal(createdUser.attributes.slug, 'jimothy');
-                done();
-            }).catch(done);
+            let createdUser = await UserModel.add(userData, context);
+            assertExists(createdUser);
+            assert.equal(createdUser.has('slug'), true);
+            assert.equal(createdUser.attributes.slug, 'jimothy');
+
+            userData.email = 'newmail@mail.com';
+            createdUser = await UserModel.add(userData, context);
+            assertExists(createdUser);
+            assert.equal(createdUser.has('slug'), true);
+            assert.equal(createdUser.attributes.slug, 'jimothy-bogendath');
+
+            userData.email = 'newmail2@mail.com';
+            createdUser = await UserModel.add(userData, context);
+            assertExists(createdUser);
+            assert.equal(createdUser.has('slug'), true);
+            assert.equal(createdUser.attributes.slug, 'jimothy-bogendath-2');
         });
 
-        it('does not short slug if not possible', function (done) {
+        it('does NOT lowercase email', async function () {
             const userData = testUtils.DataGenerator.forModel.users[2];
+            const createdUser = await UserModel.add(userData, context);
 
-            UserModel.add(userData, context).then(function (createdUser) {
-                assertExists(createdUser);
-                assert.equal(createdUser.has('slug'), true);
-                assert.equal(createdUser.attributes.slug, 'jimothy');
-            }).then(function () {
-                userData.email = 'newmail@mail.com';
-                UserModel.add(userData, context).then(function (createdUser) {
-                    assertExists(createdUser);
-                    assert.equal(createdUser.has('slug'), true);
-                    assert.equal(createdUser.attributes.slug, 'jimothy-bogendath');
-                }).then(function () {
-                    userData.email = 'newmail2@mail.com';
-                    UserModel.add(userData, context).then(function (createdUser) {
-                        assertExists(createdUser);
-                        assert.equal(createdUser.has('slug'), true);
-                        assert.equal(createdUser.attributes.slug, 'jimothy-bogendath-2');
-                        done();
-                    });
-                });
-            }).catch(done);
+            assertExists(createdUser);
+            assert.equal(createdUser.attributes.email, userData.email, 'email address correct');
         });
 
-        it('does NOT lowercase email', function (done) {
-            const userData = testUtils.DataGenerator.forModel.users[2];
-
-            UserModel.add(userData, context).then(function (createdUser) {
-                assertExists(createdUser);
-                assert.equal(createdUser.attributes.email, userData.email, 'email address correct');
-                done();
-            }).catch(done);
-        });
-
-        it('can find gravatar', function (done) {
+        it('can find gravatar', async function () {
             const userData = testUtils.DataGenerator.forModel.users[4];
 
             sinon.stub(imageLib.gravatar, 'lookup').callsFake(function (data) {
@@ -97,58 +86,47 @@ describe('User Model', function run() {
                 return Promise.resolve(data);
             });
 
-            UserModel.add(userData, context).then(function (createdUser) {
-                assertExists(createdUser);
-                assert.equal(createdUser.attributes.profile_image, 'http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404', 'Gravatar found');
-                done();
-            }).catch(done);
+            const createdUser = await UserModel.add(userData, context);
+            assertExists(createdUser);
+            assert.equal(createdUser.attributes.profile_image, 'http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404', 'Gravatar found');
         });
 
-        it('can handle no gravatar', function (done) {
+        it('can handle no gravatar', async function () {
             const userData = testUtils.DataGenerator.forModel.users[0];
 
             sinon.stub(imageLib.gravatar, 'lookup').callsFake(function (data) {
                 return Promise.resolve(data);
             });
 
-            UserModel.add(userData, context).then(function (createdUser) {
-                assertExists(createdUser);
-                assert.equal(createdUser.image, undefined);
-                done();
-            }).catch(done);
+            const createdUser = await UserModel.add(userData, context);
+            assertExists(createdUser);
+            assert.equal(createdUser.image, undefined);
         });
 
-        it('can find by email and is case insensitive', function (done) {
+        it('can find by email and is case insensitive', async function () {
             const userData = testUtils.DataGenerator.forModel.users[2];
             const email = testUtils.DataGenerator.forModel.users[2].email;
 
-            UserModel.add(userData, context).then(function () {
-                // Test same case
-                return UserModel.getByEmail(email).then(function (user) {
-                    assertExists(user);
-                    assert.equal(user.attributes.email, email);
-                });
-            }).then(function () {
-                // Test entered in lowercase
-                return UserModel.getByEmail(email.toLowerCase()).then(function (user) {
-                    assertExists(user);
-                    assert.equal(user.attributes.email, email);
-                });
-            }).then(function () {
-                // Test entered in uppercase
-                return UserModel.getByEmail(email.toUpperCase()).then(function (user) {
-                    assertExists(user);
-                    assert.equal(user.attributes.email, email);
-                });
-            }).then(function () {
-                // Test incorrect email address - swapped capital O for number 0
-                return UserModel.getByEmail('jb0gendAth@example.com').then(null, function (error) {
-                    assertExists(error);
-                    assert.equal(error.message, 'NotFound');
-                });
-            }).then(function () {
-                done();
-            }).catch(done);
+            await UserModel.add(userData, context);
+
+            // Test same case
+            let user = await UserModel.getByEmail(email);
+            assertExists(user);
+            assert.equal(user.attributes.email, email);
+
+            // Test entered in lowercase
+            user = await UserModel.getByEmail(email.toLowerCase());
+            assertExists(user);
+            assert.equal(user.attributes.email, email);
+
+            // Test entered in uppercase
+            user = await UserModel.getByEmail(email.toUpperCase());
+            assertExists(user);
+            assert.equal(user.attributes.email, email);
+
+            // Test incorrect email address - swapped capital O for number 0
+            user = await UserModel.getByEmail('jb0gendAth@example.com');
+            assert.equal(user, undefined);
         });
     });
 
@@ -166,158 +144,120 @@ describe('User Model', function run() {
             });
         });
 
-        it('sets last login time on successful login', function (done) {
+        it('sets last login time on successful login', async function () {
             const userData = testUtils.DataGenerator.forModel.users[0];
+            const activeUser = await UserModel.check({email: userData.email, password: userData.password});
 
-            UserModel.check({email: userData.email, password: userData.password}).then(function (activeUser) {
-                assertExists(activeUser.get('last_seen'));
-                done();
-            }).catch(done);
+            assertExists(activeUser.get('last_seen'));
         });
 
-        it('converts fetched dateTime fields to Date objects', function (done) {
+        it('converts fetched dateTime fields to Date objects', async function () {
             const userData = testUtils.DataGenerator.forModel.users[0];
+            const checkedUser = await UserModel.check({email: userData.email, password: userData.password});
+            const user = await UserModel.findOne({id: checkedUser.id});
 
-            UserModel.check({email: userData.email, password: userData.password}).then(function (user) {
-                return UserModel.findOne({id: user.id});
-            }).then(function (user) {
-                let lastLogin;
-                let createdAt;
-                let updatedAt;
+            assertExists(user);
 
-                assertExists(user);
+            const lastLogin = user.get('last_seen');
+            const createdAt = user.get('created_at');
+            const updatedAt = user.get('updated_at');
 
-                lastLogin = user.get('last_seen');
-                createdAt = user.get('created_at');
-                updatedAt = user.get('updated_at');
-
-                assert(lastLogin instanceof Date);
-                assert(createdAt instanceof Date);
-                assert(updatedAt instanceof Date);
-
-                done();
-            }).catch(done);
+            assert(lastLogin instanceof Date);
+            assert(createdAt instanceof Date);
+            assert(updatedAt instanceof Date);
         });
 
-        it('can findPage with limit all', function () {
-            return testUtils.fixtures.createExtraUsers().then(function () {
-                return UserModel.findPage({limit: 'all'});
-            }).then(function (results) {
-                assert.equal(results.meta.pagination.page, 1);
-                assert.equal(results.meta.pagination.limit, 'all');
-                assert.equal(results.meta.pagination.pages, 1);
-                assert.equal(results.data.length, 10);
-            });
+        it('can findPage with limit all', async function () {
+            await testUtils.fixtures.createExtraUsers();
+            const results = await UserModel.findPage({limit: 'all'});
+
+            assert.equal(results.meta.pagination.page, 1);
+            assert.equal(results.meta.pagination.limit, 'all');
+            assert.equal(results.meta.pagination.pages, 1);
+            assert.equal(results.data.length, 10);
         });
 
-        it('can findOne by role name', function () {
-            return testUtils.fixtures.createExtraUsers().then(function () {
-                return Promise.all([
-                    UserModel.findOne({role: 'Owner'}),
-                    UserModel.findOne({role: 'Editor'})
-                ]);
-            }).then(function (results) {
-                let owner = results[0];
-                let editor = results[1];
+        it('can findOne by role name', async function () {
+            await testUtils.fixtures.createExtraUsers();
 
-                assertExists(owner);
-                assertExists(editor);
+            const results = await Promise.all([
+                UserModel.findOne({role: 'Owner'}),
+                UserModel.findOne({role: 'Editor'})
+            ]);
+            let owner = results[0];
+            let editor = results[1];
 
-                owner = owner.toJSON();
-                editor = editor.toJSON();
+            assertExists(owner);
+            assertExists(editor);
 
-                assertExists(owner.roles);
-                assertExists(editor.roles);
+            owner = owner.toJSON();
+            editor = editor.toJSON();
 
-                assert.equal(owner.roles[0].name, 'Owner');
-                assert.equal(editor.roles[0].name, 'Editor');
-            });
+            assertExists(owner.roles);
+            assertExists(editor.roles);
+
+            assert.equal(owner.roles[0].name, 'Owner');
+            assert.equal(editor.roles[0].name, 'Editor');
         });
 
-        it('can add active user', function (done) {
+        it('can add active user', async function () {
             const userData = testUtils.DataGenerator.forModel.users[4];
+            const role = await RoleModel.findOne();
 
-            RoleModel.findOne().then(function (role) {
-                userData.roles = [role.toJSON()];
+            userData.roles = [role.toJSON()];
 
-                return UserModel.add(userData, _.extend({}, context, {withRelated: ['roles']}));
-            }).then(function (createdUser) {
-                assertExists(createdUser);
-                assert.notEqual(createdUser.get('password'), userData.password, 'password was hashed');
-                assert.equal(createdUser.get('email'), userData.email, 'email address correct');
-                assert.equal(createdUser.related('roles').toJSON()[0].name, 'Administrator', 'role set correctly');
+            const createdUser = await UserModel.add(userData, _.extend({}, context, {withRelated: ['roles']}));
+            assertExists(createdUser);
+            assert.notEqual(createdUser.get('password'), userData.password, 'password was hashed');
+            assert.equal(createdUser.get('email'), userData.email, 'email address correct');
+            assert.equal(createdUser.related('roles').toJSON()[0].name, 'Administrator', 'role set correctly');
 
-                assert.equal(Object.keys(eventsTriggered).length, 2);
-                assertExists(eventsTriggered['user.added']);
-                assertExists(eventsTriggered['user.activated']);
-
-                done();
-            }).catch(done);
+            assert.equal(Object.keys(eventsTriggered).length, 2);
+            assertExists(eventsTriggered['user.added']);
+            assertExists(eventsTriggered['user.activated']);
         });
 
-        it('can NOT add active user with invalid email address', function (done) {
+        it('can NOT add active user with invalid email address', async function () {
             const userData = _.clone(testUtils.DataGenerator.forModel.users[4]);
+            const role = await RoleModel.findOne();
 
             userData.email = 'invalidemailaddress';
+            userData.roles = [role.toJSON()];
 
-            RoleModel.findOne().then(function (role) {
-                userData.roles = [role.toJSON()];
+            await assert.rejects(UserModel.add(userData, _.extend({}, context, {withRelated: ['roles']})));
+        });
 
-                return UserModel.add(userData, _.extend({}, context, {withRelated: ['roles']}));
-            }).then(function () {
-                done(new Error('User was created with an invalid email address'));
-            }).catch(function () {
-                done();
+        it('can edit active user', async function () {
+            const firstUser = testUtils.DataGenerator.Content.users[0].id;
+            const results = await UserModel.findOne({id: firstUser});
+
+            assertExists(results);
+            const user = results.toJSON();
+            assert.equal(user.id, firstUser);
+            assert.equal(user.website, null);
+
+            const edited = await UserModel.edit({website: 'http://some.newurl.com'}, {id: firstUser});
+            assertExists(edited);
+            assert.equal(edited.attributes.website, 'http://some.newurl.com');
+
+            assert.equal(Object.keys(eventsTriggered).length, 2);
+            assertExists(eventsTriggered['user.activated.edited']);
+            assertExists(eventsTriggered['user.edited']);
+        });
+
+        it('can NOT set an invalid email address', async function () {
+            const firstUser = testUtils.DataGenerator.Content.users[0].id;
+            await assert.rejects(UserModel.edit({email: 'notanemailaddress'}, {id: firstUser}), (err) => {
+                assert.equal(err[0] instanceof errors.ValidationError, true);
+                return true;
             });
         });
 
-        it('can edit active user', function (done) {
-            const firstUser = testUtils.DataGenerator.Content.users[0].id;
-
-            UserModel.findOne({id: firstUser}).then(function (results) {
-                let user;
-                assertExists(results);
-                user = results.toJSON();
-                assert.equal(user.id, firstUser);
-                assert.equal(user.website, null);
-
-                return UserModel.edit({website: 'http://some.newurl.com'}, {id: firstUser});
-            }).then(function (edited) {
-                assertExists(edited);
-                assert.equal(edited.attributes.website, 'http://some.newurl.com');
-
-                assert.equal(Object.keys(eventsTriggered).length, 2);
-                assertExists(eventsTriggered['user.activated.edited']);
-                assertExists(eventsTriggered['user.edited']);
-
-                done();
-            }).catch(done);
-        });
-
-        it('can NOT set an invalid email address', function (done) {
-            const firstUser = testUtils.DataGenerator.Content.users[0].id;
-
-            UserModel.findOne({id: firstUser}).then(function (user) {
-                return user.edit({email: 'notanemailaddress'});
-            }).then(function () {
-                done(new Error('Invalid email address was accepted'));
-            }).catch(function () {
-                done();
-            });
-        });
-
-        it('can NOT set an already existing email address', function (done) {
+        it('can NOT set an already existing email address', async function () {
             const firstUser = testUtils.DataGenerator.Content.users[0];
             const secondUser = testUtils.DataGenerator.Content.users[1];
 
-            UserModel.edit({email: secondUser.email}, {id: firstUser.id})
-                .then(function () {
-                    done(new Error('Already existing email address was accepted'));
-                })
-                .catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+            await assert.rejects(UserModel.edit({email: secondUser.email}, {id: firstUser.id}), errors.ValidationError);
         });
     });
 
@@ -325,118 +265,79 @@ describe('User Model', function run() {
         beforeEach(testUtils.setup('users:roles'));
 
         describe('error', function () {
-            it('wrong old password', function (done) {
-                UserModel.changePassword({
+            it('wrong old password', async function () {
+                await assert.rejects(UserModel.changePassword({
                     newPassword: '1234567890',
                     ne2Password: '1234567890',
                     oldPassword: '123456789',
                     user_id: testUtils.DataGenerator.Content.users[0].id
-                }, testUtils.context.owner).then(function () {
-                    done(new Error('expected error!'));
-                }).catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                }, testUtils.context.owner), errors.ValidationError);
             });
 
-            it('too short password', function (done) {
-                UserModel.changePassword({
+            it('too short password', async function () {
+                await assert.rejects(UserModel.changePassword({
                     newPassword: '12345678',
                     ne2Password: '12345678',
                     oldPassword: 'Sl1m3rson99',
                     user_id: testUtils.DataGenerator.Content.users[0].id
-                }, testUtils.context.owner).then(function () {
-                    done(new Error('expected error!'));
-                }).catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                }, testUtils.context.owner), errors.ValidationError);
             });
 
-            it('very bad password', function (done) {
-                UserModel.changePassword({
+            it('very bad password', async function () {
+                await assert.rejects(UserModel.changePassword({
                     newPassword: '1234567890',
                     ne2Password: '1234567890',
                     oldPassword: 'Sl1m3rson99',
                     user_id: testUtils.DataGenerator.Content.users[0].id
-                }, testUtils.context.owner).then(function () {
-                    done(new Error('expected error!'));
-                }).catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                }, testUtils.context.owner), errors.ValidationError);
             });
 
-            it('password matches users email adress', function (done) {
-                UserModel.changePassword({
+            it('password matches users email adress', async function () {
+                await assert.rejects(UserModel.changePassword({
                     newPassword: 'jbloggs@example.com',
                     ne2Password: 'jbloggs@example.com',
                     oldPassword: 'Sl1m3rson99',
                     user_id: testUtils.DataGenerator.Content.users[0].id
-                }, testUtils.context.owner).then(function () {
-                    done(new Error('expected error!'));
-                }).catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                }, testUtils.context.owner), errors.ValidationError);
             });
 
-            it('password contains words "ghost" or "password"', function (done) {
-                UserModel.changePassword({
+            it('password contains words "ghost" or "password"', async function () {
+                await assert.rejects(UserModel.changePassword({
                     newPassword: 'onepassword',
                     ne2Password: 'onepassword',
                     oldPassword: 'Sl1m3rson99',
                     user_id: testUtils.DataGenerator.Content.users[0].id
-                }, testUtils.context.owner).then(function () {
-                    done(new Error('expected error!'));
-                }).catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                }, testUtils.context.owner), errors.ValidationError);
             });
 
-            it('password matches blog URL', function (done) {
+            it('password matches blog URL', async function () {
                 const blogUrl = new URL(config.get('url'));
                 const blogHostPassword = blogUrl.host;
-                UserModel.changePassword({
+
+                await assert.rejects(UserModel.changePassword({
                     newPassword: blogHostPassword,
                     ne2Password: blogHostPassword,
                     oldPassword: 'Sl1m3rson99',
                     user_id: testUtils.DataGenerator.Content.users[0].id
-                }, testUtils.context.owner).then(function () {
-                    done(new Error('expected error!'));
-                }).catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                }, testUtils.context.owner), errors.ValidationError);
             });
 
-            it('password contains repeating chars', function (done) {
-                UserModel.changePassword({
+            it('password contains repeating chars', async function () {
+                await assert.rejects(UserModel.changePassword({
                     newPassword: 'cdcdcdcdcd',
                     ne2Password: 'cdcdcdcdcd',
                     oldPassword: 'Sl1m3rson99',
                     user_id: testUtils.DataGenerator.Content.users[0].id
-                }, testUtils.context.owner).then(function () {
-                    done(new Error('expected error!'));
-                }).catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                }, testUtils.context.owner), errors.ValidationError);
             });
 
-            it('password contains repeating numbers', function (done) {
-                UserModel.changePassword({
+            it('password contains repeating numbers', async function () {
+                await assert.rejects(UserModel.changePassword({
                     newPassword: '1231111111',
                     ne2Password: '1231111111',
                     oldPassword: 'Sl1m3rson99',
                     user_id: testUtils.DataGenerator.Content.users[0].id
-                }, testUtils.context.owner).then(function () {
-                    done(new Error('expected error!'));
-                }).catch(function (err) {
-                    assert.equal((err instanceof errors.ValidationError), true);
-                    done();
-                });
+                }, testUtils.context.owner), errors.ValidationError);
             });
         });
     });
@@ -444,24 +345,20 @@ describe('User Model', function run() {
     describe('User setup', function () {
         beforeEach(testUtils.setup('owner'));
 
-        it('setup user', function (done) {
+        it('setup user', async function () {
             const userData = {
                 name: 'Max Mustermann',
                 email: 'test@ghost.org',
                 password: 'thisissupersafe'
             };
+            const user = await UserModel.setup(userData, {id: DataGenerator.Content.users[0].id});
 
-            UserModel.setup(userData, {id: DataGenerator.Content.users[0].id})
-                .then(function (user) {
-                    assert.equal(user.get('name'), userData.name);
-                    assert.equal(user.get('email'), userData.email);
-                    assert.equal(user.get('slug'), 'max');
+            assert.equal(user.get('name'), userData.name);
+            assert.equal(user.get('email'), userData.email);
+            assert.equal(user.get('slug'), 'max');
 
-                    // naive check that password was hashed
-                    assert.notEqual(user.get('password'), userData.password);
-                    done();
-                })
-                .catch(done);
+            // naive check that password was hashed
+            assert.notEqual(user.get('password'), userData.password);
         });
     });
 });

--- a/ghost/core/test/legacy/site/frontend.test.js
+++ b/ghost/core/test/legacy/site/frontend.test.js
@@ -14,21 +14,6 @@ const config = require('../../../core/shared/config');
 let request;
 
 describe('Frontend Routing', function () {
-    function doEnd(done) {
-        return function (err, res) {
-            if (err) {
-                return done(err);
-            }
-
-            assert.equal(res.headers['x-cache-invalidate'], undefined);
-            assert.equal(res.headers['X-CSRF-Token'], undefined);
-            assert.equal(res.headers['set-cookie'], undefined);
-            assertExists(res.headers.date);
-
-            done();
-        };
-    }
-
     function assertCorrectFrontendHeaders(res) {
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         assert.equal(res.headers['X-CSRF-Token'], undefined);
@@ -58,55 +43,55 @@ describe('Frontend Routing', function () {
 
     describe('Test with Initial Fixtures', function () {
         describe('Error', function () {
-            it('should 404 for unknown post with invalid characters', function (done) {
-                request.get('/$pec+acular~/')
+            it('should 404 for unknown post with invalid characters', async function () {
+                await request.get('/$pec+acular~/')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
-                    .end(doEnd(done));
+                    .expect(assertCorrectFrontendHeaders);
             });
 
-            it('should 404 for unknown frontend route', function (done) {
-                request.get('/spectacular/marvellous/')
+            it('should 404 for unknown frontend route', async function () {
+                await request.get('/spectacular/marvellous/')
                     .set('Accept', 'application/json')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
-                    .end(doEnd(done));
+                    .expect(assertCorrectFrontendHeaders);
             });
 
-            it('should 404 for encoded char not 301 from uncapitalise', function (done) {
-                request.get('/|/')
+            it('should 404 for encoded char not 301 from uncapitalise', async function () {
+                await request.get('/|/')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
-                    .end(doEnd(done));
+                    .expect(assertCorrectFrontendHeaders);
             });
         });
 
         describe('Default Redirects (clean URLS)', function () {
-            it('Single post should redirect without slash', function (done) {
-                request.get('/welcome')
+            it('Single post should redirect without slash', async function () {
+                await request.get('/welcome')
                     .expect('Location', '/welcome/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
                     .expect(301)
-                    .end(doEnd(done));
+                    .expect(assertCorrectFrontendHeaders);
             });
 
-            it('Single post should redirect uppercase', function (done) {
-                request.get('/Welcome/')
+            it('Single post should redirect uppercase', async function () {
+                await request.get('/Welcome/')
                     .expect('Location', '/welcome/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
                     .expect(301)
-                    .end(doEnd(done));
+                    .expect(assertCorrectFrontendHeaders);
             });
 
-            it('Single post should sanitize double slashes when redirecting uppercase', function (done) {
-                request.get('///Google/')
+            it('Single post should sanitize double slashes when redirecting uppercase', async function () {
+                await request.get('///Google/')
                     .expect('Location', '/google/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
                     .expect(301)
-                    .end(doEnd(done));
+                    .expect(assertCorrectFrontendHeaders);
             });
         });
     });
@@ -115,33 +100,25 @@ describe('Frontend Routing', function () {
         before(addPosts);
 
         describe('Static page', function () {
-            it('should respond with html', function (done) {
-                request.get('/static-page-test/')
+            it('should respond with html', async function () {
+                const res = await request.get('/static-page-test/')
                     .expect('Content-Type', /html/)
                     .expect('Cache-Control', testUtils.cacheRules.public)
                     .expect(200)
-                    .end(function (err, res) {
-                        const $ = cheerio.load(res.text);
+                    .expect(assertCorrectFrontendHeaders);
 
-                        assert.equal(res.headers['x-cache-invalidate'], undefined);
-                        assert.equal(res.headers['X-CSRF-Token'], undefined);
-                        assert.equal(res.headers['set-cookie'], undefined);
-                        assertExists(res.headers.date);
-
-                        assert.equal($('title').text(), 'This is a static page');
-                        assert.equal($('body.page-template').length, 1);
-                        assert.equal($('article.post').length, 1);
-
-                        doEnd(done)(err, res);
-                    });
+                const $ = cheerio.load(res.text);
+                assert.equal($('title').text(), 'This is a static page');
+                assert.equal($('body.page-template').length, 1);
+                assert.equal($('article.post').length, 1);
             });
 
-            it('should redirect without slash', function (done) {
-                request.get('/static-page-test')
+            it('should redirect without slash', async function () {
+                await request.get('/static-page-test')
                     .expect('Location', '/static-page-test/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
                     .expect(301)
-                    .end(doEnd(done));
+                    .expect(assertCorrectFrontendHeaders);
             });
 
             describe('edit', function () {
@@ -194,31 +171,31 @@ describe('Frontend Routing', function () {
                     await addPosts();
                 });
 
-                it('should redirect without slash', function (done) {
-                    request.get('/static-page-test/edit')
+                it('should redirect without slash', async function () {
+                    await request.get('/static-page-test/edit')
                         .expect('Location', '/static-page-test/edit/')
                         .expect('Cache-Control', testUtils.cacheRules.year)
                         .expect(301)
-                        .end(doEnd(done));
+                        .expect(assertCorrectFrontendHeaders);
                 });
 
-                it('should not redirect to editor', function (done) {
-                    request.get('/static-page-test/edit/')
+                it('should not redirect to editor', async function () {
+                    await request.get('/static-page-test/edit/')
                         .expect(404)
                         .expect('Cache-Control', testUtils.cacheRules.noCache)
-                        .end(doEnd(done));
+                        .expect(assertCorrectFrontendHeaders);
                 });
             });
 
             describe('amp', function () {
                 // AMP is no longer supported as of v6.0, so we only check the case in which it's disabled
                 describe('amp disabled', function (){
-                    it('should 301 for amp parameter', function (done) {
+                    it('should 301 for amp parameter', async function () {
                         // NOTE: only post pages are supported so the router doesn't have a way to distinguish if
                         //       the request was done after AMP 'Page' or 'Post'
-                        request.get('/static-page-test/amp/')
+                        await request.get('/static-page-test/amp/')
                             .expect(301)
-                            .end(doEnd(done));
+                            .expect(assertCorrectFrontendHeaders);
                     });
                 });
             });
@@ -227,11 +204,11 @@ describe('Frontend Routing', function () {
         describe('Post with Ghost in the url', function () {
             // All of Ghost's admin depends on the /ghost/ in the url to work properly
             // Badly formed regexs can cause breakage if a post slug starts with the 5 letters ghost
-            it('should retrieve a blog post with ghost at the start of the url', function (done) {
-                request.get('/ghostly-kitchen-sink/')
+            it('should retrieve a blog post with ghost at the start of the url', async function () {
+                await request.get('/ghostly-kitchen-sink/')
                     .expect('Cache-Control', testUtils.cacheRules.public)
                     .expect(200)
-                    .end(doEnd(done));
+                    .expect(assertCorrectFrontendHeaders);
             });
         });
     });

--- a/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
@@ -8,7 +8,7 @@ const LocalStorageBase = require('../../../../../core/server/adapters/storage/Lo
 
 describe('Local Storage Base', function () {
     describe('serve', function () {
-        it('returns a 416 RangeNotSatisfiableError if given an invalid range', function (done) {
+        it('returns a 416 RangeNotSatisfiableError if given an invalid range', async function () {
             const localStorageBase = new LocalStorageBase({
                 storagePath: path.resolve(__dirname, 'media-storage'),
                 staticFileURLPrefix: 'content/media',
@@ -27,10 +27,11 @@ describe('Local Storage Base', function () {
                 range: 'bytes=1000-999'
             };
 
-            localStorageBase.serve()(req, res, (err) => {
-                assert.equal(err.errorType, 'RangeNotSatisfiableError');
-                done();
+            const err = await new Promise((resolve) => {
+                localStorageBase.serve()(req, res, resolve);
             });
+
+            assert.equal(err.errorType, 'RangeNotSatisfiableError');
         });
     });
 

--- a/ghost/core/test/unit/server/services/themes/loader.test.js
+++ b/ghost/core/test/unit/server/services/themes/loader.test.js
@@ -25,7 +25,7 @@ describe('Themes', function () {
         });
 
         describe('Load All', function () {
-            it('should load directory and include only folders', function (done) {
+            it('should load directory and include only folders', async function () {
                 // create trash
                 fs.writeFileSync(join(themePath.name, 'casper.zip'), '');
                 fs.writeFileSync(join(themePath.name, '.DS_Store'), '');
@@ -36,27 +36,22 @@ describe('Themes', function () {
                 fs.writeFileSync(join(themePath.name, 'casper', 'index.hbs'), '');
                 fs.writeFileSync(join(themePath.name, 'casper', 'partials', 'navigation.hbs'), '');
 
-                loader.loadAllThemes()
-                    .then(function (result) {
-                        const themeResult = themeList.getAll();
+                const result = await loader.loadAllThemes();
+                const themeResult = themeList.getAll();
 
-                        // Loader doesn't return anything
-                        assert.equal(result, undefined);
+                // Loader doesn't return anything
+                assert.equal(result, undefined);
 
-                        assert.deepEqual(themeResult, {
-                            casper: {
-                                name: 'casper',
-                                path: join(themePath.name, 'casper'),
-                                'package.json': null
-                            }
-                        });
-
-                        done();
-                    })
-                    .catch(done);
+                assert.deepEqual(themeResult, {
+                    casper: {
+                        name: 'casper',
+                        path: join(themePath.name, 'casper'),
+                        'package.json': null
+                    }
+                });
             });
 
-            it('should read directory and read package.json if present', function (done) {
+            it('should read directory and read package.json if present', async function () {
                 // create trash
                 fs.writeFileSync(join(themePath.name, 'README.md'), '');
                 fs.writeFileSync(join(themePath.name, 'Thumbs.db'), '');
@@ -69,34 +64,29 @@ describe('Themes', function () {
                     JSON.stringify({name: 'casper', version: '0.1.2'})
                 );
 
-                loader.loadAllThemes()
-                    .then(function (result) {
-                        const themeResult = themeList.getAll();
+                const result = await loader.loadAllThemes();
+                const themeResult = themeList.getAll();
 
-                        // Loader doesn't return anything
-                        assert.equal(result, undefined);
+                // Loader doesn't return anything
+                assert.equal(result, undefined);
 
-                        assert.deepEqual(themeResult, {
-                            casper: {
-                                name: 'casper',
-                                path: join(themePath.name, 'casper'),
-                                'package.json': {name: 'casper', version: '0.1.2'}
-                            },
-                            'not-casper': {
-                                name: 'not-casper',
-                                path: join(themePath.name, 'not-casper'),
-                                'package.json': null
-                            }
-                        });
-
-                        done();
-                    })
-                    .catch(done);
+                assert.deepEqual(themeResult, {
+                    casper: {
+                        name: 'casper',
+                        path: join(themePath.name, 'casper'),
+                        'package.json': {name: 'casper', version: '0.1.2'}
+                    },
+                    'not-casper': {
+                        name: 'not-casper',
+                        path: join(themePath.name, 'not-casper'),
+                        'package.json': null
+                    }
+                });
             });
         });
 
         describe('Load One', function () {
-            it('should read directory and include only single requested theme', function (done) {
+            it('should read directory and include only single requested theme', async function () {
                 // create trash
                 fs.writeFileSync(join(themePath.name, 'casper.zip'), '');
                 fs.writeFileSync(join(themePath.name, '.DS_Store'), '');
@@ -111,32 +101,27 @@ describe('Themes', function () {
                 fs.mkdirSync(join(themePath.name, 'not-casper'));
                 fs.writeFileSync(join(themePath.name, 'not-casper', 'index.hbs'), '');
 
-                loader.loadOneTheme('casper')
-                    .then(function (themeResult) {
-                        assert.deepEqual(themeResult, {
-                            name: 'casper',
-                            path: join(themePath.name, 'casper'),
-                            'package.json': {name: 'casper', version: '0.1.2'}
-                        });
+                const themeResult = await loader.loadOneTheme('casper');
 
-                        done();
-                    })
-                    .catch(done);
+                assert.deepEqual(themeResult, {
+                    name: 'casper',
+                    path: join(themePath.name, 'casper'),
+                    'package.json': {name: 'casper', version: '0.1.2'}
+                });
             });
 
-            it('should throw an error if theme cannot be found', function (done) {
+            it('should throw an error if theme cannot be found', async function () {
                 // create trash
                 fs.writeFileSync(join(themePath.name, 'casper.zip'), '');
                 fs.writeFileSync(join(themePath.name, '.DS_Store'), '');
 
-                loader.loadOneTheme('casper')
-                    .then(function () {
-                        done('Should have thrown an error');
-                    })
-                    .catch(function (err) {
+                await assert.rejects(
+                    loader.loadOneTheme('casper'),
+                    (err) => {
                         assert.equal(err.message, 'Package not found');
-                        done();
-                    });
+                        return true;
+                    }
+                );
             });
         });
     });

--- a/ghost/core/test/unit/server/web/api/middleware/update-user-last-seen.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/update-user-last-seen.test.js
@@ -1,57 +1,57 @@
 const assert = require('node:assert/strict');
+const {promisify} = require('node:util');
 const sinon = require('sinon');
 const moment = require('moment');
 const updateUserLastSeenMiddleware = require('../../../../../../core/server/web/api/middleware/update-user-last-seen');
+
+const updateUserLastSeen = promisify(updateUserLastSeenMiddleware);
 
 describe('updateUserLastSeenMiddleware', function () {
     afterEach(function () {
         sinon.restore();
     });
 
-    it('calls next with no error if there is no user on the request', function (done) {
-        updateUserLastSeenMiddleware({}, {}, function next(err) {
-            assert.equal(err, undefined);
-            done();
-        });
+    it('calls next with no error if there is no user on the request', async function () {
+        await updateUserLastSeen({}, {});
     });
 
-    it('calls next with no error if the current last_seen is less than an hour before now', function (done) {
+    it('calls next with no error if the current last_seen is less than an hour before now', async function () {
         const fakeLastSeen = new Date();
         const fakeUser = {
             get: sinon.stub().withArgs('last_seen').returns(fakeLastSeen)
         };
-        updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
-            assert.equal(err, undefined);
-            done();
-        });
+        await updateUserLastSeen({user: fakeUser}, {});
     });
 
     describe('when the last_seen is longer than an hour ago', function () {
-        it('calls updateLastSeen on the req.user, calling next with nothing if success', function (done) {
+        it('calls updateLastSeen on the req.user, calling next with nothing if success', async function () {
             const fakeLastSeen = moment().subtract(1, 'hours').toDate();
             const fakeUser = {
                 get: sinon.stub().withArgs('last_seen').returns(fakeLastSeen),
                 updateLastSeen: sinon.stub().resolves()
             };
-            updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
-                assert.equal(err, undefined);
-                sinon.assert.calledOnce(fakeUser.updateLastSeen);
-                done();
-            });
+            await updateUserLastSeen({user: fakeUser}, {});
+
+            sinon.assert.calledOnce(fakeUser.updateLastSeen);
         });
 
-        it('calls updateLastSeen on the req.user, calling next with err if error', function (done) {
+        it('calls updateLastSeen on the req.user, calling next with err if error', async function () {
             const fakeLastSeen = moment().subtract(1, 'hours').toDate();
             const fakeError = new Error('gonna need a bigger boat');
             const fakeUser = {
                 get: sinon.stub().withArgs('last_seen').returns(fakeLastSeen),
                 updateLastSeen: sinon.stub().rejects(fakeError)
             };
-            updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
-                assert.equal(err, fakeError);
-                sinon.assert.calledOnce(fakeUser.updateLastSeen);
-                done();
-            });
+
+            await assert.rejects(
+                updateUserLastSeen({user: fakeUser}, {}),
+                (err) => {
+                    assert.equal(err, fakeError);
+                    return true;
+                }
+            );
+
+            sinon.assert.calledOnce(fakeUser.updateLastSeen);
         });
     });
 });

--- a/ghost/core/test/unit/server/web/shared/middleware/cache-control.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/cache-control.test.js
@@ -1,10 +1,21 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 
 const cacheControl = require('../../../../../../core/server/web/shared/middleware/cache-control');
 
 describe('Cache-Control middleware', function () {
     let res;
+
+    const runMiddleware = async function (middleware) {
+        await new Promise((resolve, reject) => {
+            middleware(null, res, function (err) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    };
 
     beforeEach(function () {
         res = {
@@ -16,87 +27,70 @@ describe('Cache-Control middleware', function () {
         sinon.restore();
     });
 
-    it('correctly sets the public profile headers', function (done) {
-        cacheControl('public')(null, res, function (a) {
-            assert(!a);
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
-            done();
+    it('correctly sets the public profile headers', async function () {
+        await runMiddleware(cacheControl('public'));
+
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
+    });
+
+    it('correctly sets the public profile headers with custom maxAge', async function () {
+        await runMiddleware(cacheControl('public', {maxAge: 123456}));
+
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=123456'});
+    });
+
+    it('correctly sets the public profile headers with staleWhileRevalidate', async function () {
+        await runMiddleware(cacheControl('public', {maxAge: 1, staleWhileRevalidate: 9}));
+
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=1, stale-while-revalidate=9'});
+    });
+
+    it('correctly sets the private profile headers', async function () {
+        await runMiddleware(cacheControl('private'));
+
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {
+            'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
         });
     });
 
-    it('correctly sets the public profile headers with custom maxAge', function (done) {
-        cacheControl('public', {maxAge: 123456})(null, res, function (a) {
-            assert(!a);
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=123456'});
-            done();
-        });
+    it('correctly sets the noCache profile headers', async function () {
+        await runMiddleware(cacheControl('noCache'));
+
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': 'no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'});
     });
 
-    it('correctly sets the public profile headers with staleWhileRevalidate', function (done) {
-        cacheControl('public', {maxAge: 1, staleWhileRevalidate: 9})(null, res, function (a) {
-            assert(!a);
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=1, stale-while-revalidate=9'});
-            done();
-        });
+    it('will not set headers without a profile', async function () {
+        await runMiddleware(cacheControl());
+
+        sinon.assert.notCalled(res.set);
     });
 
-    it('correctly sets the private profile headers', function (done) {
-        cacheControl('private')(null, res, function (a) {
-            assert(!a);
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, {
-                'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-            });
-            done();
-        });
-    });
-
-    it('correctly sets the noCache profile headers', function (done) {
-        cacheControl('noCache')(null, res, function (a) {
-            assert(!a);
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, {'Cache-Control': 'no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'});
-            done();
-        });
-    });
-
-    it('will not set headers without a profile', function (done) {
-        cacheControl()(null, res, function (a) {
-            assert(!a);
-            sinon.assert.notCalled(res.set);
-            done();
-        });
-    });
-
-    it('will not get confused between serving public and private', function (done) {
+    it('will not get confused between serving public and private', async function () {
         const publicCC = cacheControl('public');
         const privateCC = cacheControl('private');
 
-        publicCC(null, res, function () {
-            sinon.assert.calledOnce(res.set);
-            sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
+        await runMiddleware(publicCC);
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
 
-            privateCC(null, res, function () {
-                sinon.assert.calledTwice(res.set);
-                sinon.assert.calledWith(res.set, {
-                    'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-                });
+        await runMiddleware(privateCC);
+        sinon.assert.calledTwice(res.set);
+        sinon.assert.calledWith(res.set, {
+            'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
+        });
 
-                publicCC(null, res, function () {
-                    sinon.assert.calledThrice(res.set);
-                    sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
+        await runMiddleware(publicCC);
+        sinon.assert.calledThrice(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
 
-                    privateCC(null, res, function () {
-                        sinon.assert.calledWith(res.set, {
-                            'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-                        });
-                        done();
-                    });
-                });
-            });
+        await runMiddleware(privateCC);
+        sinon.assert.calledWith(res.set, {
+            'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
         });
     });
 });

--- a/ghost/core/test/unit/server/web/shared/middleware/uncapitalise.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/uncapitalise.test.js
@@ -22,43 +22,39 @@ describe('Middleware: uncapitalise', function () {
     });
 
     describe('Signup or reset request', function () {
-        it('[signup] does nothing if there are no capitals in req.path', function (done) {
+        it('[signup] does nothing if there are no capitals in req.path', function () {
             req.path = '/ghost/signup/';
             uncapitalise(req, res, next);
 
             sinon.assert.calledOnce(next);
-            done();
         });
 
-        it('[signup] does nothing if there are no capitals in the baseUrl', function (done) {
+        it('[signup] does nothing if there are no capitals in the baseUrl', function () {
             req.baseUrl = '/ghost/signup/';
             req.path = '';
             uncapitalise(req, res, next);
 
             sinon.assert.calledOnce(next);
-            done();
         });
 
-        it('[signup] does nothing if there are no capitals except in a token', function (done) {
+        it('[signup] does nothing if there are no capitals except in a token', function () {
             req.baseUrl = '/blog';
             req.path = '/ghost/signup/XEB123';
 
             uncapitalise(req, res, next);
 
             sinon.assert.calledOnce(next);
-            done();
         });
 
-        it('[reset] does nothing if there are no capitals except in a token', function (done) {
+        it('[reset] does nothing if there are no capitals except in a token', function () {
             req.baseUrl = '/blog';
             req.path = '/ghost/reset/NCR3NjY4NzI1ODI1OHzlcmlzZHNAZ51haWwuY29tfEpWeGxRWHUzZ3Y0cEpQRkNYYzQvbUZyc2xFSVozU3lIZHZWeFJLRml6cY54';
             uncapitalise(req, res, next);
 
             sinon.assert.calledOnce(next);
-            done();
         });
 
-        it('[signup] redirects if there are capitals in req.path', function (done) {
+        it('[signup] redirects if there are capitals in req.path', function () {
             req.path = '/ghost/SignUP/';
             req.url = req.path;
 
@@ -67,10 +63,9 @@ describe('Middleware: uncapitalise', function () {
             sinon.assert.notCalled(next);
             sinon.assert.calledOnce(res.redirect);
             sinon.assert.calledWith(res.redirect, 301, '/ghost/signup/');
-            done();
         });
 
-        it('[signup] redirects if there are capitals in req.baseUrl', function (done) {
+        it('[signup] redirects if there are capitals in req.baseUrl', function () {
             req.baseUrl = '/ghost/SignUP/';
             req.path = '';
             req.url = req.path;
@@ -81,10 +76,9 @@ describe('Middleware: uncapitalise', function () {
             sinon.assert.notCalled(next);
             sinon.assert.calledOnce(res.redirect);
             sinon.assert.calledWith(res.redirect, 301, '/ghost/signup/');
-            done();
         });
 
-        it('[signup] redirects correctly if there are capitals in req.path and req.baseUrl', function (done) {
+        it('[signup] redirects correctly if there are capitals in req.path and req.baseUrl', function () {
             req.baseUrl = '/Blog';
             req.path = '/ghosT/signUp/';
             req.url = req.path;
@@ -95,10 +89,9 @@ describe('Middleware: uncapitalise', function () {
             sinon.assert.notCalled(next);
             sinon.assert.calledOnce(res.redirect);
             sinon.assert.calledWith(res.redirect, 301, '/blog/ghost/signup/');
-            done();
         });
 
-        it('[signup] redirects correctly with capitals in req.path if there is a token', function (done) {
+        it('[signup] redirects correctly with capitals in req.path if there is a token', function () {
             req.path = '/ghosT/sigNup/XEB123';
             req.url = req.path;
 
@@ -107,10 +100,9 @@ describe('Middleware: uncapitalise', function () {
             sinon.assert.notCalled(next);
             sinon.assert.calledOnce(res.redirect);
             sinon.assert.calledWith(res.redirect, 301, '/ghost/signup/XEB123');
-            done();
         });
 
-        it('[reset] redirects correctly with capitals in req.path & req.baseUrl if there is a token', function (done) {
+        it('[reset] redirects correctly with capitals in req.path & req.baseUrl if there is a token', function () {
             req.baseUrl = '/Blog';
             req.path = '/Ghost/Reset/NCR3NjY4NzI1ODI1OHzlcmlzZHNAZ51haWwuY29tfEpWeGxRWHUzZ3Y0cEpQRkNYYzQvbUZyc2xFSVozU3lIZHZWeFJLRml6cY54';
             req.url = req.path;
@@ -121,7 +113,6 @@ describe('Middleware: uncapitalise', function () {
             sinon.assert.notCalled(next);
             sinon.assert.calledOnce(res.redirect);
             sinon.assert.calledWith(res.redirect, 301, '/blog/ghost/reset/NCR3NjY4NzI1ODI1OHzlcmlzZHNAZ51haWwuY29tfEpWeGxRWHUzZ3Y0cEpQRkNYYzQvbUZyc2xFSVozU3lIZHZWeFJLRml6cY54');
-            done();
         });
     });
 
@@ -132,18 +123,16 @@ describe('Middleware: uncapitalise', function () {
             };
 
             describe(`for ${apiVersion}`, function () {
-                it('does nothing if there are no capitals', function (done) {
+                it('does nothing if there are no capitals', function () {
                     req.path = `/ghost/api${getApiPath(apiVersion)}/endpoint/`;
                     uncapitalise(req, res, next);
 
                     sinon.assert.calledOnce(next);
-                    done();
                 });
 
-                it('version identifier is uppercase', function (done) {
+                it('version identifier is uppercase', function () {
                     // CASE: capitalizing "empty" string does not make sense
                     if (apiVersion === null) {
-                        done();
                         return;
                     }
 
@@ -155,10 +144,9 @@ describe('Middleware: uncapitalise', function () {
                     sinon.assert.notCalled(next);
                     sinon.assert.calledOnce(res.redirect);
                     sinon.assert.calledWith(res.redirect, 301, `/ghost/api${getApiPath(apiVersion)}/endpoint/`);
-                    done();
                 });
 
-                it('redirects to the lower case slug if there are capitals', function (done) {
+                it('redirects to the lower case slug if there are capitals', function () {
                     req.path = `/ghost/api${getApiPath(apiVersion)}/ASDfJ/`;
                     req.url = req.path;
 
@@ -167,10 +155,9 @@ describe('Middleware: uncapitalise', function () {
                     sinon.assert.notCalled(next);
                     sinon.assert.calledOnce(res.redirect);
                     sinon.assert.calledWith(res.redirect, 301, `/ghost/api${getApiPath(apiVersion)}/asdfj/`);
-                    done();
                 });
 
-                it('redirects to the lower case slug if there are capitals in req.baseUrl', function (done) {
+                it('redirects to the lower case slug if there are capitals in req.baseUrl', function () {
                     req.baseUrl = '/Blog';
                     req.path = `/ghost/api${getApiPath(apiVersion)}/ASDfJ/`;
                     req.url = req.path;
@@ -181,10 +168,9 @@ describe('Middleware: uncapitalise', function () {
                     sinon.assert.notCalled(next);
                     sinon.assert.calledOnce(res.redirect);
                     sinon.assert.calledWith(res.redirect, 301, `/blog/ghost/api${getApiPath(apiVersion)}/asdfj/`);
-                    done();
                 });
 
-                it('does not convert any capitals after the endpoint', function (done) {
+                it('does not convert any capitals after the endpoint', function () {
                     const query = '?filter=mAgic';
                     req.path = `/Ghost/API${getApiPath(apiVersion)}/settings/is_private/`;
                     req.url = `${req.path}${query}`;
@@ -194,10 +180,9 @@ describe('Middleware: uncapitalise', function () {
                     sinon.assert.notCalled(next);
                     sinon.assert.calledOnce(res.redirect);
                     sinon.assert.calledWith(res.redirect, 301, `/ghost/api${getApiPath(apiVersion)}/settings/is_private/${query}`);
-                    done();
                 });
 
-                it('does not convert any capitals after the endpoint with baseUrl', function (done) {
+                it('does not convert any capitals after the endpoint with baseUrl', function () {
                     const query = '?filter=mAgic';
                     req.baseUrl = '/Blog';
                     req.path = `/ghost/api${getApiPath(apiVersion)}/mail/test@example.COM/`;
@@ -209,22 +194,20 @@ describe('Middleware: uncapitalise', function () {
                     sinon.assert.notCalled(next);
                     sinon.assert.calledOnce(res.redirect);
                     sinon.assert.calledWith(res.redirect, 301, `/blog/ghost/api${getApiPath(apiVersion)}/mail/test@example.COM/${query}`);
-                    done();
                 });
             });
         });
     });
 
     describe('Any other request', function () {
-        it('does nothing if there are no capitals', function (done) {
+        it('does nothing if there are no capitals', function () {
             req.path = '/this-is-my-blog-post';
             uncapitalise(req, res, next);
 
             sinon.assert.calledOnce(next);
-            done();
         });
 
-        it('redirects to the lower case slug if there are capitals', function (done) {
+        it('redirects to the lower case slug if there are capitals', function () {
             req.path = '/THis-iS-my-BLOg-poSt';
             req.url = req.path;
 
@@ -233,7 +216,6 @@ describe('Middleware: uncapitalise', function () {
             sinon.assert.notCalled(next);
             sinon.assert.calledOnce(res.redirect);
             sinon.assert.calledWith(res.redirect, 301, '/this-is-my-blog-post');
-            done();
         });
     });
 });

--- a/ghost/core/test/unit/server/web/shared/middleware/url-redirects.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/url-redirects.test.js
@@ -59,7 +59,7 @@ describe('UNIT: url redirects', function () {
     });
 
     describe('expect redirect', function () {
-        it('site is https, request is http', function (done) {
+        it('site is https, request is http', function () {
             configUtils.set({
                 url: 'https://default.com:2368/'
             });
@@ -72,10 +72,9 @@ describe('UNIT: url redirects', function () {
             sinon.assert.called(res.redirect);
             sinon.assert.calledWith(res.redirect, 301, 'https://default.com:2368/');
             sinon.assert.called(res.set);
-            done();
         });
 
-        it('site host is !== request host', function (done) {
+        it('site host is !== request host', function () {
             configUtils.set({
                 url: 'https://default.com'
             });
@@ -87,11 +86,10 @@ describe('UNIT: url redirects', function () {
             sinon.assert.called(res.redirect);
             sinon.assert.calledWith(res.redirect, 301, 'https://localhost:2368/');
             sinon.assert.called(res.set);
-            done();
         });
 
         describe(`admin redirects`, function () {
-            it('url and admin url are equal, but protocol is different, request is http', function (done) {
+            it('url and admin url are equal, but protocol is different, request is http', function () {
                 configUtils.set({
                     url: 'http://default.com:2368',
                     admin: {
@@ -106,10 +104,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.notCalled(next);
                 sinon.assert.calledWith(res.redirect, 301, 'https://default.com:2368/ghost/');
                 sinon.assert.called(res.set);
-                done();
             });
 
-            it('url and admin url are different, request is http', function (done) {
+            it('url and admin url are different, request is http', function () {
                 configUtils.set({
                     url: 'http://default.com:2368',
                     admin: {
@@ -124,10 +121,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.notCalled(next);
                 sinon.assert.calledWith(res.redirect, 301, 'https://admin.default.com:2368/ghost/');
                 sinon.assert.called(res.set);
-                done();
             });
 
-            it('subdirectory', function (done) {
+            it('subdirectory', function () {
                 configUtils.set({
                     url: 'http://default.com:2368/blog',
                     admin: {
@@ -149,10 +145,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.called(next);
                 sinon.assert.calledOnce(res.redirect);
                 sinon.assert.calledOnce(res.set);
-                done();
             });
 
-            it('keeps query', function (done) {
+            it('keeps query', function () {
                 configUtils.set({
                     url: 'http://default.com:2368',
                     admin: {
@@ -171,10 +166,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.notCalled(next);
                 sinon.assert.calledWith(res.redirect, 301, 'https://admin.default.com:2368/ghost/?test=true');
                 sinon.assert.called(res.set);
-                done();
             });
 
-            it('original url has search params', function (done) {
+            it('original url has search params', function () {
                 configUtils.set({
                     url: 'http://default.com:2368',
                     admin: {
@@ -193,10 +187,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.notCalled(next);
                 sinon.assert.calledWith(res.redirect, 301, 'https://admin.default.com:2368/ghost/something/?a=b');
                 sinon.assert.called(res.set);
-                done();
             });
 
-            it('ensure redirect loop won\'t happen', function (done) {
+            it('ensure redirect loop won\'t happen', function () {
                 configUtils.set({
                     url: 'http://default.com:2368',
                     admin: {
@@ -220,13 +213,12 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.notCalled(res.redirect);
                 sinon.assert.calledOnce(res.set);
                 sinon.assert.called(next);
-                done();
             });
         });
     });
 
     describe('expect no redirect', function () {
-        it('site is http, request is http', function (done) {
+        it('site is http, request is http', function () {
             configUtils.set({
                 url: 'http://default.com:2368/'
             });
@@ -239,10 +231,9 @@ describe('UNIT: url redirects', function () {
             sinon.assert.notCalled(res.redirect);
             sinon.assert.notCalled(res.set);
             sinon.assert.calledWith(next);
-            done();
         });
 
-        it('site is http, request is https', function (done) {
+        it('site is http, request is https', function () {
             configUtils.set({
                 url: 'http://default.com:2368/'
             });
@@ -255,10 +246,9 @@ describe('UNIT: url redirects', function () {
             sinon.assert.called(next);
             sinon.assert.notCalled(res.redirect);
             sinon.assert.notCalled(res.set);
-            done();
         });
 
-        it('blog is http, request is https (trailing slash is missing)', function (done) {
+        it('blog is http, request is https (trailing slash is missing)', function () {
             configUtils.set({
                 url: 'http://default.com:2368/'
             });
@@ -271,10 +261,9 @@ describe('UNIT: url redirects', function () {
             sinon.assert.called(next);
             sinon.assert.notCalled(res.redirect);
             sinon.assert.notCalled(res.set);
-            done();
         });
 
-        it('blog is https, request is https', function (done) {
+        it('blog is https, request is https', function () {
             configUtils.set({
                 url: 'https://default.com:2368/'
             });
@@ -288,10 +277,9 @@ describe('UNIT: url redirects', function () {
             sinon.assert.calledWith(next);
             sinon.assert.notCalled(res.redirect);
             sinon.assert.notCalled(res.set);
-            done();
         });
 
-        it('blog host is !== request host', function (done) {
+        it('blog host is !== request host', function () {
             configUtils.set({
                 url: 'https://default.com'
             });
@@ -304,11 +292,10 @@ describe('UNIT: url redirects', function () {
             sinon.assert.called(next);
             sinon.assert.notCalled(res.redirect);
             sinon.assert.notCalled(res.set);
-            done();
         });
 
         describe(`admin redirects`, function () {
-            it('admin is blog url and http, requester is http', function (done) {
+            it('admin is blog url and http, requester is http', function () {
                 configUtils.set({
                     url: 'http://default.com:2368'
                 });
@@ -320,10 +307,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.called(next);
                 sinon.assert.notCalled(res.redirect);
                 sinon.assert.notCalled(res.set);
-                done();
             });
 
-            it('admin request, no custom admin.url configured', function (done) {
+            it('admin request, no custom admin.url configured', function () {
                 configUtils.set({
                     url: 'http://default.com:2368'
                 });
@@ -335,10 +321,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.called(next);
                 sinon.assert.notCalled(res.redirect);
                 sinon.assert.notCalled(res.set);
-                done();
             });
 
-            it('url and admin url are different, protocol is different, request is not secure', function (done) {
+            it('url and admin url are different, protocol is different, request is not secure', function () {
                 configUtils.set({
                     url: 'http://ghost.org/blog/',
                     admin: {
@@ -354,10 +339,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.notCalled(res.redirect);
                 sinon.assert.notCalled(res.set);
                 sinon.assert.called(next);
-                done();
             });
 
-            it('url and admin url are different, protocol is different, request is secure', function (done) {
+            it('url and admin url are different, protocol is different, request is secure', function () {
                 configUtils.set({
                     url: 'http://ghost.org/blog/',
                     admin: {
@@ -374,10 +358,9 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.notCalled(res.redirect);
                 sinon.assert.notCalled(res.set);
                 sinon.assert.called(next);
-                done();
             });
 
-            it('url and admin url are different, request matches, uses a port', function (done) {
+            it('url and admin url are different, request matches, uses a port', function () {
                 configUtils.set({
                     url: 'https://default.com:2368',
                     admin: {
@@ -394,8 +377,6 @@ describe('UNIT: url redirects', function () {
                 sinon.assert.notCalled(res.redirect);
                 sinon.assert.notCalled(res.set);
                 sinon.assert.called(next);
-
-                done();
             });
         });
     });


### PR DESCRIPTION
no ref

We want to switch to Vitest, which doesn't support `done` callbacks. This replaces several files with promises.
