### PR TITLE
🎨 Added direct access-code entry for private sites

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
@@ -76,29 +76,46 @@
                                         </form>
                                     {{/if}}
                                 </header>
-                            </section>
-                            <dialog class="gh-private-dialog" id="access" aria-labelledby="private-access-title" {{#if @site.accent_color}} style="--gh-private-accent-color: {{@site.accent_color}}; --gh-private-accent-color-rgba: {{color_to_rgba @site.accent_color 0.25}}; --gh-private-accent-contrast-color: {{contrast_text_color @site.accent_color}};"{{/if}} {{#if error}}data-auto-open="true"{{/if}}>
-                                <div class="gh-private-dialog-panel">
-                                    <button class="gh-private-dialog-close" type="button" data-ghost-private-close aria-label="{{t "Close"}}">
-                                        <svg class="gh-private-dialog-close-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
-                                            <path d="M6 6L18 18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2.5"></path>
-                                            <path d="M18 6L6 18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2.5"></path>
-                                        </svg>
-                                    </button>
-                                    <header class="gh-private-dialog-header">
-                                        <h2 id="private-access-title">{{t "Enter access code"}}</h2>
-                                    </header>
-                                    <form class="gh-signin gh-private-signin" method="post" novalidate="novalidate">
-                                        <div class="form-group{{#if error}} error{{/if}}">
-                                                {{input_password class="gh-input" placeholder=(t "Access code") data-1p-ignore="true"}}
-                                                {{#if error}}
-                                                    <p class="main-error">{{error.message}}</p>
-                                                {{/if}}
+                                {{#unless @site.allow_self_signup}}
+                                    <form class="gh-signin gh-private-signin gh-private-access-form" method="post" novalidate="novalidate">
+                                        <div class="gh-private-signup-fields">
+                                            <div class="form-group gh-private-access-input-wrap{{#if error}} error{{/if}}">
+                                                    {{input_password class="gh-input gh-private-signup-input" placeholder=(t "Access code") data-1p-ignore="true"}}
+                                                    {{#if error}}
+                                                        <p class="main-error">{{error.message}}</p>
+                                                    {{/if}}
+                                            </div>
+                                            <button class="gh-btn gh-private-signup-btn" type="submit"><span>{{t "Enter"}} &rarr;</span></button>
                                         </div>
-                                        <button class="gh-btn" type="submit"><span>{{t "Enter"}} &rarr;</span></button>
                                     </form>
-                                </div>
-                            </dialog>
+                                {{/unless}}
+                            </section>
+                            {{#if @site.allow_self_signup}}
+                                <dialog class="gh-private-dialog" id="access" aria-labelledby="private-access-title" {{#if @site.accent_color}} style="--gh-private-accent-color: {{@site.accent_color}}; --gh-private-accent-color-rgba: {{color_to_rgba @site.accent_color 0.25}}; --gh-private-accent-contrast-color: {{contrast_text_color @site.accent_color}};"{{/if}} {{#if error}}data-auto-open="true"{{/if}}>
+                                    <div class="gh-private-dialog-panel">
+                                        <button class="gh-private-dialog-close" type="button" data-ghost-private-close aria-label="{{t "Close"}}">
+                                            <svg class="gh-private-dialog-close-icon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                                                <path d="M6 6L18 18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2.5"></path>
+                                                <path d="M18 6L6 18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2.5"></path>
+                                            </svg>
+                                        </button>
+                                        <header class="gh-private-dialog-header">
+                                            <h2 id="private-access-title">{{t "Enter access code"}}</h2>
+                                        </header>
+                                        <form class="gh-signin gh-private-signin gh-private-access-form" method="post" novalidate="novalidate">
+                                            <div class="gh-private-signup-fields">
+                                                <div class="form-group gh-private-access-input-wrap{{#if error}} error{{/if}}">
+                                                        {{input_password class="gh-input gh-private-signup-input" placeholder=(t "Access code") data-1p-ignore="true"}}
+                                                        {{#if error}}
+                                                            <p class="main-error">{{error.message}}</p>
+                                                        {{/if}}
+                                                </div>
+                                                <button class="gh-btn gh-private-signup-btn" type="submit"><span>{{t "Enter"}} &rarr;</span></button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </dialog>
+                            {{/if}}
                             <div class="gh-private-trigger-wrap">
                                 <div class="gh-private-footer-links">
                                     <a class="gh-private-powered" href="https://ghost.org" target="_blank" rel="noopener noreferrer">
@@ -108,8 +125,10 @@
                                         <span>Powered by Ghost</span>
                                     </a>
                                     <span class="gh-private-footer-separator" aria-hidden="true">|</span>
-                                    <a class="gh-private-trigger" href="#access" data-ghost-private-trigger>{{t "Enter access code"}}</a>
-                                    <span class="gh-private-footer-separator" aria-hidden="true">|</span>
+                                    {{#if @site.allow_self_signup}}
+                                        <a class="gh-private-trigger" href="#access" data-ghost-private-trigger>{{t "Enter access code"}}</a>
+                                        <span class="gh-private-footer-separator" aria-hidden="true">|</span>
+                                    {{/if}}
                                     <a href="{{@site.admin_url}}">{{t "Site owner login"}}</a>
                                 </div>
                             </div>

--- a/ghost/core/core/frontend/public/ghost.css
+++ b/ghost/core/core/frontend/public/ghost.css
@@ -736,7 +736,8 @@ h2 {
     text-wrap: balance;
 }
 
-.gh-private-signup-form {
+.gh-private-signup-form,
+.gh-flow-content.private > .gh-private-access-form {
     width: min(100%, 550px);
     margin: 40px auto 0;
 }
@@ -758,7 +759,8 @@ h2 {
     margin: 0;
 }
 
-.gh-private-signup-form .gh-private-signup-btn {
+.gh-private-signup-form .gh-private-signup-btn,
+.gh-private-access-form .gh-private-signup-btn {
     width: auto;
     margin-top: 0;
 }
@@ -922,6 +924,12 @@ h2 {
 .gh-private-signin .gh-btn {
     width: 100%;
     max-width: none;
+}
+
+.gh-private-access-form .form-group {
+    flex: 1;
+    min-width: 0;
+    margin-bottom: 0;
 }
 
 .gh-private-signin .main-error {
@@ -1212,7 +1220,8 @@ h2 {
 }
 
 #access .gh-private-signin .gh-input:focus,
-.gh-flow-content-wrap .gh-private-signup-form.gh-signin .gh-input:focus {
+.gh-flow-content-wrap .gh-private-signup-form.gh-signin .gh-input:focus,
+.gh-flow-content-wrap .gh-private-access-form.gh-signin .gh-input:focus {
     border: 1px solid var(--gh-private-accent-color, #30cf43);
     box-shadow: 0 0 0 3px var(--gh-private-accent-color-rgba, rgba(48,207,67,.25));
 }
@@ -1234,7 +1243,8 @@ h2 {
     -webkit-font-smoothing: subpixel-antialiased;
 }
 
-.gh-private-signup-form.gh-signin .gh-private-signup-btn {
+.gh-private-signup-form.gh-signin .gh-private-signup-btn,
+.gh-private-access-form.gh-signin .gh-private-signup-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1246,7 +1256,8 @@ h2 {
     fill: var(--gh-private-accent-contrast-color, #FFFFFF);
 }
 
-.gh-private-signup-form.gh-signin .gh-private-signup-btn span {
+.gh-private-signup-form.gh-signin .gh-private-signup-btn span,
+.gh-private-access-form.gh-signin .gh-private-signup-btn span {
     color: var(--gh-private-accent-contrast-color, #FFFFFF);
 }
 

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -190,6 +190,9 @@ describe('private.hbs template translation', function () {
                 assert(html.includes('class="gh-private-signup-btn-loading"'));
                 assert(html.includes('class="gh-private-signup-btn-success"'));
                 assert(html.includes('data-ghost-private-subscribe-feedback'));
+                assert(html.includes('id="access"'));
+                assert(html.includes('data-ghost-private-trigger'));
+                assert(html.includes('Enter access code'));
                 assert(html.includes('id="gh-private-config"'));
                 assert(html.includes('src="/private.js"'));
             });
@@ -211,12 +214,54 @@ describe('private.hbs template translation', function () {
                 const html = renderPrivateTemplate(context);
 
                 assertExists(html);
-                assert(!/<form class="gh-private-signup-form gh-signin"[^>]*data-ghost-private-subscribe-form/.test(html));
+                assert(!html.includes('data-ghost-private-subscribe-form'));
+                assert(!html.includes('data-members-form="subscribe"'));
+            });
+
+            it('renders the access form inline when self signup is disabled', function () {
+                const context = {
+                    site: {title: 'Test', description: 'A private publication', url: 'http://test.local', locale: 'en', allow_self_signup: false, admin_url: 'http://test.local/ghost/'}
+                };
+                const html = renderPrivateTemplate(context);
+
+                assertExists(html);
+                assert(html.includes('A private publication'));
+                assert(/<form[^>]*method="post"[\s\S]*name="password"/.test(html));
+                assert(html.includes('placeholder="Access code"'));
+                assert(html.includes('data-1p-ignore'));
+                assert(html.includes('type="submit"'));
+                assert(html.includes('Enter &rarr;'));
+            });
+
+            it('does not render the access dialog or footer access link when self signup is disabled', function () {
+                const context = {
+                    site: {title: 'Test', url: 'http://test.local', locale: 'en', allow_self_signup: false, admin_url: 'http://test.local/ghost/'}
+                };
+                const html = renderPrivateTemplate(context);
+
+                assertExists(html);
+                assert(!html.includes('id="access"'));
+                assert(!html.includes('data-ghost-private-trigger'));
+                assert(!html.includes('href="#access"'));
+                assert(html.includes('Powered by Ghost'));
+                assert(html.includes('Site owner login'));
+            });
+
+            it('renders access form errors inline when self signup is disabled', function () {
+                const context = {
+                    error: {message: 'Wrong code'},
+                    site: {title: 'Test', url: 'http://test.local', locale: 'en', allow_self_signup: false, admin_url: 'http://test.local/ghost/'}
+                };
+                const html = renderPrivateTemplate(context);
+
+                assertExists(html);
+                assert(/<form[^>]*method="post"[\s\S]*Wrong code[\s\S]*<\/form>/.test(html));
+                assert(!html.includes('data-auto-open="true"'));
             });
 
             it('renders English strings when locale is en', function () {
                 const context = {
-                    site: {title: 'Test', url: 'http://test.local', locale: 'en', admin_url: 'http://test.local/ghost/'}
+                    site: {title: 'Test', url: 'http://test.local', locale: 'en', allow_self_signup: true, admin_url: 'http://test.local/ghost/'}
                 };
                 const html = renderPrivateTemplate(context);
                 assertExists(html);
@@ -236,7 +281,7 @@ describe('private.hbs template translation', function () {
             it('renders German strings when locale is de', function () {
                 initLocale({useNewTranslation, locale: 'de'});
                 const context = {
-                    site: {title: 'Test', url: 'http://test.local', locale: 'de', admin_url: 'http://test.local/ghost/'}
+                    site: {title: 'Test', url: 'http://test.local', locale: 'de', allow_self_signup: true, admin_url: 'http://test.local/ghost/'}
                 };
                 const html = renderPrivateTemplate(context);
                 assertExists(html);
@@ -250,7 +295,7 @@ describe('private.hbs template translation', function () {
             it('falls back to English when locale is fr (no fr.json)', function () {
                 initLocale({useNewTranslation, locale: 'fr'});
                 const context = {
-                    site: {title: 'Test', url: 'http://test.local', locale: 'fr', admin_url: 'http://test.local/ghost/'}
+                    site: {title: 'Test', url: 'http://test.local', locale: 'fr', allow_self_signup: true, admin_url: 'http://test.local/ghost/'}
                 };
                 const html = renderPrivateTemplate(context);
                 assertExists(html);
@@ -264,7 +309,7 @@ describe('private.hbs template translation', function () {
             it('auto-opens the dialog when an error is present', function () {
                 const context = {
                     error: {message: 'Wrong code'},
-                    site: {title: 'Test', url: 'http://test.local', locale: 'en', admin_url: 'http://test.local/ghost/'}
+                    site: {title: 'Test', url: 'http://test.local', locale: 'en', allow_self_signup: true, admin_url: 'http://test.local/ghost/'}
                 };
                 const html = renderPrivateTemplate(context);
 


### PR DESCRIPTION
## Summary

The private page now shows the access-code form directly beneath the site branding and description, like the old private page template, when signups are disabled. Sites that allow self-signup keep the newer signup-first experience, including the access-code dialog and footer link. 

### New signin flow (signup disabled)
<img width="1624" height="1060" alt="Screenshot 2026-04-30 at 09 17 32" src="https://github.com/user-attachments/assets/0e992339-2f43-40f5-bced-0e555062dbba" />

### Existing signup flow (signups enabled)
<img width="1624" height="1060" alt="Screenshot 2026-04-30 at 09 17 41" src="https://github.com/user-attachments/assets/41d6fc23-5f31-4ef2-818b-115aaa258d82" />

## Why

Private sites without public signup didn't have any clear call to action on the private landing page. Tucking the access code entry away in the footer made it hard to discover. 

## Tests

- git diff --check
- pnpm --dir ghost/core test:single test/unit/frontend/apps/private-blogging/controller.test.js
- pnpm --dir ghost/core test:single test/unit/frontend/public/private.test.js

ref https://linear.app/ghost/issue/BER-3558/oss-issue-subscribing-possible-on-password-protected-page