### PR TITLE
Updated member detail to show gift subscription price

### DIFF
--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -2,6 +2,10 @@ import moment from 'moment-timezone';
 import {getNonDecimal, getSymbol} from 'ghost-admin/utils/currency';
 
 export function getSubscriptionData(sub) {
+    const giftTierPrice = isGift(sub) ? getGiftTierPrice(sub) : null;
+    const priceAmount = giftTierPrice?.amount ?? sub.price.amount;
+    const priceCurrency = giftTierPrice?.currency ?? sub.price.currency;
+
     const data = {
         ...sub,
         attribution: {
@@ -16,8 +20,10 @@ export function getSubscriptionData(sub) {
         cancellationReason: sub.cancellation_reason,
         price: {
             ...sub.price,
-            currencySymbol: getSymbol(sub.price.currency),
-            nonDecimalAmount: getNonDecimal(sub.price.amount)
+            amount: priceAmount,
+            currency: priceCurrency,
+            currencySymbol: getSymbol(priceCurrency),
+            nonDecimalAmount: getNonDecimal(priceAmount)
         },
         isComplimentary: isComplimentary(sub),
         isGift: isGift(sub),
@@ -68,6 +74,24 @@ export function isGift(sub) {
     const giftNickname = sub.plan?.nickname?.toLowerCase() === 'gift subscription';
 
     return !sub.id && giftNickname;
+}
+
+export function getGiftTierPrice(sub) {
+    if (!sub.tier) {
+        return null;
+    }
+
+    const interval = sub.price?.interval;
+    const amount = interval === 'month' ? sub.tier.monthly_price : sub.tier.yearly_price;
+
+    if (!amount) {
+        return null;
+    }
+
+    return {
+        amount,
+        currency: sub.tier.currency || sub.price?.currency
+    };
 }
 
 export function isCanceled(sub) {

--- a/ghost/admin/tests/acceptance/members/details-test.js
+++ b/ghost/admin/tests/acceptance/members/details-test.js
@@ -327,6 +327,9 @@ describe('Acceptance: Member details', function () {
             description: null,
             monthly_price_id: 'gift-monthly-price',
             yearly_price_id: 'gift-yearly-price',
+            monthly_price: 500,
+            yearly_price: 5000,
+            currency: 'usd',
             type: 'paid',
             active: true,
             welcome_page_url: '/',
@@ -386,6 +389,9 @@ describe('Acceptance: Member details', function () {
         expect(subscriptionSummaryText(giftTier.id)).to.equal('Gift subscription - Expires 3 Apr 2022');
         expect(tierCard).to.contain.text('Gift subscription');
         expect(find(`[data-test-tier="${giftTier.id}"] [data-test-button="subscription-actions"]`)).to.not.exist;
+
+        const amountElement = find(`[data-test-tier="${giftTier.id}"] .gh-tier-card-price .amount`);
+        expect(amountElement.textContent.trim()).to.equal('50');
     });
 
     it('displays comped subscriptions with expiry text and a complimentary action menu', async function () {

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -533,11 +533,15 @@ describe('Unit: Util: subscription-data', function () {
                     nickname: 'Gift subscription'
                 },
                 tier: {
-                    expiry_at: moment.utc('2021-05-31').toISOString()
+                    expiry_at: moment.utc('2021-05-31').toISOString(),
+                    monthly_price: 500,
+                    yearly_price: 5000,
+                    currency: 'usd'
                 },
                 price: {
                     currency: 'usd',
                     amount: 0,
+                    interval: 'year',
                     nickname: 'Gift subscription'
                 }
             };
@@ -555,6 +559,36 @@ describe('Unit: Util: subscription-data', function () {
                 priceLabel: 'Gift subscription',
                 validityDetails: ' – Expires 31 May 2021'
             });
+            expect(data.price.amount).to.equal(5000);
+            expect(data.price.currency).to.equal('usd');
+        });
+
+        it('uses the tier monthly price for monthly gift subscriptions', function () {
+            let sub = {
+                id: null,
+                status: 'active',
+                cancel_at_period_end: false,
+                current_period_end: '2021-05-31',
+                trial_end_at: null,
+                plan: {
+                    nickname: 'Gift subscription'
+                },
+                tier: {
+                    expiry_at: moment.utc('2021-05-31').toISOString(),
+                    monthly_price: 500,
+                    yearly_price: 5000,
+                    currency: 'usd'
+                },
+                price: {
+                    currency: 'usd',
+                    amount: 0,
+                    interval: 'month',
+                    nickname: 'Gift subscription'
+                }
+            };
+            let data = getSubscriptionData(sub);
+
+            expect(data.price.amount).to.equal(500);
         });
 
         it('sets hasActiveDiscount with discounted and original prices', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3576/price-tag-on-member-with-a-gift-sub

When a member has a gift subscription, the member detail screen showed $0/year, which made gifts visually indistinguishable from complimentary subscriptions. A gift isn't free — someone paid for it — so the price tag should reflect the actual amount.