### PR TITLE
Fixed missing toast after gift-to-paid upgrade in Portal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.25",
+  "version": "2.68.26",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -559,6 +559,9 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             const identity = await api.member.identity();
             const url = endpointFor({type: 'members', resource: 'create-stripe-checkout-session'});
 
+            const checkoutSuccessUrl = window.location.href.startsWith(siteUrlObj.href) ? new URL(window.location.href) : new URL(siteUrl);
+            checkoutSuccessUrl.searchParams.set('stripe', 'success');
+
             const checkoutCancelUrl = window.location.href.startsWith(siteUrlObj.href) ? new URL(window.location.href) : new URL(siteUrl);
             checkoutCancelUrl.searchParams.set('stripe', 'cancel');
 
@@ -566,7 +569,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 type: 'subscription',
                 continueFromGift: true,
                 identity,
-                successUrl: siteUrl,
+                successUrl: checkoutSuccessUrl.href,
                 cancelUrl: checkoutCancelUrl.href,
                 metadata: {
                     checkoutType: 'upgrade',


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3477

- Gift members upgrading to paid via Portal got no success toast after Stripe checkout
- Fixed by building the success URL with `?stripe=success`, mirroring the cancel URL just above. No backend change.

## Test plan

- [x] Gift member → "Continue subscription" → complete Stripe checkout (`4242 4242 4242 4242`) → "Your account is fully activated…" toast appears
- [x] Cancel from Stripe → existing cancel toast still works
- [x] Regular non-gift paid upgrade → regression check