### PR TITLE
Avoided possible false positive in Cache-Control middleware test

### DIFF
--- a/ghost/core/test/unit/server/web/shared/middleware/cache-control.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/cache-control.test.js
@@ -76,20 +76,21 @@ describe('Cache-Control middleware', function () {
 
         await runMiddleware(publicCC);
         sinon.assert.calledOnce(res.set);
-        sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
+        sinon.assert.calledWith(res.set.getCall(0), {'Cache-Control': 'public, max-age=0'});
 
         await runMiddleware(privateCC);
         sinon.assert.calledTwice(res.set);
-        sinon.assert.calledWith(res.set, {
+        sinon.assert.calledWith(res.set.getCall(1), {
             'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
         });
 
         await runMiddleware(publicCC);
         sinon.assert.calledThrice(res.set);
-        sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
+        sinon.assert.calledWith(res.set.getCall(2), {'Cache-Control': 'public, max-age=0'});
 
         await runMiddleware(privateCC);
-        sinon.assert.calledWith(res.set, {
+        sinon.assert.callCount(res.set, 4);
+        sinon.assert.calledWith(res.set.getCall(3), {
             'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
         });
     });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/27603#discussion_r3154979716

This is a test-only change. [CodeRabbit noticed][0] that this test could have a false positive.

The test didn't have a false positive--everything was fine!--but this is still worth shoring up.

[0]: https://github.com/TryGhost/Ghost/pull/27603#discussion_r3154979716
