### PR TITLE
Included gift members in `/members/stats/count` response

### DIFF
--- a/ghost/admin/app/services/members-stats.js
+++ b/ghost/admin/app/services/members-stats.js
@@ -125,7 +125,8 @@ export default class MembersStatsService extends Service {
             paid: initialDateInRangeVal ? initialDateInRangeVal.paid : 0,
             free: initialDateInRangeVal ? initialDateInRangeVal.free : 0,
             comped: initialDateInRangeVal ? initialDateInRangeVal.comped : 0,
-            total: initialDateInRangeVal ? (initialDateInRangeVal.paid + initialDateInRangeVal.free + initialDateInRangeVal.comped) : 0
+            gift: initialDateInRangeVal ? initialDateInRangeVal.gift : 0,
+            total: initialDateInRangeVal ? (initialDateInRangeVal.paid + initialDateInRangeVal.free + initialDateInRangeVal.comped + initialDateInRangeVal.gift) : 0
         };
         while (currentRangeDate.isBefore(endDate)) {
             let dateStr = currentRangeDate.format('YYYY-MM-DD');
@@ -134,7 +135,8 @@ export default class MembersStatsService extends Service {
                 paid: dataOnDate.paid,
                 free: dataOnDate.free,
                 comped: dataOnDate.comped,
-                total: dataOnDate.paid + dataOnDate.free + dataOnDate.comped
+                gift: dataOnDate.gift,
+                total: dataOnDate.paid + dataOnDate.free + dataOnDate.comped + dataOnDate.gift
             } : lastVal;
             lastVal = output[dateStr];
             currentRangeDate = currentRangeDate.add(1, 'day');

--- a/ghost/admin/mirage/config/members.js
+++ b/ghost/admin/mirage/config/members.js
@@ -64,7 +64,8 @@ export function mockMembersStats(server) {
                     date: key,
                     free: arr[key],
                     paid: 0,
-                    comped: 0
+                    comped: 0,
+                    gift: 0
                 };
             })
         };

--- a/ghost/core/core/server/api/endpoints/members.js
+++ b/ghost/core/core/server/api/endpoints/members.js
@@ -453,16 +453,17 @@ const controller = {
         },
         async query() {
             const memberStats = await membersService.api.events.getStatuses();
-            let totalMembers = _.last(memberStats) ? (_.last(memberStats).paid + _.last(memberStats).free + _.last(memberStats).comped) : 0;
+            const last = _.last(memberStats);
+            let totalMembers = last ? (last.paid + last.free + last.comped + last.gift) : 0;
 
             return {
                 resource: 'members',
                 total: totalMembers,
                 data: memberStats.map((d) => {
-                    const {paid, free, comped} = d;
+                    const {paid, free, comped, gift} = d;
                     return {
                         date: moment(d.date).format('YYYY-MM-DD'),
-                        paid, free, comped
+                        paid, free, comped, gift
                     };
                 })
             };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -3999,11 +3999,12 @@ Object {
       "comped": 5,
       "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "free": 5,
+      "gift": 1,
       "paid": 2,
     },
   ],
   "resource": "members",
-  "total": 12,
+  "total": 13,
 }
 `;
 
@@ -4011,7 +4012,7 @@ exports[`Members API Can fetch member counts stats 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "93",
+  "content-length": "102",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -64,6 +64,19 @@ async function createMember(data) {
     return member;
 }
 
+async function createGiftMember(data) {
+    const member = await createMember({
+        ...data,
+        status: 'gift'
+    });
+    await models.MemberStatusEvent.add({
+        member_id: member.id,
+        from_status: null,
+        to_status: 'gift'
+    });
+    return member;
+}
+
 const newsletterSnapshot = {
     id: anyObjectId
 };
@@ -2767,6 +2780,8 @@ describe('Members API', function () {
     // Get stats
 
     it('Can fetch member counts stats', async function () {
+        await createGiftMember({email: 'gift-member@test.com'});
+
         await agent
             .get(`/members/stats/count/`)
             .expectStatus(200)


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/BER-3509

- the `memberStats` controller summed `paid` + `free` + `comped` and dropped the `gift` field even though the underlying service, model, and SQL aggregation already calculated it
- gift members were therefore invisible to any consumer of this endpoint, including the admin total member count, leading to undercounted totals on sites with gift subscriptions
- the data shape now matches the sibling `/stats/member_count/` endpoint which already exposed `gift`
- updated the Ember mirage mock and the unused `fillCountDates` helper to keep the data shape consistent across the admin code that touches this response
