### PR TITLE
Improved newsletter messaging when access is set to nobody

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/enable-newsletters.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/enable-newsletters.tsx
@@ -35,8 +35,9 @@ const EnableNewsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const enableToggle = (
         <>
             <Toggle
-                checked={newslettersEnabled !== 'disabled'}
+                checked={newslettersEnabled !== 'disabled' && !isDisabled}
                 direction='rtl'
+                disabled={isDisabled}
                 onChange={handleToggleChange}
             />
         </>
@@ -55,22 +56,24 @@ const EnableNewsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
             values={[
                 {
                     key: 'private',
-                    value: (newslettersEnabled !== 'disabled') ? (<div className='w-full'>
+                    value: (newslettersEnabled !== 'disabled' && !isDisabled) ? (<div className='w-full'>
                         <div className='flex items-center gap-2'>
                             <Icon colorClass='text-green' name='check' size='sm' />
                             <span>Enabled</span>
                         </div>
-                        {isDisabled &&
-                        <Banner className='mt-6 text-sm' color='grey'>
-                            Your <button className='underline!' type="button" onClick={() => {
-                                updateRoute('members');
-                            }}>Subscription access</button> is set to &lsquo;Nobody&rsquo;, only existing members will receive newsletters.
-                        </Banner>
-                        }
                     </div>) :
-                        <div className='flex items-center gap-2 text-grey-900'>
-                            <Icon colorClass='text-grey-600' name='mail-block' size='sm' />
-                            <span>Disabled</span>
+                        <div className='w-full'>
+                            <div className='flex items-center gap-2 text-grey-900'>
+                                <Icon colorClass='text-grey-600' name='mail-block' size='sm' />
+                                <span>Disabled</span>
+                            </div>
+                            {isDisabled &&
+                            <Banner className='mt-6 text-sm' color='grey'>
+                                Your <button className='underline!' type="button" onClick={() => {
+                                    updateRoute('members');
+                                }}>Subscription access</button> is set to &lsquo;Nobody&rsquo;, which disables all newsletter sending. Change to &lsquo;Invite-only&rsquo; to send newsletters to existing members without allowing new signups.
+                            </Banner>
+                            }
                         </div>
                 }
             ]}

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -127,7 +127,7 @@ test.describe('Access settings', async () => {
         await expect(section.getByTestId('subscription-access-select')).toContainText('Nobody');
 
         await expect(page.getByTestId('portal').getByRole('button', {name: 'Customize'})).toBeDisabled();
-        await expect(page.getByTestId('enable-newsletters')).toContainText('only existing members will receive newsletters');
+        await expect(page.getByTestId('enable-newsletters')).toContainText('which disables all newsletter sending');
     });
 
     test('Supports selecting specific tiers', async ({page}) => {


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1166/support-escalation-re-email-needs-verification

Previously we would imply that newsletter sending was still possible when access was set to Nobody. Access = Nobody disables newsletter sending. The messaging has been updated to reflect that. The disabled state has also been improved.

| Before | After |
|--------|--------|
| <img width="714" height="353" alt="Screenshot 2026-05-01 at 12 53 36" src="https://github.com/user-attachments/assets/8e5cb169-53d1-4f29-a9b2-76573678273a" /> | <img width="707" height="375" alt="Screenshot 2026-05-01 at 12 53 09" src="https://github.com/user-attachments/assets/77bd1013-fe0b-44f2-8baa-92da92c94a07" /> | 