### PR TITLE
Changed label pickers to use option sources

### DIFF
--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -42,13 +42,6 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
         triggerText = `${picker.resolvedSelectedLabels.length} labels`;
     }
 
-    // Convert labels to FilterOption format for MultiSelectCombobox
-    const options = picker.labels.map(label => ({
-        value: label.slug,
-        label: label.name,
-        metadata: {id: label.id}
-    }));
-
     const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
 
     const renderItem = useCallback(({option, isSelected, onSelect}: RenderItemProps<string>) => {
@@ -142,7 +135,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                 } else {
                     // MultiSelectCombobox remounts with an empty input, so clear the picker query
                     // too or the hidden search state keeps filtering labels after reopen.
-                    picker.onSearchChange('');
+                    picker.optionSource.onSearchChange?.('');
                 }
             }}
         >
@@ -156,7 +149,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                 </button>
             </PopoverTrigger>
             <PopoverContent align="start" alignOffset={alignOffset} className="w-64 p-0">
-                {picker.isLoading ? (
+                {picker.optionSource.isInitialLoad ? (
                     <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
                         Loading labels...
                     </div>
@@ -167,12 +160,10 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                             searchPlaceholder: 'Search labels...',
                             noResultsFound: 'No labels found'
                         }}
-                        options={options}
+                        optionSource={picker.optionSource}
                         renderItem={renderItem}
-                        shouldFilter={false}
                         values={values}
                         onChange={onChange}
-                        onSearchChange={picker.onSearchChange}
                     />
                 )}
             </PopoverContent>

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -1,29 +1,23 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {Badge, Command, CommandEmpty, CommandGroup, CommandItem, CommandList} from '@tryghost/shade/components';
+import {
+    Badge,
+    type ComboboxOptionSource,
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandItem,
+    CommandList
+} from '@tryghost/shade/components';
 import {EditRow} from './edit-row';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
 import {LucideIcon} from '@tryghost/shade/utils';
 
-function useControlledSearch(controlledValue?: string, onControlledChange?: (value: string) => void) {
-    const [localSearch, setLocalSearch] = useState('');
-    const search = controlledValue ?? localSearch;
-
-    const handleSearchChange = useCallback((value: string) => {
-        setLocalSearch(value);
-        onControlledChange?.(value);
-    }, [onControlledChange]);
-
-    return {search, handleSearchChange};
-}
-
 export interface LabelPickerProps {
     labels: Label[];
+    optionSource: ComboboxOptionSource<string>;
     selectedSlugs: string[];
     resolvedSelectedLabels?: Label[];
-    isLoading?: boolean;
     onToggle: (slug: string) => void;
-    searchValue?: string;
-    onSearchChange?: (search: string) => void;
     // Creation
     canCreateFromSearch?: (inputValue: string) => boolean;
     onCreate?: (name: string) => Promise<Label | undefined>;
@@ -109,7 +103,6 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
         : labels;
     const showCreate = !!onCreate && search.trim() && canCreateFromSearch?.(search);
     const showEdit = !!onEdit;
-
     const handleCreate = async () => {
         if (onCreate) {
             const newLabel = await onCreate(search.trim());
@@ -208,12 +201,10 @@ const SelectedPills: React.FC<SelectedPillsProps> = ({labels, onToggle}) => (
 
 const LabelPicker: React.FC<LabelPickerProps> = ({
     labels,
+    optionSource,
     selectedSlugs,
     resolvedSelectedLabels,
-    isLoading,
     onToggle,
-    searchValue,
-    onSearchChange,
     canCreateFromSearch,
     onCreate,
     isCreating,
@@ -230,15 +221,13 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
             canCreateFromSearch={canCreateFromSearch}
             isCreating={isCreating}
             isDuplicateName={isDuplicateName}
-            isLoading={isLoading}
             labels={labels}
-            searchValue={searchValue}
+            optionSource={optionSource}
             selectedLabels={selectedLabels}
             selectedSlugs={selectedSlugs}
             onCreate={onCreate}
             onDelete={onDelete}
             onEdit={onEdit}
-            onSearchChange={onSearchChange}
             onToggle={onToggle}
         />
     );
@@ -248,12 +237,10 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
 
 interface ComboboxPickerProps {
     labels: Label[];
+    optionSource: ComboboxOptionSource<string>;
     selectedLabels: Label[];
     selectedSlugs: string[];
     onToggle: (slug: string) => void;
-    isLoading?: boolean;
-    searchValue?: string;
-    onSearchChange?: (search: string) => void;
     canCreateFromSearch?: (inputValue: string) => boolean;
     onCreate?: (name: string) => Promise<Label | undefined>;
     isCreating?: boolean;
@@ -264,12 +251,10 @@ interface ComboboxPickerProps {
 
 const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     labels,
+    optionSource,
     selectedLabels,
     selectedSlugs,
     onToggle,
-    isLoading,
-    searchValue,
-    onSearchChange,
     canCreateFromSearch,
     onCreate,
     isCreating,
@@ -278,9 +263,14 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     isDuplicateName
 }) => {
     const [open, setOpen] = useState(false);
-    const {search, handleSearchChange} = useControlledSearch(searchValue, onSearchChange);
+    const [search, setSearch] = useState('');
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
+
+    const handleSearchChange = useCallback((value: string) => {
+        setSearch(value);
+        optionSource.onSearchChange?.(value);
+    }, [optionSource]);
 
     // Close on click outside — no Radix Popover portal needed since this
     // component lives inside a Dialog. Avoiding the portal keeps the dropdown
@@ -336,7 +326,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
             </div>
             {open && (
                 <div className="absolute top-full left-0 z-50 mt-1 w-full rounded-md border bg-white shadow-md dark:bg-gray-950">
-                    {isLoading ? (
+                    {optionSource.isInitialLoad ? (
                         <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
                             Loading labels...
                         </div>

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -2,6 +2,7 @@ import {Label, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/adm
 import {ValueSource} from '@tryghost/shade/patterns';
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {useLabelValueSource} from './filter-sources/use-label-value-source';
+import type {ComboboxOptionSource} from '@tryghost/shade/components';
 
 export interface UseLabelPickerOptions {
     selectedSlugs: string[];
@@ -11,12 +12,10 @@ export interface UseLabelPickerOptions {
 
 export interface UseLabelPickerResult {
     labels: Label[];
+    optionSource: ComboboxOptionSource<string>;
     selectedSlugs: string[];
     resolvedSelectedLabels: Label[];
 
-    isLoading: boolean;
-    searchValue: string;
-    onSearchChange: (search: string) => void;
     toggleLabel: (slug: string) => void;
     createLabel: (name: string) => Promise<Label | undefined>;
     editLabel: (id: string, name: string) => Promise<void>;
@@ -53,6 +52,11 @@ export function useLabelPicker({
             }];
         });
     }, [labelSourceState.options]);
+    const optionSource: ComboboxOptionSource<string> = {
+        ...labelSourceState,
+        shouldClientFilter: false,
+        onSearchChange: setSearchValue
+    };
 
     const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
     const {mutateAsync: editLabelMutation} = useEditLabel();
@@ -125,15 +129,11 @@ export function useLabelPicker({
 
     return {
         labels,
+        optionSource,
         selectedSlugs,
         resolvedSelectedLabels: selectedSlugs
             .map(slug => labels.find(label => label.slug === slug))
             .filter((label): label is Label => !!label),
-        // Keep the current picker content visible during background refreshes
-        // after create/edit/delete; only block the UI on the initial empty load.
-        isLoading: labelSourceState.isInitialLoad,
-        searchValue,
-        onSearchChange: setSearchValue,
         toggleLabel,
         createLabel,
         editLabel,

--- a/apps/posts/src/views/members/components/bulk-action-modals/add-label-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/add-label-modal.tsx
@@ -1,5 +1,6 @@
 import {Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle} from '@tryghost/shade/components';
 import {LabelPicker} from '@src/components/label-picker';
+import {formatNumber} from '@tryghost/shade/utils';
 import {useCallback, useState} from 'react';
 import {useLabelPicker} from '@src/hooks/use-label-picker';
 
@@ -46,7 +47,7 @@ export function AddLabelModal({
             <DialogContent className="gap-5" onOpenAutoFocus={e => e.preventDefault()}>
                 <DialogHeader>
                     <DialogTitle>
-                        Add label to {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                        Add label to {formatNumber(memberCount)} {memberCount === 1 ? 'member' : 'members'}
                     </DialogTitle>
                 </DialogHeader>
 
@@ -54,15 +55,13 @@ export function AddLabelModal({
                     canCreateFromSearch={picker.canCreateFromSearch}
                     isCreating={picker.isCreating}
                     isDuplicateName={picker.isDuplicateName}
-                    isLoading={picker.isLoading}
                     labels={picker.labels}
+                    optionSource={picker.optionSource}
                     resolvedSelectedLabels={picker.resolvedSelectedLabels}
-                    searchValue={picker.searchValue}
                     selectedSlugs={selectedSlugs}
                     onCreate={picker.createLabel}
                     onDelete={picker.deleteLabel}
                     onEdit={picker.editLabel}
-                    onSearchChange={picker.onSearchChange}
                     onToggle={picker.toggleLabel}
                 />
 
@@ -74,7 +73,7 @@ export function AddLabelModal({
                         disabled={selectedSlugs.length === 0 || isLoading}
                         onClick={handleConfirm}
                     >
-                        {isLoading ? 'Adding...' : selectedSlugs.length > 1 ? `Add ${selectedSlugs.length} labels` : 'Add label'}
+                        {isLoading ? 'Adding...' : selectedSlugs.length > 1 ? `Add ${formatNumber(selectedSlugs.length)} labels` : 'Add label'}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/apps/posts/src/views/members/components/bulk-action-modals/import-members/components/mapping-step.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/import-members/components/mapping-step.tsx
@@ -166,15 +166,13 @@ export function MappingStep({
                                 canCreateFromSearch={labelPicker.canCreateFromSearch}
                                 isCreating={labelPicker.isCreating}
                                 isDuplicateName={labelPicker.isDuplicateName}
-                                isLoading={labelPicker.isLoading}
                                 labels={labelPicker.labels}
+                                optionSource={labelPicker.optionSource}
                                 resolvedSelectedLabels={labelPicker.resolvedSelectedLabels}
-                                searchValue={labelPicker.searchValue}
                                 selectedSlugs={labelPicker.selectedSlugs}
                                 onCreate={labelPicker.createLabel}
                                 onDelete={labelPicker.deleteLabel}
                                 onEdit={labelPicker.editLabel}
-                                onSearchChange={labelPicker.onSearchChange}
                                 onToggle={labelPicker.toggleLabel}
                             />
                         </div>

--- a/apps/posts/src/views/members/components/bulk-action-modals/remove-label-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/remove-label-modal.tsx
@@ -1,5 +1,6 @@
 import {Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle} from '@tryghost/shade/components';
 import {LabelPicker} from '@src/components/label-picker';
+import {formatNumber} from '@tryghost/shade/utils';
 import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
 import {useCallback, useMemo, useState} from 'react';
 import {useLabelPicker} from '@src/hooks/use-label-picker';
@@ -53,8 +54,10 @@ export function RemoveLabelModal({
         onSelectionChange: setSelectedSlugs
     });
 
-    // Filter labels to only those assigned to the filtered members
-    const availableLabels = useMemo(() => picker.labels.filter(l => memberLabelSlugs.has(l.slug)), [picker.labels, memberLabelSlugs]);
+    const availableOptionSource = {
+        ...picker.optionSource,
+        options: picker.optionSource.options.filter(option => memberLabelSlugs.has(String(option.value)))
+    };
 
     const handleOpenChange = useCallback((isOpen: boolean) => {
         if (!isOpen) {
@@ -77,20 +80,21 @@ export function RemoveLabelModal({
             <DialogContent className="gap-5" onOpenAutoFocus={e => e.preventDefault()}>
                 <DialogHeader>
                     <DialogTitle>
-                        Remove label from {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                        Remove label from {formatNumber(memberCount)} {memberCount === 1 ? 'member' : 'members'}
                     </DialogTitle>
                 </DialogHeader>
 
                 <LabelPicker
                     isDuplicateName={picker.isDuplicateName}
-                    isLoading={picker.isLoading || isMembersLoading}
-                    labels={availableLabels}
+                    labels={picker.labels.filter(label => memberLabelSlugs.has(label.slug))}
+                    optionSource={{
+                        ...availableOptionSource,
+                        isInitialLoad: availableOptionSource.isInitialLoad || isMembersLoading
+                    }}
                     resolvedSelectedLabels={picker.resolvedSelectedLabels.filter(label => memberLabelSlugs.has(label.slug))}
-                    searchValue={picker.searchValue}
                     selectedSlugs={selectedSlugs}
                     onDelete={picker.deleteLabel}
                     onEdit={picker.editLabel}
-                    onSearchChange={picker.onSearchChange}
                     onToggle={picker.toggleLabel}
                 />
 
@@ -102,7 +106,7 @@ export function RemoveLabelModal({
                         disabled={selectedSlugs.length === 0 || isLoading}
                         onClick={handleConfirm}
                     >
-                        {isLoading ? 'Removing...' : selectedSlugs.length > 1 ? `Remove ${selectedSlugs.length} labels` : 'Remove label'}
+                        {isLoading ? 'Removing...' : selectedSlugs.length > 1 ? `Remove ${formatNumber(selectedSlugs.length)} labels` : 'Remove label'}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/apps/shade/src/components/ui/multi-select-combobox.tsx
+++ b/apps/shade/src/components/ui/multi-select-combobox.tsx
@@ -48,7 +48,20 @@ export interface FooterRenderProps {
     clearSearch: () => void;
 }
 
+export interface ComboboxOptionSource<T = unknown> {
+    options: FilterOption<T>[];
+    isInitialLoad: boolean;
+    isSearching: boolean;
+    isLoadingMore: boolean;
+    hasMore: boolean;
+    loadMore: () => void;
+    shouldClientFilter: boolean;
+    onSearchChange?: (value: string) => void;
+}
+
 export interface MultiSelectComboboxProps<T = unknown> {
+    /** Normalized option source used for custom/static/async options */
+    optionSource?: ComboboxOptionSource<T>;
     /** All available options (used for static/client-filtered mode) */
     options?: FilterOption<T>[];
     /** Currently selected values */
@@ -100,32 +113,30 @@ function filterOptionsBySearch<T = unknown>(options: FilterOption<T>[], search: 
 
 // --- Hooks ---
 
-interface ResolvedSourceState<T> {
-    options: FilterOption<T>[];
-    isInitialLoad: boolean;
-    isSearching: boolean;
-    hasMore: boolean;
-    isLoadingMore: boolean;
-    loadMore: () => void;
-    shouldClientFilter: boolean;
-}
-
 function useResolvedSource<T>(
+    optionSource: ComboboxOptionSource<T> | undefined,
     valueSource: ValueSource<string> | undefined,
     staticOptions: FilterOption<T>[] | undefined,
     searchInput: string,
     values: T[],
     isLoading: boolean,
     shouldFilterProp: boolean | undefined
-): ResolvedSourceState<T> {
+): ComboboxOptionSource<T> {
+    if (optionSource) {
+        return {
+            ...optionSource,
+            shouldClientFilter: shouldFilterProp ?? optionSource.shouldClientFilter
+        };
+    }
+
     const isAsync = Boolean(valueSource);
     const sourceState = valueSource?.useOptions({
         query: searchInput,
         selectedValues: values as string[]
     });
-    const options = useMemo(() => (isAsync
+    const options = isAsync
         ? (sourceState?.options as FilterOption<T>[] | undefined) ?? []
-        : staticOptions ?? []), [isAsync, sourceState?.options, staticOptions]);
+        : staticOptions ?? [];
 
     return {
         options,
@@ -145,6 +156,7 @@ function useResolvedSource<T>(
 // --- Component ---
 
 export function MultiSelectCombobox<T = unknown>({
+    optionSource,
     options: staticOptions,
     values,
     onChange,
@@ -172,11 +184,12 @@ export function MultiSelectCombobox<T = unknown>({
     const [searchInput, setSearchInput] = useState('');
     const updateSearchInput = useCallback((value: string) => {
         setSearchInput(value);
+        optionSource?.onSearchChange?.(value);
         onSearchChangeProp?.(value);
-    }, [onSearchChangeProp]);
+    }, [onSearchChangeProp, optionSource]);
 
     // --- ValueSource integration ---
-    const source = useResolvedSource(valueSource, staticOptions, searchInput, values, isLoading, shouldFilterProp);
+    const source = useResolvedSource(optionSource, valueSource, staticOptions, searchInput, values, isLoading, shouldFilterProp);
     const resolvedOptions = source.options;
 
     // --- Option caching (preserve selected options during async search) ---
@@ -219,8 +232,10 @@ export function MultiSelectCombobox<T = unknown>({
         [searchInput, selectedOptions]
     );
 
-    const unselectedOptions = resolvedOptions.filter(opt => !values.includes(opt.value));
-
+    const unselectedOptions = useMemo(
+        () => resolvedOptions.filter(opt => !values.includes(opt.value)),
+        [resolvedOptions, values]
+    );
     // --- Handlers ---
 
     const handleDeselect = useCallback((option: FilterOption<T>) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3334/

## Summary
- Added an optionSource path for label picker consumers using the shared combobox source shape.
- Kept label-specific picker internals label-native while removing stale search/loading props from useLabelPicker.
- Updated label picker callers to pass labels plus optionSource explicitly.

## Why
This separates the source plumbing refactor from the infinite-scroll behavior so the next PR can focus on pagination support.