### PR TITLE
Added price details for gift subscriptions in Members API

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-bookshelf-repository.ts
@@ -93,6 +93,29 @@ export class GiftBookshelfRepository implements GiftRepository {
         return model ? this.toGift(model) : null;
     }
 
+    async getActiveByMembers(memberIds: string[], options: RepositoryTransactionOptions = {}): Promise<Map<string, Gift>> {
+        const map = new Map<string, Gift>();
+
+        if (memberIds.length === 0) {
+            return map;
+        }
+
+        const idList = memberIds.map(id => `'${id}'`).join(',');
+        const collection = await this.model.findAll({
+            filter: `redeemer_member_id:[${idList}]+status:redeemed`,
+            ...options
+        });
+
+        for (const model of collection.models) {
+            const gift = this.toGift(model);
+            if (gift.redeemerMemberId) {
+                map.set(gift.redeemerMemberId, gift);
+            }
+        }
+
+        return map;
+    }
+
     async findPendingConsumption(): Promise<Gift[]> {
         const now = new Date();
 

--- a/ghost/core/core/server/services/gifts/gift-repository.ts
+++ b/ghost/core/core/server/services/gifts/gift-repository.ts
@@ -21,6 +21,7 @@ export interface GiftRepository {
     findPendingExpiration(): Promise<Gift[]>;
     findPendingReminder(options: FindPendingReminderOptions): Promise<Gift[]>;
     getActiveByMember(memberId: string, options?: RepositoryTransactionOptions): Promise<Gift | null>;
+    getActiveByMembers(memberIds: string[], options?: RepositoryTransactionOptions): Promise<Map<string, Gift>>;
     create(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     update(gift: Gift, options?: RepositoryTransactionOptions): Promise<void>;
     transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;

--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -368,6 +368,13 @@ export class GiftService {
         return this.deps.giftRepository.getActiveByMember(memberId, options);
     }
 
+    async getActiveByMembers(memberIds: string[], options: {transacting?: unknown} = {}): Promise<Map<string, Gift>> {
+        if (!memberIds || memberIds.length === 0) {
+            return new Map();
+        }
+        return this.deps.giftRepository.getActiveByMembers(memberIds, options);
+    }
+
     getRemainingActiveDays(gift: Gift, now: Date = new Date()): number {
         if (!gift.isRedeemed() || !gift.consumesAt || gift.isConsumed()) {
             return 0;

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -164,7 +164,8 @@ module.exports = function MembersAPI({
         emailSuppressionList,
         settingsHelpers,
         nextPaymentCalculator,
-        commentsService
+        commentsService,
+        giftService
     });
 
     const geolocationService = new GeolocationService();

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -28,6 +28,11 @@ const messages = {
  * @typedef {import('@tryghost/members-offers/lib/application/OfferMapper').OfferDTO} OfferDTO
  */
 
+/**
+ * @typedef {object} IGiftServiceWrapper
+ * @prop {{getActiveByMembers: (memberIds: string[]) => Promise<Map<string, {cadence: 'month' | 'year', currency: string, amount: number}>>}} service
+ */
+
 module.exports = class MemberBREADService {
     /**
      * @param {object} deps
@@ -40,8 +45,9 @@ module.exports = class MemberBREADService {
      * @param {import('@tryghost/email-suppression-list/lib/email-suppression-list').IEmailSuppressionList} deps.emailSuppressionList
      * @param {import('@tryghost/settings-helpers')} deps.settingsHelpers
      * @param {import('./next-payment-calculator')} deps.nextPaymentCalculator
+     * @param {IGiftServiceWrapper} deps.giftService
      */
-    constructor({memberRepository, labsService, emailService, stripeService, offersAPI, memberAttributionService, emailSuppressionList, settingsHelpers, nextPaymentCalculator, commentsService}) {
+    constructor({memberRepository, labsService, emailService, stripeService, offersAPI, memberAttributionService, emailSuppressionList, settingsHelpers, nextPaymentCalculator, commentsService, giftService}) {
         this.offersAPI = offersAPI;
         /** @private */
         this.memberRepository = memberRepository;
@@ -61,13 +67,17 @@ module.exports = class MemberBREADService {
         this.nextPaymentCalculator = nextPaymentCalculator;
         /** @private */
         this.commentsService = commentsService;
+        /** @private */
+        this.giftService = giftService;
     }
 
     /**
      * @private
      * Adds missing complimentary subscriptions to a member and makes sure the tier of all subscriptions is set correctly.
+     * @param {Object} member JSON serialized member
+     * @param {Map<string, {cadence: 'month' | 'year', currency: string, amount: number}>} [giftMap] Map of memberId → active redeemed gift, used to populate real price details on synthetic gift subscriptions
      */
-    attachSubscriptionsToMember(member) {
+    attachSubscriptionsToMember(member, giftMap = new Map()) {
         if (!member.products || !Array.isArray(member.products)) {
             return member;
         }
@@ -87,6 +97,22 @@ module.exports = class MemberBREADService {
         // Note: a complimentary or gift subscription should always be the current member subscription and match its status,
         // as non-Stripe subscriptions are removed when a member continues with a Stripe paid subscription
         if (member.status === 'comped' || member.status === 'gift') {
+            let interval = 'year';
+            let currency = 'USD';
+            let amount = 0;
+            const nickname = member.status === 'gift' ? 'Gift subscription' : 'Complimentary';
+
+            if (member.status === 'gift') {
+                const gift = giftMap.get(member.id);
+                if (gift) {
+                    interval = gift.cadence;
+                    currency = gift.currency;
+                    amount = gift.amount;
+                } else {
+                    logging.warn(`No active gift found for gift member ${member.id} — falling back to default subscription price details.`);
+                }
+            }
+
             for (const product of member.products) {
                 if (!subscriptionProducts.includes(product.id)) {
                     const productAddEvent = member.productEvents.find(event => event.product_id === product.id && event.action === 'added');
@@ -96,8 +122,6 @@ module.exports = class MemberBREADService {
                     } else {
                         startDate = moment(productAddEvent.created_at);
                     }
-
-                    const nickname = member.status === 'gift' ? 'Gift subscription' : 'Complimentary';
 
                     member.subscriptions.push({
                         id: '',
@@ -110,9 +134,9 @@ module.exports = class MemberBREADService {
                         plan: {
                             id: '',
                             nickname,
-                            interval: 'year',
-                            currency: 'USD',
-                            amount: 0
+                            interval,
+                            currency,
+                            amount
                         },
                         status: 'active',
                         start_date: startDate,
@@ -124,10 +148,10 @@ module.exports = class MemberBREADService {
                             id: '',
                             price_id: '',
                             nickname,
-                            amount: 0,
-                            interval: 'year',
+                            amount,
+                            interval,
                             type: 'recurring',
-                            currency: 'USD',
+                            currency,
                             product: {
                                 id: '',
                                 product_id: product.id
@@ -283,6 +307,30 @@ module.exports = class MemberBREADService {
         }
     }
 
+    /**
+     * @private
+     * Fetches active redeemed gifts for any gift-status members in the input list.
+     * @param {import('bookshelf').Model[]} members - Bookshelf member models
+     * @returns {Promise<Map<string, {cadence: 'month' | 'year', currency: string, amount: number}>>} keyed by member.id → active Gift
+     */
+    async fetchActiveGiftsForMembers(members) {
+        const giftMemberIds = members
+            .filter(m => m.get('status') === 'gift')
+            .map(m => m.id);
+
+        if (giftMemberIds.length === 0) {
+            return new Map();
+        }
+
+        try {
+            return await this.giftService.service.getActiveByMembers(giftMemberIds);
+        } catch (e) {
+            logging.error(`Failed to load active gifts for members - ${giftMemberIds.join(', ')}.`);
+            logging.error(e);
+            return new Map();
+        }
+    }
+
     async read(data, options = {}) {
         const defaultWithRelated = [
             'labels',
@@ -324,12 +372,13 @@ module.exports = class MemberBREADService {
         const stripeSubscriptions = model.related('stripeSubscriptions');
 
         member.subscriptions = member.subscriptions.filter(sub => !!sub.price);
-        this.attachSubscriptionsToMember(member);
 
-        const [offerMap, offerRedemptionsMap] = await Promise.all([
+        const [offerMap, offerRedemptionsMap, giftMap] = await Promise.all([
             this.fetchSubscriptionOffers(stripeSubscriptions),
-            this.fetchSubscriptionOfferRedemptions(stripeSubscriptions)
+            this.fetchSubscriptionOfferRedemptions(stripeSubscriptions),
+            this.fetchActiveGiftsForMembers([model])
         ]);
+        this.attachSubscriptionsToMember(member, giftMap);
         this.attachOffersToSubscriptions(member, offerMap, offerRedemptionsMap);
         this.attachNextPaymentToSubscriptions(member);
         await this.attachAttributionsToMember(member, subscriptionIdMap);
@@ -578,9 +627,10 @@ module.exports = class MemberBREADService {
         }
 
         const subscriptions = page.data.flatMap(model => model.related('stripeSubscriptions').slice());
-        const [offerMap, offerRedemptionsMap] = await Promise.all([
+        const [offerMap, offerRedemptionsMap, giftMap] = await Promise.all([
             this.fetchSubscriptionOffers(subscriptions),
-            this.fetchSubscriptionOfferRedemptions(subscriptions)
+            this.fetchSubscriptionOfferRedemptions(subscriptions),
+            this.fetchActiveGiftsForMembers(page.data)
         ]);
 
         const bulkSuppressionData = await this.emailSuppressionList.getBulkSuppressionData(page.data.map(member => member.get('email')));
@@ -588,7 +638,7 @@ module.exports = class MemberBREADService {
         const data = page.data.map((model, index) => {
             const member = model.toJSON(options);
             member.subscriptions = member.subscriptions.filter(sub => !!sub.price);
-            this.attachSubscriptionsToMember(member);
+            this.attachSubscriptionsToMember(member, giftMap);
             this.attachOffersToSubscriptions(member, offerMap, offerRedemptionsMap);
             this.attachNextPaymentToSubscriptions(member);
             if (!originalWithRelated.includes('products')) {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -14,6 +14,7 @@ const testUtils = require('../../utils');
 const Papa = require('papaparse');
 
 const models = require('../../../core/server/models');
+const {knex} = require('../../../core/server/data/db');
 const membersService = require('../../../core/server/services/members');
 const memberAttributionService = require('../../../core/server/services/member-attribution');
 const urlService = require('../../../core/server/services/url');
@@ -904,6 +905,85 @@ describe('Members API', function () {
                 'content-version': anyContentVersion,
                 etag: anyEtag
             });
+    });
+
+    it('Can read a member with an active gift subscription', async function () {
+        const member = await createGiftMember({email: 'gift-member-api-shape@test.com'});
+        const paidProduct = await getPaidProduct();
+        let gift;
+
+        try {
+            await models.Member.edit({
+                products: [{id: paidProduct.id}]
+            }, {id: member.id});
+
+            const giftAmount = 1500;
+            const giftCurrency = 'eur';
+            const giftCadence = 'month';
+
+            gift = await models.Gift.add({
+                token: `gift-admin-shape-${member.id}`,
+                buyer_email: 'gift-buyer@test.com',
+                buyer_member_id: null,
+                redeemer_member_id: member.id,
+                tier_id: paidProduct.id,
+                cadence: giftCadence,
+                duration: 1,
+                currency: giftCurrency,
+                amount: giftAmount,
+                stripe_checkout_session_id: `cs_admin_shape_${member.id}`,
+                stripe_payment_intent_id: `pi_admin_shape_${member.id}`,
+                consumes_at: new Date('2099-01-01T00:00:00.000Z'),
+                expires_at: new Date('2099-01-01T00:00:00.000Z'),
+                status: 'redeemed',
+                purchased_at: new Date(),
+                redeemed_at: new Date(),
+                consumed_at: null,
+                expired_at: null,
+                refunded_at: null
+            });
+
+            const {body: readBody} = await agent
+                .get(`/members/${member.id}/`)
+                .expectStatus(200);
+
+            assert.equal(readBody.members[0].status, 'gift');
+            assert.equal(readBody.members[0].subscriptions.length, 1, 'Gift member should expose a single synthetic subscription');
+
+            const readSub = readBody.members[0].subscriptions[0];
+            assert.equal(readSub.plan.nickname, 'Gift subscription');
+            assert.equal(readSub.price.nickname, 'Gift subscription');
+            assert.equal(readSub.plan.amount, giftAmount);
+            assert.equal(readSub.plan.currency, giftCurrency);
+            assert.equal(readSub.plan.interval, giftCadence);
+            assert.equal(readSub.price.amount, giftAmount);
+            assert.equal(readSub.price.currency, giftCurrency);
+            assert.equal(readSub.price.interval, giftCadence);
+
+            const {body: browseBody} = await agent
+                .get(`/members/?filter=${encodeURIComponent(`id:${member.id}`)}`)
+                .expectStatus(200);
+
+            const browsedMember = browseBody.members.find(m => m.id === member.id);
+            assert.ok(browsedMember, 'Gift member should appear in the browse response');
+
+            const browseSub = browsedMember.subscriptions[0];
+            assert.equal(browseSub.plan.nickname, 'Gift subscription');
+            assert.equal(browseSub.price.nickname, 'Gift subscription');
+            assert.equal(browseSub.plan.amount, giftAmount);
+            assert.equal(browseSub.plan.currency, giftCurrency);
+            assert.equal(browseSub.plan.interval, giftCadence);
+            assert.equal(browseSub.price.amount, giftAmount);
+            assert.equal(browseSub.price.currency, giftCurrency);
+            assert.equal(browseSub.price.interval, giftCadence);
+        } finally {
+            // Avoid leaking this fixture into later tests that count members.
+            // Gift.destroy is blocked by the model — fall back to a raw delete.
+            if (gift) {
+                await knex('gifts').where({id: gift.id}).del();
+            }
+            await models.Member.destroy({id: member.id});
+        }
     });
 
     // Create a member

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -634,32 +634,6 @@ describe('Gift Subscriptions', function () {
                 assert.ok(gift.get('redeemed_at'));
                 assert.ok(gift.get('consumes_at'));
 
-                const memberResponse = await agent
-                    .get('/api/member/')
-                    .expectStatus(200);
-
-                assert.equal(memberResponse.body.status, 'gift');
-                assert.equal(
-                    memberResponse.body.subscriptions.length,
-                    1,
-                    'Gift members should receive a synthetic gift subscription in the member API'
-                );
-                assert.equal(
-                    memberResponse.body.subscriptions[0].tier.id,
-                    paidProduct.id,
-                    'The gift subscription should point at the redeemed tier'
-                );
-                assert.equal(
-                    memberResponse.body.subscriptions[0].plan.nickname,
-                    'Gift subscription',
-                    'The synthetic subscription plan should be marked as a gift'
-                );
-                assert.equal(
-                    memberResponse.body.subscriptions[0].price.nickname,
-                    'Gift subscription',
-                    'The synthetic subscription price should be marked as a gift'
-                );
-
                 // Verify staff notification email was sent
                 mockManager.assert.sentEmail({
                     subject: /paid subscription started/i,
@@ -1171,6 +1145,51 @@ describe('Gift Subscriptions', function () {
                     }
                 })
                 .expectStatus(403);
+        });
+    });
+
+    describe('Read a member with an active gift subscription', function () {
+        it('returns gift price details and correct nickname on the member subscription', async function () {
+            const agent = membersAgent.duplicate();
+            const email = `gift-api-shape-${giftSequence + 1}@example.com`;
+
+            await agent.loginAs(email);
+
+            const member = await models.Member.findOne({email}, {require: true});
+            const consumesAt = addYears(new Date('2026-04-07T10:00:00.000Z'), 1);
+
+            const gift = await createGift({
+                cadence: 'month',
+                duration: 1,
+                currency: 'eur',
+                amount: 1500,
+                redeemer_member_id: member.id,
+                redeemed_at: new Date('2026-04-07T10:00:00.000Z'),
+                consumes_at: consumesAt,
+                status: 'redeemed'
+            });
+
+            await models.Member.edit({
+                status: 'gift',
+                products: [{id: paidProduct.id}]
+            }, {id: member.id});
+
+            const {body} = await agent
+                .get('/api/member/')
+                .expectStatus(200);
+
+            assert.equal(body.status, 'gift');
+            assert.equal(body.subscriptions.length, 1, 'Gift members should receive a single synthetic subscription');
+
+            const subscription = body.subscriptions[0];
+            assert.equal(subscription.plan.nickname, 'Gift subscription');
+            assert.equal(subscription.price.nickname, 'Gift subscription');
+            assert.equal(subscription.plan.amount, gift.get('amount'));
+            assert.equal(subscription.plan.currency, gift.get('currency'));
+            assert.equal(subscription.plan.interval, gift.get('cadence'));
+            assert.equal(subscription.price.amount, gift.get('amount'));
+            assert.equal(subscription.price.currency, gift.get('currency'));
+            assert.equal(subscription.price.interval, gift.get('cadence'));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-bookshelf-repository.test.ts
@@ -612,4 +612,121 @@ describe('GiftBookshelfRepository', function () {
             assert.equal(gift, null);
         });
     });
+
+    describe('getActiveByMembers', function () {
+        function buildGiftRow(overrides: Record<string, unknown> = {}) {
+            return {
+                token: 'gift-token',
+                buyer_email: 'buyer@example.com',
+                buyer_member_id: 'buyer_member_1',
+                redeemer_member_id: 'member_2',
+                tier_id: 'tier_1',
+                cadence: 'year',
+                duration: 1,
+                currency: 'usd',
+                amount: 5000,
+                stripe_checkout_session_id: 'cs_123',
+                stripe_payment_intent_id: 'pi_456',
+                consumes_at: new Date('2027-01-01T00:00:00.000Z'),
+                expires_at: new Date('2030-01-01T00:00:00.000Z'),
+                status: 'redeemed',
+                purchased_at: new Date('2026-01-01T00:00:00.000Z'),
+                redeemed_at: new Date('2026-06-01T00:00:00.000Z'),
+                consumed_at: null,
+                expired_at: null,
+                refunded_at: null,
+                ...overrides
+            };
+        }
+
+        it('returns an empty map without hitting the model when memberIds is empty', async function () {
+            const GiftModel = {
+                add: sinon.stub(),
+                transaction: sinon.stub(),
+                findOne: sinon.stub(),
+                findAll: sinon.stub()
+            };
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const result = await repository.getActiveByMembers([]);
+
+            assert.equal(result.size, 0);
+            sinon.assert.notCalled(GiftModel.findAll);
+        });
+
+        it('queries with an NQL filter for redeemed status and the supplied member ids', async function () {
+            const GiftModel = {
+                add: sinon.stub(),
+                transaction: sinon.stub(),
+                findOne: sinon.stub(),
+                findAll: sinon.stub().resolves({models: []})
+            };
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            await repository.getActiveByMembers(['member_1', 'member_2']);
+
+            sinon.assert.calledOnce(GiftModel.findAll);
+            const callArg = GiftModel.findAll.firstCall.args[0];
+            assert.equal(
+                callArg.filter,
+                `redeemer_member_id:['member_1','member_2']+status:redeemed`
+            );
+        });
+
+        it('keys returned gifts by their redeemer_member_id', async function () {
+            const GiftModel = {
+                add: sinon.stub(),
+                transaction: sinon.stub(),
+                findOne: sinon.stub(),
+                findAll: sinon.stub().resolves({
+                    models: [
+                        {toJSON: () => buildGiftRow({token: 'token-a', redeemer_member_id: 'member_1'})},
+                        {toJSON: () => buildGiftRow({token: 'token-b', redeemer_member_id: 'member_2'})}
+                    ]
+                })
+            };
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const result = await repository.getActiveByMembers(['member_1', 'member_2']);
+
+            assert.equal(result.size, 2);
+            assert.equal(result.get('member_1')?.token, 'token-a');
+            assert.equal(result.get('member_2')?.token, 'token-b');
+        });
+
+        it('skips rows without a redeemer_member_id', async function () {
+            const GiftModel = {
+                add: sinon.stub(),
+                transaction: sinon.stub(),
+                findOne: sinon.stub(),
+                findAll: sinon.stub().resolves({
+                    models: [
+                        {toJSON: () => buildGiftRow({token: 'token-a', redeemer_member_id: 'member_1'})},
+                        {toJSON: () => buildGiftRow({token: 'token-orphan', redeemer_member_id: null})}
+                    ]
+                })
+            };
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            const result = await repository.getActiveByMembers(['member_1']);
+
+            assert.equal(result.size, 1);
+            assert.equal(result.get('member_1')?.token, 'token-a');
+        });
+
+        it('forwards transacting options to the model', async function () {
+            const GiftModel = {
+                add: sinon.stub(),
+                transaction: sinon.stub(),
+                findOne: sinon.stub(),
+                findAll: sinon.stub().resolves({models: []})
+            };
+            const repository = new GiftBookshelfRepository({GiftModel});
+
+            await repository.getActiveByMembers(['member_1'], {transacting: 'trx'});
+
+            const callArg = GiftModel.findAll.firstCall.args[0];
+            assert.equal(callArg.transacting, 'trx');
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -34,6 +34,7 @@ describe('GiftService', function () {
         getByToken: sinon.SinonStub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>;
         getByPaymentIntentId: sinon.SinonStub<[string], Promise<Gift | null>>;
         getActiveByMember: sinon.SinonStub<Parameters<GiftRepository['getActiveByMember']>, ReturnType<GiftRepository['getActiveByMember']>>;
+        getActiveByMembers: sinon.SinonStub<Parameters<GiftRepository['getActiveByMembers']>, ReturnType<GiftRepository['getActiveByMembers']>>;
         findPendingConsumption: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingExpiration: sinon.SinonStub<[], Promise<Gift[]>>;
         findPendingReminder: sinon.SinonStub<[FindPendingReminderOptions], Promise<Gift[]>>;
@@ -80,6 +81,7 @@ describe('GiftService', function () {
             getByToken: sinon.stub<Parameters<GiftRepository['getByToken']>, ReturnType<GiftRepository['getByToken']>>().resolves(null),
             getByPaymentIntentId: sinon.stub<[string], Promise<Gift | null>>().resolves(null),
             getActiveByMember: sinon.stub<Parameters<GiftRepository['getActiveByMember']>, ReturnType<GiftRepository['getActiveByMember']>>().resolves(null),
+            getActiveByMembers: sinon.stub<Parameters<GiftRepository['getActiveByMembers']>, ReturnType<GiftRepository['getActiveByMembers']>>().resolves(new Map()),
             findPendingConsumption: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingExpiration: sinon.stub<[], Promise<Gift[]>>().resolves([]),
             findPendingReminder: sinon.stub<[FindPendingReminderOptions], Promise<Gift[]>>().resolves([]),
@@ -1621,6 +1623,41 @@ describe('GiftService', function () {
 
             assert.equal(result, null);
             sinon.assert.notCalled(giftRepository.getActiveByMember);
+        });
+    });
+
+    describe('getActiveByMembers', function () {
+        it('returns the redeemed gifts keyed by member id', async function () {
+            const giftA = buildRedeemedGift({redeemerMemberId: 'member_1', token: 'gift-token-a'});
+            const giftB = buildRedeemedGift({redeemerMemberId: 'member_2', token: 'gift-token-b'});
+            const repoMap = new Map([
+                ['member_1', giftA],
+                ['member_2', giftB]
+            ]);
+
+            giftRepository.getActiveByMembers.resolves(repoMap);
+
+            const service = createService();
+            const result = await service.getActiveByMembers(['member_1', 'member_2']);
+
+            assert.equal(result, repoMap);
+            sinon.assert.calledOnceWithExactly(giftRepository.getActiveByMembers, ['member_1', 'member_2'], {});
+        });
+
+        it('returns an empty map without hitting the repository when memberIds is empty', async function () {
+            const service = createService();
+            const result = await service.getActiveByMembers([]);
+
+            assert.equal(result.size, 0);
+            sinon.assert.notCalled(giftRepository.getActiveByMembers);
+        });
+
+        it('returns an empty map without hitting the repository when memberIds is null/undefined', async function () {
+            const service = createService();
+            const result = await service.getActiveByMembers(null as unknown as string[]);
+
+            assert.equal(result.size, 0);
+            sinon.assert.notCalled(giftRepository.getActiveByMembers);
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -296,6 +296,12 @@ describe('MemberBreadService', function () {
             getRedeemedOfferIdsForSubscriptions: sinon.stub().resolves([])
         };
 
+        const defaultGiftService = {
+            service: {
+                getActiveByMembers: sinon.stub().resolves(new Map())
+            }
+        };
+
         const getService = (options = {}) => {
             return new MemberBreadService({
                 settingsHelpers: {
@@ -305,7 +311,8 @@ describe('MemberBreadService', function () {
                 memberAttributionService: memberAttributionServiceStub,
                 emailSuppressionList: emailSuppressionListStub,
                 nextPaymentCalculator: options.nextPaymentCalculator || nextPaymentCalculator,
-                offersAPI: options.offersAPI || defaultOffersAPI
+                offersAPI: options.offersAPI || defaultOffersAPI,
+                giftService: options.giftService || defaultGiftService
             });
         };
 
@@ -637,12 +644,24 @@ describe('MemberBreadService', function () {
                 productEvents: productEventsJSON
             });
 
+            memberModelStub.status = 'gift';
+
             memberRepositoryStub.isActiveSubscriptionStatus = sinon.stub().returns(true);
 
-            const memberBreadService = getService();
+            const giftServiceStub = {
+                service: {
+                    getActiveByMembers: sinon.stub().resolves(new Map([
+                        [MEMBER_ID, {cadence: 'month', currency: 'eur', amount: 1500}]
+                    ]))
+                }
+            };
+
+            const memberBreadService = getService({giftService: giftServiceStub});
             const member = await memberBreadService.read({id: MEMBER_ID});
 
             assert.equal(member.subscriptions.length, 1);
+
+            sinon.assert.calledOnceWithExactly(giftServiceStub.service.getActiveByMembers, [MEMBER_ID]);
 
             sinon.assert.match(member.subscriptions[0], {
                 id: '',
@@ -655,9 +674,9 @@ describe('MemberBreadService', function () {
                 plan: {
                     id: '',
                     nickname: 'Gift subscription',
-                    interval: 'year',
-                    currency: 'USD',
-                    amount: 0
+                    interval: 'month',
+                    currency: 'eur',
+                    amount: 1500
                 },
                 status: 'active',
                 start_date: moment(productEventsJSON[0].created_at),
@@ -669,16 +688,37 @@ describe('MemberBreadService', function () {
                     id: '',
                     price_id: '',
                     nickname: 'Gift subscription',
-                    amount: 0,
-                    interval: 'year',
+                    amount: 1500,
+                    interval: 'month',
                     type: 'recurring',
-                    currency: 'USD',
+                    currency: 'eur',
                     product: {
                         id: '',
                         product_id: productsJSON[0].id
                     }
                 }
             });
+        });
+
+        it('does not call giftService for non-gift members', async function () {
+            memberModelStub.toJSON.returns({
+                ...memberModelJSON,
+                status: 'free',
+                subscriptions: [],
+                products: [],
+                productEvents: []
+            });
+
+            const giftServiceStub = {
+                service: {
+                    getActiveByMembers: sinon.stub().resolves(new Map())
+                }
+            };
+
+            const memberBreadService = getService({giftService: giftServiceStub});
+            await memberBreadService.read({id: MEMBER_ID});
+
+            sinon.assert.notCalled(giftServiceStub.service.getActiveByMembers);
         });
 
         it('returns a member with attribution data', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3576

- attachSubscriptionsToMember was hardcoding amount: 0, currency: 'USD', and interval: 'year' on the synthetic subscription returned for gift-status members, even though the gift row already stores the real cadence/currency/amount
- now hydrates the synthetic subscription with the values from the gift, via a new bulk getActiveByMembers lookup on the gift repository to keep browse() to a single query
- complimentary subscriptions keep the existing hardcoded shape; gift-status members with no active redeemed gift fall back to the defaults with a warning so the read/browse paths stay robust




## Changes

**Gift repository — new bulk lookup**
- `GiftRepository.getActiveByMembers(memberIds[])` returns a `Map<memberId, Gift>` of redeemed gifts, in a single NQL query
- Implemented on `GiftBookshelfRepository`; thin pass-through on `GiftService`
- Existing `getActiveByMember` (single) is kept — still used by the redemption flow

**MemberBREADService**
- Added `giftService` as a constructor dep (passed through from `members-api.js`, matching the `commentsService` wrapper pattern)
- New `fetchActiveGiftsForMembers(members)` helper runs alongside existing offer fetches in the `Promise.all` blocks of `read()` and `browse()` — one bulk query per request, gated to gift-status members only (no cost when a page has zero gift members)
- `attachSubscriptionsToMember(member, giftMap)` now reads `cadence` / `currency` / `amount` from the gift map for `status === 'gift'` members
- Falls back to the previous hardcoded values (`'year'` / `'USD'` / `0`) plus a `logging.warn` if a gift-status member has no active redeemed gift row, so the read/browse paths stay robust

**Unchanged behaviour**
- `'comped'` members keep their existing hardcoded `0` / `'USD'` / `'year'` shape (no gift row to read from)
- Currency casing for gift members reflects what's stored on the gift (lowercase, e.g. `'usd'`), matching Stripe's convention used elsewhere

## API shape

For a gift member, `subscriptions[0].plan` and `subscriptions[0].price` previously returned:
```json
{ "amount": 0, "currency": "USD", "interval": "year" }
```

After this PR they return the actual gift values, e.g.:
```
{ "amount": 5000, "currency": "usd", "interval": "year" }
```


## Test plan

- [x] Existing `member-bread-service` unit tests still pass (22 passing)
- [x] Existing gift unit tests still pass (`gift-email-service`, `gift-reminders`)
- [x] `pnpm lint:types` passes
- [x] Manual: redeem a gift via Portal in `pnpm dev`, then confirm `GET /ghost/api/admin/members/:id` returns the real gift `amount` / `currency` / `cadence` on `subscriptions[0].plan` and `subscriptions[0].price`
- [x] Manual: confirm a comped member still shows `0` / `USD` / `year`
- [x] Manual: confirm `GET /ghost/api/admin/members?filter=status:gift` returns the same shape for browse

