### PR TITLE
Fixed slow database migration on large tables

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.36/2026-04-29-12-13-44-add-batch-id-to-members-status-events.js
+++ b/ghost/core/core/server/data/migrations/versions/6.36/2026-04-29-12-13-44-add-batch-id-to-members-status-events.js
@@ -4,4 +4,4 @@ module.exports = createAddColumnMigration('members_status_events', 'batch_id', {
     type: 'string',
     maxlength: 24,
     nullable: true
-});
+}, {algorithm: 'auto'});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3565
ref https://linear.app/ghost/issue/BER-3542
ref https://github.com/TryGhost/Ghost/pull/27615
ref https://ghost.slack.com/archives/CJBJ3MZFD/p1777972226248739

## What changed

The migration `2026-04-29-12-13-44-add-batch-id-to-members-status-events.js` now passes `{algorithm: 'auto'}` to `createAddColumnMigration`, so the emitted DDL is `ALTER TABLE members_status_events ADD COLUMN batch_id...` omits the default `ALGORITHM=COPY`.

## Why

`createAddColumnMigration` delegates to `commands.addColumn`, which on MySQL appends `ALGORITHM=COPY` by default unless `{algorithm: 'auto'}` is explicitly passed. `ALGORITHM=COPY` rebuilds the entire table: it creates a new copy with the new column, copies every row across, then swaps it in. The cost is O(rows), and on `members_status_events` — which gets one row per member status change — this scales with the size of the member base.

We hit this on a staging site with ~6M `members_status_events` rows on boot:

```
[MIGRATE] Migration error:  alter table `members_status_events` add `batch_id` varchar(24) null, algorithm=copy - Connection lost: The server closed the connection.
```

`ALGORITHM=AUTO` lets MySQL pick the best strategy. For a nullable trailing-column add on MySQL 8.0+ it picks `INSTANT`, which is a metadata-only change and effectively constant-time regardless of table size.

This isn't a new conclusion — [#25018 (`Added utm_ columns to events tables`)](https://github.com/TryGhost/Ghost/commit/2ea046c3e88aafea6d8544aafde9e5f473cc5012) introduced the `algorithm` option for exactly this reason after observing 60–250s migrations on a 2M-row `members_created_events` table vs. 2–3s when MySQL was allowed to choose. All the column adds in that PR (and the canonical `add-utm-fields.js` migration) use `{algorithm: 'auto'}`.

## Why we're modifying an existing migration

We don't normally do this — `.agents/skills/create-database-migration/rules.md` states migrations are immutable once on `main`. We're making an exception here because:

1. **A new migration cannot fix the original.** The bad `ALTER TABLE` runs first when production upgrades through `6.36/`. Adding a fix in a later folder doesn't change that.
2. **The schema is unchanged.** Only the MySQL execution hint differs. `schema.js` is untouched, so the integrity hash isn't bumped, and the end-state column definition is identical.
3. **The migration helper is idempotent.** `createColumnMigration` checks `hasColumn` and skips if the column already exists — so sites that already ran the original version on `6.36.0` simply no-op when redeployed against this commit. They don't see the migration twice and there's no schema drift between sites that ran the old version and sites that will run the new one.

In short: existing sites that already migrated are unaffected; sites that haven't yet (including production) get the fast path.

## Test plan

- [x] Verify migration runs successfully on a staging site with a large `members_status_events` table
- [x] Verify migration is a no-op on a site where `batch_id` already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)