### PR TITLE
Fixed vertical text rendering in ActivityPub reader on mobile

### DIFF
--- a/apps/activitypub/src/components/feed/feed-item.tsx
+++ b/apps/activitypub/src/components/feed/feed-item.tsx
@@ -174,7 +174,7 @@ export function renderFeedAttachment(
 function renderInboxAttachment(object: ObjectProperties, isLoading: boolean | undefined) {
     const attachment = getAttachment(object);
 
-    const videoAttachmentStyles = 'ml-8 md:ml-9 shrink-0 rounded-md h-[91px] w-[121px] relative';
+    const videoAttachmentStyles = 'ml-8 md:ml-9 shrink-0 rounded-md h-[91px] w-[121px] relative hidden @md/inbox-item:block';
     const imageAttachmentStyles = clsx('object-cover outline outline-1 -outline-offset-1 outline-black/[0.05]', videoAttachmentStyles);
 
     if (isLoading) {
@@ -686,7 +686,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
         return (
             <>
                 {object && (
-                    <div className='group/article relative -mx-4 -my-px flex min-h-[112px] min-w-0 cursor-pointer items-center justify-between rounded-lg p-6 hover:bg-gray-75 dark:hover:bg-gray-950/50' data-layout='inbox' data-object-id={object.id} onClick={onClick}>
+                    <div className='group/article @container/inbox-item relative -mx-4 -my-px flex min-h-[112px] min-w-0 cursor-pointer items-center justify-between rounded-lg p-6 hover:bg-gray-75 dark:hover:bg-gray-950/50' data-layout='inbox' data-object-id={object.id} onClick={onClick}>
                         <div className='w-full min-w-0'>
                             <div className='z-10 mb-1.5 flex w-full min-w-0 items-center gap-1.5 text-sm group-hover/article:border-transparent'>
                                 {!isLoading ?
@@ -694,7 +694,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                         <ProfilePreviewHoverCard actor={author} isCurrentUser={isAuthorCurrentUser}>
                                             <div className='flex items-center gap-1'>
                                                 <APAvatar author={author} size='2xs' />
-                                                <span className='break-anywhere min-w-0 font-semibold text-gray-900 hover:underline dark:text-gray-600'
+                                                <span className='min-w-0 truncate font-semibold text-gray-900 hover:underline dark:text-gray-600'
                                                     data-test-activity-heading
                                                     onClick={(e) => {
                                                         handleProfileClick(author, navigate, e);


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3578/

## Summary

On phone-width viewports, the author name in the ActivityPub reader inbox could render one character per line — looking like vertical text — whenever the inbox row was also showing an "X reposted" indicator and timestamp.

## What changed

In [feed-item.tsx:697](apps/activitypub/src/components/feed/feed-item.tsx#L697), swapped `break-anywhere min-w-0` for `truncate` (= `min-w-0` + `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`) on the author-name span in the inbox layout.

## Why

`break-anywhere` (`overflow-wrap: anywhere`) lowers the intrinsic min-content width of text to a single character. Combined with `min-w-0` and a flex row that has to fit `[avatar + name]` + `[X reposted]` + `[timestamp]`, the name span shrunk to ~1 char wide on mobile and the browser broke the name onto its own line for each character. With `truncate` the name now ellipsises on a single line when squeezed.

The other `break-anywhere` usages in the file are either already paired with `truncate` (lines 451, 563, 625) or live in non-constrained content blocks (titles, body content), so this was the only spot that exhibited the bug.

## Test plan

- [ ] On a phone-width viewport (<= ~400px), open the ActivityPub reader inbox and view a post that was reposted by another account whose display name is long enough to fill the row. The author name should ellipsise on one line, not render vertically.
- [ ] On desktop, confirm the inbox header still looks unchanged for short and long author names.

