### PR TITLE
Properly use `Set` when sanitizing Bookshelf options

### DIFF
--- a/ghost/core/core/server/models/base/plugins/sanitize.js
+++ b/ghost/core/core/server/models/base/plugins/sanitize.js
@@ -164,9 +164,9 @@ module.exports = function (Bookshelf) {
 
             let options = _.cloneDeep(unfilteredOptions);
             const extraAllowedProperties = filterConfig.extraAllowedProperties || [];
-            const permittedOptions = [...new Set([...this.permittedOptions(methodName, options), ...extraAllowedProperties])];
+            const permittedOptions = new Set([...this.permittedOptions(methodName, options), ...extraAllowedProperties]);
             options = Object.fromEntries(
-                Object.entries(options).filter(([key]) => permittedOptions.includes(key))
+                Object.entries(options).filter(([key]) => permittedOptions.has(key))
             );
 
             if (this.defaultRelations) {


### PR DESCRIPTION
ref dd68fca9686cb83aa4e048a1f55586c57852cbba

This change should have no user impact, but should offer a small performance boost.

Before this change, we created a `Set`, converted it to an array, then used it as if it was a set.

After this change, we create the `Set` and use it directly. In addition to being clearer, this avoids unnecessary work and uses `Set` for its intended purpose.

Old pseudocode:

```js
const permittedSet = new Set([/* ... */]);
const permitted = Array.from(permittedSet);
// ...
const isAllowed = permitted.includes(value);
```

New pseudocode:

```js
const permitted = new Set([/* ... */]);
// ...
const isAllowed = permitted.has(value);
```
