### PR TITLE
Folded gift signups into Monthly / Annual on the paid subscription breakdown chart

### DIFF
--- a/apps/stats/src/views/Stats/Growth/components/new-subscribers-cadence.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/new-subscribers-cadence.tsx
@@ -5,7 +5,6 @@ import {LucideIcon, Recharts, formatNumber} from '@tryghost/shade/utils';
 import {formatQueryDate, getRangeDates} from '@tryghost/shade/app';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
-import {useGlobalData} from '@src/providers/global-data-provider';
 import {useMemberCountHistory, useSubscriptionStats} from '@tryghost/admin-x-framework/api/stats';
 
 type NewSubscribersCadenceProps = {
@@ -54,8 +53,6 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
         }
     });
     const {data: {tiers: tierObjects = []} = {}} = useBrowseTiers();
-    const {data: globalConfig} = useGlobalData();
-    const giftSubscriptionsEnabled = globalConfig?.labs?.giftSubscriptions === true;
     const [breakdownType, setBreakdownType] = useState<BreakdownType>('billing-period');
 
     // Calculate date range for filtering
@@ -73,9 +70,9 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
             }));
     }, [tierObjects]);
 
-    // Helper: compute positive delta for a given status field (e.g. comped, gift)
+    // Helper: compute positive delta for a given status field (e.g. comped)
     // from the first to the last data point within the date range.
-    const calculateStatusSignups = useCallback((statusField: 'comped' | 'gift') => {
+    const calculateStatusSignups = useCallback((statusField: 'comped') => {
         if (!memberCountResponse?.stats || memberCountResponse.stats.length === 0) {
             return 0;
         }
@@ -107,13 +104,6 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
     // Calculate complimentary member signups (change in comped) within date range
     const compedSignups = useMemo(() => calculateStatusSignups('comped'), [calculateStatusSignups]);
 
-    // Calculate gift member signups (change in gift) within date range.
-    // Skipped when the giftSubscriptions labs flag is off — keeps cadence UI unchanged for sites not using gifts.
-    const giftSignups = useMemo(
-        () => (giftSubscriptionsEnabled ? calculateStatusSignups('gift') : 0),
-        [calculateStatusSignups, giftSubscriptionsEnabled]
-    );
-
     // Process subscription data for billing period breakdown (cadence) - NEW SUBSCRIBERS in date range
     const billingPeriodData = useMemo(() => {
         if (!subscriptionStatsResponse?.stats) {
@@ -143,10 +133,6 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
             cadenceTotals.complimentary = compedSignups;
         }
 
-        if (giftSignups > 0) {
-            cadenceTotals.gift = giftSignups;
-        }
-
         // Convert to array format for pie chart
         const chartData = Object.entries(cadenceTotals).map(([cadence, count], index) => {
             // Map cadence values to display labels and colors
@@ -166,10 +152,6 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
                 label = 'Complimentary';
                 fillGradient = 'url(#gradientBlue)';
                 solidColor = 'var(--chart-blue)';
-            } else if (cadence === 'gift') {
-                label = 'Gift';
-                fillGradient = 'url(#gradientRose)';
-                solidColor = 'var(--chart-rose)';
             }
 
             return {
@@ -182,7 +164,7 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
         });
 
         return chartData;
-    }, [subscriptionStatsResponse, dateFrom, dateTo, compedSignups, giftSignups]);
+    }, [subscriptionStatsResponse, dateFrom, dateTo, compedSignups]);
 
     // Process subscription data for tier breakdown - NEW SUBSCRIBERS in date range
     const tierData = useMemo(() => {

--- a/apps/stats/test/unit/components/growth/new-subscribers-cadence.test.tsx
+++ b/apps/stats/test/unit/components/growth/new-subscribers-cadence.test.tsx
@@ -14,12 +14,6 @@ vi.mock('@tryghost/admin-x-framework/api/tiers', () => ({
     useBrowseTiers: vi.fn()
 }));
 
-vi.mock('@src/providers/global-data-provider', () => ({
-    useGlobalData: vi.fn(() => ({
-        data: {labs: {giftSubscriptions: true}}
-    }))
-}));
-
 // Mock date helpers from @tryghost/shade/app
 vi.mock('@tryghost/shade/app', async () => {
     const actual = await vi.importActual('@tryghost/shade/app');
@@ -47,13 +41,11 @@ vi.mock('@tryghost/shade/utils', async () => {
 });
 
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
-import {useGlobalData} from '@src/providers/global-data-provider';
 import {useMemberCountHistory, useSubscriptionStats} from '@tryghost/admin-x-framework/api/stats';
 
 const mockedUseSubscriptionStats = useSubscriptionStats as ReturnType<typeof vi.fn>;
 const mockedUseMemberCountHistory = useMemberCountHistory as ReturnType<typeof vi.fn>;
 const mockedUseBrowseTiers = useBrowseTiers as ReturnType<typeof vi.fn>;
-const mockedUseGlobalData = useGlobalData as ReturnType<typeof vi.fn>;
 
 describe('NewSubscribersCadence Component', () => {
     beforeEach(() => {
@@ -215,52 +207,31 @@ describe('NewSubscribersCadence Component', () => {
         expect(screen.getByText('20%')).toBeInTheDocument();
     });
 
-    it('shows Gift slice when giftSubscriptions labs flag is enabled and gift count increases', () => {
-        mockedUseGlobalData.mockReturnValue({data: {labs: {giftSubscriptions: true}}});
-
+    it('folds gift signups into the matching cadence bucket', () => {
         mockSuccess(mockedUseSubscriptionStats, {
             stats: [
-                {date: '2024-01-15', tier: 'tier-1', cadence: 'month', signups: 50, cancellations: 0, count: 100}
+                // 30 paid monthly + 6 monthly gifts = 36 total monthly signups
+                {date: '2024-01-15', tier: 'tier-1', cadence: 'month', signups: 36, cancellations: 0, count: 100},
+                // 10 paid yearly + 4 yearly gifts = 14 total yearly signups
+                {date: '2024-01-15', tier: 'tier-1', cadence: 'year', signups: 14, cancellations: 0, count: 50}
             ],
-            meta: {totals: [{tier: 'tier-1', cadence: 'month', count: 100}]}
-        });
-
-        mockSuccess(mockedUseMemberCountHistory, {
-            stats: [
-                {date: '2024-01-01', paid: 80, free: 50, comped: 0, gift: 0},
-                {date: '2024-01-31', paid: 100, free: 60, comped: 0, gift: 10}
-            ],
-            meta: {totals: {paid: 100, free: 60, comped: 0, gift: 10}}
+            meta: {
+                totals: [
+                    {tier: 'tier-1', cadence: 'month', count: 100},
+                    {tier: 'tier-1', cadence: 'year', count: 50}
+                ]
+            }
         });
 
         render(<NewSubscribersCadence isLoading={false} range={30} />);
 
         expect(screen.getByText('Monthly')).toBeInTheDocument();
-        expect(screen.getByText('Gift')).toBeInTheDocument();
-    });
-
-    it('hides Gift slice when giftSubscriptions labs flag is disabled, even when gift count increases', () => {
-        mockedUseGlobalData.mockReturnValue({data: {labs: {giftSubscriptions: false}}});
-
-        mockSuccess(mockedUseSubscriptionStats, {
-            stats: [
-                {date: '2024-01-15', tier: 'tier-1', cadence: 'month', signups: 50, cancellations: 0, count: 100}
-            ],
-            meta: {totals: [{tier: 'tier-1', cadence: 'month', count: 100}]}
-        });
-
-        mockSuccess(mockedUseMemberCountHistory, {
-            stats: [
-                {date: '2024-01-01', paid: 80, free: 50, comped: 0, gift: 0},
-                {date: '2024-01-31', paid: 100, free: 60, comped: 0, gift: 10}
-            ],
-            meta: {totals: {paid: 100, free: 60, comped: 0, gift: 10}}
-        });
-
-        render(<NewSubscribersCadence isLoading={false} range={30} />);
-
-        expect(screen.getByText('Monthly')).toBeInTheDocument();
+        expect(screen.getByText('Annual')).toBeInTheDocument();
         expect(screen.queryByText('Gift')).not.toBeInTheDocument();
+
+        // 36/50 = 72%, 14/50 = 28%
+        expect(screen.getByText('72%')).toBeInTheDocument();
+        expect(screen.getByText('28%')).toBeInTheDocument();
     });
 
     it('does not show complimentary when comped count does not increase', () => {

--- a/ghost/core/core/server/services/stats/subscription-stats-service.js
+++ b/ghost/core/core/server/services/stats/subscription-stats-service.js
@@ -132,25 +132,35 @@ class SubscriptionStatsService {
     }
 
     /**
-      * Get the current total subscriptions grouped by Cadence and Tier
+      * Get the current total subscriptions grouped by Cadence and Tier.
+      * Includes both paid subscriptions and currently-redeemed gifts so the
+      * totals stay consistent with the gift-aware delta stream.
       * @returns {Promise<SubscriptionCount[]>}
       **/
     async fetchSubscriptionCounts() {
         const knex = this.knex;
 
-        const data = await knex('members_stripe_customers_subscriptions')
-            .select(knex.raw(`
-                  COUNT(members_stripe_customers_subscriptions.id) AS count,
-                  products.id AS tier,
-                  stripe_prices.interval AS cadence
-             `))
-            .join('stripe_prices', 'stripe_prices.stripe_price_id', '=', 'members_stripe_customers_subscriptions.stripe_price_id')
-            .join('stripe_products', 'stripe_products.stripe_product_id', '=', 'stripe_prices.stripe_product_id')
-            .join('products', 'products.id', '=', 'stripe_products.product_id')
-            .whereNot('members_stripe_customers_subscriptions.mrr', 0)
-            .groupBy('tier', 'cadence');
+        const [paidCounts, giftCounts] = await Promise.all([
+            knex('members_stripe_customers_subscriptions')
+                .select(knex.raw(`
+                      COUNT(members_stripe_customers_subscriptions.id) AS count,
+                      products.id AS tier,
+                      stripe_prices.interval AS cadence
+                 `))
+                .join('stripe_prices', 'stripe_prices.stripe_price_id', '=', 'members_stripe_customers_subscriptions.stripe_price_id')
+                .join('stripe_products', 'stripe_products.stripe_product_id', '=', 'stripe_prices.stripe_product_id')
+                .join('products', 'products.id', '=', 'stripe_products.product_id')
+                .whereNot('members_stripe_customers_subscriptions.mrr', 0)
+                .groupBy('tier', 'cadence'),
+            knex('gifts')
+                .where('status', 'redeemed')
+                .select(knex.raw('COUNT(id) as count'))
+                .select('tier_id as tier')
+                .select('cadence')
+                .groupBy('tier_id', 'cadence')
+        ]);
 
-        return data;
+        return aggregateCounts(paidCounts.concat(giftCounts));
     }
 
     /**
@@ -188,6 +198,26 @@ class SubscriptionStatsService {
             ...cancellations.map(r => ({date: r.date, tier: r.tier, cadence: r.cadence, positive_delta: 0, negative_delta: r.count, signups: 0, cancellations: r.count}))
         ];
     }
+}
+
+/**
+ * Sum SubscriptionCount entries that share the same (tier, cadence) key.
+ * @param {SubscriptionCount[]} counts
+ * @returns {SubscriptionCount[]}
+ */
+function aggregateCounts(counts) {
+    /** @type {Map<string, SubscriptionCount>} */
+    const byKey = new Map();
+    for (const entry of counts) {
+        const key = `${entry.tier}|${entry.cadence}`;
+        const existing = byKey.get(key);
+        if (existing) {
+            existing.count += entry.count;
+        } else {
+            byKey.set(key, {tier: entry.tier, cadence: entry.cadence, count: entry.count});
+        }
+    }
+    return Array.from(byKey.values());
 }
 
 /**

--- a/ghost/core/core/server/services/stats/subscription-stats-service.js
+++ b/ghost/core/core/server/services/stats/subscription-stats-service.js
@@ -14,12 +14,11 @@ class SubscriptionStatsService {
     async getSubscriptionHistory() {
         const paidDeltas = await this.fetchAllSubscriptionDeltas();
         const giftDeltas = await this.fetchAllGiftDeltas();
-        // The loop below walks deltas backwards to roll the running `count`
-        // back through history, so the merged array must be in ascending
-        // date order for those snapshots to be correct.
-        const subscriptionDeltaEntries = paidDeltas.concat(giftDeltas).sort((a, b) => {
-            return moment(a.date).valueOf() - moment(b.date).valueOf();
-        });
+        // Sum paid+gift entries that share (date, tier, cadence) so each
+        // row produces a single coherent `count` snapshot. Sort ascending
+        // because the rollback loop below walks the array backwards.
+        const subscriptionDeltaEntries = aggregateDeltas(paidDeltas.concat(giftDeltas))
+            .sort((a, b) => moment(a.date).valueOf() - moment(b.date).valueOf());
         const counts = await this.fetchSubscriptionCounts();
 
         /** @type {Object.<string, Object.<string, number>>} */
@@ -189,6 +188,38 @@ class SubscriptionStatsService {
             ...cancellations.map(r => ({date: r.date, tier: r.tier, cadence: r.cadence, positive_delta: 0, negative_delta: r.count, signups: 0, cancellations: r.count}))
         ];
     }
+}
+
+/**
+ * Sum SubscriptionDelta entries that share the same (date, tier, cadence) key.
+ * @param {SubscriptionDelta[]} deltas
+ * @returns {SubscriptionDelta[]}
+ */
+function aggregateDeltas(deltas) {
+    /** @type {Map<string, SubscriptionDelta>} */
+    const byKey = new Map();
+    for (const entry of deltas) {
+        const date = moment(entry.date).format('YYYY-MM-DD');
+        const key = `${date}|${entry.tier}|${entry.cadence}`;
+        const existing = byKey.get(key);
+        if (existing) {
+            existing.positive_delta += entry.positive_delta;
+            existing.negative_delta += entry.negative_delta;
+            existing.signups += entry.signups;
+            existing.cancellations += entry.cancellations;
+        } else {
+            byKey.set(key, {
+                date,
+                tier: entry.tier,
+                cadence: entry.cadence,
+                positive_delta: entry.positive_delta,
+                negative_delta: entry.negative_delta,
+                signups: entry.signups,
+                cancellations: entry.cancellations
+            });
+        }
+    }
+    return Array.from(byKey.values());
 }
 
 /** @typedef {object} SubscriptionCount

--- a/ghost/core/core/server/services/stats/subscription-stats-service.js
+++ b/ghost/core/core/server/services/stats/subscription-stats-service.js
@@ -175,6 +175,7 @@ class SubscriptionStatsService {
                 .groupByRaw('DATE(redeemed_at), tier_id, cadence'),
             knex('gifts')
                 .whereIn('status', ['consumed', 'expired', 'refunded'])
+                .whereNotNull('redeemed_at')
                 .whereRaw(`${cancellationDate} IS NOT NULL`)
                 .select(knex.raw(`DATE(${cancellationDate}) as date`))
                 .select('tier_id as tier')

--- a/ghost/core/core/server/services/stats/subscription-stats-service.js
+++ b/ghost/core/core/server/services/stats/subscription-stats-service.js
@@ -14,7 +14,12 @@ class SubscriptionStatsService {
     async getSubscriptionHistory() {
         const paidDeltas = await this.fetchAllSubscriptionDeltas();
         const giftDeltas = await this.fetchAllGiftDeltas();
-        const subscriptionDeltaEntries = paidDeltas.concat(giftDeltas);
+        // The loop below walks deltas backwards to roll the running `count`
+        // back through history, so the merged array must be in ascending
+        // date order for those snapshots to be correct.
+        const subscriptionDeltaEntries = paidDeltas.concat(giftDeltas).sort((a, b) => {
+            return moment(a.date).valueOf() - moment(b.date).valueOf();
+        });
         const counts = await this.fetchSubscriptionCounts();
 
         /** @type {Object.<string, Object.<string, number>>} */

--- a/ghost/core/core/server/services/stats/subscription-stats-service.js
+++ b/ghost/core/core/server/services/stats/subscription-stats-service.js
@@ -12,7 +12,9 @@ class SubscriptionStatsService {
      * @returns {Promise<{data: SubscriptionHistoryEntry[]}>}
      **/
     async getSubscriptionHistory() {
-        const subscriptionDeltaEntries = await this.fetchAllSubscriptionDeltas();
+        const paidDeltas = await this.fetchAllSubscriptionDeltas();
+        const giftDeltas = await this.fetchAllGiftDeltas();
+        const subscriptionDeltaEntries = paidDeltas.concat(giftDeltas);
         const counts = await this.fetchSubscriptionCounts();
 
         /** @type {Object.<string, Object.<string, number>>} */
@@ -145,6 +147,41 @@ class SubscriptionStatsService {
             .groupBy('tier', 'cadence');
 
         return data;
+    }
+
+    /**
+     * Gift redemptions (signups) and gifts that have been consumed, expired,
+     * or refunded (cancellations), shaped as SubscriptionDelta rows so they
+     * appear alongside paid subscription deltas in the cadence breakdown.
+     * @returns {Promise<SubscriptionDelta[]>}
+     */
+    async fetchAllGiftDeltas() {
+        const knex = this.knex;
+        // A gift is no longer active once it has been consumed, expired, or refunded.
+        // Use whichever of those timestamps was set as the cancellation date.
+        const cancellationDate = 'COALESCE(consumed_at, expired_at, refunded_at)';
+        const [signups, cancellations] = await Promise.all([
+            knex('gifts')
+                .whereNotNull('redeemed_at')
+                .select(knex.raw('DATE(redeemed_at) as date'))
+                .select('tier_id as tier')
+                .select('cadence')
+                .select(knex.raw('COUNT(id) as count'))
+                .groupByRaw('DATE(redeemed_at), tier_id, cadence'),
+            knex('gifts')
+                .whereIn('status', ['consumed', 'expired', 'refunded'])
+                .whereRaw(`${cancellationDate} IS NOT NULL`)
+                .select(knex.raw(`DATE(${cancellationDate}) as date`))
+                .select('tier_id as tier')
+                .select('cadence')
+                .select(knex.raw('COUNT(id) as count'))
+                .groupByRaw(`DATE(${cancellationDate}), tier_id, cadence`)
+        ]);
+
+        return [
+            ...signups.map(r => ({date: r.date, tier: r.tier, cadence: r.cadence, positive_delta: r.count, negative_delta: 0, signups: r.count, cancellations: 0})),
+            ...cancellations.map(r => ({date: r.date, tier: r.tier, cadence: r.cadence, positive_delta: 0, negative_delta: r.count, signups: 0, cancellations: r.count}))
+        ];
     }
 }
 

--- a/ghost/core/test/unit/server/services/stats/subscriptions.test.js
+++ b/ghost/core/test/unit/server/services/stats/subscriptions.test.js
@@ -426,6 +426,25 @@ describe('SubscriptionStatsService', function () {
             assert.equal(sumWhere('basic', 'year', '1970-01-02', 'cancellations'), 1);
         });
 
+        it('Includes active gifts in the current totals so rolled-back snapshots stay accurate', async function () {
+            await createTiers(['basic']);
+
+            // Two active redeemed gifts, no paid subs.
+            await db('gifts').insert([
+                {id: 'g1', tier_id: 'basic', cadence: 'year', status: 'redeemed', redeemed_at: '1970-01-01T00:00:00.000Z'},
+                {id: 'g2', tier_id: 'basic', cadence: 'year', status: 'redeemed', redeemed_at: '1970-01-02T00:00:00.000Z'}
+            ]);
+
+            const stats = new SubscriptionStatsService({knex: db});
+            const result = await stats.getSubscriptionHistory();
+
+            // Without including gifts in totals, the baseline would be 0 and rolled-back
+            // counts would all be negative (clamped to 0), undercounting history.
+            const yearlyTotal = result.meta.totals.find(t => t.tier === 'basic' && t.cadence === 'year');
+            assert(yearlyTotal);
+            assert.equal(yearlyTotal.count, 2);
+        });
+
         it('Aggregates paid and gift deltas that share (date, tier, cadence) into a single row', async function () {
             const tiers = await createTiers(['basic']);
 
@@ -504,21 +523,19 @@ describe('SubscriptionStatsService', function () {
             const stats = new SubscriptionStatsService({knex: db});
             const result = await stats.getSubscriptionHistory();
 
-            // fetchSubscriptionCounts() only counts paid subs (1 yearly), not gifts.
-            // Walking backwards from countData=1:
-            //   day 3 (paid signup):  emit count=1, then countData -= 1 → 0
-            //   day 1 (gift signup):  emit count=0, then countData -= 1 → -1
-            // Both snapshots clamp to non-negative on the frontend, but the ordering
-            // is what matters: each row should reflect the count *at* that moment.
+            // fetchSubscriptionCounts() returns 2 yearly basic subs (1 paid + 1 active gift).
+            // Walking backwards from countData=2 in ascending date order:
+            //   day 3 (paid signup):  emit count=2, then countData -= 1 → 1
+            //   day 1 (gift signup):  emit count=1, then countData -= 1 → 0
             const day1Yearly = result.data.find(r => r.tier === 'basic' && r.cadence === 'year' && r.date === '1970-01-01');
             const day3Yearly = result.data.find(r => r.tier === 'basic' && r.cadence === 'year' && r.date === '1970-01-03');
 
             assert(day1Yearly);
             assert(day3Yearly);
-            // After paid signup on day 3: count is 1 (current total)
-            assert.equal(day3Yearly.count, 1);
-            // After gift signup on day 1, before paid signup: count is 0
-            assert.equal(day1Yearly.count, 0);
+            // After both signups: 2 yearly subs total
+            assert.equal(day3Yearly.count, 2);
+            // After only the gift signup, before the paid signup: 1 yearly sub
+            assert.equal(day1Yearly.count, 1);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/stats/subscriptions.test.js
+++ b/ghost/core/test/unit/server/services/stats/subscriptions.test.js
@@ -425,5 +425,49 @@ describe('SubscriptionStatsService', function () {
             // Day 2 yearly: 1 gift cancellation (consumed)
             assert.equal(sumWhere('basic', 'year', '1970-01-02', 'cancellations'), 1);
         });
+
+        it('Sorts merged paid+gift deltas by date so running counts roll back correctly', async function () {
+            const tiers = await createTiers(['basic']);
+
+            // Gift yearly redemption on day 1 (earliest event)
+            await db('gifts').insert({
+                id: 'g-early',
+                tier_id: 'basic',
+                cadence: 'year',
+                status: 'redeemed',
+                redeemed_at: '1970-01-01T00:00:00.000Z'
+            });
+
+            // Paid yearly signup on day 3 (latest event). paidDeltas comes first
+            // in the concat, so without sorting the order would be:
+            //   [paid@day3, gift@day1]
+            // Walking backwards: gift@day1 then paid@day3 — earlier-dated entry
+            // applied to the running count BEFORE the later one, corrupting snapshots.
+            const NEW = createEvent('created');
+            await insertEvents([
+                [],
+                [],
+                [NEW('A', tiers.basic.yearly)]
+            ]);
+
+            const stats = new SubscriptionStatsService({knex: db});
+            const result = await stats.getSubscriptionHistory();
+
+            // fetchSubscriptionCounts() only counts paid subs (1 yearly), not gifts.
+            // Walking backwards from countData=1:
+            //   day 3 (paid signup):  emit count=1, then countData -= 1 → 0
+            //   day 1 (gift signup):  emit count=0, then countData -= 1 → -1
+            // Both snapshots clamp to non-negative on the frontend, but the ordering
+            // is what matters: each row should reflect the count *at* that moment.
+            const day1Yearly = result.data.find(r => r.tier === 'basic' && r.cadence === 'year' && r.date === '1970-01-01');
+            const day3Yearly = result.data.find(r => r.tier === 'basic' && r.cadence === 'year' && r.date === '1970-01-03');
+
+            assert(day1Yearly);
+            assert(day3Yearly);
+            // After paid signup on day 3: count is 1 (current total)
+            assert.equal(day3Yearly.count, 1);
+            // After gift signup on day 1, before paid signup: count is 0
+            assert.equal(day1Yearly.count, 0);
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/stats/subscriptions.test.js
+++ b/ghost/core/test/unit/server/services/stats/subscriptions.test.js
@@ -40,6 +40,16 @@ describe('SubscriptionStatsService', function () {
                 table.string('stripe_price_id');
                 table.integer('mrr');
             });
+            await db.schema.createTable('gifts', function (table) {
+                table.string('id');
+                table.string('tier_id');
+                table.string('cadence');
+                table.string('status');
+                table.dateTime('redeemed_at');
+                table.dateTime('consumed_at');
+                table.dateTime('expired_at');
+                table.dateTime('refunded_at');
+            });
         });
 
         afterEach(async function () {
@@ -381,6 +391,39 @@ describe('SubscriptionStatsService', function () {
             assert.equal(days[1].beyond.yearly.negative_delta, 0);
             assert.equal(days[1].beyond.yearly.signups, 1);
             assert.equal(days[1].beyond.yearly.cancellations, 0);
+        });
+
+        it('Includes gift redemptions and end-of-life events alongside paid deltas', async function () {
+            const tiers = await createTiers(['basic']);
+
+            // One paid monthly signup on day 1
+            const NEW = createEvent('created');
+            await insertEvents([
+                [NEW('A', tiers.basic.monthly)]
+            ]);
+
+            // Two gifts: monthly redeemed day 1 (still active), yearly redeemed
+            // day 1 then consumed day 2.
+            await db('gifts').insert([
+                {id: 'g-month', tier_id: 'basic', cadence: 'month', status: 'redeemed', redeemed_at: '1970-01-01T00:00:00.000Z'},
+                {id: 'g-year', tier_id: 'basic', cadence: 'year', status: 'consumed', redeemed_at: '1970-01-01T00:00:00.000Z', consumed_at: '1970-01-02T00:00:00.000Z'}
+            ]);
+
+            const stats = new SubscriptionStatsService({knex: db});
+            const result = await stats.getSubscriptionHistory();
+
+            // Sum signups/cancellations across all rows for a given (tier, cadence, date).
+            // Paid and gift contribute separate rows that aggregate downstream.
+            const sumWhere = (tier, cadence, date, field) => result.data
+                .filter(r => r.tier === tier && r.cadence === cadence && r.date === date)
+                .reduce((acc, r) => acc + r[field], 0);
+
+            // Day 1 monthly: 1 paid + 1 gift = 2 signups
+            assert.equal(sumWhere('basic', 'month', '1970-01-01', 'signups'), 2);
+            // Day 1 yearly: 1 gift signup
+            assert.equal(sumWhere('basic', 'year', '1970-01-01', 'signups'), 1);
+            // Day 2 yearly: 1 gift cancellation (consumed)
+            assert.equal(sumWhere('basic', 'year', '1970-01-02', 'cancellations'), 1);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/stats/subscriptions.test.js
+++ b/ghost/core/test/unit/server/services/stats/subscriptions.test.js
@@ -426,6 +426,28 @@ describe('SubscriptionStatsService', function () {
             assert.equal(sumWhere('basic', 'year', '1970-01-02', 'cancellations'), 1);
         });
 
+        it('Excludes unredeemed gifts (expired/refunded before redemption) from cancellations', async function () {
+            await createTiers(['basic']);
+
+            // A gift that was purchased and refunded without ever being redeemed.
+            // It never produced a signup, so it must not produce a cancellation.
+            await db('gifts').insert({
+                id: 'g-refunded',
+                tier_id: 'basic',
+                cadence: 'year',
+                status: 'refunded',
+                redeemed_at: null,
+                refunded_at: '1970-01-02T00:00:00.000Z'
+            });
+
+            const stats = new SubscriptionStatsService({knex: db});
+            const result = await stats.getSubscriptionHistory();
+
+            // No rows should exist for this gift at all.
+            const giftRows = result.data.filter(r => r.tier === 'basic' && r.cadence === 'year');
+            assert.equal(giftRows.length, 0);
+        });
+
         it('Sorts merged paid+gift deltas by date so running counts roll back correctly', async function () {
             const tiers = await createTiers(['basic']);
 

--- a/ghost/core/test/unit/server/services/stats/subscriptions.test.js
+++ b/ghost/core/test/unit/server/services/stats/subscriptions.test.js
@@ -402,28 +402,38 @@ describe('SubscriptionStatsService', function () {
                 [NEW('A', tiers.basic.monthly)]
             ]);
 
-            // Two gifts: monthly redeemed day 1 (still active), yearly redeemed
-            // day 1 then consumed day 2.
+            // Gifts covering each end-of-life branch:
+            //  - g-month: redeemed day 1, still active
+            //  - g-year-consumed:  redeemed day 1, consumed day 2
+            //  - g-year-expired:   redeemed day 1, expired day 3
+            //  - g-month-refunded: redeemed day 1, refunded day 4
             await db('gifts').insert([
                 {id: 'g-month', tier_id: 'basic', cadence: 'month', status: 'redeemed', redeemed_at: '1970-01-01T00:00:00.000Z'},
-                {id: 'g-year', tier_id: 'basic', cadence: 'year', status: 'consumed', redeemed_at: '1970-01-01T00:00:00.000Z', consumed_at: '1970-01-02T00:00:00.000Z'}
+                {id: 'g-year-consumed', tier_id: 'basic', cadence: 'year', status: 'consumed', redeemed_at: '1970-01-01T00:00:00.000Z', consumed_at: '1970-01-02T00:00:00.000Z'},
+                {id: 'g-year-expired', tier_id: 'basic', cadence: 'year', status: 'expired', redeemed_at: '1970-01-01T00:00:00.000Z', expired_at: '1970-01-03T00:00:00.000Z'},
+                {id: 'g-month-refunded', tier_id: 'basic', cadence: 'month', status: 'refunded', redeemed_at: '1970-01-01T00:00:00.000Z', refunded_at: '1970-01-04T00:00:00.000Z'}
             ]);
 
             const stats = new SubscriptionStatsService({knex: db});
             const result = await stats.getSubscriptionHistory();
 
             // Sum signups/cancellations across all rows for a given (tier, cadence, date).
-            // Paid and gift contribute separate rows that aggregate downstream.
             const sumWhere = (tier, cadence, date, field) => result.data
                 .filter(r => r.tier === tier && r.cadence === cadence && r.date === date)
                 .reduce((acc, r) => acc + r[field], 0);
 
-            // Day 1 monthly: 1 paid + 1 gift = 2 signups
-            assert.equal(sumWhere('basic', 'month', '1970-01-01', 'signups'), 2);
-            // Day 1 yearly: 1 gift signup
-            assert.equal(sumWhere('basic', 'year', '1970-01-01', 'signups'), 1);
-            // Day 2 yearly: 1 gift cancellation (consumed)
+            // Day 1 monthly: 1 paid + 2 gift redemptions (g-month, g-month-refunded) = 3 signups
+            assert.equal(sumWhere('basic', 'month', '1970-01-01', 'signups'), 3);
+            // Day 1 yearly: 2 gift redemptions (g-year-consumed, g-year-expired)
+            assert.equal(sumWhere('basic', 'year', '1970-01-01', 'signups'), 2);
+
+            // Each end-of-life branch produces a cancellation on its own date:
+            //  - day 2: g-year-consumed
             assert.equal(sumWhere('basic', 'year', '1970-01-02', 'cancellations'), 1);
+            //  - day 3: g-year-expired
+            assert.equal(sumWhere('basic', 'year', '1970-01-03', 'cancellations'), 1);
+            //  - day 4: g-month-refunded
+            assert.equal(sumWhere('basic', 'month', '1970-01-04', 'cancellations'), 1);
         });
 
         it('Includes active gifts in the current totals so rolled-back snapshots stay accurate', async function () {
@@ -477,23 +487,21 @@ describe('SubscriptionStatsService', function () {
         it('Excludes unredeemed gifts (expired/refunded before redemption) from cancellations', async function () {
             await createTiers(['basic']);
 
-            // A gift that was purchased and refunded without ever being redeemed.
-            // It never produced a signup, so it must not produce a cancellation.
-            await db('gifts').insert({
-                id: 'g-refunded',
-                tier_id: 'basic',
-                cadence: 'year',
-                status: 'refunded',
-                redeemed_at: null,
-                refunded_at: '1970-01-02T00:00:00.000Z'
-            });
+            // Both branches of "ended without ever being redeemed":
+            //  - refunded before redemption
+            //  - expired before redemption
+            // Neither produced a signup, so neither must produce a cancellation.
+            await db('gifts').insert([
+                {id: 'g-refunded', tier_id: 'basic', cadence: 'year', status: 'refunded', redeemed_at: null, refunded_at: '1970-01-02T00:00:00.000Z'},
+                {id: 'g-expired', tier_id: 'basic', cadence: 'month', status: 'expired', redeemed_at: null, expired_at: '1970-01-03T00:00:00.000Z'}
+            ]);
 
             const stats = new SubscriptionStatsService({knex: db});
             const result = await stats.getSubscriptionHistory();
 
-            // No rows should exist for this gift at all.
-            const giftRows = result.data.filter(r => r.tier === 'basic' && r.cadence === 'year');
-            assert.equal(giftRows.length, 0);
+            // No rows should exist for either tier/cadence combination.
+            assert.equal(result.data.filter(r => r.tier === 'basic' && r.cadence === 'year').length, 0);
+            assert.equal(result.data.filter(r => r.tier === 'basic' && r.cadence === 'month').length, 0);
         });
 
         it('Sorts merged paid+gift deltas by date so running counts roll back correctly', async function () {

--- a/ghost/core/test/unit/server/services/stats/subscriptions.test.js
+++ b/ghost/core/test/unit/server/services/stats/subscriptions.test.js
@@ -426,6 +426,35 @@ describe('SubscriptionStatsService', function () {
             assert.equal(sumWhere('basic', 'year', '1970-01-02', 'cancellations'), 1);
         });
 
+        it('Aggregates paid and gift deltas that share (date, tier, cadence) into a single row', async function () {
+            const tiers = await createTiers(['basic']);
+
+            // Paid yearly signup on day 1
+            const NEW = createEvent('created');
+            await insertEvents([
+                [NEW('A', tiers.basic.yearly)]
+            ]);
+
+            // Gift yearly signup on the same day (basic tier)
+            await db('gifts').insert({
+                id: 'g-same-day',
+                tier_id: 'basic',
+                cadence: 'year',
+                status: 'redeemed',
+                redeemed_at: '1970-01-01T00:00:00.000Z'
+            });
+
+            const stats = new SubscriptionStatsService({knex: db});
+            const result = await stats.getSubscriptionHistory();
+
+            // There should be exactly one row for (basic, year, day 1) with combined deltas,
+            // not two — otherwise the row's `count` snapshot is ambiguous.
+            const rows = result.data.filter(r => r.tier === 'basic' && r.cadence === 'year' && r.date === '1970-01-01');
+            assert.equal(rows.length, 1);
+            assert.equal(rows[0].signups, 2);
+            assert.equal(rows[0].positive_delta, 2);
+        });
+
         it('Excludes unredeemed gifts (expired/refunded before redemption) from cancellations', async function () {
             await createTiers(['basic']);
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3491

- the "Paid subscription breakdown" pie chart was showing "Gift" as a separate slice alongside Monthly/Annual/Complimentary, which mixed billing-period semantics with member-status semantics
- gifts have an inherent cadence (month/year) stored on the gifts table, so they belong in the corresponding billing-period bucket rather than as their own slice
- surfaced gifts through the existing subscription-stats endpoint by adding `fetchAllGiftDeltas` (gift redemptions as signups, consumed/expired/refunded gifts as cancellations) so the chart's existing per-cadence aggregation picks them up with no special-casing in the frontend
- preferred extending subscription-stats over a new endpoint to keep the change small; the side effect is that gifts now also count toward the "Paid subscriptions" daily new/cancelled chart, which is consistent with treating gifts as paid acquisitions
