### PR TITLE
Fixed spinner colour in ActivityPub share your profile

### DIFF
--- a/apps/activitypub/src/views/preferences/components/profile.tsx
+++ b/apps/activitypub/src/views/preferences/components/profile.tsx
@@ -405,7 +405,7 @@ const Profile: React.FC<ProfileProps> = ({account, isLoading}) => {
                             </a>
                         </div>
                         <Button className={`min-w-[160px] dark:bg-black dark:text-white dark:hover:bg-black/90 ${backgroundColor === 'dark' && 'bg-white text-black hover:bg-gray-50 dark:bg-white dark:text-black dark:hover:bg-gray-50/90'}`} onClick={handleCopy}>
-                            {isProcessing ? <LoadingIndicator color={`${backgroundColor === 'dark' ? 'dark' : 'light'}`} size='sm' /> : <LucideIcon.Copy />}
+                            {isProcessing ? <LoadingIndicator className='!border-current/10 before:!bg-current' size='sm' /> : <LucideIcon.Copy />}
                             {!isProcessing && 'Copy image'}
                         </Button>
                     </div>


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/DES-1206/oss-issue-spinner-colours-of-copy-image-button-on-share-your-profile

The spinner logic got a bit funky here because the app colour mode, card colour and button colour can all change independently of each other.
