### PR TITLE
Fixed gift subscription worker jobs not running as expected

### DIFF
--- a/ghost/core/core/server/services/members/jobs/clean-gifts.js
+++ b/ghost/core/core/server/services/members/jobs/clean-gifts.js
@@ -30,6 +30,20 @@ if (parentPort) {
         const cleanupStartDate = new Date();
         debug('Starting gift cleanup');
 
+        /**
+         * Explicitly initialize services required to run the job - We need to
+         * do this manually because the job is run in a worker thread and not
+         * in the main process
+         */
+        const settings = require('../../settings/settings-service');
+        await settings.init();
+
+        const stripeService = require('../../stripe');
+        await stripeService.init();
+
+        const membersService = require('../../members');
+        await membersService.init();
+
         const giftService = require('../../gifts');
         await giftService.init();
 

--- a/ghost/core/core/server/services/members/jobs/send-gift-reminders.js
+++ b/ghost/core/core/server/services/members/jobs/send-gift-reminders.js
@@ -30,6 +30,23 @@ if (parentPort) {
         const startDate = new Date();
         debug('Starting gift reminder send');
 
+        /**
+         * Explicitly initialize services required to run the job - We need to
+         * do this manually because the job is run in a worker thread and not
+         * in the main process
+         */
+        const settings = require('../../settings/settings-service');
+        await settings.init();
+
+        const emailAddressService = require('../../email-address');
+        emailAddressService.init();
+
+        const membersService = require('../../members');
+        await membersService.init();
+
+        const tiersService = require('../../tiers');
+        await tiersService.init();
+
         const giftService = require('../../gifts');
         await giftService.init();
 


### PR DESCRIPTION
no ref

The gift subscription worker jobs were not running as expected due to not all service dependencies being available. We need to explicitly initialize the services needed for the worker jobs as they are run in a worker process and not as part of the main process (where boot.js has already initialized the services)