### PR TITLE
🐛 Declared lodash as a phantom dep in apps/admin

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -20,6 +20,7 @@
     "@tryghost/posts": "workspace:*",
     "@tryghost/shade": "workspace:*",
     "@tryghost/stats": "workspace:*",
+    "lodash": "4.18.1",
     "mingo": "2.5.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       '@tryghost/stats':
         specifier: workspace:*
         version: link:../stats
+      lodash:
+        specifier: 4.18.1
+        version: 4.18.1
       mingo:
         specifier: 2.5.3
         version: 2.5.3


### PR DESCRIPTION
## Problem

Running `pnpm dev` against a fresh install crashes the Vite admin dev server during esbuild's dependency optimization with `Could not resolve "lodash"` pointing at `node_modules/@tryghost/nql/lib/utils.js`. The admin frontend never starts and `http://localhost:2368/ghost/` is unreachable.

## Root cause

`@tryghost/nql@0.12.10` does `require('lodash')` in `lib/utils.js` but does not declare `lodash` in its own `dependencies`. It's a classic phantom dependency — it only resolved historically because `lodash` happened to be hoisted into the workspace root by some other package.

This was previously masked by `shamefully-hoist=true` in our pnpm config, which flattened every transitive into the root `node_modules`. [#27343](https://github.com/TryGhost/Ghost/pull/27343) (commit [dc2ae810f4](https://github.com/TryGhost/Ghost/commit/dc2ae810f4)) flipped pnpm to strict isolation in April and explicitly chased down the phantom decls that fell out — about 18 `package.json`s gained explicit declarations in that PR. The `lodash`-via-`nql` case slipped through because nothing in `apps/admin`'s direct source imports lodash; the require only happens deep inside nql at runtime/optimize time.

## Why a workspace-side patch

The proper fix belongs in `@tryghost/nql` itself, and it's already in flight at [TryGhost/NQL#138](https://github.com/TryGhost/NQL/pull/138). But that needs to land, cut a release, and get a version bump in this repo before it unblocks `pnpm dev` here. Declaring `lodash` directly in `apps/admin/package.json` is the same consumer-side pattern [#27343](https://github.com/TryGhost/Ghost/pull/27343) used for the other phantoms — once nql ships the fix and we bump it, this line can come out.

The change is one line: `"lodash": "4.18.1"` added in alphabetical position in `apps/admin/package.json`'s `dependencies`. `pnpm-lock.yaml` was not modified because pnpm reused the existing lockfile entry.

## Test plan

`pnpm install` followed by `pnpm dev` boots Vite cleanly (`VITE v7.1.12 ready`, dev URL returns 200) and admin loads at `http://localhost:2368/ghost/`. Deep-link redirects (e.g. `/ghost/members/import` → `/ghost/#/members/import`) continue to resolve normally.