### PR TITLE
Added paid welcome email for gift member signups

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/constants.js
+++ b/ghost/core/core/server/services/member-welcome-emails/constants.js
@@ -7,6 +7,11 @@ const MEMBER_WELCOME_EMAIL_SLUGS = {
     paid: 'member-welcome-email-paid'
 };
 
+const MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES = {
+    free: ['free'],
+    paid: ['paid', 'gift']
+};
+
 const MEMBER_WELCOME_EMAIL_TAG = 'member-welcome-email';
 
 const MESSAGES = {
@@ -23,5 +28,6 @@ module.exports = {
     MEMBER_WELCOME_EMAIL_LOG_KEY,
     MEMBER_WELCOME_EMAIL_TAG,
     MEMBER_WELCOME_EMAIL_SLUGS,
+    MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES,
     MESSAGES
 };

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -382,26 +382,47 @@ module.exports = class MemberRepository {
         let member;
 
         const isFreeSignup = !stripeCustomer && memberData.status === 'free';
-        const shouldCheckFreeWelcomeEmail = WELCOME_EMAIL_SOURCES.includes(source) && isFreeSignup;
-        let isFreeWelcomeEmailActive = false;
-        let freeWelcomeAutomation = null;
-        let freeWelcomeEmail = null;
+        const isGiftSignup = !stripeCustomer && memberData.status === 'gift';
+        let welcomeEmailToEnqueue = null;
 
-        if (shouldCheckFreeWelcomeEmail && this._WelcomeEmailAutomation) {
-            freeWelcomeAutomation = await this._WelcomeEmailAutomation.findOne(
-                {slug: MEMBER_WELCOME_EMAIL_SLUGS.free},
-                {...options, withRelated: ['welcomeEmailAutomatedEmail']}
-            );
-            freeWelcomeEmail = freeWelcomeAutomation?.related('welcomeEmailAutomatedEmail');
-            isFreeWelcomeEmailActive = Boolean(
-                freeWelcomeAutomation &&
-                freeWelcomeEmail &&
-                freeWelcomeEmail.get('lexical') &&
-                freeWelcomeAutomation.get('status') === 'active'
-            );
+        if (this._WelcomeEmailAutomation && WELCOME_EMAIL_SOURCES.includes(source)) {
+            if (isFreeSignup) {
+                const freeWelcomeAutomation = await this._WelcomeEmailAutomation.findOne(
+                    {slug: MEMBER_WELCOME_EMAIL_SLUGS.free},
+                    {...options, withRelated: ['welcomeEmailAutomatedEmail']}
+                );
+                const freeWelcomeEmail = freeWelcomeAutomation?.related('welcomeEmailAutomatedEmail');
+                const isFreeWelcomeEmailActive = Boolean(
+                    freeWelcomeAutomation &&
+                    freeWelcomeEmail &&
+                    freeWelcomeEmail.get('lexical') &&
+                    freeWelcomeAutomation.get('status') === 'active'
+                );
+
+                if (isFreeWelcomeEmailActive) {
+                    welcomeEmailToEnqueue = {automation: freeWelcomeAutomation, email: freeWelcomeEmail};
+                }
+            } else if (isGiftSignup) {
+                // As gift members get access to a paid tier, they receive the paid welcome email
+                const paidWelcomeAutomation = await this._WelcomeEmailAutomation.findOne(
+                    {slug: MEMBER_WELCOME_EMAIL_SLUGS.paid},
+                    {...options, withRelated: ['welcomeEmailAutomatedEmail']}
+                );
+                const paidWelcomeEmail = paidWelcomeAutomation?.related('welcomeEmailAutomatedEmail');
+                const isPaidWelcomeEmailActive = Boolean(
+                    paidWelcomeAutomation &&
+                    paidWelcomeEmail &&
+                    paidWelcomeEmail.get('lexical') &&
+                    paidWelcomeAutomation.get('status') === 'active'
+                );
+
+                if (isPaidWelcomeEmailActive) {
+                    welcomeEmailToEnqueue = {automation: paidWelcomeAutomation, email: paidWelcomeEmail};
+                }
+            }
         }
 
-        if (isFreeWelcomeEmailActive && isFreeSignup) {
+        if (welcomeEmailToEnqueue) {
             const runMemberCreation = async (transacting) => {
                 const newMember = await this._Member.add({
                     ...memberData,
@@ -409,9 +430,9 @@ module.exports = class MemberRepository {
                 }, {...memberAddOptions, transacting});
 
                 await this._WelcomeEmailAutomationRun.add({
-                    welcome_email_automation_id: freeWelcomeAutomation.id,
+                    welcome_email_automation_id: welcomeEmailToEnqueue.automation.id,
                     member_id: newMember.id,
-                    next_welcome_email_automated_email_id: freeWelcomeEmail.id,
+                    next_welcome_email_automated_email_id: welcomeEmailToEnqueue.email.id,
                     ready_at: new Date(),
                     step_started_at: null,
                     step_attempts: 0,
@@ -1527,7 +1548,8 @@ module.exports = class MemberRepository {
             // Send paid welcome email if:
             // 1. The paid welcome email is active
             // 2. The member status changed to 'paid'
-            if (updatedMember.get('status') === 'paid' && isPaidWelcomeEmailActive) {
+            // 3. The previous status wasn't 'gift', as gift members already received the paid welcome email on signup
+            if (updatedMember.get('status') === 'paid' && updatedMember._previousAttributes.status !== 'gift' && isPaidWelcomeEmailActive) {
                 await this._WelcomeEmailAutomationRun.add({
                     welcome_email_automation_id: paidWelcomeAutomation.id,
                     member_id: memberModel.id,

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -386,39 +386,27 @@ module.exports = class MemberRepository {
         let welcomeEmailToEnqueue = null;
 
         if (this._WelcomeEmailAutomation && WELCOME_EMAIL_SOURCES.includes(source)) {
-            if (isFreeSignup) {
-                const freeWelcomeAutomation = await this._WelcomeEmailAutomation.findOne(
-                    {slug: MEMBER_WELCOME_EMAIL_SLUGS.free},
+            const getActiveWelcomeEmailToEnqueue = async (slug) => {
+                const automation = await this._WelcomeEmailAutomation.findOne(
+                    {slug},
                     {...options, withRelated: ['welcomeEmailAutomatedEmail']}
                 );
-                const freeWelcomeEmail = freeWelcomeAutomation?.related('welcomeEmailAutomatedEmail');
-                const isFreeWelcomeEmailActive = Boolean(
-                    freeWelcomeAutomation &&
-                    freeWelcomeEmail &&
-                    freeWelcomeEmail.get('lexical') &&
-                    freeWelcomeAutomation.get('status') === 'active'
+                const email = automation?.related('welcomeEmailAutomatedEmail');
+                const isActive = Boolean(
+                    automation &&
+                    email &&
+                    email.get('lexical') &&
+                    automation.get('status') === 'active'
                 );
 
-                if (isFreeWelcomeEmailActive) {
-                    welcomeEmailToEnqueue = {automation: freeWelcomeAutomation, email: freeWelcomeEmail};
-                }
+                return isActive ? {automation, email} : null;
+            };
+
+            if (isFreeSignup) {
+                welcomeEmailToEnqueue = await getActiveWelcomeEmailToEnqueue(MEMBER_WELCOME_EMAIL_SLUGS.free);
             } else if (isGiftSignup) {
                 // As gift members get access to a paid tier, they receive the paid welcome email
-                const paidWelcomeAutomation = await this._WelcomeEmailAutomation.findOne(
-                    {slug: MEMBER_WELCOME_EMAIL_SLUGS.paid},
-                    {...options, withRelated: ['welcomeEmailAutomatedEmail']}
-                );
-                const paidWelcomeEmail = paidWelcomeAutomation?.related('welcomeEmailAutomatedEmail');
-                const isPaidWelcomeEmailActive = Boolean(
-                    paidWelcomeAutomation &&
-                    paidWelcomeEmail &&
-                    paidWelcomeEmail.get('lexical') &&
-                    paidWelcomeAutomation.get('status') === 'active'
-                );
-
-                if (isPaidWelcomeEmailActive) {
-                    welcomeEmailToEnqueue = {automation: paidWelcomeAutomation, email: paidWelcomeEmail};
-                }
+                welcomeEmailToEnqueue = await getActiveWelcomeEmailToEnqueue(MEMBER_WELCOME_EMAIL_SLUGS.paid);
             }
         }
 

--- a/ghost/core/core/server/services/welcome-email-automations/poll.js
+++ b/ghost/core/core/server/services/welcome-email-automations/poll.js
@@ -1,6 +1,6 @@
 const logging = require('@tryghost/logging');
 const db = require('../../data/db');
-const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../member-welcome-emails/constants');
+const {MEMBER_WELCOME_EMAIL_SLUGS, MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES} = require('../member-welcome-emails/constants');
 const {AutomatedEmailRecipient, Member, WelcomeEmailAutomationRun} = require('../../models');
 /** @import {Knex} from 'knex' */
 
@@ -206,7 +206,8 @@ async function processRun({
 
         // TODO(NY-1193): Bail if member is unsubscribed
 
-        if (member.get('status') !== memberStatus) {
+        const eligibleStatuses = MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES[memberStatus];
+        if (!eligibleStatuses.includes(member.get('status'))) {
             await markExited(run.id, 'member changed status');
             return;
         }

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -750,26 +750,41 @@ describe('Gift Subscriptions', function () {
                     const existingMember = await models.Member.findOne({email}, {require: false});
                     assert.equal(existingMember, null, 'Member should not exist before magic link confirmation');
 
-                    // Set up an active free welcome email automation so the test would catch
-                    // any regression that re-introduces the spurious automation run for gift members
-                    const emailDesignSetting = await models.EmailDesignSetting.findOne(
-                        {slug: 'default-automated-email'},
-                        {require: true}
-                    );
-                    const welcomeEmailAutomation = await models.WelcomeEmailAutomation.add({
-                        name: 'Free welcome email',
-                        slug: 'member-welcome-email-free',
-                        status: 'active'
-                    });
-                    await models.WelcomeEmailAutomatedEmail.add({
-                        welcome_email_automation_id: welcomeEmailAutomation.id,
-                        delay_days: 0,
-                        subject: 'Welcome to the site!',
-                        lexical: JSON.stringify({root: {children: [{type: 'paragraph', children: [{text: 'Welcome'}]}]}}),
-                        email_design_setting_id: emailDesignSetting.id
-                    });
+                    let freeWelcomeAutomation;
+                    let paidWelcomeAutomation;
 
                     try {
+                        // Set up both free and paid welcome email automations to verify gift
+                        // redemption picks the paid welcome email (not the free one).
+                        const emailDesignSetting = await models.EmailDesignSetting.findOne(
+                            {slug: 'default-automated-email'},
+                            {require: true}
+                        );
+                        freeWelcomeAutomation = await models.WelcomeEmailAutomation.add({
+                            name: 'Free welcome email',
+                            slug: 'member-welcome-email-free',
+                            status: 'active'
+                        });
+                        await models.WelcomeEmailAutomatedEmail.add({
+                            welcome_email_automation_id: freeWelcomeAutomation.id,
+                            delay_days: 0,
+                            subject: 'Welcome to the site!',
+                            lexical: JSON.stringify({root: {children: [{type: 'paragraph', children: [{text: 'Welcome'}]}]}}),
+                            email_design_setting_id: emailDesignSetting.id
+                        });
+                        paidWelcomeAutomation = await models.WelcomeEmailAutomation.add({
+                            name: 'Paid welcome email',
+                            slug: 'member-welcome-email-paid',
+                            status: 'active'
+                        });
+                        await models.WelcomeEmailAutomatedEmail.add({
+                            welcome_email_automation_id: paidWelcomeAutomation.id,
+                            delay_days: 0,
+                            subject: 'Welcome to the paid tier!',
+                            lexical: JSON.stringify({root: {children: [{type: 'paragraph', children: [{text: 'Welcome paid'}]}]}}),
+                            email_design_setting_id: emailDesignSetting.id
+                        });
+
                         await models.Product.edit({
                             welcome_page_url: ''
                         }, {
@@ -805,11 +820,17 @@ describe('Gift Subscriptions', function () {
                         assert.ok(gift.get('redeemed_at'));
                         assert.ok(gift.get('consumes_at'));
 
-                        // Verify the free welcome automation did NOT enqueue a run for this gift member
+                        // Verify the paid welcome automation enqueued a run for this gift member
+                        // (and the free welcome automation did NOT — gift redemption is a paid-tier experience)
                         const welcomeRuns = await models.WelcomeEmailAutomationRun.findAll({
                             filter: `member_id:'${member.id}'`
                         });
-                        assert.equal(welcomeRuns.length, 0, 'Should not enqueue free welcome email automation for gift member');
+                        assert.equal(welcomeRuns.length, 1, 'Should enqueue exactly one welcome email automation run for gift member');
+                        assert.equal(
+                            welcomeRuns.models[0].get('welcome_email_automation_id'),
+                            paidWelcomeAutomation.id,
+                            'Should enqueue the paid welcome email automation, not the free one'
+                        );
 
                         // Verify gift subscription started staff notification was sent,
                         // and that no other unwanted staff notifications were sent (i.e. no "Free member signup" email)
@@ -830,7 +851,19 @@ describe('Gift Subscriptions', function () {
                         }, {
                             id: paidProduct.id
                         });
-                        await models.WelcomeEmailAutomation.destroy({id: welcomeEmailAutomation.id});
+
+                        for (const automation of [freeWelcomeAutomation, paidWelcomeAutomation]) {
+                            if (!automation) {
+                                continue;
+                            }
+                            const runs = await models.WelcomeEmailAutomationRun.findAll({
+                                filter: `welcome_email_automation_id:'${automation.id}'`
+                            });
+                            for (const run of runs.models) {
+                                await models.WelcomeEmailAutomationRun.destroy({id: run.id});
+                            }
+                            await models.WelcomeEmailAutomation.destroy({id: automation.id});
+                        }
                     }
                 });
             });
@@ -1066,6 +1099,69 @@ describe('Gift Subscriptions', function () {
             const giftAfterActivation = await models.Gift.findOne({token: gift.get('token')}, {require: true});
             assert.equal(giftAfterActivation.get('status'), 'consumed');
             assert.ok(giftAfterActivation.get('consumed_at'), 'Gift should have consumed_at set');
+        });
+
+        it('does not enqueue a second paid welcome email when a gift member upgrades to paid', async function () {
+            const {member, gift} = await setupGiftMember({cadence: 'month', consumesInDays: 30});
+
+            let paidWelcomeAutomation;
+
+            try {
+                const emailDesignSetting = await models.EmailDesignSetting.findOne(
+                    {slug: 'default-automated-email'},
+                    {require: true}
+                );
+                paidWelcomeAutomation = await models.WelcomeEmailAutomation.add({
+                    name: 'Paid welcome email',
+                    slug: 'member-welcome-email-paid',
+                    status: 'active'
+                });
+                await models.WelcomeEmailAutomatedEmail.add({
+                    welcome_email_automation_id: paidWelcomeAutomation.id,
+                    delay_days: 0,
+                    subject: 'Welcome to the paid tier!',
+                    lexical: JSON.stringify({root: {children: [{type: 'paragraph', children: [{text: 'Welcome paid'}]}]}}),
+                    email_design_setting_id: emailDesignSetting.id
+                });
+
+                const runsBefore = await models.WelcomeEmailAutomationRun.findAll({
+                    filter: `member_id:'${member.id}'`
+                });
+
+                const customer = stripeMocker.createCustomer({email: member.get('email')});
+                const price = await stripeMocker.getPriceForTier('default-product', 'month');
+
+                await stripeMocker.createSubscription({customer, price});
+                await DomainEvents.allSettled();
+
+                // Gift consumed, member upgraded to paid
+                const giftAfterActivation = await models.Gift.findOne({token: gift.get('token')}, {require: true});
+                assert.equal(giftAfterActivation.get('status'), 'consumed');
+
+                const memberAfterActivation = await models.Member.findOne({id: member.id}, {require: true});
+                assert.equal(memberAfterActivation.get('status'), 'paid');
+
+                // No new paid welcome run should have been enqueued — the gift redemption
+                // already onboarded this member with the paid welcome email.
+                const runsAfter = await models.WelcomeEmailAutomationRun.findAll({
+                    filter: `member_id:'${member.id}'`
+                });
+                assert.equal(
+                    runsAfter.length,
+                    runsBefore.length,
+                    'Should not enqueue a second paid welcome email on gift → paid transition'
+                );
+            } finally {
+                if (paidWelcomeAutomation) {
+                    const runs = await models.WelcomeEmailAutomationRun.findAll({
+                        filter: `welcome_email_automation_id:'${paidWelcomeAutomation.id}'`
+                    });
+                    for (const run of runs.models) {
+                        await models.WelcomeEmailAutomationRun.destroy({id: run.id});
+                    }
+                    await models.WelcomeEmailAutomation.destroy({id: paidWelcomeAutomation.id});
+                }
+            }
         });
 
         it('Returns 401 for unauthenticated members', async function () {

--- a/ghost/core/test/integration/services/welcome-email-automations/poll.test.js
+++ b/ghost/core/test/integration/services/welcome-email-automations/poll.test.js
@@ -496,6 +496,45 @@ describe('welcome email automations poll', function () {
         assert.equal(updatedRun.step_attempts, 0);
     });
 
+    it('allows the paid welcome email to be sent to a gift member', async function () {
+        const automation = await createAutomation({
+            slug: MEMBER_WELCOME_EMAIL_SLUGS.paid
+        });
+        const automatedEmail = await createAutomatedEmail({
+            welcome_email_automation_id: automation.id
+        });
+        const member = await createMember({
+            email: 'gift-member@example.com',
+            name: 'Gift Member',
+            status: 'gift'
+        });
+        const run = await createRun({
+            welcome_email_automation_id: automation.id,
+            member_id: member.id,
+            next_welcome_email_automated_email_id: automatedEmail.id,
+            ready_at: new Date(Date.now() - 1000)
+        });
+
+        await poll(options);
+
+        sinon.assert.calledWith(options.memberWelcomeEmailService.api.send, sinon.match({
+            member: {
+                name: 'Gift Member',
+                email: 'gift-member@example.com',
+                uuid: member.uuid
+            },
+            memberStatus: 'paid'
+        }));
+
+        const updatedRun = await readRun(run.id);
+        assert.equal(updatedRun.exit_reason, 'finished');
+        assert.equal(updatedRun.next_welcome_email_automated_email_id, null);
+
+        const recipients = await readTrackedRecipients();
+        assert.equal(recipients.length, 1);
+        assert.equal(recipients[0].member_email, 'gift-member@example.com');
+    });
+
     it('fails if run stored with more attempts than now supported', async function () {
         const automation = await createAutomation();
         const automatedEmail = await createAutomatedEmail({

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1538,7 +1538,7 @@ describe('MemberRepository', function () {
             process.env.NODE_ENV = oldNodeEnv;
         });
 
-        it('creates automation run for allowed source', async function () {
+        it('creates automation run for free member signup (free welcome email)', async function () {
             const repo = new MemberRepository({
                 Member,
                 Outbox,
@@ -1561,6 +1561,83 @@ describe('MemberRepository', function () {
             assert.equal(runCall.step_started_at, null);
             assert.equal(runCall.step_attempts, 0);
             assert.equal(runCall.exit_reason, null);
+        });
+
+        it('creates automation run for gift member signup (paid welcome email)', async function () {
+            // Override stub with paid welcome email
+            WelcomeEmailAutomation.findOne = sinon.stub().resolves({
+                id: 'automation_id_paid',
+                get: sinon.stub().callsFake((key) => {
+                    const data = {status: 'active'};
+                    return data[key];
+                }),
+                related: sinon.stub().callsFake((relation) => {
+                    assert.equal(relation, 'welcomeEmailAutomatedEmail');
+                    return {
+                        id: 'automated_email_id_paid',
+                        get: sinon.stub().callsFake((key) => {
+                            const data = {lexical: '{"root":{}}'};
+                            return data[key];
+                        })
+                    };
+                })
+            });
+
+            const repo = new MemberRepository({
+                Member,
+                Outbox,
+                WelcomeEmailAutomationRun,
+                MemberStatusEvent,
+                MemberSubscribeEventModel: MemberSubscribeEvent,
+                newslettersService,
+                WelcomeEmailAutomation,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            await repo.create({email: 'test@example.com', name: 'Test Member', status: 'gift'}, {});
+
+            sinon.assert.calledOnce(WelcomeEmailAutomation.findOne);
+            assert.equal(WelcomeEmailAutomation.findOne.firstCall.args[0].slug, 'member-welcome-email-paid');
+
+            sinon.assert.calledOnce(WelcomeEmailAutomationRun.add);
+            const runCall = WelcomeEmailAutomationRun.add.firstCall.args[0];
+            assert.equal(runCall.welcome_email_automation_id, 'automation_id_paid');
+            assert.equal(runCall.member_id, 'member_id_123');
+            assert.equal(runCall.next_welcome_email_automated_email_id, 'automated_email_id_paid');
+        });
+
+        it('does NOT create automation run for a gift signup when the paid welcome email is inactive', async function () {
+            // Override stub with inactive paid welcome email
+            WelcomeEmailAutomation.findOne = sinon.stub().resolves({
+                id: 'automation_id_paid',
+                get: sinon.stub().callsFake((key) => {
+                    const data = {status: 'inactive'};
+                    return data[key];
+                }),
+                related: sinon.stub().callsFake(() => ({
+                    id: 'automated_email_id_paid',
+                    get: sinon.stub().callsFake((key) => {
+                        const data = {lexical: '{"root":{}}'};
+                        return data[key];
+                    })
+                }))
+            });
+
+            const repo = new MemberRepository({
+                Member,
+                Outbox,
+                WelcomeEmailAutomationRun,
+                MemberStatusEvent,
+                MemberSubscribeEventModel: MemberSubscribeEvent,
+                newslettersService,
+                WelcomeEmailAutomation,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            await repo.create({email: 'test@example.com', name: 'Test Member', status: 'gift'}, {});
+
+            sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
+            sinon.assert.notCalled(Member.transaction);
         });
 
         it('does not create automation run for disallowed sources', async function () {
@@ -1638,6 +1715,7 @@ describe('MemberRepository', function () {
 
             sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
         });
+
         it('does NOT create automation run when member is signing up for a paid subscription (stripeCustomer is present)', async function () {
             const StripeCustomer = {
                 upsert: sinon.stub().resolves()
@@ -1678,25 +1756,6 @@ describe('MemberRepository', function () {
             }, {});
 
             // The free welcome email should NOT be sent when stripeCustomer is present
-            sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
-            sinon.assert.notCalled(WelcomeEmailAutomation.findOne);
-            sinon.assert.notCalled(Member.transaction);
-        });
-
-        it('does NOT create automation run when member is created with a non-free status (e.g. gift)', async function () {
-            const repo = new MemberRepository({
-                Member,
-                Outbox,
-                WelcomeEmailAutomationRun,
-                MemberStatusEvent,
-                MemberSubscribeEventModel: MemberSubscribeEvent,
-                newslettersService,
-                WelcomeEmailAutomation,
-                OfferRedemption: mockOfferRedemption
-            });
-
-            await repo.create({email: 'test@example.com', name: 'Test Member', status: 'gift'}, {});
-
             sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
             sinon.assert.notCalled(WelcomeEmailAutomation.findOne);
             sinon.assert.notCalled(Member.transaction);
@@ -1983,6 +2042,45 @@ describe('MemberRepository', function () {
                             return data[key];
                         })
                     };
+                })
+            });
+
+            const repo = new MemberRepository({
+                Member,
+                Outbox,
+                WelcomeEmailAutomationRun,
+                MemberPaidSubscriptionEvent,
+                StripeCustomerSubscription,
+                MemberProductEvent,
+                MemberStatusEvent,
+                stripeAPIService,
+                productRepository,
+                WelcomeEmailAutomation,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
+
+            await repo.linkSubscription({
+                id: 'member_id_123',
+                subscription: subscriptionData
+            }, {
+                transacting: {
+                    executionPromise: Promise.resolve()
+                },
+                context: {}
+            });
+
+            sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
+        });
+
+        it('does NOT create automation run when previous status was "gift" (already received paid welcome at redemption)', async function () {
+            Member.edit.resolves({
+                attributes: {status: 'paid'},
+                _previousAttributes: {status: 'gift'},
+                get: sinon.stub().callsFake((key) => {
+                    const data = {status: 'paid'};
+                    return data[key];
                 })
             });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3541

## Summary

Send the **paid welcome email** when a new member redeems a gift subscription, and suppress
the duplicate paid welcome when that gift member subsequently starts a real paid
subscription.

Previously, gift members received no welcome email on signup. 

## Changes

All changes are localized to `member-repository.js` to keep welcome-email policy
in one place — `gift-service.ts` and the rest of the gift flow are untouched.

- **`create()`** — When a new member is created with `status: 'gift'` (gift-redemption
  path, no Stripe customer), enqueue the **paid** welcome email automation
  (`member-welcome-email-paid`) in the same transaction as member creation. Mirrors
  the existing free-signup branch; refactored both branches to share a single
  transaction wrapper via a `welcomeEmailToEnqueue` config.
- **`update()`** — Skip the paid welcome email on the `gift → paid` transition by
  guarding on `updatedMember._previousAttributes.status !== 'gift'`. Without this
  guard, the same person would receive the paid welcome twice.


## Test plan

- [x] `pnpm test:single test/unit/server/services/members/members-api/repositories/member-repository.test.js` — 52 passing.
  - Updated existing `'create - automation run integration'` block: gift signup
    now asserts the **paid** automation slug is looked up and the run is enqueued
    with the paid automation/email IDs.
  - Added `'gift signup when paid welcome inactive'` unit test (no run enqueued).
  - Added `'previous status was gift'` unit test under `linkSubscription` (no run
    enqueued on `gift → paid`).
- [x] Updated existing magic-link gift redemption e2e test to register **both**
  free and paid welcome automations and assert exactly one paid run is enqueued
  for the gift member.
- [x] Added new e2e regression test `'does not enqueue a second paid welcome email
  when a gift member upgrades to paid'` covering the gift → paid suppression.
- [x] Manual end-to-end:
  - In Ghost Admin, ensure the paid welcome email automation is active and has
    body content.
  - Generate a gift link, redeem as a fresh email in another browser, and confirm
    the paid welcome email arrives in Mailpit (`http://localhost:8025`).
  - Have that gift member subsequently start a paid subscription via Portal/Stripe
    checkout. Confirm Mailpit shows **no** second paid welcome email.
- [x] Manual negative path: disable the paid welcome automation, redeem a new
  gift, confirm member is created with `status: 'gift'` and no welcome is sent.