### PR TITLE
Refreshed Portal gift selection screen design

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.19",
+  "version": "2.68.20",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/frame.styles.js
+++ b/apps/portal/src/components/frame.styles.js
@@ -22,6 +22,7 @@ import EmailSuppressionFAQ from './pages/email-suppression-faq.css?inline';
 import EmailReceivingFAQ from './pages/email-receiving-faq.css?inline';
 import {TipsAndDonationsSuccessStyle} from './pages/support-success';
 import {GiftRedemptionStyles} from './pages/gift-redemption-page';
+import {GiftPageStyles} from './pages/gift-page';
 import {GiftSuccessStyle} from './pages/gift-success-page';
 import {TipsAndDonationsErrorStyle} from './pages/support-error';
 import {RecommendationsPageStyles} from './pages/recommendations-page';
@@ -1316,6 +1317,7 @@ export function getFrameStyles({site}) {
         EmailReceivingFAQ +
         TipsAndDonationsSuccessStyle +
         GiftRedemptionStyles +
+        GiftPageStyles +
         TipsAndDonationsErrorStyle +
         GiftSuccessStyle +
         RecommendationsPageStyles +

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -5,11 +5,134 @@ import SiteTitleBackButton from '../common/site-title-back-button';
 import ActionButton from '../common/action-button';
 import LoadingPage from './loading-page';
 import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
+import {ReactComponent as GiftIcon} from '../../images/icons/gift.svg';
 import {getAvailableProducts, getCurrencySymbol, formatNumber, getStripeAmount, isCookiesDisabled, getActiveInterval} from '../../utils/helpers';
 import calculateDiscount from '../../utils/discount';
 
 // TODO: wrap strings with t() once copy is finalised
 /* eslint-disable i18next/no-literal-string */
+
+export const GiftPageStyles = `
+.gh-portal-content.gift {
+    position: relative;
+    padding-top: 0;
+}
+
+.gh-portal-gift-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 320px;
+    background: linear-gradient(180deg, var(--brandcolor), transparent);
+    opacity: 0.08;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.gh-portal-popup-wrapper.full-size .gh-portal-gift-bg {
+    top: -2vmin;
+    left: -6vmin;
+    right: -6vmin;
+    height: calc(320px + 2vmin);
+}
+
+.gh-portal-gift-sitetitle {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 15px 32px 0;
+}
+
+.gh-portal-gift-sitetitle-icon {
+    display: block;
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    background-position: 50%;
+    background-size: cover;
+    object-fit: cover;
+}
+
+.gh-portal-gift-sitetitle-name {
+    font-size: 1.5rem;
+    font-weight: 500;
+    color: var(--grey0);
+    line-height: 1;
+}
+
+.gh-portal-gift-hero {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 56px 32px 40px;
+}
+
+.gh-portal-gift-hero-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    color: var(--brandcolor);
+    margin-bottom: 20px;
+}
+
+.gh-portal-gift-hero-icon svg {
+    width: 48px;
+    height: 48px;
+    stroke-width: 1.5;
+}
+
+.gh-portal-gift-hero .gh-portal-main-title {
+    margin: 0 0 14px;
+}
+
+.gh-portal-gift-hero .gh-portal-main-subtitle {
+    margin: 0;
+    font-size: 1.7rem;
+    line-height: 1.45em;
+    color: var(--grey3);
+    text-align: center;
+}
+
+.gh-portal-content.gift > section {
+    position: relative;
+    z-index: 1;
+}
+
+.gh-portal-popup-wrapper.gift .gh-portal-btn-site-title-back {
+    background: transparent;
+    border-color: transparent;
+}
+
+.gh-portal-popup-wrapper.gift .gh-portal-btn-site-title-back:hover {
+    border-color: transparent;
+}
+
+.gh-portal-content.gift .gh-portal-signup-message {
+    margin: 32px 0 40px;
+    color: var(--grey5);
+    text-align: center;
+    text-wrap: pretty;
+}
+
+@media (max-width: 480px) {
+    .gh-portal-gift-hero {
+        padding: 40px 24px 32px;
+    }
+
+    .gh-portal-gift-bg {
+        height: 240px;
+    }
+}
+`;
 
 function GiftProductCardBenefits({product}) {
     if (!product.benefits || !product.benefits.length) {
@@ -85,7 +208,7 @@ function GiftProductCard({brandColor, product, selectedInterval, isDisabled, isP
                 <div className='gh-portal-btn-product'>
                     <ActionButton
                         dataTestId='purchase-gift'
-                        label={<><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{marginRight: '6px', verticalAlign: 'middle'}}><rect x="3" y="8" width="18" height="4" rx="1"/><path d="M12 8v13"/><path d="M19 12v7a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-7"/><path d="M7.5 8a2.5 2.5 0 0 1 0-5A4.8 8 0 0 1 12 8a4.8 8 0 0 1 4.5-5 2.5 2.5 0 0 1 0 5"/></svg> Gift this</>}
+                        label='Gift this'
                         onClick={e => onPurchase(e, product)}
                         disabled={isDisabled}
                         isRunning={isPurchasing}
@@ -146,21 +269,37 @@ const GiftPage = () => {
 
     const products = getAvailableProducts({site}).filter(p => p.type === 'paid');
 
+    const siteIcon = site.icon;
+    const siteTitle = site.title || '';
+
+    const giftPageHeader = (
+        <>
+            <div className='gh-portal-gift-bg' aria-hidden='true' />
+            <div className='gh-portal-gift-sitetitle'>
+                {siteIcon && (
+                    <img className='gh-portal-gift-sitetitle-icon' src={siteIcon} alt='' />
+                )}
+                <span className='gh-portal-gift-sitetitle-name'>{siteTitle}</span>
+            </div>
+            <div className='gh-portal-gift-hero'>
+                <div className='gh-portal-gift-hero-icon'>
+                    <GiftIcon />
+                </div>
+                <h1 className='gh-portal-main-title'>Gift someone a membership</h1>
+                <p className='gh-portal-main-subtitle'>Pick a plan and send it to someone as a gift</p>
+            </div>
+        </>
+    );
+
     if (products.length === 0) {
-        const siteIcon = site.icon;
         return (
             <>
                 <div className='gh-portal-back-sitetitle'>
                     <SiteTitleBackButton />
                 </div>
                 <CloseButton />
-                <div className='gh-portal-content signup'>
-                    <header className='gh-portal-signup-header'>
-                        {siteIcon && (
-                            <img className='gh-portal-signup-logo' src={siteIcon} alt={site.title} />
-                        )}
-                        <h1 className="gh-portal-main-title">{site.title || ''}</h1>
-                    </header>
+                <div className='gh-portal-content signup gift'>
+                    {giftPageHeader}
                     <section>
                         <div className='gh-portal-section'>
                             <p className='gh-portal-invite-only-notification'>
@@ -173,8 +312,6 @@ const GiftPage = () => {
         );
     }
 
-    const siteIcon = site.icon;
-    const siteTitle = site.title || '';
     const isPurchasing = action === 'checkoutGift:running';
     const isDisabled = isCookiesDisabled() || isPurchasing;
 
@@ -195,14 +332,8 @@ const GiftPage = () => {
                 <SiteTitleBackButton />
             </div>
             <CloseButton />
-            <div className='gh-portal-content signup'>
-                <header className='gh-portal-signup-header'>
-                    {siteIcon && (
-                        <img className='gh-portal-signup-logo' src={siteIcon} alt={siteTitle} />
-                    )}
-                    <h1 className="gh-portal-main-title">{siteTitle}</h1>
-                    <p className="gh-portal-main-subtitle" style={{fontSize: '1.7rem', marginTop: '8px'}}>Give the gift of a membership</p>
-                </header>
+            <div className='gh-portal-content signup gift'>
+                {giftPageHeader}
 
                 <section className="gh-portal-signup">
                     <div className='gh-portal-section'>
@@ -228,7 +359,7 @@ const GiftPage = () => {
                         </section>
 
                         <div className='gh-portal-signup-message'>
-                            <div>Only redeemable by free or new members.</div>
+                            <div>Gift can only be redeemed by members without an active paid subscription.</div>
                         </div>
                     </div>
                 </section>

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -359,7 +359,7 @@ const GiftPage = () => {
                         </section>
 
                         <div className='gh-portal-signup-message'>
-                            <div>Gift can only be redeemed by members without an active paid subscription.</div>
+                            <div>Only redeemable by free or new members.</div>
                         </div>
                     </div>
                 </section>

--- a/apps/portal/test/portal-links.test.js
+++ b/apps/portal/test/portal-links.test.js
@@ -418,7 +418,7 @@ describe('Portal Data links:', () => {
             popupFrame = await utils.findByTitle(/portal-popup/i);
             expect(popupFrame).toBeInTheDocument();
 
-            const giftSubtitle = within(popupFrame.contentDocument).queryByText(/give the gift of a membership/i);
+            const giftSubtitle = within(popupFrame.contentDocument).queryByText(/pick a plan and send it to someone as a gift/i);
             expect(giftSubtitle).toBeInTheDocument();
         });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3571/subscription-selection-screen-design

The gift purchase screen now leads with the publication identity at the top and a brand-tinted gradient that fades out before the plan toggle, letting the gift offer feel more like a dedicated landing moment than a generic signup flow.