### PR TITLE
Added permissions for browsing, reading, and editing automations

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.36/2026-04-28-22-57-29-add-automations-permissions.js
+++ b/ghost/core/core/server/data/migrations/versions/6.36/2026-04-28-22-57-29-add-automations-permissions.js
@@ -1,0 +1,28 @@
+const {combineTransactionalMigrations, addPermissionWithRoles} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse automations',
+        action: 'browse',
+        object: 'automation'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read automations',
+        action: 'read',
+        object: 'automation'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit automations',
+        action: 'edit',
+        object: 'automation'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ])
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -775,6 +775,21 @@
                     "object_type": "recommendation"
                 },
                 {
+                    "name": "Browse automations",
+                    "action_type": "browse",
+                    "object_type": "automation"
+                },
+                {
+                    "name": "Read automations",
+                    "action_type": "read",
+                    "object_type": "automation"
+                },
+                {
+                    "name": "Edit automations",
+                    "action_type": "edit",
+                    "object_type": "automation"
+                },
+                {
                     "name": "Poll automations",
                     "action_type": "poll",
                     "object_type": "automation"
@@ -951,6 +966,7 @@
                     "mention": "browse",
                     "collection": "all",
                     "recommendation": "all",
+                    "automation": ["browse", "read", "edit"],
                     "identity": "read"
                 },
                 "DB Backup Integration": {
@@ -1000,6 +1016,7 @@
                     "mention": "browse",
                     "collection": "all",
                     "recommendation": "all",
+                    "automation": ["browse", "read", "edit"],
                     "member_signin_url": "read"
                 },
                 "Super Editor": {

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -91,7 +91,7 @@ describe('Migrations', function () {
         // Custom assertion to wrap all permissions
         function assertCompletePermissions(permissions) {
             // If you have to change this number, please add the relevant `assertHavePermission` checks below
-            assert.equal(permissions.length, 132);
+            assert.equal(permissions.length, 135);
 
             assertHavePermission(permissions, 'Export database', ['Administrator', 'DB Backup Integration']);
             assertHavePermission(permissions, 'Import database', ['Administrator', 'Self-Serve Migration Integration', 'DB Backup Integration']);
@@ -242,6 +242,9 @@ describe('Migrations', function () {
             assertHavePermission(permissions, 'Edit automated emails', ['Administrator', 'Admin Integration']);
             assertHavePermission(permissions, 'Add automated emails', ['Administrator', 'Admin Integration']);
             assertHavePermission(permissions, 'Delete automated emails', ['Administrator', 'Admin Integration']);
+            assertHavePermission(permissions, 'Browse automations', ['Administrator', 'Admin Integration']);
+            assertHavePermission(permissions, 'Read automations', ['Administrator', 'Admin Integration']);
+            assertHavePermission(permissions, 'Edit automations', ['Administrator', 'Admin Integration']);
             assertHavePermission(permissions, 'Poll automations', ['Scheduler Integration']);
 
             assertHavePermission(permissions, 'Browse email design settings', ['Administrator', 'Admin Integration']);

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -402,7 +402,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             const result = await fixtureManager.addFixturesForRelation(fixtures.relations[0]);
-            const FIXTURE_COUNT = 141;
+            const FIXTURE_COUNT = 143;
             assertExists(result);
             assert(_.isPlainObject(result));
             assert.equal(result.expected, FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'db036dfc567b48b78bdd36cd6604909f';
+    const currentSchemaHash = '20b3032b2ec14edfdac13d1485391f19';
     const currentFixturesHash = 'b76d01321e02fb99b11e7a29f91859f7';
     const currentSettingsHash = 'a102b80d2ab0cd92325ed007c94d7da6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,8 +35,8 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '20b3032b2ec14edfdac13d1485391f19';
-    const currentFixturesHash = '911c57c12a164237078b618c5b63042d';
+    const currentSchemaHash = 'db036dfc567b48b78bdd36cd6604909f';
+    const currentFixturesHash = 'b76d01321e02fb99b11e7a29f91859f7';
     const currentSettingsHash = 'a102b80d2ab0cd92325ed007c94d7da6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -776,6 +776,21 @@
                     "object_type": "recommendation"
                 },
                 {
+                    "name": "Browse automations",
+                    "action_type": "browse",
+                    "object_type": "automation"
+                },
+                {
+                    "name": "Read automations",
+                    "action_type": "read",
+                    "object_type": "automation"
+                },
+                {
+                    "name": "Edit automations",
+                    "action_type": "edit",
+                    "object_type": "automation"
+                },
+                {
                     "name": "Poll automations",
                     "action_type": "poll",
                     "object_type": "automation"
@@ -1105,6 +1120,7 @@
                     "mention": "browse",
                     "collection": "all",
                     "recommendation": "all",
+                    "automation": ["browse", "read", "edit"],
                     "identity": "read"
                 },
                 "DB Backup Integration": {
@@ -1154,7 +1170,8 @@
                     "link": "all",
                     "mention": "browse",
                     "collection": "all",
-                    "recommendation": "all"
+                    "recommendation": "all",
+                    "automation": ["browse", "read", "edit"]
                 },
                 "Editor": {
                     "notification": "all",


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1259
ref https://github.com/TryGhost/Ghost/pull/27607

This adds three new permissions: `automation.browse`, `automation.read`, and `automation.edit`. We'll use these in some upcoming changes, such as [this one][0].

This was one-shotted with the following prompt to a coding agent:

<blockquote>
Add permissions for browsing, reading, and editing automations.

We have an `automations.poll` permission, used in `ghost/core/core/server/api/endpoints/automations.js`. This is used for the `/automations/poll` endpoint.

We want three new permissions: `automations.browse`, `automations.read`, and `automations.edit`. All three should be for `Administrator` and `Admin Integration`.

Commit `b01f1c0ed2e0e04660b779b3d3f0752f4a36c2d5` shows an example of how this was added. `ghost/core/core/server/data/migrations/versions/6.25/2026-03-30-20-22-25-add-email-design-setting-permissions.js` might also be useful. The skill in `.agents/skills/add-admin-api-endpoint/permissions.md` might also be helpful to reference.
</blockquote>

[0]: https://github.com/TryGhost/Ghost/pull/27607