### PR TITLE
Added gift purchase and redemption events to member activity filters

### DIFF
--- a/ghost/admin/app/components/members-activity/event-type-filter.js
+++ b/ghost/admin/app/components/members-activity/event-type-filter.js
@@ -25,7 +25,7 @@ export default class MembersActivityEventTypeFilter extends Component {
 
     @action
     toggleEventType(eventType) {
-        const newExcludedEvents = toggleEventType(eventType, this.eventTypes);
+        const newExcludedEvents = toggleEventType(eventType, this.args.excludedEvents);
         this.args.onChange(newExcludedEvents || null);
     }
 }

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -29,17 +29,23 @@ export function getAvailableEventTypes(settings, hiddenEvents = []) {
 export function toggleEventType(eventType, eventTypes) {
     const excludedEvents = new Set(eventTypes.filter(type => !type.isSelected).map(type => type.event));
 
-    if (eventType === 'payment_event') {
+    if (eventType === 'subscription_event') {
+        if (excludedEvents.has('subscription_event')) {
+            excludedEvents.delete('subscription_event');
+            excludedEvents.delete('gift_redemption_event');
+        } else {
+            excludedEvents.add('subscription_event');
+            excludedEvents.add('gift_redemption_event');
+        }
+    } else if (eventType === 'payment_event') {
         if (excludedEvents.has('payment_event')) {
             excludedEvents.delete('payment_event');
             excludedEvents.delete('donation_event');
             excludedEvents.delete('gift_purchase_event');
-            excludedEvents.delete('gift_redemption_event');
         } else {
             excludedEvents.add('payment_event');
             excludedEvents.add('donation_event');
             excludedEvents.add('gift_purchase_event');
-            excludedEvents.add('gift_redemption_event');
         }
     } else {
         if (excludedEvents.has(eventType)) {

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -26,8 +26,12 @@ export function getAvailableEventTypes(settings, hiddenEvents = []) {
     return extended.filter(t => !hiddenEvents.includes(t.event));
 }
 
-export function toggleEventType(eventType, eventTypes) {
-    const excludedEvents = new Set(eventTypes.filter(type => !type.isSelected).map(type => type.event));
+export function toggleEventType(eventType, currentExcludedEvents = []) {
+    const excludedEvents = new Set(
+        Array.isArray(currentExcludedEvents)
+            ? currentExcludedEvents
+            : (currentExcludedEvents || '').split(',').filter(Boolean)
+    );
 
     if (eventType === 'subscription_event') {
         if (excludedEvents.has('subscription_event')) {

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -17,22 +17,42 @@ describe('Unit | Utility | event-type-utils', function () {
         expect(eventTypes).to.deep.include({event: 'click_event', icon: 'filter-dropdown-clicked-in-email', name: 'Clicked link in email', group: 'others'});
     });
 
-    it('should toggle both payment_event and donation_event when toggling payment_event', function () {
+    it('should toggle payment_event together with donation_event and gift_purchase_event when toggling payment_event', function () {
         const eventTypes = [
             {event: 'payment_event', isSelected: true}
         ];
 
         const newExcludedEvents = toggleEventType('payment_event', eventTypes);
 
-        expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event,gift_redemption_event');
+        expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event');
     });
 
-    it('should toggle both payment_event and donation_event off when toggling payment_event off', function () {
+    it('should toggle payment_event group off when toggling payment_event off', function () {
         const eventTypes = [
             {event: 'payment_event', isSelected: false}
         ];
 
         const newExcludedEvents = toggleEventType('payment_event', eventTypes);
+
+        expect(newExcludedEvents).to.equal('');
+    });
+
+    it('should toggle subscription_event together with gift_redemption_event', function () {
+        const eventTypes = [
+            {event: 'subscription_event', isSelected: true}
+        ];
+
+        const newExcludedEvents = toggleEventType('subscription_event', eventTypes);
+
+        expect(newExcludedEvents).to.equal('subscription_event,gift_redemption_event');
+    });
+
+    it('should toggle subscription_event group off when toggling subscription_event off', function () {
+        const eventTypes = [
+            {event: 'subscription_event', isSelected: false}
+        ];
+
+        const newExcludedEvents = toggleEventType('subscription_event', eventTypes);
 
         expect(newExcludedEvents).to.equal('');
     });

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -18,43 +18,45 @@ describe('Unit | Utility | event-type-utils', function () {
     });
 
     it('should toggle payment_event together with donation_event and gift_purchase_event when toggling payment_event', function () {
-        const eventTypes = [
-            {event: 'payment_event', isSelected: true}
-        ];
-
-        const newExcludedEvents = toggleEventType('payment_event', eventTypes);
+        const newExcludedEvents = toggleEventType('payment_event', []);
 
         expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event');
     });
 
     it('should toggle payment_event group off when toggling payment_event off', function () {
-        const eventTypes = [
-            {event: 'payment_event', isSelected: false}
-        ];
-
-        const newExcludedEvents = toggleEventType('payment_event', eventTypes);
+        const newExcludedEvents = toggleEventType('payment_event', ['payment_event', 'donation_event', 'gift_purchase_event']);
 
         expect(newExcludedEvents).to.equal('');
     });
 
     it('should toggle subscription_event together with gift_redemption_event', function () {
-        const eventTypes = [
-            {event: 'subscription_event', isSelected: true}
-        ];
-
-        const newExcludedEvents = toggleEventType('subscription_event', eventTypes);
+        const newExcludedEvents = toggleEventType('subscription_event', []);
 
         expect(newExcludedEvents).to.equal('subscription_event,gift_redemption_event');
     });
 
     it('should toggle subscription_event group off when toggling subscription_event off', function () {
-        const eventTypes = [
-            {event: 'subscription_event', isSelected: false}
-        ];
-
-        const newExcludedEvents = toggleEventType('subscription_event', eventTypes);
+        const newExcludedEvents = toggleEventType('subscription_event', ['subscription_event', 'gift_redemption_event']);
 
         expect(newExcludedEvents).to.equal('');
+    });
+
+    it('should preserve previously-excluded payment group when toggling subscription_event', function () {
+        const newExcludedEvents = toggleEventType('subscription_event', ['payment_event', 'donation_event', 'gift_purchase_event']);
+
+        expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event,subscription_event,gift_redemption_event');
+    });
+
+    it('should preserve previously-excluded subscription group when toggling payment_event', function () {
+        const newExcludedEvents = toggleEventType('payment_event', ['subscription_event', 'gift_redemption_event']);
+
+        expect(newExcludedEvents).to.equal('subscription_event,gift_redemption_event,payment_event,donation_event,gift_purchase_event');
+    });
+
+    it('should accept a comma-separated string for currentExcludedEvents', function () {
+        const newExcludedEvents = toggleEventType('subscription_event', 'payment_event,donation_event,gift_purchase_event');
+
+        expect(newExcludedEvents).to.equal('payment_event,donation_event,gift_purchase_event,subscription_event,gift_redemption_event');
     });
 
     it('should return correct divider need based on event groups', function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3526

## Summary

Wires the three new gift subscription events into the existing **Paid subscriptions** and **Payments** toggles in the member activity filter dropdown, and fixes a pre-existing bug in the toggle logic that surfaced along the way.

- `gift_purchase_event` (e.g. "Purchased gift subscription for $10") is filtered under **Payments**, since it represents an actual one-off transaction
-`gift_redemption_event` ("started paid subscription via gift") is filtered under **Paid subscriptions**, since redeeming a gift starts the recipient's paid subscription.
- The third variant — "continued paid subscription after gift" — is just a regular `subscription_event` with `previous_status: 'gift'`, so it's already covered by the **Paid subscriptions** toggle without further changes.


## Changes

### 1. Regrouped `gift_redemption_event` under "Paid subscriptions"

Previously the **Payments** toggle controlled `payment_event`, `donation_event`, `gift_purchase_event`, **and** `gift_redemption_event`. Conceptually a gift redemption is the start of a paid subscription, not a payment, so it now lives in the **Paid subscriptions** group alongside `subscription_event`. **Payments** still controls `payment_event`, `donation_event`, and `gift_purchase_event`.

### 2. Fixed hidden sub-events being dropped during toggling

While testing the regrouping I hit a related bug: turning off **Payments** and then **Paid subscriptions** caused "Purchased gift subscription" to reappear in the feed.

`toggleEventType()` rebuilt the excluded-events `Set` by filtering the visible top-level toggle list, which doesn't include hidden sub-events (`donation_event`, `gift_purchase_event`, `gift_redemption_event`). Any hidden sub-event that was already excluded got silently dropped whenever a *different* toggle was changed.

Fixed by passing the actual current excluded list to `toggleEventType()` instead of inferring it from the visible toggle array, so hidden sub-events outside the toggled group are preserved across toggles.

## Test plan

- [x] Unit tests pass — added cross-group regression coverage in `member-event-types-test.js` (10/10 passing)
- [ ] Manual smoke test in `pnpm dev` with a member that has all three gift event variants:
  - [ ] Toggle **Paid subscriptions** off → "started paid subscription via gift" and "continued paid subscription after gift" disappear; "Purchased gift subscription…" stays
  - [ ] Toggle **Payments** off → "Purchased gift subscription…" disappears; the redemption / continued events stay
  - [ ] Toggle both off → all three gift events disappear (this is the regression case from the second commit)
  - [ ] Toggle either back on → the corresponding events return without the other group flipping
- [ ] Verify same behavior on the global Activity page and on the per-member activity dropdown (both consume the same `event-type-filter` component)