### PR TITLE
Fixed overlapping titles in Portal modals

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.21",
+  "version": "2.68.22",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/frame.styles.js
+++ b/apps/portal/src/components/frame.styles.js
@@ -600,6 +600,7 @@ html[dir="rtl"] .gh-portal-logout-container {
     align-items: center;
     justify-content: center;
     margin: -2px 0 40px;
+    padding-inline: 60px;
 }
 
 .gh-portal-detail-footer .gh-portal-btn {
@@ -1049,7 +1050,6 @@ const MobileStyles = `
     .gh-portal-popup-container:not(.account-plan) .gh-portal-detail-header .gh-portal-main-title {
         font-size: 2.1rem;
         margin-top: 1px;
-        padding: 0 74px;
         text-align: center;
     }
 

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -16,10 +16,6 @@ export const AccountPlanPageStyles = `
         margin-top: 44px;
     }
 
-    .account-plan:not(.full-size) .gh-portal-detail-header {
-        padding-inline: 60px;
-    }
-
     .gh-portal-accountplans-main {
         margin-top: 24px;
         margin-bottom: 0;


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1271/ui-issue-with-the-portal-overlay

Applied the account modal styles globally so that all titles will wrap if they need to.

| Before | After |
|--------|--------|
| <img width="535" height="615" alt="Screenshot 2026-04-29 at 14 06 21" src="https://github.com/user-attachments/assets/7ee863a3-1b08-4ac4-9977-a36bdc065639" /> | <img width="537" height="641" alt="Screenshot 2026-04-29 at 14 06 02" src="https://github.com/user-attachments/assets/634adbab-e1cf-4deb-bd60-6e784d8e3c82" /> | 
