### PR TITLE
Decoupled share script from portal when portal is turned off

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.27",
+  "version": "2.68.28",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "dev": "concurrently \"pnpm preview -l silent\" \"pnpm build:watch\"",
-    "build": "vite build",
-    "build:watch": "vite build --watch",
+    "build": "vite build && PORTAL_BUILD=share vite build",
+    "build:watch": "concurrently \"vite build --watch\" \"PORTAL_BUILD=share vite build --watch\"",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -60,6 +60,8 @@ export default class App extends React.Component {
     constructor(props) {
         super(props);
 
+        this.shareDisabled = this.getShareDisabled();
+
         this.setupCustomTriggerButton();
 
         this.state = {
@@ -705,7 +707,7 @@ export default class App extends React.Component {
 
             return giftLinkData;
         }
-        if (path && shareRegex.test(path)) {
+        if (path && shareRegex.test(path) && !this.shareDisabled) {
             return {
                 showPopup: true,
                 page: 'share'
@@ -778,6 +780,12 @@ export default class App extends React.Component {
             return scriptTag.dataset.accentColor;
         }
         return false;
+    }
+
+    /* Whether the share modal is disabled via the script tag data attribute */
+    getShareDisabled() {
+        const scriptTag = document.querySelector('script[data-ghost]');
+        return scriptTag?.dataset.disableShare === 'true';
     }
 
     /** Fetch site, member session data and member offers with Ghost Apis  */
@@ -1132,6 +1140,9 @@ export default class App extends React.Component {
                 page: 'gift'
             };
         } else if (path === 'share') {
+            if (this.shareDisabled) {
+                return null;
+            }
             return {
                 page: 'share'
             };
@@ -1300,7 +1311,10 @@ export default class App extends React.Component {
      * portal. Especially useful for copy/pasted links from Admin screens.
      */
     transformPortalLinksToRelative() {
-        document.querySelectorAll('a[href*="#/portal"], a[href*="#/share"]').forEach(transformPortalAnchorToRelative);
+        const selector = this.shareDisabled
+            ? 'a[href*="#/portal"]'
+            : 'a[href*="#/portal"], a[href*="#/share"]';
+        document.querySelectorAll(selector).forEach(transformPortalAnchorToRelative);
     }
 
     render() {

--- a/apps/portal/src/components/common/close-button.js
+++ b/apps/portal/src/components/common/close-button.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import AppContext from '../../app-context';
-import {ReactComponent as CloseIcon} from '../../images/icons/close.svg';
+import CloseIconButton from './close-icon-button';
 
 export default class CloseButton extends React.Component {
     static contextType = AppContext;
@@ -12,12 +12,6 @@ export default class CloseButton extends React.Component {
     render() {
         const {onClick} = this.props;
 
-        return (
-            <div className='gh-portal-closeicon-container' data-test-button='close-popup'>
-                <CloseIcon
-                    className='gh-portal-closeicon' alt='Close' onClick = {onClick || this.closePopup} data-testid='close-popup'
-                />
-            </div>
-        );
+        return <CloseIconButton onClick={onClick || this.closePopup} />;
     }
 }

--- a/apps/portal/src/components/common/close-icon-button.js
+++ b/apps/portal/src/components/common/close-icon-button.js
@@ -1,0 +1,18 @@
+import {ReactComponent as CloseIcon} from '../../images/icons/close.svg';
+import {t} from '../../utils/i18n';
+
+const CloseIconButton = ({onClick, ariaLabel}) => {
+    return (
+        <div className='gh-portal-closeicon-container' data-test-button='close-popup'>
+            <CloseIcon
+                className='gh-portal-closeicon'
+                alt='Close'
+                aria-label={ariaLabel || t('Close')}
+                onClick={onClick}
+                data-testid='close-popup'
+            />
+        </div>
+    );
+};
+
+export default CloseIconButton;

--- a/apps/portal/src/components/pages/feedback-page.js
+++ b/apps/portal/src/components/pages/feedback-page.js
@@ -258,7 +258,7 @@ const ConfirmDialog = ({onConfirm, loading, initialScore}) => {
                 isRunning={loading}
                 tabIndex={3}
             />
-            <CloseButton close={() => close(false)} />
+            <CloseButton onClick={() => close(false)} />
         </div>
     );
 };

--- a/apps/portal/src/components/pages/share/share-modal.js
+++ b/apps/portal/src/components/pages/share/share-modal.js
@@ -1,4 +1,4 @@
-import CloseButton from '../../common/close-button';
+import CloseIconButton from '../../common/close-icon-button';
 import copyTextToClipboard from '../../../utils/copy-to-clipboard';
 import useShareData from './use-share-data';
 import {ReactComponent as BlueSkyIcon} from '../../../images/icons/share-bluesky.svg';
@@ -13,7 +13,7 @@ import {ReactComponent as XIcon} from '../../../images/icons/share-x.svg';
 import {useEffect, useRef, useState} from 'react';
 import {t} from '../../../utils/i18n';
 
-const ShareModal = () => {
+const ShareModal = ({onClose}) => {
     const [copied, setCopied] = useState(false);
     const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false);
     const copyTimeoutRef = useRef();
@@ -84,7 +84,7 @@ const ShareModal = () => {
 
     return (
         <div className='gh-portal-content gh-portal-share'>
-            <CloseButton />
+            <CloseIconButton onClick={onClose} />
             <div className='gh-portal-share-header'>
                 <h1 className='gh-portal-main-title'>{t('Share')}</h1>
             </div>

--- a/apps/portal/src/components/pages/share/share-page.js
+++ b/apps/portal/src/components/pages/share/share-page.js
@@ -1,0 +1,13 @@
+import AppContext from '../../../app-context';
+import ShareModal from './share-modal';
+import {useContext} from 'react';
+
+const SharePage = () => {
+    const {doAction} = useContext(AppContext);
+
+    return (
+        <ShareModal onClose={() => doAction('closePopup')} />
+    );
+};
+
+export default SharePage;

--- a/apps/portal/src/components/pages/share/share-shell.styles.js
+++ b/apps/portal/src/components/pages/share/share-shell.styles.js
@@ -1,0 +1,225 @@
+import {GlobalStyles} from '../../global.styles';
+import {ShareModalStyles} from './share-modal.styles';
+
+export const ShareShellStyles = `
+${GlobalStyles}
+
+:root {
+    --brandcolor: var(--ghost-accent-color, #3eb0ef);
+}
+
+.gh-portal-share-shell {
+    position: fixed;
+    inset: 0;
+    z-index: 3999999;
+    overflow: hidden;
+}
+
+.gh-portal-main-title {
+    text-align: center;
+    color: var(--grey0);
+    line-height: 1.1em;
+    text-wrap: pretty;
+}
+
+/* Buttons
+/* ----------------------------------------------------- */
+.gh-portal-btn {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    font-weight: 500;
+    line-height: 1em;
+    letter-spacing: 0.2px;
+    text-align: center;
+    white-space: nowrap;
+    text-decoration: none;
+    color: var(--grey0);
+    background: var(--white);
+    border: 1px solid var(--grey12);
+    min-width: 80px;
+    height: 44px;
+    padding: 0 1.8rem;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all .25s ease;
+    box-shadow: none;
+    user-select: none;
+    outline: none;
+}
+
+.gh-portal-btn:hover {
+    border-color: var(--grey10);
+}
+
+/* Global layout styles
+/* ----------------------------------------------------- */
+.gh-portal-popup-background {
+    position: absolute;
+    display: block;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    animation: fadein 0.2s;
+    background: linear-gradient(315deg , rgba(var(--blackrgb),0.2) 0%, rgba(var(--blackrgb),0.1) 100%);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    -webkit-transform: translate3d(0, 0, 0);
+    -moz-transform: translate3d(0, 0, 0);
+    -ms-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+}
+
+@keyframes fadein {
+    0% { opacity: 0; }
+    100%{ opacity: 1.0; }
+}
+
+.gh-portal-popup-wrapper {
+    position: relative;
+    padding: 5vmin 0 0;
+    height: 100%;
+    max-height: 100vh;
+    overflow: scroll;
+}
+
+/* Hiding scrollbars */
+.gh-portal-popup-wrapper {
+    padding-inline-end: 30px !important;
+    margin-inline-end: -30px !important;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+.gh-portal-popup-wrapper::-webkit-scrollbar {
+    display: none;
+}
+
+.gh-portal-popup-container {
+    outline: none;
+    position: relative;
+    display: flex;
+    box-sizing: border-box;
+    flex-direction: column;
+    justify-content: flex-start;
+    font-size: 1.5rem;
+    text-align: start;
+    letter-spacing: 0;
+    text-rendering: optimizeLegibility;
+    background: var(--white);
+    width: 500px;
+    margin: 0 auto 40px;
+    padding: 32px;
+    transform: translateY(0px);
+    border-radius: 10px;
+    box-shadow: 0 3.8px 2.2px rgba(var(--blackrgb), 0.028), 0 9.2px 5.3px rgba(var(--blackrgb), 0.04), 0 17.3px 10px rgba(var(--blackrgb), 0.05), 0 30.8px 17.9px rgba(var(--blackrgb), 0.06), 0 57.7px 33.4px rgba(var(--blackrgb), 0.072), 0 138px 80px rgba(var(--blackrgb), 0.1);
+    animation: popup 0.25s ease-in-out;
+    z-index: 9999;
+}
+
+@keyframes popup {
+    0% {
+        transform: translateY(-30px);
+        opacity: 0;
+    }
+    1% {
+        transform: translateY(30px);
+        opacity: 0;
+    }
+    100%{
+        transform: translateY(0);
+        opacity: 1.0;
+    }
+}
+
+/* Sets the main content area of the popup scrollable. */
+.gh-portal-content {
+    position: relative;
+}
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.gh-portal-content::-webkit-scrollbar {
+    display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.gh-portal-content {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+.gh-portal-closeicon-container {
+    position: fixed;
+    top: 24px;
+    right: 24px;
+    z-index: 10000;
+}
+html[dir="rtl"] .gh-portal-closeicon-container {
+    right: unset;
+    left: 24px;
+}
+
+.gh-portal-closeicon {
+    color: var(--grey10);
+    cursor: pointer;
+    width: 20px;
+    height: 20px;
+    padding: 12px;
+    transition: all 0.2s ease-in-out;
+}
+
+.gh-portal-closeicon:hover {
+    color: var(--grey5);
+}
+
+@media (max-width: 1440px) {
+    .gh-portal-popup-container:not(.full-size):not(.large-size):not(.preview) {
+        width: 480px;
+    }
+}
+
+@media (max-width: 480px) {
+    .gh-portal-popup-wrapper {
+        height: 100%;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: space-between;
+        background: var(--white);
+        overflow-y: auto;
+    }
+
+    .gh-portal-popup-container {
+        width: 100% !important;
+        border-radius: 0;
+        overflow: unset;
+        animation: popup-mobile 0.25s ease-in-out;
+        box-shadow: none !important;
+        transform: translateY(0);
+        padding: 28px !important;
+    }
+}
+
+@media (min-width: 480px) and (max-height: 880px) {
+    .gh-portal-popup-wrapper {
+        padding: 4vmin 0 0;
+    }
+}
+
+@keyframes popup-mobile {
+    0% {
+        opacity: 0;
+    }
+    100%{
+        opacity: 1.0;
+    }
+}
+
+${ShareModalStyles}
+`;
+
+export default ShareShellStyles;

--- a/apps/portal/src/pages.js
+++ b/apps/portal/src/pages.js
@@ -20,7 +20,7 @@ import RecommendationsPage from './components/pages/recommendations-page';
 import GiftPage from './components/pages/gift-page';
 import GiftRedemptionPage from './components/pages/gift-redemption-page';
 import GiftSuccessPage from './components/pages/gift-success-page';
-import ShareModal from './components/pages/share/share-modal';
+import SharePage from './components/pages/share/share-page';
 
 /** List of all available pages in Portal, mapped to their UI component
  * Any new page added to portal needs to be mapped here
@@ -48,7 +48,7 @@ const Pages = {
     gift: GiftPage,
     giftRedemption: GiftRedemptionPage,
     giftSuccess: GiftSuccessPage,
-    share: ShareModal
+    share: SharePage
 };
 
 /** Return page if valid, fallback to signup */

--- a/apps/portal/src/share.js
+++ b/apps/portal/src/share.js
@@ -1,0 +1,241 @@
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import ReactDOM from 'react-dom';
+import Frame from './components/frame';
+import ShareModal from './components/pages/share/share-modal';
+import ShareShellStyles from './components/pages/share/share-shell.styles';
+import i18n from './utils/i18n';
+
+const ROOT_DIV_ID = 'ghost-portal-share-root';
+const SHARE_HASH_REGEX = /^#\/share\/?$/;
+
+const getScriptData = () => {
+    const scriptTag = document.querySelector('script[data-portal-share]');
+    return {
+        locale: scriptTag?.dataset.locale || 'en',
+        accentColor: scriptTag?.dataset.accentColor || ''
+    };
+};
+
+const isShareHash = () => SHARE_HASH_REGEX.test(window.location.hash);
+
+const getSameOriginShareLink = (target) => {
+    const anchor = target?.closest?.('a[href]');
+    if (!anchor) {
+        return null;
+    }
+
+    try {
+        const url = new URL(anchor.href, window.location.href);
+        if (url.origin === window.location.origin && SHARE_HASH_REGEX.test(url.hash)) {
+            return anchor;
+        }
+    } catch {
+        // Ignore invalid hrefs
+    }
+
+    return null;
+};
+
+const getModalContainerStyle = () => ({
+    position: 'fixed',
+    inset: 0,
+    zIndex: '3999999',
+    overflow: 'hidden'
+});
+
+const getFrameStyle = () => ({
+    margin: 'auto',
+    position: 'relative',
+    padding: '0',
+    outline: '0',
+    width: '100%',
+    height: '100%',
+    opacity: '1',
+    overflow: 'hidden'
+});
+
+const getScrollbarWidth = () => {
+    const div = document.createElement('div');
+    div.style.visibility = 'hidden';
+    div.style.overflow = 'scroll';
+    document.body.appendChild(div);
+
+    const scrollbarWidth = div.offsetWidth - div.clientWidth;
+
+    document.body.removeChild(div);
+
+    return scrollbarWidth;
+};
+
+const clearShareHash = () => {
+    if (!isShareHash()) {
+        return;
+    }
+
+    window.history.pushState('', document.title, window.location.pathname + window.location.search);
+};
+
+function addRootDiv() {
+    let elem = document.getElementById(ROOT_DIV_ID);
+    if (!elem) {
+        elem = document.createElement('div');
+        elem.id = ROOT_DIV_ID;
+        elem.setAttribute('data-testid', 'portal-share-root');
+        document.body.appendChild(elem);
+    }
+    return elem;
+}
+
+const ShareShell = ({accentColor}) => {
+    const [isOpen, setIsOpen] = useState(isShareHash);
+    const [frameDocument, setFrameDocument] = useState(null);
+    const containerRef = useRef(null);
+    const bodyOverflowRef = useRef('');
+    const bodyMarginRef = useRef('');
+    const dir = i18n.dir() || 'ltr';
+
+    useEffect(() => {
+        const onHashChange = () => {
+            if (isShareHash()) {
+                setIsOpen(true);
+            }
+        };
+
+        const onClick = (event) => {
+            if (event.target?.closest?.('[data-portal="share"]')) {
+                event.preventDefault();
+                setIsOpen(true);
+                return;
+            }
+
+            if (getSameOriginShareLink(event.target)) {
+                event.preventDefault();
+                if (!isShareHash()) {
+                    window.location.hash = '#/share';
+                }
+                setIsOpen(true);
+            }
+        };
+
+        window.addEventListener('hashchange', onHashChange);
+        document.addEventListener('click', onClick);
+
+        return () => {
+            window.removeEventListener('hashchange', onHashChange);
+            document.removeEventListener('click', onClick);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        bodyOverflowRef.current = document.body.style.overflow;
+        bodyMarginRef.current = window.getComputedStyle(document.body).getPropertyValue('margin-right');
+        document.body.style.overflow = 'hidden';
+        const scrollbarWidth = getScrollbarWidth();
+        if (scrollbarWidth) {
+            document.body.style.marginRight = `calc(${bodyMarginRef.current} + ${scrollbarWidth}px)`;
+        }
+
+        return () => {
+            document.body.style.overflow = bodyOverflowRef.current || '';
+            if (!bodyMarginRef.current || bodyMarginRef.current === '0px') {
+                document.body.style.marginRight = '';
+            } else {
+                document.body.style.marginRight = bodyMarginRef.current;
+            }
+        };
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (!isOpen || !frameDocument) {
+            return;
+        }
+
+        const onKeyUp = (event) => {
+            if (event.key === 'Escape') {
+                close();
+            }
+        };
+
+        frameDocument.addEventListener('keyup', onKeyUp);
+        containerRef.current?.focus();
+
+        return () => {
+            frameDocument.removeEventListener('keyup', onKeyUp);
+        };
+    }, [frameDocument, isOpen]);
+
+    const close = () => {
+        setIsOpen(false);
+        clearShareHash();
+    };
+
+    const setContainerNode = useCallback((node) => {
+        containerRef.current = node;
+        const nextDocument = node?.ownerDocument || null;
+        setFrameDocument((currentDocument) => {
+            return currentDocument === nextDocument ? currentDocument : nextDocument;
+        });
+    }, []);
+
+    const renderFrameHead = () => {
+        const styles = accentColor
+            ? `${ShareShellStyles}:root { --brandcolor: ${accentColor}; }`
+            : ShareShellStyles;
+
+        return (
+            <>
+                <style dangerouslySetInnerHTML={{__html: styles}} />
+                <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+            </>
+        );
+    };
+
+    const onBackdropClick = (event) => {
+        if (event.target === event.currentTarget) {
+            close();
+        }
+    };
+
+    if (!isOpen) {
+        return null;
+    }
+
+    return (
+        <div style={getModalContainerStyle()}>
+            <Frame
+                dataDir={dir}
+                dataTestId='portal-share-frame'
+                head={renderFrameHead()}
+                style={getFrameStyle()}
+                title='portal-share'
+            >
+                <div className='gh-portal-share-shell' dir={dir}>
+                    <div className='gh-portal-popup-background' onClick={close}></div>
+                    <div className='gh-portal-popup-wrapper share' onClick={onBackdropClick}>
+                        <div className='gh-portal-popup-container share' ref={setContainerNode} tabIndex={-1}>
+                            <ShareModal onClose={close} />
+                        </div>
+                    </div>
+                </div>
+            </Frame>
+        </div>
+    );
+};
+
+function init() {
+    const {locale, accentColor} = getScriptData();
+    i18n.changeLanguage(locale);
+
+    ReactDOM.render(
+        <React.StrictMode>
+            <ShareShell accentColor={accentColor} />
+        </React.StrictMode>,
+        addRootDiv()
+    );
+}
+
+init();

--- a/apps/portal/test/app.test.js
+++ b/apps/portal/test/app.test.js
@@ -90,6 +90,105 @@ describe('App', function () {
         expect(link.getAttribute('href')).toBe('#/share');
     });
 
+    describe('with data-disable-share on portal script tag', () => {
+        let scriptTag;
+
+        beforeEach(() => {
+            scriptTag = document.createElement('script');
+            scriptTag.setAttribute('data-ghost', 'http://example.com');
+            scriptTag.setAttribute('data-disable-share', 'true');
+            document.head.appendChild(scriptTag);
+        });
+
+        afterEach(() => {
+            scriptTag.remove();
+        });
+
+        test('does not transform #/share links on render', async () => {
+            const link = document.createElement('a');
+            link.setAttribute('href', 'http://example.com/#/share');
+            document.body.appendChild(link);
+
+            const ghostApi = setupApi();
+            const utils = appRender(
+                <App siteUrl="http://example.com" api={ghostApi} />
+            );
+
+            await utils.findByTitle(/portal-popup/i);
+
+            expect(link.getAttribute('href')).toBe('http://example.com/#/share');
+        });
+
+        test('still transforms #/portal links on render', async () => {
+            const link = document.createElement('a');
+            link.setAttribute('href', 'http://example.com/#/portal/signup');
+            document.body.appendChild(link);
+
+            const ghostApi = setupApi();
+            const utils = appRender(
+                <App siteUrl="http://example.com" api={ghostApi} />
+            );
+
+            await utils.findByTitle(/portal-popup/i);
+
+            expect(link.getAttribute('href')).toBe('#/portal/signup');
+        });
+
+        test('fetchLinkData does not match #/share hash', async () => {
+            window.location.hash = '#/share';
+
+            const app = new App({siteUrl: 'http://example.com'});
+            const result = await app.fetchLinkData(FixtureSite.singleTier.basic, FixtureMember.free);
+
+            expect(result).toEqual({});
+        });
+
+        test('getPageFromLinkPath returns null for share path', () => {
+            const app = new App({siteUrl: 'http://example.com'});
+            expect(app.getPageFromLinkPath('share')).toBeNull();
+        });
+
+        test('share trigger click does not dispatch openPopup', async () => {
+            const app = new App({siteUrl: 'http://example.com'});
+            app.dispatchAction = vi.fn();
+            app.state = {
+                ...app.state,
+                initStatus: 'success',
+                site: FixtureSite.singleTier.basic
+            };
+
+            await app.clickHandler({
+                preventDefault: vi.fn(),
+                currentTarget: {
+                    dataset: {
+                        portal: 'share'
+                    }
+                }
+            });
+
+            expect(app.dispatchAction).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('without data-disable-share', () => {
+        test('fetchLinkData matches #/share hash and opens share popup', async () => {
+            window.location.hash = '#/share';
+
+            const app = new App({siteUrl: 'http://example.com'});
+            const result = await app.fetchLinkData(FixtureSite.singleTier.basic, FixtureMember.free);
+
+            expect(result).toEqual({
+                showPopup: true,
+                page: 'share'
+            });
+        });
+
+        test('getPageFromLinkPath returns share page for share path', () => {
+            const app = new App({siteUrl: 'http://example.com'});
+            expect(app.getPageFromLinkPath('share')).toEqual({page: 'share'});
+        });
+    });
+
     test('shows gift redemption success notification when popup is open on load', async () => {
         window.location = new URL('http://example.com/?action=subscribe&success=true#/portal/account?giftRedemption=true');
 

--- a/apps/portal/test/share.test.js
+++ b/apps/portal/test/share.test.js
@@ -1,0 +1,193 @@
+import {fireEvent, screen, waitFor, within} from './utils/test-utils';
+import ReactDOM from 'react-dom';
+
+const unmountShareRoot = () => {
+    const root = document.getElementById('ghost-portal-share-root');
+    if (root) {
+        ReactDOM.unmountComponentAtNode(root);
+    }
+};
+
+const loadShareEntry = async ({hash = ''} = {}) => {
+    unmountShareRoot();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    document.body.style.overflow = '';
+    window.history.replaceState({}, '', `/post/${hash}`);
+
+    const script = document.createElement('script');
+    script.setAttribute('data-portal-share', 'true');
+    script.setAttribute('data-locale', 'en');
+    document.head.appendChild(script);
+
+    vi.resetModules();
+    await import('../src/share');
+    await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+};
+
+const loadShareEntryWithAccentColor = async (accentColor) => {
+    unmountShareRoot();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    document.body.style.overflow = '';
+    document.body.style.marginRight = '';
+    window.history.replaceState({}, '', '/post/#/share');
+
+    const script = document.createElement('script');
+    script.setAttribute('data-portal-share', 'true');
+    script.setAttribute('data-locale', 'en');
+    script.setAttribute('data-accent-color', accentColor);
+    document.head.appendChild(script);
+
+    vi.resetModules();
+    await import('../src/share');
+    await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+};
+
+const mockScrollbarWidth = (width) => {
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(width);
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(0);
+};
+
+const getShareFrameDocument = async () => {
+    const frame = await screen.findByTitle('portal-share');
+    await waitFor(() => {
+        expect(within(frame.contentDocument).getByRole('heading', {name: 'Share'})).toBeInTheDocument();
+    });
+    return frame.contentDocument;
+};
+
+const expectShareFrameClosed = async () => {
+    await waitFor(() => {
+        expect(screen.queryByTitle('portal-share')).not.toBeInTheDocument();
+    });
+};
+
+describe('share entry', () => {
+    beforeEach(() => {
+        document.body.style.overflow = '';
+        document.body.style.marginRight = '';
+    });
+
+    afterEach(() => {
+        unmountShareRoot();
+        vi.restoreAllMocks();
+        document.body.style.overflow = '';
+        document.body.style.marginRight = '';
+        window.history.replaceState({}, '', '/');
+    });
+
+    test('opens from initial share hash and closes from close button', async () => {
+        mockScrollbarWidth(15);
+        document.body.style.marginRight = '10px';
+
+        await loadShareEntry({hash: '#/share'});
+
+        expect(screen.queryByRole('heading', {name: 'Share'})).not.toBeInTheDocument();
+        const frameDocument = await getShareFrameDocument();
+
+        await waitFor(() => {
+            expect(document.body.style.overflow).toBe('hidden');
+            expect(document.body.style.marginRight).toBe('calc(25px)');
+        });
+
+        fireEvent.click(within(frameDocument).getByTestId('close-popup'));
+
+        await expectShareFrameClosed();
+        expect(document.body.style.overflow).toBe('');
+        expect(document.body.style.marginRight).toBe('10px');
+        expect(window.location.hash).toBe('');
+    });
+
+    test('uses accent color from script data inside iframe styles', async () => {
+        await loadShareEntryWithAccentColor('#123456');
+
+        const frame = await screen.findByTitle('portal-share');
+
+        await waitFor(() => {
+            expect(frame.contentDocument.head.textContent).toContain(':root { --brandcolor: #123456; }');
+            expect(frame.contentDocument.head.textContent.indexOf('--brandcolor: #123456')).toBeGreaterThan(frame.contentDocument.head.textContent.indexOf('--brandcolor: var(--ghost-accent-color, #3eb0ef)'));
+        });
+    });
+
+    test('opens from hashchange', async () => {
+        await loadShareEntry();
+
+        expect(screen.queryByRole('heading', {name: 'Share'})).not.toBeInTheDocument();
+        expect(screen.queryByTitle('portal-share')).not.toBeInTheDocument();
+
+        window.history.replaceState({}, '', '/post/#/share');
+        fireEvent(window, new HashChangeEvent('hashchange'));
+
+        await getShareFrameDocument();
+    });
+
+    test('opens from share links and data portal triggers', async () => {
+        await loadShareEntry();
+
+        const link = document.createElement('a');
+        link.href = `${window.location.origin}/post/#/share`;
+        link.textContent = 'Share link';
+        document.body.appendChild(link);
+
+        fireEvent.click(link);
+
+        let frameDocument = await getShareFrameDocument();
+
+        expect(window.location.pathname).toBe('/post/');
+        expect(window.location.hash).toBe('#/share');
+
+        fireEvent.click(within(frameDocument).getByTestId('close-popup'));
+
+        await expectShareFrameClosed();
+        expect(window.location.hash).toBe('');
+
+        const absoluteLink = document.createElement('a');
+        absoluteLink.href = `${window.location.origin}/#/share`;
+        absoluteLink.textContent = 'Absolute share link';
+        document.body.appendChild(absoluteLink);
+
+        fireEvent.click(absoluteLink);
+
+        frameDocument = await getShareFrameDocument();
+        expect(window.location.pathname).toBe('/post/');
+        expect(window.location.hash).toBe('#/share');
+
+        fireEvent.click(within(frameDocument).getByTestId('close-popup'));
+
+        await expectShareFrameClosed();
+        expect(window.location.hash).toBe('');
+
+        const button = document.createElement('button');
+        button.dataset.portal = 'share';
+        button.textContent = 'Share';
+        document.body.appendChild(button);
+
+        fireEvent.click(button);
+
+        await getShareFrameDocument();
+        expect(window.location.hash).toBe('');
+    });
+
+    test('closes from backdrop and Escape', async () => {
+        await loadShareEntry({hash: '#/share'});
+
+        let frameDocument = await getShareFrameDocument();
+        fireEvent.click(frameDocument.querySelector('.gh-portal-popup-background'));
+
+        await expectShareFrameClosed();
+
+        window.history.replaceState({}, '', '/post/#/share');
+        fireEvent(window, new HashChangeEvent('hashchange'));
+        frameDocument = await getShareFrameDocument();
+
+        fireEvent.keyUp(frameDocument, {key: 'Escape'});
+
+        await expectShareFrameClosed();
+        expect(document.body.style.overflow).toBe('');
+    });
+});

--- a/apps/portal/test/unit/components/pages/share-modal.test.js
+++ b/apps/portal/test/unit/components/pages/share-modal.test.js
@@ -15,8 +15,8 @@ const addHeadTag = ({tagName, attrs = {}}) => {
     return element;
 };
 
-const setup = () => {
-    return render(<ShareModal />);
+const setup = ({onClose} = {}) => {
+    return render(<ShareModal onClose={onClose} />);
 };
 
 describe('ShareModal', () => {
@@ -258,5 +258,14 @@ describe('ShareModal', () => {
         await waitFor(() => {
             expect(getByRole('button', {name: 'Copy link'})).toBeInTheDocument();
         });
+    });
+
+    test('calls close callback when close icon is clicked', () => {
+        const onClose = vi.fn();
+        const {getByTestId} = setup({onClose});
+
+        fireEvent.click(getByTestId('close-popup'));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/portal/vite.config.mjs
+++ b/apps/portal/vite.config.mjs
@@ -13,6 +13,9 @@ import {SUPPORTED_LOCALES} from '@tryghost/i18n';
 
 export default defineConfig((config) => {
     const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
+    const isShareBuild = process.env.PORTAL_BUILD === 'share';
+    const isWatch = process.argv.includes('--watch') || process.argv.includes('-w');
+    const bundleName = isShareBuild ? 'share' : outputFileName;
 
     return {
         logLevel: process.env.CI ? 'info' : 'warn',
@@ -60,16 +63,16 @@ export default defineConfig((config) => {
         },
         build: {
             outDir: resolve(__dirname, 'umd'),
-            emptyOutDir: true,
+            emptyOutDir: !isShareBuild && !isWatch,
             reportCompressedSize: false,
             minify: true,
             sourcemap: true,
             cssCodeSplit: false,
             lib: {
-                entry: resolve(__dirname, 'src/index.js'),
+                entry: resolve(__dirname, isShareBuild ? 'src/share.js' : 'src/index.js'),
                 formats: ['umd'],
                 name: pkg.name,
-                fileName: format => `${outputFileName}.min.js`
+                fileName: () => `${bundleName}.min.js`
             },
             rollupOptions: {
                 output: {

--- a/docker/dev-gateway/README.md
+++ b/docker/dev-gateway/README.md
@@ -30,7 +30,7 @@ Caddy uses environment variables (set in `compose.dev.yaml`) to configure proxy 
 **Note:** AdminX React apps (admin-x-settings, activitypub, posts, stats) are served through the admin dev server so they don't need separate proxy entries.
 
 ### Ghost Configuration
-Ghost is configured via environment variables in `compose.dev.yaml` to load public app assets from `/ghost/assets/*` (e.g., `portal__url: /ghost/assets/portal/portal.min.js`). This uses the same path structure as built admin assets.
+Ghost is configured via environment variables in `compose.dev.yaml` to load public app assets from `/ghost/assets/*` (e.g., `portal__url: /ghost/assets/portal/portal.min.js` and `portal__shareUrl: /ghost/assets/portal/share.min.js`). This uses the same path structure as built admin assets.
 
 ### Routing Rules
 The Caddyfile defines these routing rules:
@@ -43,7 +43,7 @@ The Caddyfile defines these routing rules:
 | `/.well-known/webfinger`             | ActivityPub server (port 8080)      | *Optional:* WebFinger for federation                                   |
 | `/.well-known/nodeinfo`              | ActivityPub server (port 8080)      | *Optional:* NodeInfo for federation                                    |
 | `/ghost/assets/koenig-lexical/*`     | Lexical dev server (port 4173)      | *Optional:* Koenig Lexical editor (falls back to Ghost if not running) |
-| `/ghost/assets/portal/*`             | Portal dev server (port 4175)       | Membership UI                                                          |
+| `/ghost/assets/portal/*`             | Portal dev server (port 4175)       | Membership UI (`portal.min.js` and `share.min.js`)                     |
 | `/ghost/assets/comments-ui/*`        | Comments dev server (port 7173)     | Comments widget                                                        |
 | `/ghost/assets/signup-form/*`        | Signup dev server (port 6174)       | Signup form widget                                                     |
 | `/ghost/assets/sodo-search/*`        | Search dev server (port 4178)       | Search widget (JS + CSS)                                               |

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -44,6 +44,7 @@ RUN chmod +x entrypoint.sh
 # Public app assets are served via /ghost/assets/* in dev mode.
 # Caddy forwards these paths to host frontend dev servers.
 ENV portal__url=/ghost/assets/portal/portal.min.js \
+    portal__shareUrl=/ghost/assets/portal/share.min.js \
     comments__url=/ghost/assets/comments-ui/comments-ui.min.js \
     sodoSearch__url=/ghost/assets/sodo-search/sodo-search.min.js \
     sodoSearch__styles=/ghost/assets/sodo-search/main.css \

--- a/e2e/Dockerfile.e2e
+++ b/e2e/Dockerfile.e2e
@@ -19,6 +19,7 @@ COPY apps/signup-form/umd /home/ghost/content/files/signup-form
 COPY apps/announcement-bar/umd /home/ghost/content/files/announcement-bar
 
 ENV portal__url=/content/files/portal/portal.min.js
+ENV portal__shareUrl=/content/files/portal/share.min.js
 ENV comments__url=/content/files/comments-ui/comments-ui.min.js
 ENV sodoSearch__url=/content/files/sodo-search/sodo-search.min.js
 ENV sodoSearch__styles=/content/files/sodo-search/main.css

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -49,32 +49,46 @@ function finaliseStructuredData(meta) {
 }
 
 function getMembersHelper(data, frontendKey, excludeList) {
-    // Do not load Portal if both Memberships and Tips & Donations and Recommendations are disabled
-    if (!settingsCache.get('members_enabled') && !settingsCache.get('donations_enabled') && !settingsCache.get('recommendations_enabled')) {
-        return '';
-    }
     let membersHelper = '';
-    if (!excludeList.has('portal')) {
-        const {scriptUrl} = getFrontendAppConfig('portal');
+    const fullPortalEnabled = Boolean(settingsCache.get('members_enabled') || settingsCache.get('donations_enabled') || settingsCache.get('recommendations_enabled'));
+    const portalDisabled = excludeList.has('portal');
+    const {scriptUrl, shareScriptUrl} = getFrontendAppConfig('portal');
+    const shareDisabled = shareScriptUrl === false || excludeList.has('share');
+    const locale = settingsCache.get('locale') || 'en';
 
+    if (fullPortalEnabled && !portalDisabled) {
         const colorString = (_.has(data, 'site._preview') && data.site.accent_color) ? data.site.accent_color : '';
         const attributes = {
             i18n: true,
             ghost: urlUtils.getSiteUrl(),
             key: frontendKey,
             api: urlUtils.urlFor('api', {type: 'content'}, true),
-            locale: settingsCache.get('locale') || 'en'
+            locale
+        };
+        if (colorString) {
+            attributes['accent-color'] = colorString;
+        }
+        if (shareDisabled) {
+            attributes['disable-share'] = true;
+        }
+        const dataAttributes = getDataAttributes(attributes);
+        membersHelper += `<script defer src="${scriptUrl}" ${dataAttributes} crossorigin="anonymous"></script>`;
+    } else if (!shareDisabled && shareScriptUrl) {
+        const colorString = (_.has(data, 'site.accent_color') && data.site.accent_color) ? data.site.accent_color : '';
+        const attributes = {
+            'portal-share': true,
+            locale
         };
         if (colorString) {
             attributes['accent-color'] = colorString;
         }
         const dataAttributes = getDataAttributes(attributes);
-        membersHelper += `<script defer src="${scriptUrl}" ${dataAttributes} crossorigin="anonymous"></script>`;
+        membersHelper += `<script defer src="${shareScriptUrl}" ${dataAttributes} crossorigin="anonymous"></script>`;
     }
-    if (!excludeList.has('cta_styles')) {
+    if (fullPortalEnabled && !excludeList.has('cta_styles')) {
         membersHelper += (`<style id="gh-members-styles">${templateStyles}</style>`);
     }
-    if (settingsCache.get('paid_members_enabled')) {
+    if (fullPortalEnabled && settingsCache.get('paid_members_enabled')) {
         membersHelper += `<script async src="https://js.stripe.com/v3/"></script>`;
     }
     return membersHelper;

--- a/ghost/core/core/frontend/utils/frontend-apps.js
+++ b/ghost/core/core/frontend/utils/frontend-apps.js
@@ -3,15 +3,20 @@ const {config} = require('../services/proxy');
 function getFrontendAppConfig(app) {
     const appVersion = config.get(`${app}:version`);
     let scriptUrl = config.get(`${app}:url`);
+    let shareScriptUrl = config.get(`${app}:shareUrl`);
     let stylesUrl = config.get(`${app}:styles`);
     if (typeof scriptUrl === 'string' && scriptUrl.includes('{version}')) {
         scriptUrl = scriptUrl.replace('{version}', appVersion);
+    }
+    if (typeof shareScriptUrl === 'string' && shareScriptUrl.includes('{version}')) {
+        shareScriptUrl = shareScriptUrl.replace('{version}', appVersion);
     }
     if (typeof stylesUrl === 'string' && stylesUrl?.includes('{version}')) {
         stylesUrl = stylesUrl.replace('{version}', appVersion);
     }
     return {
         scriptUrl,
+        shareScriptUrl,
         stylesUrl,
         appVersion
     };

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -241,6 +241,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
+        "shareUrl": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/share.min.js",
         "version": "2.68"
     },
     "sodoSearch": {

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
@@ -203,7 +203,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -214,7 +214,7 @@ exports[`{{ghost_head}} helper accent_color does not override code injection 1 1
 Object {
   "rendered": "<meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" data-accent-color=\\"#site-setting\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #site-setting;}</style>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -227,7 +227,7 @@ exports[`{{ghost_head}} helper accent_color includes style tag on templates with
 Object {
   "rendered": "<meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" data-accent-color=\\"#123456\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -300,7 +300,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" data-accent-color=\\"#123456\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -602,7 +602,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -675,7 +675,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -748,7 +748,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -821,7 +821,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -894,7 +894,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -968,7 +968,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1037,7 +1037,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1090,7 +1090,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -1115,7 +1115,7 @@ Object {
     
     <meta name=\\"generator\\" content=\\"Ghost \\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -1166,7 +1166,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -1217,7 +1217,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1269,7 +1269,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1321,7 +1321,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1373,7 +1373,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1425,7 +1425,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1477,7 +1477,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:2388/blog/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:2388/blog/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1546,7 +1546,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1598,7 +1598,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1650,7 +1650,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -1702,11 +1702,177 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+}
+`;
+
+exports[`{{ghost_head}} helper members scripts disables share inside full portal when portal.shareUrl is false via config 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-disable-share=\\"true\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+.gh-post-upgrade-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    text-align: center;
+    width: 100%;
+    color: #ffffff;
+    font-size: 16px;
+}
+
+.gh-post-upgrade-cta-content {
+    border-radius: 8px;
+    padding: 40px 4vw;
+}
+
+.gh-post-upgrade-cta h2 {
+    color: #ffffff;
+    font-size: 28px;
+    letter-spacing: -0.2px;
+    margin: 0;
+    padding: 0;
+}
+
+.gh-post-upgrade-cta p {
+    margin: 20px 0 0;
+    padding: 0;
+}
+
+.gh-post-upgrade-cta small {
+    font-size: 16px;
+    letter-spacing: -0.2px;
+}
+
+.gh-post-upgrade-cta a {
+    color: #ffffff;
+    cursor: pointer;
+    font-weight: 500;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.gh-post-upgrade-cta a:hover {
+    color: #ffffff;
+    opacity: 0.8;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.gh-post-upgrade-cta a.gh-btn {
+    display: block;
+    background: #ffffff;
+    text-decoration: none;
+    margin: 28px 0 0;
+    padding: 8px 18px;
+    border-radius: 4px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.gh-post-upgrade-cta a.gh-btn:hover {
+    opacity: 0.92;
+}</style>
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
+}
+`;
+
+exports[`{{ghost_head}} helper members scripts includes accent color on share-only portal when full portal is disabled 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" data-accent-color=\\"#123456\\" crossorigin=\\"anonymous\\"></script>
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2053,6 +2219,57 @@ Object {
 }
 `;
 
+exports[`{{ghost_head}} helper members scripts includes share-only portal and skips stripe when full portal is disabled 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
+}
+`;
+
 exports[`{{ghost_head}} helper members scripts includes stripe when connected 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
@@ -2165,6 +2382,57 @@ Object {
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
+}
+`;
+
+exports[`{{ghost_head}} helper members scripts omits share-only portal script when portal.shareUrl is disabled via config 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2378,7 +2646,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2492,7 +2760,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -2591,7 +2859,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -2629,7 +2897,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -2656,7 +2924,7 @@ Object {
     
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -2707,7 +2975,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -2872,7 +3140,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -2997,6 +3265,121 @@ Object {
 `;
 
 exports[`{{ghost_head}} helper respects values from excludes:  when exclude contains portal 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+.gh-post-upgrade-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    text-align: center;
+    width: 100%;
+    color: #ffffff;
+    font-size: 16px;
+}
+
+.gh-post-upgrade-cta-content {
+    border-radius: 8px;
+    padding: 40px 4vw;
+}
+
+.gh-post-upgrade-cta h2 {
+    color: #ffffff;
+    font-size: 28px;
+    letter-spacing: -0.2px;
+    margin: 0;
+    padding: 0;
+}
+
+.gh-post-upgrade-cta p {
+    margin: 20px 0 0;
+    padding: 0;
+}
+
+.gh-post-upgrade-cta small {
+    font-size: 16px;
+    letter-spacing: -0.2px;
+}
+
+.gh-post-upgrade-cta a {
+    color: #ffffff;
+    cursor: pointer;
+    font-weight: 500;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.gh-post-upgrade-cta a:hover {
+    color: #ffffff;
+    opacity: 0.8;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.gh-post-upgrade-cta a.gh-btn {
+    display: block;
+    background: #ffffff;
+    text-decoration: none;
+    margin: 28px 0 0;
+    padding: 8px 18px;
+    border-radius: 4px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.gh-post-upgrade-cta a.gh-btn:hover {
+    opacity: 0.92;
+}</style><script async src=\\"https://js.stripe.com/v3/\\"></script>
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
+}
+`;
+
+exports[`{{ghost_head}} helper respects values from excludes:  when exclude contains portal and share 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
@@ -3225,6 +3608,172 @@ Object {
 }
 `;
 
+exports[`{{ghost_head}} helper respects values from excludes:  when exclude contains share with full portal disabled 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
+}
+`;
+
+exports[`{{ghost_head}} helper respects values from excludes:  when exclude contains share with full portal enabled 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-disable-share=\\"true\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+.gh-post-upgrade-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    text-align: center;
+    width: 100%;
+    color: #ffffff;
+    font-size: 16px;
+}
+
+.gh-post-upgrade-cta-content {
+    border-radius: 8px;
+    padding: 40px 4vw;
+}
+
+.gh-post-upgrade-cta h2 {
+    color: #ffffff;
+    font-size: 28px;
+    letter-spacing: -0.2px;
+    margin: 0;
+    padding: 0;
+}
+
+.gh-post-upgrade-cta p {
+    margin: 20px 0 0;
+    padding: 0;
+}
+
+.gh-post-upgrade-cta small {
+    font-size: 16px;
+    letter-spacing: -0.2px;
+}
+
+.gh-post-upgrade-cta a {
+    color: #ffffff;
+    cursor: pointer;
+    font-weight: 500;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.gh-post-upgrade-cta a:hover {
+    color: #ffffff;
+    opacity: 0.8;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.gh-post-upgrade-cta a.gh-btn {
+    display: block;
+    background: #ffffff;
+    text-decoration: none;
+    margin: 28px 0 0;
+    padding: 8px 18px;
+    border-radius: 4px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.gh-post-upgrade-cta a.gh-btn:hover {
+    opacity: 0.92;
+}</style>
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
+}
+`;
+
 exports[`{{ghost_head}} helper respects values from excludes:  when excludes is empty 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
@@ -3384,7 +3933,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3486,7 +4035,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3500,7 +4049,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/site/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/site/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3514,7 +4063,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
@@ -3529,7 +4078,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
@@ -3544,7 +4093,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
@@ -3560,7 +4109,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
@@ -3575,7 +4124,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"origin\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/site/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3590,7 +4139,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3615,7 +4164,7 @@ Object {
     
     <meta name=\\"generator\\" content=\\"Ghost \\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3666,7 +4215,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3679,7 +4228,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3692,7 +4241,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3706,7 +4255,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost \\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3757,7 +4306,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
@@ -3809,7 +4358,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
@@ -3832,7 +4381,7 @@ Object {
     
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3897,7 +4446,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3948,7 +4497,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3970,7 +4519,7 @@ Object {
     
     <meta name=\\"generator\\" content=\\"Ghost 0.9\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3983,7 +4532,7 @@ Object {
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -3998,7 +4547,7 @@ Object {
     <link rel=\\"next\\" href=\\"http://localhost:65530/page/4/\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4013,7 +4562,7 @@ Object {
     <link rel=\\"next\\" href=\\"http://localhost:65530/page/3/\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4065,7 +4614,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4115,7 +4664,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4195,7 +4744,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4246,7 +4795,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4326,7 +4875,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4406,7 +4955,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4474,7 +5023,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4546,7 +5095,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4619,7 +5168,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4692,7 +5241,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4765,7 +5314,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4830,7 +5379,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4878,7 +5427,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
@@ -4930,7 +5479,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/share.min.js\\" data-portal-share=\\"true\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -1186,37 +1186,46 @@ describe('{{ghost_head}} helper', function () {
         it('includes portal when members enabled', async function () {
             getStub.withArgs('members_enabled').returns(true);
 
-            await testGhostHead(testUtils.createHbsResponse({
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
                     relativeUrl: '/',
                     context: ['home', 'index'],
                     safeVersion: '4.3'
                 }
             }));
+
+            assert.match(rendered, /portal\.min\.js/);
+            assert.doesNotMatch(rendered, /share\.min\.js/);
         });
 
         it('includes portal when recommendations enabled', async function () {
             getStub.withArgs('recommendations_enabled').returns(true);
 
-            await testGhostHead(testUtils.createHbsResponse({
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
                     relativeUrl: '/',
                     context: ['home', 'index'],
                     safeVersion: '4.3'
                 }
             }));
+
+            assert.match(rendered, /portal\.min\.js/);
+            assert.doesNotMatch(rendered, /share\.min\.js/);
         });
 
         it('includes portal when donations enabled', async function () {
             getStub.withArgs('donations_enabled').returns(true);
 
-            await testGhostHead(testUtils.createHbsResponse({
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
                     relativeUrl: '/',
                     context: ['home', 'index'],
                     safeVersion: '4.3'
                 }
             }));
+
+            assert.match(rendered, /portal\.min\.js/);
+            assert.doesNotMatch(rendered, /share\.min\.js/);
         });
 
         it('includes stripe when connected', async function () {
@@ -1232,17 +1241,94 @@ describe('{{ghost_head}} helper', function () {
             }));
         });
 
-        it('skips portal and stripe when members are disabled', async function () {
+        it('includes share-only portal and skips stripe when full portal is disabled', async function () {
             getStub.withArgs('members_enabled').returns(false);
             getStub.withArgs('paid_members_enabled').returns(true);
 
-            await testGhostHead(testUtils.createHbsResponse({
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
                     relativeUrl: '/',
                     context: ['home', 'index'],
                     safeVersion: '4.3'
                 }
             }));
+
+            assert.match(rendered, /share\.min\.js/);
+            assert.match(rendered, /data-portal-share="true"/);
+            assert.doesNotMatch(rendered, /portal\.min\.js/);
+            assert.doesNotMatch(rendered, /js\.stripe\.com/);
+        });
+
+        it('includes accent color on share-only portal when full portal is disabled', async function () {
+            getStub.withArgs('members_enabled').returns(false);
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                templateOptions: {
+                    site: {
+                        accent_color: '#123456'
+                    }
+                },
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            assert.match(rendered, /share\.min\.js/);
+            assert.match(rendered, /data-accent-color="#123456"/);
+        });
+
+        it('omits share-only portal script when portal.shareUrl is disabled via config', async function () {
+            getStub.withArgs('members_enabled').returns(false);
+            configUtils.set('portal:shareUrl', false);
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            assert.doesNotMatch(rendered, /share\.min\.js/);
+            assert.doesNotMatch(rendered, /data-portal-share/);
+            assert.doesNotMatch(rendered, /src="false"/);
+            assert.doesNotMatch(rendered, /src="undefined"/);
+        });
+
+        it('disables share inside full portal when portal.shareUrl is false via config', async function () {
+            getStub.withArgs('members_enabled').returns(true);
+            configUtils.set('portal:shareUrl', false);
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            assert.match(rendered, /portal\.min\.js/);
+            assert.match(rendered, /data-disable-share="true"/);
+            assert.doesNotMatch(rendered, /share\.min\.js/);
+        });
+
+        it('omits all portal scripts when both exclude=portal and portal.shareUrl=false', async function () {
+            getStub.withArgs('members_enabled').returns(true);
+            configUtils.set('portal:shareUrl', false);
+
+            const rendered = (await ghost_head({hash: {exclude: 'portal'}, ...testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            })})).toString();
+
+            assert.doesNotMatch(rendered, /portal\.min\.js/);
+            assert.doesNotMatch(rendered, /share\.min\.js/);
+            assert.doesNotMatch(rendered, /data-disable-share/);
         });
 
         it('skips stripe if not set up', async function () {
@@ -1576,8 +1662,68 @@ describe('{{ghost_head}} helper', function () {
                 }
             })});
             assert.match(rendered, /sodo-search@/);
-            assert.doesNotMatch(rendered, /portal@/);
+            assert.doesNotMatch(rendered, /portal\.min\.js/);
+            assert.match(rendered, /share\.min\.js/);
             assert.match(rendered, /js.stripe.com/);
+        });
+        it('when exclude contains portal and full portal is disabled', async function () {
+            getStub.withArgs('members_enabled').returns(false);
+            getStub.withArgs('paid_members_enabled').returns(true);
+
+            const rendered = (await ghost_head({hash: {exclude: 'portal'}, ...testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            })})).toString();
+
+            assert.match(rendered, /sodo-search@/);
+            assert.doesNotMatch(rendered, /portal\.min\.js/);
+            assert.match(rendered, /share\.min\.js/);
+            assert.doesNotMatch(rendered, /js.stripe.com/);
+        });
+        it('when exclude contains portal and share', async function () {
+            getStub.withArgs('members_enabled').returns(true);
+            getStub.withArgs('paid_members_enabled').returns(true);
+
+            let rendered = await testGhostHead({hash: {exclude: 'portal,share'}, ...testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            })});
+            assert.doesNotMatch(rendered, /portal\.min\.js/);
+            assert.doesNotMatch(rendered, /share\.min\.js/);
+        });
+        it('when exclude contains share with full portal enabled', async function () {
+            getStub.withArgs('members_enabled').returns(true);
+
+            let rendered = await testGhostHead({hash: {exclude: 'share'}, ...testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            })});
+            assert.match(rendered, /portal\.min\.js/);
+            assert.match(rendered, /data-disable-share="true"/);
+            assert.doesNotMatch(rendered, /share\.min\.js/);
+        });
+        it('when exclude contains share with full portal disabled', async function () {
+            getStub.withArgs('members_enabled').returns(false);
+
+            let rendered = await testGhostHead({hash: {exclude: 'share'}, ...testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            })});
+            assert.doesNotMatch(rendered, /portal\.min\.js/);
+            assert.doesNotMatch(rendered, /share\.min\.js/);
+            assert.doesNotMatch(rendered, /data-disable-share/);
         });
         it('can handle multiple excludes', async function () {
             getStub.withArgs('members_enabled').returns(true);
@@ -1591,7 +1737,8 @@ describe('{{ghost_head}} helper', function () {
                 }
             })});
             assert.doesNotMatch(rendered, /sodo-search@/);
-            assert.doesNotMatch(rendered, /portal@/);
+            assert.doesNotMatch(rendered, /portal\.min\.js/);
+            assert.match(rendered, /share\.min\.js/);
             assert.match(rendered, /js.stripe.com/);
         });
 

--- a/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
+++ b/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
@@ -6,6 +6,7 @@ describe('Frontend apps:', function () {
     describe('getFrontendAppConfig', function () {
         before(function () {
             configUtils.set({'portal:url': 'https://cdn.example.com/~{version}/portal.min.js'});
+            configUtils.set({'portal:shareUrl': 'https://cdn.example.com/~{version}/share.min.js'});
             configUtils.set({'portal:version': '1.0'});
             configUtils.set({'portal:styles': 'https://cdn.example.com/~{version}/main.css'});
         });
@@ -15,10 +16,11 @@ describe('Frontend apps:', function () {
         });
 
         it('should return app urls and version from config', async function () {
-            const {stylesUrl, scriptUrl, appVersion} = getFrontendAppConfig('portal');
+            const {stylesUrl, scriptUrl, shareScriptUrl, appVersion} = getFrontendAppConfig('portal');
             assert.equal(appVersion, '1.0');
             assert.equal(stylesUrl, 'https://cdn.example.com/~1.0/main.css');
             assert.equal(scriptUrl, 'https://cdn.example.com/~1.0/portal.min.js');
+            assert.equal(shareScriptUrl, 'https://cdn.example.com/~1.0/share.min.js');
         });
     });
 


### PR DESCRIPTION
## Problem

The Portal share modal lived inside `portal.min.js` and only loaded when full Portal was enabled (members, donations, or recommendations). Sites that disabled Portal lost the share modal entirely, with no way to keep just the share UI. There was also no way to disable share when Portal was on, short of disabling members altogether.

## What changed

### Standalone share bundle

Built a separate `share.min.js` entry (`apps/portal/src/share.js`) that mounts only the share modal, with its own root, iframe shell, hash listener, and click interceptor. Ghost emits this bundle in place of `portal.min.js` when full Portal is disabled, so themes that include share buttons keep working on members-disabled sites.

### Two independent ways to disable share

1. **Server config** — `portal.shareUrl: false` in `config.production.json` (matches the `sodoSearch.url: false` convention).
2. **Theme** — `{{ghost_head exclude="share"}}`.

Either lever works whether Portal is on or off. When Portal is on, share is disabled in-place via a `data-disable-share="true"` attribute on the existing `portal.min.js` script tag; Portal reads it on boot and skips its share-route registration, click interceptor, and `#/share` anchor transformation.

### `exclude="portal"` no longer suppresses share

Previously `{{ghost_head exclude="portal"}}` would have made share stop working too. Now it only suppresses `portal.min.js` — share gets a chance to ship via `share.min.js` if it isn't separately disabled.

### Opportunistic cleanup

- Extracted `CloseIconButton` (pure presentational) so `share-modal.js` can render the close icon without depending on Portal's `AppContext`. The legacy `CloseButton` keeps its existing context-bound default behaviour by delegating to `CloseIconButton`, so all ~19 existing call sites are unchanged.
- Fixed a latent typo in `feedback-page.js` where `<CloseButton close={...} />` was silently ignored (the prop is `onClick`).

## Behavior matrix

| `fullPortalEnabled` | `exclude="portal"` | share disabled (config or `exclude="share"`) | Output |
|---|---|---|---|
| on | no | no | `portal.min.js` |
| on | no | yes | `portal.min.js` + `data-disable-share="true"` |
| on | yes | no | `share.min.js` |
| on | yes | yes | nothing |
| off | no | no | `share.min.js` |
| off | no | yes | nothing |
| off | yes | no | `share.min.js` |
| off | yes | yes | nothing |

## Tests

- `ghost/core/test/unit/frontend/helpers/ghost-head.test.js` — covers each row of the matrix above; existing snapshots updated where the new behaviour legitimately differs.
- `apps/portal/test/app.test.js` — `data-disable-share` blocks `fetchLinkData`, `getPageFromLinkPath`, click handler, and `#/share` link transformation.
- `apps/portal/test/share.test.js` — exercises the standalone bundle (initial hash, hashchange, click triggers, backdrop, Escape, accent color).
