### PR TITLE
Improved magic link popup copy during gift redemption

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.26",
+  "version": "2.68.27",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -266,7 +266,7 @@ async function redeemGift({data, state, api}) {
 
         return {
             page: 'magiclink',
-            lastPage: 'giftRedemption',
+            lastPage: 'gift',
             ...(otcRef ? {otcRef} : {}),
             inboxLinks,
             pageData: {

--- a/apps/portal/src/components/pages/magic-link-page.js
+++ b/apps/portal/src/components/pages/magic-link-page.js
@@ -100,24 +100,30 @@ export default class MagicLinkPage extends React.Component {
                 withOTC: t('If you have an account, an email has been sent to {submittedEmailOrInbox}. Click the link inside or enter your code below.', {submittedEmailOrInbox}),
                 withoutOTC: t('If you have an account, a login link has been sent to your inbox. If it doesn\'t arrive in 3 minutes, be sure to check your spam folder.')
             },
-            signup: t('To complete signup, click the confirmation link in your inbox. If it doesn\'t arrive within 3 minutes, check your spam folder!')
+            signup: t('To complete signup, click the confirmation link in your inbox. If it doesn\'t arrive within 3 minutes, check your spam folder!'),
+            gift: t('Click the confirmation link in your inbox to finish redeeming your membership. If it doesn\'t arrive within 3 minutes, check your spam folder.')
         };
     }
 
     /**
      * Gets the appropriate translated description based on page context
      * @param {Object} params - Configuration object
-     * @param {string} params.lastPage - The previous page ('signin' or 'signup')
+     * @param {string} params.lastPage - The previous page ('signin', 'signup', or 'gift')
      * @param {boolean} params.otcRef - Whether one-time code is being used
      * @param {string} params.submittedEmailOrInbox - The email address or 'your inbox' fallback
      * @returns {string} The translated description
      */
     getTranslatedDescription({lastPage, otcRef, submittedEmailOrInbox}) {
         const descriptionConfig = this.getDescriptionConfig(submittedEmailOrInbox);
-        const normalizedPage = (lastPage === 'signup' || lastPage === 'signin') ? lastPage : 'signin';
+        const allowedPages = ['signup', 'signin', 'gift'];
+        const normalizedPage = allowedPages.includes(lastPage) ? lastPage : 'signin';
 
         if (normalizedPage === 'signup') {
             return descriptionConfig.signup;
+        }
+
+        if (normalizedPage === 'gift') {
+            return descriptionConfig.gift;
         }
 
         return otcRef ? descriptionConfig.signin.withOTC : descriptionConfig.signin.withoutOTC;

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -177,7 +177,7 @@ describe('redeemGift action', () => {
 
         expect(result).toMatchObject({
             page: 'magiclink',
-            lastPage: 'giftRedemption',
+            lastPage: 'gift',
             otcRef: 'otc-ref-123',
             pageData: {
                 token: 'gift-token-123',

--- a/ghost/i18n/locales/af/portal.json
+++ b/ghost/i18n/locales/af/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Kies u nuusbriefs",
     "Click here to retry": "Kliek hier om weer te probeer",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Sluit",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/ar/portal.json
+++ b/ghost/i18n/locales/ar/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "اختر خطة",
     "Choose your newsletters": "اختر نشرتك الإخبارية المفضلة",
     "Click here to retry": "انقر هنا لإعادة المحاولة",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "إغلاق",
     "Code": "كود",
     "Comment preferences updated.": "تم تعديل تفضيلات التعليقات.",

--- a/ghost/i18n/locales/bg/portal.json
+++ b/ghost/i18n/locales/bg/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Изберете план",
     "Choose your newsletters": "Изберете бюлетини",
     "Click here to retry": "Щракнете за нов опит",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Затвори",
     "Code": "Код",
     "Comment preferences updated.": "Настройките за коментиране са обновени.",

--- a/ghost/i18n/locales/bn/portal.json
+++ b/ghost/i18n/locales/bn/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "আপনার নিউজলেটার বেছে নিন",
     "Click here to retry": "আবার চেষ্টা করতে এখানে ক্লিক করুন",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "বন্ধ করুন",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/bs/portal.json
+++ b/ghost/i18n/locales/bs/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Odaberi svoje newslettere",
     "Click here to retry": "Pokušaj ponovo",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Zatvori",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/ca/portal.json
+++ b/ghost/i18n/locales/ca/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Selecciona un pla",
     "Choose your newsletters": "Selecciona els teus butlletins",
     "Click here to retry": "Fes clic aquí per tornar-ho a intentar",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Tanca",
     "Code": "",
     "Comment preferences updated.": "Preferències de comentaris actualitzades",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -48,6 +48,7 @@
     "Choose a plan": "Header for the plan selection screen in Portal",
     "Choose your newsletters": "A title for a screen where members can choose which email newsletters to receive",
     "Click here to retry": "A link to retry the login process",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "Confirmation message shown on the magic link popup during gift redemption.",
     "Close": "A button to close or dismiss portal and other UI components",
     "Code": "Aria-label for the one-time code input field on the verification page in Portal",
     "Comment": "Button text to post your comment, on smaller devices",

--- a/ghost/i18n/locales/cs/portal.json
+++ b/ghost/i18n/locales/cs/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Vyberte si newsletter",
     "Click here to retry": "Klikněte zde pro opakování",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Zavřít",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/da/portal.json
+++ b/ghost/i18n/locales/da/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Vælg et abonnement",
     "Choose your newsletters": "Hvilke nyhedsbreve ønsker du",
     "Click here to retry": "Klik her for at prøve igen",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Luk",
     "Code": "",
     "Comment preferences updated.": "Kommentarpræferencer blev opdateret.",

--- a/ghost/i18n/locales/de-CH/portal.json
+++ b/ghost/i18n/locales/de-CH/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Tarif wählen",
     "Choose your newsletters": "Wählen Sie Ihren Newsletter",
     "Click here to retry": "Hier klicken zum Wiederholen",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Schliessen",
     "Code": "Code",
     "Comment preferences updated.": "Kommentar-Einstellungen aktualisiert.",

--- a/ghost/i18n/locales/de/portal.json
+++ b/ghost/i18n/locales/de/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Tarif wählen",
     "Choose your newsletters": "Wähle deine Newsletter",
     "Click here to retry": "Hier klicken zum Wiederholen",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Schließen",
     "Code": "Bestätigungscode",
     "Comment preferences updated.": "Kommentar-Einstellungen aktualisiert.",

--- a/ghost/i18n/locales/el/portal.json
+++ b/ghost/i18n/locales/el/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Επιλέξτε τα ενημερωτικά δελτία σας",
     "Click here to retry": "Κάντε κλικ εδώ για επανάληψη",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Κλείσιμο",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "",
     "Click here to retry": "",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/eo/portal.json
+++ b/ghost/i18n/locales/eo/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Elektu viajn bultenojn",
     "Click here to retry": "",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Fermu",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Elige un plan",
     "Choose your newsletters": "Elige tus boletines",
     "Click here to retry": "Haz click aquí para reintentar",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Cerrar",
     "Code": "",
     "Comment preferences updated.": "Preferencias de los comentarios actualizadas",

--- a/ghost/i18n/locales/et/portal.json
+++ b/ghost/i18n/locales/et/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Vali pakett",
     "Choose your newsletters": "Vali oma uudiskirjad",
     "Click here to retry": "Klõpsake siia, et uuesti proovida",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Sulge",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/eu/portal.json
+++ b/ghost/i18n/locales/eu/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Aukeratu plan bat",
     "Choose your newsletters": "Aukeratu zure buletinak",
     "Click here to retry": "Klikatu hemen berriro saiatzeko",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Itxi",
     "Code": "",
     "Comment preferences updated.": "Iruzkinen hobespenak eguneratu dira.",

--- a/ghost/i18n/locales/fa/portal.json
+++ b/ghost/i18n/locales/fa/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "خبرنامه\u200cی خود را انتخاب کنید",
     "Click here to retry": "برای تلاش دوباره اینجا را کلیک کنید",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "بستن",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/fi/portal.json
+++ b/ghost/i18n/locales/fi/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Valitse tilaus",
     "Choose your newsletters": "Valitse uutiskirjeesi",
     "Click here to retry": "Klikkaa tästä kokeillaksesi uudestaan",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Sulje",
     "Code": "Koodi",
     "Comment preferences updated.": "Kommenttiasetukset on päivitetty.",

--- a/ghost/i18n/locales/fr/portal.json
+++ b/ghost/i18n/locales/fr/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Choisir un abonnement",
     "Choose your newsletters": "Choisir vos newsletters",
     "Click here to retry": "Cliquez ici pour réessayer",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Fermer",
     "Code": "Code",
     "Comment preferences updated.": "Préférences de commentaires mises à jour.",

--- a/ghost/i18n/locales/gd/portal.json
+++ b/ghost/i18n/locales/gd/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Tagh plana",
     "Choose your newsletters": "Tagh na cuairt-litrichean agad",
     "Click here to retry": "Briog an seo gus feuchainn a-rithist",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Dùin",
     "Code": "",
     "Comment preferences updated.": "Chaidh roghainnean nam beachd ùrachadh",

--- a/ghost/i18n/locales/he/portal.json
+++ b/ghost/i18n/locales/he/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "בחרו תוכנית",
     "Choose your newsletters": "בחרו את הניוזלטרים שלכם",
     "Click here to retry": "לחצו כאן כדי לנסות שוב",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "סגירה",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/hi/portal.json
+++ b/ghost/i18n/locales/hi/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "एक योजना चुनें",
     "Choose your newsletters": "अपने न्यूज़लेटर चुनें",
     "Click here to retry": "फिर से प्रयास करने के लिए यहां क्लिक करें",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "बंद करें",
     "Code": "",
     "Comment preferences updated.": "टिप्पणी की प्राथमिकताएं अपडेट की गई।",

--- a/ghost/i18n/locales/hr/portal.json
+++ b/ghost/i18n/locales/hr/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Odaberite plan",
     "Choose your newsletters": "Odaberite vaš newsletter",
     "Click here to retry": "Klikni ovdje za ponovni pokušaj",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Zatvori",
     "Code": "",
     "Comment preferences updated.": "Postavke komentara su ažurirane.",

--- a/ghost/i18n/locales/hu/portal.json
+++ b/ghost/i18n/locales/hu/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Válassz egy csomagot",
     "Choose your newsletters": "Válaszd ki a hírleveleidet",
     "Click here to retry": "Kattints ide az újrapróbálkozáshoz",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Bezár",
     "Code": "",
     "Comment preferences updated.": "Hozzászólási beállítások frissítve.",

--- a/ghost/i18n/locales/id/portal.json
+++ b/ghost/i18n/locales/id/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Pilih paket",
     "Choose your newsletters": "Pilih buletin Anda",
     "Click here to retry": "Klik di sini untuk mencoba lagi",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Tutup",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/is/portal.json
+++ b/ghost/i18n/locales/is/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Velja fréttabréf",
     "Click here to retry": "Smellið hér til að reyna aftur",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Loka",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/it/portal.json
+++ b/ghost/i18n/locales/it/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Scegli un piano",
     "Choose your newsletters": "Scegli la tua newsletter",
     "Click here to retry": "Clicca qui per riprovare",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Chiudi",
     "Code": "Codice",
     "Comment preferences updated.": "Impostazioni dei commenti aggiornate.",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "プランを選択",
     "Choose your newsletters": "ニュースレターを選択",
     "Click here to retry": "再試行するにはここをクリックしてください",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "閉じる",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/ko/portal.json
+++ b/ghost/i18n/locales/ko/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "요금제 선택",
     "Choose your newsletters": "뉴스레터 선택",
     "Click here to retry": "다시 시도하려면 여기를 클릭해 주세요",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "닫기",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/kz/portal.json
+++ b/ghost/i18n/locales/kz/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Ақпараттық бюллетеньдерді таңдау",
     "Click here to retry": "Қайта көру үшін мұнда басыңыз",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Жабу",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/lt/portal.json
+++ b/ghost/i18n/locales/lt/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Pasirinkite norimus naujienlaiškius",
     "Click here to retry": "Spauskite čia, kad pakartotumėte",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Uždaryti",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/lv/portal.json
+++ b/ghost/i18n/locales/lv/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Izvēlieties plānu",
     "Choose your newsletters": "Izvēlieties savus biļetenus",
     "Click here to retry": "Noklikšķiniet šeit, lai mēģinātu vēlreiz",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Aizvērt",
     "Code": "",
     "Comment preferences updated.": "Komentāru preferences ir atjauninātas.",

--- a/ghost/i18n/locales/mk/portal.json
+++ b/ghost/i18n/locales/mk/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Изберете ги вашите билтени",
     "Click here to retry": "Кликнете тука за да се обидите повторно",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Затворете",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/mn/portal.json
+++ b/ghost/i18n/locales/mn/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Багц сонгох",
     "Choose your newsletters": "Товхимолоо сонгох",
     "Click here to retry": "Дахин оролдохын тулд энд дарна уу",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Хаах",
     "Code": "",
     "Comment preferences updated.": "Сэтгэгдлийн тохиргоо шинэчлэгдлээ.",

--- a/ghost/i18n/locales/ms/portal.json
+++ b/ghost/i18n/locales/ms/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Pilih newsletter anda",
     "Click here to retry": "Klik di sini untuk cuba semula",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Tutup",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/nb/portal.json
+++ b/ghost/i18n/locales/nb/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Velg en avtale",
     "Choose your newsletters": "Velg nyhetsbrev",
     "Click here to retry": "Klikk her for å prøve igjen",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Lukk",
     "Code": "",
     "Comment preferences updated.": "Innstillingene for kommentarer ble oppdatert.",

--- a/ghost/i18n/locales/ne/portal.json
+++ b/ghost/i18n/locales/ne/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "",
     "Click here to retry": "",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/nl/portal.json
+++ b/ghost/i18n/locales/nl/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Kies een abonnement",
     "Choose your newsletters": "Kies jouw nieuwsbrieven",
     "Click here to retry": "Klik hier om opnieuw te proberen",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Sluiten",
     "Code": "",
     "Comment preferences updated.": "Reactievoorkeuren bijgewerkt.",

--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Vel nyheitsbrevet ditt",
     "Click here to retry": "Klikk her for å prøva på ny",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Lukk",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/pa/portal.json
+++ b/ghost/i18n/locales/pa/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "ਇੱਕ ਪਲਾਨ ਚੁਣੋ",
     "Choose your newsletters": "ਆਪਣੇ ਖ਼ਬਰਨਾਮੇ ਚੁਣੋ",
     "Click here to retry": "ਮੁੜ ਕੋਸ਼ਿਸ਼ ਕਰਨ ਲਈ ਇੱਥੇ ਕਲਿੱਕ ਕਰੋ",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "ਬੰਦ ਕਰੋ",
     "Code": "",
     "Comment preferences updated.": "ਟਿੱਪਣੀ ਤਰਜੀਹਾਂ ਅੱਪਡੇਟ ਕੀਤੀਆਂ ਗਈਆਂ।",

--- a/ghost/i18n/locales/pl/portal.json
+++ b/ghost/i18n/locales/pl/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Wybierz plan",
     "Choose your newsletters": "Wybierz swoje newslettery",
     "Click here to retry": "Kliknij tu żeby potwierdzić",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Zamknij",
     "Code": "",
     "Comment preferences updated.": "Zaktualizowano preferencje dotyczące komentarzy.",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Escolher um plano",
     "Choose your newsletters": "Escolha suas newsletters",
     "Click here to retry": "Clique aqui para tentar novamente",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Fechar",
     "Code": "Código",
     "Comment preferences updated.": "Preferências de comentários atualizadas",

--- a/ghost/i18n/locales/pt/portal.json
+++ b/ghost/i18n/locales/pt/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Escolha um plano",
     "Choose your newsletters": "Escolha as suas newsletters",
     "Click here to retry": "Clique aqui para tentar novamente",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Fechar",
     "Code": "",
     "Comment preferences updated.": "Preferências de comentários atualizadas.",

--- a/ghost/i18n/locales/ro/portal.json
+++ b/ghost/i18n/locales/ro/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Alege-ți newsletterele",
     "Click here to retry": "Clic aici pentru a reîncerca",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Închide",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/ru/portal.json
+++ b/ghost/i18n/locales/ru/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Выберите план",
     "Choose your newsletters": "Выбор и управление рассылками",
     "Click here to retry": "Нажмите здесь, чтобы повторить попытку",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Закрыть",
     "Code": "Код",
     "Comment preferences updated.": "Настройки комментариев обновлены.",

--- a/ghost/i18n/locales/si/portal.json
+++ b/ghost/i18n/locales/si/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "ඔබගේ newsletter වර්ගය තෝරන්න",
     "Click here to retry": "නැවත උත්සාහ කිරීම සඳහා මෙහි click කරන්න",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "වසන්න",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/sk/portal.json
+++ b/ghost/i18n/locales/sk/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Vyberte si plán",
     "Choose your newsletters": "Vyberte si newsletter",
     "Click here to retry": "Kliknite sem pre obnovenie",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Zatvoriť",
     "Code": "",
     "Comment preferences updated.": "Nastavenia komentárov aktualizované",

--- a/ghost/i18n/locales/sl/portal.json
+++ b/ghost/i18n/locales/sl/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Izberite paket",
     "Choose your newsletters": "Izberite svoje novice",
     "Click here to retry": "Kliknite tukaj, da poskusite znova",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Zapri",
     "Code": "",
     "Comment preferences updated.": "Nastavitve komentarjev so bile posodobljene.",

--- a/ghost/i18n/locales/sq/portal.json
+++ b/ghost/i18n/locales/sq/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Zgjidh buletinin tend",
     "Click here to retry": "Kliko ketu per te provuar perseri",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Mbyll",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/sr-Cyrl/portal.json
+++ b/ghost/i18n/locales/sr-Cyrl/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Изаберите план",
     "Choose your newsletters": "Изаберите своје билтене",
     "Click here to retry": "Кликните овде да покушате поново",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Затворите",
     "Code": "Код",
     "Comment preferences updated.": "Преференце коментара ажуриране.",

--- a/ghost/i18n/locales/sr/portal.json
+++ b/ghost/i18n/locales/sr/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Izaberite plan",
     "Choose your newsletters": "Izaberite svoje biltene",
     "Click here to retry": "Kliknite ovde da pokušate ponovo",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Zatvorite",
     "Code": "Kod",
     "Comment preferences updated.": "Preference komentara ažurirane.",

--- a/ghost/i18n/locales/sv/portal.json
+++ b/ghost/i18n/locales/sv/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Välj en plan",
     "Choose your newsletters": "Välj dina nyhetsbrev",
     "Click here to retry": "Klicka här för att försöka igen",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Stäng",
     "Code": "Kod",
     "Comment preferences updated.": "Kommentarinställningar uppdaterade.",

--- a/ghost/i18n/locales/sw/portal.json
+++ b/ghost/i18n/locales/sw/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Chagua majarida yako",
     "Click here to retry": "Bofya hapa kurudia",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Funga",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/ta/portal.json
+++ b/ghost/i18n/locales/ta/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "ஒரு திட்டத்தைத் தேர்வு செய்யவும்",
     "Choose your newsletters": "உங்கள் செய்திமடல்களைத் தேர்வு செய்யவும்",
     "Click here to retry": "மீண்டும் முயற்சிக்க இங்கே கிளிக் செய்யவும்",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "மூடு",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/th/portal.json
+++ b/ghost/i18n/locales/th/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "เลือกอีเมลที่ต้องการรับจดหมายข่าว",
     "Click here to retry": "คลิกที่นี่เพื่อลองอีกครั้ง",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "ปิด",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/tr/portal.json
+++ b/ghost/i18n/locales/tr/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Bir plan seçin",
     "Choose your newsletters": "Bültenleri seç",
     "Click here to retry": "Tekrar denemek için buraya tıkla",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Kapat",
     "Code": "Kod",
     "Comment preferences updated.": "Yorum tercihleri güncellendi.",

--- a/ghost/i18n/locales/uk/portal.json
+++ b/ghost/i18n/locales/uk/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Оберіть план",
     "Choose your newsletters": "Оберіть свої підписки",
     "Click here to retry": "Натисніть тут, щоб повторити спробу",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Закрити",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/ur/portal.json
+++ b/ghost/i18n/locales/ur/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "اپنے نیوزلیٹر کو منتخب کریں",
     "Click here to retry": "دوبارہ کوشش کرنے کے لئے یہاں کلک کریں",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "بند کریں",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/uz/portal.json
+++ b/ghost/i18n/locales/uz/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "",
     "Choose your newsletters": "Pochta xabarlarini tanlang",
     "Click here to retry": "",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Yopmoq",
     "Code": "",
     "Comment preferences updated.": "",

--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "Chọn một gói",
     "Choose your newsletters": "Chọn bản tin bạn muốn nhận",
     "Click here to retry": "Nhấn vào đây thử lại",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "Đóng",
     "Code": "Mã",
     "Comment preferences updated.": "Đã cập nhật thiết lập bình luận.",

--- a/ghost/i18n/locales/zh-Hant/portal.json
+++ b/ghost/i18n/locales/zh-Hant/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "選擇方案",
     "Choose your newsletters": "選擇您的電子報",
     "Click here to retry": "點擊重試",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "關閉",
     "Code": "驗證碼",
     "Comment preferences updated.": "留言偏好設定已更新。",

--- a/ghost/i18n/locales/zh/portal.json
+++ b/ghost/i18n/locales/zh/portal.json
@@ -46,6 +46,7 @@
     "Choose a plan": "选择一个订阅方案",
     "Choose your newsletters": "选择您的新闻信",
     "Click here to retry": "请点此处重试",
+    "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder.": "",
     "Close": "关闭",
     "Code": "验证码",
     "Comment preferences updated.": "评论偏好设置已更新",


### PR DESCRIPTION
no issue

## Summary

During gift redemption, the "Now check your email!" popup was showing the **signin** description:

> "If you have an account, a login link has been sent to your inbox. If it doesn't arrive in 3 minutes, be sure to check your spam folder."

Now, it shows a copy that fits better into the flow:

> "Click the confirmation link in your inbox to finish redeeming your membership. If it doesn't arrive within 3 minutes, check your spam folder."


## Test plan

- [x] `pnpm --filter @tryghost/portal test` passes
- [x] `pnpm --filter @tryghost/i18n lint:translations` passes
- [x] Manual: with `pnpm dev`, open a gift URL in an incognito window, submit an email that doesn't match an existing member, confirm the popup now shows the gift-specific copy
- [x] Manual: click the magic link from Mailpit and confirm the redemption still completes successfully and the success toast appears
- [x] Manual: the existing signup and signin magic-link flows still show their respective copies (regression check on the `getTranslatedDescription` branching)

