### PR TITLE
Added infinite scroll support to filter options

### DIFF
--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -6,7 +6,9 @@ import {
     CommandEmpty,
     CommandGroup,
     CommandItem,
-    CommandList
+    CommandList,
+    FilterOptionsLoadMore,
+    useFilterOptionsInfiniteScroll
 } from '@tryghost/shade/components';
 import {EditRow} from './edit-row';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
@@ -72,6 +74,7 @@ interface LabelListItemsProps {
     labels: Label[];
     selectedSlugs: string[];
     search: string;
+    optionSource: ComboboxOptionSource<string>;
     onToggle: (slug: string) => void;
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
@@ -84,6 +87,7 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
     labels,
     selectedSlugs,
     search,
+    optionSource,
     onToggle,
     onEdit,
     onDelete,
@@ -98,6 +102,12 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
         : labels;
     const showCreate = !!onCreate && canCreateLabel(labels, search);
     const showEdit = !!onEdit;
+    const loadMoreSentinelRef = useFilterOptionsInfiniteScroll({
+        optionSource,
+        optionsCount: visibleLabels.length,
+        resetKey: search
+    });
+
     const handleCreate = async () => {
         if (!onCreate) {
             return;
@@ -127,7 +137,7 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
 
     return (
         <>
-            {!showCreate && visibleLabels.length === 0 && (
+            {!showCreate && visibleLabels.length === 0 && !optionSource.hasMore && (
                 <CommandEmpty>No labels found</CommandEmpty>
             )}
             {visibleLabels.length > 0 && (
@@ -164,6 +174,15 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
                         {isCreating ? 'Creating...' : `Create "${search.trim()}"`}
                     </CommandItem>
                 </CommandGroup>
+            )}
+            {optionSource.hasMore && (
+                <FilterOptionsLoadMore
+                    isLoadingMore={optionSource.isLoadingMore}
+                    label="Load more"
+                    loadingLabel="Loading labels..."
+                    sentinelRef={loadMoreSentinelRef}
+                    onLoadMore={optionSource.loadMore}
+                />
             )}
         </>
     );
@@ -326,6 +345,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
                                 <LabelListItems
                                     isCreating={isCreating}
                                     labels={labels}
+                                    optionSource={optionSource}
                                     search={search}
                                     selectedSlugs={selectedSlugs}
                                     onCreate={onCreate}

--- a/apps/posts/src/hooks/filter-sources/create-combined-value-source.ts
+++ b/apps/posts/src/hooks/filter-sources/create-combined-value-source.ts
@@ -15,7 +15,14 @@ export function createCombinedValueSource<T = string>(
         const useOptions = useCallback(({query, selectedValues}: ValueSourceParams<T>): ValueSourceState<T> => {
             const firstState = firstSource.useOptions({query, selectedValues});
             const secondState = secondSource.useOptions({query, selectedValues});
-            const mergedOptions = mergeFilterOptions(firstState.options, secondState.options);
+            // Withhold the second source's options until the first has no more pages.
+            // Both sources fetch their first page eagerly, but rendering the second
+            // source's options while the first can still grow would push freshly
+            // loaded first-source pages in above options already in view - revealing
+            // the (pre-fetched) second source only once the first is exhausted keeps
+            // every load appending below the fold.
+            const visibleSecondOptions = firstState.hasMore ? [] : secondState.options;
+            const mergedOptions = mergeFilterOptions(firstState.options, visibleSecondOptions);
             const fallbackOptions = getMissingSelectedOption ? selectedValues.flatMap((selectedValue) => {
                 const hasMatch = mergedOptions.some(option => option.value === selectedValue);
 
@@ -35,8 +42,11 @@ export function createCombinedValueSource<T = string>(
                 isLoadingMore: firstState.isLoadingMore || secondState.isLoadingMore,
                 hasMore: firstState.hasMore || secondState.hasMore,
                 loadMore: () => {
+                    // Paginate one source at a time, matching the render order above:
+                    // advance the first until it runs out, then the second.
                     if (firstState.hasMore) {
                         firstState.loadMore();
+                        return;
                     }
 
                     if (secondState.hasMore) {

--- a/apps/posts/test/unit/hooks/create-combined-value-source.test.tsx
+++ b/apps/posts/test/unit/hooks/create-combined-value-source.test.tsx
@@ -1,6 +1,7 @@
+import {FilterOption, ValueSourceState} from '@tryghost/shade/patterns';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {createCombinedValueSource} from '@src/hooks/filter-sources/create-combined-value-source';
 import {createRemoteValueSource} from '@src/hooks/filter-sources/create-remote-value-source';
-import {describe, expect, it} from 'vitest';
 import {renderHook} from '@testing-library/react';
 
 type TestItem = {
@@ -53,7 +54,7 @@ const useSecondSource = createRemoteValueSource<TestItem>({
     })
 });
 
-const useCombinedSource = createCombinedValueSource(
+const useRemoteCombinedSource = createCombinedValueSource(
     useFirstSource,
     useSecondSource,
     value => ({
@@ -62,7 +63,36 @@ const useCombinedSource = createCombinedValueSource(
     })
 );
 
+const firstOptions: FilterOption<string>[] = [
+    {value: 'post-1', label: 'Post 1'},
+    {value: 'post-2', label: 'Post 2'}
+];
+
+const secondOptions: FilterOption<string>[] = [
+    {value: 'page-1', label: 'Page 1'},
+    {value: 'page-2', label: 'Page 2'}
+];
+
+function buildState(options: FilterOption<string>[], overrides: Partial<ValueSourceState<string>> = {}): ValueSourceState<string> {
+    return {
+        options,
+        isInitialLoad: false,
+        isSearching: false,
+        isLoadingMore: false,
+        hasMore: false,
+        loadMore: () => {},
+        ...overrides
+    };
+}
+
 describe('createCombinedValueSource', () => {
+    beforeEach(() => {
+        firstBrowseData = undefined;
+        firstHydrateData = undefined;
+        secondBrowseData = undefined;
+        secondHydrateData = undefined;
+    });
+
     it('prefers a hydrated option from one source over a fallback from another source', () => {
         firstBrowseData = [];
         firstHydrateData = [];
@@ -70,7 +100,7 @@ describe('createCombinedValueSource', () => {
         secondHydrateData = [{id: 'page-id', label: 'About page'}];
 
         const {result} = renderHook(() => {
-            const source = useCombinedSource();
+            const source = useRemoteCombinedSource();
 
             return source.useOptions({
                 query: '',
@@ -93,7 +123,7 @@ describe('createCombinedValueSource', () => {
         secondHydrateData = [];
 
         const {result} = renderHook(() => {
-            const source = useCombinedSource();
+            const source = useRemoteCombinedSource();
 
             return source.useOptions({
                 query: '',
@@ -107,5 +137,141 @@ describe('createCombinedValueSource', () => {
                 label: 'ID: missing-id'
             }
         ]);
+    });
+
+    it('orders first source options before second source options', () => {
+        const useCombinedSource = createCombinedValueSource(
+            () => ({
+                id: 'posts',
+                useOptions: () => buildState(firstOptions)
+            }),
+            () => ({
+                id: 'pages',
+                useOptions: () => buildState(secondOptions)
+            })
+        );
+
+        const {result} = renderHook(() => {
+            const source = useCombinedSource();
+            return source.useOptions({query: '', selectedValues: []});
+        });
+
+        expect(result.current.options).toEqual([
+            {value: 'post-1', label: 'Post 1'},
+            {value: 'post-2', label: 'Post 2'},
+            {value: 'page-1', label: 'Page 1'},
+            {value: 'page-2', label: 'Page 2'}
+        ]);
+    });
+
+    it('hides second source options while the first source still has more pages', () => {
+        const useCombinedSource = createCombinedValueSource(
+            () => ({
+                id: 'posts',
+                useOptions: () => buildState(firstOptions, {hasMore: true})
+            }),
+            () => ({
+                id: 'pages',
+                useOptions: () => buildState(secondOptions)
+            })
+        );
+
+        const {result} = renderHook(() => {
+            const source = useCombinedSource();
+            return source.useOptions({query: '', selectedValues: []});
+        });
+
+        expect(result.current.options).toEqual([
+            {value: 'post-1', label: 'Post 1'},
+            {value: 'post-2', label: 'Post 2'}
+        ]);
+        expect(result.current.hasMore).toBe(true);
+    });
+
+    it('reveals second source options once the first source is exhausted', () => {
+        const useCombinedSource = createCombinedValueSource(
+            () => ({
+                id: 'posts',
+                useOptions: () => buildState(firstOptions, {hasMore: false})
+            }),
+            () => ({
+                id: 'pages',
+                useOptions: () => buildState(secondOptions, {hasMore: true})
+            })
+        );
+
+        const {result} = renderHook(() => {
+            const source = useCombinedSource();
+            return source.useOptions({query: '', selectedValues: []});
+        });
+
+        expect(result.current.options).toEqual([
+            {value: 'post-1', label: 'Post 1'},
+            {value: 'post-2', label: 'Post 2'},
+            {value: 'page-1', label: 'Page 1'},
+            {value: 'page-2', label: 'Page 2'}
+        ]);
+    });
+
+    it('loads more from the first source while it still has more pages', () => {
+        const loadMoreFirst = vi.fn();
+        const loadMoreSecond = vi.fn();
+        const useCombinedSource = createCombinedValueSource(
+            () => ({
+                id: 'posts',
+                useOptions: () => buildState(firstOptions, {
+                    hasMore: true,
+                    loadMore: loadMoreFirst
+                })
+            }),
+            () => ({
+                id: 'pages',
+                useOptions: () => buildState(secondOptions, {
+                    hasMore: true,
+                    loadMore: loadMoreSecond
+                })
+            })
+        );
+
+        const {result} = renderHook(() => {
+            const source = useCombinedSource();
+            return source.useOptions({query: '', selectedValues: []});
+        });
+
+        result.current.loadMore();
+
+        expect(loadMoreFirst).toHaveBeenCalledTimes(1);
+        expect(loadMoreSecond).not.toHaveBeenCalled();
+    });
+
+    it('loads more from the second source once the first source is exhausted', () => {
+        const loadMoreFirst = vi.fn();
+        const loadMoreSecond = vi.fn();
+        const useCombinedSource = createCombinedValueSource(
+            () => ({
+                id: 'posts',
+                useOptions: () => buildState(firstOptions, {
+                    hasMore: false,
+                    loadMore: loadMoreFirst
+                })
+            }),
+            () => ({
+                id: 'pages',
+                useOptions: () => buildState(secondOptions, {
+                    hasMore: true,
+                    loadMore: loadMoreSecond
+                })
+            })
+        );
+
+        const {result} = renderHook(() => {
+            const source = useCombinedSource();
+            return source.useOptions({query: '', selectedValues: []});
+        });
+
+        result.current.loadMore();
+
+        expect(loadMoreFirst).not.toHaveBeenCalled();
+        expect(loadMoreSecond).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/shade/src/components.ts
+++ b/apps/shade/src/components.ts
@@ -48,7 +48,9 @@ export * from './components/ui/tabs';
 export * from './components/ui/textarea';
 export * from './components/ui/toggle-group';
 export * from './components/ui/tooltip';
+export * from './components/ui/filter-options-load-more';
 export * from './components/ui/trend-badge';
+export * from './components/ui/use-filter-options-infinite-scroll';
 
 export type {DropdownMenuCheckboxItemProps as DropdownMenuCheckboxItemProps} from '@radix-ui/react-dropdown-menu';
 export type {ContextMenuCheckboxItemProps as ContextMenuCheckboxItemProps} from '@radix-ui/react-context-menu';

--- a/apps/shade/src/components/patterns/filters.tsx
+++ b/apps/shade/src/components/patterns/filters.tsx
@@ -19,8 +19,10 @@ import {
     DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 import {Popover, PopoverContent, PopoverTrigger} from '@/components/ui/popover';
+import {FilterOptionsLoadMore} from '@/components/ui/filter-options-load-more';
 import {Switch} from '@/components/ui/switch';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import {type FilterOptionsInfiniteScrollSource, useFilterOptionsInfiniteScroll} from '@/components/ui/use-filter-options-infinite-scroll';
 import {cva, type VariantProps} from 'class-variance-authority';
 import {AlertCircle, Calendar as CalendarIcon, Check, Loader2, Plus, X} from 'lucide-react';
 import {cn} from '@/lib/utils';
@@ -1317,10 +1319,8 @@ interface SelectOptionsListProps<T = unknown> {
     contextLabel?: string;
     selectedOptions: FilterOption<T>[];
     unselectedOptions: FilterOption<T>[];
-    isInitialLoad: boolean;
-    isLoadingMore: boolean;
-    hasMore: boolean;
-    onLoadMore: () => void;
+    optionSource: FilterOptionsInfiniteScrollSource;
+    searchInput: string;
     onSelectSelected: (option: FilterOption<T>) => void;
     onSelectUnselected: (option: FilterOption<T>) => void;
 }
@@ -1329,19 +1329,23 @@ function SelectOptionsList<T = unknown>({
     contextLabel,
     selectedOptions,
     unselectedOptions,
-    isInitialLoad,
-    isLoadingMore,
-    hasMore,
-    onLoadMore,
+    optionSource,
+    searchInput,
     onSelectSelected,
     onSelectUnselected
 }: Readonly<SelectOptionsListProps<T>>) {
     const context = useFilterContext();
+    const renderedOptionsCount = selectedOptions.length + unselectedOptions.length;
+    const loadMoreSentinelRef = useFilterOptionsInfiniteScroll({
+        optionSource,
+        optionsCount: renderedOptionsCount,
+        resetKey: searchInput
+    });
 
     return (
         <CommandList className="outline-hidden">
-            {isInitialLoad ? (
-                <div className="flex items-center justify-center py-6 text-muted-foreground">
+            {optionSource.isInitialLoad ? (
+                <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
                     <Loader2 className="mr-2 size-4 animate-spin" />
                     {context.i18n.loading}
                 </div>
@@ -1390,20 +1394,16 @@ function SelectOptionsList<T = unknown>({
                     </CommandGroup>
                 </>
             )}
-            {hasMore && (
+            {optionSource.hasMore && (
                 <>
                     {(selectedOptions.length > 0 || unselectedOptions.length > 0) && <CommandSeparator />}
-                    <div className="p-1.5">
-                        <button
-                            className="flex w-full items-center justify-center rounded-xs px-2.5 py-1.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
-                            disabled={isLoadingMore}
-                            type="button"
-                            onClick={onLoadMore}
-                        >
-                            {isLoadingMore && <Loader2 className="mr-2 size-4 animate-spin" />}
-                            {isLoadingMore ? context.i18n.loading : context.i18n.loadMore}
-                        </button>
-                    </div>
+                    <FilterOptionsLoadMore
+                        isLoadingMore={optionSource.isLoadingMore}
+                        label={context.i18n.loadMore}
+                        loadingLabel={context.i18n.loading}
+                        sentinelRef={loadMoreSentinelRef}
+                        onLoadMore={optionSource.loadMore}
+                    />
                 </>
             )}
         </CommandList>
@@ -1429,6 +1429,13 @@ function ResolvedSelectOptionsPopover<T = unknown>({
     // Track selected options separately so they persist during async search
     const [cachedSelectedOptions, setCachedSelectedOptions] = useState<FilterOption<T>[]>([]);
     const context = useFilterContext();
+    const optionSource: FilterOptionsInfiniteScrollSource = {
+        hasMore,
+        isInitialLoad,
+        isLoadingMore,
+        isSearching,
+        loadMore: onLoadMore
+    };
 
     const isMultiSelect = field.type === 'multiselect' || values.length > 1;
     const effectiveValues = useMemo(() => field.value ?? values, [field.value, values]);
@@ -1518,12 +1525,10 @@ function ResolvedSelectOptionsPopover<T = unknown>({
                     />
                     <SelectOptionsList
                         contextLabel={field.label || 'Selected'}
-                        hasMore={hasMore}
-                        isInitialLoad={isInitialLoad}
-                        isLoadingMore={isLoadingMore}
+                        optionSource={optionSource}
+                        searchInput={searchInput}
                         selectedOptions={visibleSelectedOptions}
                         unselectedOptions={unselectedOptions}
-                        onLoadMore={onLoadMore}
                         onSelectSelected={(option) => {
                             if (isMultiSelect) {
                                 const next = effectiveValues.filter(v => v !== option.value) as T[];
@@ -1624,12 +1629,10 @@ function ResolvedSelectOptionsPopover<T = unknown>({
                         onSearchChange={handleSearchChange}
                     />
                     <SelectOptionsList
-                        hasMore={hasMore}
-                        isInitialLoad={isInitialLoad}
-                        isLoadingMore={isLoadingMore}
+                        optionSource={optionSource}
+                        searchInput={searchInput}
                         selectedOptions={visibleSelectedOptions}
                         unselectedOptions={unselectedOptions}
-                        onLoadMore={onLoadMore}
                         onSelectSelected={(option) => {
                             if (isMultiSelect) {
                                 onChange(values.filter(v => v !== option.value) as T[]);

--- a/apps/shade/src/components/ui/filter-options-load-more.tsx
+++ b/apps/shade/src/components/ui/filter-options-load-more.tsx
@@ -1,0 +1,38 @@
+import {Loader2} from 'lucide-react';
+import {cn} from '@/lib/utils';
+import type {Ref} from 'react';
+
+interface FilterOptionsLoadMoreProps {
+    // Attach the infinite-scroll sentinel returned by useFilterOptionsInfiniteScroll
+    sentinelRef: Ref<HTMLDivElement>;
+    isLoadingMore: boolean;
+    label: string;
+    loadingLabel: string;
+    onLoadMore: () => void;
+    className?: string;
+}
+
+// Shared load-more affordance for filter option lists: a sentinel-wrapped button
+// that doubles as the manual fallback when auto-loading isn't triggered.
+export function FilterOptionsLoadMore({
+    sentinelRef,
+    isLoadingMore,
+    label,
+    loadingLabel,
+    onLoadMore,
+    className
+}: Readonly<FilterOptionsLoadMoreProps>) {
+    return (
+        <div ref={sentinelRef} className={cn('p-1.5', className)}>
+            <button
+                className="flex w-full items-center justify-center rounded-xs px-2 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+                disabled={isLoadingMore}
+                type="button"
+                onClick={onLoadMore}
+            >
+                {isLoadingMore && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {isLoadingMore ? loadingLabel : label}
+            </button>
+        </div>
+    );
+}

--- a/apps/shade/src/components/ui/multi-select-combobox.tsx
+++ b/apps/shade/src/components/ui/multi-select-combobox.tsx
@@ -11,6 +11,8 @@ import {
     CommandList,
     CommandSeparator
 } from '@/components/ui/command';
+import {FilterOptionsLoadMore} from '@/components/ui/filter-options-load-more';
+import {useFilterOptionsInfiniteScroll} from '@/components/ui/use-filter-options-infinite-scroll';
 import {Check, Loader2} from 'lucide-react';
 import {cn} from '@/lib/utils';
 import type {FilterOption, ValueSource} from '@/components/patterns/filters';
@@ -236,6 +238,13 @@ export function MultiSelectCombobox<T = unknown>({
         () => resolvedOptions.filter(opt => !values.includes(opt.value)),
         [resolvedOptions, values]
     );
+    const renderedOptionsCount = visibleSelectedOptions.length + unselectedOptions.length;
+    const loadMoreSentinelRef = useFilterOptionsInfiniteScroll({
+        optionSource: source,
+        optionsCount: renderedOptionsCount,
+        resetKey: searchInput
+    });
+
     // --- Handlers ---
 
     const handleDeselect = useCallback((option: FilterOption<T>) => {
@@ -352,17 +361,13 @@ export function MultiSelectCombobox<T = unknown>({
                     {source.hasMore && (
                         <>
                             {(visibleSelectedOptions.length > 0 || unselectedOptions.length > 0) && <CommandSeparator />}
-                            <div className="p-1.5">
-                                <button
-                                    className="flex w-full items-center justify-center rounded-xs px-2 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
-                                    disabled={source.isLoadingMore}
-                                    type="button"
-                                    onClick={source.loadMore}
-                                >
-                                    {source.isLoadingMore && <Loader2 className="mr-2 size-4 animate-spin" />}
-                                    {source.isLoadingMore ? i18n.loading : i18n.loadMore}
-                                </button>
-                            </div>
+                            <FilterOptionsLoadMore
+                                isLoadingMore={source.isLoadingMore}
+                                label={i18n.loadMore}
+                                loadingLabel={i18n.loading}
+                                sentinelRef={loadMoreSentinelRef}
+                                onLoadMore={source.loadMore}
+                            />
                         </>
                     )}
                 </CommandList>

--- a/apps/shade/src/components/ui/use-filter-options-infinite-scroll.ts
+++ b/apps/shade/src/components/ui/use-filter-options-infinite-scroll.ts
@@ -1,0 +1,83 @@
+import {useCallback, useEffect, useRef} from 'react';
+
+export interface FilterOptionsInfiniteScrollSource {
+    hasMore: boolean;
+    isInitialLoad: boolean;
+    isLoadingMore: boolean;
+    isSearching: boolean;
+    loadMore: () => void;
+}
+
+interface UseFilterOptionsInfiniteScrollOptions {
+    optionSource: FilterOptionsInfiniteScrollSource;
+    optionsCount: number;
+    resetKey: string;
+}
+
+export function useFilterOptionsInfiniteScroll({
+    optionSource,
+    optionsCount,
+    resetKey
+}: UseFilterOptionsInfiniteScrollOptions) {
+    const {
+        hasMore,
+        isInitialLoad,
+        isLoadingMore,
+        isSearching,
+        loadMore
+    } = optionSource;
+    const observerRef = useRef<IntersectionObserver | null>(null);
+    // Tracks the optionsCount at which we last triggered onLoadMore, so we don't
+    // fire repeatedly while the same page of results is still in view.
+    const requestedOptionsCountRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        requestedOptionsCountRef.current = null;
+    }, [resetKey]);
+
+    const requestLoadMoreIfReady = useCallback(() => {
+        if (
+            hasMore &&
+            !isInitialLoad &&
+            !isLoadingMore &&
+            !isSearching &&
+            optionsCount > 0 &&
+            requestedOptionsCountRef.current !== optionsCount
+        ) {
+            requestedOptionsCountRef.current = optionsCount;
+            loadMore();
+        }
+    }, [hasMore, isInitialLoad, isLoadingMore, isSearching, loadMore, optionsCount]);
+
+    const sentinelRef = useCallback((node: HTMLDivElement | null) => {
+        observerRef.current?.disconnect();
+        observerRef.current = null;
+
+        if (!node || typeof IntersectionObserver === 'undefined') {
+            return;
+        }
+
+        const root = node.closest('[data-slot="command-list"]');
+        observerRef.current = new IntersectionObserver((entries) => {
+            const [entry] = entries;
+
+            if (entry?.isIntersecting) {
+                requestLoadMoreIfReady();
+            }
+        }, {
+            root,
+            rootMargin: '0px 0px 48px 0px'
+        });
+
+        observerRef.current.observe(node);
+    }, [requestLoadMoreIfReady]);
+
+    useEffect(() => {
+        return () => {
+            observerRef.current?.disconnect();
+            observerRef.current = null;
+        };
+    }, []);
+
+    return sentinelRef;
+}

--- a/apps/shade/test/unit/components/patterns/filters.test.tsx
+++ b/apps/shade/test/unit/components/patterns/filters.test.tsx
@@ -33,6 +33,12 @@ const ALL_OPTIONS: TestOption[] = [
     {value: 'draft', label: 'Draft'}
 ];
 
+type IntersectionObserverCallback = ConstructorParameters<typeof IntersectionObserver>[0];
+
+let intersectionObserverCallback: IntersectionObserverCallback | undefined;
+const observe = vi.fn();
+const disconnect = vi.fn();
+
 interface DateFiltersProps {
     initialValue?: string;
     onFiltersChange: ReturnType<typeof vi.fn<(value: string) => void>>;
@@ -125,6 +131,21 @@ function createMatchingValueSource() {
     return {id: 'status', useOptions};
 }
 
+async function intersectLoadMoreSentinel() {
+    await act(async () => {
+        intersectionObserverCallback?.(
+            [{isIntersecting: true} as IntersectionObserverEntry],
+            {} as IntersectionObserver
+        );
+    });
+}
+
+async function expectLoadMoreObserverToAttach() {
+    await waitFor(() => {
+        expect(observe).toHaveBeenCalled();
+    });
+}
+
 function openCalendar() {
     fireEvent.click(screen.getByRole('button', {name: 'Open calendar'}));
 }
@@ -146,10 +167,26 @@ describe('Filters', () => {
                 }
             } as unknown as typeof ResizeObserver;
             HTMLElement.prototype.scrollIntoView = vi.fn();
+            global.IntersectionObserver = class {
+                readonly root = null;
+                readonly rootMargin = '';
+                readonly thresholds = [];
+
+                constructor(callback: IntersectionObserverCallback) {
+                    intersectionObserverCallback = callback;
+                }
+
+                observe = observe;
+                disconnect = disconnect;
+                takeRecords = () => [];
+                unobserve = vi.fn();
+            } as unknown as typeof IntersectionObserver;
         });
 
         afterEach(() => {
             vi.useRealTimers();
+            vi.clearAllMocks();
+            intersectionObserverCallback = undefined;
         });
 
         it('calls the value source with local query state and selected values', async () => {
@@ -261,6 +298,76 @@ describe('Filters', () => {
             fireEvent.click(loadMoreButton);
 
             expect(loadMore).toHaveBeenCalledTimes(1);
+        });
+
+        it('automatically loads more when the end of the option list is reached', async () => {
+            const loadMore = vi.fn();
+            const useOptions = vi.fn(() => ({
+                options: ALL_OPTIONS,
+                isInitialLoad: false,
+                isSearching: false,
+                isLoadingMore: false,
+                hasMore: true,
+                loadMore
+            }));
+
+            render(<TestFilters valueSource={{id: 'status', useOptions}} />);
+
+            openSelectedValuePopover();
+            await expectLoadMoreObserverToAttach();
+
+            await intersectLoadMoreSentinel();
+
+            expect(loadMore).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not automatically load more while a page is already loading', async () => {
+            const loadMore = vi.fn();
+            const useOptions = vi.fn(() => ({
+                options: ALL_OPTIONS,
+                isInitialLoad: false,
+                isSearching: false,
+                isLoadingMore: true,
+                hasMore: true,
+                loadMore
+            }));
+
+            render(<TestFilters valueSource={{id: 'status', useOptions}} />);
+
+            openSelectedValuePopover();
+            await expectLoadMoreObserverToAttach();
+
+            await intersectLoadMoreSentinel();
+
+            expect(loadMore).not.toHaveBeenCalled();
+        });
+
+        it('waits for rendered options before automatically loading more after a search change', async () => {
+            const loadMore = vi.fn();
+            const useOptions = vi.fn(({query, selectedValues}: {query: string; selectedValues: string[]}) => ({
+                options: query ? [] : ALL_OPTIONS.filter(option => selectedValues.includes(option.value) || option.value === 'draft'),
+                isInitialLoad: false,
+                isSearching: !!query,
+                isLoadingMore: false,
+                hasMore: true,
+                loadMore
+            }));
+
+            render(<TestFilters valueSource={{id: 'status', useOptions}} />);
+
+            openSelectedValuePopover();
+            await expectLoadMoreObserverToAttach();
+
+            const input = await screen.findByPlaceholderText('Search status...');
+            fireEvent.change(input, {target: {value: 'missing'}});
+
+            await waitFor(() => {
+                expect(screen.queryByText('Draft')).toBeNull();
+            });
+
+            await intersectLoadMoreSentinel();
+
+            expect(loadMore).not.toHaveBeenCalled();
         });
 
         it('shows loading states for static select fields', async () => {

--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -89,6 +89,15 @@ export class MembersListPage extends AdminPage {
         }
     }
 
+    async openFilterField(fieldName: string): Promise<void> {
+        await this.filterButton.click();
+        await this.page.getByRole('option', {name: fieldName, exact: true}).click();
+    }
+
+    getFilterOption(name: string | RegExp): Locator {
+        return this.page.getByRole('option', {name});
+    }
+
     async addSearchableFilter(fieldName: string, searchText: string, optionName: string): Promise<void> {
         await this.filterButton.click();
         await this.page.getByRole('option', {name: fieldName, exact: true}).click();

--- a/e2e/tests/admin/members/multiselect-filters.test.ts
+++ b/e2e/tests/admin/members/multiselect-filters.test.ts
@@ -63,6 +63,58 @@ async function createOfferAndRedeem(page: Page, request: APIRequestContext, stri
     return {offer, suffix};
 }
 
+async function mockPaginatedLabels(page: Page, totalLabels: number): Promise<Set<number>> {
+    const labels = Array.from({length: totalLabels}, (_label, index) => {
+        const paddedIndex = index.toString().padStart(3, '0');
+
+        return {
+            id: `label-${paddedIndex}`,
+            name: `Infinite Label ${paddedIndex}`,
+            slug: `infinite-label-${paddedIndex}`,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z'
+        };
+    });
+    const requestedPages = new Set<number>();
+
+    await page.route('**/ghost/api/admin/labels/**', async (route) => {
+        const request = route.request();
+
+        if (request.method() !== 'GET') {
+            await route.fallback();
+            return;
+        }
+
+        const requestUrl = new URL(request.url());
+        const limit = Number(requestUrl.searchParams.get('limit') ?? 100);
+        const pageNumber = Number(requestUrl.searchParams.get('page') ?? 1);
+        requestedPages.add(pageNumber);
+        const start = (pageNumber - 1) * limit;
+        const pageLabels = labels.slice(start, start + limit);
+        const pages = Math.ceil(labels.length / limit);
+        const next = pageNumber < pages ? pageNumber + 1 : null;
+
+        await route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({
+                labels: pageLabels,
+                meta: {
+                    pagination: {
+                        page: pageNumber,
+                        limit,
+                        pages,
+                        total: labels.length,
+                        next,
+                        prev: pageNumber > 1 ? pageNumber - 1 : null
+                    }
+                }
+            })
+        });
+    });
+
+    return requestedPages;
+}
+
 test.describe('Ghost Admin - Members Label Multiselect Filter', () => {
     let memberFactory: MemberFactory;
 
@@ -113,6 +165,22 @@ test.describe('Ghost Admin - Members Label Multiselect Filter', () => {
 
         await expect(membersPage.memberRows).toHaveCount(1);
         await expect(membersPage.getMemberByName('Targeted Member')).toBeVisible();
+    });
+
+    test('label filter value options load more remote labels', async ({page}) => {
+        const requestedLabelPages = await mockPaginatedLabels(page, 120);
+        const membersPage = await seedMembersAndNavigate(memberFactory, page, [
+            {name: 'Visible Member', email: 'visible@example.com'}
+        ]);
+
+        await membersPage.openFilterField('Label');
+        await membersPage.getFilterOption(/Infinite Label 000/).click();
+        await membersPage.openFilterValue('Label');
+
+        await page.getByRole('button', {name: 'Load more'}).click();
+
+        await expect.poll(() => requestedLabelPages.has(2)).toBe(true);
+        await expect(membersPage.getFilterOption(/Infinite Label 105/)).toBeVisible();
     });
 
     test('deselects a label from the combobox to update results', async ({page}) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3334/

## Summary
- Added a shared useFilterOptionsInfiniteScroll hook for filter option lists.
- Wired the filter dropdowns, combobox, and label picker fallback load-more rows into the shared hook.
- Added focused Shade tests and members E2E coverage for loading additional remote label pages.

## Stack
Stacked on #27605.