### PR TITLE
🐛 Fixed What's New banner breaking on null changelog fields

### DIFF
--- a/apps/admin/src/whats-new/hooks/use-changelog.test.tsx
+++ b/apps/admin/src/whats-new/hooks/use-changelog.test.tsx
@@ -144,6 +144,41 @@ describe("useChangelog", () => {
         });
     });
 
+    describe("nullable fields", () => {
+        test("accepts null for custom_excerpt, feature_image, and html", async ({ server, wrapper }) => {
+            server.use(
+                http.get(CHANGELOG_API_URL, () => {
+                    return HttpResponse.json({
+                        posts: [
+                            {
+                                slug: "post-without-excerpt",
+                                title: "Post Without Excerpt",
+                                custom_excerpt: null,
+                                feature_image: null,
+                                html: null,
+                                url: "https://ghost.org/changelog/post-without-excerpt",
+                                published_at: "2026-04-29T10:00:00.000+00:00",
+                                featured: "true",
+                            },
+                        ],
+                        changelogUrl: "https://ghost.org/changelog",
+                    });
+                })
+            );
+
+            const { result } = renderHook(() => useChangelog(), { wrapper });
+            await waitForQuerySettled(result);
+
+            expect(result.current.isSuccess).toBe(true);
+            expect(result.current.data?.entries[0]).toMatchObject({
+                slug: "post-without-excerpt",
+                customExcerpt: null,
+                featureImage: null,
+                html: null,
+            });
+        });
+    });
+
     describe("network errors", () => {
         [
             {

--- a/apps/admin/src/whats-new/hooks/use-changelog.ts
+++ b/apps/admin/src/whats-new/hooks/use-changelog.ts
@@ -7,12 +7,12 @@ const ChangelogEntrySchema = z
     .looseObject({
         slug: z.string(),
         title: z.string(),
-        custom_excerpt: z.string(),
+        custom_excerpt: z.string().nullish(),
         url: z.string().url(),
         published_at: isoDatetimeToDate,
         featured: z.stringbool(),
-        feature_image: z.string().url().optional(),
-        html: z.string().optional(),
+        feature_image: z.string().url().nullish(),
+        html: z.string().nullish(),
     })
     .transform((data) => ({
         slug: data.slug,


### PR DESCRIPTION
## Problem

The What's New banner in Ghost Admin silently fails to render when a changelog post on Ghost.org has a null `custom_excerpt`. The Zod schema validating responses from the changelog endpoint only allowed strings or `undefined` for `custom_excerpt`, `feature_image`, and `html`, but the upstream Hugo template on ghost.org explicitly emits JSON `null` for those fields whenever the source value is falsy. As soon as one entry returns `null`, validation throws and the entire banner disappears with no user-facing indication of what went wrong.

## Solution

Loosen the schema to accept `null` alongside `string` and `undefined` for the three optional fields by switching from `.optional()` to `.nullish()`. This mirrors what the ghost.org changelog endpoint actually returns, so newly published changelog entries with empty excerpts, missing feature images, or empty HTML bodies will now parse cleanly and surface in the banner as intended. Tests were updated to cover the null cases so the contract is locked in.