### PR TITLE
Started canceling runs when automation becomes inactive

### DIFF
--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1200,7 +1200,7 @@ module.exports = {
         ready_at: {type: 'dateTime', nullable: true},
         step_started_at: {type: 'dateTime', nullable: true},
         step_attempts: {type: 'integer', unsigned: true, nullable: false, defaultTo: 0},
-        exit_reason: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['email send failed', 'member unsubscribed', 'member changed status', 'finished']]}},
+        exit_reason: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['email send failed', 'member unsubscribed', 'member changed status', 'finished', 'automation disabled']]}},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         '@@INDEXES@@': [

--- a/ghost/core/core/server/services/welcome-email-automations/poll.js
+++ b/ghost/core/core/server/services/welcome-email-automations/poll.js
@@ -12,6 +12,7 @@ const {AutomatedEmailRecipient, Member, WelcomeEmailAutomationRun} = require('..
  * @prop {number} step_attempts
  * @prop {null | string} next_welcome_email_automated_email_id
  * @prop {string} automation_slug
+ * @prop {string} automation_status
  * @prop {string} automated_email_id
  */
 
@@ -61,7 +62,7 @@ async function fetchAndLockRuns() {
             .where(function () {
                 this.whereNull('r.step_started_at').orWhere('r.step_started_at', '<', lockCutoff);
             })
-            .select('r.id', 'r.member_id', 'r.step_attempts', 'r.next_welcome_email_automated_email_id', 'a.slug as automation_slug', 'e.id as automated_email_id')
+            .select('r.id', 'r.member_id', 'r.step_attempts', 'r.next_welcome_email_automated_email_id', 'a.slug as automation_slug', 'a.status as automation_status', 'e.id as automated_email_id')
             .limit(MAX_RUNS_PER_BATCH);
 
         if (runs.length === 0) {
@@ -103,7 +104,7 @@ async function updateRun(runId, attrs, transacting) {
 
 /**
  * @param {string} runId
- * @param {'finished' | 'email send failed' | 'member changed status' | 'member unsubscribed'} exitReason
+ * @param {'finished' | 'email send failed' | 'member changed status' | 'member unsubscribed' | 'automation disabled'} exitReason
  * @param {Knex.Transaction} [transacting]
  * @returns {Promise<void>}
  */
@@ -161,6 +162,11 @@ async function processRun({
 }) {
     if (run.step_attempts > MAX_ATTEMPTS) {
         await markMaxAttemptsExceeded(run.id);
+        return;
+    }
+
+    if (run.automation_status !== 'active') {
+        await markExited(run.id, 'automation disabled');
         return;
     }
 

--- a/ghost/core/test/integration/services/welcome-email-automations/poll.test.js
+++ b/ghost/core/test/integration/services/welcome-email-automations/poll.test.js
@@ -400,6 +400,36 @@ describe('welcome email automations poll', function () {
         assert.equal(updatedRun.step_attempts, 0);
     });
 
+    it('bails if the automation is disabled', async function () {
+        const automation = await createAutomation({
+            status: 'inactive'
+        });
+        const automatedEmail = await createAutomatedEmail({
+            welcome_email_automation_id: automation.id
+        });
+        const member = await createMember();
+        const run = await createRun({
+            welcome_email_automation_id: automation.id,
+            member_id: member.id,
+            next_welcome_email_automated_email_id: automatedEmail.id,
+            ready_at: new Date(Date.now() - 1000)
+        });
+
+        await poll(options);
+
+        sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
+        sinon.assert.notCalled(options.enqueueAnotherPollNow);
+        sinon.assert.notCalled(options.enqueueAnotherPollAt);
+        assert.deepEqual(await readTrackedRecipients(), []);
+
+        const updatedRun = await readRun(run.id);
+        assert.equal(updatedRun.exit_reason, 'automation disabled');
+        assert.equal(updatedRun.next_welcome_email_automated_email_id, null);
+        assert.equal(updatedRun.ready_at, null);
+        assert.equal(updatedRun.step_started_at, null);
+        assert.equal(updatedRun.step_attempts, 0);
+    });
+
     it('does not send email if member is deleted mid-run (race condition)', async function () {
         const automation = await createAutomation();
         const automatedEmail = await createAutomatedEmail({


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1261

This was built by Kimi K2.6 with the following prompt:

> @ghost/core/core/server/services/welcome-email-automations/poll.js runs pending automation runs. This is good! But it has a missing feature: if the welcome email automation is inactive (see `welcome_email_automations`'s `status` column), we still run the automation. Let's implement this behavior!
>
> Using red/green TDD (edit `poll.test.js`, probably), make it so that we cancel an automation run if the automation is disabled. This will also mean adding a new `exit_reason` to the `welcome_email_automation_runs` table (see @ghost/core/core/server/data/schema/schema.js), and a new type for the `exitReason` argument of `markExited` in poll.js.
>
> (There's a chance this feature already exists, in which case this request is a no-op. But I'm pretty sure we need to implement it.)

I made a few small tweaks and put it up for review.
