### PR TITLE
✨ Added a built-in theme code editor

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -44,6 +44,7 @@ interface MockRequestConfig {
     method: string;
     path: string | RegExp;
     response: unknown;
+    rawResponse?: string | ArrayBuffer | Uint8Array | Buffer;
     responseStatus?: number;
     responseHeaders?: {[key: string]: string};
 }
@@ -208,6 +209,22 @@ export function createMockRequests(overrides: Record<string, MockRequestConfig> 
 export async function mockApi<Requests extends Record<string, MockRequestConfig>>({page, requests, options = {}}: {page: Page, requests: Requests, options?: {useActivityPub?: boolean}}) {
     const lastApiRequests: {[key in keyof Requests]?: RequestRecord} = {};
 
+    const getResponseBody = (matchingMock: MockRequestConfig) => {
+        if (typeof matchingMock.rawResponse === 'string' || Buffer.isBuffer(matchingMock.rawResponse)) {
+            return matchingMock.rawResponse;
+        }
+
+        if (matchingMock.rawResponse instanceof ArrayBuffer) {
+            return Buffer.from(matchingMock.rawResponse);
+        }
+
+        if (matchingMock.rawResponse instanceof Uint8Array) {
+            return Buffer.from(matchingMock.rawResponse);
+        }
+
+        return typeof matchingMock.response === 'string' ? matchingMock.response : JSON.stringify(matchingMock.response);
+    };
+
     const namedRequests = Object.entries(requests).reduce(
         (array, [key, value]) => array.concat({name: key, ...value}),
         [] as Array<MockRequestConfig & {name: keyof Requests}>
@@ -260,7 +277,7 @@ export async function mockApi<Requests extends Record<string, MockRequestConfig>
 
         await route.fulfill({
             status: matchingMock.responseStatus || 200,
-            body: typeof matchingMock.response === 'string' ? matchingMock.response : JSON.stringify(matchingMock.response),
+            body: getResponseBody(matchingMock),
             headers: matchingMock.responseHeaders || {}
         });
     });

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -60,7 +60,7 @@
     "@tryghost/timezone-data": "catalog:",
     "@uiw/react-codemirror": "4.25.2",
     "clsx": "catalog:",
-    "jszip": "^3.10.1",
+    "jszip": "3.10.1",
     "lucide-react": "0.577.0",
     "mingo": "2.5.3",
     "react": "18.3.1",

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -40,7 +40,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@codemirror/theme-one-dark": "6.1.3",
+    "@codemirror/lang-css": "6.3.1",
     "@codemirror/lang-html": "6.4.11",
+    "@codemirror/lang-javascript": "6.2.4",
+    "@codemirror/lang-json": "6.0.2",
+    "@codemirror/lang-markdown": "6.3.4",
+    "@codemirror/search": "6.6.0",
+    "@codemirror/lang-yaml": "6.1.2",
     "@dnd-kit/sortable": "7.0.2",
     "@ebay/nice-modal-react": "1.2.13",
     "@sentry/react": "catalog:",
@@ -53,6 +60,7 @@
     "@tryghost/timezone-data": "catalog:",
     "@uiw/react-codemirror": "4.25.2",
     "clsx": "catalog:",
+    "jszip": "^3.10.1",
     "lucide-react": "0.577.0",
     "mingo": "2.5.3",
     "react": "18.3.1",

--- a/apps/admin-x-settings/src/components/providers/settings-router.tsx
+++ b/apps/admin-x-settings/src/components/providers/settings-router.tsx
@@ -7,6 +7,7 @@ export const modalPaths: {[key: string]: ModalName} = {
     'design/change-theme': 'DesignAndThemeModal',
     'design/edit': 'DesignAndThemeModal',
     'theme/install': 'DesignAndThemeModal', // this is a special route, because it can install a theme directly from the Ghost Marketplace
+    'theme/edit/:name': 'DesignAndThemeModal',
     'navigation/edit': 'NavigationModal',
     'staff/invite': 'InviteUserModal',
     'staff/:slug/social-links': 'UserDetailModal',

--- a/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
@@ -1,8 +1,9 @@
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, LimitModal, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {type Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
+import {Button, Heading, LimitModal, Menu, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {type Theme, isDefaultOrLegacyTheme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
+import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '../../../hooks/use-check-theme-limit-error';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
@@ -10,7 +11,7 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const [themeLimitError, setThemeLimitError] = useState<string|null>(null);
     const [isCheckingLimit, setIsCheckingLimit] = useState(false);
     const {checkThemeLimitError} = useCheckThemeLimitError();
-    const {updateRoute} = useRouting();
+    const {route, updateRoute} = useRouting();
     const {data: themesData} = useBrowseThemes();
     const activeTheme = themesData?.themes.find((theme: Theme) => theme.active);
 
@@ -41,21 +42,73 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
         }
     };
 
+    const openThemeEditor = async () => {
+        if (!activeTheme) {
+            return;
+        }
+
+        const limitError = await checkThemeLimitError(isDefaultOrLegacyTheme(activeTheme) ? '.' : activeTheme.name);
+
+        if (limitError) {
+            NiceModal.show(LimitModal, {
+                prompt: limitError,
+                onOk: () => updateRoute({route: '/pro', isExternal: true})
+            });
+            return;
+        }
+
+        updateRoute(`theme/edit/${encodeURIComponent(activeTheme.name)}?from=${encodeURIComponent(route ?? '')}`);
+    };
+
+    const downloadTheme = () => {
+        if (!activeTheme) {
+            return;
+        }
+
+        const {apiRoot} = getGhostPaths();
+        downloadFile(`${apiRoot}/themes/${activeTheme.name}/download`);
+    };
+
+    const themeMenuItems = [
+        {
+            id: 'edit-code',
+            label: 'Edit code',
+            onClick: openThemeEditor
+        },
+        {
+            id: 'download',
+            label: 'Download',
+            onClick: downloadTheme
+        }
+    ];
+
     const values = (
-        <SettingGroupContent
-            values={[
-                {
-                    heading: 'Active theme',
-                    key: 'active-theme',
-                    value: activeTheme ? `${activeTheme.name} (v${activeTheme.package?.version || '1.0'})` : 'Loading...'
-                }
-            ]}
-        />
+        <SettingGroupContent>
+            <div className='flex flex-col'>
+                <Heading grey={false} level={6}>Active theme</Heading>
+                <div className='mt-1 flex w-full items-center justify-between gap-4'>
+                    <div>{activeTheme ? `${activeTheme.name} (v${activeTheme.package?.version || '1.0'})` : 'Loading...'}</div>
+                    <div className='-mr-3'>
+                        <Menu
+                            items={themeMenuItems}
+                            position='end'
+                            triggerButtonProps={{
+                                disabled: !activeTheme,
+                                iconColorClass: 'text-base',
+                                size: 'sm'
+                            }}
+                        />
+                    </div>
+                </div>
+            </div>
+        </SettingGroupContent>
     );
 
     return (
         <TopLevelGroup
-            customButtons={<Button className='mt-[-5px]' color='clear' label='Change theme' size='sm' onClick={openPreviewModal}/>}
+            customButtons={
+                <Button className='mt-[-5px]' color='clear' label='Change theme' size='sm' onClick={openPreviewModal} />
+            }
             description="Browse and install official themes or upload one"
             keywords={keywords}
             navid='theme'

--- a/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
@@ -17,7 +17,7 @@ const parseEditingThemeRoute = (path: string): {themeName: string | null; isInva
 
     const encodedThemeName = path.slice('theme/edit/'.length).split('?')[0];
 
-    if (!encodedThemeName) {
+    if (!encodedThemeName || encodedThemeName.includes('/')) {
         return {
             themeName: null,
             isInvalid: true
@@ -25,8 +25,17 @@ const parseEditingThemeRoute = (path: string): {themeName: string | null; isInva
     }
 
     try {
+        const themeName = decodeURIComponent(encodedThemeName);
+
+        if (!themeName || themeName.includes('/')) {
+            return {
+                themeName: null,
+                isInvalid: true
+            };
+        }
+
         return {
-            themeName: decodeURIComponent(encodedThemeName),
+            themeName,
             isInvalid: false
         };
     } catch {

--- a/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
@@ -7,14 +7,34 @@ import {LimitModal} from '@tryghost/admin-x-design-system';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
 import {useCheckThemeLimitError} from '../../../hooks/use-check-theme-limit-error';
 
-const getEditingThemeName = (path: string) => {
+const parseEditingThemeRoute = (path: string): {themeName: string | null; isInvalid: boolean} => {
     if (!path.startsWith('theme/edit/')) {
-        return null;
+        return {
+            themeName: null,
+            isInvalid: false
+        };
     }
 
-    const encodedThemeName = path.replace('theme/edit/', '').split('?')[0];
+    const encodedThemeName = path.slice('theme/edit/'.length).split('?')[0];
 
-    return encodedThemeName ? decodeURIComponent(encodedThemeName) : null;
+    if (!encodedThemeName) {
+        return {
+            themeName: null,
+            isInvalid: true
+        };
+    }
+
+    try {
+        return {
+            themeName: decodeURIComponent(encodedThemeName),
+            isInvalid: false
+        };
+    } catch {
+        return {
+            themeName: null,
+            isInvalid: true
+        };
+    }
 };
 
 const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
@@ -29,7 +49,7 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
     const {checkThemeLimitError, isThemeLimitCheckReady, noThemeChangesAllowed, isThemeLimited} = useCheckThemeLimitError();
     const [installationAllowed, setInstallationAllowed] = useState<boolean | null>(null);
     const [hasCheckedInstallation, setHasCheckedInstallation] = useState(false);
-    const editingThemeName = getEditingThemeName(currentPath);
+    const {themeName: editingThemeName, isInvalid: hasInvalidEditingThemeRoute} = parseEditingThemeRoute(currentPath);
 
     const showThemeLimitModal = useCallback((error: string) => {
         NiceModal.show(LimitModal, {
@@ -76,6 +96,15 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
             setIsCheckingInstallation(false);
         }
     }, [currentPath]);
+
+    useEffect(() => {
+        if (!hasInvalidEditingThemeRoute) {
+            return;
+        }
+
+        modal.remove();
+        updateRoute('theme');
+    }, [hasInvalidEditingThemeRoute, modal, updateRoute]);
 
     useEffect(() => {
         let isCancelled = false;
@@ -260,14 +289,15 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
 
         // Installation is allowed, render the ChangeThemeModal with the source and ref
         return <ChangeThemeModal source={source} themeRef={ref} />;
-    } else if (editingThemeName) {
-        if (isCheckingEditorLimit || editorThemeError) {
+    } else if (currentPath.startsWith('theme/edit/')) {
+        if (hasInvalidEditingThemeRoute || !editingThemeName || isCheckingEditorLimit || editorThemeError) {
             return null;
         }
 
         return <ThemeCodeEditorModal themeName={editingThemeName} />;
     } else {
         modal.remove();
+        return null;
     }
 };
 

--- a/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
@@ -1,20 +1,42 @@
 import ChangeThemeModal from './theme-modal';
 import DesignModal from './design-modal';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
+import ThemeCodeEditorModal from './theme/theme-code-editor-modal';
 import {LimitModal} from '@tryghost/admin-x-design-system';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
 import {useCheckThemeLimitError} from '../../../hooks/use-check-theme-limit-error';
 
+const getEditingThemeName = (path: string) => {
+    if (!path.startsWith('theme/edit/')) {
+        return null;
+    }
+
+    const encodedThemeName = path.replace('theme/edit/', '').split('?')[0];
+
+    return encodedThemeName ? decodeURIComponent(encodedThemeName) : null;
+};
+
 const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {route, updateRoute} = useRouting();
+    const currentPath = route || pathName;
     const [themeChangeError, setThemeChangeError] = useState<string|null>(null);
     const [isCheckingLimit, setIsCheckingLimit] = useState(false);
     const [isCheckingInstallation, setIsCheckingInstallation] = useState(false);
+    const [editorThemeError, setEditorThemeError] = useState<string | null>(null);
+    const [isCheckingEditorLimit, setIsCheckingEditorLimit] = useState(false);
     const {checkThemeLimitError, isThemeLimitCheckReady, noThemeChangesAllowed, isThemeLimited} = useCheckThemeLimitError();
     const [installationAllowed, setInstallationAllowed] = useState<boolean | null>(null);
     const [hasCheckedInstallation, setHasCheckedInstallation] = useState(false);
+    const editingThemeName = getEditingThemeName(currentPath);
+
+    const showThemeLimitModal = useCallback((error: string) => {
+        NiceModal.show(LimitModal, {
+            prompt: error,
+            onOk: () => updateRoute({route: '/pro', isExternal: true})
+        });
+    }, [updateRoute]);
 
     useEffect(() => {
         const checkIfThemeChangeAllowed = async () => {
@@ -33,30 +55,73 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
 
             // Show limit modal immediately if there's an error
             if (error) {
-                NiceModal.show(LimitModal, {
-                    prompt: error,
-                    onOk: () => updateRoute({route: '/pro', isExternal: true})
-                });
+                showThemeLimitModal(error);
                 modal.remove(); // Close the current modal
             }
         };
 
-        if (pathName === 'design/change-theme' && isThemeLimitCheckReady) {
+        if (currentPath === 'design/change-theme' && isThemeLimitCheckReady) {
             checkIfThemeChangeAllowed();
         } else {
             setThemeChangeError(null);
             setIsCheckingLimit(false);
         }
-    }, [checkThemeLimitError, isThemeLimitCheckReady, pathName, modal, updateRoute, noThemeChangesAllowed]);
+    }, [checkThemeLimitError, currentPath, isThemeLimitCheckReady, modal, noThemeChangesAllowed, showThemeLimitModal]);
 
     // Reset states when pathName changes
     useEffect(() => {
-        if (pathName !== 'theme/install') {
+        if (currentPath !== 'theme/install') {
             setHasCheckedInstallation(false);
             setInstallationAllowed(null);
             setIsCheckingInstallation(false);
         }
-    }, [pathName]);
+    }, [currentPath]);
+
+    useEffect(() => {
+        let isCancelled = false;
+
+        const checkThemeEditorAccess = async () => {
+            if (!editingThemeName) {
+                setEditorThemeError(null);
+                setIsCheckingEditorLimit(false);
+                return;
+            }
+
+            if (!isThemeLimitCheckReady) {
+                setIsCheckingEditorLimit(true);
+                return;
+            }
+
+            if (!isThemeLimited) {
+                setEditorThemeError(null);
+                setIsCheckingEditorLimit(false);
+                return;
+            }
+
+            setIsCheckingEditorLimit(true);
+
+            const error = await checkThemeLimitError(editingThemeName.toLowerCase());
+
+            if (isCancelled) {
+                return;
+            }
+
+            setEditorThemeError(error);
+            setIsCheckingEditorLimit(false);
+
+            if (error) {
+                showThemeLimitModal(error);
+                modal.remove();
+                updateRoute('theme');
+            }
+        };
+
+        void checkThemeEditorAccess();
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [checkThemeLimitError, editingThemeName, isThemeLimitCheckReady, isThemeLimited, modal, showThemeLimitModal, updateRoute]);
 
     // Check theme installation limits
     useEffect(() => {
@@ -79,21 +144,16 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
             // Immediately prevent any installation attempts
             setInstallationAllowed(false);
 
-            const limitModalConfig = {
-                prompt: error,
-                onOk: () => updateRoute({route: '/pro', isExternal: true})
-            };
-
             if (noThemeChangesAllowed) {
                 // Single theme - show limit modal and redirect to /theme
-                NiceModal.show(LimitModal, limitModalConfig);
+                showThemeLimitModal(error);
                 // Clear URL parameters
                 window.history.replaceState({}, '', window.location.pathname + window.location.hash.split('?')[0]);
                 modal.remove();
                 updateRoute('theme');
             } else {
                 // Multiple themes allowed - show limit modal and then redirect
-                NiceModal.show(LimitModal, limitModalConfig);
+                showThemeLimitModal(error);
                 modal.remove();
                 // Don't redirect to change-theme modal - just stay on current route
                 // This prevents both modals from being visible at the same time
@@ -103,7 +163,7 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
 
         const checkThemeInstallation = async () => {
             // Early return if not on theme/install path
-            if (pathName !== 'theme/install') {
+            if (currentPath !== 'theme/install') {
                 setIsCheckingInstallation(false);
                 return;
             }
@@ -140,7 +200,7 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
             const error = await checkThemeLimitError(themeName);
 
             // Double-check again after async operation
-            if (pathName !== 'theme/install') {
+            if (currentPath !== 'theme/install') {
                 setIsCheckingInstallation(false);
                 return;
             }
@@ -160,11 +220,11 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
         };
 
         checkThemeInstallation();
-    }, [pathName, isThemeLimitCheckReady, checkThemeLimitError, noThemeChangesAllowed, isThemeLimited, modal, updateRoute]);
+    }, [checkThemeLimitError, currentPath, isThemeLimitCheckReady, noThemeChangesAllowed, isThemeLimited, modal, showThemeLimitModal, updateRoute]);
 
-    if (pathName === 'design/edit') {
+    if (currentPath === 'design/edit') {
         return <DesignModal />;
-    } else if (pathName === 'design/change-theme') {
+    } else if (currentPath === 'design/change-theme') {
         // Don't show the change theme modal if we're still checking limits or if there's
         // a theme limit error
         if (isCheckingLimit || themeChangeError) {
@@ -172,7 +232,7 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
         }
 
         return <ChangeThemeModal />;
-    } else if (pathName === 'theme/install') {
+    } else if (currentPath === 'theme/install') {
         // Always wait for the installation check to complete
         // This prevents any race conditions
         if (!hasCheckedInstallation || !isThemeLimitCheckReady || isCheckingInstallation || installationAllowed === null) {
@@ -200,6 +260,12 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
 
         // Installation is allowed, render the ChangeThemeModal with the source and ref
         return <ChangeThemeModal source={source} themeRef={ref} />;
+    } else if (editingThemeName) {
+        if (isCheckingEditorLimit || editorThemeError) {
+            return null;
+        }
+
+        return <ThemeCodeEditorModal themeName={editingThemeName} />;
     } else {
         modal.remove();
     }

--- a/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
@@ -2,11 +2,13 @@ import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
 import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import useCustomFonts from '../../../../hooks/use-custom-fonts';
-import {Button, type ButtonProps, ConfirmationModal, List, ListItem, Menu, ModalPage, showToast} from '@tryghost/admin-x-design-system';
+import {Button, type ButtonProps, ConfirmationModal, LimitModal, List, ListItem, Menu, ModalPage, showToast} from '@tryghost/admin-x-design-system';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
-import {type Theme, isActiveTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
+import {type Theme, isActiveTheme, isDefaultOrLegacyTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {useCheckThemeLimitError} from '../../../../hooks/use-check-theme-limit-error';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 interface ThemeActionProps {
     theme: Theme;
@@ -51,6 +53,8 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     const {mutateAsync: deleteTheme} = useDeleteTheme();
     const {refreshActiveThemeData} = useCustomFonts();
     const handleError = useHandleError();
+    const {route, updateRoute} = useRouting();
+    const {checkThemeLimitError} = useCheckThemeLimitError();
 
     const handleActivate = async () => {
         try {
@@ -64,7 +68,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
         } catch (e) {
             let fatalErrors: FatalErrors | null = null;
             if (e instanceof JSONError && e.response?.status === 422 && e.data?.errors) {
-                fatalErrors = (e.data.errors as any) as FatalErrors;
+                fatalErrors = e.data.errors as unknown as FatalErrors;
             } else {
                 handleError(e);
             }
@@ -122,6 +126,20 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
         });
     };
 
+    const handleEditCode = async () => {
+        const limitError = await checkThemeLimitError(isDefaultOrLegacyTheme(theme) ? '.' : theme.name);
+
+        if (limitError) {
+            NiceModal.show(LimitModal, {
+                prompt: limitError,
+                onOk: () => updateRoute({route: '/pro', isExternal: true})
+            });
+            return;
+        }
+
+        updateRoute(`theme/edit/${encodeURIComponent(theme.name)}?from=${encodeURIComponent(route ?? '')}`);
+    };
+
     let actions = [];
 
     if (!isActiveTheme(theme)) {
@@ -138,6 +156,11 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     }
 
     let menuItems = [
+        {
+            id: 'edit-code',
+            label: 'Edit code',
+            onClick: handleEditCode
+        },
         {
             id: 'download',
             label: 'Download',

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -1,0 +1,1314 @@
+import CodeMirror, {EditorView} from '@uiw/react-codemirror';
+import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
+import NiceModal, {useModal} from '@ebay/nice-modal-react';
+import React, {useEffect, useMemo, useState} from 'react';
+import ThemeInstalledModal from './theme-installed-modal';
+import {
+    ChevronDown,
+    ChevronRight,
+    CircleDot,
+    FileCode2,
+    Folder,
+    FolderOpen,
+    Pencil,
+    Plus,
+    Save,
+    TextWrap,
+    Trash2,
+    Undo2,
+    X
+} from 'lucide-react';
+import {Modal, TextField, showToast} from '@tryghost/admin-x-design-system';
+import {
+    cloneThemeFiles,
+    createFolderRenameMap,
+    extractThemeArchive,
+    getExtension,
+    getThemeChanges,
+    isDefaultThemeName,
+    isEditablePath,
+    normaliseRelativePath,
+    packThemeArchive
+} from './theme-editor-utils';
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {oneDark} from '@codemirror/theme-one-dark';
+import {search} from '@codemirror/search';
+import {useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useQueryClient} from '@tanstack/react-query';
+import {useRouting} from '@tryghost/admin-x-framework/routing';
+import type {ThemeChange, ThemeEditorFile} from './theme-editor-utils';
+import type {ThemesInstallResponseType} from '@tryghost/admin-x-framework/api/themes';
+
+type SelectedNode =
+    | {type: 'file'; path: string}
+    | {type: 'dir'; path: string}
+    | null;
+
+type TreeNode = {
+    type: 'dir' | 'file';
+    name: string;
+    path: string;
+    editable?: boolean;
+    children?: Map<string, TreeNode>;
+};
+
+type ReviewItem = {
+    path: string;
+    editable: boolean;
+    status: ThemeChange['status'];
+    before: string | null;
+    after: string | null;
+};
+
+const buildTree = (files: Record<string, ThemeEditorFile>) => {
+    const root: TreeNode = {
+        type: 'dir',
+        name: '',
+        path: '',
+        children: new Map()
+    };
+
+    for (const path of Object.keys(files).sort()) {
+        const segments = path.split('/');
+        let cursor = root;
+
+        for (let index = 0; index < segments.length; index += 1) {
+            const segment = segments[index];
+            const isLast = index === segments.length - 1;
+
+            if (isLast) {
+                cursor.children!.set(segment, {
+                    type: 'file',
+                    name: segment,
+                    path,
+                    editable: files[path].editable
+                });
+                continue;
+            }
+
+            const dirPath = `${segments.slice(0, index + 1).join('/')}/`;
+            const existing = cursor.children!.get(segment);
+
+            if (existing?.type === 'dir') {
+                cursor = existing;
+                continue;
+            }
+
+            const next: TreeNode = {
+                type: 'dir',
+                name: segment,
+                path: dirPath,
+                children: new Map()
+            };
+
+            cursor.children!.set(segment, next);
+            cursor = next;
+        }
+    }
+
+    return root;
+};
+
+const sortTreeNodes = (nodes: TreeNode[]) => {
+    return nodes.sort((left, right) => {
+        if (left.type !== right.type) {
+            return left.type === 'dir' ? -1 : 1;
+        }
+
+        return left.name.localeCompare(right.name);
+    });
+};
+
+const getLanguageExtension = (path: string) => {
+    const extension = getExtension(path);
+
+    switch (extension) {
+    case 'css':
+    case 'scss':
+    case 'sass':
+    case 'less':
+        return import('@codemirror/lang-css').then(module => module.css());
+    case 'js':
+    case 'cjs':
+    case 'mjs':
+        return import('@codemirror/lang-javascript').then(module => module.javascript());
+    case 'json':
+        return import('@codemirror/lang-json').then(module => module.json());
+    case 'md':
+    case 'markdown':
+        return import('@codemirror/lang-markdown').then(module => module.markdown());
+    case 'yaml':
+    case 'yml':
+        return import('@codemirror/lang-yaml').then(module => module.yaml());
+    case 'hbs':
+    case 'handlebars':
+    case 'html':
+    case 'htm':
+    case 'svg':
+    case 'xml':
+        return import('@codemirror/lang-html').then(module => module.html());
+    default:
+        return import('@codemirror/lang-html').then(module => module.html());
+    }
+};
+
+const getLanguageLabel = (path: string) => {
+    const extension = getExtension(path);
+
+    if (!extension) {
+        return 'text';
+    }
+
+    switch (extension) {
+    case 'hbs':
+        return 'handlebars';
+    case 'htm':
+        return 'html';
+    case 'yml':
+        return 'yaml';
+    default:
+        return extension;
+    }
+};
+
+const getDefaultSelection = (files: Record<string, ThemeEditorFile>): SelectedNode => {
+    if (files['package.json']?.editable) {
+        return {type: 'file', path: 'package.json'};
+    }
+
+    const nextEditable = Object.keys(files).sort().find(path => files[path].editable);
+
+    if (nextEditable) {
+        return {type: 'file', path: nextEditable};
+    }
+
+    const firstPath = Object.keys(files).sort()[0];
+
+    return firstPath ? {type: 'file', path: firstPath} : null;
+};
+
+const getParentDirectories = (path: string) => {
+    const segments = path.split('/');
+    const directories: string[] = [''];
+
+    for (let index = 0; index < segments.length - 1; index += 1) {
+        directories.push(`${segments.slice(0, index + 1).join('/')}/`);
+    }
+
+    return directories;
+};
+
+const buildReviewItems = ({
+    baseFiles,
+    currentFiles,
+    changes
+}: {
+    baseFiles: Record<string, ThemeEditorFile>;
+    currentFiles: Record<string, ThemeEditorFile>;
+    changes: ThemeChange[];
+}) => {
+    return changes.map((change) => {
+        const baseFile = baseFiles[change.path];
+        const currentFile = currentFiles[change.path];
+
+        return {
+            path: change.path,
+            editable: change.editable,
+            status: change.status,
+            before: baseFile?.editable ? (baseFile.content ?? '') : null,
+            after: currentFile?.editable ? (currentFile.content ?? '') : null
+        };
+    });
+};
+
+const formatReviewSummary = (reviewItems: ReviewItem[]) => {
+    const added = reviewItems.filter(item => item.status === 'added').length;
+    const modified = reviewItems.filter(item => item.status === 'modified').length;
+    const deleted = reviewItems.filter(item => item.status === 'deleted').length;
+
+    return `${modified} modified, ${added} added, ${deleted} deleted`;
+};
+
+const getReturnRouteFromHash = () => {
+    const hash = window.location.hash.substring(1);
+    const domain = `${window.location.protocol}//${window.location.hostname}`;
+    const url = new URL(hash || '/', domain);
+
+    return url.searchParams.get('from');
+};
+
+const buildThemeEditorRoute = (themeName: string, fromRoute: string | null) => {
+    const nextRoute = `theme/edit/${encodeURIComponent(themeName)}`;
+
+    if (fromRoute === null) {
+        return nextRoute;
+    }
+
+    return `${nextRoute}?from=${encodeURIComponent(fromRoute)}`;
+};
+
+const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string) => {
+    return !file.editable && isEditablePath(nextPath);
+};
+
+const iconButtonClass = 'inline-flex h-7 w-7 items-center justify-center rounded-full border border-[#2f333b] bg-transparent text-[#c8ccd3] transition-colors hover:bg-[#1f2228] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-50';
+const toolbarButtonClass = 'inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-50';
+const ghostButtonClass = `${toolbarButtonClass} border-[#2f333b] bg-transparent text-[#e6e7ea] hover:bg-[#1f2228]`;
+const primaryButtonClass = `${toolbarButtonClass} border-transparent bg-green text-black hover:bg-green-400`;
+const wrapToggleClass = (active: boolean) => `inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] ${active ? 'opacity-100' : 'opacity-60'}`;
+const fileActionButtonClass = 'inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-30';
+const editorSelectionTheme = EditorView.theme({
+    '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
+        backgroundColor: '#355070'
+    },
+    '.cm-content ::selection': {
+        color: '#ffffff'
+    }
+}, {dark: true});
+
+type ThemeEditorConfirmModalProps = {
+    title: string;
+    prompt: React.ReactNode;
+    cancelLabel?: string;
+    okLabel?: string;
+    okColor?: 'black' | 'red' | 'green' | 'outline';
+};
+
+const ThemeEditorConfirmModal = NiceModal.create<ThemeEditorConfirmModalProps>(({
+    title,
+    prompt,
+    cancelLabel = 'Cancel',
+    okLabel = 'OK',
+    okColor = 'black'
+}) => {
+    const modal = useModal();
+
+    const closeWithResult = (result: boolean) => {
+        modal.resolve(result);
+        modal.remove();
+    };
+
+    return (
+        <Modal
+            backDropClick={false}
+            cancelLabel={cancelLabel}
+            okColor={okColor}
+            okLabel={okLabel}
+            testId='theme-editor-confirm-modal'
+            title={title}
+            width={540}
+            onCancel={() => closeWithResult(false)}
+            onOk={() => closeWithResult(true)}
+        >
+            <div className='py-4'>
+                {prompt}
+            </div>
+        </Modal>
+    );
+});
+
+type ThemeEditorInputModalProps = {
+    title: string;
+    prompt?: React.ReactNode;
+    fieldTitle: string;
+    initialValue: string;
+    placeholder?: string;
+    cancelLabel?: string;
+    okLabel?: string;
+};
+
+const ThemeEditorInputModal = NiceModal.create<ThemeEditorInputModalProps>(({
+    title,
+    prompt,
+    fieldTitle,
+    initialValue,
+    placeholder,
+    cancelLabel = 'Cancel',
+    okLabel = 'Continue'
+}) => {
+    const modal = useModal();
+    const [value, setValue] = useState(initialValue);
+
+    const closeWithResult = (result: string | null) => {
+        modal.resolve(result);
+        modal.remove();
+    };
+
+    return (
+        <Modal
+            backDropClick={false}
+            cancelLabel={cancelLabel}
+            okDisabled={!value.trim()}
+            okLabel={okLabel}
+            testId='theme-editor-input-modal'
+            title={title}
+            width={540}
+            onCancel={() => closeWithResult(null)}
+            onOk={() => closeWithResult(value)}
+        >
+            <div className='flex flex-col gap-4 py-4'>
+                {prompt}
+                <TextField
+                    clearBg={false}
+                    placeholder={placeholder}
+                    title={fieldTitle}
+                    value={value}
+                    autoFocus
+                    onChange={event => setValue(event.target.value)}
+                />
+            </div>
+        </Modal>
+    );
+});
+
+const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
+    const modal = useModal();
+    const {updateRoute} = useRouting();
+    const queryClient = useQueryClient();
+    const handleError = useHandleError();
+    const {data: themesData} = useBrowseThemes();
+
+    const [currentThemeName, setCurrentThemeName] = useState(themeName);
+    const [baseFiles, setBaseFiles] = useState<Record<string, ThemeEditorFile>>({});
+    const [currentFiles, setCurrentFiles] = useState<Record<string, ThemeEditorFile>>({});
+    const [rootPrefix, setRootPrefix] = useState('');
+    const [selectedNode, setSelectedNode] = useState<SelectedNode>(null);
+    const [expandedDirectories, setExpandedDirectories] = useState<Set<string>>(new Set(['']));
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [isReviewOpen, setIsReviewOpen] = useState(false);
+    const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
+    const [selectedReviewPath, setSelectedReviewPath] = useState<string | null>(null);
+    const [editorExtensions, setEditorExtensions] = useState<Array<ReturnType<typeof search> | typeof oneDark | typeof editorSelectionTheme | typeof EditorView.lineWrapping | Awaited<ReturnType<typeof getLanguageExtension>>>>([]);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const loadTheme = async () => {
+            setIsLoading(true);
+            setLoadError(null);
+
+            try {
+                const {apiRoot} = getGhostPaths();
+                const response = await fetch(`${apiRoot}/themes/${encodeURIComponent(themeName)}/download/`, {
+                    credentials: 'include',
+                    headers: {
+                        Accept: 'application/zip, application/octet-stream, */*'
+                    }
+                });
+
+                if (!response.ok) {
+                    throw new Error(`Failed to load theme "${themeName}" (${response.status})`);
+                }
+
+                const archive = await response.arrayBuffer();
+                const snapshot = await extractThemeArchive(archive);
+                const nextFiles = cloneThemeFiles(snapshot.files);
+                const nextSelection = getDefaultSelection(nextFiles);
+
+                if (!isMounted) {
+                    return;
+                }
+
+                setCurrentThemeName(themeName);
+                setBaseFiles(cloneThemeFiles(snapshot.files));
+                setCurrentFiles(nextFiles);
+                setRootPrefix(snapshot.rootPrefix);
+                setSelectedNode(nextSelection);
+                setExpandedDirectories(new Set(nextSelection?.type === 'file' ? getParentDirectories(nextSelection.path) : ['']));
+            } catch (error) {
+                if (!isMounted) {
+                    return;
+                }
+
+                setLoadError(error instanceof Error ? error.message : 'Failed to load theme');
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        loadTheme();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [themeName]);
+
+    useEffect(() => {
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, []);
+
+    const changes = useMemo(() => getThemeChanges({baseFiles, currentFiles}), [baseFiles, currentFiles]);
+    const changesMap = useMemo(() => new Map(changes.map(change => [change.path, change.status])), [changes]);
+    const reviewItems = useMemo(() => buildReviewItems({baseFiles, currentFiles, changes}), [baseFiles, currentFiles, changes]);
+    const selectedFile = selectedNode?.type === 'file' ? currentFiles[selectedNode.path] : null;
+    const selectedReviewItem = reviewItems.find(item => item.path === selectedReviewPath) || reviewItems[0] || null;
+
+    useEffect(() => {
+        if (!selectedReviewItem) {
+            setSelectedReviewPath(null);
+            return;
+        }
+
+        if (!selectedReviewPath || !reviewItems.some(item => item.path === selectedReviewPath)) {
+            setSelectedReviewPath(selectedReviewItem.path);
+        }
+    }, [reviewItems, selectedReviewItem, selectedReviewPath]);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        if (!selectedFile?.editable) {
+            setEditorExtensions([]);
+            return () => {
+                isMounted = false;
+            };
+        }
+
+        Promise.all([oneDark, getLanguageExtension(selectedFile.path)]).then((extensions) => {
+            if (isMounted) {
+                setEditorExtensions([
+                    search({top: true}),
+                    ...extensions,
+                    ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
+                    editorSelectionTheme
+                ]);
+            }
+        }).catch(() => {
+            if (isMounted) {
+                setEditorExtensions([
+                    search({top: true}),
+                    oneDark,
+                    ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
+                    editorSelectionTheme
+                ]);
+            }
+        });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [isTextWrapEnabled, selectedFile]);
+
+    const requestConfirmation = async ({
+        title,
+        prompt,
+        cancelLabel,
+        okLabel,
+        okColor
+    }: ThemeEditorConfirmModalProps) => {
+        const confirmed = await NiceModal.show(ThemeEditorConfirmModal, {
+            title,
+            prompt,
+            cancelLabel,
+            okLabel,
+            okColor
+        }) as boolean | undefined;
+
+        return Boolean(confirmed);
+    };
+
+    const requestInput = async ({
+        title,
+        prompt,
+        fieldTitle,
+        initialValue,
+        placeholder,
+        cancelLabel,
+        okLabel
+    }: ThemeEditorInputModalProps) => {
+        return await NiceModal.show(ThemeEditorInputModal, {
+            title,
+            prompt,
+            fieldTitle,
+            initialValue,
+            placeholder,
+            cancelLabel,
+            okLabel
+        }) as string | null;
+    };
+
+    const closeEditor = async () => {
+        if (changes.length > 0) {
+            const shouldDiscard = await requestConfirmation({
+                title: 'Discard changes?',
+                prompt: 'You have unsaved theme changes. Close the editor and discard them?',
+                okLabel: 'Discard changes',
+                okColor: 'red'
+            });
+
+            if (!shouldDiscard) {
+                return;
+            }
+        }
+
+        modal.remove();
+        updateRoute(getReturnRouteFromHash() ?? 'design/change-theme');
+    };
+
+    useEffect(() => {
+        const handleKeydown = (event: KeyboardEvent) => {
+            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+                event.preventDefault();
+                void handleSave();
+                return;
+            }
+
+            if (event.key !== 'Escape') {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+        };
+
+        window.addEventListener('keydown', handleKeydown, true);
+
+        return () => {
+            window.removeEventListener('keydown', handleKeydown, true);
+        };
+    });
+
+    const ensurePathExpanded = (path: string) => {
+        setExpandedDirectories((current) => {
+            const next = new Set(current);
+
+            for (const dir of getParentDirectories(path)) {
+                next.add(dir);
+            }
+
+            return next;
+        });
+    };
+
+    const setFilesAndSelection = (files: Record<string, ThemeEditorFile>, nextSelection?: SelectedNode) => {
+        setCurrentFiles(files);
+
+        if (nextSelection) {
+            setSelectedNode(nextSelection);
+            if (nextSelection.type === 'file') {
+                ensurePathExpanded(nextSelection.path);
+            }
+            return;
+        }
+
+        if (selectedNode?.type === 'file' && files[selectedNode.path]) {
+            return;
+        }
+
+        setSelectedNode(getDefaultSelection(files));
+    };
+
+    const handleCreateFile = async () => {
+        const requestedPath = await requestInput({
+            title: 'Create file',
+            fieldTitle: 'File path',
+            initialValue: 'partials/new-file.hbs',
+            okLabel: 'Create file',
+            prompt: 'Add a new editable file to this theme.'
+        });
+        const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
+
+        if (!nextPath) {
+            return;
+        }
+
+        if (!isEditablePath(nextPath)) {
+            showToast({
+                type: 'error',
+                title: 'Only text files can be created here',
+                message: 'Use a text-based theme file extension such as .hbs, .css, .js, or .json.'
+            });
+            return;
+        }
+
+        if (currentFiles[nextPath]) {
+            showToast({
+                type: 'error',
+                title: 'File already exists'
+            });
+            return;
+        }
+
+        const nextFiles = {
+            ...currentFiles,
+            [nextPath]: {
+                path: nextPath,
+                editable: true,
+                content: '',
+                binary: null,
+                date: new Date(),
+                unixPermissions: null,
+                dosPermissions: null
+            }
+        };
+
+        setFilesAndSelection(nextFiles, {type: 'file', path: nextPath});
+    };
+
+    const handleRenameSelected = async () => {
+        if (!selectedNode) {
+            return;
+        }
+
+        const defaultValue = selectedNode.type === 'dir'
+            ? selectedNode.path.replace(/\/$/, '')
+            : selectedNode.path;
+        const promptLabel = selectedNode.type === 'dir' ? 'Rename folder to' : 'Rename file to';
+        const requestedPath = await requestInput({
+            title: selectedNode.type === 'dir' ? 'Rename folder' : 'Rename file',
+            fieldTitle: 'Path',
+            initialValue: defaultValue,
+            okLabel: 'Rename',
+            prompt: promptLabel
+        });
+        const nextPath = requestedPath ? normaliseRelativePath(requestedPath) : null;
+
+        if (!nextPath || nextPath === defaultValue) {
+            return;
+        }
+
+        if (selectedNode.type === 'file') {
+            const fileToRename = currentFiles[selectedNode.path];
+
+            if (!isEditablePath(nextPath) && fileToRename.editable) {
+                showToast({
+                    type: 'error',
+                    title: 'Text files must keep a text file extension'
+                });
+                return;
+            }
+
+            if (wouldRenameBinaryFileToEditable(fileToRename, nextPath)) {
+                showToast({
+                    type: 'error',
+                    title: 'Binary files cannot be renamed to a text file',
+                    message: 'Rename this file with a non-text extension to keep its contents intact.'
+                });
+                return;
+            }
+
+            if (currentFiles[nextPath]) {
+                showToast({
+                    type: 'error',
+                    title: 'A file with that name already exists'
+                });
+                return;
+            }
+
+            const nextFiles = {...currentFiles};
+            const file = nextFiles[selectedNode.path];
+            delete nextFiles[selectedNode.path];
+            nextFiles[nextPath] = {
+                ...file,
+                path: nextPath,
+                editable: isEditablePath(nextPath)
+            };
+
+            setFilesAndSelection(nextFiles, {type: 'file', path: nextPath});
+            return;
+        }
+
+        const nextDirectoryPath = `${nextPath}/`;
+
+        if (nextDirectoryPath.startsWith(selectedNode.path)) {
+            showToast({
+                type: 'error',
+                title: 'A folder cannot be renamed inside itself'
+            });
+            return;
+        }
+
+        const conflictingPath = Object.keys(currentFiles).find(path => path.startsWith(nextDirectoryPath));
+
+        if (conflictingPath) {
+            showToast({
+                type: 'error',
+                title: 'A folder with that path already exists'
+            });
+            return;
+        }
+
+        const nextFiles = createFolderRenameMap({
+            files: currentFiles,
+            oldPrefix: selectedNode.path,
+            newPrefix: nextDirectoryPath
+        });
+
+        setFilesAndSelection(nextFiles, {type: 'dir', path: nextDirectoryPath});
+        setExpandedDirectories((current) => {
+            const next = new Set<string>();
+
+            for (const directory of current) {
+                if (!directory.startsWith(selectedNode.path)) {
+                    next.add(directory);
+                    continue;
+                }
+
+                next.add(`${nextDirectoryPath}${directory.slice(selectedNode.path.length)}`);
+            }
+
+            return next;
+        });
+    };
+
+    const handleDeleteSelected = async () => {
+        if (!selectedNode) {
+            return;
+        }
+
+        if (selectedNode.type === 'file') {
+            const confirmed = await requestConfirmation({
+                title: 'Delete file',
+                prompt: <>Delete <strong>{selectedNode.path}</strong> from this theme?</>,
+                okLabel: 'Delete',
+                okColor: 'red'
+            });
+
+            if (!confirmed) {
+                return;
+            }
+
+            const nextFiles = {...currentFiles};
+            delete nextFiles[selectedNode.path];
+            setFilesAndSelection(nextFiles);
+            return;
+        }
+
+        const matchingPaths = Object.keys(currentFiles).filter(path => path.startsWith(selectedNode.path));
+
+        if (!matchingPaths.length) {
+            return;
+        }
+
+        const confirmed = await requestConfirmation({
+            title: 'Delete folder',
+            prompt: <>Delete {matchingPaths.length} file{matchingPaths.length === 1 ? '' : 's'} from <strong>{selectedNode.path}</strong>?</>,
+            okLabel: 'Delete',
+            okColor: 'red'
+        });
+
+        if (!confirmed) {
+            return;
+        }
+
+        const nextFiles = {...currentFiles};
+
+        for (const path of matchingPaths) {
+            delete nextFiles[path];
+        }
+
+        setFilesAndSelection(nextFiles);
+    };
+
+    const handleRevertPath = (path: string) => {
+        const baseFile = baseFiles[path];
+        const currentFile = currentFiles[path];
+        const nextFiles = {...currentFiles};
+
+        if (!baseFile && currentFile) {
+            delete nextFiles[path];
+        } else if (baseFile) {
+            nextFiles[path] = {
+                ...baseFile,
+                binary: baseFile.binary ? new Uint8Array(baseFile.binary) : null
+            };
+        }
+
+        setFilesAndSelection(nextFiles);
+    };
+
+    const requestSaveAsThemeName = async () => {
+        const requestedName = await requestInput({
+            title: 'Save as new theme',
+            fieldTitle: 'Theme name',
+            initialValue: `${currentThemeName}-edited`,
+            okLabel: 'Continue',
+            prompt: 'Default themes cannot be overwritten. Save your edits as a new theme instead.'
+        });
+        const nextName = requestedName?.trim().toLowerCase();
+
+        if (!nextName) {
+            return null;
+        }
+
+        if (nextName.includes('/') || nextName.includes('\\')) {
+            showToast({
+                type: 'error',
+                title: 'Theme names cannot contain slashes'
+            });
+            return null;
+        }
+
+        if (isDefaultThemeName(nextName)) {
+            showToast({
+                type: 'error',
+                title: 'Built-in themes cannot be overwritten'
+            });
+            return null;
+        }
+
+        return nextName;
+    };
+
+    const handleSave = async () => {
+        if (isSaving) {
+            return;
+        }
+
+        if (changes.length === 0) {
+            showToast({
+                type: 'info',
+                title: 'No changes to save'
+            });
+            return;
+        }
+
+        const previousThemeName = currentThemeName;
+        const nextThemeName = isDefaultThemeName(previousThemeName) ? await requestSaveAsThemeName() : previousThemeName;
+
+        if (!nextThemeName) {
+            return;
+        }
+
+        const isSaveAs = nextThemeName !== previousThemeName;
+        const themeExists = themesData?.themes.some(theme => theme.name === nextThemeName) || false;
+        const confirmMessage = isSaveAs
+            ? `Save your edits as "${nextThemeName}"?`
+            : `Upload ${changes.length} changed file${changes.length === 1 ? '' : 's'} and replace "${previousThemeName}"?`;
+
+        const confirmedSave = await requestConfirmation({
+            title: isSaveAs ? 'Save theme as new copy' : 'Update theme',
+            prompt: confirmMessage,
+            okLabel: isSaveAs ? 'Save theme' : 'Replace theme'
+        });
+
+        if (!confirmedSave) {
+            return;
+        }
+
+        if (isSaveAs && themeExists) {
+            const confirmedOverwrite = await requestConfirmation({
+                title: 'Overwrite theme',
+                prompt: <><strong>{nextThemeName}</strong> already exists. Do you want to overwrite it?</>,
+                okLabel: 'Overwrite',
+                okColor: 'red'
+            });
+
+            if (!confirmedOverwrite) {
+                return;
+            }
+        }
+
+        setIsSaving(true);
+
+        try {
+            const blob = await packThemeArchive({
+                files: currentFiles,
+                rootPrefix
+            });
+
+            const formData = new FormData();
+            formData.append('file', blob, `${nextThemeName}.zip`);
+
+            const response = await fetch(`${getGhostPaths().apiRoot}/themes/upload/`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: {
+                    Accept: 'application/json'
+                },
+                body: formData
+            });
+
+            const data = await response.json().catch(() => null) as ThemesInstallResponseType & {errors?: FatalErrors};
+
+            if (!response.ok) {
+                if (response.status === 422 && data?.errors) {
+                    NiceModal.show(InvalidThemeModal, {
+                        title: 'Invalid Theme',
+                        prompt: <>Fix the validation errors below and try saving again.</>,
+                        fatalErrors: data.errors as FatalErrors
+                    });
+                    return;
+                }
+
+                throw new Error((data as {errors?: Array<{message?: string}>} | null)?.errors?.[0]?.message || 'Theme upload failed.');
+            }
+
+            const uploadedTheme = data.themes[0];
+            const returnRoute = getReturnRouteFromHash();
+
+            setBaseFiles(cloneThemeFiles(currentFiles));
+
+            if (isSaveAs) {
+                setCurrentThemeName(nextThemeName);
+                setRootPrefix(rootPrefix ? `${nextThemeName}/` : '');
+                updateRoute(buildThemeEditorRoute(nextThemeName, returnRoute));
+            }
+
+            await queryClient.invalidateQueries(['ThemesResponseType']);
+
+            if (isSaveAs || uploadedTheme.errors?.length || uploadedTheme.warnings?.length) {
+                NiceModal.show(ThemeInstalledModal, {
+                    title: isSaveAs ? 'Theme saved' : 'Theme updated',
+                    prompt: <><strong>{uploadedTheme.name}</strong> saved successfully.</>,
+                    installedTheme: uploadedTheme
+                });
+            } else {
+                showToast({
+                    type: 'success',
+                    title: 'Theme saved',
+                    message: <div><span className='capitalize'>{uploadedTheme.name}</span> has been updated.</div>
+                });
+            }
+        } catch (error) {
+            handleError(error);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const openFile = (path: string) => {
+        setSelectedNode({type: 'file', path});
+        ensurePathExpanded(path);
+    };
+
+    const renderTreeNode = (node: TreeNode, depth = 0): React.ReactNode => {
+        if (node.type === 'file') {
+            const isSelected = selectedNode?.type === 'file' && selectedNode.path === node.path;
+            const changeStatus = changesMap.get(node.path);
+
+            return (
+                <button
+                    key={node.path}
+                    className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#243043] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'} ${!node.editable ? 'opacity-70' : ''}`}
+                    style={{paddingLeft: `${depth * 14 + 8}px`}}
+                    type='button'
+                    onClick={() => openFile(node.path)}
+                >
+                    <span className='w-3 shrink-0' />
+                    <FileCode2 size={14} />
+                    <span className='min-w-0 grow truncate'>{node.name}</span>
+                    {changeStatus && (
+                        <span className={`mr-1 h-1.5 w-1.5 shrink-0 rounded-full ${changeStatus === 'deleted' ? 'bg-[#ff6b6b]' : changeStatus === 'added' ? 'bg-[#14b886]' : 'bg-[#f5a623]'}`} />
+                    )}
+                </button>
+            );
+        }
+
+        const isExpanded = expandedDirectories.has(node.path);
+        const isSelected = selectedNode?.type === 'dir' && selectedNode.path === node.path;
+        const children = sortTreeNodes(Array.from(node.children?.values() || []));
+
+        return (
+            <div key={node.path || 'root'}>
+                {node.path && (
+                    <button
+                        className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#202630] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'}`}
+                        style={{paddingLeft: `${depth * 14 + 8}px`}}
+                        type='button'
+                        onClick={() => {
+                            setSelectedNode({type: 'dir', path: node.path});
+                            setExpandedDirectories((current) => {
+                                const next = new Set(current);
+
+                                if (next.has(node.path)) {
+                                    next.delete(node.path);
+                                } else {
+                                    next.add(node.path);
+                                }
+
+                                return next;
+                            });
+                        }}
+                    >
+                        {isExpanded ? <ChevronDown className='shrink-0 text-[#6a6f78]' size={12} /> : <ChevronRight className='shrink-0 text-[#6a6f78]' size={12} />}
+                        {isExpanded ? <FolderOpen className='shrink-0 text-[#8a8f98]' size={14} /> : <Folder className='shrink-0 text-[#8a8f98]' size={14} />}
+                        <span className='truncate'>{node.name}</span>
+                    </button>
+                )}
+                {(node.path === '' || isExpanded) && (
+                    <div>
+                        {children.map(child => renderTreeNode(child, node.path ? depth + 1 : depth))}
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    const selectedFileStatus = selectedFile ? changesMap.get(selectedFile.path) : null;
+    const reviewSummary = formatReviewSummary(reviewItems);
+
+    return (
+        <div
+            aria-label={`Edit theme ${themeName}`}
+            aria-modal='true'
+            className='dark fixed inset-0 z-[140] bg-[rgba(10,11,13,0.72)] text-[#e6e7ea] backdrop-blur-[4px]'
+            data-testid='theme-code-editor-modal'
+            role='dialog'
+            onClick={(event) => {
+                if (event.target === event.currentTarget) {
+                    closeEditor();
+                }
+            }}
+        >
+            <div className='relative flex h-full w-full flex-col overflow-hidden bg-[#15171a]'>
+                <div className='flex items-center gap-3 border-b border-[#23262c] bg-[#1a1d21] px-4 py-3'>
+                    <div className='flex min-w-0 items-baseline gap-2'>
+                        <h2 className='truncate text-[14px] font-semibold text-[#f4f5f7]'>Edit theme</h2>
+                        <span className='truncate text-[12px] text-[#8a8f98]'>{currentThemeName}</span>
+                    </div>
+                    {changes.length > 0 && (
+                        <button
+                            className='rounded-full border border-transparent bg-[#3b2a16] px-2.5 py-1 text-[11px] leading-none text-[#f5a623] hover:bg-[#49311a]'
+                            type='button'
+                            onClick={() => {
+                                setSelectedReviewPath(reviewItems[0]?.path ?? null);
+                                setIsReviewOpen(true);
+                            }}
+                        >
+                            {changes.length} {changes.length === 1 ? 'file modified' : 'files modified'}
+                        </button>
+                    )}
+                    <div className='grow' />
+                    <button className={ghostButtonClass} type='button' onClick={closeEditor}>
+                        <X size={14} />
+                        Close
+                    </button>
+                    <button className={primaryButtonClass} disabled={isSaving} type='button' onClick={() => void handleSave()}>
+                        <Save size={14} />
+                        {isSaving ? 'Saving…' : 'Save'}
+                    </button>
+                </div>
+
+                {loadError && (
+                    <div className='border-b border-[#512828] bg-[#3a1d1d] px-4 py-2 text-[12px] text-[#ffbdbd]'>
+                        {loadError}
+                    </div>
+                )}
+
+                <div className='flex min-h-0 flex-1'>
+                    <aside className='flex w-[280px] shrink-0 flex-col border-r border-[#23262c] bg-[#16181c]'>
+                        <div className='flex items-center justify-between gap-2 border-b border-[#23262c] px-3 py-2'>
+                            <div className='text-[12px] font-medium text-[#c8ccd3]'>{Object.keys(currentFiles).length} files</div>
+                            <div className='flex items-center gap-2'>
+                                <button aria-label='New file' className={fileActionButtonClass} type='button' onClick={handleCreateFile}>
+                                    <Plus size={13} />
+                                </button>
+                                <button aria-label='Rename selected item' className={fileActionButtonClass} disabled={!selectedNode} type='button' onClick={handleRenameSelected}>
+                                    <Pencil size={13} />
+                                </button>
+                                <button aria-label='Delete selected item' className={fileActionButtonClass} disabled={!selectedNode} type='button' onClick={handleDeleteSelected}>
+                                    <Trash2 size={13} />
+                                </button>
+                            </div>
+                        </div>
+                        <div className='min-h-0 flex-1 overflow-y-auto px-2 py-2'>
+                            {isLoading ? (
+                                <div className='flex h-full flex-col items-center justify-center gap-3 text-center text-[13px] text-[#8a8f98]'>
+                                    <div className='h-5 w-5 animate-spin rounded-full border-2 border-[#2f333b] border-t-[#14b886]' />
+                                    <span>Loading theme files…</span>
+                                </div>
+                            ) : Object.keys(currentFiles).length === 0 ? (
+                                <div className='px-3 py-4 text-[12px] text-[#8a8f98]'>This theme archive does not contain any files.</div>
+                            ) : (
+                                renderTreeNode(buildTree(currentFiles))
+                            )}
+                        </div>
+                    </aside>
+
+                    <section className='flex min-w-0 flex-1 flex-col bg-[#16181c]'>
+                        <div className='flex items-center gap-2 border-b border-[#23262c] bg-[#17191d] px-4 py-2 text-[12px] text-[#8a8f98]'>
+                            {selectedFile ? (
+                                <>
+                                    <span className='min-w-0 truncate font-medium text-[#e6e7ea]'>{selectedFile.path}</span>
+                                    <span className='rounded bg-[#2a2d33] px-2 py-0.5 text-[10px] tracking-[0.04em] text-[#c8ccd3] uppercase'>
+                                        {getLanguageLabel(selectedFile.path)}
+                                    </span>
+                                    {selectedFileStatus && (
+                                        <button
+                                            className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-[10px] tracking-[0.04em] uppercase ${selectedFileStatus === 'deleted' ? 'bg-[#4a2222] text-[#ffbdbd]' : selectedFileStatus === 'added' ? 'bg-[#17342a] text-[#a5e8c8]' : 'bg-[#3b2a16] text-[#f5a623]'}`}
+                                            type='button'
+                                            onClick={() => handleRevertPath(selectedFile.path)}
+                                        >
+                                            <Undo2 size={11} />
+                                            Revert
+                                        </button>
+                                    )}
+                                    <div className='grow' />
+                                    {selectedFile.editable && (
+                                        <button
+                                            aria-label={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
+                                            aria-pressed={isTextWrapEnabled}
+                                            className={wrapToggleClass(isTextWrapEnabled)}
+                                            title={isTextWrapEnabled ? 'Disable text wrap' : 'Enable text wrap'}
+                                            type='button'
+                                            onClick={() => setIsTextWrapEnabled(value => !value)}
+                                        >
+                                            <TextWrap className='shrink-0' size={14} strokeWidth={2} />
+                                        </button>
+                                    )}
+                                </>
+                            ) : (
+                                <span>No file selected</span>
+                            )}
+                        </div>
+
+                        <div className='min-h-0 flex-1'>
+                            {!selectedNode && !isLoading && (
+                                <div className='flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                    Select a file from the tree to start editing.
+                                </div>
+                            )}
+
+                            {selectedNode?.type === 'dir' && (
+                                <div className='flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                    Folder selected. Choose a file to edit, or rename or delete the folder from the file pane.
+                                </div>
+                            )}
+
+                            {selectedFile && !selectedFile.editable && (
+                                <div className='flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                    This file cannot be edited in the browser.
+                                </div>
+                            )}
+
+                            {selectedFile?.editable && (
+                                <CodeMirror
+                                    key={`${selectedFile.path}:${editorExtensions.length}`}
+                                    basicSetup={{
+                                        highlightActiveLine: false,
+                                        highlightActiveLineGutter: false
+                                    }}
+                                    className='h-full [&_.cm-button]:h-8 [&_.cm-button]:rounded-md [&_.cm-button]:border [&_.cm-button]:border-[#2f333b] [&_.cm-button]:bg-[#1f2228] [&_.cm-button]:bg-none [&_.cm-button]:px-3 [&_.cm-button]:text-[13px] [&_.cm-button]:text-[#c8ccd3] [&_.cm-button:hover]:bg-[#2a2d33] [&_.cm-content]:min-h-full [&_.cm-content]:py-3 [&_.cm-content_*::selection]:bg-[#355070] [&_.cm-cursor]:border-l-[#e6e7ea] [&_.cm-editor]:h-full [&_.cm-editor]:rounded-none [&_.cm-editor]:border-0 [&_.cm-editor]:bg-[#16181c] [&_.cm-gutters]:border-r-[#23262c] [&_.cm-gutters]:bg-[#17191d] [&_.cm-line::selection]:bg-[#355070] [&_.cm-panel]:bg-[#17191d] [&_.cm-panel]:shadow-none [&_.cm-panel.cm-search]:gap-2 [&_.cm-panel.cm-search]:px-3 [&_.cm-panel.cm-search]:py-2 [&_.cm-panel.cm-search]:text-[13px] [&_.cm-panels]:border-b [&_.cm-panels]:border-[#23262c] [&_.cm-panels]:bg-[#17191d] [&_.cm-panels]:text-[#c8ccd3] [&_.cm-scroller]:min-h-full [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:bg-[#16181c] [&_.cm-search]:flex [&_.cm-search]:flex-wrap [&_.cm-search]:items-center [&_.cm-search]:gap-2 [&_.cm-search_label]:inline-flex [&_.cm-search_label]:items-center [&_.cm-search_label]:gap-1.5 [&_.cm-search_label]:text-[#a5abb4] [&_.cm-search_label_input]:h-4 [&_.cm-search_label_input]:w-4 [&_.cm-search_label_input]:accent-[#14b886] [&_.cm-searchMatch]:bg-[#243043] [&_.cm-searchMatch-selected]:bg-[#3b2a16] [&_.cm-searchMatch-selected]:outline-none [&_.cm-selectionBackground]:!bg-[#355070] [&_.cm-selectionLayer_.cm-selectionBackground]:!bg-[#355070] [&_.cm-textfield]:h-8 [&_.cm-textfield]:min-w-[220px] [&_.cm-textfield]:rounded-md [&_.cm-textfield]:border [&_.cm-textfield]:border-[#2f333b] [&_.cm-textfield]:bg-[#16181c] [&_.cm-textfield]:px-2.5 [&_.cm-textfield]:text-[#e6e7ea] [&_.cm-textfield]:outline-none [&_.cm-textfield]:placeholder:text-[#6a6f78]'
+                                    extensions={editorExtensions}
+                                    height='full'
+                                    theme={oneDark}
+                                    value={selectedFile.content || ''}
+                                    autoFocus
+                                    onChange={(value) => {
+                                        setCurrentFiles(files => ({
+                                            ...files,
+                                            [selectedFile.path]: {
+                                                ...files[selectedFile.path],
+                                                content: value
+                                            }
+                                        }));
+                                    }}
+                                />
+                            )}
+                        </div>
+                    </section>
+                </div>
+
+                {isReviewOpen && (
+                    <div className='absolute inset-0 z-10 flex items-center justify-center bg-[rgba(8,10,14,0.64)]' onClick={() => setIsReviewOpen(false)}>
+                        <div className='flex h-[min(78vh,calc(100%-24px))] w-[min(1240px,calc(100%-24px))] flex-col overflow-hidden rounded-[10px] border border-[#2b3038] bg-[#171a20] p-4 shadow-[0_24px_64px_rgba(0,0,0,0.45)]' onClick={event => event.stopPropagation()}>
+                            <div className='mb-2 flex items-center justify-between gap-3'>
+                                <div>
+                                    <h3 className='text-[16px] font-semibold text-[#f4f5f7]'>All changes</h3>
+                                    <p className='mt-1 text-[12px] text-[#9aa0aa]'>{reviewSummary}</p>
+                                </div>
+                                <button aria-label='Close review' className={iconButtonClass} type='button' onClick={() => setIsReviewOpen(false)}>
+                                    <X size={14} />
+                                </button>
+                            </div>
+
+                            <div className='grid min-h-0 flex-1 grid-cols-[320px_1fr] gap-3'>
+                                <div className='min-h-0 overflow-auto rounded-lg border border-[#2a2d33] bg-[#111319] p-2'>
+                                    {reviewItems.map(item => (
+                                        <button
+                                            key={`${item.status}-${item.path}`}
+                                            className={`flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-[13px] ${selectedReviewItem?.path === item.path ? 'border-[#355070] bg-[#243043] text-white' : 'border-transparent text-[#d4d8de] hover:bg-[#1d2028]'}`}
+                                            type='button'
+                                            onClick={() => setSelectedReviewPath(item.path)}
+                                        >
+                                            <span className={`rounded px-1.5 py-0.5 text-[10px] tracking-[0.04em] uppercase ${item.status === 'deleted' ? 'bg-[#4a2222] text-[#ffbdbd]' : item.status === 'added' ? 'bg-[#17342a] text-[#a5e8c8]' : 'bg-[#3b2a16] text-[#f5a623]'}`}>
+                                                {item.status}
+                                            </span>
+                                            <span className='min-w-0 grow truncate'>{item.path}</span>
+                                            {!item.editable && <CircleDot className='text-[#6a6f78]' size={12} />}
+                                        </button>
+                                    ))}
+                                    {reviewItems.length === 0 && (
+                                        <div className='px-3 py-4 text-[12px] text-[#8a8f98]'>No unsaved changes.</div>
+                                    )}
+                                </div>
+
+                                <div className='flex min-h-0 flex-col overflow-hidden rounded-lg border border-[#2a2d33] bg-[#111319]'>
+                                    {selectedReviewItem ? (
+                                        <>
+                                            <div className='flex items-center gap-2 border-b border-[#23262c] px-4 py-3'>
+                                                <div className='min-w-0 grow'>
+                                                    <div className='truncate text-[13px] font-medium text-[#f4f5f7]'>{selectedReviewItem.path}</div>
+                                                    <div className='mt-1 text-[12px] text-[#8a8f98]'>
+                                                        {selectedReviewItem.editable ? 'Text file preview' : 'Binary file'}
+                                                    </div>
+                                                </div>
+                                                {selectedReviewItem.status !== 'deleted' && (
+                                                    <button className={ghostButtonClass} type='button' onClick={() => {
+                                                        openFile(selectedReviewItem.path);
+                                                        setIsReviewOpen(false);
+                                                    }}>
+                                                        Open in editor
+                                                    </button>
+                                                )}
+                                                <button className={ghostButtonClass} type='button' onClick={() => handleRevertPath(selectedReviewItem.path)}>
+                                                    <Undo2 size={14} />
+                                                    Revert
+                                                </button>
+                                            </div>
+
+                                            {!selectedReviewItem.editable ? (
+                                                <div className='flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                                    Binary files are kept intact in the archive. Open or revert the change from here, but binary contents are not shown.
+                                                </div>
+                                            ) : selectedReviewItem.status === 'added' ? (
+                                                <div className='min-h-0 flex-1 overflow-auto p-4'>
+                                                    <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>After</div>
+                                                    <pre className='overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.after ?? ''}</pre>
+                                                </div>
+                                            ) : selectedReviewItem.status === 'deleted' ? (
+                                                <div className='min-h-0 flex-1 overflow-auto p-4'>
+                                                    <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>Before</div>
+                                                    <pre className='overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.before ?? ''}</pre>
+                                                </div>
+                                            ) : (
+                                                <div className='grid min-h-0 flex-1 grid-cols-2 gap-4 p-4'>
+                                                    <div className='min-h-0 overflow-auto'>
+                                                        <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>Before</div>
+                                                        <pre className='h-full overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.before ?? ''}</pre>
+                                                    </div>
+                                                    <div className='min-h-0 overflow-auto'>
+                                                        <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>After</div>
+                                                        <pre className='h-full overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.after ?? ''}</pre>
+                                                    </div>
+                                                </div>
+                                            )}
+                                        </>
+                                    ) : (
+                                        <div className='flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                            Select a changed file to review it.
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default ThemeCodeEditorModal;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -386,9 +386,19 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     useEffect(() => {
         let isMounted = true;
 
+        const resetLoadedTheme = () => {
+            setCurrentThemeName(themeName);
+            setBaseFiles({});
+            setCurrentFiles({});
+            setRootPrefix('');
+            setSelectedNode(null);
+            setExpandedDirectories(new Set(['']));
+        };
+
         const loadTheme = async () => {
             setIsLoading(true);
             setLoadError(null);
+            resetLoadedTheme();
 
             try {
                 const {apiRoot} = getGhostPaths();

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -175,6 +175,51 @@ const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string
 // stripping on Windows when the archive is later unzipped.
 const THEME_NAME_PATTERN = /^[a-z0-9][\w-]{0,63}$/;
 
+type UploadSizeLimitError = {
+    message?: string;
+    code?: string;
+    errorDetails?: {
+        entryName?: string;
+        observedBytes?: number;
+        limitBytes?: number;
+    };
+};
+
+const UPLOAD_SIZE_LIMIT_TITLES: Record<string, string> = {
+    COMPRESSED_TOO_LARGE: 'Theme too large to upload',
+    ENTRY_TOO_LARGE: 'File too large',
+    TOTAL_TOO_LARGE: 'Theme contents too large'
+};
+
+const formatLimitBytes = (bytes: number | undefined) => {
+    if (!bytes || bytes <= 0) {
+        return 'the allowed size';
+    }
+    const mb = bytes / (1024 * 1024);
+    if (mb >= 1) {
+        return `${mb.toFixed(1)} MB`;
+    }
+    return `${Math.round(bytes / 1024)} KB`;
+};
+
+const buildUploadSizeLimitMessage = (err: UploadSizeLimitError) => {
+    const {entryName, limitBytes} = err.errorDetails ?? {};
+    const limit = formatLimitBytes(limitBytes);
+
+    switch (err.code) {
+    case 'COMPRESSED_TOO_LARGE':
+        return `The theme archive is too large to upload (max ${limit}).`;
+    case 'ENTRY_TOO_LARGE':
+        return entryName
+            ? `The file "${entryName}" is too large (max ${limit} per file).`
+            : `One of the files is too large (max ${limit} per file).`;
+    case 'TOTAL_TOO_LARGE':
+        return `The theme contents exceed the maximum allowed size of ${limit}.`;
+    default:
+        return err.message || 'Theme upload failed.';
+    }
+};
+
 const wrapToggleClass = (active: boolean) => `inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] ${active ? 'opacity-100' : 'opacity-60'}`;
 
 const editorPaneEmptyStateClass = 'flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]';
@@ -777,7 +822,18 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                     return;
                 }
 
-                throw new Error((data as {errors?: Array<{message?: string}>} | null)?.errors?.[0]?.message || 'Theme upload failed.');
+                const serverError = (data as {errors?: Array<UploadSizeLimitError>} | null)?.errors?.[0];
+
+                if (serverError?.code && UPLOAD_SIZE_LIMIT_TITLES[serverError.code]) {
+                    showToast({
+                        type: 'error',
+                        title: UPLOAD_SIZE_LIMIT_TITLES[serverError.code],
+                        message: buildUploadSizeLimitMessage(serverError)
+                    });
+                    return;
+                }
+
+                throw new Error(serverError?.message || 'Theme upload failed.');
             }
 
             const uploadedTheme = data.themes[0];

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -2,23 +2,13 @@ import CodeMirror, {EditorView} from '@uiw/react-codemirror';
 import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
+import ThemeEditorConfirmModal from './theme-editor-confirm-modal';
+import ThemeEditorInputModal from './theme-editor-input-modal';
+import ThemeEditorToolbar from './theme-editor-toolbar';
+import ThemeFileTree from './theme-file-tree';
 import ThemeInstalledModal from './theme-installed-modal';
-import {
-    ChevronDown,
-    ChevronRight,
-    CircleDot,
-    FileCode2,
-    Folder,
-    FolderOpen,
-    Pencil,
-    Plus,
-    Save,
-    TextWrap,
-    Trash2,
-    Undo2,
-    X
-} from 'lucide-react';
-import {Modal, TextField, showToast} from '@tryghost/admin-x-design-system';
+import ThemeReviewModal, {buildReviewItems} from './theme-review-modal';
+import {TextWrap, Undo2} from 'lucide-react';
 import {
     cloneThemeFiles,
     createFolderRenameMap,
@@ -33,92 +23,16 @@ import {
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {oneDark} from '@codemirror/theme-one-dark';
 import {search} from '@codemirror/search';
+import {showToast} from '@tryghost/admin-x-design-system';
 import {useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tanstack/react-query';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
-import type {ThemeChange, ThemeEditorFile} from './theme-editor-utils';
+import type {SelectedNode} from './theme-file-tree';
+import type {ThemeEditorConfirmModalProps} from './theme-editor-confirm-modal';
+import type {ThemeEditorFile} from './theme-editor-utils';
+import type {ThemeEditorInputModalProps} from './theme-editor-input-modal';
 import type {ThemesInstallResponseType} from '@tryghost/admin-x-framework/api/themes';
-
-type SelectedNode =
-    | {type: 'file'; path: string}
-    | {type: 'dir'; path: string}
-    | null;
-
-type TreeNode = {
-    type: 'dir' | 'file';
-    name: string;
-    path: string;
-    editable?: boolean;
-    children?: Map<string, TreeNode>;
-};
-
-type ReviewItem = {
-    path: string;
-    editable: boolean;
-    status: ThemeChange['status'];
-    before: string | null;
-    after: string | null;
-};
-
-const buildTree = (files: Record<string, ThemeEditorFile>) => {
-    const root: TreeNode = {
-        type: 'dir',
-        name: '',
-        path: '',
-        children: new Map()
-    };
-
-    for (const path of Object.keys(files).sort()) {
-        const segments = path.split('/');
-        let cursor = root;
-
-        for (let index = 0; index < segments.length; index += 1) {
-            const segment = segments[index];
-            const isLast = index === segments.length - 1;
-
-            if (isLast) {
-                cursor.children!.set(segment, {
-                    type: 'file',
-                    name: segment,
-                    path,
-                    editable: files[path].editable
-                });
-                continue;
-            }
-
-            const dirPath = `${segments.slice(0, index + 1).join('/')}/`;
-            const existing = cursor.children!.get(segment);
-
-            if (existing?.type === 'dir') {
-                cursor = existing;
-                continue;
-            }
-
-            const next: TreeNode = {
-                type: 'dir',
-                name: segment,
-                path: dirPath,
-                children: new Map()
-            };
-
-            cursor.children!.set(segment, next);
-            cursor = next;
-        }
-    }
-
-    return root;
-};
-
-const sortTreeNodes = (nodes: TreeNode[]) => {
-    return nodes.sort((left, right) => {
-        if (left.type !== right.type) {
-            return left.type === 'dir' ? -1 : 1;
-        }
-
-        return left.name.localeCompare(right.name);
-    });
-};
 
 const getLanguageExtension = (path: string) => {
     const extension = getExtension(path);
@@ -199,37 +113,6 @@ const getParentDirectories = (path: string) => {
     return directories;
 };
 
-const buildReviewItems = ({
-    baseFiles,
-    currentFiles,
-    changes
-}: {
-    baseFiles: Record<string, ThemeEditorFile>;
-    currentFiles: Record<string, ThemeEditorFile>;
-    changes: ThemeChange[];
-}) => {
-    return changes.map((change) => {
-        const baseFile = baseFiles[change.path];
-        const currentFile = currentFiles[change.path];
-
-        return {
-            path: change.path,
-            editable: change.editable,
-            status: change.status,
-            before: baseFile?.editable ? (baseFile.content ?? '') : null,
-            after: currentFile?.editable ? (currentFile.content ?? '') : null
-        };
-    });
-};
-
-const formatReviewSummary = (reviewItems: ReviewItem[]) => {
-    const added = reviewItems.filter(item => item.status === 'added').length;
-    const modified = reviewItems.filter(item => item.status === 'modified').length;
-    const deleted = reviewItems.filter(item => item.status === 'deleted').length;
-
-    return `${modified} modified, ${added} added, ${deleted} deleted`;
-};
-
 const getReturnRouteFromHash = () => {
     const hash = window.location.hash.substring(1);
     const domain = `${window.location.protocol}//${window.location.hostname}`;
@@ -270,12 +153,8 @@ const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string
 // stripping on Windows when the archive is later unzipped.
 const THEME_NAME_PATTERN = /^[a-z0-9][\w-]{0,63}$/;
 
-const iconButtonClass = 'inline-flex h-7 w-7 items-center justify-center rounded-full border border-[#2f333b] bg-transparent text-[#c8ccd3] transition-colors hover:bg-[#1f2228] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-50';
-const toolbarButtonClass = 'inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-50';
-const ghostButtonClass = `${toolbarButtonClass} border-[#2f333b] bg-transparent text-[#e6e7ea] hover:bg-[#1f2228]`;
-const primaryButtonClass = `${toolbarButtonClass} border-transparent bg-green text-black hover:bg-green-400`;
 const wrapToggleClass = (active: boolean) => `inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] ${active ? 'opacity-100' : 'opacity-60'}`;
-const fileActionButtonClass = 'inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-30';
+
 const editorSelectionTheme = EditorView.theme({
     '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
         backgroundColor: '#355070'
@@ -284,101 +163,6 @@ const editorSelectionTheme = EditorView.theme({
         color: '#ffffff'
     }
 }, {dark: true});
-
-type ThemeEditorConfirmModalProps = {
-    title: string;
-    prompt: React.ReactNode;
-    cancelLabel?: string;
-    okLabel?: string;
-    okColor?: 'black' | 'red' | 'green' | 'outline';
-};
-
-const ThemeEditorConfirmModal = NiceModal.create<ThemeEditorConfirmModalProps>(({
-    title,
-    prompt,
-    cancelLabel = 'Cancel',
-    okLabel = 'OK',
-    okColor = 'black'
-}) => {
-    const modal = useModal();
-
-    const closeWithResult = (result: boolean) => {
-        modal.resolve(result);
-        modal.remove();
-    };
-
-    return (
-        <Modal
-            backDropClick={false}
-            cancelLabel={cancelLabel}
-            okColor={okColor}
-            okLabel={okLabel}
-            testId='theme-editor-confirm-modal'
-            title={title}
-            width={540}
-            onCancel={() => closeWithResult(false)}
-            onOk={() => closeWithResult(true)}
-        >
-            <div className='py-4'>
-                {prompt}
-            </div>
-        </Modal>
-    );
-});
-
-type ThemeEditorInputModalProps = {
-    title: string;
-    prompt?: React.ReactNode;
-    fieldTitle: string;
-    initialValue: string;
-    placeholder?: string;
-    cancelLabel?: string;
-    okLabel?: string;
-};
-
-const ThemeEditorInputModal = NiceModal.create<ThemeEditorInputModalProps>(({
-    title,
-    prompt,
-    fieldTitle,
-    initialValue,
-    placeholder,
-    cancelLabel = 'Cancel',
-    okLabel = 'Continue'
-}) => {
-    const modal = useModal();
-    const [value, setValue] = useState(initialValue);
-
-    const closeWithResult = (result: string | null) => {
-        modal.resolve(result);
-        modal.remove();
-    };
-
-    return (
-        <Modal
-            backDropClick={false}
-            cancelLabel={cancelLabel}
-            okDisabled={!value.trim()}
-            okLabel={okLabel}
-            testId='theme-editor-input-modal'
-            title={title}
-            width={540}
-            onCancel={() => closeWithResult(null)}
-            onOk={() => closeWithResult(value)}
-        >
-            <div className='flex flex-col gap-4 py-4'>
-                {prompt}
-                <TextField
-                    clearBg={false}
-                    placeholder={placeholder}
-                    title={fieldTitle}
-                    value={value}
-                    autoFocus
-                    onChange={event => setValue(event.target.value)}
-                />
-            </div>
-        </Modal>
-    );
-});
 
 const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const modal = useModal();
@@ -398,7 +182,6 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const [loadError, setLoadError] = useState<string | null>(null);
     const [isReviewOpen, setIsReviewOpen] = useState(false);
     const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
-    const [selectedReviewPath, setSelectedReviewPath] = useState<string | null>(null);
     const [editorExtensions, setEditorExtensions] = useState<Array<ReturnType<typeof search> | typeof oneDark | typeof editorSelectionTheme | typeof EditorView.lineWrapping | Awaited<ReturnType<typeof getLanguageExtension>>>>([]);
 
     useEffect(() => {
@@ -479,18 +262,6 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const changesMap = useMemo(() => new Map(changes.map(change => [change.path, change.status])), [changes]);
     const reviewItems = useMemo(() => buildReviewItems({baseFiles, currentFiles, changes}), [baseFiles, currentFiles, changes]);
     const selectedFile = selectedNode?.type === 'file' ? currentFiles[selectedNode.path] : null;
-    const selectedReviewItem = reviewItems.find(item => item.path === selectedReviewPath) || reviewItems[0] || null;
-
-    useEffect(() => {
-        if (!selectedReviewItem) {
-            setSelectedReviewPath(null);
-            return;
-        }
-
-        if (!selectedReviewPath || !reviewItems.some(item => item.path === selectedReviewPath)) {
-            setSelectedReviewPath(selectedReviewItem.path);
-        }
-    }, [reviewItems, selectedReviewItem, selectedReviewPath]);
 
     useEffect(() => {
         let isMounted = true;
@@ -1027,71 +798,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         ensurePathExpanded(path);
     };
 
-    const renderTreeNode = (node: TreeNode, depth = 0): React.ReactNode => {
-        if (node.type === 'file') {
-            const isSelected = selectedNode?.type === 'file' && selectedNode.path === node.path;
-            const changeStatus = changesMap.get(node.path);
-
-            return (
-                <button
-                    key={node.path}
-                    className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#243043] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'} ${!node.editable ? 'opacity-70' : ''}`}
-                    style={{paddingLeft: `${depth * 14 + 8}px`}}
-                    type='button'
-                    onClick={() => openFile(node.path)}
-                >
-                    <span className='w-3 shrink-0' />
-                    <FileCode2 size={14} />
-                    <span className='min-w-0 grow truncate'>{node.name}</span>
-                    {changeStatus && (
-                        <span className={`mr-1 h-1.5 w-1.5 shrink-0 rounded-full ${changeStatus === 'deleted' ? 'bg-[#ff6b6b]' : changeStatus === 'added' ? 'bg-[#14b886]' : 'bg-[#f5a623]'}`} />
-                    )}
-                </button>
-            );
-        }
-
-        const isExpanded = expandedDirectories.has(node.path);
-        const isSelected = selectedNode?.type === 'dir' && selectedNode.path === node.path;
-        const children = sortTreeNodes(Array.from(node.children?.values() || []));
-
-        return (
-            <div key={node.path || 'root'}>
-                {node.path && (
-                    <button
-                        className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#202630] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'}`}
-                        style={{paddingLeft: `${depth * 14 + 8}px`}}
-                        type='button'
-                        onClick={() => {
-                            setSelectedNode({type: 'dir', path: node.path});
-                            setExpandedDirectories((current) => {
-                                const next = new Set(current);
-
-                                if (next.has(node.path)) {
-                                    next.delete(node.path);
-                                } else {
-                                    next.add(node.path);
-                                }
-
-                                return next;
-                            });
-                        }}
-                    >
-                        {isExpanded ? <ChevronDown className='shrink-0 text-[#6a6f78]' size={12} /> : <ChevronRight className='shrink-0 text-[#6a6f78]' size={12} />}
-                        {isExpanded ? <FolderOpen className='shrink-0 text-[#8a8f98]' size={14} /> : <Folder className='shrink-0 text-[#8a8f98]' size={14} />}
-                        <span className='truncate'>{node.name}</span>
-                    </button>
-                )}
-                {(node.path === '' || isExpanded) && (
-                    <div>
-                        {children.map(child => renderTreeNode(child, node.path ? depth + 1 : depth))}
-                    </div>
-                )}
-            </div>
-        );
-    };
-
     const selectedFileStatus = selectedFile ? changesMap.get(selectedFile.path) : null;
-    const reviewSummary = formatReviewSummary(reviewItems);
 
     return (
         <div
@@ -1107,33 +814,14 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
             }}
         >
             <div className='relative flex h-full w-full flex-col overflow-hidden bg-[#15171a]'>
-                <div className='flex items-center gap-3 border-b border-[#23262c] bg-[#1a1d21] px-4 py-3'>
-                    <div className='flex min-w-0 items-baseline gap-2'>
-                        <h2 className='truncate text-[14px] font-semibold text-[#f4f5f7]'>Edit theme</h2>
-                        <span className='truncate text-[12px] text-[#8a8f98]'>{currentThemeName}</span>
-                    </div>
-                    {changes.length > 0 && (
-                        <button
-                            className='rounded-full border border-transparent bg-[#3b2a16] px-2.5 py-1 text-[11px] leading-none text-[#f5a623] hover:bg-[#49311a]'
-                            type='button'
-                            onClick={() => {
-                                setSelectedReviewPath(reviewItems[0]?.path ?? null);
-                                setIsReviewOpen(true);
-                            }}
-                        >
-                            {changes.length} {changes.length === 1 ? 'file modified' : 'files modified'}
-                        </button>
-                    )}
-                    <div className='grow' />
-                    <button className={ghostButtonClass} type='button' onClick={closeEditor}>
-                        <X size={14} />
-                        Close
-                    </button>
-                    <button className={primaryButtonClass} disabled={isSaving} type='button' onClick={() => void handleSave()}>
-                        <Save size={14} />
-                        {isSaving ? 'Saving…' : 'Save'}
-                    </button>
-                </div>
+                <ThemeEditorToolbar
+                    changes={changes}
+                    currentThemeName={currentThemeName}
+                    isSaving={isSaving}
+                    onClose={closeEditor}
+                    onOpenReview={() => setIsReviewOpen(true)}
+                    onSave={() => void handleSave()}
+                />
 
                 {loadError && (
                     <div className='border-b border-[#512828] bg-[#3a1d1d] px-4 py-2 text-[12px] text-[#ffbdbd]'>
@@ -1142,34 +830,19 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                 )}
 
                 <div className='flex min-h-0 flex-1'>
-                    <aside className='flex w-[280px] shrink-0 flex-col border-r border-[#23262c] bg-[#16181c]'>
-                        <div className='flex items-center justify-between gap-2 border-b border-[#23262c] px-3 py-2'>
-                            <div className='text-[12px] font-medium text-[#c8ccd3]'>{Object.keys(currentFiles).length} files</div>
-                            <div className='flex items-center gap-2'>
-                                <button aria-label='New file' className={fileActionButtonClass} type='button' onClick={handleCreateFile}>
-                                    <Plus size={13} />
-                                </button>
-                                <button aria-label='Rename selected item' className={fileActionButtonClass} disabled={!selectedNode} type='button' onClick={handleRenameSelected}>
-                                    <Pencil size={13} />
-                                </button>
-                                <button aria-label='Delete selected item' className={fileActionButtonClass} disabled={!selectedNode} type='button' onClick={handleDeleteSelected}>
-                                    <Trash2 size={13} />
-                                </button>
-                            </div>
-                        </div>
-                        <div className='min-h-0 flex-1 overflow-y-auto px-2 py-2'>
-                            {isLoading ? (
-                                <div className='flex h-full flex-col items-center justify-center gap-3 text-center text-[13px] text-[#8a8f98]'>
-                                    <div className='h-5 w-5 animate-spin rounded-full border-2 border-[#2f333b] border-t-[#14b886]' />
-                                    <span>Loading theme files…</span>
-                                </div>
-                            ) : Object.keys(currentFiles).length === 0 ? (
-                                <div className='px-3 py-4 text-[12px] text-[#8a8f98]'>This theme archive does not contain any files.</div>
-                            ) : (
-                                renderTreeNode(buildTree(currentFiles))
-                            )}
-                        </div>
-                    </aside>
+                    <ThemeFileTree
+                        changesMap={changesMap}
+                        currentFiles={currentFiles}
+                        expandedDirectories={expandedDirectories}
+                        isLoading={isLoading}
+                        selectedNode={selectedNode}
+                        setExpandedDirectories={setExpandedDirectories}
+                        setSelectedNode={setSelectedNode}
+                        onCreateFile={handleCreateFile}
+                        onDeleteSelected={handleDeleteSelected}
+                        onOpenFile={openFile}
+                        onRenameSelected={handleRenameSelected}
+                    />
 
                     <section className='flex min-w-0 flex-1 flex-col bg-[#16181c]'>
                         <div className='flex items-center gap-2 border-b border-[#23262c] bg-[#17191d] px-4 py-2 text-[12px] text-[#8a8f98]'>
@@ -1256,99 +929,15 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                 </div>
 
                 {isReviewOpen && (
-                    <div className='absolute inset-0 z-10 flex items-center justify-center bg-[rgba(8,10,14,0.64)]' onClick={() => setIsReviewOpen(false)}>
-                        <div className='flex h-[min(78vh,calc(100%-24px))] w-[min(1240px,calc(100%-24px))] flex-col overflow-hidden rounded-[10px] border border-[#2b3038] bg-[#171a20] p-4 shadow-[0_24px_64px_rgba(0,0,0,0.45)]' onClick={event => event.stopPropagation()}>
-                            <div className='mb-2 flex items-center justify-between gap-3'>
-                                <div>
-                                    <h3 className='text-[16px] font-semibold text-[#f4f5f7]'>All changes</h3>
-                                    <p className='mt-1 text-[12px] text-[#9aa0aa]'>{reviewSummary}</p>
-                                </div>
-                                <button aria-label='Close review' className={iconButtonClass} type='button' onClick={() => setIsReviewOpen(false)}>
-                                    <X size={14} />
-                                </button>
-                            </div>
-
-                            <div className='grid min-h-0 flex-1 grid-cols-[320px_1fr] gap-3'>
-                                <div className='min-h-0 overflow-auto rounded-lg border border-[#2a2d33] bg-[#111319] p-2'>
-                                    {reviewItems.map(item => (
-                                        <button
-                                            key={`${item.status}-${item.path}`}
-                                            className={`flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-[13px] ${selectedReviewItem?.path === item.path ? 'border-[#355070] bg-[#243043] text-white' : 'border-transparent text-[#d4d8de] hover:bg-[#1d2028]'}`}
-                                            type='button'
-                                            onClick={() => setSelectedReviewPath(item.path)}
-                                        >
-                                            <span className={`rounded px-1.5 py-0.5 text-[10px] tracking-[0.04em] uppercase ${item.status === 'deleted' ? 'bg-[#4a2222] text-[#ffbdbd]' : item.status === 'added' ? 'bg-[#17342a] text-[#a5e8c8]' : 'bg-[#3b2a16] text-[#f5a623]'}`}>
-                                                {item.status}
-                                            </span>
-                                            <span className='min-w-0 grow truncate'>{item.path}</span>
-                                            {!item.editable && <CircleDot className='text-[#6a6f78]' size={12} />}
-                                        </button>
-                                    ))}
-                                    {reviewItems.length === 0 && (
-                                        <div className='px-3 py-4 text-[12px] text-[#8a8f98]'>No unsaved changes.</div>
-                                    )}
-                                </div>
-
-                                <div className='flex min-h-0 flex-col overflow-hidden rounded-lg border border-[#2a2d33] bg-[#111319]'>
-                                    {selectedReviewItem ? (
-                                        <>
-                                            <div className='flex items-center gap-2 border-b border-[#23262c] px-4 py-3'>
-                                                <div className='min-w-0 grow'>
-                                                    <div className='truncate text-[13px] font-medium text-[#f4f5f7]'>{selectedReviewItem.path}</div>
-                                                    <div className='mt-1 text-[12px] text-[#8a8f98]'>
-                                                        {selectedReviewItem.editable ? 'Text file preview' : 'Binary file'}
-                                                    </div>
-                                                </div>
-                                                {selectedReviewItem.status !== 'deleted' && (
-                                                    <button className={ghostButtonClass} type='button' onClick={() => {
-                                                        openFile(selectedReviewItem.path);
-                                                        setIsReviewOpen(false);
-                                                    }}>
-                                                        Open in editor
-                                                    </button>
-                                                )}
-                                                <button className={ghostButtonClass} type='button' onClick={() => handleRevertPath(selectedReviewItem.path)}>
-                                                    <Undo2 size={14} />
-                                                    Revert
-                                                </button>
-                                            </div>
-
-                                            {!selectedReviewItem.editable ? (
-                                                <div className='flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
-                                                    Binary files are kept intact in the archive. Open or revert the change from here, but binary contents are not shown.
-                                                </div>
-                                            ) : selectedReviewItem.status === 'added' ? (
-                                                <div className='min-h-0 flex-1 overflow-auto p-4'>
-                                                    <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>After</div>
-                                                    <pre className='overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.after ?? ''}</pre>
-                                                </div>
-                                            ) : selectedReviewItem.status === 'deleted' ? (
-                                                <div className='min-h-0 flex-1 overflow-auto p-4'>
-                                                    <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>Before</div>
-                                                    <pre className='overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.before ?? ''}</pre>
-                                                </div>
-                                            ) : (
-                                                <div className='grid min-h-0 flex-1 grid-cols-2 gap-4 p-4'>
-                                                    <div className='min-h-0 overflow-auto'>
-                                                        <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>Before</div>
-                                                        <pre className='h-full overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.before ?? ''}</pre>
-                                                    </div>
-                                                    <div className='min-h-0 overflow-auto'>
-                                                        <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>After</div>
-                                                        <pre className='h-full overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.after ?? ''}</pre>
-                                                    </div>
-                                                </div>
-                                            )}
-                                        </>
-                                    ) : (
-                                        <div className='flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
-                                            Select a changed file to review it.
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <ThemeReviewModal
+                        reviewItems={reviewItems}
+                        onClose={() => setIsReviewOpen(false)}
+                        onOpenInEditor={(path) => {
+                            openFile(path);
+                            setIsReviewOpen(false);
+                        }}
+                        onRevert={handleRevertPath}
+                    />
                 )}
             </div>
         </div>

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -113,12 +113,27 @@ const getParentDirectories = (path: string) => {
     return directories;
 };
 
+const ALLOWED_RETURN_ROUTE_PREFIXES = ['theme', 'design'];
+
+const isAllowedReturnRoute = (route: string): boolean => {
+    return ALLOWED_RETURN_ROUTE_PREFIXES.some(prefix => route === prefix || route.startsWith(`${prefix}/`));
+};
+
 const getReturnRouteFromHash = () => {
     const hash = window.location.hash.substring(1);
     const domain = `${window.location.protocol}//${window.location.hostname}`;
     const url = new URL(hash || '/', domain);
+    const from = url.searchParams.get('from');
 
-    return url.searchParams.get('from');
+    if (from === null) {
+        return null;
+    }
+
+    if (from === '' || isAllowedReturnRoute(from)) {
+        return from;
+    }
+
+    return null;
 };
 
 const buildThemeEditorRoute = (themeName: string, fromRoute: string | null) => {

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -122,7 +122,14 @@ const isAllowedReturnRoute = (route: string): boolean => {
 const getReturnRouteFromHash = () => {
     const hash = window.location.hash.substring(1);
     const domain = `${window.location.protocol}//${window.location.hostname}`;
-    const url = new URL(hash || '/', domain);
+
+    let url: URL;
+    try {
+        url = new URL(hash || '/', domain);
+    } catch {
+        return null;
+    }
+
     const from = url.searchParams.get('from');
 
     if (from === null) {

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -484,11 +484,16 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
             };
         }
 
-        Promise.all([oneDark, getLanguageExtension(selectedFile.path)]).then((extensions) => {
+        // Only the language extension is async (dynamic import); oneDark and
+        // the other extensions are static. Awaiting just the language load
+        // keeps the Promise types honest and makes the fallback branch read
+        // more clearly.
+        getLanguageExtension(selectedFile.path).then((languageExtension) => {
             if (isMounted) {
                 setEditorExtensions([
                     search({top: true}),
-                    ...extensions,
+                    oneDark,
+                    languageExtension,
                     ...(isTextWrapEnabled ? [EditorView.lineWrapping] : []),
                     editorSelectionTheme
                 ]);

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -252,6 +252,24 @@ const wouldRenameBinaryFileToEditable = (file: ThemeEditorFile, nextPath: string
     return !file.editable && isEditablePath(nextPath);
 };
 
+// Positive allowlist for theme names typed into the "Save as" flow.
+// The server (BaseStorage.getSanitizedFileName) silently replaces any
+// non [\w@.] characters with a dash, so the file ends up persisted under
+// a name that may not match what the user typed. Failing fast on the
+// client gives a clear error instead of a surprising rename.
+//
+// Rules (input is already lower-cased before the test):
+//  - 1-64 characters total
+//  - first character must be a letter or digit (no leading dash /
+//    underscore, avoiding hidden-file conventions and Unicode oddities)
+//  - remaining characters: word chars or dashes only
+//
+// Dots are deliberately excluded: real Ghost themes are kebab-case and
+// have no legitimate use for dots, while allowing them invites extension
+// confusion (`mytheme.zip` saved as a theme name) and trailing-dot
+// stripping on Windows when the archive is later unzipped.
+const THEME_NAME_PATTERN = /^[a-z0-9][\w-]{0,63}$/;
+
 const iconButtonClass = 'inline-flex h-7 w-7 items-center justify-center rounded-full border border-[#2f333b] bg-transparent text-[#c8ccd3] transition-colors hover:bg-[#1f2228] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-50';
 const toolbarButtonClass = 'inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-50';
 const ghostButtonClass = `${toolbarButtonClass} border-[#2f333b] bg-transparent text-[#e6e7ea] hover:bg-[#1f2228]`;
@@ -863,10 +881,11 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
             return null;
         }
 
-        if (nextName.includes('/') || nextName.includes('\\')) {
+        if (!THEME_NAME_PATTERN.test(nextName)) {
             showToast({
                 type: 'error',
-                title: 'Theme names cannot contain slashes'
+                title: 'Invalid theme name',
+                message: 'Use 1-64 characters, starting with a letter or number. Allowed: letters, numbers, dashes, and underscores.'
             });
             return null;
         }

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -1,7 +1,7 @@
 import CodeMirror, {EditorView} from '@uiw/react-codemirror';
 import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import ThemeInstalledModal from './theme-installed-modal';
 import {
     ChevronDown,
@@ -565,11 +565,17 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         updateRoute(getReturnRouteFromHash() ?? 'design/change-theme');
     };
 
+    // Keep a ref to the latest handleSave so the keydown listener can call
+    // the freshest version without re-registering on every render. handleSave
+    // captures state (currentFiles, changes, isSaving, ...) and is recreated
+    // each render — using a ref decouples that churn from the global listener.
+    const handleSaveRef = useRef<() => void>(() => {});
+
     useEffect(() => {
         const handleKeydown = (event: KeyboardEvent) => {
             if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
                 event.preventDefault();
-                void handleSave();
+                void handleSaveRef.current();
                 return;
             }
 
@@ -587,7 +593,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         return () => {
             window.removeEventListener('keydown', handleKeydown, true);
         };
-    });
+    }, []);
 
     const ensurePathExpanded = (path: string) => {
         setExpandedDirectories((current) => {
@@ -987,6 +993,10 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
             setIsSaving(false);
         }
     };
+
+    useEffect(() => {
+        handleSaveRef.current = handleSave;
+    });
 
     const openFile = (path: string) => {
         setSelectedNode({type: 'file', path});

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -177,6 +177,8 @@ const THEME_NAME_PATTERN = /^[a-z0-9][\w-]{0,63}$/;
 
 const wrapToggleClass = (active: boolean) => `inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] ${active ? 'opacity-100' : 'opacity-60'}`;
 
+const editorPaneEmptyStateClass = 'flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]';
+
 const editorSelectionTheme = EditorView.theme({
     '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
         backgroundColor: '#355070'
@@ -905,19 +907,19 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
 
                         <div className='min-h-0 flex-1'>
                             {!selectedNode && !isLoading && (
-                                <div className='flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                <div className={editorPaneEmptyStateClass}>
                                     Select a file from the tree to start editing.
                                 </div>
                             )}
 
                             {selectedNode?.type === 'dir' && (
-                                <div className='flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                <div className={editorPaneEmptyStateClass}>
                                     Folder selected. Choose a file to edit, or rename or delete the folder from the file pane.
                                 </div>
                             )}
 
                             {selectedFile && !selectedFile.editable && (
-                                <div className='flex h-full items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                <div className={editorPaneEmptyStateClass}>
                                     This file cannot be edited in the browser.
                                 </div>
                             )}

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-confirm-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-confirm-modal.tsx
@@ -1,0 +1,46 @@
+import NiceModal, {useModal} from '@ebay/nice-modal-react';
+import React from 'react';
+import {Modal} from '@tryghost/admin-x-design-system';
+
+export type ThemeEditorConfirmModalProps = {
+    title: string;
+    prompt: React.ReactNode;
+    cancelLabel?: string;
+    okLabel?: string;
+    okColor?: 'black' | 'red' | 'green' | 'outline';
+};
+
+const ThemeEditorConfirmModal = NiceModal.create<ThemeEditorConfirmModalProps>(({
+    title,
+    prompt,
+    cancelLabel = 'Cancel',
+    okLabel = 'OK',
+    okColor = 'black'
+}) => {
+    const modal = useModal();
+
+    const closeWithResult = (result: boolean) => {
+        modal.resolve(result);
+        modal.remove();
+    };
+
+    return (
+        <Modal
+            backDropClick={false}
+            cancelLabel={cancelLabel}
+            okColor={okColor}
+            okLabel={okLabel}
+            testId='theme-editor-confirm-modal'
+            title={title}
+            width={540}
+            onCancel={() => closeWithResult(false)}
+            onOk={() => closeWithResult(true)}
+        >
+            <div className='py-4'>
+                {prompt}
+            </div>
+        </Modal>
+    );
+});
+
+export default ThemeEditorConfirmModal;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-input-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-input-modal.tsx
@@ -1,0 +1,59 @@
+import NiceModal, {useModal} from '@ebay/nice-modal-react';
+import React, {useState} from 'react';
+import {Modal, TextField} from '@tryghost/admin-x-design-system';
+
+export type ThemeEditorInputModalProps = {
+    title: string;
+    prompt?: React.ReactNode;
+    fieldTitle: string;
+    initialValue: string;
+    placeholder?: string;
+    cancelLabel?: string;
+    okLabel?: string;
+};
+
+const ThemeEditorInputModal = NiceModal.create<ThemeEditorInputModalProps>(({
+    title,
+    prompt,
+    fieldTitle,
+    initialValue,
+    placeholder,
+    cancelLabel = 'Cancel',
+    okLabel = 'Continue'
+}) => {
+    const modal = useModal();
+    const [value, setValue] = useState(initialValue);
+
+    const closeWithResult = (result: string | null) => {
+        modal.resolve(result);
+        modal.remove();
+    };
+
+    return (
+        <Modal
+            backDropClick={false}
+            cancelLabel={cancelLabel}
+            okDisabled={!value.trim()}
+            okLabel={okLabel}
+            testId='theme-editor-input-modal'
+            title={title}
+            width={540}
+            onCancel={() => closeWithResult(null)}
+            onOk={() => closeWithResult(value)}
+        >
+            <div className='flex flex-col gap-4 py-4'>
+                {prompt}
+                <TextField
+                    clearBg={false}
+                    placeholder={placeholder}
+                    title={fieldTitle}
+                    value={value}
+                    autoFocus
+                    onChange={event => setValue(event.target.value)}
+                />
+            </div>
+        </Modal>
+    );
+});
+
+export default ThemeEditorInputModal;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-styles.ts
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-styles.ts
@@ -1,0 +1,10 @@
+// Shared button class strings used across the theme editor surface.
+// Kept in one place so the toolbar and the main editor's review pane stay
+// visually in sync without drift.
+
+export const iconButtonClass = 'inline-flex h-7 w-7 items-center justify-center rounded-full border border-[#2f333b] bg-transparent text-[#c8ccd3] transition-colors hover:bg-[#1f2228] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-50';
+
+const toolbarButtonClass = 'inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-50';
+
+export const ghostButtonClass = `${toolbarButtonClass} border-[#2f333b] bg-transparent text-[#e6e7ea] hover:bg-[#1f2228]`;
+export const primaryButtonClass = `${toolbarButtonClass} border-transparent bg-green text-black hover:bg-green-400`;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-toolbar.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-toolbar.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {Save, X} from 'lucide-react';
+import {ghostButtonClass, primaryButtonClass} from './theme-editor-styles';
+import type {ThemeChange} from './theme-editor-utils';
+
+type ThemeEditorToolbarProps = {
+    currentThemeName: string;
+    changes: ThemeChange[];
+    isSaving: boolean;
+    onOpenReview: () => void;
+    onClose: () => void;
+    onSave: () => void;
+};
+
+const ThemeEditorToolbar: React.FC<ThemeEditorToolbarProps> = ({
+    currentThemeName,
+    changes,
+    isSaving,
+    onOpenReview,
+    onClose,
+    onSave
+}) => {
+    return (
+        <div className='flex items-center gap-3 border-b border-[#23262c] bg-[#1a1d21] px-4 py-3'>
+            <div className='flex min-w-0 items-baseline gap-2'>
+                <h2 className='truncate text-[14px] font-semibold text-[#f4f5f7]'>Edit theme</h2>
+                <span className='truncate text-[12px] text-[#8a8f98]'>{currentThemeName}</span>
+            </div>
+            {changes.length > 0 && (
+                <button
+                    className='rounded-full border border-transparent bg-[#3b2a16] px-2.5 py-1 text-[11px] leading-none text-[#f5a623] hover:bg-[#49311a]'
+                    type='button'
+                    onClick={onOpenReview}
+                >
+                    {changes.length} {changes.length === 1 ? 'file modified' : 'files modified'}
+                </button>
+            )}
+            <div className='grow' />
+            <button className={ghostButtonClass} type='button' onClick={onClose}>
+                <X size={14} />
+                Close
+            </button>
+            <button className={primaryButtonClass} disabled={isSaving} type='button' onClick={onSave}>
+                <Save size={14} />
+                {isSaving ? 'Saving…' : 'Save'}
+            </button>
+        </div>
+    );
+};
+
+export default ThemeEditorToolbar;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-utils.ts
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-utils.ts
@@ -20,14 +20,6 @@ export const THEME_EDITOR_ARCHIVE_LIMITS = {
     maxExtractedBytes: 32 * 1024 * 1024
 } as const;
 
-type ThemeArchiveMetadata = {
-    uncompressedSize?: number;
-};
-
-type ThemeArchiveEntry = JSZip.JSZipObject & {
-    _data?: ThemeArchiveMetadata;
-};
-
 export class ThemeArchiveExtractionError extends Error {
     reason: 'invalid_archive' | 'too_many_files' | 'too_large';
 
@@ -150,16 +142,6 @@ export const cloneThemeFiles = (files: Record<string, ThemeEditorFile>) => {
 
 const invalidArchiveMessage = 'Failed to open the theme archive. Download the theme again and retry.';
 
-const getEntryUncompressedSize = (entry: JSZip.JSZipObject) => {
-    const size = (entry as ThemeArchiveEntry)._data?.uncompressedSize;
-
-    if (typeof size !== 'number' || !Number.isFinite(size) || size < 0) {
-        throw new ThemeArchiveExtractionError('invalid_archive', invalidArchiveMessage);
-    }
-
-    return size;
-};
-
 const getThemeArchiveSizeLabel = (bytes: number) => {
     const megabytes = bytes / (1024 * 1024);
 
@@ -189,19 +171,6 @@ const assertThemeArchiveLimits = (entries: Array<[string, JSZip.JSZipObject]>) =
             `This theme archive contains too many files for the browser editor (${entries.length}/${THEME_EDITOR_ARCHIVE_LIMITS.maxFiles}).`
         );
     }
-
-    let extractedBytes = 0;
-
-    for (const [, entry] of entries) {
-        extractedBytes += getEntryUncompressedSize(entry);
-
-        if (extractedBytes > THEME_EDITOR_ARCHIVE_LIMITS.maxExtractedBytes) {
-            throw new ThemeArchiveExtractionError(
-                'too_large',
-                `This theme archive is too large to open in the browser editor. Extracted files must stay under ${getThemeArchiveSizeLabel(THEME_EDITOR_ARCHIVE_LIMITS.maxExtractedBytes)}.`
-            );
-        }
-    }
 };
 
 const loadThemeArchive = async (arrayBuffer: ArrayBuffer) => {
@@ -220,6 +189,37 @@ const readThemeBinaryFile = async (entry: JSZip.JSZipObject) => {
     }
 };
 
+const readThemeTextFile = async (entry: JSZip.JSZipObject) => {
+    try {
+        return await entry.async('string');
+    } catch {
+        throw new ThemeArchiveExtractionError('invalid_archive', invalidArchiveMessage);
+    }
+};
+
+const getNormalizedArchivePath = (path: string) => {
+    const normalizedPath = normaliseRelativePath(path);
+
+    if (!normalizedPath || normalizedPath !== path) {
+        throw new ThemeArchiveExtractionError('invalid_archive', invalidArchiveMessage);
+    }
+
+    return normalizedPath;
+};
+
+const trackExtractedBytes = (totalBytes: number, fileBytes: number) => {
+    const nextTotal = totalBytes + fileBytes;
+
+    if (nextTotal > THEME_EDITOR_ARCHIVE_LIMITS.maxExtractedBytes) {
+        throw new ThemeArchiveExtractionError(
+            'too_large',
+            `This theme archive is too large to open in the browser editor. Extracted files must stay under ${getThemeArchiveSizeLabel(THEME_EDITOR_ARCHIVE_LIMITS.maxExtractedBytes)}.`
+        );
+    }
+
+    return nextTotal;
+};
+
 export const extractThemeArchive = async (arrayBuffer: ArrayBuffer): Promise<ThemeEditorSnapshot> => {
     const zip = await loadThemeArchive(arrayBuffer);
     const entries = collectArchiveEntries(zip);
@@ -228,6 +228,8 @@ export const extractThemeArchive = async (arrayBuffer: ArrayBuffer): Promise<The
 
     const rootPrefix = detectCommonRoot(entries.map(([path]) => path));
     const files: Record<string, ThemeEditorFile> = {};
+    const textEncoder = new TextEncoder();
+    let extractedBytes = 0;
 
     for (const [zipPath, entry] of entries) {
         const displayPath = rootPrefix ? zipPath.slice(rootPrefix.length) : zipPath;
@@ -236,14 +238,16 @@ export const extractThemeArchive = async (arrayBuffer: ArrayBuffer): Promise<The
             continue;
         }
 
-        const editable = isEditablePath(displayPath);
+        const normalizedPath = getNormalizedArchivePath(displayPath);
+        const editable = isEditablePath(normalizedPath);
 
         if (editable) {
             try {
-                const content = await entry.async('string');
+                const content = await readThemeTextFile(entry);
+                extractedBytes = trackExtractedBytes(extractedBytes, textEncoder.encode(content).byteLength);
 
-                files[displayPath] = {
-                    path: displayPath,
+                files[normalizedPath] = {
+                    path: normalizedPath,
                     editable: true,
                     content,
                     binary: null,
@@ -257,11 +261,14 @@ export const extractThemeArchive = async (arrayBuffer: ArrayBuffer): Promise<The
             }
         }
 
-        files[displayPath] = {
-            path: displayPath,
+        const binary = await readThemeBinaryFile(entry);
+        extractedBytes = trackExtractedBytes(extractedBytes, binary.byteLength);
+
+        files[normalizedPath] = {
+            path: normalizedPath,
             editable: false,
             content: null,
-            binary: await readThemeBinaryFile(entry),
+            binary,
             date: entry.date || new Date(),
             unixPermissions: typeof entry.unixPermissions === 'number' ? entry.unixPermissions : null,
             dosPermissions: typeof entry.dosPermissions === 'number' ? entry.dosPermissions : null

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-utils.ts
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-utils.ts
@@ -1,0 +1,380 @@
+import JSZip from 'jszip';
+
+export type ThemeEditorFile = {
+    path: string;
+    editable: boolean;
+    content: string | null;
+    binary: Uint8Array | null;
+    date: Date;
+    unixPermissions: number | null;
+    dosPermissions: number | null;
+};
+
+export type ThemeEditorSnapshot = {
+    files: Record<string, ThemeEditorFile>;
+    rootPrefix: string;
+};
+
+export const THEME_EDITOR_ARCHIVE_LIMITS = {
+    maxFiles: 1000,
+    maxExtractedBytes: 32 * 1024 * 1024
+} as const;
+
+type ThemeArchiveMetadata = {
+    uncompressedSize?: number;
+};
+
+type ThemeArchiveEntry = JSZip.JSZipObject & {
+    _data?: ThemeArchiveMetadata;
+};
+
+export class ThemeArchiveExtractionError extends Error {
+    reason: 'invalid_archive' | 'too_many_files' | 'too_large';
+
+    constructor(reason: 'invalid_archive' | 'too_many_files' | 'too_large', message: string) {
+        super(message);
+        this.name = 'ThemeArchiveExtractionError';
+        this.reason = reason;
+    }
+}
+
+const editableExtensions = new Set([
+    'css',
+    'cjs',
+    'hbs',
+    'handlebars',
+    'htm',
+    'html',
+    'js',
+    'json',
+    'less',
+    'md',
+    'markdown',
+    'mjs',
+    'sass',
+    'scss',
+    'svg',
+    'txt',
+    'xml',
+    'yaml',
+    'yml'
+]);
+
+const editableBasenames = new Set([
+    '.editorconfig',
+    '.eslintignore',
+    '.eslintrc',
+    '.gitattributes',
+    '.gitignore',
+    '.npmignore',
+    '.prettierignore',
+    '.prettierrc',
+    'CODEOWNERS',
+    'LICENSE',
+    'LICENCE',
+    'NOTICE',
+    'Procfile'
+]);
+
+export const isEditablePath = (path: string) => {
+    if (editableExtensions.has(getExtension(path))) {
+        return true;
+    }
+
+    const segments = path.split('/');
+    const basename = segments.at(-1) || path;
+
+    return editableBasenames.has(basename);
+};
+
+export const getExtension = (path: string) => {
+    const dotIndex = path.lastIndexOf('.');
+    if (dotIndex === -1) {
+        return '';
+    }
+
+    return path.slice(dotIndex + 1).toLowerCase();
+};
+
+export const normaliseRelativePath = (input: string) => {
+    const cleaned = input.trim().replace(/^\/+/, '').replace(/\/+/g, '/');
+
+    if (!cleaned) {
+        return null;
+    }
+
+    const segments = cleaned.split('/').filter(Boolean);
+
+    if (segments.length === 0) {
+        return null;
+    }
+
+    if (segments.some(segment => segment === '.' || segment === '..')) {
+        return null;
+    }
+
+    return segments.join('/');
+};
+
+export const isDefaultThemeName = (themeName: string) => ['casper', 'source'].includes(themeName.toLowerCase());
+
+export const detectCommonRoot = (paths: string[]) => {
+    if (paths.length === 0) {
+        return '';
+    }
+
+    const firstSlash = paths[0].indexOf('/');
+
+    if (firstSlash <= 0) {
+        return '';
+    }
+
+    const prefix = paths[0].slice(0, firstSlash + 1);
+
+    if (paths.every(path => path.startsWith(prefix))) {
+        return prefix;
+    }
+
+    return '';
+};
+
+export const cloneThemeFiles = (files: Record<string, ThemeEditorFile>) => {
+    return Object.fromEntries(Object.entries(files).map(([path, file]) => {
+        return [path, {
+            ...file,
+            date: new Date(file.date),
+            binary: file.binary ? new Uint8Array(file.binary) : null
+        }];
+    }));
+};
+
+const invalidArchiveMessage = 'Failed to open the theme archive. Download the theme again and retry.';
+
+const getEntryUncompressedSize = (entry: JSZip.JSZipObject) => {
+    const size = (entry as ThemeArchiveEntry)._data?.uncompressedSize;
+
+    if (typeof size !== 'number' || !Number.isFinite(size) || size < 0) {
+        throw new ThemeArchiveExtractionError('invalid_archive', invalidArchiveMessage);
+    }
+
+    return size;
+};
+
+const getThemeArchiveSizeLabel = (bytes: number) => {
+    const megabytes = bytes / (1024 * 1024);
+
+    if (Number.isInteger(megabytes)) {
+        return `${megabytes} MB`;
+    }
+
+    return `${megabytes.toFixed(1)} MB`;
+};
+
+const collectArchiveEntries = (zip: JSZip) => {
+    const entries: Array<[string, JSZip.JSZipObject]> = [];
+
+    zip.forEach((relativePath, entry) => {
+        if (!entry.dir) {
+            entries.push([relativePath, entry]);
+        }
+    });
+
+    return entries;
+};
+
+const assertThemeArchiveLimits = (entries: Array<[string, JSZip.JSZipObject]>) => {
+    if (entries.length > THEME_EDITOR_ARCHIVE_LIMITS.maxFiles) {
+        throw new ThemeArchiveExtractionError(
+            'too_many_files',
+            `This theme archive contains too many files for the browser editor (${entries.length}/${THEME_EDITOR_ARCHIVE_LIMITS.maxFiles}).`
+        );
+    }
+
+    let extractedBytes = 0;
+
+    for (const [, entry] of entries) {
+        extractedBytes += getEntryUncompressedSize(entry);
+
+        if (extractedBytes > THEME_EDITOR_ARCHIVE_LIMITS.maxExtractedBytes) {
+            throw new ThemeArchiveExtractionError(
+                'too_large',
+                `This theme archive is too large to open in the browser editor. Extracted files must stay under ${getThemeArchiveSizeLabel(THEME_EDITOR_ARCHIVE_LIMITS.maxExtractedBytes)}.`
+            );
+        }
+    }
+};
+
+const loadThemeArchive = async (arrayBuffer: ArrayBuffer) => {
+    try {
+        return await JSZip.loadAsync(arrayBuffer);
+    } catch {
+        throw new ThemeArchiveExtractionError('invalid_archive', invalidArchiveMessage);
+    }
+};
+
+const readThemeBinaryFile = async (entry: JSZip.JSZipObject) => {
+    try {
+        return await entry.async('uint8array');
+    } catch {
+        throw new ThemeArchiveExtractionError('invalid_archive', invalidArchiveMessage);
+    }
+};
+
+export const extractThemeArchive = async (arrayBuffer: ArrayBuffer): Promise<ThemeEditorSnapshot> => {
+    const zip = await loadThemeArchive(arrayBuffer);
+    const entries = collectArchiveEntries(zip);
+
+    assertThemeArchiveLimits(entries);
+
+    const rootPrefix = detectCommonRoot(entries.map(([path]) => path));
+    const files: Record<string, ThemeEditorFile> = {};
+
+    for (const [zipPath, entry] of entries) {
+        const displayPath = rootPrefix ? zipPath.slice(rootPrefix.length) : zipPath;
+
+        if (!displayPath) {
+            continue;
+        }
+
+        const editable = isEditablePath(displayPath);
+
+        if (editable) {
+            try {
+                const content = await entry.async('string');
+
+                files[displayPath] = {
+                    path: displayPath,
+                    editable: true,
+                    content,
+                    binary: null,
+                    date: entry.date || new Date(),
+                    unixPermissions: typeof entry.unixPermissions === 'number' ? entry.unixPermissions : null,
+                    dosPermissions: typeof entry.dosPermissions === 'number' ? entry.dosPermissions : null
+                };
+                continue;
+            } catch {
+                // Fall back to binary handling below.
+            }
+        }
+
+        files[displayPath] = {
+            path: displayPath,
+            editable: false,
+            content: null,
+            binary: await readThemeBinaryFile(entry),
+            date: entry.date || new Date(),
+            unixPermissions: typeof entry.unixPermissions === 'number' ? entry.unixPermissions : null,
+            dosPermissions: typeof entry.dosPermissions === 'number' ? entry.dosPermissions : null
+        };
+    }
+
+    return {files, rootPrefix};
+};
+
+export const packThemeArchive = async ({files, rootPrefix}: ThemeEditorSnapshot) => {
+    const zip = new JSZip();
+
+    for (const [path, file] of Object.entries(files)) {
+        const zipPath = `${rootPrefix}${path}`;
+        const options = {
+            date: file.date,
+            createFolders: true,
+            unixPermissions: file.unixPermissions ?? undefined,
+            dosPermissions: file.dosPermissions ?? undefined
+        };
+
+        if (file.editable) {
+            zip.file(zipPath, file.content ?? '', options);
+        } else {
+            zip.file(zipPath, file.binary!, {
+                ...options,
+                binary: true
+            });
+        }
+    }
+
+    return zip.generateAsync({
+        type: 'blob',
+        mimeType: 'application/zip',
+        compression: 'DEFLATE',
+        compressionOptions: {level: 6}
+    });
+};
+
+export type ThemeChange = {
+    path: string;
+    editable: boolean;
+    status: 'added' | 'deleted' | 'modified';
+};
+
+export const getThemeChanges = ({baseFiles, currentFiles}: {
+    baseFiles: Record<string, ThemeEditorFile>;
+    currentFiles: Record<string, ThemeEditorFile>;
+}) => {
+    const allPaths = new Set([...Object.keys(baseFiles), ...Object.keys(currentFiles)]);
+    const changes: ThemeChange[] = [];
+
+    for (const path of Array.from(allPaths).sort()) {
+        const baseFile = baseFiles[path];
+        const currentFile = currentFiles[path];
+
+        if (!baseFile && currentFile) {
+            changes.push({
+                path,
+                editable: currentFile.editable,
+                status: 'added'
+            });
+            continue;
+        }
+
+        if (baseFile && !currentFile) {
+            changes.push({
+                path,
+                editable: baseFile.editable,
+                status: 'deleted'
+            });
+            continue;
+        }
+
+        if (!baseFile || !currentFile) {
+            continue;
+        }
+
+        if (baseFile.editable && currentFile.editable && baseFile.content !== currentFile.content) {
+            changes.push({
+                path,
+                editable: true,
+                status: 'modified'
+            });
+        }
+    }
+
+    return changes;
+};
+
+export const createFolderRenameMap = ({
+    files,
+    oldPrefix,
+    newPrefix
+}: {
+    files: Record<string, ThemeEditorFile>;
+    oldPrefix: string;
+    newPrefix: string;
+}) => {
+    const updates: Record<string, ThemeEditorFile> = {};
+
+    for (const [path, file] of Object.entries(files)) {
+        if (!path.startsWith(oldPrefix)) {
+            updates[path] = file;
+            continue;
+        }
+
+        const updatedPath = `${newPrefix}${path.slice(oldPrefix.length)}`;
+        updates[updatedPath] = {
+            ...file,
+            path: updatedPath
+        };
+    }
+
+    return updates;
+};

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-file-tree.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-file-tree.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import {
+    ChevronDown,
+    ChevronRight,
+    FileCode2,
+    Folder,
+    FolderOpen,
+    Pencil,
+    Plus,
+    Trash2
+} from 'lucide-react';
+import type {ThemeChange, ThemeEditorFile} from './theme-editor-utils';
+
+export type SelectedNode =
+    | {type: 'file'; path: string}
+    | {type: 'dir'; path: string}
+    | null;
+
+type TreeNode = {
+    type: 'dir' | 'file';
+    name: string;
+    path: string;
+    editable?: boolean;
+    children?: Map<string, TreeNode>;
+};
+
+const buildTree = (files: Record<string, ThemeEditorFile>) => {
+    const root: TreeNode = {
+        type: 'dir',
+        name: '',
+        path: '',
+        children: new Map()
+    };
+
+    for (const path of Object.keys(files).sort()) {
+        const segments = path.split('/');
+        let cursor = root;
+
+        for (let index = 0; index < segments.length; index += 1) {
+            const segment = segments[index];
+            const isLast = index === segments.length - 1;
+
+            if (isLast) {
+                cursor.children!.set(segment, {
+                    type: 'file',
+                    name: segment,
+                    path,
+                    editable: files[path].editable
+                });
+                continue;
+            }
+
+            const dirPath = `${segments.slice(0, index + 1).join('/')}/`;
+            const existing = cursor.children!.get(segment);
+
+            if (existing?.type === 'dir') {
+                cursor = existing;
+                continue;
+            }
+
+            const next: TreeNode = {
+                type: 'dir',
+                name: segment,
+                path: dirPath,
+                children: new Map()
+            };
+
+            cursor.children!.set(segment, next);
+            cursor = next;
+        }
+    }
+
+    return root;
+};
+
+const sortTreeNodes = (nodes: TreeNode[]) => {
+    return nodes.sort((left, right) => {
+        if (left.type !== right.type) {
+            return left.type === 'dir' ? -1 : 1;
+        }
+
+        return left.name.localeCompare(right.name);
+    });
+};
+
+const fileActionButtonClass = 'inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-30';
+
+type ThemeFileTreeProps = {
+    currentFiles: Record<string, ThemeEditorFile>;
+    selectedNode: SelectedNode;
+    setSelectedNode: (node: SelectedNode) => void;
+    expandedDirectories: Set<string>;
+    setExpandedDirectories: React.Dispatch<React.SetStateAction<Set<string>>>;
+    changesMap: Map<string, ThemeChange['status']>;
+    isLoading: boolean;
+    onCreateFile: () => void;
+    onRenameSelected: () => void;
+    onDeleteSelected: () => void;
+    onOpenFile: (path: string) => void;
+};
+
+const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
+    currentFiles,
+    selectedNode,
+    setSelectedNode,
+    expandedDirectories,
+    setExpandedDirectories,
+    changesMap,
+    isLoading,
+    onCreateFile,
+    onRenameSelected,
+    onDeleteSelected,
+    onOpenFile
+}) => {
+    const renderTreeNode = (node: TreeNode, depth = 0): React.ReactNode => {
+        if (node.type === 'file') {
+            const isSelected = selectedNode?.type === 'file' && selectedNode.path === node.path;
+            const changeStatus = changesMap.get(node.path);
+
+            return (
+                <button
+                    key={node.path}
+                    className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#243043] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'} ${!node.editable ? 'opacity-70' : ''}`}
+                    style={{paddingLeft: `${depth * 14 + 8}px`}}
+                    type='button'
+                    onClick={() => onOpenFile(node.path)}
+                >
+                    <span className='w-3 shrink-0' />
+                    <FileCode2 size={14} />
+                    <span className='min-w-0 grow truncate'>{node.name}</span>
+                    {changeStatus && (
+                        <span className={`mr-1 h-1.5 w-1.5 shrink-0 rounded-full ${changeStatus === 'deleted' ? 'bg-[#ff6b6b]' : changeStatus === 'added' ? 'bg-[#14b886]' : 'bg-[#f5a623]'}`} />
+                    )}
+                </button>
+            );
+        }
+
+        const isExpanded = expandedDirectories.has(node.path);
+        const isSelected = selectedNode?.type === 'dir' && selectedNode.path === node.path;
+        const children = sortTreeNodes(Array.from(node.children?.values() || []));
+
+        return (
+            <div key={node.path || 'root'}>
+                {node.path && (
+                    <button
+                        className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#202630] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'}`}
+                        style={{paddingLeft: `${depth * 14 + 8}px`}}
+                        type='button'
+                        onClick={() => {
+                            setSelectedNode({type: 'dir', path: node.path});
+                            setExpandedDirectories((current) => {
+                                const next = new Set(current);
+
+                                if (next.has(node.path)) {
+                                    next.delete(node.path);
+                                } else {
+                                    next.add(node.path);
+                                }
+
+                                return next;
+                            });
+                        }}
+                    >
+                        {isExpanded ? <ChevronDown className='shrink-0 text-[#6a6f78]' size={12} /> : <ChevronRight className='shrink-0 text-[#6a6f78]' size={12} />}
+                        {isExpanded ? <FolderOpen className='shrink-0 text-[#8a8f98]' size={14} /> : <Folder className='shrink-0 text-[#8a8f98]' size={14} />}
+                        <span className='truncate'>{node.name}</span>
+                    </button>
+                )}
+                {(node.path === '' || isExpanded) && (
+                    <div>
+                        {children.map(child => renderTreeNode(child, node.path ? depth + 1 : depth))}
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    return (
+        <aside className='flex w-[280px] shrink-0 flex-col border-r border-[#23262c] bg-[#16181c]'>
+            <div className='flex items-center justify-between gap-2 border-b border-[#23262c] px-3 py-2'>
+                <div className='text-[12px] font-medium text-[#c8ccd3]'>{Object.keys(currentFiles).length} files</div>
+                <div className='flex items-center gap-2'>
+                    <button aria-label='New file' className={fileActionButtonClass} type='button' onClick={onCreateFile}>
+                        <Plus size={13} />
+                    </button>
+                    <button aria-label='Rename selected item' className={fileActionButtonClass} disabled={!selectedNode} type='button' onClick={onRenameSelected}>
+                        <Pencil size={13} />
+                    </button>
+                    <button aria-label='Delete selected item' className={fileActionButtonClass} disabled={!selectedNode} type='button' onClick={onDeleteSelected}>
+                        <Trash2 size={13} />
+                    </button>
+                </div>
+            </div>
+            <div className='min-h-0 flex-1 overflow-y-auto px-2 py-2'>
+                {isLoading ? (
+                    <div className='flex h-full flex-col items-center justify-center gap-3 text-center text-[13px] text-[#8a8f98]'>
+                        <div className='h-5 w-5 animate-spin rounded-full border-2 border-[#2f333b] border-t-[#14b886]' />
+                        <span>Loading theme files…</span>
+                    </div>
+                ) : Object.keys(currentFiles).length === 0 ? (
+                    <div className='px-3 py-4 text-[12px] text-[#8a8f98]'>This theme archive does not contain any files.</div>
+                ) : (
+                    renderTreeNode(buildTree(currentFiles))
+                )}
+            </div>
+        </aside>
+    );
+};
+
+export default ThemeFileTree;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-review-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-review-modal.tsx
@@ -3,6 +3,10 @@ import {CircleDot, Undo2, X} from 'lucide-react';
 import {ghostButtonClass, iconButtonClass} from './theme-editor-styles';
 import type {ThemeChange, ThemeEditorFile} from './theme-editor-utils';
 
+const previewBlockClass = 'overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]';
+const previewSectionLabelClass = 'mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase';
+const previewEmptyStateClass = 'flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]';
+
 export type ReviewItem = {
     path: string;
     editable: boolean;
@@ -130,34 +134,34 @@ const ThemeReviewModal: React.FC<ThemeReviewModalProps> = ({
                                 </div>
 
                                 {!selectedReviewItem.editable ? (
-                                    <div className='flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                    <div className={previewEmptyStateClass}>
                                         Binary files are kept intact in the archive. Open or revert the change from here, but binary contents are not shown.
                                     </div>
                                 ) : selectedReviewItem.status === 'added' ? (
                                     <div className='min-h-0 flex-1 overflow-auto p-4'>
-                                        <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>After</div>
-                                        <pre className='overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.after ?? ''}</pre>
+                                        <div className={previewSectionLabelClass}>After</div>
+                                        <pre className={previewBlockClass}>{selectedReviewItem.after ?? ''}</pre>
                                     </div>
                                 ) : selectedReviewItem.status === 'deleted' ? (
                                     <div className='min-h-0 flex-1 overflow-auto p-4'>
-                                        <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>Before</div>
-                                        <pre className='overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.before ?? ''}</pre>
+                                        <div className={previewSectionLabelClass}>Before</div>
+                                        <pre className={previewBlockClass}>{selectedReviewItem.before ?? ''}</pre>
                                     </div>
                                 ) : (
                                     <div className='grid min-h-0 flex-1 grid-cols-2 gap-4 p-4'>
                                         <div className='min-h-0 overflow-auto'>
-                                            <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>Before</div>
-                                            <pre className='h-full overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.before ?? ''}</pre>
+                                            <div className={previewSectionLabelClass}>Before</div>
+                                            <pre className={`h-full ${previewBlockClass}`}>{selectedReviewItem.before ?? ''}</pre>
                                         </div>
                                         <div className='min-h-0 overflow-auto'>
-                                            <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>After</div>
-                                            <pre className='h-full overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.after ?? ''}</pre>
+                                            <div className={previewSectionLabelClass}>After</div>
+                                            <pre className={`h-full ${previewBlockClass}`}>{selectedReviewItem.after ?? ''}</pre>
                                         </div>
                                     </div>
                                 )}
                             </>
                         ) : (
-                            <div className='flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                            <div className={previewEmptyStateClass}>
                                 Select a changed file to review it.
                             </div>
                         )}

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-review-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-review-modal.tsx
@@ -1,0 +1,171 @@
+import React, {useEffect, useState} from 'react';
+import {CircleDot, Undo2, X} from 'lucide-react';
+import {ghostButtonClass, iconButtonClass} from './theme-editor-styles';
+import type {ThemeChange, ThemeEditorFile} from './theme-editor-utils';
+
+export type ReviewItem = {
+    path: string;
+    editable: boolean;
+    status: ThemeChange['status'];
+    before: string | null;
+    after: string | null;
+};
+
+export const buildReviewItems = ({
+    baseFiles,
+    currentFiles,
+    changes
+}: {
+    baseFiles: Record<string, ThemeEditorFile>;
+    currentFiles: Record<string, ThemeEditorFile>;
+    changes: ThemeChange[];
+}): ReviewItem[] => {
+    return changes.map((change) => {
+        const baseFile = baseFiles[change.path];
+        const currentFile = currentFiles[change.path];
+
+        return {
+            path: change.path,
+            editable: change.editable,
+            status: change.status,
+            before: baseFile?.editable ? (baseFile.content ?? '') : null,
+            after: currentFile?.editable ? (currentFile.content ?? '') : null
+        };
+    });
+};
+
+const formatReviewSummary = (reviewItems: ReviewItem[]) => {
+    const added = reviewItems.filter(item => item.status === 'added').length;
+    const modified = reviewItems.filter(item => item.status === 'modified').length;
+    const deleted = reviewItems.filter(item => item.status === 'deleted').length;
+
+    return `${modified} modified, ${added} added, ${deleted} deleted`;
+};
+
+type ThemeReviewModalProps = {
+    reviewItems: ReviewItem[];
+    onClose: () => void;
+    onOpenInEditor: (path: string) => void;
+    onRevert: (path: string) => void;
+};
+
+const ThemeReviewModal: React.FC<ThemeReviewModalProps> = ({
+    reviewItems,
+    onClose,
+    onOpenInEditor,
+    onRevert
+}) => {
+    const [selectedReviewPath, setSelectedReviewPath] = useState<string | null>(null);
+    const selectedReviewItem = reviewItems.find(item => item.path === selectedReviewPath) || reviewItems[0] || null;
+
+    // Keep selectedReviewPath valid as reviewItems change. If the currently
+    // selected path was reverted (and so dropped out of reviewItems), or if
+    // nothing is selected yet, fall back to the first remaining item.
+    useEffect(() => {
+        if (!selectedReviewItem) {
+            setSelectedReviewPath(null);
+            return;
+        }
+
+        if (!selectedReviewPath || !reviewItems.some(item => item.path === selectedReviewPath)) {
+            setSelectedReviewPath(selectedReviewItem.path);
+        }
+    }, [reviewItems, selectedReviewItem, selectedReviewPath]);
+
+    const reviewSummary = formatReviewSummary(reviewItems);
+
+    return (
+        <div className='absolute inset-0 z-10 flex items-center justify-center bg-[rgba(8,10,14,0.64)]' onClick={onClose}>
+            <div className='flex h-[min(78vh,calc(100%-24px))] w-[min(1240px,calc(100%-24px))] flex-col overflow-hidden rounded-[10px] border border-[#2b3038] bg-[#171a20] p-4 shadow-[0_24px_64px_rgba(0,0,0,0.45)]' onClick={event => event.stopPropagation()}>
+                <div className='mb-2 flex items-center justify-between gap-3'>
+                    <div>
+                        <h3 className='text-[16px] font-semibold text-[#f4f5f7]'>All changes</h3>
+                        <p className='mt-1 text-[12px] text-[#9aa0aa]'>{reviewSummary}</p>
+                    </div>
+                    <button aria-label='Close review' className={iconButtonClass} type='button' onClick={onClose}>
+                        <X size={14} />
+                    </button>
+                </div>
+
+                <div className='grid min-h-0 flex-1 grid-cols-[320px_1fr] gap-3'>
+                    <div className='min-h-0 overflow-auto rounded-lg border border-[#2a2d33] bg-[#111319] p-2'>
+                        {reviewItems.map(item => (
+                            <button
+                                key={`${item.status}-${item.path}`}
+                                className={`flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-[13px] ${selectedReviewItem?.path === item.path ? 'border-[#355070] bg-[#243043] text-white' : 'border-transparent text-[#d4d8de] hover:bg-[#1d2028]'}`}
+                                type='button'
+                                onClick={() => setSelectedReviewPath(item.path)}
+                            >
+                                <span className={`rounded px-1.5 py-0.5 text-[10px] tracking-[0.04em] uppercase ${item.status === 'deleted' ? 'bg-[#4a2222] text-[#ffbdbd]' : item.status === 'added' ? 'bg-[#17342a] text-[#a5e8c8]' : 'bg-[#3b2a16] text-[#f5a623]'}`}>
+                                    {item.status}
+                                </span>
+                                <span className='min-w-0 grow truncate'>{item.path}</span>
+                                {!item.editable && <CircleDot className='text-[#6a6f78]' size={12} />}
+                            </button>
+                        ))}
+                        {reviewItems.length === 0 && (
+                            <div className='px-3 py-4 text-[12px] text-[#8a8f98]'>No unsaved changes.</div>
+                        )}
+                    </div>
+
+                    <div className='flex min-h-0 flex-col overflow-hidden rounded-lg border border-[#2a2d33] bg-[#111319]'>
+                        {selectedReviewItem ? (
+                            <>
+                                <div className='flex items-center gap-2 border-b border-[#23262c] px-4 py-3'>
+                                    <div className='min-w-0 grow'>
+                                        <div className='truncate text-[13px] font-medium text-[#f4f5f7]'>{selectedReviewItem.path}</div>
+                                        <div className='mt-1 text-[12px] text-[#8a8f98]'>
+                                            {selectedReviewItem.editable ? 'Text file preview' : 'Binary file'}
+                                        </div>
+                                    </div>
+                                    {selectedReviewItem.status !== 'deleted' && (
+                                        <button className={ghostButtonClass} type='button' onClick={() => onOpenInEditor(selectedReviewItem.path)}>
+                                            Open in editor
+                                        </button>
+                                    )}
+                                    <button className={ghostButtonClass} type='button' onClick={() => onRevert(selectedReviewItem.path)}>
+                                        <Undo2 size={14} />
+                                        Revert
+                                    </button>
+                                </div>
+
+                                {!selectedReviewItem.editable ? (
+                                    <div className='flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                        Binary files are kept intact in the archive. Open or revert the change from here, but binary contents are not shown.
+                                    </div>
+                                ) : selectedReviewItem.status === 'added' ? (
+                                    <div className='min-h-0 flex-1 overflow-auto p-4'>
+                                        <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>After</div>
+                                        <pre className='overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.after ?? ''}</pre>
+                                    </div>
+                                ) : selectedReviewItem.status === 'deleted' ? (
+                                    <div className='min-h-0 flex-1 overflow-auto p-4'>
+                                        <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>Before</div>
+                                        <pre className='overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.before ?? ''}</pre>
+                                    </div>
+                                ) : (
+                                    <div className='grid min-h-0 flex-1 grid-cols-2 gap-4 p-4'>
+                                        <div className='min-h-0 overflow-auto'>
+                                            <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>Before</div>
+                                            <pre className='h-full overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.before ?? ''}</pre>
+                                        </div>
+                                        <div className='min-h-0 overflow-auto'>
+                                            <div className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>After</div>
+                                            <pre className='h-full overflow-auto rounded-md border border-[#23262c] bg-[#15171a] p-4 text-[12px] leading-5 text-[#d4d8de]'>{selectedReviewItem.after ?? ''}</pre>
+                                        </div>
+                                    </div>
+                                )}
+                            </>
+                        ) : (
+                            <div className='flex flex-1 items-center justify-center p-8 text-center text-[13px] text-[#6a6f78]'>
+                                Select a changed file to review it.
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ThemeReviewModal;

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -1,3 +1,4 @@
+import JSZip from 'jszip';
 import path from 'path';
 import {expect, test} from '@playwright/test';
 import {expectExternalNavigate, globalDataRequests, limitRequests, mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
@@ -30,6 +31,14 @@ const themeDownloadRequest = (themeName: string) => ({
     rawResponse: themeEditorZip,
     responseHeaders: {'content-type': 'application/zip'}
 });
+
+const createArchiveBuffer = async (build: (zip: JSZip) => void) => {
+    const zip = new JSZip();
+
+    build(zip);
+
+    return Buffer.from(await zip.generateAsync({type: 'uint8array'}));
+};
 
 async function openChangeThemeModal(page: Page) {
     await page.goto('/#/settings/theme');
@@ -585,6 +594,23 @@ test.describe('Theme settings', async () => {
         await expect(page.getByTestId('theme-code-editor-modal')).not.toBeVisible();
     });
 
+    test('Redirects malformed theme editor routes back to theme settings', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes}
+        }});
+
+        const pageErrors: string[] = [];
+        page.on('pageerror', error => pageErrors.push(error.message));
+
+        await page.goto('/#/settings/theme/edit/%E0%A4%A');
+
+        await expect(page).toHaveURL(/#\/settings\/theme$/);
+        await expect(page.getByTestId('theme')).toBeVisible();
+        await expect(page.getByTestId('theme-code-editor-modal')).not.toBeVisible();
+        expect(pageErrors).toEqual([]);
+    });
+
     test('Allows selecting a non-editable file and shows the browser-edit message', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
@@ -598,6 +624,34 @@ test.describe('Theme settings', async () => {
 
         await expect(editorModal).toContainText('This file cannot be edited in the browser.');
         await expect(editorModal.locator('.cm-editor')).toHaveCount(0);
+    });
+
+    test('Shows a controlled error when the downloaded theme archive exceeds editor limits', async ({page}) => {
+        const oversizedThemeZip = await createArchiveBuffer((zip) => {
+            for (let index = 0; index <= 1000; index += 1) {
+                zip.file(`theme/partials/file-${index}.hbs`, `{{! file ${index} }}`);
+            }
+        });
+
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: {
+                method: 'GET',
+                path: '/themes/edition/download/',
+                response: '',
+                rawResponse: oversizedThemeZip,
+                responseHeaders: {'content-type': 'application/zip'}
+            }
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+
+        await expect(editorModal).toContainText('This theme archive contains too many files for the browser editor');
+        await expect(editorModal.getByRole('button', {name: 'Save'})).toBeEnabled();
+        await editorModal.getByRole('button', {name: 'Save'}).click();
+        await expect(page.getByTestId('toast-info')).toHaveText(/No changes to save/i);
+        await expect(editorModal).toContainText('Select a file from the tree to start editing.');
     });
 
     test('Theme install route works without limits', async ({page}) => {

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -1,5 +1,63 @@
+import path from 'path';
 import {expect, test} from '@playwright/test';
 import {expectExternalNavigate, globalDataRequests, limitRequests, mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
+import {readFileSync} from 'fs';
+import type {Page} from '@playwright/test';
+
+const themeEditorZip = readFileSync(path.join(__dirname, '../../utils/responses/theme.zip'));
+
+const customThemesLimitConfig = (allowlist: string[], error: string) => ({
+    ...globalDataRequests.browseConfig,
+    response: {
+        config: {
+            ...responseFixtures.config.config,
+            hostSettings: {
+                limits: {
+                    customThemes: {
+                        allowlist,
+                        error
+                    }
+                }
+            }
+        }
+    }
+});
+
+const themeDownloadRequest = (themeName: string) => ({
+    method: 'GET' as const,
+    path: `/themes/${themeName}/download/`,
+    response: '',
+    rawResponse: themeEditorZip,
+    responseHeaders: {'content-type': 'application/zip'}
+});
+
+async function openChangeThemeModal(page: Page) {
+    await page.goto('/#/settings/theme');
+    await page.getByTestId('theme').getByRole('button', {name: 'Change theme'}).click();
+
+    return page.getByTestId('theme-modal');
+}
+
+async function openInstalledThemeEditor(page: Page, themeName: string) {
+    const modal = await openChangeThemeModal(page);
+    await modal.getByRole('tab', {name: 'Installed'}).click();
+
+    const themeListItem = modal.getByTestId('theme-list-item').filter({hasText: new RegExp(themeName, 'i')});
+    await themeListItem.getByRole('button', {name: 'Menu'}).click();
+    await page.getByTestId('popover-content').getByRole('button', {name: 'Edit code'}).click();
+
+    return page.getByTestId('theme-code-editor-modal');
+}
+
+async function openActiveThemeEditorFromSettings(page: Page) {
+    await page.goto('/#/settings');
+
+    const themeSection = page.getByTestId('theme');
+    await themeSection.getByRole('button', {name: 'Menu'}).click();
+    await page.getByTestId('popover-content').getByRole('button', {name: 'Edit code'}).click();
+
+    return page.getByTestId('theme-code-editor-modal');
+}
 
 test.describe('Theme settings', async () => {
     test('Browsing and installing default themes', async ({page}) => {
@@ -187,6 +245,86 @@ test.describe('Theme settings', async () => {
         await expect(modal.getByTestId('theme-list-item')).toHaveCount(3);
 
         expect(lastApiRequests.uploadTheme).toBeTruthy();
+    });
+
+    test('Supports editing and saving a custom theme in browser', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition'),
+            uploadTheme: {
+                method: 'POST',
+                path: '/themes/upload/',
+                response: {
+                    themes: [{
+                        name: 'edition',
+                        package: {
+                            name: 'Edition',
+                            version: '1.0.0'
+                        },
+                        active: true,
+                        templates: []
+                    }]
+                }
+            }
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+        await expect(editorModal).toBeVisible();
+        await expect(editorModal).toContainText('Edit theme');
+        await expect(editorModal).toContainText('edition');
+
+        const codeEditor = editorModal.locator('.cm-content');
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('{"name":"edition","version":"1.0.0"}\n');
+
+        await editorModal.getByRole('button', {name: 'Save'}).click();
+        await page.getByTestId('theme-editor-confirm-modal').getByRole('button', {name: 'Replace theme'}).click();
+
+        await expect(page.getByTestId('toast-success')).toHaveText(/Theme saved/i);
+        expect(lastApiRequests.downloadTheme?.url).toMatch(/\/themes\/edition\/download/);
+        expect(lastApiRequests.uploadTheme?.url).toMatch(/\/themes\/upload\//);
+    });
+
+    test('Saves built-in themes as a new theme name', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('casper'),
+            uploadTheme: {
+                method: 'POST',
+                path: '/themes/upload/',
+                response: {
+                    themes: [{
+                        name: 'casper-edited',
+                        package: {
+                            name: 'Casper Edited',
+                            version: '1.0.0'
+                        },
+                        active: false,
+                        templates: []
+                    }]
+                }
+            }
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'casper');
+        await expect(editorModal).toBeVisible();
+
+        const codeEditor = editorModal.locator('.cm-content');
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('{"name":"casper","version":"1.0.0"}\n');
+
+        await editorModal.getByRole('button', {name: 'Save'}).click();
+        const inputModal = page.getByTestId('theme-editor-input-modal');
+        await inputModal.getByLabel('Theme name').fill('casper-edited');
+        await inputModal.getByRole('button', {name: 'Continue'}).click();
+        await page.getByTestId('theme-editor-confirm-modal').getByRole('button', {name: 'Save theme'}).click();
+
+        await expect(page).toHaveURL(/#\/settings\/theme\/edit\/casper-edited/);
+        await expect(editorModal).toContainText('casper-edited');
     });
 
     test('Limits uploading new themes and redirect to /pro', async ({page}) => {
@@ -396,22 +534,7 @@ test.describe('Theme settings', async () => {
             ...globalDataRequests,
             ...limitRequests,
             browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
-            browseConfig: {
-                ...globalDataRequests.browseConfig,
-                response: {
-                    config: {
-                        ...responseFixtures.config.config,
-                        hostSettings: {
-                            limits: {
-                                customThemes: {
-                                    allowlist: ['casper'],
-                                    error: 'Upgrade to use custom themes'
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            browseConfig: customThemesLimitConfig(['casper'], 'Upgrade to use custom themes')
         }});
 
         // Navigate directly to the change theme route
@@ -426,6 +549,55 @@ test.describe('Theme settings', async () => {
 
         // Theme modal should not be visible
         await expect(page.getByTestId('theme-modal')).not.toBeVisible();
+    });
+
+    test('Opens the editor from the active theme overflow menu and returns to settings on close', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition')
+        }});
+
+        const editorModal = await openActiveThemeEditorFromSettings(page);
+
+        await expect(editorModal).toBeVisible();
+        await expect(page).toHaveURL(/#\/settings\/theme\/edit\/edition/);
+
+        await editorModal.getByRole('button', {name: 'Close'}).click();
+
+        await expect(page).toHaveURL(/#\/settings$/);
+        await expect(page.getByTestId('theme')).toBeVisible();
+    });
+
+    test('Prevents direct access to theme editor route when editing is limited', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: customThemesLimitConfig(['casper'], 'Upgrade to use custom themes')
+        }});
+
+        await page.goto('/#/settings/theme/edit/edition');
+
+        await page.waitForSelector('[data-testid="limit-modal"]', {timeout: 10000});
+
+        await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to use custom themes/);
+        await expect(page.getByTestId('theme-code-editor-modal')).not.toBeVisible();
+    });
+
+    test('Allows selecting a non-editable file and shows the browser-edit message', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition')
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+
+        await editorModal.getByRole('button', {name: '.DS_Store'}).click();
+
+        await expect(editorModal).toContainText('This file cannot be edited in the browser.');
+        await expect(editorModal.locator('.cm-editor')).toHaveCount(0);
     });
 
     test('Theme install route works without limits', async ({page}) => {

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -611,6 +611,23 @@ test.describe('Theme settings', async () => {
         expect(pageErrors).toEqual([]);
     });
 
+    test('Redirects encoded-slash theme editor routes back to theme settings', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes}
+        }});
+
+        const pageErrors: string[] = [];
+        page.on('pageerror', error => pageErrors.push(error.message));
+
+        await page.goto('/#/settings/theme/edit/%2Fedition');
+
+        await expect(page).toHaveURL(/#\/settings\/theme$/);
+        await expect(page.getByTestId('theme')).toBeVisible();
+        await expect(page.getByTestId('theme-code-editor-modal')).not.toBeVisible();
+        expect(pageErrors).toEqual([]);
+    });
+
     test('Allows selecting a non-editable file and shows the browser-edit message', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -578,6 +578,36 @@ test.describe('Theme settings', async () => {
         await expect(page.getByTestId('theme')).toBeVisible();
     });
 
+    test('Confirms before discarding unsaved theme edits on close', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition')
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+
+        const codeEditor = editorModal.locator('.cm-content');
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('{"name":"edition","version":"1.0.0"}\n');
+        await expect(editorModal).toContainText('1 file modified');
+
+        // Cancelling the discard keeps the editor open with the change intact
+        await editorModal.getByRole('button', {name: 'Close'}).click();
+        const confirmModal = page.getByTestId('theme-editor-confirm-modal');
+        await expect(confirmModal).toContainText('You have unsaved theme changes');
+        await confirmModal.getByRole('button', {name: 'Cancel'}).click();
+        await expect(editorModal).toBeVisible();
+        await expect(editorModal).toContainText('1 file modified');
+
+        // Confirming the discard closes the editor
+        await editorModal.getByRole('button', {name: 'Close'}).click();
+        await expect(confirmModal).toContainText('You have unsaved theme changes');
+        await confirmModal.getByRole('button', {name: 'Discard changes'}).click();
+        await expect(page.getByTestId('theme-code-editor-modal')).not.toBeVisible();
+    });
+
     test('Prevents direct access to theme editor route when editing is limited', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -334,6 +334,30 @@ test.describe('Theme settings', async () => {
         expect(lastApiRequests.uploadTheme?.url).toMatch(/\/themes\/upload\//);
     });
 
+    test('Loads CodeMirror with the dynamic language extension applied', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition')
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+
+        // The CodeMirror surface only renders after the dynamic language
+        // module import resolves and the extensions array is set. Proving
+        // the editor accepts input verifies the success branch of the load
+        // chain — if extensions never landed, the surface would be inert.
+        const codeEditor = editorModal.locator('.cm-content');
+        await expect(codeEditor).toBeVisible();
+        await expect(editorModal).toContainText(/json/i);
+
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('{"name":"edition","version":"1.0.0"}\n');
+
+        await expect(editorModal).toContainText(/1 file modified/);
+    });
+
     test('Saves built-in themes as a new theme name', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -296,6 +296,44 @@ test.describe('Theme settings', async () => {
         expect(lastApiRequests.uploadTheme?.url).toMatch(/\/themes\/upload\//);
     });
 
+    test('Saves via the Cmd+S keyboard shortcut', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition'),
+            uploadTheme: {
+                method: 'POST',
+                path: '/themes/upload/',
+                response: {
+                    themes: [{
+                        name: 'edition',
+                        package: {name: 'Edition', version: '1.0.0'},
+                        active: true,
+                        templates: []
+                    }]
+                }
+            }
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+
+        const codeEditor = editorModal.locator('.cm-content');
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('{"name":"edition","version":"1.0.0"}\n');
+
+        // Pressing Cmd+S (or Ctrl+S) should run the same save flow as
+        // clicking Save, with the listener reading the freshest handleSave
+        // through the latest-ref pattern. If the ref ever got out of sync,
+        // the save would see stale state (no changes) and abort with the
+        // "No changes to save" toast instead of opening this confirmation.
+        await page.keyboard.press('ControlOrMeta+S');
+        await page.getByTestId('theme-editor-confirm-modal').getByRole('button', {name: 'Replace theme'}).click();
+
+        await expect(page.getByTestId('toast-success')).toHaveText(/Theme saved/i);
+        expect(lastApiRequests.uploadTheme?.url).toMatch(/\/themes\/upload\//);
+    });
+
     test('Saves built-in themes as a new theme name', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -334,6 +334,47 @@ test.describe('Theme settings', async () => {
         expect(lastApiRequests.uploadTheme?.url).toMatch(/\/themes\/upload\//);
     });
 
+    test('Surfaces server-side upload size-limit errors with a user-friendly toast', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition'),
+            uploadTheme: {
+                method: 'POST',
+                path: '/themes/upload/',
+                responseStatus: 415,
+                response: {
+                    errors: [{
+                        message: 'Zip entry exceeds maximum uncompressed size.',
+                        errorType: 'UnsupportedMediaTypeError',
+                        code: 'ENTRY_TOO_LARGE',
+                        errorDetails: {
+                            entryName: 'partials/huge.hbs',
+                            observedBytes: 2_000_000,
+                            limitBytes: 1_048_576
+                        }
+                    }]
+                }
+            }
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+        const codeEditor = editorModal.locator('.cm-content');
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('{"name":"edition","version":"1.0.0"}\n');
+
+        await editorModal.getByRole('button', {name: 'Save'}).click();
+        await page.getByTestId('theme-editor-confirm-modal').getByRole('button', {name: 'Replace theme'}).click();
+
+        // The toast should mention the offending file and the limit, not just
+        // a generic "something went wrong" message.
+        const errorToast = page.getByTestId('toast-error');
+        await expect(errorToast).toContainText(/partials\/huge\.hbs/);
+        await expect(errorToast).toContainText(/1\.0 MB/);
+        await expect(errorToast).not.toContainText(/something went wrong/i);
+    });
+
     test('Loads CodeMirror with the dynamic language extension applied', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -398,6 +398,38 @@ test.describe('Theme settings', async () => {
         await expect(editorModal).toContainText('casper-edited');
     });
 
+    test('Rejects invalid theme names in the save-as flow', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('casper')
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'casper');
+
+        const codeEditor = editorModal.locator('.cm-content');
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('{"name":"casper","version":"1.0.0"}\n');
+
+        const inputModal = page.getByTestId('theme-editor-input-modal');
+
+        // Disallowed characters (spaces, punctuation, leading dots, etc.)
+        // are caught by the new format check and surfaced as a clear toast
+        // instead of being silently renamed by the server's sanitiser.
+        await editorModal.getByRole('button', {name: 'Save'}).click();
+        await inputModal.getByLabel('Theme name').fill('Foo Bar!');
+        await inputModal.getByRole('button', {name: 'Continue'}).click();
+        await expect(page.getByText(/Invalid theme name/i)).toBeVisible();
+
+        // Default theme names go through a separate guard with a more
+        // specific error message that should keep surfacing on its own.
+        await editorModal.getByRole('button', {name: 'Save'}).click();
+        await inputModal.getByLabel('Theme name').fill('casper');
+        await inputModal.getByRole('button', {name: 'Continue'}).click();
+        await expect(page.getByText(/Built-in themes cannot be overwritten/i)).toBeVisible();
+    });
+
     test('Limits uploading new themes and redirect to /pro', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -702,6 +702,47 @@ test.describe('Theme settings', async () => {
         await expect(page.getByTestId('theme-code-editor-modal')).not.toBeVisible();
     });
 
+    test('Ignores from= values that point outside the editor return allowlist', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition')
+        }});
+
+        // An attacker-crafted from= pointing at an unrelated admin route
+        // should not be honoured. The editor should still load, but on close
+        // we should land on the safe fallback (design/change-theme) rather
+        // than the crafted destination.
+        await page.goto('/#/settings/theme/edit/edition?from=staff/owner-transfer');
+
+        const editorModal = page.getByTestId('theme-code-editor-modal');
+        await expect(editorModal).toBeVisible();
+
+        await editorModal.getByRole('button', {name: 'Close'}).click();
+
+        await expect(page).not.toHaveURL(/staff\/owner-transfer/);
+        await expect(page).toHaveURL(/#\/settings\/design\/change-theme/);
+    });
+
+    test('Honours legitimate from= values when closing the editor', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition')
+        }});
+
+        // A from= value pointing at the theme settings page is in the
+        // allowlist and should be honoured on close.
+        await page.goto('/#/settings/theme/edit/edition?from=theme');
+
+        const editorModal = page.getByTestId('theme-code-editor-modal');
+        await expect(editorModal).toBeVisible();
+
+        await editorModal.getByRole('button', {name: 'Close'}).click();
+
+        await expect(page).toHaveURL(/#\/settings\/theme$/);
+    });
+
     test('Prevents direct access to theme editor route when editing is limited', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,

--- a/apps/admin-x-settings/test/unit/utils/theme-editor-utils.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/theme-editor-utils.test.ts
@@ -118,6 +118,23 @@ describe('theme-editor-utils', function () {
                 }
             );
         });
+
+        it('rejects archives with non-normalized entry paths', async function () {
+            const archive = await createArchiveBuffer((zip) => {
+                zip.file('/post-card.hbs', '{{title}}');
+            });
+
+            await assert.rejects(
+                extractThemeArchive(archive),
+                (error: unknown) => {
+                    assert.ok(error instanceof ThemeArchiveExtractionError);
+                    assert.equal(error.reason, 'invalid_archive');
+                    assert.match(error.message, /failed to open the theme archive/i);
+
+                    return true;
+                }
+            );
+        });
     });
 
     describe('packThemeArchive', function () {

--- a/apps/admin-x-settings/test/unit/utils/theme-editor-utils.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/theme-editor-utils.test.ts
@@ -1,0 +1,286 @@
+import * as assert from 'assert/strict';
+import JSZip from 'jszip';
+import {
+    THEME_EDITOR_ARCHIVE_LIMITS,
+    ThemeArchiveExtractionError,
+    type ThemeEditorSnapshot,
+    cloneThemeFiles,
+    createFolderRenameMap,
+    extractThemeArchive,
+    getThemeChanges,
+    isEditablePath,
+    packThemeArchive
+} from '@src/components/settings/site/theme/theme-editor-utils';
+
+const createArchiveBuffer = async (build: (zip: JSZip) => void) => {
+    const zip = new JSZip();
+
+    build(zip);
+
+    return zip.generateAsync({type: 'arraybuffer'});
+};
+
+const uint8ArrayToArray = (value: Uint8Array | null) => Array.from(value ?? []);
+
+describe('theme-editor-utils', function () {
+    describe('isEditablePath', function () {
+        it('treats extension-based theme source files as editable', function () {
+            assert.equal(isEditablePath('partials/post-card.hbs'), true);
+            assert.equal(isEditablePath('assets/app.css'), true);
+        });
+
+        it('treats common extensionless text files as editable', function () {
+            assert.equal(isEditablePath('.gitignore'), true);
+            assert.equal(isEditablePath('LICENSE'), true);
+            assert.equal(isEditablePath('subdir/.editorconfig'), true);
+        });
+
+        it('keeps binary assets non-editable', function () {
+            assert.equal(isEditablePath('assets/logo.png'), false);
+            assert.equal(isEditablePath('assets/font.woff2'), false);
+        });
+    });
+
+    describe('extractThemeArchive', function () {
+        it('detects and strips a shared root prefix while preserving file contents', async function () {
+            const packageJson = JSON.stringify({name: 'source-edited'}, null, 2);
+            const binaryLogo = new Uint8Array([137, 80, 78, 71, 0, 255, 12]);
+            const date = new Date('2026-05-03T12:00:00.000Z');
+            const archive = await createArchiveBuffer((zip) => {
+                zip.file('source-edited/package.json', packageJson, {
+                    date,
+                    unixPermissions: 0o644
+                });
+                zip.file('source-edited/assets/logo.png', binaryLogo, {
+                    binary: true,
+                    date,
+                    unixPermissions: 0o644
+                });
+            });
+
+            const snapshot = await extractThemeArchive(archive);
+
+            assert.equal(snapshot.rootPrefix, 'source-edited/');
+            assert.deepEqual(Object.keys(snapshot.files).sort(), ['assets/logo.png', 'package.json']);
+            assert.equal(snapshot.files['package.json'].editable, true);
+            assert.equal(snapshot.files['package.json'].content, packageJson);
+            assert.equal(snapshot.files['assets/logo.png'].editable, false);
+            assert.deepEqual(uint8ArrayToArray(snapshot.files['assets/logo.png'].binary), Array.from(binaryLogo));
+        });
+
+        it('leaves flat archives without a synthetic root prefix', async function () {
+            const archive = await createArchiveBuffer((zip) => {
+                zip.file('index.hbs', '{{!< default}}');
+                zip.file('assets/app.css', 'body { color: red; }');
+            });
+
+            const snapshot = await extractThemeArchive(archive);
+
+            assert.equal(snapshot.rootPrefix, '');
+            assert.deepEqual(Object.keys(snapshot.files).sort(), ['assets/app.css', 'index.hbs']);
+        });
+
+        it('rejects archives with too many files before extracting them', async function () {
+            const archive = await createArchiveBuffer((zip) => {
+                for (let index = 0; index <= THEME_EDITOR_ARCHIVE_LIMITS.maxFiles; index += 1) {
+                    zip.file(`partials/file-${index}.hbs`, `{{! file ${index} }}`);
+                }
+            });
+
+            await assert.rejects(
+                extractThemeArchive(archive),
+                (error: unknown) => {
+                    assert.ok(error instanceof ThemeArchiveExtractionError);
+                    assert.equal(error.reason, 'too_many_files');
+                    assert.match(error.message, /too many files/i);
+
+                    return true;
+                }
+            );
+        });
+
+        it('rejects archives whose extracted contents exceed the browser limit', async function () {
+            const archive = await createArchiveBuffer((zip) => {
+                zip.file('assets/huge.bin', new Uint8Array(THEME_EDITOR_ARCHIVE_LIMITS.maxExtractedBytes + 1), {
+                    binary: true,
+                    compression: 'DEFLATE'
+                });
+            });
+
+            await assert.rejects(
+                extractThemeArchive(archive),
+                (error: unknown) => {
+                    assert.ok(error instanceof ThemeArchiveExtractionError);
+                    assert.equal(error.reason, 'too_large');
+                    assert.match(error.message, /too large/i);
+
+                    return true;
+                }
+            );
+        });
+    });
+
+    describe('packThemeArchive', function () {
+        it('preserves root prefixes, editable text, and binary bytes across a roundtrip', async function () {
+            const originalArchive = await createArchiveBuffer((zip) => {
+                zip.file('source-edited/index.hbs', '<main>{{title}}</main>', {
+                    date: new Date('2026-05-03T13:00:00.000Z')
+                });
+                zip.file('source-edited/assets/logo.png', new Uint8Array([0, 1, 2, 200, 255]), {
+                    binary: true,
+                    date: new Date('2026-05-03T13:00:00.000Z')
+                });
+            });
+
+            const extractedSnapshot = await extractThemeArchive(originalArchive);
+            const packedArchive = await packThemeArchive(extractedSnapshot);
+            const repackedBuffer = await packedArchive.arrayBuffer();
+            const rawZip = await JSZip.loadAsync(repackedBuffer);
+            const roundTrippedSnapshot = await extractThemeArchive(repackedBuffer);
+
+            assert.deepEqual(
+                Object.keys(rawZip.files).filter(path => !rawZip.files[path].dir).sort(),
+                ['source-edited/assets/logo.png', 'source-edited/index.hbs']
+            );
+            assert.equal(roundTrippedSnapshot.rootPrefix, 'source-edited/');
+            assert.equal(roundTrippedSnapshot.files['index.hbs'].content, '<main>{{title}}</main>');
+            assert.deepEqual(
+                uint8ArrayToArray(roundTrippedSnapshot.files['assets/logo.png'].binary),
+                [0, 1, 2, 200, 255]
+            );
+        });
+
+        it('writes the current editable content into the archive instead of stale source text', async function () {
+            const snapshot: ThemeEditorSnapshot = {
+                rootPrefix: 'source-edited/',
+                files: {
+                    'index.hbs': {
+                        path: 'index.hbs',
+                        editable: true,
+                        content: '<main>updated</main>',
+                        binary: null,
+                        date: new Date('2026-05-03T14:00:00.000Z'),
+                        unixPermissions: null,
+                        dosPermissions: null
+                    }
+                }
+            };
+
+            const packedArchive = await packThemeArchive(snapshot);
+            const zip = await JSZip.loadAsync(await packedArchive.arrayBuffer());
+
+            assert.equal(await zip.file('source-edited/index.hbs')?.async('string'), '<main>updated</main>');
+        });
+    });
+
+    describe('getThemeChanges', function () {
+        it('reports sorted added, deleted, and modified text files', function () {
+            const date = new Date('2026-05-03T15:00:00.000Z');
+            const baseFiles = {
+                'assets/logo.png': {
+                    path: 'assets/logo.png',
+                    editable: false,
+                    content: null,
+                    binary: new Uint8Array([1, 2, 3]),
+                    date,
+                    unixPermissions: null,
+                    dosPermissions: null
+                },
+                'index.hbs': {
+                    path: 'index.hbs',
+                    editable: true,
+                    content: '<main>before</main>',
+                    binary: null,
+                    date,
+                    unixPermissions: null,
+                    dosPermissions: null
+                }
+            };
+            const currentFiles = {
+                'assets/app.css': {
+                    path: 'assets/app.css',
+                    editable: true,
+                    content: 'body { color: green; }',
+                    binary: null,
+                    date,
+                    unixPermissions: null,
+                    dosPermissions: null
+                },
+                'index.hbs': {
+                    path: 'index.hbs',
+                    editable: true,
+                    content: '<main>after</main>',
+                    binary: null,
+                    date,
+                    unixPermissions: null,
+                    dosPermissions: null
+                }
+            };
+
+            assert.deepEqual(getThemeChanges({baseFiles, currentFiles}), [
+                {path: 'assets/app.css', editable: true, status: 'added'},
+                {path: 'assets/logo.png', editable: false, status: 'deleted'},
+                {path: 'index.hbs', editable: true, status: 'modified'}
+            ]);
+        });
+    });
+
+    describe('cloneThemeFiles', function () {
+        it('deep-clones mutable file fields used by revert and save flows', function () {
+            const originalDate = new Date('2026-05-03T16:00:00.000Z');
+            const originalFiles = {
+                'assets/logo.png': {
+                    path: 'assets/logo.png',
+                    editable: false,
+                    content: null,
+                    binary: new Uint8Array([4, 5, 6]),
+                    date: originalDate,
+                    unixPermissions: null,
+                    dosPermissions: null
+                }
+            };
+
+            const clonedFiles = cloneThemeFiles(originalFiles);
+
+            clonedFiles['assets/logo.png'].binary![0] = 99;
+            clonedFiles['assets/logo.png'].date.setUTCFullYear(2030);
+
+            assert.deepEqual(uint8ArrayToArray(originalFiles['assets/logo.png'].binary), [4, 5, 6]);
+            assert.equal(originalFiles['assets/logo.png'].date.getUTCFullYear(), 2026);
+        });
+    });
+
+    describe('createFolderRenameMap', function () {
+        it('renames every file under a folder prefix without touching siblings', function () {
+            const date = new Date('2026-05-03T17:00:00.000Z');
+            const renamedFiles = createFolderRenameMap({
+                files: {
+                    'assets/app.css': {
+                        path: 'assets/app.css',
+                        editable: true,
+                        content: 'body {}',
+                        binary: null,
+                        date,
+                        unixPermissions: null,
+                        dosPermissions: null
+                    },
+                    'partials/post-card.hbs': {
+                        path: 'partials/post-card.hbs',
+                        editable: true,
+                        content: '{{title}}',
+                        binary: null,
+                        date,
+                        unixPermissions: null,
+                        dosPermissions: null
+                    }
+                },
+                oldPrefix: 'assets/',
+                newPrefix: 'static/'
+            });
+
+            assert.deepEqual(Object.keys(renamedFiles).sort(), ['partials/post-card.hbs', 'static/app.css']);
+            assert.equal(renamedFiles['static/app.css'].path, 'static/app.css');
+            assert.equal(renamedFiles['partials/post-card.hbs'].path, 'partials/post-card.hbs');
+        });
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -811,7 +811,7 @@ importers:
         specifier: 'catalog:'
         version: 2.1.1
       jszip:
-        specifier: ^3.10.1
+        specifier: 3.10.1
         version: 3.10.1
       lucide-react:
         specifier: 0.577.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,9 +750,30 @@ importers:
 
   apps/admin-x-settings:
     dependencies:
+      '@codemirror/lang-css':
+        specifier: 6.3.1
+        version: 6.3.1
       '@codemirror/lang-html':
         specifier: 6.4.11
         version: 6.4.11
+      '@codemirror/lang-javascript':
+        specifier: 6.2.4
+        version: 6.2.4
+      '@codemirror/lang-json':
+        specifier: 6.0.2
+        version: 6.0.2
+      '@codemirror/lang-markdown':
+        specifier: 6.3.4
+        version: 6.3.4
+      '@codemirror/lang-yaml':
+        specifier: 6.1.2
+        version: 6.1.2
+      '@codemirror/search':
+        specifier: 6.6.0
+        version: 6.6.0
+      '@codemirror/theme-one-dark':
+        specifier: 6.1.3
+        version: 6.1.3
       '@dnd-kit/sortable':
         specifier: 7.0.2
         version: 7.0.2(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -789,6 +810,9 @@ importers:
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: 0.577.0
         version: 0.577.0(react@18.3.1)
@@ -3799,8 +3823,17 @@ packages:
   '@codemirror/lang-html@6.4.11':
     resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
 
-  '@codemirror/lang-javascript@6.2.5':
-    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+  '@codemirror/lang-javascript@6.2.4':
+    resolution: {integrity: sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-markdown@6.3.4':
+    resolution: {integrity: sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==}
+
+  '@codemirror/lang-yaml@6.1.2':
+    resolution: {integrity: sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==}
 
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
@@ -5241,8 +5274,17 @@ packages:
   '@lezer/javascript@1.5.4':
     resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
 
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
   '@lezer/lr@1.4.8':
     resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
 
   '@lint-todo/utils@13.1.1':
     resolution: {integrity: sha512-F5z53uvRIF4dYfFfJP3a2Cqg+4P1dgJchJsFnsZE0eZp0LK8X7g2J0CsJHRgns+skpXOlM7n5vFGwkWCWj8qJg==}
@@ -16004,6 +16046,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   juice@9.1.0:
     resolution: {integrity: sha512-odblShmPrUoHUwRuC8EmLji5bPP2MLO1GL+gt4XU3tT2ECmbSrrMjtMQaqg3wgMFP2zvUzdPZGfxc5Trk3Z+fQ==}
     engines: {node: '>=10.0.0'}
@@ -16217,6 +16262,9 @@ packages:
 
   lie@3.1.1:
     resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   liftoff@3.1.0:
     resolution: {integrity: sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==}
@@ -23833,7 +23881,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-css': 6.3.1
-      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-javascript': 6.2.4
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.40.0
@@ -23841,7 +23889,7 @@ snapshots:
       '@lezer/css': 1.3.3
       '@lezer/html': 1.3.13
 
-  '@codemirror/lang-javascript@6.2.5':
+  '@codemirror/lang-javascript@6.2.4':
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
@@ -23850,6 +23898,31 @@ snapshots:
       '@codemirror/view': 6.40.0
       '@lezer/common': 1.5.1
       '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-markdown@6.3.4':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/lang-yaml@6.1.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      '@lezer/yaml': 1.0.4
 
   '@codemirror/language@6.12.3':
     dependencies:
@@ -25674,9 +25747,26 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
 
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
   '@lezer/lr@1.4.8':
     dependencies:
       '@lezer/common': 1.5.1
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
 
   '@lint-todo/utils@13.1.1':
     dependencies:
@@ -40329,6 +40419,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   juice@9.1.0(encoding@0.1.13):
     dependencies:
       cheerio: 0.22.0
@@ -40612,6 +40709,10 @@ snapshots:
   libheif-js@1.19.8: {}
 
   lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
+  lie@3.3.0:
     dependencies:
       immediate: 3.0.6
 


### PR DESCRIPTION
## What

This adds a Ghost-native theme code editor inside settings. 

Based on community work originally done here by @muratcorlu:
https://github.com/synapsmedia/ghost-theme-editor

- adds editor entry points from the installed themes list and active theme settings
- supports browser-based editing of text theme files while preserving binary assets through ZIP round-trips
- adds create, rename, delete, revert, save, and save-as flows for built-in themes
- hardens the editor against malformed direct routes and oversized or hostile archives
- adds acceptance and unit coverage for the editor flows and ZIP utilities

---

<img width="2144" height="768" alt="CleanShot 2026-05-03 at 19 49 46@2x" src="https://github.com/user-attachments/assets/f4cf4e3a-32d8-4b85-bebe-d2a43cef9ab5" />

---

<img width="3246" height="2120" alt="CleanShot 2026-05-03 at 19 48 54@2x" src="https://github.com/user-attachments/assets/37f266a7-0a07-4a22-8db0-1ddc496d66eb" />

