### PR TITLE
Small design fixes for the gift subscription flow in Portal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
@@ -68,7 +68,7 @@ const PortalLinks: React.FC = () => {
                 <PortalLink name='Default' value={isDataAttributes ? 'data-portal' : `${homePageURL}#/portal`} />
                 <PortalLink name='Sign in' value={isDataAttributes ? 'data-portal="signin"' : `${homePageURL}#/portal/signin`} />
                 <PortalLink name='Sign up' value={isDataAttributes ? 'data-portal="signup"' : `${homePageURL}#/portal/signup`} />
-                {hasGiftSubscriptions && <PortalLink name='Gift' value={isDataAttributes ? 'data-portal="gift"' : `${homePageURL}#/portal/gift`} />}
+                {hasGiftSubscriptions && <PortalLink name='Gift subscription' value={isDataAttributes ? 'data-portal="gift"' : `${homePageURL}#/portal/gift`} />}
             </List>
 
             <List className='mt-14' title='Tiers' titleSize='lg'>

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.22",
+  "version": "2.68.23",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/account-home-page.css
+++ b/apps/portal/src/components/pages/AccountHomePage/account-home-page.css
@@ -151,6 +151,25 @@ footer.gh-portal-account-footer {
     position: relative;
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
+}
+
+.gh-portal-account-expiry {
+    white-space: nowrap;
+}
+
+.gh-portal-account-expiry-separator {
+    margin: 0 4px;
+}
+
+@media (max-width: 480px) {
+    .gh-portal-account-expiry-separator {
+        display: none;
+    }
+
+    .gh-portal-account-expiry {
+        flex-basis: 100%;
+    }
 }
 
 .gh-portal-account-old-price {

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -40,7 +40,9 @@ const PaidAccountActions = () => {
             return (
                 <p className="gh-portal-account-discountcontainer">
                     <GiftIcon className="gh-portal-account-tagicon" />
-                    <span>{`${t('Gift subscription')} - ${t('Expires {expiryDate}', {expiryDate: subscriptionExpiry})}`}</span>
+                    <span>{t('Gift subscription')}</span>
+                    <span className="gh-portal-account-expiry-separator">-</span>
+                    <span className="gh-portal-account-expiry">{t('Expires {expiryDate}', {expiryDate: subscriptionExpiry})}</span>
                 </p>
             );
         } else if (isComplimentary) {

--- a/apps/portal/src/components/pages/gift-redemption-page.js
+++ b/apps/portal/src/components/pages/gift-redemption-page.js
@@ -16,6 +16,7 @@ export const GiftRedemptionStyles = `
         max-width: 500px;
         padding: 0;
         overflow: hidden;
+        flex-shrink: 0;
     }
 
     .gh-portal-popup-container.giftRedemption .gh-portal-closeicon-container {
@@ -160,6 +161,10 @@ export const GiftRedemptionStyles = `
     }
 
     @media (max-width: 480px) {
+        .gh-portal-popup-container.giftRedemption {
+            padding: 0 !important;
+        }
+
         .gh-gift-redemption-panel {
             padding: 32px 24px 24px;
         }

--- a/apps/portal/src/components/pages/recommendations-page.js
+++ b/apps/portal/src/components/pages/recommendations-page.js
@@ -71,7 +71,7 @@ export const RecommendationsPageStyles = `
     transition: 0.2s ease-in-out opacity;
     }
 
-    .gh-portal-list-detail:hover {
+    .gh-portal-recommendation-item .gh-portal-list-detail:hover {
     cursor: pointer;
     opacity: 0.8;
     }

--- a/apps/portal/src/components/popup-modal.js
+++ b/apps/portal/src/components/popup-modal.js
@@ -107,6 +107,10 @@ class PopupContent extends React.Component {
         if (hasMode(['preview']) || (otcRef && page === 'magiclink')) {
             return;
         }
+        // Hard-to-trigger flows: require explicit dismissal via the X button
+        if (page === 'giftRedemption' || page === 'giftSuccess') {
+            return;
+        }
         if (e.target === e.currentTarget) {
             this.context.doAction('closePopup');
         }
@@ -266,6 +270,11 @@ export default class PopupModal extends React.Component {
 
     handlePopupClose(e) {
         e.preventDefault();
+        const {page} = this.context;
+        // Hard-to-trigger flows: require explicit dismissal via the X button
+        if (page === 'giftRedemption' || page === 'giftSuccess') {
+            return;
+        }
         if (e.target === e.currentTarget) {
             this.context.doAction('closePopup');
         }

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -385,7 +385,7 @@ export function useMemberFilterFields({
 
             subscriptionFields.push(
                 createFieldConfig('status', giftSubscriptionsEnabled ? {
-                    options: [...memberFields.status.options, {value: 'gift', label: 'Gift'}]
+                    options: [...memberFields.status.options, {value: 'gift', label: 'Gift subscription'}]
                 } : {}),
                 createFieldConfig('subscriptions.plan_interval'),
                 createFieldConfig('subscriptions.status'),


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3568/gift-sub-screen-broken-on-mobile
ref https://linear.app/ghost/issue/BER-3573/no-op-link-in-account-modal
ref https://linear.app/ghost/issue/BER-3574/gift-link-in-portal-settings
ref https://linear.app/ghost/issue/BER-3575/alignment-detail-on-mobile
ref https://linear.app/ghost/issue/BER-3577/member-status-is-gift-this-doesnt-make-much-sense-in-english
ref https://linear.app/ghost/issue/BER-3592/dont-dismiss-the-modal-on-outside-click

- Fixed gift subscription expiry text wrapping mid-date on mobile in the account modal — "Expires {date}" now drops to its own line, left-aligned with the gift icon
- Fixed pointer cursor leaking into non-clickable rows in the account modal
- Fixed gift redemption modal scrolling and padding on mobile
- Renamed "Gift" → "Gift subscription" in Portal links and the member status filter for consistency
- Disabled outside-click dismissal on the gift redemption modal (recipient) and gift link modal (buyer) — both are hard to re-trigger after closing, so they now require explicit dismissal via the X button