### PR TITLE
Added endpoint for listing automations

### DIFF
--- a/ghost/core/core/server/api/endpoints/automations.js
+++ b/ghost/core/core/server/api/endpoints/automations.js
@@ -1,9 +1,29 @@
 const domainEvents = require('@tryghost/domain-events');
+const models = require('../../models');
 const StartAutomationsPollEvent = require('../../services/welcome-email-automations/events/start-automations-poll-event');
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
     docName: 'automations',
+
+    browse: {
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: true,
+        async query() {
+            const automations = await models.WelcomeEmailAutomation.findAll({
+                order: 'created_at ASC'
+            });
+            return {
+                data: automations.map(automation => ({
+                    id: automation.get('id'),
+                    name: automation.get('name'),
+                    status: automation.get('status')
+                }))
+            };
+        }
+    },
 
     poll: {
         statusCode: 204,

--- a/ghost/core/core/server/api/endpoints/automations.js
+++ b/ghost/core/core/server/api/endpoints/automations.js
@@ -12,9 +12,7 @@ const controller = {
         },
         permissions: true,
         async query() {
-            const automations = await models.WelcomeEmailAutomation.findAll({
-                order: 'created_at ASC'
-            });
+            const automations = await models.WelcomeEmailAutomation.findAll();
             return {
                 data: automations.map(automation => ({
                     id: automation.get('id'),

--- a/ghost/core/core/server/models/welcome-email-automation.js
+++ b/ghost/core/core/server/models/welcome-email-automation.js
@@ -50,6 +50,10 @@ const WelcomeEmailAutomation = ghostBookshelf.Model.extend({
             }
         }, isEnableTransition ? 'Welcome email automation enabled' : 'Welcome email automation disabled');
     }
+}, {
+    orderDefaultRaw() {
+        return '`created_at` ASC';
+    }
 });
 
 module.exports = {

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -186,6 +186,7 @@ module.exports = function apiRoutes() {
     router.delete('/labels/:id', mw.authAdminApi, http(api.labels.destroy));
 
     // ## Automations
+    router.get('/automations', mw.authAdminApi, http(api.automations.browse));
     router.put('/automations/poll', mw.authAdminApiWithUrl, http(api.automations.poll));
 
     // ## Automated Emails

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -41,16 +41,18 @@ describe('Automations API', function () {
             await dbUtils.truncate('welcome_email_automations');
         });
 
-        it('returns welcome email automations with only id, name, and status', async function () {
-            const first = await models.WelcomeEmailAutomation.add({
-                name: 'Welcome Email (Free)',
-                slug: 'member-welcome-email-free',
-                status: 'active'
-            });
+        it('returns welcome email automations ordered by creation time', async function () {
             const second = await models.WelcomeEmailAutomation.add({
                 name: 'Welcome Email (Premium)',
                 slug: 'member-welcome-email-premium',
-                status: 'inactive'
+                status: 'inactive',
+                created_at: new Date('2025-01-02T00:00:00Z')
+            });
+            const first = await models.WelcomeEmailAutomation.add({
+                name: 'Welcome Email (Free)',
+                slug: 'member-welcome-email-free',
+                status: 'active',
+                created_at: new Date('2025-01-01T00:00:00Z')
             });
 
             const {body} = await agent

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -1,8 +1,9 @@
 const sinon = require('sinon');
 const domainEvents = require('@tryghost/domain-events');
+const assert = require('node:assert/strict');
 const models = require('../../../core/server/models');
 const {getSignedAdminToken} = require('../../../core/server/adapters/scheduling/utils');
-const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
+const {agentProvider, dbUtils, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
 const StartAutomationsPollEvent = require('../../../core/server/services/welcome-email-automations/events/start-automations-poll-event');
 
 const {anyContentVersion, anyEtag, anyErrorId} = matchers;
@@ -15,7 +16,8 @@ describe('Automations API', function () {
 
     before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
-        await fixtureManager.init('integrations', 'api_keys');
+        await fixtureManager.init('users', 'integrations', 'api_keys');
+        await agent.loginAsOwner();
 
         schedulerIntegration = await models.Integration.findOne(
             {slug: 'ghost-scheduler'},
@@ -31,6 +33,40 @@ describe('Automations API', function () {
 
     afterEach(function () {
         sinon.restore();
+    });
+
+    describe('browse', function () {
+        beforeEach(async function () {
+            await dbUtils.truncate('welcome_email_automated_emails');
+            await dbUtils.truncate('welcome_email_automations');
+        });
+
+        it('returns welcome email automations with only id, name, and status', async function () {
+            const first = await models.WelcomeEmailAutomation.add({
+                name: 'Welcome Email (Free)',
+                slug: 'member-welcome-email-free',
+                status: 'active'
+            });
+            const second = await models.WelcomeEmailAutomation.add({
+                name: 'Welcome Email (Premium)',
+                slug: 'member-welcome-email-premium',
+                status: 'inactive'
+            });
+
+            const {body} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            assert.deepEqual(body.automations, [{
+                id: first.id,
+                name: first.get('name'),
+                status: first.get('status')
+            }, {
+                id: second.id,
+                name: second.get('name'),
+                status: second.get('status')
+            }]);
+        });
     });
 
     describe('poll', function () {

--- a/ghost/core/test/unit/api/endpoints/automations.test.js
+++ b/ghost/core/test/unit/api/endpoints/automations.test.js
@@ -1,18 +1,61 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const domainEvents = require('@tryghost/domain-events');
+const models = require('../../../../core/server/models');
 const automationsController = require('../../../../core/server/api/endpoints/automations');
 const StartAutomationsPollEvent = require('../../../../core/server/services/welcome-email-automations/events/start-automations-poll-event');
 
 describe('Automations controller', function () {
+    before(function () {
+        models.init();
+    });
+
+    function createMockAutomation(id, name, status) {
+        return {
+            get(key) {
+                switch (key) {
+                case 'id':
+                    return id;
+                case 'name':
+                    return name;
+                case 'status':
+                    return status;
+                default:
+                    throw new Error(`Unexpected field: ${key}`);
+                }
+            }
+        };
+    }
+
     let dispatchStub;
 
     beforeEach(function () {
+        sinon.stub(models.WelcomeEmailAutomation, 'findAll').resolves([
+            createMockAutomation('automation-id-1', 'Welcome Email (Free)', 'active'),
+            createMockAutomation('automation-id-2', 'Welcome Email (Premium)', 'inactive')
+        ]);
+
         dispatchStub = sinon.stub(domainEvents, 'dispatch');
     });
 
     afterEach(function () {
         sinon.restore();
+    });
+
+    describe('browse', function () {
+        it('returns only id, name, and status fields', async function () {
+            const result = await automationsController.browse.query({});
+
+            assert.deepEqual(result.data, [{
+                id: 'automation-id-1',
+                name: 'Welcome Email (Free)',
+                status: 'active'
+            }, {
+                id: 'automation-id-2',
+                name: 'Welcome Email (Premium)',
+                status: 'inactive'
+            }]);
+        });
     });
 
     describe('poll', function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1258

This PR adds `GET /automations`, which lists all of your automations.

For now, it only includes the ID, name, and status. We can add more fields in the future.