### PR TITLE
🐛 Fixed newsletter reply-to verification links failing after signin

### DIFF
--- a/e2e/tests/admin/signin.test.ts
+++ b/e2e/tests/admin/signin.test.ts
@@ -35,4 +35,27 @@ test.describe('Ghost Admin - Signin Redirect', () => {
 
         await postsPage.waitForPageToFullyLoad();
     });
+
+    test('query params on a deep link survive signin redirect', async ({page, ghostAccountOwner}) => {
+        // Newsletter reply-to verification emails point at
+        // /settings/newsletters/?verifyEmail=<token>. If the user clicks the
+        // link in a browser that isn't signed in, the param needs to survive
+        // the signin round-trip, otherwise the verify-on-mount handler in
+        // newsletters.tsx no-ops and the customer thinks their reply-to
+        // address didn't save (ONC-1618 / ONC-1642).
+        await logout(page);
+
+        await page.goto('/ghost/#/settings/newsletters/?verifyEmail=fake-token-xyz');
+
+        const loginPage = new LoginPage(page);
+        await expect(loginPage.signInButton).toBeVisible();
+
+        await loginPage.signIn(ghostAccountOwner.email, ghostAccountOwner.password);
+
+        // The error modal is the signal that the React verify handler ran:
+        // it only renders when newsletters.tsx attempted to redeem a token
+        // and the API rejected it (expected, since the token is fake).
+        await expect(page.getByRole('heading', {name: 'Error verifying email address'})).toBeVisible();
+        expect(page.url()).toContain('verifyEmail=fake-token-xyz');
+    });
 });

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -1,5 +1,7 @@
+import AuthConfiguration from 'ember-simple-auth/configuration';
 import ESASessionService from 'ember-simple-auth/services/session';
 import RSVP from 'rsvp';
+import windowProxy from 'ghost-admin/utils/window-proxy';
 import {configureScope} from '@sentry/ember';
 import {getOwner} from '@ember/application';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -91,7 +93,11 @@ export default class SessionService extends ESASessionService {
             const redirectUrl = window.sessionStorage.getItem('ghost-signin-redirect');
             window.sessionStorage.removeItem('ghost-signin-redirect');
             if (redirectUrl && !redirectUrl.startsWith('/signin') && !redirectUrl.startsWith('/signup') && !redirectUrl.startsWith('/setup')) {
-                this.router.transitionTo(redirectUrl);
+                // Hard navigate rather than router.transitionTo: the catch-all
+                // react-fallback route has no controller-declared queryParams,
+                // so transitionTo strips params like ?verifyEmail=<token> used
+                // by newsletter reply-to confirmation links.
+                windowProxy.replaceLocation(`${AuthConfiguration.rootURL}#${redirectUrl}`);
                 return;
             }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1658/

## Summary

When a customer clicks a newsletter reply-to verification email in a browser that isn't signed in to admin, the link silently no-ops — they have to click it a second time for the address to actually save. Two customers hit this in the past few weeks (ONC-1618, ONC-1642).

The signin-redirect flow added in #27316 stores the original URL in `sessionStorage` and replays it via `router.transitionTo(redirectUrl)` after auth. But `react-fallback` is a wildcard route with no controller-declared `queryParams`, so Ember strips `?verifyEmail=<token>` on the replay. The verify-on-mount `useEffect` in `newsletters.tsx` then short-circuits because the token is missing.

This swaps the soft `transitionTo` for `windowProxy.replaceLocation` — already the auth-flow primitive used in `authenticated.js:20` and `application.js:113`. A hard navigation feeds the URL straight to the browser and sidesteps Ember's URL-rebuilding entirely, so the query param survives byte-for-byte.

## Test plan — base case

1. With `pnpm dev` running, sign out of admin.
2. Paste into the address bar: `http://localhost:2368/ghost/#/settings/newsletters/?verifyEmail=fake-token-xyz`
3. You'll be redirected to signin. Sign in.
4. **Expected:** address bar still shows `?verifyEmail=fake-token-xyz`, and within a moment an "Error verifying email address" / "Verification link has expired" modal appears (because the token is fake — that's success: it means the round-trip worked and the API was actually called).
5. **Pre-fix behaviour:** address bar shows `/settings/newsletters/` with no query param, no modal — the silent no-op customers reported.

## Test plan — regression checks

- [ ] Deep-link to a no-query-param React route while logged out: `/ghost/#/tags` → signin → land on Tags. (covered by existing e2e)
- [ ] Deep-link to an Ember route while logged out: `/ghost/#/posts` → signin → land on Posts. (covered by existing e2e)
- [ ] Normal signin from `/ghost/` (no `sessionStorage` redirect): land on home/dashboard as before.
- [ ] End-to-end: trigger a real reply-to verification email by editing a newsletter's Reply-to address, grab the link from Mailpit (`http://localhost:8025`), open it in an incognito window, sign in, confirm the "Reply-to address verified" success modal.

## Automated coverage

Added an e2e in `e2e/tests/admin/signin.test.ts` that round-trips a `?verifyEmail=` deep link through signin and asserts both that the URL retains the param and that the verify error modal renders (which only happens if `newsletters.tsx` actually called the API). Verified to fail on the unfixed code.