### PR TITLE
Fixed gift preview redirect for invalid tokens

### DIFF
--- a/ghost/core/core/server/web/gift-preview/controller.js
+++ b/ghost/core/core/server/web/gift-preview/controller.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
 const {generateGiftPreviewImage} = require('./image');
 
 function getCadenceLabel(cadence, duration) {
@@ -32,6 +33,10 @@ async function giftPreview(req, res) {
 
     try {
         gift = await giftService.getByToken(token);
+
+        if (!gift) {
+            throw new errors.NotFoundError({message: `Gift not found for token`});
+        }
     } catch (err) {
         logging.warn(`Gift preview: failed to load required gift data, redirecting to homepage`, err);
 

--- a/ghost/core/test/unit/server/web/gift-preview/controller.test.js
+++ b/ghost/core/test/unit/server/web/gift-preview/controller.test.js
@@ -61,6 +61,18 @@ describe('Gift Preview Controller', function () {
             sinon.assert.calledWith(res.redirect, 302, 'https://example.com/');
         });
 
+        it('redirects to homepage when gift token is not found (null)', async function () {
+            sinon.stub(labs, 'isSet').withArgs('giftSubscriptions').returns(true);
+            giftServiceWrapper.service = {
+                getByToken: sinon.stub().resolves(null)
+            };
+
+            await controller.giftPreview(req, res);
+
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 302, 'https://example.com/');
+        });
+
         it('returns HTML with OG tags for a valid gift', async function () {
             sinon.stub(labs, 'isSet').withArgs('giftSubscriptions').returns(true);
             giftServiceWrapper.service = {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3524

- Visiting `/gift/<invalid-token>` (e.g. a stale share link or mistyped URL) crashed the request with: `ERROR Unhandled rejection: Cannot read properties of null (reading 'cadence')`
 - `giftService.getByToken` resolves with `null` for an unknown token rather than throwing, so the controller's existing `try/catch` did not cover the missing-gift case. The handler then dereferenced `gift.cadence` and produced a 500 for visitors hitting any non-resolving gift URL.

## Changes

- `ghost/core/core/server/web/gift-preview/controller.js` — when `getByToken` returns `null`, throw a `NotFoundError` inside the existing `try` block so the same `catch` (warn + 302 to homepage) handles both the throw and the not-found paths. No new branch, no duplicated redirect logic.
- `ghost/core/test/unit/server/web/gift-preview/controller.test.js` — added a regression test that mocks `getByToken` to resolve `null` and asserts the homepage redirect.

## Test plan

- [x] New unit test covers the `null` return path
- [x] `pnpm test:single test/unit/server/web/gift-preview/controller.test.js` from `ghost/core/`
- [x] Manual: `curl -i https://<host>/gift/abc` returns `302` to `/`, no unhandled rejection in logs
- [x] Valid gift tokens still render the OG preview HTML (existing tests cover this)