### PR TITLE
Add batch_id column to members_status_events table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.36/2026-04-29-12-13-44-add-batch-id-to-members-status-events.js
+++ b/ghost/core/core/server/data/migrations/versions/6.36/2026-04-29-12-13-44-add-batch-id-to-members-status-events.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members_status_events', 'batch_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -595,7 +595,8 @@ module.exports = {
                 isIn: [['free', 'paid', 'comped', 'gift']]
             }
         },
-        created_at: {type: 'dateTime', nullable: false}
+        created_at: {type: 'dateTime', nullable: false},
+        batch_id: {type: 'string', maxlength: 24, nullable: true}
     },
     members_product_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'db036dfc567b48b78bdd36cd6604909f';
+    const currentSchemaHash = '20b3032b2ec14edfdac13d1485391f19';
     const currentFixturesHash = '911c57c12a164237078b618c5b63042d';
     const currentSettingsHash = 'a102b80d2ab0cd92325ed007c94d7da6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
## Summary

Adds a nullable `batch_id` column (string, maxlength 24) to the `members_status_events` table so that member-status events can be associated with member-created or subscription-create events created in the same batch.

This change is being made in the context of gift subscriptions, for which we need a way to identify:
- gift signup events (member-created event + member-status event with `from_status` set to `null` and `to_status` set to `gift`)
- gift to paid conversion events (subscription-created event + member-status event with `from_status` set to `gift` and `to_status` set to `paid`)


## Changes

- New migration: `ghost/core/core/server/data/migrations/versions/6.36/2026-04-29-12-13-44-add-batch-id-to-members-status-events.js`, using `createAddColumnMigration`.
- Schema update in `ghost/core/core/server/data/schema/schema.js` to add the `batch_id` column definition.
- Updated `currentSchemaHash` in `ghost/core/test/unit/server/data/schema/integrity.test.js` to reflect the new schema.

## Test plan

- [x] `pnpm knex-migrator migrate` completes without errors on a fresh DB
- [x] `pnpm knex-migrator rollback` removes the column cleanly
- [x] `cd ghost/core && pnpm test:single test/unit/server/data/schema/integrity.test.js` passes
- [x] Existing members_status_events writes/reads continue to work (column is nullable, no backfill required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)