### PR TITLE
Fixed member import tier mapping

### DIFF
--- a/apps/posts/src/views/members/components/bulk-action-modals/import-members-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/import-members-modal.tsx
@@ -1,12 +1,13 @@
 import {CompleteStep, ErrorStep, InitStep, MappingStep, ProcessingStep} from './import-members/components';
 import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@tryghost/shade/components';
 import {type ImportResponse} from './import-members/state';
-import {MembersFieldMapping, detectFieldTypes} from './import-members/mapping';
+import {MembersFieldMapping, detectFieldTypes, getFieldMappings} from './import-members/mapping';
 import {buildImportResponse} from './import-members/upload';
 import {cn} from '@tryghost/shade/utils';
 import {createInitialImportState, importReducer} from './import-members/reducer';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {parseCSV} from './import-members/csv';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useCallback, useEffect, useMemo, useReducer, useRef} from 'react';
 import {useLabelPicker} from '@src/hooks/use-label-picker';
 
@@ -25,6 +26,9 @@ export function ImportMembersModal({
 }: ImportMembersModalProps) {
     const [state, dispatch] = useReducer(importReducer, undefined, createInitialImportState);
     const errorCsvUrlRef = useRef<string | null>(null);
+    const {data: configData} = useBrowseConfig();
+    const importMemberTier = configData?.config?.labs?.importMemberTier === true;
+    const fieldMappings = useMemo(() => getFieldMappings({importMemberTier}), [importMemberTier]);
 
     const labelPicker = useLabelPicker({
         selectedSlugs: state.selectedLabelSlugs,
@@ -79,7 +83,7 @@ export function ImportMembersModal({
                 const data = parseCSV(text);
 
                 if (data.length > 0) {
-                    const detectedMapping = detectFieldTypes(data);
+                    const detectedMapping = detectFieldTypes(data, {importMemberTier});
                     const fieldMapping = new MembersFieldMapping(detectedMapping);
 
                     dispatch({
@@ -131,7 +135,7 @@ export function ImportMembersModal({
                 reader.abort();
             }
         };
-    }, [state.file]);
+    }, [importMemberTier, state.file]);
 
     const validateFile = useCallback((file: File): boolean => {
         const match = /(?:\.([^.]+))?$/.exec(file.name);
@@ -325,6 +329,7 @@ export function ImportMembersModal({
                 {(state.status === 'MAPPING' || state.status === 'UPLOADING') && (
                     <MappingStep
                         dataPreviewIndex={state.dataPreviewIndex}
+                        fieldMappings={fieldMappings}
                         fileData={state.fileData}
                         hasNextRecord={hasNextRecord}
                         hasPrevRecord={hasPrevRecord}

--- a/apps/posts/src/views/members/components/bulk-action-modals/import-members/components/mapping-step.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/import-members/components/mapping-step.tsx
@@ -1,7 +1,7 @@
 import {Button, DialogFooter, LoadingIndicator, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
-import {FIELD_MAPPINGS, MembersFieldMapping} from '../mapping';
 import {LabelPicker} from '@src/components/label-picker';
-import {LucideIcon, cn} from '@tryghost/shade/utils';
+import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
+import {MembersFieldMapping} from '../mapping';
 import {UseLabelPickerResult} from '@src/hooks/use-label-picker';
 
 interface MappingPreviewRow {
@@ -20,6 +20,7 @@ interface MappingStepProps {
     dataPreviewIndex: number;
     hasPrevRecord: boolean;
     hasNextRecord: boolean;
+    fieldMappings: {label: string; value: string}[];
     labelPicker: UseLabelPickerResult;
     onUpdateMapping: (from: string, to: string | null) => void;
     onDataPreviewIndexChange: (next: number) => void;
@@ -37,6 +38,7 @@ export function MappingStep({
     dataPreviewIndex,
     hasPrevRecord,
     hasNextRecord,
+    fieldMappings,
     labelPicker,
     onUpdateMapping,
     onDataPreviewIndexChange,
@@ -72,7 +74,7 @@ export function MappingStep({
                                             <TableHead className="w-1/3">
                                                 <div className="flex items-center justify-between">
                                                     <span>
-                                                        Sample data <span className="text-muted-foreground">(#{(dataPreviewIndex + 1).toLocaleString()})</span>
+                                                        Sample data <span className="text-muted-foreground">(#{formatNumber(dataPreviewIndex + 1)})</span>
                                                     </span>
                                                     <div className="flex items-center">
                                                         <button
@@ -126,7 +128,7 @@ export function MappingStep({
                                                             </SelectTrigger>
                                                             <SelectContent>
                                                                 <SelectItem value="__not_imported__">Not imported</SelectItem>
-                                                                {FIELD_MAPPINGS.map(field => (
+                                                                {fieldMappings.map(field => (
                                                                     <SelectItem key={field.value} value={field.value}>
                                                                         {field.label}
                                                                     </SelectItem>
@@ -198,7 +200,7 @@ export function MappingStep({
                             Uploading
                         </span>
                     ) : membersCount > 0 ? (
-                        `Import ${membersCount.toLocaleString()} ${membersCount === 1 ? 'member' : 'members'}`
+                        `Import ${formatNumber(membersCount)} ${membersCount === 1 ? 'member' : 'members'}`
                     ) : (
                         'Import members'
                     )}

--- a/apps/posts/src/views/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/posts/src/views/members/components/bulk-action-modals/import-members/mapping.ts
@@ -1,3 +1,7 @@
+type FieldMappingOptions = {
+    importMemberTier?: boolean;
+};
+
 export const FIELD_MAPPINGS = [
     {label: 'Email', value: 'email'},
     {label: 'Name', value: 'name'},
@@ -9,6 +13,8 @@ export const FIELD_MAPPINGS = [
     {label: 'Created at', value: 'created_at'}
 ];
 
+const IMPORT_TIER_FIELD_MAPPING = {label: 'Tier', value: 'import_tier'};
+
 const SUPPORTED_TYPES = [
     'email',
     'name',
@@ -19,6 +25,20 @@ const SUPPORTED_TYPES = [
     'labels',
     'created_at'
 ];
+
+function getSupportedTypes({importMemberTier = false}: FieldMappingOptions = {}): string[] {
+    return [
+        ...SUPPORTED_TYPES,
+        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING.value] : [])
+    ];
+}
+
+export function getFieldMappings({importMemberTier = false}: FieldMappingOptions = {}) {
+    return [
+        ...FIELD_MAPPINGS,
+        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : [])
+    ];
+}
 
 const AUTO_DETECTED_TYPES = ['email'];
 
@@ -117,9 +137,10 @@ export function sampleData(data: Record<string, string>[], validationSampleSize 
  *
  * Returned mapping object contains mappings accepted by the members upload API.
  */
-export function detectFieldTypes(data: Record<string, string>[]): Record<string, string> {
+export function detectFieldTypes(data: Record<string, string>[], options: FieldMappingOptions = {}): Record<string, string> {
     const sampledData = sampleData(data);
     const mapping: Record<string, string> = {};
+    const supportedTypes = getSupportedTypes(options);
 
     // Match column headers against supported types using all headers from the
     // original data. sampleData only keeps keys with non-empty values, so
@@ -132,7 +153,7 @@ export function detectFieldTypes(data: Record<string, string>[]): Record<string,
                 continue;
             }
 
-            if (!mapping[key] && SUPPORTED_TYPES.includes(key) && !AUTO_DETECTED_TYPES.includes(key)) {
+            if (!mapping[key] && supportedTypes.includes(key) && !AUTO_DETECTED_TYPES.includes(key)) {
                 mapping[key] = key;
             }
         }

--- a/apps/posts/test/unit/views/members/import-members/mapping.test.ts
+++ b/apps/posts/test/unit/views/members/import-members/mapping.test.ts
@@ -1,4 +1,4 @@
-import {MembersFieldMapping, detectFieldTypes, formatImportError, sampleData} from '@src/views/members/components/bulk-action-modals/import-members/mapping';
+import {MembersFieldMapping, detectFieldTypes, formatImportError, getFieldMappings, sampleData} from '@src/views/members/components/bulk-action-modals/import-members/mapping';
 import {describe, expect, it} from 'vitest';
 
 describe('mapping helpers', () => {
@@ -45,6 +45,20 @@ describe('mapping helpers', () => {
         expect(mapping.note).toBe('note');
         expect(mapping.subscribed_to_emails).toBe('subscribed_to_emails');
         expect(mapping.labels).toBe('labels');
+    });
+
+    it('detects import tier mapping when enabled', () => {
+        const mapping = detectFieldTypes([
+            {email: 'member@example.com', import_tier: 'Gold'}
+        ], {importMemberTier: true});
+
+        expect(mapping.import_tier).toBe('import_tier');
+    });
+
+    it('adds tier as an available field mapping when enabled', () => {
+        const fieldMappings = getFieldMappings({importMemberTier: true});
+
+        expect(fieldMappings).toContainEqual({label: 'Tier', value: 'import_tier'});
     });
 
     it('updates mapping while preventing duplicate targets', () => {

--- a/apps/posts/test/unit/views/members/import-members/modal.test.tsx
+++ b/apps/posts/test/unit/views/members/import-members/modal.test.tsx
@@ -2,6 +2,18 @@ import {ImportMembersModal} from '@src/views/members/components/bulk-action-moda
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 
+vi.mock('@tryghost/admin-x-framework/api/config', () => ({
+    useBrowseConfig: () => ({
+        data: {
+            config: {
+                labs: {
+                    importMemberTier: true
+                }
+            }
+        }
+    })
+}));
+
 vi.mock('@tryghost/admin-x-framework/helpers', () => ({
     getGhostPaths: () => ({
         apiRoot: '/ghost/api/admin'
@@ -42,7 +54,7 @@ class MockFileReader {
     readAsText() {
         this.onload?.({
             target: {
-                result: 'email,name\nmember@example.com,Member'
+                result: mockCsvContents
             }
         });
     }
@@ -52,11 +64,13 @@ class MockFileReader {
     }
 }
 
+let mockCsvContents = 'email,name\nmember@example.com,Member';
+
 const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
-
 describe('ImportMembersModal', () => {
     beforeEach(() => {
+        mockCsvContents = 'email,name\nmember@example.com,Member';
         vi.stubGlobal('FileReader', MockFileReader);
         vi.stubGlobal('fetch', vi.fn(async () => new Response(null, {status: 202})));
         Object.defineProperty(URL, 'createObjectURL', {
@@ -119,5 +133,33 @@ describe('ImportMembersModal', () => {
         });
 
         expect(screen.getByRole('heading', {name: /import in progress/i})).toBeInTheDocument();
+    });
+
+    it('shows tier as a mapped field when importMemberTier is enabled', async () => {
+        mockCsvContents = 'email,import_tier\nmember@example.com,Gold';
+
+        render(
+            <ImportMembersModal
+                open
+                onOpenChange={() => {}}
+            />
+        );
+
+        const dropTarget = screen.getByRole('button', {name: /select or drop a csv file/i});
+        const csvFile = createFile('members.csv', 'text/csv', mockCsvContents);
+
+        fireEvent.drop(dropTarget, {
+            dataTransfer: {
+                files: [csvFile],
+                items: [{
+                    kind: 'file',
+                    type: csvFile.type,
+                    getAsFile: () => csvFile
+                }],
+                types: ['Files']
+            }
+        });
+
+        expect(await screen.findByText('Tier')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary

Restores the feature-flagged tier mapping behavior in the React member import flow.

## Root Cause

The legacy Ember import UI added the `Tier` / `import_tier` mapping option when `importMemberTier` was enabled. The recently ported React member import flow used a static field mapping list and static supported type list, so customers with the flag enabled could no longer select or auto-detect tier columns.

## Changes

- Read `config.labs.importMemberTier` in the React member import modal.
- Add feature-aware mapping helpers for available field mappings and supported auto-detected CSV headers.
- Pass the computed mapping list into the mapping step dropdown.
- Add regression coverage for `import_tier` detection and the mapped Tier UI state.

## Validation

- `pnpm --filter @tryghost/posts exec vitest run test/unit/views/members/import-members`
- `pnpm --filter @tryghost/posts build`
- `pnpm --filter @tryghost/posts lint:code`