### PR TITLE
Updated gift link preview design

### DIFF
--- a/ghost/core/core/server/web/gift-preview/controller.js
+++ b/ghost/core/core/server/web/gift-preview/controller.js
@@ -47,7 +47,7 @@ async function giftPreview(req, res) {
     }
 
     const cadenceLabel = getCadenceLabel(gift.cadence, gift.duration);
-    const ogTitle = `Enjoy your gift to ${siteTitle} for ${cadenceLabel}`;
+    const ogTitle = `You've been gifted ${cadenceLabel} of ${siteTitle}`;
     const ogDescription = 'Open this link to redeem your gift.';
     const ogImage = `${siteUrl}/gift/${encodeURIComponent(token)}/image`;
     const ogUrl = `${siteUrl}/gift/${encodeURIComponent(token)}`;

--- a/ghost/core/core/server/web/gift-preview/controller.js
+++ b/ghost/core/core/server/web/gift-preview/controller.js
@@ -47,8 +47,8 @@ async function giftPreview(req, res) {
     }
 
     const cadenceLabel = getCadenceLabel(gift.cadence, gift.duration);
-    const ogTitle = `A gift membership to ${siteTitle}`;
-    const ogDescription = `${tier.name} \u00B7 ${cadenceLabel}`;
+    const ogTitle = `Enjoy your gift to ${siteTitle} for ${cadenceLabel}`;
+    const ogDescription = 'Open this link to redeem your gift.';
     const ogImage = `${siteUrl}/gift/${encodeURIComponent(token)}/image`;
     const ogUrl = `${siteUrl}/gift/${encodeURIComponent(token)}`;
     const redirectUrl = `${siteUrl}/#/portal/gift/redeem/${encodeURIComponent(token)}`;
@@ -81,7 +81,7 @@ async function giftPreview(req, res) {
 </head>
 <body>
     <script>window.location.replace(${JSON.stringify(redirectUrl)});</script>
-    <noscript><a href="${escapeHtml(redirectUrl)}">Redeem your gift membership</a></noscript>
+    <noscript><a href="${escapeHtml(redirectUrl)}">Redeem your gift subscription</a></noscript>
 </body>
 </html>`;
 
@@ -93,7 +93,6 @@ async function giftPreview(req, res) {
 async function giftPreviewImage(req, res) {
     const labs = require('../../../shared/labs');
     const giftService = require('../../services/gifts').service;
-    const tiersService = require('../../services/tiers');
     const settingsCache = require('../../../shared/settings-cache');
 
     if (!labs.isSet('giftSubscriptions')) {
@@ -102,28 +101,18 @@ async function giftPreviewImage(req, res) {
 
     const token = req.params.token;
 
-    let gift;
-    let tier;
-
     try {
-        gift = await giftService.getByToken(token);
-        tier = await tiersService.api.read(gift.tierId);
-
-        if (!tier) {
-            throw new errors.NotFoundError({message: `Tier not found: ${gift.tierId}`});
-        }
+        await giftService.getByToken(token);
     } catch (err) {
         logging.warn('Gift preview image: failed to load required gift data', err);
 
         return res.sendStatus(404);
     }
 
-    const tierName = tier.name;
-    const cadenceLabel = getCadenceLabel(gift.cadence, gift.duration);
     const accentColor = settingsCache.get('accent_color') || '#15171A';
 
     try {
-        const png = await generateGiftPreviewImage({tierName, cadenceLabel, accentColor});
+        const png = await generateGiftPreviewImage({accentColor});
 
         res.set('Content-Type', 'image/png');
         res.set('Cache-Control', 'public, max-age=86400');

--- a/ghost/core/core/server/web/gift-preview/controller.js
+++ b/ghost/core/core/server/web/gift-preview/controller.js
@@ -1,4 +1,3 @@
-const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const {generateGiftPreviewImage} = require('./image');
 
@@ -17,7 +16,6 @@ function escapeHtml(str) {
 async function giftPreview(req, res) {
     const labs = require('../../../shared/labs');
     const giftService = require('../../services/gifts').service;
-    const tiersService = require('../../services/tiers');
     const urlUtils = require('../../../shared/url-utils');
     const settingsCache = require('../../../shared/settings-cache');
 
@@ -31,15 +29,9 @@ async function giftPreview(req, res) {
     const siteTitle = settingsCache.get('title') || 'Ghost';
 
     let gift;
-    let tier;
 
     try {
         gift = await giftService.getByToken(token);
-        tier = await tiersService.api.read(gift.tierId);
-
-        if (!tier) {
-            throw new errors.NotFoundError({message: `Tier not found: ${gift.tierId}`});
-        }
     } catch (err) {
         logging.warn(`Gift preview: failed to load required gift data, redirecting to homepage`, err);
 
@@ -92,20 +84,9 @@ async function giftPreview(req, res) {
 
 async function giftPreviewImage(req, res) {
     const labs = require('../../../shared/labs');
-    const giftService = require('../../services/gifts').service;
     const settingsCache = require('../../../shared/settings-cache');
 
     if (!labs.isSet('giftSubscriptions')) {
-        return res.sendStatus(404);
-    }
-
-    const token = req.params.token;
-
-    try {
-        await giftService.getByToken(token);
-    } catch (err) {
-        logging.warn('Gift preview image: failed to load required gift data', err);
-
         return res.sendStatus(404);
     }
 

--- a/ghost/core/core/server/web/gift-preview/image.js
+++ b/ghost/core/core/server/web/gift-preview/image.js
@@ -44,14 +44,15 @@ function getBackgroundColor(accentColor) {
     return `rgb(${blend(r)}, ${blend(g)}, ${blend(b)})`;
 }
 
-function buildSvg({tierName, cadenceLabel, accentColor}) {
-    const displayTier = tierName.length > 30 ? tierName.slice(0, 28) + '...' : tierName;
+function buildSvg({accentColor}) {
     const bgColor = getBackgroundColor(accentColor);
+    const escapedAccentColor = escapeXml(accentColor);
 
     // Gift box icon from Portal (apps/portal/src/images/icons/gift.svg)
-    // Original viewBox 0 0 24 24, scaled 4x and centered at x=600
+    // Original viewBox 0 0 24 24, scaled and centered in the seal.
     const giftIcon = `
-        <g transform="translate(552, 145) scale(4)" fill="none" stroke="${escapeXml(accentColor)}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <g transform="translate(564, 279) scale(3)" fill="none" stroke="#FFFFFF"
+            stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="8" width="18" height="4" rx="1"/>
             <path d="M12 8v13"/>
             <path d="M19 12v7a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-7"/>
@@ -62,37 +63,27 @@ function buildSvg({tierName, cadenceLabel, accentColor}) {
 
     return `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
-    <!-- Background: accent color at 6% opacity over white -->
     <rect width="1200" height="630" fill="${bgColor}"/>
 
+    <rect x="0" y="303" width="1200" height="24" fill="${escapedAccentColor}"/>
+    <rect x="588" y="0" width="24" height="630" fill="${escapedAccentColor}"/>
+
+    <circle cx="600" cy="315" r="70" fill="${bgColor}"/>
+    <circle cx="600" cy="315" r="58" fill="${escapedAccentColor}"/>
+
     ${giftIcon}
-
-    <!-- GIFT MEMBERSHIP label -->
-    <text x="600" y="303" text-anchor="middle"
-          font-family="Arial, Helvetica, sans-serif" font-size="30" font-weight="700"
-          letter-spacing="2" fill="${escapeXml(accentColor)}">GIFT MEMBERSHIP</text>
-
-    <!-- Main heading -->
-    <text x="600" y="380" text-anchor="middle"
-          font-family="Arial, Helvetica, sans-serif" font-size="54" font-weight="800"
-          letter-spacing="-1" fill="#15171A">You&#x2019;ve been gifted a membership</text>
-
-    <!-- Tier and duration -->
-    <text x="600" y="445" text-anchor="middle"
-          font-family="Arial, Helvetica, sans-serif" font-size="36"
-          fill="#666666"><tspan font-weight="700">${escapeXml(displayTier)}</tspan> &#x00B7; ${escapeXml(cadenceLabel)}</text>
 </svg>`;
 }
 
-async function generateGiftPreviewImage({tierName, cadenceLabel, accentColor}) {
-    const cacheKey = `${tierName}:${cadenceLabel}:${accentColor}`;
+async function generateGiftPreviewImage({accentColor}) {
+    const cacheKey = accentColor;
 
     if (cache.has(cacheKey)) {
         return cache.get(cacheKey);
     }
 
     const imageTransform = require('@tryghost/image-transform');
-    const svg = buildSvg({tierName, cadenceLabel, accentColor});
+    const svg = buildSvg({accentColor});
     const image = await imageTransform.resizeFromBuffer(Buffer.from(svg), {
         width: 1200,
         format: 'png',

--- a/ghost/core/test/unit/server/web/gift-preview/controller.test.js
+++ b/ghost/core/test/unit/server/web/gift-preview/controller.test.js
@@ -5,14 +5,12 @@ const labs = require('../../../../../core/shared/labs');
 const urlUtils = require('../../../../../core/shared/url-utils');
 const settingsCache = require('../../../../../core/shared/settings-cache');
 const giftServiceWrapper = require('../../../../../core/server/services/gifts');
-const tiersService = require('../../../../../core/server/services/tiers');
 
 const controller = require('../../../../../core/server/web/gift-preview/controller');
 
 describe('Gift Preview Controller', function () {
     let req;
     let res;
-    let originalTiersServiceAPI;
     let originalGiftService;
 
     beforeEach(function () {
@@ -27,7 +25,6 @@ describe('Gift Preview Controller', function () {
             sendStatus: sinon.stub(),
             set: sinon.stub()
         };
-        originalTiersServiceAPI = tiersService.api;
         originalGiftService = giftServiceWrapper.service;
 
         sinon.stub(urlUtils, 'getSiteUrl').returns('https://example.com/');
@@ -37,7 +34,6 @@ describe('Gift Preview Controller', function () {
     });
 
     afterEach(function () {
-        tiersService.api = originalTiersServiceAPI;
         giftServiceWrapper.service = originalGiftService;
 
         sinon.restore();
@@ -65,25 +61,6 @@ describe('Gift Preview Controller', function () {
             sinon.assert.calledWith(res.redirect, 302, 'https://example.com/');
         });
 
-        it('redirects to homepage when tier lookup fails', async function () {
-            sinon.stub(labs, 'isSet').withArgs('giftSubscriptions').returns(true);
-            giftServiceWrapper.service = {
-                getByToken: sinon.stub().resolves({
-                    tierId: 'tier_1',
-                    cadence: 'year',
-                    duration: 1
-                })
-            };
-            tiersService.api = {
-                read: sinon.stub().rejects(new Error('Tier not found'))
-            };
-
-            await controller.giftPreview(req, res);
-
-            sinon.assert.calledOnce(res.redirect);
-            sinon.assert.calledWith(res.redirect, 302, 'https://example.com/');
-        });
-
         it('returns HTML with OG tags for a valid gift', async function () {
             sinon.stub(labs, 'isSet').withArgs('giftSubscriptions').returns(true);
             giftServiceWrapper.service = {
@@ -92,9 +69,6 @@ describe('Gift Preview Controller', function () {
                     cadence: 'year',
                     duration: 1
                 })
-            };
-            tiersService.api = {
-                read: sinon.stub().resolves({name: 'Gold'})
             };
 
             await controller.giftPreview(req, res);
@@ -126,9 +100,6 @@ describe('Gift Preview Controller', function () {
                     duration: 3
                 })
             };
-            tiersService.api = {
-                read: sinon.stub().resolves({name: 'Silver'})
-            };
 
             await controller.giftPreview(req, res);
 
@@ -146,9 +117,6 @@ describe('Gift Preview Controller', function () {
                     cadence: 'month',
                     duration: 3
                 })
-            };
-            tiersService.api = {
-                read: sinon.stub().resolves({name: 'Bronze'})
             };
 
             await controller.giftPreview(req, res);
@@ -169,9 +137,6 @@ describe('Gift Preview Controller', function () {
                     duration: 1
                 })
             };
-            tiersService.api = {
-                read: sinon.stub().resolves({name: 'Premium'})
-            };
 
             await controller.giftPreview(req, res);
 
@@ -189,39 +154,6 @@ describe('Gift Preview Controller', function () {
 
             sinon.assert.calledOnce(res.sendStatus);
             sinon.assert.calledWith(res.sendStatus, 404);
-        });
-
-        it('returns 404 when gift token is invalid', async function () {
-            sinon.stub(labs, 'isSet').withArgs('giftSubscriptions').returns(true);
-            giftServiceWrapper.service = {
-                getByToken: sinon.stub().rejects(new Error('Not found'))
-            };
-
-            await controller.giftPreviewImage(req, res);
-
-            sinon.assert.calledOnce(res.sendStatus);
-            sinon.assert.calledWith(res.sendStatus, 404);
-        });
-
-        it('does not require tier data for the decorative image', async function () {
-            sinon.stub(labs, 'isSet').withArgs('giftSubscriptions').returns(true);
-            giftServiceWrapper.service = {
-                getByToken: sinon.stub().resolves({
-                    tierId: 'tier_1',
-                    cadence: 'year',
-                    duration: 1
-                })
-            };
-            tiersService.api = {
-                read: sinon.stub().rejects(new Error('Tier should not be read'))
-            };
-
-            await controller.giftPreviewImage(req, res);
-
-            sinon.assert.notCalled(tiersService.api.read);
-            sinon.assert.calledWith(res.set, 'Content-Type', 'image/png');
-            sinon.assert.calledWith(res.set, 'Cache-Control', 'public, max-age=86400');
-            sinon.assert.calledOnce(res.send);
         });
     });
 });

--- a/ghost/core/test/unit/server/web/gift-preview/controller.test.js
+++ b/ghost/core/test/unit/server/web/gift-preview/controller.test.js
@@ -104,7 +104,7 @@ describe('Gift Preview Controller', function () {
             sinon.assert.calledOnce(res.send);
 
             const html = res.send.firstCall.args[0];
-            const expectedTitle = '<meta property="og:title" content="Enjoy your gift to Test Blog for 1 year">';
+            const expectedTitle = '<meta property="og:title" content="You\'ve been gifted 1 year of Test Blog">';
             const expectedDescription = '<meta property="og:description" content="' +
                 'Open this link to redeem your gift.">';
             const expectedImage = '<meta property="og:image" content="https://example.com/gift/test-token-123/image">';
@@ -155,7 +155,7 @@ describe('Gift Preview Controller', function () {
 
             const html = res.send.firstCall.args[0];
 
-            assert.ok(html.includes('Enjoy your gift to Test Blog for 3 months'));
+            assert.ok(html.includes('You\'ve been gifted 3 months of Test Blog'));
             assert.ok(html.includes('Open this link to redeem your gift.'));
         });
 
@@ -177,7 +177,7 @@ describe('Gift Preview Controller', function () {
 
             const html = res.send.firstCall.args[0];
 
-            assert.ok(html.includes('Enjoy your gift to Ghost for 1 year'));
+            assert.ok(html.includes('You\'ve been gifted 1 year of Ghost'));
         });
     });
 

--- a/ghost/core/test/unit/server/web/gift-preview/controller.test.js
+++ b/ghost/core/test/unit/server/web/gift-preview/controller.test.js
@@ -104,10 +104,14 @@ describe('Gift Preview Controller', function () {
             sinon.assert.calledOnce(res.send);
 
             const html = res.send.firstCall.args[0];
+            const expectedTitle = '<meta property="og:title" content="Enjoy your gift to Test Blog for 1 year">';
+            const expectedDescription = '<meta property="og:description" content="' +
+                'Open this link to redeem your gift.">';
+            const expectedImage = '<meta property="og:image" content="https://example.com/gift/test-token-123/image">';
 
-            assert.ok(html.includes('<meta property="og:title" content="A gift membership to Test Blog">'));
-            assert.ok(html.includes('<meta property="og:description" content="Gold \u00B7 1 year">'));
-            assert.ok(html.includes('<meta property="og:image" content="https://example.com/gift/test-token-123/image">'));
+            assert.ok(html.includes(expectedTitle));
+            assert.ok(html.includes(expectedDescription));
+            assert.ok(html.includes(expectedImage));
             assert.ok(html.includes('<meta property="og:url" content="https://example.com/gift/test-token-123">'));
             assert.ok(html.includes('content="0;url=https://example.com/#/portal/gift/redeem/test-token-123"'));
         });
@@ -151,7 +155,8 @@ describe('Gift Preview Controller', function () {
 
             const html = res.send.firstCall.args[0];
 
-            assert.ok(html.includes('Bronze \u00B7 3 months'));
+            assert.ok(html.includes('Enjoy your gift to Test Blog for 3 months'));
+            assert.ok(html.includes('Open this link to redeem your gift.'));
         });
 
         it('defaults site title to Ghost', async function () {
@@ -172,7 +177,7 @@ describe('Gift Preview Controller', function () {
 
             const html = res.send.firstCall.args[0];
 
-            assert.ok(html.includes('A gift membership to Ghost'));
+            assert.ok(html.includes('Enjoy your gift to Ghost for 1 year'));
         });
     });
 
@@ -198,7 +203,7 @@ describe('Gift Preview Controller', function () {
             sinon.assert.calledWith(res.sendStatus, 404);
         });
 
-        it('returns 404 when tier lookup fails', async function () {
+        it('does not require tier data for the decorative image', async function () {
             sinon.stub(labs, 'isSet').withArgs('giftSubscriptions').returns(true);
             giftServiceWrapper.service = {
                 getByToken: sinon.stub().resolves({
@@ -208,13 +213,15 @@ describe('Gift Preview Controller', function () {
                 })
             };
             tiersService.api = {
-                read: sinon.stub().rejects(new Error('Tier not found'))
+                read: sinon.stub().rejects(new Error('Tier should not be read'))
             };
 
             await controller.giftPreviewImage(req, res);
 
-            sinon.assert.calledOnce(res.sendStatus);
-            sinon.assert.calledWith(res.sendStatus, 404);
+            sinon.assert.notCalled(tiersService.api.read);
+            sinon.assert.calledWith(res.set, 'Content-Type', 'image/png');
+            sinon.assert.calledWith(res.set, 'Cache-Control', 'public, max-age=86400');
+            sinon.assert.calledOnce(res.send);
         });
     });
 });

--- a/ghost/core/test/unit/server/web/gift-preview/image.test.js
+++ b/ghost/core/test/unit/server/web/gift-preview/image.test.js
@@ -10,8 +10,6 @@ describe('Gift Preview Image', function () {
     describe('generateGiftPreviewImage', function () {
         it('generates a PNG buffer', async function () {
             const result = await imageModule.generateGiftPreviewImage({
-                tierName: 'Gold',
-                cadenceLabel: '1 year',
                 accentColor: '#FF5733'
             });
 
@@ -27,8 +25,6 @@ describe('Gift Preview Image', function () {
 
         it('returns cached result on second call with same params', async function () {
             const params = {
-                tierName: 'CacheTest',
-                cadenceLabel: '1 year',
                 accentColor: '#000000'
             };
 
@@ -38,7 +34,7 @@ describe('Gift Preview Image', function () {
             assert.equal(first, second, 'Should return the exact same buffer reference from cache');
         });
 
-        it('returns different results for different params', async function () {
+        it('returns the same result for different gift details with the same accent color', async function () {
             const result1 = await imageModule.generateGiftPreviewImage({
                 tierName: 'Gold',
                 cadenceLabel: '1 year',
@@ -48,6 +44,18 @@ describe('Gift Preview Image', function () {
             const result2 = await imageModule.generateGiftPreviewImage({
                 tierName: 'Silver',
                 cadenceLabel: '3 months',
+                accentColor: '#FF5733'
+            });
+
+            assert.equal(result1, result2);
+        });
+
+        it('returns different results for different accent colors', async function () {
+            const result1 = await imageModule.generateGiftPreviewImage({
+                accentColor: '#FF5733'
+            });
+
+            const result2 = await imageModule.generateGiftPreviewImage({
                 accentColor: '#333333'
             });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3572/branded-unfurl

Gift link previews need to stay readable in clients that ignore descriptions, so the title carries the redeem context while the image remains decorative and brand-colored.
