### PR TITLE
Fixed missing onboarding flow in React admin shell

### DIFF
--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -1,7 +1,7 @@
 import { test as baseTest, describe, expect } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import type { QueryClient } from "@tanstack/react-query";
-import { useUserPreferences, useEditUserPreferences, DEFAULT_NAVIGATION_PREFERENCES } from "./user-preferences";
+import { useUserPreferences, useEditUserPreferences, DEFAULT_NAVIGATION_PREFERENCES, DEFAULT_ONBOARDING_PREFERENCES } from "./user-preferences";
 import { HttpResponse, http } from "msw";
 import { mockUser } from "@test-utils/factories";
 import { waitForQuerySettled } from "@test-utils/test-helpers";
@@ -30,6 +30,7 @@ const fixtures = {
     },
     defaults: {
         navigation: DEFAULT_NAVIGATION_PREFERENCES,
+        onboarding: DEFAULT_ONBOARDING_PREFERENCES,
     }
 };
 
@@ -209,6 +210,11 @@ describe("useUserPreferences", () => {
         queryTest("gracefully handles invalid schema values", async ({ setup }) => {
             const result = await setup({
                 accessibility: JSON.stringify({
+                    onboarding: {
+                        checklistState: "unknown",
+                        completedSteps: "customize-design",
+                        startedAt: "not-a-valid-datetime",
+                    },
                     whatsNew: {
                         lastSeenDate: "not-a-valid-datetime",
                     },
@@ -222,6 +228,24 @@ describe("useUserPreferences", () => {
                 whatsNew: {
                     lastSeenDate: undefined,
                 },
+            });
+        });
+
+        queryTest("parses onboarding startedAt into a date", async ({ setup }) => {
+            const result = await setup({
+                accessibility: JSON.stringify({
+                    onboarding: {
+                        completedSteps: ["customize-design"],
+                        checklistState: "started",
+                        startedAt: "2026-04-30T10:00:00.000Z",
+                    },
+                }),
+            });
+
+            expect(result.current.data?.onboarding).toEqual({
+                completedSteps: ["customize-design"],
+                checklistState: "started",
+                startedAt: new Date("2026-04-30T10:00:00.000Z"),
             });
         });
 
@@ -322,6 +346,7 @@ describe("useUserPreferences", () => {
             await waitFor(() => {
                 expect(result.current.query.data).toEqual({
                     navigation: DEFAULT_NAVIGATION_PREFERENCES,
+                    onboarding: DEFAULT_ONBOARDING_PREFERENCES,
                     whatsNew: {
                         lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
                     },
@@ -349,6 +374,7 @@ describe("useUserPreferences", () => {
                             posts: false,
                         },
                     },
+                    onboarding: DEFAULT_ONBOARDING_PREFERENCES,
                     whatsNew: {
                         lastSeenDate: new Date("2025-01-01T00:00:00.000Z"),
                     },
@@ -423,6 +449,10 @@ describe("useEditUserPreferences", () => {
                         expanded: { posts: false, members: false },
                         menu: { visible: true },
                     },
+                    onboarding: {
+                        completedSteps: ["customize-design"],
+                        checklistState: "started",
+                    },
                     nightShift: true,
                 }),
             });
@@ -430,6 +460,7 @@ describe("useEditUserPreferences", () => {
             await act(async () => {
                 await mutation.current.mutateAsync({
                     navigation: { expanded: { posts: true } },
+                    onboarding: { completedSteps: ["customize-design", "first-post"] },
                 });
             });
 
@@ -438,6 +469,10 @@ describe("useEditUserPreferences", () => {
                     navigation: {
                         expanded: { posts: true, members: false },
                         menu: { visible: true }, // Preserved
+                    },
+                    onboarding: {
+                        completedSteps: ["customize-design", "first-post"],
+                        checklistState: "started",
                     },
                     nightShift: true, // Preserved
                 });

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -10,6 +10,18 @@ const WhatsNewPreferencesSchema = z.looseObject({
     lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
 });
 
+export const DEFAULT_ONBOARDING_PREFERENCES = {
+    completedSteps: [] as string[],
+    checklistState: "pending" as const,
+    startedAt: undefined as Date | undefined,
+};
+
+export const OnboardingPreferencesSchema = z.looseObject({
+    completedSteps: z.array(z.string()).default(DEFAULT_ONBOARDING_PREFERENCES.completedSteps).catch(DEFAULT_ONBOARDING_PREFERENCES.completedSteps),
+    checklistState: z.enum(["pending", "started", "completed", "dismissed"]).default(DEFAULT_ONBOARDING_PREFERENCES.checklistState).catch(DEFAULT_ONBOARDING_PREFERENCES.checklistState),
+    startedAt: isoDatetimeToDate.optional().catch(DEFAULT_ONBOARDING_PREFERENCES.startedAt),
+});
+
 export const DEFAULT_NAVIGATION_PREFERENCES = {
     expanded: { posts: true, members: true },
     menu: { visible: true },
@@ -28,11 +40,13 @@ export const NavigationPreferencesSchema = z.looseObject({
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
     nightShift: z.boolean().optional(),
+    onboarding: OnboardingPreferencesSchema.default(DEFAULT_ONBOARDING_PREFERENCES).catch(DEFAULT_ONBOARDING_PREFERENCES),
     navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(DEFAULT_NAVIGATION_PREFERENCES),
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
 export type WhatsNewPreferences = z.infer<typeof WhatsNewPreferencesSchema>;
+export type OnboardingPreferences = z.infer<typeof OnboardingPreferencesSchema>;
 export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
 
 const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
@@ -80,7 +94,6 @@ export const useEditUserPreferences = (): UseMutationResult<void, Error, DeepPar
 
             const currentPreferences = queryClient.getQueryData<Preferences>(userPreferencesQueryKey(user)) ?? PreferencesSchema.parse({});
 
-            // TODO: use zod to validate?
             const newPreferences = deepMerge(currentPreferences, updatedPreferences);
 
             const encodedForStorage = PreferencesSchema.encode(newPreferences);

--- a/apps/admin/src/onboarding/components/onboarding-checklist.tsx
+++ b/apps/admin/src/onboarding/components/onboarding-checklist.tsx
@@ -1,0 +1,102 @@
+import {Button} from "@tryghost/shade/components";
+import {LucideIcon} from "@tryghost/shade/utils";
+import {ONBOARDING_STEPS, type OnboardingStep} from "@/onboarding/constants";
+import {OnboardingLogoVideo} from "@/onboarding/components/onboarding-logo-video";
+import {OnboardingStepItem} from "@/onboarding/components/onboarding-step-item";
+
+interface OnboardingChecklistProps {
+    allStepsCompleted: boolean;
+    completedSteps: string[];
+    nextStep: OnboardingStep | undefined;
+    onComplete: () => void;
+    onDismiss: () => void;
+    onStepClick: (step: OnboardingStep) => void;
+    siteTitle: string;
+}
+
+export function OnboardingChecklist({
+    allStepsCompleted,
+    completedSteps,
+    nextStep,
+    onComplete,
+    onDismiss,
+    onStepClick,
+    siteTitle,
+}: OnboardingChecklistProps) {
+    const completedStepSet = new Set(completedSteps);
+
+    return (
+        <main className="relative flex min-h-screen flex-col items-center justify-center px-6 py-8">
+            <section className="mt-[-48px] flex w-full flex-col items-center" data-test-dashboard="onboarding-checklist" data-testid="onboarding-checklist">
+                <div className="mb-8 flex flex-col items-center text-center">
+                    <OnboardingLogoVideo />
+                    {allStepsCompleted ?
+                        <h1 className="text-[32px] leading-[1.15] font-bold tracking-normal text-foreground max-[480px]:text-[24px]">You&apos;re all set.</h1>
+                        :
+                        <>
+                            <h1 className="text-[32px] leading-[1.15] font-bold tracking-normal text-foreground max-[480px]:text-[24px]">Let&apos;s get started!</h1>
+                            <p className="mt-2 mb-0 text-[15px] text-muted-foreground max-[480px]:m-0 max-[480px]:text-[14px]">Welcome! It&apos;s time to set up {siteTitle}.</p>
+                        </>
+                    }
+                </div>
+
+                <div className="w-full max-w-[540px] rounded-md border border-border bg-background px-6 pt-4 pb-1">
+                    <div className={`mt-[-12px] flex items-center justify-between py-6 ${nextStep === "customize-design" ? "border-b-0" : "border-b border-border"}`}>
+                        <span className="flex min-w-0 items-center opacity-20">
+                            <LucideIcon.Rocket className="mr-4 size-5 shrink-0 text-purple" />
+                            <span className="truncate pr-8 text-[16px] leading-[1.3] font-bold text-foreground">Start a new Ghost publication</span>
+                        </span>
+                        <span className="shrink-0 text-green">
+                            <LucideIcon.Check className="size-5" />
+                        </span>
+                    </div>
+
+                    {ONBOARDING_STEPS.map((step, index) => (
+                        <OnboardingStepItem
+                            key={step.id}
+                            complete={completedStepSet.has(step.id)}
+                            id={`ob-${step.id}`}
+                            isBeforeNext={ONBOARDING_STEPS[index + 1]?.id === nextStep}
+                            isLast={index === ONBOARDING_STEPS.length - 1}
+                            isNext={nextStep === step.id}
+                            step={step}
+                            onClick={() => onStepClick(step.id)}
+                        />
+                    ))}
+                </div>
+
+                {allStepsCompleted &&
+                    <Button
+                        className="mt-6 h-auto w-full max-w-[540px] px-3 py-3 text-[16px] max-[480px]:text-[15px]"
+                        data-testid="onboarding-complete"
+                        id="ob-completed"
+                        type="button"
+                        onClick={onComplete}
+                    >
+                        Explore your dashboard
+                    </Button>
+                }
+
+                <p className="mt-8 mb-0 text-[15px] text-muted-foreground max-[480px]:text-[14px]">
+                    More questions? Check out our{" "}
+                    <Button asChild className="h-auto p-0 align-baseline text-[15px] text-green hover:text-green/90 max-[480px]:text-[14px]" variant="link">
+                        <a href="https://ghost.org/help?utm_source=admin&utm_campaign=onboarding" id="ob-help-center" rel="noreferrer" target="_blank">Help Center</a>
+                    </Button>.
+                </p>
+
+                {!allStepsCompleted &&
+                    <Button
+                        className="mt-6 h-[38px] overflow-hidden px-3.5 py-px text-[15px] font-normal whitespace-nowrap text-muted-foreground hover:border-gray-300 hover:text-foreground"
+                        data-testid="onboarding-skip"
+                        id="ob-skip"
+                        type="button"
+                        variant="outline"
+                        onClick={onDismiss}
+                    >
+                        Skip onboarding
+                    </Button>
+                }
+            </section>
+        </main>
+    );
+}

--- a/apps/admin/src/onboarding/components/onboarding-logo-video.tsx
+++ b/apps/admin/src/onboarding/components/onboarding-logo-video.tsx
@@ -1,0 +1,40 @@
+import logoLoaderDarkUrl from "@/assets/videos/logo-loader-dark.mp4";
+import logoLoaderUrl from "@/assets/videos/logo-loader.mp4";
+
+export function OnboardingLogoVideo() {
+    return (
+        <div className="relative mb-6 size-20">
+            <video
+                aria-hidden="true"
+                autoPlay
+                className="size-20 dark:hidden"
+                height={80}
+                loop
+                muted
+                playsInline
+                preload="metadata"
+                role="presentation"
+                tabIndex={-1}
+                width={80}
+            >
+                <source src={logoLoaderUrl} type="video/mp4" />
+            </video>
+            <video
+                aria-hidden="true"
+                autoPlay
+                className="hidden size-20 dark:block"
+                height={80}
+                loop
+                muted
+                playsInline
+                preload="metadata"
+                role="presentation"
+                tabIndex={-1}
+                width={80}
+            >
+                <source src={logoLoaderDarkUrl} type="video/mp4" />
+            </video>
+            <div className="pointer-events-none absolute inset-0 hidden bg-[hsl(216deg_11%_70%/1%)] dark:block" />
+        </div>
+    );
+}

--- a/apps/admin/src/onboarding/components/onboarding-step-item.tsx
+++ b/apps/admin/src/onboarding/components/onboarding-step-item.tsx
@@ -1,0 +1,51 @@
+import {LucideIcon} from "@tryghost/shade/utils";
+import {type OnboardingStepDefinition} from "@/onboarding/constants";
+
+interface OnboardingStepItemProps {
+    complete: boolean;
+    id: string;
+    isBeforeNext: boolean;
+    isLast: boolean;
+    isNext: boolean;
+    onClick: () => void;
+    step: OnboardingStepDefinition;
+}
+
+export function OnboardingStepItem({
+    complete,
+    id,
+    isBeforeNext,
+    isLast,
+    isNext,
+    onClick,
+    step,
+}: OnboardingStepItemProps) {
+    const Icon = step.icon;
+    const hideBorder = isLast || isBeforeNext || isNext;
+    const rowClassName = isNext
+        ? `relative z-10 -mx-8 flex w-[calc(100%+64px)] items-center justify-between rounded-md bg-background px-8 py-6 text-left shadow-[0_1px_0_rgba(17,17,26,0.05),0_0_8px_rgba(17,17,26,0.10)] transition-none dark:ring-1 dark:ring-border ${isLast ? "-mb-[18px]" : "mb-1.5"}`
+        : `relative flex w-full items-center justify-between bg-transparent py-6 text-left ${hideBorder ? "" : "after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-border after:content-['']"}`;
+
+    return (
+        <button
+            className={`group ${rowClassName}`}
+            data-testid={`onboarding-step-${step.id}`}
+            id={id}
+            type="button"
+            onClick={onClick}
+        >
+            <span className={`flex min-w-0 items-center ${complete ? "opacity-20 group-hover:opacity-25" : "group-hover:opacity-90"}`}>
+                <Icon className="mr-4 size-5 shrink-0 text-purple" />
+                <span className="min-w-0 text-left">
+                    <span className="block truncate pr-8 text-[16px] leading-[1.3] font-bold text-foreground">{step.title}</span>
+                    {isNext &&
+                        <span className="mt-1 block pr-8 text-[15px] leading-[1.4] text-muted-foreground">{step.description}</span>
+                    }
+                </span>
+            </span>
+            <span className={`flex shrink-0 items-center transition-transform group-hover:translate-x-[5px] ${complete ? "text-green" : "text-purple"}`}>
+                {complete ? <LucideIcon.Check className="size-5" /> : <LucideIcon.ArrowRight className="size-3.5" />}
+            </span>
+        </button>
+    );
+}

--- a/apps/admin/src/onboarding/components/share-publication-dialog.tsx
+++ b/apps/admin/src/onboarding/components/share-publication-dialog.tsx
@@ -1,0 +1,84 @@
+import {Button} from "@tryghost/shade/components";
+import {ShareModal, type ShareModalSocialLink} from "@tryghost/shade/patterns";
+
+interface SharePublicationDialogProps {
+    description: string;
+    imageUrl: string;
+    onOpenChange: (open: boolean) => void;
+    open: boolean;
+    siteTitle: string;
+    siteUrl: string;
+}
+
+export function SharePublicationDialog({
+    description,
+    imageUrl,
+    onOpenChange,
+    open,
+    siteTitle,
+    siteUrl,
+}: SharePublicationDialogProps) {
+    const encodedUrl = encodeURIComponent(siteUrl);
+    const socialLinks: ShareModalSocialLink[] = [
+        {
+            href: `https://twitter.com/intent/tweet?url=${encodedUrl}`,
+            id: "ob-share-on-x",
+            label: "Share your publication on X",
+            service: "x",
+        },
+        {
+            href: `https://threads.net/intent/post?text=${encodedUrl}`,
+            id: "ob-share-on-threads",
+            label: "Share your publication on Threads",
+            service: "threads",
+        },
+        {
+            href: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+            id: "ob-share-on-fb",
+            label: "Share your publication on Facebook",
+            service: "facebook",
+        },
+        {
+            href: `https://www.linkedin.com/feed/?shareActive=true&text=${encodedUrl}`,
+            id: "ob-share-on-li",
+            label: "Share your publication on LinkedIn",
+            service: "linkedin",
+        },
+    ];
+
+    return (
+        <ShareModal
+            actionsLayout="footer"
+            closeButtonId="ob-close-share-modal"
+            contentProps={{
+                className: "dark:bg-surface-elevated",
+                "data-test-modal": "onboarding-share",
+                "data-testid": "onboarding-share-modal",
+            }}
+            copyButtonId="ob-copy-publication-link"
+            copyButtonTestId="onboarding-copy-link"
+            copyLabel="Copy link"
+            copyURL={siteUrl}
+            guidance={(
+                <p className="text-sm text-muted-foreground">
+                    Set your publication&apos;s cover image and description in{" "}
+                    <Button asChild className="h-auto p-0 align-baseline text-sm text-green hover:text-green/90" variant="link">
+                        <a href="#/settings/design/edit?ref=setup" id="ob-share-modal-design-settings">Design settings</a>
+                    </Button>.
+                </p>
+            )}
+            open={open}
+            preview={{
+                description,
+                imageURL: imageUrl,
+                title: siteTitle,
+                url: siteUrl,
+            }}
+            socialLinks={socialLinks}
+            title="Share your publication"
+            variant="publication"
+            onClose={() => onOpenChange(false)}
+            onOpenChange={onOpenChange}
+        />
+    );
+}

--- a/apps/admin/src/onboarding/constants.ts
+++ b/apps/admin/src/onboarding/constants.ts
@@ -1,0 +1,44 @@
+import type React from "react";
+import {LucideIcon} from "@tryghost/shade/utils";
+
+type OnboardingStepDefinitionShape = {
+    description: string;
+    icon: React.ComponentType<{className?: string}>;
+    id: string;
+    route?: string;
+    title: string;
+};
+
+export const ONBOARDING_STEPS = [
+    {
+        description: "Craft a look that reflects your brand and style.",
+        icon: LucideIcon.Brush,
+        id: "customize-design",
+        route: "/settings/design/edit?ref=setup",
+        title: "Customize your design",
+    },
+    {
+        description: "Get to know a writing experience you'll love.",
+        icon: LucideIcon.PenLine,
+        id: "first-post",
+        route: "/editor/post",
+        title: "Explore the editor",
+    },
+    {
+        description: "Add members and grow your readership.",
+        icon: LucideIcon.UserPlus,
+        id: "build-audience",
+        route: "/members",
+        title: "Build your audience",
+    },
+    {
+        description: "Expand your reach on social media.",
+        icon: LucideIcon.Megaphone,
+        id: "share-publication",
+        route: undefined,
+        title: "Share your publication",
+    },
+] as const satisfies readonly OnboardingStepDefinitionShape[];
+
+export type OnboardingStepDefinition = typeof ONBOARDING_STEPS[number];
+export type OnboardingStep = OnboardingStepDefinition["id"];

--- a/apps/admin/src/onboarding/hooks/use-onboarding.test.tsx
+++ b/apps/admin/src/onboarding/hooks/use-onboarding.test.tsx
@@ -1,0 +1,209 @@
+import {act, renderHook, waitFor} from "@testing-library/react";
+import {describe, expect, test as baseTest} from "vitest";
+import {HttpResponse, http} from "msw";
+import {mockUser} from "@test-utils/factories";
+import {queryClientFixtures, type TestWrapperComponent} from "@test-utils/fixtures/query-client";
+import {serverFixture} from "@test-utils/fixtures/msw";
+import {useOnboarding} from "./use-onboarding";
+import type {QueryClient} from "@tanstack/react-query";
+import type {SetupServer} from "msw/node";
+import type {UpdateUserRequestBody, UsersResponseType, User} from "@tryghost/admin-x-framework/api/users";
+
+const USERS_API_URL = "/ghost/api/admin/users/me/";
+const USER_UPDATE_API_URL = "/ghost/api/admin/users/:id/";
+
+const ownerRole = {
+    id: "owner-role",
+    name: "Owner",
+    description: "Owner",
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+} as const;
+
+async function setupOnboarding(
+    server: SetupServer,
+    wrapper: TestWrapperComponent,
+    userOverrides: Partial<User> = {}
+) {
+    server.use(
+        http.get(USERS_API_URL, () => {
+            return HttpResponse.json({
+                users: [{
+                    ...mockUser,
+                    roles: [ownerRole],
+                    ...userOverrides,
+                }],
+            });
+        }),
+        http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+            USER_UPDATE_API_URL,
+            async ({request}) => {
+                const body = await request.json();
+                return HttpResponse.json({
+                    users: [{
+                        ...mockUser,
+                        roles: [ownerRole],
+                        accessibility: body.users[0]?.accessibility ?? "",
+                    }],
+                });
+            }
+        )
+    );
+
+    const {result} = renderHook(() => useOnboarding(), {wrapper});
+    await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+    });
+    return result;
+}
+
+const onboardingTest = baseTest.extend<{
+    server: SetupServer;
+    queryClient: QueryClient;
+    wrapper: TestWrapperComponent;
+    setup: (userOverrides?: Partial<User>) => ReturnType<typeof setupOnboarding>;
+}>({
+    ...serverFixture,
+    ...queryClientFixtures,
+    setup: async ({server, wrapper}, provide) => {
+        await provide((userOverrides) => setupOnboarding(server, wrapper, userOverrides));
+    },
+});
+
+describe("useOnboarding", () => {
+    onboardingTest("shows checklist for owners when onboarding is started", async ({setup}) => {
+        const result = await setup({
+            accessibility: JSON.stringify({
+                onboarding: {
+                    completedSteps: ["customize-design"],
+                    checklistState: "started",
+                    startedAt: "2026-04-30T10:00:00.000Z",
+                },
+            }),
+        });
+
+        expect(result.current.shouldShowChecklist).toBe(true);
+        expect(result.current.nextStep).toBe("first-post");
+        expect(result.current.allStepsCompleted).toBe(false);
+    });
+
+    onboardingTest("does not show checklist for non-owner users", async ({setup}) => {
+        const result = await setup({
+            accessibility: JSON.stringify({
+                onboarding: {
+                    completedSteps: [],
+                    checklistState: "started",
+                    startedAt: "2026-04-30T10:00:00.000Z",
+                },
+            }),
+            roles: [{
+                id: "admin-role",
+                name: "Administrator",
+                description: "Admin",
+                created_at: "2024-01-01T00:00:00.000Z",
+                updated_at: "2024-01-01T00:00:00.000Z",
+            }],
+        });
+
+        expect(result.current.shouldShowChecklist).toBe(false);
+    });
+
+    onboardingTest("updates completed steps without duplicating existing steps", async ({setup}) => {
+        const result = await setup({
+            accessibility: JSON.stringify({
+                onboarding: {
+                    completedSteps: ["customize-design"],
+                    checklistState: "started",
+                    startedAt: "2026-04-30T10:00:00.000Z",
+                },
+            }),
+        });
+
+        await act(async () => {
+            await result.current.markStepCompleted("customize-design");
+            await result.current.markStepCompleted("first-post");
+        });
+
+        await waitFor(() => {
+            expect(result.current.completedSteps).toEqual(["customize-design", "first-post"]);
+        });
+    });
+
+    onboardingTest("updates checklist state", async ({setup}) => {
+        const result = await setup({
+            accessibility: JSON.stringify({
+                onboarding: {
+                    completedSteps: [],
+                    checklistState: "started",
+                    startedAt: "2026-04-30T10:00:00.000Z",
+                },
+            }),
+        });
+
+        await act(async () => {
+            await result.current.dismissChecklist();
+        });
+
+        await waitFor(() => {
+            expect(result.current.checklistState).toBe("dismissed");
+            expect(result.current.shouldShowChecklist).toBe(false);
+        });
+    });
+
+    onboardingTest("starts checklist with a start date", async ({setup}) => {
+        const result = await setup({
+            accessibility: JSON.stringify({
+                onboarding: {
+                    completedSteps: ["customize-design"],
+                    checklistState: "pending",
+                },
+            }),
+        });
+
+        await act(async () => {
+            await result.current.startChecklist();
+        });
+
+        await waitFor(() => {
+            expect(result.current.checklistState).toBe("started");
+            expect(result.current.completedSteps).toEqual([]);
+            expect(result.current.hasActiveStartedAt).toBe(true);
+            expect(result.current.shouldShowChecklist).toBe(true);
+        });
+    });
+
+    onboardingTest("dismisses started checklist when startedAt is missing", async ({setup}) => {
+        const result = await setup({
+            accessibility: JSON.stringify({
+                onboarding: {
+                    completedSteps: [],
+                    checklistState: "started",
+                },
+            }),
+        });
+
+        expect(result.current.shouldShowChecklist).toBe(false);
+
+        await waitFor(() => {
+            expect(result.current.checklistState).toBe("dismissed");
+        });
+    });
+
+    onboardingTest("dismisses started checklist when startedAt is before the cutoff", async ({setup}) => {
+        const result = await setup({
+            accessibility: JSON.stringify({
+                onboarding: {
+                    completedSteps: [],
+                    checklistState: "started",
+                    startedAt: "2026-04-29T23:59:59.999Z",
+                },
+            }),
+        });
+
+        expect(result.current.shouldShowChecklist).toBe(false);
+
+        await waitFor(() => {
+            expect(result.current.checklistState).toBe("dismissed");
+        });
+    });
+});

--- a/apps/admin/src/onboarding/hooks/use-onboarding.ts
+++ b/apps/admin/src/onboarding/hooks/use-onboarding.ts
@@ -1,0 +1,96 @@
+import {useCallback, useEffect, useMemo, useRef} from "react";
+import {useCurrentUser} from "@tryghost/admin-x-framework/api/current-user";
+import {isOwnerUser} from "@tryghost/admin-x-framework/api/users";
+import {useEditUserPreferences, useUserPreferences} from "@/hooks/user-preferences";
+import type {OnboardingPreferences} from "@/hooks/user-preferences";
+import {ONBOARDING_STEPS, type OnboardingStep} from "@/onboarding/constants";
+
+const ONBOARDING_STARTED_AT_CUTOFF = new Date("2026-04-30T00:00:00.000Z");
+
+function isAfterOnboardingStartedAtCutoff(date: Date | undefined) {
+    if (!date) {
+        return false;
+    }
+
+    return date >= ONBOARDING_STARTED_AT_CUTOFF;
+}
+
+export function useOnboarding() {
+    const {data: currentUser, isLoading: isUserLoading} = useCurrentUser();
+    const {data: preferences, isLoading: isPreferencesLoading} = useUserPreferences();
+    const {mutateAsync: editPreferences} = useEditUserPreferences();
+    const hasAttemptedInvalidStartedStateDismissalRef = useRef(false);
+
+    const completedSteps = useMemo(() => preferences?.onboarding.completedSteps || [], [preferences?.onboarding.completedSteps]);
+    const completedStepSet = useMemo(() => new Set(completedSteps), [completedSteps]);
+    const checklistState = preferences?.onboarding.checklistState || "pending";
+    const startedAt = preferences?.onboarding.startedAt;
+    const hasActiveStartedAt = isAfterOnboardingStartedAtCutoff(startedAt);
+    const isOwner = currentUser ? isOwnerUser(currentUser) : false;
+    const shouldShowChecklist = isOwner && checklistState === "started" && hasActiveStartedAt;
+    const nextStep = ONBOARDING_STEPS.find(step => !completedStepSet.has(step.id))?.id;
+    const allStepsCompleted = ONBOARDING_STEPS.every(step => completedStepSet.has(step.id));
+
+    const updateOnboarding = useCallback((updates: {
+        completedSteps?: string[];
+        checklistState?: OnboardingPreferences["checklistState"];
+        startedAt?: Date;
+    }) => {
+        return editPreferences({
+            onboarding: updates,
+        });
+    }, [editPreferences]);
+
+    const markStepCompleted = useCallback(async (step: OnboardingStep) => {
+        if (completedStepSet.has(step)) {
+            return;
+        }
+
+        await updateOnboarding({
+            completedSteps: [...completedSteps, step],
+        });
+    }, [completedStepSet, completedSteps, updateOnboarding]);
+
+    const dismissChecklist = useCallback(() => {
+        return updateOnboarding({checklistState: "dismissed"});
+    }, [updateOnboarding]);
+
+    useEffect(() => {
+        if (isUserLoading || isPreferencesLoading || !isOwner || checklistState !== "started" || hasActiveStartedAt || hasAttemptedInvalidStartedStateDismissalRef.current) {
+            return;
+        }
+
+        hasAttemptedInvalidStartedStateDismissalRef.current = true;
+        void dismissChecklist().catch((error) => {
+            hasAttemptedInvalidStartedStateDismissalRef.current = false;
+            console.error(error);
+        });
+    }, [checklistState, dismissChecklist, hasActiveStartedAt, isOwner, isPreferencesLoading, isUserLoading]);
+
+    const startChecklist = useCallback(() => {
+        return updateOnboarding({
+            completedSteps: [],
+            checklistState: "started",
+            startedAt: new Date(),
+        });
+    }, [updateOnboarding]);
+
+    const completeChecklist = useCallback(() => {
+        return updateOnboarding({checklistState: "completed"});
+    }, [updateOnboarding]);
+
+    return {
+        allStepsCompleted,
+        checklistState,
+        completeChecklist,
+        completedSteps,
+        dismissChecklist,
+        hasActiveStartedAt,
+        isOwner,
+        shouldShowChecklist,
+        isLoading: isUserLoading || isPreferencesLoading,
+        markStepCompleted,
+        nextStep,
+        startChecklist,
+    };
+}

--- a/apps/admin/src/onboarding/onboarding-redirect.tsx
+++ b/apps/admin/src/onboarding/onboarding-redirect.tsx
@@ -1,0 +1,23 @@
+import type React from "react";
+import {Navigate, useLocation} from "@tryghost/admin-x-framework";
+import {useOnboarding} from "@/onboarding/hooks/use-onboarding";
+
+interface OnboardingRedirectProps {
+    children: React.ReactNode;
+}
+
+export function OnboardingRedirect({children}: OnboardingRedirectProps) {
+    const location = useLocation();
+    const onboarding = useOnboarding();
+
+    if (onboarding.isLoading) {
+        return null;
+    }
+
+    if (onboarding.shouldShowChecklist) {
+        const returnTo = `${location.pathname}${location.search}`;
+        return <Navigate replace to={`/setup/onboarding?returnTo=${encodeURIComponent(returnTo)}`} />;
+    }
+
+    return children;
+}

--- a/apps/admin/src/onboarding/onboarding-route.tsx
+++ b/apps/admin/src/onboarding/onboarding-route.tsx
@@ -1,0 +1,105 @@
+import {Navigate, useNavigate, useSearchParams} from "@tryghost/admin-x-framework";
+import {getSettingValue, useBrowseSettings} from "@tryghost/admin-x-framework/api/settings";
+import {useBrowseSite} from "@tryghost/admin-x-framework/api/site";
+import {useRef, useState} from "react";
+import {OnboardingChecklist} from "@/onboarding/components/onboarding-checklist";
+import {SharePublicationDialog} from "@/onboarding/components/share-publication-dialog";
+import {useOnboarding} from "@/onboarding/hooks/use-onboarding";
+import {ONBOARDING_STEPS, type OnboardingStep} from "./constants";
+
+function getSafeReturnTo(value: string | null) {
+    return value && /^\/analytics(?:\/|\?|$)/.test(value) ? value : "/analytics";
+}
+
+export default function OnboardingRoute() {
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const returnTo = getSafeReturnTo(searchParams.get("returnTo"));
+    const onboarding = useOnboarding();
+    const settings = useBrowseSettings();
+    const site = useBrowseSite();
+    const isLeavingRef = useRef(false);
+    const [isLeaving, setIsLeaving] = useState(false);
+    const [shareDialogOpen, setShareDialogOpen] = useState(false);
+
+    const siteTitle = String(getSettingValue(settings.data?.settings, "title") || site.data?.site.title || "your publication");
+    const description = String(getSettingValue(settings.data?.settings, "description") || site.data?.site.description || "");
+    const imageUrl = String(getSettingValue(settings.data?.settings, "cover_image") || "");
+    const siteUrl = site.data?.site.url || "/";
+
+    const {
+        allStepsCompleted,
+        completeChecklist,
+        completedSteps,
+        dismissChecklist,
+        shouldShowChecklist,
+        isLoading,
+        markStepCompleted,
+        nextStep,
+    } = onboarding;
+
+    if (isLoading || site.isLoading || isLeaving || isLeavingRef.current) {
+        return null;
+    }
+
+    if (!shouldShowChecklist) {
+        return <Navigate crossApp replace to={returnTo} />;
+    }
+
+    const navigateAfterUpdate = async (update: () => Promise<unknown>) => {
+        isLeavingRef.current = true;
+        setIsLeaving(true);
+        try {
+            await update();
+            navigate(returnTo, {crossApp: true, replace: true});
+        } catch (error) {
+            isLeavingRef.current = false;
+            setIsLeaving(false);
+            console.error(error);
+        }
+    };
+
+    const handleStepClick = async (step: OnboardingStep) => {
+        if (step === "share-publication") {
+            await markStepCompleted(step);
+            setShareDialogOpen(true);
+            return;
+        }
+
+        await markStepCompleted(step);
+
+        const stepRoute = ONBOARDING_STEPS.find(({id}) => id === step)?.route;
+        if (stepRoute) {
+            navigate(stepRoute, {crossApp: true});
+        }
+    };
+
+    return (
+        <>
+            <OnboardingChecklist
+                allStepsCompleted={allStepsCompleted}
+                completedSteps={completedSteps}
+                nextStep={nextStep}
+                siteTitle={siteTitle}
+                onComplete={() => {
+                    void navigateAfterUpdate(completeChecklist);
+                }}
+                onDismiss={() => {
+                    void navigateAfterUpdate(dismissChecklist);
+                }}
+                onStepClick={(step) => {
+                    void handleStepClick(step);
+                }}
+            />
+
+            <SharePublicationDialog
+                description={description}
+                imageUrl={imageUrl}
+                open={shareDialogOpen}
+                siteTitle={siteTitle}
+                siteUrl={siteUrl}
+                onOpenChange={setShareDialogOpen}
+            />
+        </>
+    );
+}

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -14,6 +14,7 @@ import MyProfileRedirect from "./my-profile-redirect";
 import { EmberFallback, ForceUpgradeGuard } from "./ember-bridge";
 import type { RouteHandle } from "./ember-bridge";
 import { MembersRoute } from "./members-route";
+import { OnboardingRedirect } from "./onboarding/onboarding-redirect";
 
 import { NotFound } from "./not-found";
 
@@ -98,11 +99,17 @@ export const routes: RouteObject[] = [
             },
             {
                 element: (
-                    <GlobalDataProvider>
-                        <Outlet />
-                    </GlobalDataProvider>
+                    <OnboardingRedirect>
+                        <GlobalDataProvider>
+                            <Outlet />
+                        </GlobalDataProvider>
+                    </OnboardingRedirect>
                 ),
                 children: statsRoutes,
+            },
+            {
+                path: "setup/onboarding",
+                lazy: lazyComponent(() => import("./onboarding/onboarding-route")),
             },
             {
                 path: `network`,

--- a/apps/admin/src/utils/deep-merge.ts
+++ b/apps/admin/src/utils/deep-merge.ts
@@ -1,7 +1,7 @@
 /**
  * Deep partial type that makes all properties optional recursively.
  */
-export type DeepPartial<T> = T extends object ? {
+export type DeepPartial<T> = T extends Array<infer U> ? Array<DeepPartial<U>> : T extends object ? {
     [P in keyof T]?: DeepPartial<T[P]>;
 } : T;
 

--- a/apps/shade/.storybook/preview.tsx
+++ b/apps/shade/.storybook/preview.tsx
@@ -45,6 +45,35 @@ const customViewports = {
 	},
 };
 
+const StorybookSchemeDecorator = ({Story, scheme}: {Story: React.ComponentType; scheme: string}) => {
+	React.useEffect(() => {
+		const isDark = scheme === 'dark';
+
+		document.documentElement.classList.toggle('dark', isDark);
+		document.body.classList.toggle('dark', isDark);
+
+		return () => {
+			document.documentElement.classList.remove('dark');
+			document.body.classList.remove('dark');
+		};
+	}, [scheme]);
+
+	return (
+		<div className={`shade ${scheme === 'dark' ? 'dark' : ''}`} style={{
+			// padding: '24px',
+			// width: 'unset',
+			height: 'unset',
+			// overflow: 'unset',
+			background: (scheme === 'dark' ? '#131416' : '')
+		}}>
+			{/* 👇 Decorators in Storybook also accept a function. Replace <Story/> with Story() to enable it  */}
+			<ShadeProvider darkMode={scheme === 'dark'}>
+				<Story />
+			</ShadeProvider>
+		</div>
+	);
+};
+
 const preview: Preview = {
 	parameters: {
 		actions: { argTypesRegex: "^on[A-Z].*" },
@@ -87,19 +116,7 @@ const preview: Preview = {
 		(Story, context) => {
 			let {scheme} = context.globals;
 
-			return (
-			<div className={`shade ${scheme === 'dark' ? 'dark' : ''}`} style={{
-				// padding: '24px',
-				// width: 'unset',
-				height: 'unset',
-				// overflow: 'unset',
-				background: (scheme === 'dark' ? '#131416' : '')
-			}}>
-				{/* 👇 Decorators in Storybook also accept a function. Replace <Story/> with Story() to enable it  */}
-				<ShadeProvider darkMode={scheme === ''}>
-					<Story />
-				</ShadeProvider>
-			</div>);
+			return <StorybookSchemeDecorator Story={Story} scheme={scheme} />;
 	},
 	],
 	globalTypes: {

--- a/apps/shade/src/components/features/post-share-modal/post-share-modal.tsx
+++ b/apps/shade/src/components/features/post-share-modal/post-share-modal.tsx
@@ -1,137 +1,101 @@
-import {H3} from '@/components/layout/heading';
+import ShareModal, {type ShareModalSocialLink} from '@/components/features/share-modal/share-modal';
 import {Button} from '@/components/ui/button';
-import {Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger} from '@/components/ui/dialog';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import {Check, Link, X} from 'lucide-react';
-import React, {useState} from 'react';
+import React from 'react';
 
 interface PostShareModalProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root> {
+    author?: string;
+    children?: React.ReactNode;
+    description?: React.ReactNode;
     emailOnly?: boolean;
+    faviconURL?: string;
+    featureImageURL?: string;
+    onClose?: () => void;
+    postExcerpt?: string;
+    postTitle?: string;
     postURL?: string;
     primaryTitle?: string;
     secondaryTitle?: string;
-    description?: React.ReactNode;
-    featureImageURL?: string;
-    postTitle?: string;
-    postExcerpt?: string;
-    faviconURL?: string;
     siteTitle?: string;
-    author?: string;
-    onClose?: () => void;
-    children?: React.ReactNode;
 }
 
-const PostShareModal: React.FC<PostShareModalProps> = (
-    {emailOnly = false,
-        postURL = '',
-        primaryTitle = 'Your post is published.',
-        secondaryTitle = 'Spread the word!',
-        description = '',
-        featureImageURL = '',
-        postTitle = '',
-        postExcerpt = '',
-        faviconURL = '',
-        siteTitle = '',
-        author = '',
-        onClose = () => {},
-        children,
-        ...props}) => {
-    const [isCopied, setIsCopied] = useState(false);
-
-    const handleCopyLink = async () => {
-        try {
-            await navigator.clipboard.writeText(postURL);
-            setIsCopied(true);
-            // Reset the copied state after 2 seconds
-            setTimeout(() => setIsCopied(false), 2000);
-        } catch {
-            // Could add toast notification for copy failure
-        }
-    };
-
+const PostShareModal: React.FC<PostShareModalProps> = ({
+    author = '',
+    children,
+    description = '',
+    emailOnly = false,
+    faviconURL = '',
+    featureImageURL = '',
+    onClose = () => {},
+    postExcerpt = '',
+    postTitle = '',
+    postURL = '',
+    primaryTitle = 'Your post is published.',
+    secondaryTitle = 'Spread the word!',
+    siteTitle = '',
+    ...props
+}) => {
     const encodedPostTitle = encodeURIComponent(postTitle);
     const encodedPostURL = encodeURIComponent(postURL);
     const encodedPostURLTitle = encodeURIComponent(`${postTitle} ${postURL}`);
+    const socialLinks: ShareModalSocialLink[] = emailOnly ? [] : [
+        {
+            href: `https://twitter.com/intent/tweet?text=${encodedPostTitle}%0A${encodedPostURL}`,
+            label: 'Share on X',
+            service: 'x'
+        },
+        {
+            href: `https://threads.net/intent/post?text=${encodedPostURLTitle}`,
+            label: 'Share on Threads',
+            service: 'threads'
+        },
+        {
+            href: `https://www.facebook.com/sharer/sharer.php?u=${encodedPostURL}`,
+            label: 'Share on Facebook',
+            service: 'facebook'
+        },
+        {
+            href: `https://www.linkedin.com/shareArticle?mini=true&title=${encodedPostTitle}&url=${encodedPostURL}`,
+            label: 'Share on LinkedIn',
+            service: 'linkedin'
+        }
+    ];
 
     return (
-        <Dialog {...props}>
-            <DialogTrigger className="cursor-pointer" asChild>
-                {children}
-            </DialogTrigger>
-            <DialogContent className='max-h-[calc(100vh-16vmin)] max-w-[540px] overflow-y-auto p-8'>
-                <div className='sticky top-0 ml-auto size-0'>
-                    <Button className='absolute -top-5 -right-5 cursor-pointer p-2 text-muted-foreground hover:text-foreground [&_svg]:size-6!' size='lg' variant='link' onClick={onClose}><X size={24} strokeWidth={1} /></Button>
-                </div>
-                <DialogHeader className='relative -mt-5'>
-                    <DialogTitle className='text-3xl leading-[1.15em] font-bold'>
-                        <span className='text-state-success'>{primaryTitle}</span><br />
-                        <span>{secondaryTitle}</span>
-                    </DialogTitle>
-                    {description &&
-                        <DialogDescription className='mb-0 pt-1 pb-0 text-lg text-foreground'>
-                            {description}
-                        </DialogDescription>
-                    }
-                </DialogHeader>
-                <a className='flex flex-col items-stretch overflow-hidden rounded-md border transition-all hover:border-muted-foreground/40' href={postURL} rel="noopener noreferrer" target='_blank'>
-                    {featureImageURL &&
-                        <div className='aspect-video bg-cover bg-center' style={{
-                            backgroundImage: `url(${featureImageURL})`
-                        }}></div>
-                    }
-                    <div className='p-6 pt-5'>
-                        <H3>{postTitle}</H3>
-                        {postExcerpt &&
-                            <p>{postExcerpt}</p>
-                        }
-                        <div className='mt-2 flex items-start gap-2'>
-                            <div className='mt-0.5 size-4 bg-cover bg-center' style={{
-                                backgroundImage: `url(${faviconURL})`
-                            }}></div>
-                            <div className='flex gap-1'>
-                                <strong>{siteTitle}</strong>
-                                <span>&bull;</span>
-                                <span>{author}</span>
-                            </div>
+        <ShareModal
+            actionsLayout="footer"
+            copyURL={postURL}
+            description={description}
+            footerAction={emailOnly ? (
+                <Button className="cursor-pointer" type="button" onClick={onClose}>
+                    Close
+                </Button>
+            ) : undefined}
+            preview={{
+                description: postExcerpt,
+                imageURL: featureImageURL,
+                meta: (
+                    <div className="mt-2 flex items-start gap-2">
+                        <div className="mt-0.5 size-4 bg-cover bg-center" style={{backgroundImage: `url(${faviconURL})`}}></div>
+                        <div className="flex gap-1">
+                            <strong>{siteTitle}</strong>
+                            <span>&bull;</span>
+                            <span>{author}</span>
                         </div>
                     </div>
-                </a>
-                <DialogFooter className='justify-between gap-6'>
-                    {emailOnly ?
-                        <Button className='cursor-pointer' type="submit" onClick={onClose}>
-                            Close
-                        </Button>
-                        :
-                        <>
-                            <div className='flex items-center gap-2'>
-                                <a aria-label='Share on X' className='flex h-(--control-height) w-14 items-center justify-center rounded-xs bg-muted px-3 hover:bg-muted-foreground/20 [&_svg]:h-4' href={`https://twitter.com/intent/tweet?text=${encodedPostTitle}%0A${encodedPostURL}`} rel="noopener noreferrer" target='_blank'>
-                                    <svg aria-hidden="true" viewBox="0 0 24 24"><path className="social-x_svg__x" d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></svg>
-                                </a>
-                                <a aria-label='Share on Threads' className='flex h-(--control-height) w-14 items-center justify-center rounded-xs bg-muted px-3 hover:bg-muted-foreground/20 [&_svg]:h-4' href={`https://threads.net/intent/post?text=${encodedPostURLTitle}`} rel="noopener noreferrer" target='_blank'>
-                                    <svg fill="none" viewBox="0 0 18 18"><g clipPath="url(#social-threads_svg__clip0_351_18008)"><path d="M13.033 8.38a5.924 5.924 0 00-.223-.102c-.13-2.418-1.452-3.802-3.67-3.816h-.03c-1.327 0-2.43.566-3.11 1.597l1.22.837c.507-.77 1.304-.934 1.89-.934h.02c.73.004 1.282.217 1.639.63.26.302.433.72.519 1.245a9.334 9.334 0 00-2.097-.101c-2.109.121-3.465 1.351-3.374 3.06.047.868.478 1.614 1.216 2.1.624.413 1.428.614 2.263.568 1.103-.06 1.969-.48 2.572-1.25.459-.585.749-1.342.877-2.296.526.317.915.735 1.13 1.236.366.854.387 2.255-.756 3.398-1.003 1.002-2.207 1.435-4.028 1.448-2.02-.015-3.547-.663-4.54-1.925-.93-1.182-1.41-2.89-1.428-5.075.018-2.185.498-3.893 1.428-5.075.993-1.262 2.52-1.91 4.54-1.925 2.034.015 3.588.666 4.62 1.934.505.622.886 1.405 1.137 2.317l1.43-.382c-.305-1.122-.784-2.09-1.436-2.892C13.52 1.35 11.587.517 9.096.5h-.01C6.6.517 4.689 1.354 3.404 2.986 2.262 4.44 1.672 6.46 1.652 8.994v.012c.02 2.534.61 4.555 1.752 6.008C4.69 16.646 6.6 17.483 9.086 17.5h.01c2.21-.015 3.768-.594 5.051-1.876 1.68-1.678 1.629-3.78 1.075-5.07-.397-.927-1.154-1.678-2.189-2.175zm-3.816 3.587c-.924.052-1.884-.363-1.932-1.252-.035-.659.47-1.394 1.99-1.482a8.9 8.9 0 01.512-.014c.552 0 1.068.053 1.538.156-.175 2.187-1.203 2.542-2.108 2.592z" fill="#000"></path></g><defs><clipPath id="social-threads_svg__clip0_351_18008"><path d="M0 0h17v17H0z" fill="#fff" transform="translate(.5 .5)"></path></clipPath></defs></svg>
-                                </a>
-                                <a aria-label='Share on Facebook' className='flex h-(--control-height) w-14 items-center justify-center rounded-xs bg-muted px-3 hover:bg-muted-foreground/20 [&_svg]:h-4' href={`https://www.facebook.com/sharer/sharer.php?u=${encodedPostURL}`} rel="noopener noreferrer" target='_blank'>
-                                    <svg fill="none" viewBox="0 0 40 40"><title>social-facebook</title><path className="social-facebook_svg__fb" d="M20 40.004c11.046 0 20-8.955 20-20 0-11.046-8.954-20-20-20s-20 8.954-20 20c0 11.045 8.954 20 20 20z" fill="#1977f3"></path><path d="M27.785 25.785l.886-5.782h-5.546V16.25c0-1.58.773-3.125 3.26-3.125h2.522V8.204s-2.29-.39-4.477-.39c-4.568 0-7.555 2.767-7.555 7.781v4.408h-5.08v5.782h5.08v13.976a20.08 20.08 0 003.125.242c1.063 0 2.107-.085 3.125-.242V25.785h4.66z" fill="#fff"></path></svg>
-                                </a>
-                                <a aria-label='Share on LinkedIn' className='flex h-(--control-height) w-14 items-center justify-center rounded-xs bg-muted px-3 hover:bg-muted-foreground/20 [&_svg]:h-4' href={`https://www.linkedin.com/shareArticle?mini=true&title=${encodedPostTitle}&url=${encodedPostURL}`} rel="noopener noreferrer" target='_blank'>
-                                    <svg fill="none" viewBox="0 0 16 16"><g clipPath="url(#social-linkedin_svg__clip0_537_833)"><path className="social-linkedin_svg__linkedin" clipRule="evenodd" d="M1.778 16h12.444c.982 0 1.778-.796 1.778-1.778V1.778C16 .796 15.204 0 14.222 0H1.778C.796 0 0 .796 0 1.778v12.444C0 15.204.796 16 1.778 16z" fill="#007ebb" fillRule="evenodd"></path><path clipRule="evenodd" d="M13.778 13.778h-2.374V9.734c0-1.109-.421-1.729-1.299-1.729-.955 0-1.453.645-1.453 1.729v4.044H6.363V6.074h2.289v1.038s.688-1.273 2.322-1.273c1.634 0 2.804.997 2.804 3.061v4.878zM3.634 5.065c-.78 0-1.411-.636-1.411-1.421s.631-1.422 1.41-1.422c.78 0 1.411.637 1.411 1.422 0 .785-.631 1.421-1.41 1.421zm-1.182 8.713h2.386V6.074H2.452v7.704z" fill="#fff" fillRule="evenodd"></path></g><defs><clipPath id="social-linkedin_svg__clip0_537_833"><path d="M0 0h16v16H0z" fill="#fff"></path></clipPath></defs></svg>
-                                </a>
-                            </div>
-                            <Button
-                                className='ml-0! grow cursor-pointer'
-                                disabled={!postURL}
-                                type="button"
-                                onClick={handleCopyLink}
-                            >
-                                {isCopied ? <Check /> : <Link />}
-                                {isCopied ? 'Copied!' : 'Copy link'}
-                            </Button>
-                        </>
-                    }
-
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+                ),
+                title: postTitle,
+                url: postURL
+            }}
+            primaryTitle={primaryTitle}
+            secondaryTitle={secondaryTitle}
+            socialLinks={socialLinks}
+            variant="post"
+            onClose={onClose}
+            {...props}
+        >
+            {children}
+        </ShareModal>
     );
 };
 

--- a/apps/shade/src/components/features/share-modal/index.ts
+++ b/apps/shade/src/components/features/share-modal/index.ts
@@ -1,0 +1,2 @@
+export {default} from './share-modal';
+export type {ShareModalSocialLink} from './share-modal';

--- a/apps/shade/src/components/features/share-modal/share-modal.stories.tsx
+++ b/apps/shade/src/components/features/share-modal/share-modal.stories.tsx
@@ -1,0 +1,300 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {useState} from 'react';
+import {Button} from '@/components/ui/button';
+import ShareModal, {type ShareModalSocialLink} from './share-modal';
+
+const meta = {
+    title: 'Features / Share Modal',
+    component: ShareModal,
+    tags: ['autodocs'],
+    argTypes: {
+        children: {
+            table: {
+                disable: true
+            }
+        }
+    }
+} satisfies Meta<typeof ShareModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const postUrl = 'https://example.com/copy-clipboard-react-guide';
+const encodedPostTitle = encodeURIComponent('Copy to Clipboard in React: Complete Guide');
+const encodedPostUrl = encodeURIComponent(postUrl);
+const encodedPostTitleAndUrl = encodeURIComponent(`Copy to Clipboard in React: Complete Guide ${postUrl}`);
+
+const publicationUrl = 'https://ghost.org';
+const encodedPublicationUrl = encodeURIComponent(publicationUrl);
+
+const postSocialLinks: ShareModalSocialLink[] = [
+    {
+        href: `https://twitter.com/intent/tweet?text=${encodedPostTitle}%0A${encodedPostUrl}`,
+        label: 'Share on X',
+        service: 'x'
+    },
+    {
+        href: `https://threads.net/intent/post?text=${encodedPostTitleAndUrl}`,
+        label: 'Share on Threads',
+        service: 'threads'
+    },
+    {
+        href: `https://www.facebook.com/sharer/sharer.php?u=${encodedPostUrl}`,
+        label: 'Share on Facebook',
+        service: 'facebook'
+    },
+    {
+        href: `https://www.linkedin.com/shareArticle?mini=true&title=${encodedPostTitle}&url=${encodedPostUrl}`,
+        label: 'Share on LinkedIn',
+        service: 'linkedin'
+    }
+];
+
+const publicationSocialLinks: ShareModalSocialLink[] = [
+    {
+        href: `https://twitter.com/intent/tweet?url=${encodedPublicationUrl}`,
+        label: 'Share your publication on X',
+        service: 'x'
+    },
+    {
+        href: `https://threads.net/intent/post?text=${encodedPublicationUrl}`,
+        label: 'Share your publication on Threads',
+        service: 'threads'
+    },
+    {
+        href: `https://www.facebook.com/sharer/sharer.php?u=${encodedPublicationUrl}`,
+        label: 'Share your publication on Facebook',
+        service: 'facebook'
+    },
+    {
+        href: `https://www.linkedin.com/feed/?shareActive=true&text=${encodedPublicationUrl}`,
+        label: 'Share your publication on LinkedIn',
+        service: 'linkedin'
+    }
+];
+
+const postArgs = {
+    copyURL: postUrl,
+    description: <>
+        Your post was published on your site and sent to <strong>3 subscribers</strong> of <strong>Ghost Blog</strong>, on <strong>June 13th</strong> at <strong>12:02</strong>.
+    </>,
+    preview: {
+        description: 'A comprehensive guide to implementing copy-to-clipboard functionality in React applications with proper error handling and user feedback.',
+        imageURL: 'https://picsum.photos/800/600?random=1',
+        meta: (
+            <div className="mt-2 flex items-start gap-2">
+                <div className="mt-0.5 size-4 bg-cover bg-center" style={{backgroundImage: 'url(https://www.google.com/s2/favicons?domain=ghost.org&sz=64)'}}></div>
+                <div className="flex gap-1">
+                    <strong>Ghost Blog</strong>
+                    <span>&bull;</span>
+                    <span>Jane Smith</span>
+                </div>
+            </div>
+        ),
+        title: 'Copy to Clipboard in React: Complete Guide',
+        url: postUrl
+    },
+    primaryTitle: 'Your post is published.',
+    secondaryTitle: 'Spread the word!',
+    socialLinks: postSocialLinks,
+    variant: 'post' as const
+};
+
+const publicationArgs = {
+    actionsLayout: 'footer' as const,
+    copyURL: publicationUrl,
+    guidance: (
+        <p className="text-sm text-muted-foreground">
+            Set your publication&apos;s cover image and description in <Button className="h-auto p-0 align-baseline text-sm text-green hover:text-green/90" variant="link" asChild><a href="#/settings/design/edit?ref=setup">Design settings</a></Button>.
+        </p>
+    ),
+    preview: {
+        description: 'Thoughts, stories and ideas.',
+        imageURL: 'https://picsum.photos/800/600?random=2',
+        title: 'Ghostbusters',
+        url: publicationUrl
+    },
+    socialLinks: publicationSocialLinks,
+    title: 'Share your publication',
+    variant: 'publication' as const
+};
+
+const postSource = `const [isOpen, setIsOpen] = useState(false);
+
+const postUrl = 'https://example.com/copy-clipboard-react-guide';
+const encodedPostTitle = encodeURIComponent('Copy to Clipboard in React: Complete Guide');
+const encodedPostUrl = encodeURIComponent(postUrl);
+
+<ShareModal
+    copyURL={postUrl}
+    description={<>Your post was published on your site and sent to <strong>3 subscribers</strong>.</>}
+    open={isOpen}
+    preview={{
+        description: 'A comprehensive guide to implementing copy-to-clipboard functionality in React applications.',
+        imageURL: 'https://picsum.photos/800/600?random=1',
+        meta: (
+            <div className="mt-2 flex items-start gap-2">
+                <div className="mt-0.5 size-4 bg-cover bg-center" style={{backgroundImage: 'url(https://www.google.com/s2/favicons?domain=ghost.org&sz=64)'}} />
+                <div className="flex gap-1">
+                    <strong>Ghost Blog</strong>
+                    <span>&bull;</span>
+                    <span>Jane Smith</span>
+                </div>
+            </div>
+        ),
+        title: 'Copy to Clipboard in React: Complete Guide',
+        url: postUrl
+    }}
+    primaryTitle="Your post is published."
+    secondaryTitle="Spread the word!"
+    socialLinks={[
+        {
+            href: \`https://twitter.com/intent/tweet?text=\${encodedPostTitle}%0A\${encodedPostUrl}\`,
+            label: 'Share on X',
+            service: 'x'
+        }
+    ]}
+    variant="post"
+    onClose={() => setIsOpen(false)}
+    onOpenChange={setIsOpen}
+>
+    <Button onClick={() => setIsOpen(true)}>Share post</Button>
+</ShareModal>`;
+
+const publicationSource = `const [isOpen, setIsOpen] = useState(false);
+
+const publicationUrl = 'https://ghost.org';
+const encodedPublicationUrl = encodeURIComponent(publicationUrl);
+
+<ShareModal
+    actionsLayout="footer"
+    copyURL={publicationUrl}
+    guidance={(
+        <p className="text-sm text-muted-foreground">
+            Set your publication's cover image and description in{' '}
+            <Button className="h-auto p-0 align-baseline text-sm text-green hover:text-green/90" variant="link" asChild>
+                <a href="#/settings/design/edit?ref=setup">Design settings</a>
+            </Button>.
+        </p>
+    )}
+    open={isOpen}
+    preview={{
+        description: 'Thoughts, stories and ideas.',
+        imageURL: 'https://picsum.photos/800/600?random=2',
+        title: 'Ghostbusters',
+        url: publicationUrl
+    }}
+    socialLinks={[
+        {
+            href: \`https://threads.net/intent/post?text=\${encodedPublicationUrl}\`,
+            label: 'Share your publication on Threads',
+            service: 'threads'
+        }
+    ]}
+    title="Share your publication"
+    variant="publication"
+    onClose={() => setIsOpen(false)}
+    onOpenChange={setIsOpen}
+>
+    <Button onClick={() => setIsOpen(true)}>Share publication</Button>
+</ShareModal>`;
+
+export const Post: Story = {
+    args: {
+        ...postArgs
+    },
+    render: (args) => {
+        const PostExample = () => {
+            const [isOpen, setIsOpen] = useState(false);
+
+            return (
+                <ShareModal
+                    {...args}
+                    open={isOpen}
+                    onClose={() => setIsOpen(false)}
+                    onOpenChange={setIsOpen}
+                >
+                    <Button onClick={() => setIsOpen(true)}>Share post</Button>
+                </ShareModal>
+            );
+        };
+
+        return <PostExample />;
+    },
+    parameters: {
+        docs: {
+            source: {
+                code: postSource
+            }
+        }
+    }
+};
+
+export const Publication: Story = {
+    args: {
+        ...publicationArgs
+    },
+    render: (args) => {
+        const PublicationExample = () => {
+            const [isOpen, setIsOpen] = useState(false);
+
+            return (
+                <ShareModal
+                    {...args}
+                    open={isOpen}
+                    onClose={() => setIsOpen(false)}
+                    onOpenChange={setIsOpen}
+                >
+                    <Button onClick={() => setIsOpen(true)}>Share publication</Button>
+                </ShareModal>
+            );
+        };
+
+        return <PublicationExample />;
+    },
+    parameters: {
+        docs: {
+            source: {
+                code: publicationSource
+            }
+        }
+    }
+};
+
+export const ControlledPublication: Story = {
+    args: {
+        copyURL: publicationUrl,
+        preview: {
+            title: 'Ghostbusters',
+            url: publicationUrl
+        }
+    },
+    parameters: {
+        docs: {
+            source: {
+                code: publicationSource.replace('Share publication', 'Open publication share modal')
+            }
+        }
+    },
+    render: () => {
+        const ControlledExample = () => {
+            const [isOpen, setIsOpen] = useState(false);
+
+            return (
+                <ShareModal
+                    {...publicationArgs}
+                    open={isOpen}
+                    onClose={() => setIsOpen(false)}
+                    onOpenChange={setIsOpen}
+                >
+                    <Button onClick={() => setIsOpen(true)}>
+                        Open publication share modal
+                    </Button>
+                </ShareModal>
+            );
+        };
+
+        return <ControlledExample />;
+    }
+};

--- a/apps/shade/src/components/features/share-modal/share-modal.tsx
+++ b/apps/shade/src/components/features/share-modal/share-modal.tsx
@@ -1,0 +1,269 @@
+import {H3} from '@/components/layout/heading';
+import {Button} from '@/components/ui/button';
+import {Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger} from '@/components/ui/dialog';
+import {cn} from '@/lib/utils';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import {Check, Copy, Image as ImageIcon, Link, X} from 'lucide-react';
+import React, {useState} from 'react';
+
+type ShareService = 'x' | 'threads' | 'facebook' | 'linkedin';
+
+export type ShareModalSocialLink = {
+    href: string;
+    id?: string;
+    label: string;
+    service: ShareService;
+    title?: string;
+};
+
+interface ShareModalPreview {
+    description?: React.ReactNode;
+    imageURL?: string;
+    meta?: React.ReactNode;
+    title: React.ReactNode;
+    url: string;
+}
+
+interface ShareModalProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root> {
+    actionsLayout?: 'footer' | 'stacked';
+    children?: React.ReactNode;
+    closeButtonId?: string;
+    copyButtonId?: string;
+    copyButtonTestId?: string;
+    copyLabel?: string;
+    copySuccessLabel?: string;
+    copyURL: string;
+    contentProps?: React.ComponentPropsWithoutRef<typeof DialogContent>;
+    description?: React.ReactNode;
+    footerAction?: React.ReactNode;
+    guidance?: React.ReactNode;
+    onClose?: () => void;
+    preview: ShareModalPreview;
+    primaryTitle?: React.ReactNode;
+    secondaryTitle?: React.ReactNode;
+    socialLinks?: ShareModalSocialLink[];
+    title?: React.ReactNode;
+    variant?: 'post' | 'publication';
+}
+
+async function copyTextToClipboard(text: string) {
+    if (navigator.clipboard?.writeText) {
+        try {
+            await navigator.clipboard.writeText(text);
+            return;
+        } catch {
+            // Fall back for browser contexts where the async clipboard API is blocked.
+        }
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+}
+
+function SocialIcon({service}: {service: ShareService}) {
+    if (service === 'threads') {
+        return (
+            <svg fill="none" viewBox="0 0 18 18"><g clipPath="url(#social-threads_svg__clip0_351_18008)"><path d="M13.033 8.38a5.924 5.924 0 00-.223-.102c-.13-2.418-1.452-3.802-3.67-3.816h-.03c-1.327 0-2.43.566-3.11 1.597l1.22.837c.507-.77 1.304-.934 1.89-.934h.02c.73.004 1.282.217 1.639.63.26.302.433.72.519 1.245a9.334 9.334 0 00-2.097-.101c-2.109.121-3.465 1.351-3.374 3.06.047.868.478 1.614 1.216 2.1.624.413 1.428.614 2.263.568 1.103-.06 1.969-.48 2.572-1.25.459-.585.749-1.342.877-2.296.526.317.915.735 1.13 1.236.366.854.387 2.255-.756 3.398-1.003 1.002-2.207 1.435-4.028 1.448-2.02-.015-3.547-.663-4.54-1.925-.93-1.182-1.41-2.89-1.428-5.075.018-2.185.498-3.893 1.428-5.075.993-1.262 2.52-1.91 4.54-1.925 2.034.015 3.588.666 4.62 1.934.505.622.886 1.405 1.137 2.317l1.43-.382c-.305-1.122-.784-2.09-1.436-2.892C13.52 1.35 11.587.517 9.096.5h-.01C6.6.517 4.689 1.354 3.404 2.986 2.262 4.44 1.672 6.46 1.652 8.994v.012c.02 2.534.61 4.555 1.752 6.008C4.69 16.646 6.6 17.483 9.086 17.5h.01c2.21-.015 3.768-.594 5.051-1.876 1.68-1.678 1.629-3.78 1.075-5.07-.397-.927-1.154-1.678-2.189-2.175zm-3.816 3.587c-.924.052-1.884-.363-1.932-1.252-.035-.659.47-1.394 1.99-1.482a8.9 8.9 0 01.512-.014c.552 0 1.068.053 1.538.156-.175 2.187-1.203 2.542-2.108 2.592z" fill="currentColor"></path></g><defs><clipPath id="social-threads_svg__clip0_351_18008"><path d="M0 0h17v17H0z" fill="#fff" transform="translate(.5 .5)"></path></clipPath></defs></svg>
+        );
+    }
+
+    if (service === 'facebook') {
+        return (
+            <svg fill="none" viewBox="0 0 40 40"><path d="M20 40.004c11.046 0 20-8.955 20-20 0-11.046-8.954-20-20-20s-20 8.954-20 20c0 11.045 8.954 20 20 20z" fill="#1977f3"></path><path d="M27.785 25.785l.886-5.782h-5.546V16.25c0-1.58.773-3.125 3.26-3.125h2.522V8.204s-2.29-.39-4.477-.39c-4.568 0-7.555 2.767-7.555 7.781v4.408h-5.08v5.782h5.08v13.976a20.08 20.08 0 003.125.242c1.063 0 2.107-.085 3.125-.242V25.785h4.66z" fill="#fff"></path></svg>
+        );
+    }
+
+    if (service === 'linkedin') {
+        return (
+            <svg fill="none" viewBox="0 0 16 16"><g clipPath="url(#social-linkedin_svg__clip0_537_833)"><path clipRule="evenodd" d="M1.778 16h12.444c.982 0 1.778-.796 1.778-1.778V1.778C16 .796 15.204 0 14.222 0H1.778C.796 0 0 .796 0 1.778v12.444C0 15.204.796 16 1.778 16z" fill="#007ebb" fillRule="evenodd"></path><path clipRule="evenodd" d="M13.778 13.778h-2.374V9.734c0-1.109-.421-1.729-1.299-1.729-.955 0-1.453.645-1.453 1.729v4.044H6.363V6.074h2.289v1.038s.688-1.273 2.322-1.273c1.634 0 2.804.997 2.804 3.061v4.878zM3.634 5.065c-.78 0-1.411-.636-1.411-1.421s.631-1.422 1.41-1.422c.78 0 1.411.637 1.411 1.422 0 .785-.631 1.421-1.41 1.421zm-1.182 8.713h2.386V6.074H2.452v7.704z" fill="#fff" fillRule="evenodd"></path></g><defs><clipPath id="social-linkedin_svg__clip0_537_833"><path d="M0 0h16v16H0z" fill="#fff"></path></clipPath></defs></svg>
+        );
+    }
+
+    return (
+        <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" fill="currentColor"></path></svg>
+    );
+}
+
+function SocialLinks({layout, links}: {layout: 'footer' | 'stacked'; links: ShareModalSocialLink[]}) {
+    if (layout === 'stacked') {
+        return (
+            <div className="flex gap-2">
+                {links.map(link => (
+                    <Button key={link.id ?? link.href} className="flex-1" id={link.id} variant="outline" asChild>
+                        <a aria-label={link.label} href={link.href} rel="noreferrer" target="_blank" title={link.title || link.label}>
+                            <SocialIcon service={link.service} />
+                            <span className="sr-only">{link.label}</span>
+                        </a>
+                    </Button>
+                ))}
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex items-center gap-2">
+            {links.map(link => (
+                <a key={link.id ?? link.href} aria-label={link.label} className="flex h-(--control-height) w-14 items-center justify-center rounded-xs bg-muted px-3 hover:bg-muted-foreground/20 [&_svg]:h-4" href={link.href} rel="noopener noreferrer" target="_blank" title={link.title || link.label}>
+                    <SocialIcon service={link.service} />
+                </a>
+            ))}
+        </div>
+    );
+}
+
+const ShareModal: React.FC<ShareModalProps> = ({
+    actionsLayout = 'footer',
+    children,
+    closeButtonId,
+    copyButtonId,
+    copyButtonTestId,
+    copyLabel = 'Copy link',
+    copySuccessLabel = 'Copied!',
+    copyURL,
+    contentProps,
+    description,
+    footerAction,
+    guidance,
+    onClose = () => {},
+    preview,
+    primaryTitle,
+    secondaryTitle,
+    socialLinks = [],
+    title,
+    variant = 'post',
+    ...props
+}) => {
+    const [isCopied, setIsCopied] = useState(false);
+
+    const handleCopyLink = async () => {
+        await copyTextToClipboard(copyURL);
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 2000);
+    };
+
+    const showPostHeader = variant === 'post';
+    const {className: contentClassName, ...dialogContentProps} = contentProps || {};
+    const content = (
+        <DialogContent className={cn('max-h-[calc(100vh-16vmin)] max-w-[540px] overflow-y-auto p-8', contentClassName)} {...dialogContentProps}>
+            {showPostHeader && (
+                <div className="sticky top-0 ml-auto size-0">
+                    <Button className="absolute -top-5 -right-5 cursor-pointer p-2 text-muted-foreground hover:text-foreground [&_svg]:size-6!" id={closeButtonId} size="lg" title="Close" variant="link" onClick={onClose}>
+                        <X size={24} strokeWidth={1} />
+                        <span className="sr-only">Close</span>
+                    </Button>
+                </div>
+            )}
+            <DialogHeader className={showPostHeader ? 'relative -mt-5' : 'flex-row items-center justify-between gap-4 space-y-0 text-left'}>
+                {showPostHeader ?
+                    <DialogTitle className="text-3xl leading-[1.15em] font-bold">
+                        {primaryTitle && <span className="text-state-success">{primaryTitle}</span>}
+                        {primaryTitle && secondaryTitle && <br />}
+                        {secondaryTitle && <span>{secondaryTitle}</span>}
+                    </DialogTitle>
+                    :
+                    <DialogTitle className="text-2xl">{title}</DialogTitle>
+                }
+                {!showPostHeader && (
+                    <Button className="-mr-2 cursor-pointer p-2 text-muted-foreground hover:text-foreground [&_svg]:size-6!" id={closeButtonId} size="lg" title="Close" variant="link" onClick={onClose}>
+                        <X size={24} strokeWidth={1} />
+                        <span className="sr-only">Close</span>
+                    </Button>
+                )}
+                {description &&
+                    <DialogDescription className={showPostHeader ? 'mb-0 pt-1 pb-0 text-lg text-foreground' : 'sr-only'}>
+                        {description}
+                    </DialogDescription>
+                }
+            </DialogHeader>
+
+            <a className={cn('flex flex-col items-stretch overflow-hidden border transition-all hover:border-muted-foreground/40', showPostHeader ? 'rounded-md' : 'rounded-lg bg-card')} href={preview.url} rel="noopener noreferrer" target="_blank">
+                {preview.imageURL ?
+                    <div className="aspect-video bg-cover bg-center" style={{backgroundImage: `url(${preview.imageURL})`}}></div>
+                    :
+                    !showPostHeader && (
+                        <div className="flex aspect-video items-center justify-center bg-muted text-muted-foreground">
+                            <ImageIcon className="size-8" />
+                        </div>
+                    )
+                }
+                <div className={showPostHeader ? 'p-6 pt-5' : 'p-5'}>
+                    {showPostHeader ?
+                        <H3>{preview.title}</H3>
+                        :
+                        <div className="text-lg font-semibold">{preview.title}</div>
+                    }
+                    {preview.description && (
+                        <p className={showPostHeader ? undefined : 'mt-1 text-sm text-muted-foreground'}>{preview.description}</p>
+                    )}
+                    {preview.meta}
+                </div>
+            </a>
+
+            {guidance}
+
+            {actionsLayout === 'stacked' ?
+                <>
+                    <div className="flex items-center gap-2 rounded-md border bg-muted p-2">
+                        <span className="min-w-0 flex-1 truncate px-2 text-sm">{copyURL}</span>
+                        <Button
+                            data-testid={copyButtonTestId}
+                            id={copyButtonId}
+                            size="sm"
+                            type="button"
+                            variant="outline"
+                            onClick={() => {
+                                void handleCopyLink();
+                            }}
+                        >
+                            {isCopied ? <Check /> : <Copy />}
+                            {isCopied ? copySuccessLabel : copyLabel}
+                        </Button>
+                    </div>
+                    <SocialLinks layout={actionsLayout} links={socialLinks} />
+                </>
+                :
+                <DialogFooter className="justify-between gap-6">
+                    {footerAction || (
+                        <>
+                            <SocialLinks layout={actionsLayout} links={socialLinks} />
+                            <Button
+                                className="ml-0! grow cursor-pointer"
+                                disabled={!copyURL}
+                                type="button"
+                                onClick={() => {
+                                    void handleCopyLink();
+                                }}
+                            >
+                                {isCopied ? <Check /> : <Link />}
+                                {isCopied ? copySuccessLabel : copyLabel}
+                            </Button>
+                        </>
+                    )}
+                </DialogFooter>
+            }
+        </DialogContent>
+    );
+
+    return (
+        <Dialog {...props}>
+            {children ?
+                <DialogTrigger className="cursor-pointer" asChild>
+                    {children}
+                </DialogTrigger>
+                :
+                null
+            }
+            {content}
+        </Dialog>
+    );
+};
+
+export default ShareModal;

--- a/apps/shade/src/patterns.ts
+++ b/apps/shade/src/patterns.ts
@@ -3,6 +3,8 @@ export * from './components/ui/filters';
 export {default as ColorPicker} from './components/features/color-picker/color-picker';
 export type {ColorPickerProps} from './components/features/color-picker/color-picker';
 export {default as PostShareModal} from './components/features/post-share-modal';
+export {default as ShareModal} from './components/features/share-modal';
+export type {ShareModalSocialLink} from './components/features/share-modal';
 export * from './components/features/table-filter-tabs/table-filter-tabs';
 export * from './components/features/utm-campaign-tabs/utm-campaign-tabs';
 export type {CampaignType, TabType} from './components/features/utm-campaign-tabs/utm-campaign-tabs';

--- a/e2e/helpers/pages/admin/index.ts
+++ b/e2e/helpers/pages/admin/index.ts
@@ -7,6 +7,7 @@ export * from './login-verify-page';
 export * from './settings';
 export * from './whats-new';
 export * from './analytics';
+export * from './onboarding';
 export * from './posts';
 export * from './tags';
 export * from './sidebar';

--- a/e2e/helpers/pages/admin/onboarding/index.ts
+++ b/e2e/helpers/pages/admin/onboarding/index.ts
@@ -1,0 +1,1 @@
+export * from './onboarding-page';

--- a/e2e/helpers/pages/admin/onboarding/onboarding-page.ts
+++ b/e2e/helpers/pages/admin/onboarding/onboarding-page.ts
@@ -1,0 +1,25 @@
+import {AdminPage} from '@/admin-pages';
+import {Locator, Page} from '@playwright/test';
+
+export class OnboardingPage extends AdminPage {
+    public readonly checklist: Locator;
+    public readonly completeButton: Locator;
+    public readonly copyLinkButton: Locator;
+    public readonly shareModal: Locator;
+    public readonly skipButton: Locator;
+
+    constructor(page: Page) {
+        super(page);
+
+        this.pageUrl = '/ghost/#/setup/onboarding';
+        this.checklist = page.getByTestId('onboarding-checklist');
+        this.completeButton = page.getByTestId('onboarding-complete');
+        this.copyLinkButton = page.getByTestId('onboarding-copy-link');
+        this.shareModal = page.getByTestId('onboarding-share-modal');
+        this.skipButton = page.getByTestId('onboarding-skip');
+    }
+
+    step(stepId: string) {
+        return this.page.getByTestId(`onboarding-step-${stepId}`);
+    }
+}

--- a/e2e/tests/admin/onboarding.test.ts
+++ b/e2e/tests/admin/onboarding.test.ts
@@ -1,0 +1,208 @@
+import {AnalyticsOverviewPage, OnboardingPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright';
+import type {Page} from '@playwright/test';
+
+type ChecklistState = 'pending' | 'started' | 'completed' | 'dismissed';
+
+const allSteps = ['customize-design', 'first-post', 'build-audience', 'share-publication'];
+const activeStartedAt = '2026-05-01T00:00:00.000Z';
+const navigationSteps: Array<[string, RegExp]> = [
+    ['customize-design', /\/ghost\/#\/settings\/design\/edit\?ref=setup/],
+    ['first-post', /\/ghost\/#\/editor\/post/],
+    ['build-audience', /\/ghost\/#\/members/]
+];
+
+test.use({isolation: 'per-test'});
+
+async function getCurrentUser(page: Page) {
+    const response = await page.request.get('/ghost/api/admin/users/me/?include=roles');
+    expect(response.ok()).toBe(true);
+
+    const body = await response.json();
+    return body.users[0];
+}
+
+async function setOnboardingState(page: Page, checklistState: ChecklistState, completedSteps: string[] = [], startedAt: string | null | undefined = checklistState === 'started' ? activeStartedAt : undefined) {
+    const user = await getCurrentUser(page);
+    const preferences = user.accessibility ? JSON.parse(user.accessibility) : {};
+
+    preferences.onboarding = {
+        completedSteps,
+        checklistState
+    };
+
+    if (startedAt) {
+        preferences.onboarding.startedAt = startedAt;
+    }
+
+    const response = await page.request.put(`/ghost/api/admin/users/${user.id}/?include=roles`, {
+        data: {
+            users: [{
+                ...user,
+                accessibility: JSON.stringify(preferences)
+            }]
+        }
+    });
+    expect(response.ok()).toBe(true);
+
+    await page.reload({waitUntil: 'load'});
+}
+
+async function getOnboardingPreferences(page: Page) {
+    const user = await getCurrentUser(page);
+    const preferences = user.accessibility ? JSON.parse(user.accessibility) : {};
+
+    return preferences.onboarding;
+}
+
+async function expectOnboardingRoute(page: Page, {returnTo = '/analytics'}: {returnTo?: string} = {}) {
+    await expect(page).toHaveURL((url) => {
+        const hashUrl = new URL(url.hash.slice(1), 'http://ghost.local');
+
+        return hashUrl.pathname === '/setup/onboarding' && hashUrl.searchParams.get('returnTo') === returnTo;
+    });
+}
+
+async function startOnboarding(page: Page) {
+    await setOnboardingState(page, 'started');
+    await page.goto(`/ghost/?onboardingTest=${Date.now()}#/setup/onboarding?returnTo=%2Fanalytics`);
+
+    const onboardingPage = new OnboardingPage(page);
+    await expect(onboardingPage.checklist).toBeVisible();
+}
+
+test.describe('Ghost Admin - Onboarding Checklist', () => {
+    test('new owner setup flow lands on onboarding', async ({page}) => {
+        await setOnboardingState(page, 'pending', ['customize-design']);
+
+        await page.goto('/ghost/#/setup/done');
+
+        const onboardingPage = new OnboardingPage(page);
+        await expect(onboardingPage.checklist).toBeVisible();
+        await expectOnboardingRoute(page);
+
+        const preferences = await getOnboardingPreferences(page);
+        expect(preferences).toMatchObject({
+            checklistState: 'started',
+            completedSteps: []
+        });
+        expect(typeof preferences.startedAt).toBe('string');
+    });
+
+    test('analytics routes redirect to onboarding while active', async ({page}) => {
+        await startOnboarding(page);
+
+        await page.goto('/ghost/#/analytics');
+
+        let onboardingPage = new OnboardingPage(page);
+        await expect(onboardingPage.checklist).toBeVisible();
+        await expectOnboardingRoute(page);
+
+        await page.goto('/ghost/#/analytics/web');
+
+        onboardingPage = new OnboardingPage(page);
+        await expect(onboardingPage.checklist).toBeVisible();
+        await expectOnboardingRoute(page, {returnTo: '/analytics/web'});
+    });
+
+    test('completed and dismissed users reach Analytics normally', async ({page}) => {
+        const analyticsPage = new AnalyticsOverviewPage(page);
+
+        await setOnboardingState(page, 'completed', allSteps);
+        await analyticsPage.goto();
+        await expect(analyticsPage.header).toBeVisible();
+
+        await setOnboardingState(page, 'dismissed');
+        await analyticsPage.goto();
+        await expect(analyticsPage.header).toBeVisible();
+    });
+
+    test('pending users reach Analytics normally and are not started by the React route', async ({page}) => {
+        const analyticsPage = new AnalyticsOverviewPage(page);
+
+        await setOnboardingState(page, 'pending', ['customize-design']);
+        await analyticsPage.goto();
+        await expect(analyticsPage.header).toBeVisible();
+
+        await page.goto('/ghost/#/setup/onboarding?returnTo=%2Fanalytics%3Fsource%3Dweb');
+        await expect(page).toHaveURL(/\/ghost\/#\/analytics\?source=web$/);
+
+        const preferences = await getOnboardingPreferences(page);
+        expect(preferences).toMatchObject({
+            checklistState: 'pending',
+            completedSteps: ['customize-design']
+        });
+    });
+
+    test('legacy started users without startedAt reach Analytics and are dismissed', async ({page}) => {
+        const analyticsPage = new AnalyticsOverviewPage(page);
+
+        await setOnboardingState(page, 'started', [], null);
+        await analyticsPage.goto();
+
+        await expect(analyticsPage.header).toBeVisible();
+
+        await expect.poll(async () => {
+            return (await getOnboardingPreferences(page))?.checklistState;
+        }).toBe('dismissed');
+
+        await expect.poll(async () => {
+            return (await getOnboardingPreferences(page))?.completedSteps;
+        }).toEqual([]);
+    });
+
+    navigationSteps.forEach(([step, expectedUrl]) => {
+        test(`${step} step marks complete and navigates`, async ({page}) => {
+            await startOnboarding(page);
+
+            const onboardingPage = new OnboardingPage(page);
+            await onboardingPage.step(step).click();
+
+            await expect(page).toHaveURL(expectedUrl);
+
+            const preferences = await getOnboardingPreferences(page);
+            expect(preferences.completedSteps).toContain(step);
+        });
+    });
+
+    test('share step opens the dialog and marks the step complete', async ({page}) => {
+        await startOnboarding(page);
+
+        const onboardingPage = new OnboardingPage(page);
+        await onboardingPage.step('share-publication').click();
+
+        await expect(onboardingPage.shareModal).toBeVisible();
+
+        const preferences = await getOnboardingPreferences(page);
+        expect(preferences.completedSteps).toContain('share-publication');
+    });
+
+    test('skip returns to the preserved analytics URL', async ({page}) => {
+        await startOnboarding(page);
+        await page.goto('/ghost/#/analytics?source=web');
+
+        const onboardingPage = new OnboardingPage(page);
+        await expectOnboardingRoute(page, {returnTo: '/analytics?source=web'});
+        await onboardingPage.skipButton.click();
+
+        await expect(page).toHaveURL(/\/ghost\/#\/analytics\?source=web$/);
+
+        const preferences = await getOnboardingPreferences(page);
+        expect(preferences.checklistState).toBe('dismissed');
+    });
+
+    test('completing all steps returns to the preserved analytics URL', async ({page}) => {
+        await startOnboarding(page);
+        await setOnboardingState(page, 'started', allSteps);
+        await page.goto('/ghost/#/setup/onboarding?returnTo=%2Fanalytics%3Fsource%3Dweb');
+
+        const onboardingPage = new OnboardingPage(page);
+        await expectOnboardingRoute(page, {returnTo: '/analytics?source=web'});
+        await onboardingPage.completeButton.click();
+
+        await expect(page).toHaveURL(/\/ghost\/#\/analytics\?source=web$/);
+
+        const preferences = await getOnboardingPreferences(page);
+        expect(preferences.checklistState).toBe('completed');
+    });
+});

--- a/ghost/admin/app/routes/setup/done.js
+++ b/ghost/admin/app/routes/setup/done.js
@@ -6,19 +6,19 @@ export default class SetupFinishingTouchesRoute extends AuthenticatedRoute {
     @inject config;
     @service feature;
     @service onboarding;
-    @service router;
     @service session;
     @service settings;
 
-    beforeModel() {
-        super.beforeModel(...arguments);
+    async beforeModel() {
+        await super.beforeModel(...arguments);
 
         if (this.session.user.isOwnerOnly) {
-            this.onboarding.startChecklist();
+            await this.onboarding.startChecklist();
         }
 
         if (this.session.user?.isAdmin) {
-            return this.router.transitionTo('/analytics');
+            // The React admin app owns /setup/onboarding, so hand off via hash navigation.
+            window.location.hash = '/setup/onboarding?returnTo=/analytics';
         }
     }
 }

--- a/ghost/admin/app/services/onboarding.js
+++ b/ghost/admin/app/services/onboarding.js
@@ -3,7 +3,8 @@ import {action} from '@ember/object';
 
 const EMPTY_SETTINGS = {
     completedSteps: [],
-    checklistState: 'pending' // pending, started, completed, dismissed
+    checklistState: 'pending', // pending, started, completed, dismissed
+    startedAt: undefined
 };
 
 export default class OnboardingService extends Service {
@@ -65,6 +66,7 @@ export default class OnboardingService extends Service {
 
         settings.completedSteps = [];
         settings.checklistState = 'started';
+        settings.startedAt = new Date().toISOString();
 
         await this._saveSettings(settings);
     }

--- a/ghost/admin/mirage/config/authentication.js
+++ b/ghost/admin/mirage/config/authentication.js
@@ -60,13 +60,13 @@ export default function mockAuthentication(server) {
 
     /* Setup ---------------------------------------------------------------- */
 
-    server.post('/authentication/setup', function ({roles, users}, request) {
-        let attrs = JSON.parse(request.requestBody).setup;
-        let role = roles.findBy({name: 'Owner'});
+    server.post('/authentication/setup', function (schema, request) {
+        let [attrs] = JSON.parse(request.requestBody).setup;
+        let role = schema.roles.findBy({name: 'Owner'});
 
         // create owner role unless already exists
         if (!role) {
-            role = roles.create({name: 'Owner'});
+            role = schema.roles.create({name: 'Owner'});
         }
         attrs.roles = [role];
 
@@ -74,8 +74,7 @@ export default function mockAuthentication(server) {
             attrs.slug = dasherize(attrs.email.split('@')[0]);
         }
 
-        // NOTE: server does not use the user factory to fill in blank fields
-        return users.create(attrs);
+        return schema.create('user', attrs);
     });
 
     server.get('/authentication/setup/', function () {

--- a/ghost/admin/tests/acceptance/onboarding-test.js
+++ b/ghost/admin/tests/acceptance/onboarding-test.js
@@ -1,6 +1,6 @@
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
-import {currentURL, find, visit} from '@ember/test-helpers';
+import {currentURL, find, visit, waitUntil} from '@ember/test-helpers';
 import {describe, it} from 'mocha';
 import {enableMembers} from '../helpers/members';
 import {expect} from 'chai';
@@ -45,6 +45,19 @@ describe('Acceptance: Onboarding', function () {
 
         // Onboarding checklist tests removed — checklist is now rendered by
         // the React analytics app, not Ember.
+
+        it('setup/done starts onboarding and redirects to the React onboarding route', async function () {
+            await visit('/setup/done');
+
+            await waitUntil(() => window.location.hash === '#/setup/onboarding?returnTo=/analytics');
+            expect(window.location.hash).to.equal('#/setup/onboarding?returnTo=/analytics');
+
+            let user = this.server.schema.users.first();
+            let preferences = JSON.parse(user.accessibility);
+            expect(preferences.onboarding.completedSteps).to.deep.equal([]);
+            expect(preferences.onboarding.checklistState).to.equal('started');
+            expect(preferences.onboarding.startedAt).to.match(/^\d{4}-\d{2}-\d{2}T/);
+        });
     });
 
     describe('checklist (non-owner)', function () {
@@ -60,6 +73,16 @@ describe('Acceptance: Onboarding', function () {
 
             // onboarding isn't shown
             expect(checklist()).to.not.exist;
+        });
+
+        it('setup/done redirects to the React onboarding route without starting onboarding', async function () {
+            await visit('/setup/done');
+
+            await waitUntil(() => window.location.hash === '#/setup/onboarding?returnTo=/analytics');
+            expect(window.location.hash).to.equal('#/setup/onboarding?returnTo=/analytics');
+
+            let user = this.server.schema.users.first();
+            expect(user.accessibility).to.be.null;
         });
     });
 

--- a/ghost/admin/tests/acceptance/setup-test.js
+++ b/ghost/admin/tests/acceptance/setup-test.js
@@ -2,7 +2,7 @@ import {Response} from 'miragejs';
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
-import {click, currentURL, fillIn, find, findAll} from '@ember/test-helpers';
+import {click, currentURL, fillIn, find, findAll, waitUntil} from '@ember/test-helpers';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
@@ -31,6 +31,9 @@ describe('Acceptance: Setup', function () {
         }
         if (!server.schema.settings.all().length) {
             server.loadFixtures('settings');
+        }
+        if (!server.schema.themes.all().length) {
+            server.loadFixtures('themes');
         }
         
         // mimick a new blog
@@ -120,9 +123,10 @@ describe('Acceptance: Setup', function () {
             await fillIn('[data-test-blog-title-input]', 'Blog Title');
             await click('[data-test-button="setup"]');
 
-            // it redirects to the dashboard
-            expect(currentURL(), 'url after submitting account details')
-                .to.equal('/analytics');
+            // it starts onboarding and hands off to the React onboarding route
+            await waitUntil(() => window.location.hash === '#/setup/onboarding?returnTo=/analytics');
+            expect(window.location.hash, 'url after submitting account details')
+                .to.equal('#/setup/onboarding?returnTo=/analytics');
         });
 
         it('handles validation errors in setup', async function () {
@@ -214,15 +218,20 @@ describe('Acceptance: Setup', function () {
 
     describe('?firstStart=true', function () {
         beforeEach(async function () {
+            this.server.loadFixtures('configs');
+            this.server.loadFixtures('settings');
+            this.server.loadFixtures('themes');
+
             let role = this.server.create('role', {name: 'Owner'});
             this.server.create('user', {roles: [role], slug: 'owner'});
 
             await authenticateSession();
         });
 
-        it('transitions to dashboard', async function () {
+        it('transitions to onboarding', async function () {
             await visit('/?firstStart=true');
-            expect(currentURL()).to.equal('/analytics');
+            await waitUntil(() => window.location.hash === '#/setup/onboarding?returnTo=/analytics');
+            expect(window.location.hash).to.equal('#/setup/onboarding?returnTo=/analytics');
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3587/new-signups-miss-the-onboarding-checklist

The onboarding flow was lost during the Ember->React migration of the Admin shell. This recreates it in the React admin app on a dedicated route, while keeping Analytics as the return destination until the checklist is skipped or completed.

Because onboarding has been missing for several months, existing owners may have stale onboarding preferences. This PR records `onboarding.startedAt` when `/setup/done` starts the checklist and only shows `started` checklists whose timestamp is on or after the fixed 30 April 2026 cutoff. Missing or older timestamps are dismissed so long-time product users are not suddenly forced into onboarding.

## Summary
- adds a dedicated React admin onboarding route at `/setup/onboarding`
- stores checklist state through the user preferences hooks while keeping the legacy accessibility storage detail hidden
- redirects active onboarding users away from Analytics until they skip or complete the checklist
- updates Ember `/setup/done` so new owner setup is the only path that starts onboarding
- records `onboarding.startedAt` and dismisses missing/legacy `startedAt` values before the fixed 30 April 2026 cutoff so existing long-time owners are not forced into onboarding
- shares the Shade `ShareModal` base between the onboarding publication share dialog and `PostShareModal`
- aligns publication and post share options, including X, Threads, Facebook, LinkedIn, and copy link
- adds Shade Storybook coverage for the shared share modal and fixes Storybook dark-mode handling for portaled content
- adds onboarding E2E coverage, including pending existing owners and legacy started owners reaching Analytics normally
