### PR TITLE
Redesigned Portal gift subscription flow with shared 50/50 layout

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.27",
+  "version": "2.68.28",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -600,13 +600,17 @@ export default class App extends React.Component {
 
         if (qParams.get('stripe') === 'gift-purchase-success') {
             const token = qParams.get('gift_token');
-            clearURLParams(['stripe', 'gift_token']);
+            const tierId = qParams.get('gift_tier');
+            const cadence = qParams.get('gift_cadence');
+            clearURLParams(['stripe', 'gift_token', 'gift_tier', 'gift_cadence']);
             if (token) {
                 return {
                     showPopup: true,
                     page: 'giftSuccess',
                     pageData: {
-                        token
+                        token,
+                        tierId,
+                        cadence
                     }
                 };
             }

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -593,7 +593,7 @@ const GiftPage = () => {
 
                     <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
                         <div className='gh-portal-gift-checkout-card-stack'>
-                            <div ref={cardRef} className='gh-portal-gift-checkout-card' aria-hidden='true'>
+                            <div ref={cardRef} className='gh-portal-gift-checkout-card'>
                                 <div className='gh-portal-gift-checkout-card-site'>
                                     {siteIcon && (
                                         <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
@@ -604,8 +604,8 @@ const GiftPage = () => {
                                     <div className='gh-portal-gift-checkout-card-duration'>{getDurationLabel(activeInterval)}</div>
                                     <div className='gh-portal-gift-checkout-card-tier'>{activeProduct.name}</div>
                                 </div>
-                                <div className='gh-portal-gift-checkout-card-ribbon-h' />
-                                <div className='gh-portal-gift-checkout-card-ribbon-v' />
+                                <div className='gh-portal-gift-checkout-card-ribbon-h' aria-hidden='true' />
+                                <div className='gh-portal-gift-checkout-card-ribbon-v' aria-hidden='true' />
                                 <svg className='gh-portal-gift-checkout-card-bow' viewBox='78 -2 90 86' xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='currentColor' fillRule='evenodd' clipRule='evenodd'>
                                     <path d='M144.97 1.01186C147.471 0.122129 150.26 -0.292891 153.133 0.229636C156.058 0.761757 158.682 2.19718 160.872 4.38686C165.524 9.03938 166.185 14.9291 164.582 20.2384C163.08 25.217 159.616 29.8398 155.649 33.6447C150.07 38.996 142.324 43.8128 134.494 46.1457L156.801 73.8234L147.457 81.3546L122.879 50.8595L98.3012 81.3546L88.9574 73.8234L111.19 46.2384C103.253 43.9422 95.374 39.0677 89.7201 33.6447C85.7534 29.8398 82.2893 25.2169 80.7865 20.2384C79.1841 14.9291 79.8451 9.03938 84.4975 4.38686C86.6872 2.19723 89.3105 0.761751 92.2358 0.229636C95.1087 -0.292854 97.8981 0.122143 100.399 1.01186C105.26 2.74162 109.666 6.47713 113.237 10.6242C116.925 14.9077 120.297 20.3226 122.684 25.9962C125.071 20.3224 128.444 14.9078 132.132 10.6242C135.703 6.4771 140.109 2.74161 144.97 1.01186ZM96.3764 12.3175C95.3995 11.97 94.7641 11.9671 94.3832 12.0363C94.0547 12.0961 93.5929 12.2622 92.9828 12.8722C92.0356 13.8195 91.6948 14.8501 92.2748 16.7716C92.9549 19.0242 94.8576 21.9447 98.0268 24.9845C102.298 29.0813 107.807 32.4111 112.93 34.1994C111.244 28.8435 108.061 23.0037 104.144 18.4542C101.24 15.0821 98.471 13.063 96.3764 12.3175ZM150.986 12.0363C150.605 11.9671 149.97 11.9699 148.993 12.3175C146.898 13.063 144.129 15.082 141.225 18.4542C137.308 23.0037 134.125 28.8434 132.439 34.1994C137.562 32.4111 143.071 29.0813 147.342 24.9845C150.511 21.9446 152.414 19.0242 153.094 16.7716C153.674 14.8501 153.333 13.8195 152.386 12.8722C151.776 12.2622 151.314 12.0961 150.986 12.0363Z' />
                                 </svg>

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -15,6 +15,9 @@ export const GiftPageStyles = `
 .gh-portal-popup-container.full-size.giftSuccess,
 .gh-portal-popup-container.full-size.giftRedemption {
     padding: 0;
+    /* The default opacity/translate popup-in animation feels heavy on the
+       full-bleed 50/50 layout — let the page render in place instead. */
+    animation: none;
 }
 
 .gh-portal-content.gift,

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -1,357 +1,634 @@
-import {useContext, useState} from 'react';
+import {useContext, useEffect, useRef, useState} from 'react';
 import AppContext from '../../app-context';
 import CloseButton from '../common/close-button';
-import SiteTitleBackButton from '../common/site-title-back-button';
 import ActionButton from '../common/action-button';
 import LoadingPage from './loading-page';
 import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
-import {ReactComponent as GiftIcon} from '../../images/icons/gift.svg';
 import {getAvailableProducts, getCurrencySymbol, formatNumber, getStripeAmount, isCookiesDisabled, getActiveInterval} from '../../utils/helpers';
-import calculateDiscount from '../../utils/discount';
+import useCardTilt from '../../utils/use-card-tilt';
 
 // TODO: wrap strings with t() once copy is finalised
 /* eslint-disable i18next/no-literal-string */
 
 export const GiftPageStyles = `
-.gh-portal-content.gift {
+.gh-portal-popup-container.full-size.gift,
+.gh-portal-popup-container.full-size.giftSuccess,
+.gh-portal-popup-container.full-size.giftRedemption {
+    padding: 0;
+}
+
+.gh-portal-content.gift,
+.gh-portal-content.giftSuccess,
+.gh-portal-content.giftRedemption {
     position: relative;
-    padding-top: 0;
+    padding: 0;
+    min-height: 100vh;
 }
 
-.gh-portal-gift-bg {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 320px;
-    background: linear-gradient(180deg, var(--brandcolor), transparent);
-    opacity: 0.08;
-    pointer-events: none;
-    z-index: 0;
+.gh-portal-gift-checkout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    min-height: 100vh;
+    width: 100%;
 }
 
-.gh-portal-popup-wrapper.full-size .gh-portal-gift-bg {
-    top: -2vmin;
-    left: -6vmin;
-    right: -6vmin;
-    height: calc(320px + 2vmin);
-}
-
-.gh-portal-gift-sitetitle {
+.gh-portal-gift-checkout-left {
     position: relative;
-    z-index: 1;
     display: flex;
     align-items: center;
     justify-content: center;
+    background: var(--white);
+    padding: 64px 48px 128px;
+    overflow: hidden;
+}
+
+.gh-portal-gift-checkout-bg {
+    display: none;
+}
+
+.gh-portal-gift-checkout-inner {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 496px;
+    display: flex;
+    flex-direction: column;
+}
+
+.gh-portal-gift-checkout-header {
+    margin-bottom: 8px;
+}
+
+.gh-portal-gift-checkout-header .gh-portal-main-title {
+    text-align: start;
+    margin: 0 0 12px;
+}
+
+.gh-portal-gift-checkout-subtitle {
+    margin: 0;
+    font-size: 1.6rem;
+    line-height: 1.45em;
+    color: var(--grey3);
+}
+
+.gh-portal-gift-checkout-section {
+    margin-top: 24px;
+}
+
+.gh-portal-gift-checkout-label {
+    font-size: 1.2rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--grey6);
+    margin-bottom: 12px;
+}
+
+.gh-portal-gift-checkout .gh-portal-products-pricetoggle {
+    margin: 0;
+}
+
+.gh-portal-gift-checkout-tiers {
+    display: flex;
+    flex-direction: column;
     gap: 8px;
-    padding: 15px 32px 0;
 }
 
-.gh-portal-gift-sitetitle-icon {
-    display: block;
-    width: 24px;
-    height: 24px;
-    border-radius: 4px;
-    background-position: 50%;
-    background-size: cover;
-    object-fit: cover;
+.gh-portal-gift-checkout-tier {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    width: 100%;
+    background: var(--white);
+    border: 1px solid var(--grey11);
+    border-radius: 10px;
+    padding: 16px 20px;
+    cursor: pointer;
+    text-align: start;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+    font: inherit;
+    color: inherit;
 }
 
-.gh-portal-gift-sitetitle-name {
+.gh-portal-gift-checkout-tier:hover {
+    border-color: var(--grey9);
+}
+
+.gh-portal-gift-checkout-tier.selected {
+    border-color: var(--brandcolor);
+    background: color-mix(in srgb, var(--brandcolor) 6%, var(--white));
+    box-shadow: 0 0 0 1px var(--brandcolor) inset;
+}
+
+.gh-portal-gift-checkout-tier-radio {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 1.5px solid var(--grey9);
+    background: var(--white);
+    position: relative;
+}
+
+.gh-portal-gift-checkout-tier.selected .gh-portal-gift-checkout-tier-radio {
+    border-color: var(--brandcolor);
+    background: var(--brandcolor);
+}
+
+.gh-portal-gift-checkout-tier.selected .gh-portal-gift-checkout-tier-radio::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--white);
+    transform: translate(-50%, -50%);
+}
+
+.gh-portal-gift-checkout-tier-name {
+    flex: 1;
     font-size: 1.5rem;
     font-weight: 500;
     color: var(--grey0);
-    line-height: 1;
 }
 
-.gh-portal-gift-hero {
-    position: relative;
-    z-index: 1;
+.gh-portal-gift-checkout-tier-price {
+    font-size: 1.5rem;
+    font-weight: 500;
+    color: var(--grey0);
+}
+
+.gh-portal-gift-checkout-benefits {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-left: 4px;
+}
+
+.gh-portal-gift-checkout-benefit {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    color: var(--grey1);
+    font-size: 1.45rem;
+    line-height: 1.4;
+}
+
+.gh-portal-gift-checkout-benefit svg {
+    width: 14px;
+    height: 14px;
+    margin-top: 4px;
+    color: var(--grey1);
+    flex-shrink: 0;
+}
+
+.gh-portal-gift-checkout .gh-portal-btn-primary {
+    border-radius: 999px;
+}
+
+.gh-portal-gift-checkout-cta {
+    width: 100%;
+    height: 48px;
+    margin-top: 32px;
+    font-size: 1.5rem;
+    font-weight: 600;
+}
+
+.gh-portal-gift-checkout-right {
+    position: sticky;
+    top: 0;
+    align-self: start;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(to bottom, var(--white), color-mix(in srgb, var(--brandcolor) 5%, var(--white)));
+    padding: 64px 48px 128px;
+    overflow-y: auto;
+}
+
+.gh-portal-gift-checkout-card-stack {
     display: flex;
     flex-direction: column;
     align-items: center;
-    text-align: center;
-    padding: 56px 32px 40px;
+    width: 100%;
+    max-width: 440px;
 }
 
-.gh-portal-gift-hero-icon {
+/* Wraps the card so we can tilt it forward when "Gift details" is expanded,
+   making the benefits feel like they're sliding out from behind the card.
+   Composes cleanly with the cursor-driven tilt applied to the card itself. */
+.gh-portal-gift-checkout-card-frame {
+    width: 100%;
+    transform-style: preserve-3d;
+    perspective: 1200px;
+    transition: transform 0.3s ease;
+}
+
+.gh-portal-gift-checkout-card-stack[data-revealing="true"] .gh-portal-gift-checkout-card-frame {
+    transform: rotate(3deg);
+}
+
+.gh-portal-gift-checkout-card-benefits {
+    width: 100%;
+    margin-top: 28px;
+    overflow: hidden;
+    transition: height 0.3s ease;
+}
+
+.gh-portal-gift-checkout-details-toggle {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 48px;
-    height: 48px;
-    color: var(--brandcolor);
-    margin-bottom: 20px;
+    gap: 4px;
+    margin-top: 24px;
+    padding: 8px 12px;
+    background: transparent;
+    border: none;
+    color: var(--grey5);
+    font-size: 1.4rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.15s ease;
 }
 
-.gh-portal-gift-hero-icon svg {
-    width: 48px;
-    height: 48px;
-    stroke-width: 1.5;
-}
-
-.gh-portal-gift-hero .gh-portal-main-title {
-    margin: 0 0 14px;
-}
-
-.gh-portal-gift-hero .gh-portal-main-subtitle {
-    margin: 0;
-    font-size: 1.7rem;
-    line-height: 1.45em;
+.gh-portal-gift-checkout-details-toggle:hover {
     color: var(--grey3);
-    text-align: center;
 }
 
-.gh-portal-content.gift > section {
+.gh-portal-gift-checkout-details-toggle svg {
+    width: 12px;
+    height: 12px;
+    transition: transform 0.2s ease;
+}
+
+.gh-portal-gift-checkout-details-toggle.is-open svg {
+    transform: rotate(-180deg);
+}
+
+.gh-portal-gift-checkout-details {
+    width: 100%;
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.3s ease, margin-top 0.3s ease;
+    margin-top: 0;
+}
+
+.gh-portal-gift-checkout-details[data-open="true"] {
+    grid-template-rows: 1fr;
+    margin-top: 32px;
+}
+
+.gh-portal-gift-checkout-details-inner {
+    overflow: hidden;
+}
+
+.gh-portal-gift-checkout-card {
     position: relative;
+    width: 100%;
+    max-width: 440px;
+    aspect-ratio: 1.7 / 1;
+    background: linear-gradient(to top right, var(--white), color-mix(in srgb, var(--brandcolor) 8%, var(--white)));
+    border-radius: 32px;
+    padding: 28px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), 0 24px 48px rgba(var(--blackrgb), 0.08), 0 4px 12px rgba(var(--blackrgb), 0.04);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    overflow: hidden;
+    transform-style: preserve-3d;
+    will-change: transform;
+}
+
+.gh-portal-gift-checkout-card-site {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.gh-portal-gift-checkout-card-site-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 5px;
+    object-fit: cover;
+}
+
+.gh-portal-gift-checkout-card-site-name {
+    font-size: 1.4rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--grey0);
+}
+
+.gh-portal-gift-checkout-card-meta {
+    position: relative;
+    z-index: 2;
+}
+
+.gh-portal-gift-checkout-card-duration {
+    font-size: 2.6rem;
+    font-weight: 600;
+    color: var(--grey0);
+    letter-spacing: -0.01em;
+    line-height: 1.1;
+}
+
+.gh-portal-gift-checkout-card-tier {
+    margin-top: 6px;
+    font-size: 1.4rem;
+    color: var(--grey3);
+    line-height: 1.3;
+}
+
+/* Wrapped-present cross ribbon: vertical + horizontal straps, bow at intersection */
+.gh-portal-gift-checkout-card-ribbon-v,
+.gh-portal-gift-checkout-card-ribbon-h {
+    position: absolute;
+    background: var(--brandcolor);
+    opacity: 0.3;
     z-index: 1;
 }
 
-.gh-portal-popup-wrapper.gift .gh-portal-btn-site-title-back {
-    background: transparent;
-    border-color: transparent;
+.gh-portal-gift-checkout-card-ribbon-v {
+    top: 0;
+    bottom: 0;
+    right: 22%;
+    width: 12px;
 }
 
-.gh-portal-popup-wrapper.gift .gh-portal-btn-site-title-back:hover {
-    border-color: transparent;
+.gh-portal-gift-checkout-card-ribbon-h {
+    left: 0;
+    right: 0;
+    top: 32%;
+    height: 12px;
+    transform: translateY(-50%);
+}
+
+.gh-portal-gift-checkout-card-bow {
+    position: absolute;
+    top: calc(32% - 42px);
+    right: calc(22% - 40px);
+    width: 90px;
+    height: 86px;
+    z-index: 2;
+    color: var(--brandcolor);
+    pointer-events: none;
+    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.06)) drop-shadow(0 16px 32px rgba(0, 0, 0, 0.06));
+}
+
+
+@media (max-width: 880px) {
+    .gh-portal-gift-checkout {
+        grid-template-columns: 1fr;
+        min-height: 0;
+    }
+
+    /* Drop sticky/100vh sizing — on mobile the right column should sit naturally
+       above the left content, taking only the height it needs. */
+    .gh-portal-gift-checkout-right {
+        order: -1;
+        position: static;
+        height: auto;
+        padding: 32px 24px;
+        overflow: visible;
+    }
+
+    .gh-portal-gift-checkout-left {
+        padding: 32px 24px 80px;
+    }
+
+    .gh-portal-gift-checkout-card,
+    .gh-portal-gift-checkout-card-stack {
+        max-width: 320px;
+    }
 }
 
 @media (max-width: 480px) {
-    .gh-portal-gift-hero {
-        padding: 40px 24px 32px;
+    .gh-portal-gift-checkout-header .gh-portal-main-title {
+        font-size: 2.6rem;
     }
 
-    .gh-portal-gift-bg {
-        height: 240px;
+    .gh-portal-gift-checkout-card-duration {
+        font-size: 2rem;
     }
 }
 `;
 
-function GiftProductCardBenefits({product}) {
-    if (!product.benefits || !product.benefits.length) {
-        return null;
-    }
-
-    return (
-        <div className="gh-portal-product-benefits">
-            {product.benefits.map((benefit, idx) => {
-                const key = benefit?.id || `benefit-${idx}`;
-
-                return (
-                    <div className="gh-portal-product-benefit" key={key}>
-                        <CheckmarkIcon className='gh-portal-benefit-checkmark' alt='' />
-                        <div className="gh-portal-benefit-title">{benefit.name}</div>
-                    </div>
-                );
-            })}
-        </div>
-    );
-}
-
-function GiftProductCardPrice({product, selectedInterval}) {
-    const monthlyPrice = product.monthlyPrice;
-    const yearlyPrice = product.yearlyPrice;
-
-    if (!monthlyPrice || !yearlyPrice) {
-        return null;
-    }
-
-    const activePrice = selectedInterval === 'month' ? monthlyPrice : yearlyPrice;
-    const currencySymbol = getCurrencySymbol(activePrice.currency);
-    const yearlyDiscount = calculateDiscount(monthlyPrice.amount, yearlyPrice.amount);
-
-    return (
-        <div className="gh-portal-product-card-pricecontainer">
-            <div className="gh-portal-product-card-price-trial">
-                <div className="gh-portal-product-price">
-                    <span className={'currency-sign' + (currencySymbol.length > 1 ? ' long' : '')}>{currencySymbol}</span>
-                    <span className="amount" data-testid="product-amount">{formatNumber(getStripeAmount(activePrice.amount))}</span>
-                </div>
-                {selectedInterval === 'year' && yearlyDiscount > 0 && (
-                    <span className="gh-portal-discount-label">{yearlyDiscount}% discount</span>
-                )}
-            </div>
-            <span style={{display: 'block', opacity: '0.5'}}>one-time payment</span>
-        </div>
-    );
-}
-
-function GiftProductCard({brandColor, product, selectedInterval, isDisabled, isPurchasing, onPurchase}) {
-    let productDescription = product.description;
-
-    if ((!product.benefits || !product.benefits.length) && !productDescription) {
-        productDescription = 'Full access';
-    }
-
-    return (
-        <div className='gh-portal-product-card' data-test-tier="paid">
-            <div className='gh-portal-product-card-header'>
-                <h4 className="gh-portal-product-name">{product.name}</h4>
-                <GiftProductCardPrice product={product} selectedInterval={selectedInterval} />
-            </div>
-            <div className='gh-portal-product-card-details'>
-                <div className='gh-portal-product-card-detaildata'>
-                    {productDescription && (
-                        <div className="gh-portal-product-description" data-testid="product-description">
-                            {productDescription}
-                        </div>
-                    )}
-                    <GiftProductCardBenefits product={product} />
-                </div>
-                <div className='gh-portal-btn-product'>
-                    <ActionButton
-                        dataTestId='purchase-gift'
-                        label='Continue'
-                        onClick={e => onPurchase(e, product)}
-                        disabled={isDisabled}
-                        isRunning={isPurchasing}
-                        brandColor={brandColor}
-                        style={{width: '100%'}}
-                    />
-                </div>
-            </div>
-        </div>
-    );
-}
-
-function GiftPriceSwitch({selectedInterval, setSelectedInterval, products}) {
+function GiftPriceSwitch({selectedInterval, setSelectedInterval}) {
     const {site} = useContext(AppContext);
     const {portal_plans: portalPlans} = site;
-    const discounts = products.map(product => calculateDiscount(product.monthlyPrice?.amount, product.yearlyPrice?.amount));
-    const highestDiscount = Math.max(...discounts);
 
     if (!portalPlans.includes('monthly') || !portalPlans.includes('yearly')) {
         return null;
     }
 
     return (
-        <div className='gh-portal-logged-out-form-container'>
-            <div className={'gh-portal-products-pricetoggle' + (selectedInterval === 'month' ? ' left' : '')}>
-                <button
-                    data-test-button='switch-monthly'
-                    className={'gh-portal-btn' + (selectedInterval === 'month' ? ' active' : '')}
-                    onClick={() => setSelectedInterval('month')}
-                >
-                    1 month
-                </button>
-                <button
-                    data-test-button='switch-yearly'
-                    className={'gh-portal-btn' + (selectedInterval === 'year' ? ' active' : '')}
-                    onClick={() => setSelectedInterval('year')}
-                >
-                    1 year
-                    {highestDiscount > 0 && <span className='gh-portal-maximum-discount'>(save {highestDiscount}%)</span>}
-                </button>
-            </div>
+        <div className={'gh-portal-products-pricetoggle' + (selectedInterval === 'month' ? ' left' : '')}>
+            <button
+                data-test-button='switch-monthly'
+                className={'gh-portal-btn' + (selectedInterval === 'month' ? ' active' : '')}
+                onClick={() => setSelectedInterval('month')}
+            >
+                1 month
+            </button>
+            <button
+                data-test-button='switch-yearly'
+                className={'gh-portal-btn' + (selectedInterval === 'year' ? ' active' : '')}
+                onClick={() => setSelectedInterval('year')}
+            >
+                1 year
+            </button>
         </div>
     );
+}
+
+function getTierPriceLabel(product, selectedInterval) {
+    const activePrice = selectedInterval === 'month' ? product.monthlyPrice : product.yearlyPrice;
+
+    if (!activePrice) {
+        return '';
+    }
+
+    const currencySymbol = getCurrencySymbol(activePrice.currency);
+    return `${currencySymbol}${formatNumber(getStripeAmount(activePrice.amount))}`;
+}
+
+function getDurationLabel(selectedInterval) {
+    return selectedInterval === 'month' ? '1 month' : '1 year';
 }
 
 const GiftPage = () => {
     const {site, brandColor, action, doAction} = useContext(AppContext);
     const [selectedInterval, setSelectedInterval] = useState(null);
-    const [selectedProduct, setSelectedProduct] = useState(null);
+    const [selectedProductId, setSelectedProductId] = useState(null);
+    const benefitsInnerRef = useRef(null);
+    const [benefitsHeight, setBenefitsHeight] = useState(undefined);
+    const {cardRef, containerProps: cardTiltProps} = useCardTilt();
+
+    useEffect(() => {
+        const node = benefitsInnerRef.current;
+        if (!node || typeof ResizeObserver === 'undefined') {
+            return;
+        }
+        const observer = new ResizeObserver((entries) => {
+            setBenefitsHeight(entries[0].contentRect.height);
+        });
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, []);
 
     if (!site) {
         return <LoadingPage />;
     }
 
     const {portal_plans: portalPlans, portal_default_plan: portalDefaultPlan} = site;
-
     const activeInterval = getActiveInterval({portalPlans, portalDefaultPlan, selectedInterval});
-
     const products = getAvailableProducts({site}).filter(p => p.type === 'paid');
 
     const siteIcon = site.icon;
     const siteTitle = site.title || '';
 
-    const giftPageHeader = (
-        <>
-            <div className='gh-portal-gift-bg' aria-hidden='true' />
-            <div className='gh-portal-gift-sitetitle'>
-                {siteIcon && (
-                    <img className='gh-portal-gift-sitetitle-icon' src={siteIcon} alt='' />
-                )}
-                <span className='gh-portal-gift-sitetitle-name'>{siteTitle}</span>
-            </div>
-            <div className='gh-portal-gift-hero'>
-                <div className='gh-portal-gift-hero-icon'>
-                    <GiftIcon />
-                </div>
-                <h1 className='gh-portal-main-title'>Gift a membership</h1>
-                <p className='gh-portal-main-subtitle'>Share a full membership to {siteTitle} with a friend or colleague</p>
-            </div>
-        </>
-    );
-
     if (products.length === 0) {
         return (
             <>
-                <div className='gh-portal-back-sitetitle'>
-                    <SiteTitleBackButton />
-                </div>
                 <CloseButton />
-                <div className='gh-portal-content signup gift'>
-                    {giftPageHeader}
-                    <section>
-                        <div className='gh-portal-section'>
-                            <p className='gh-portal-invite-only-notification'>
-                                Gift subscriptions are not available right now.
-                            </p>
+                <div className='gh-portal-content gift'>
+                    <div className='gh-portal-gift-checkout'>
+                        <div className='gh-portal-gift-checkout-left'>
+                            <div className='gh-portal-gift-checkout-bg' aria-hidden='true' />
+                            <div className='gh-portal-gift-checkout-inner'>
+                                <header className='gh-portal-gift-checkout-header'>
+                                    <h1 className='gh-portal-main-title'>Gift a membership</h1>
+                                    <p className='gh-portal-gift-checkout-subtitle'>
+                                        Gift subscriptions are not available right now.
+                                    </p>
+                                </header>
+                            </div>
                         </div>
-                    </section>
+                        <div className='gh-portal-gift-checkout-right' aria-hidden='true' />
+                    </div>
                 </div>
             </>
         );
     }
 
+    const activeProduct = products.find(p => p.id === selectedProductId) || products[0];
     const isPurchasing = action === 'checkoutGift:running';
     const isDisabled = isCookiesDisabled() || isPurchasing;
 
-    const handlePurchase = (e, product) => {
+    const handlePurchase = (e) => {
         e.preventDefault();
 
-        setSelectedProduct(product.id);
-
         doAction('checkoutGift', {
-            tierId: product.id,
+            tierId: activeProduct.id,
             cadence: activeInterval
         });
     };
 
     return (
         <>
-            <div className='gh-portal-back-sitetitle'>
-                <SiteTitleBackButton />
-            </div>
             <CloseButton />
-            <div className='gh-portal-content signup gift'>
-                {giftPageHeader}
+            <div className='gh-portal-content gift'>
+                <div className='gh-portal-gift-checkout'>
+                    <div className='gh-portal-gift-checkout-left'>
+                        <div className='gh-portal-gift-checkout-bg' aria-hidden='true' />
+                        <div className='gh-portal-gift-checkout-inner'>
+                            <header className='gh-portal-gift-checkout-header'>
+                                <h1 className='gh-portal-main-title'>Gift a membership</h1>
+                                <p className='gh-portal-gift-checkout-subtitle'>
+                                    Share a full membership to {siteTitle} with a friend or colleague
+                                </p>
+                            </header>
 
-                <section className="gh-portal-signup">
-                    <div className='gh-portal-section'>
-                        <section className='gh-portal-products'>
-                            <GiftPriceSwitch
-                                selectedInterval={activeInterval}
-                                setSelectedInterval={setSelectedInterval}
-                                products={products}
-                            />
-                            <div className="gh-portal-products-grid">
-                                {products.map(product => (
-                                    <GiftProductCard
-                                        key={product.id}
-                                        brandColor={brandColor}
-                                        product={product}
-                                        selectedInterval={activeInterval}
-                                        isDisabled={isDisabled}
-                                        isPurchasing={isPurchasing && selectedProduct === product.id}
-                                        onPurchase={handlePurchase}
-                                    />
-                                ))}
+                            <div className='gh-portal-gift-checkout-section'>
+                                <div className='gh-portal-gift-checkout-label'>Duration</div>
+                                <GiftPriceSwitch
+                                    selectedInterval={activeInterval}
+                                    setSelectedInterval={setSelectedInterval}
+                                />
                             </div>
-                        </section>
+
+                            <div className='gh-portal-gift-checkout-section'>
+                                <div className='gh-portal-gift-checkout-label'>Tier</div>
+                                <div className='gh-portal-gift-checkout-tiers' role='radiogroup' aria-label='Tier'>
+                                    {products.map((product) => {
+                                        const isSelected = product.id === activeProduct.id;
+                                        return (
+                                            <button
+                                                key={product.id}
+                                                type='button'
+                                                role='radio'
+                                                aria-checked={isSelected}
+                                                className={'gh-portal-gift-checkout-tier' + (isSelected ? ' selected' : '')}
+                                                onClick={() => setSelectedProductId(product.id)}
+                                                data-test-tier={product.name}
+                                            >
+                                                <span className='gh-portal-gift-checkout-tier-radio' aria-hidden='true' />
+                                                <span className='gh-portal-gift-checkout-tier-name'>{product.name}</span>
+                                                <span className='gh-portal-gift-checkout-tier-price'>{getTierPriceLabel(product, activeInterval)}</span>
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+
+                            <ActionButton
+                                dataTestId='purchase-gift'
+                                label='Continue to checkout'
+                                onClick={handlePurchase}
+                                disabled={isDisabled}
+                                isRunning={isPurchasing}
+                                brandColor={brandColor}
+                                classes='gh-portal-gift-checkout-cta'
+                                style={{width: '100%'}}
+                            />
+                        </div>
                     </div>
-                </section>
+
+                    <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
+                        <div className='gh-portal-gift-checkout-card-stack'>
+                            <div ref={cardRef} className='gh-portal-gift-checkout-card' aria-hidden='true'>
+                                <div className='gh-portal-gift-checkout-card-site'>
+                                    {siteIcon && (
+                                        <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
+                                    )}
+                                    <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
+                                </div>
+                                <div className='gh-portal-gift-checkout-card-meta'>
+                                    <div className='gh-portal-gift-checkout-card-duration'>{getDurationLabel(activeInterval)}</div>
+                                    <div className='gh-portal-gift-checkout-card-tier'>{activeProduct.name}</div>
+                                </div>
+                                <div className='gh-portal-gift-checkout-card-ribbon-h' />
+                                <div className='gh-portal-gift-checkout-card-ribbon-v' />
+                                <svg className='gh-portal-gift-checkout-card-bow' viewBox='78 -2 90 86' xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='currentColor' fillRule='evenodd' clipRule='evenodd'>
+                                    <path d='M144.97 1.01186C147.471 0.122129 150.26 -0.292891 153.133 0.229636C156.058 0.761757 158.682 2.19718 160.872 4.38686C165.524 9.03938 166.185 14.9291 164.582 20.2384C163.08 25.217 159.616 29.8398 155.649 33.6447C150.07 38.996 142.324 43.8128 134.494 46.1457L156.801 73.8234L147.457 81.3546L122.879 50.8595L98.3012 81.3546L88.9574 73.8234L111.19 46.2384C103.253 43.9422 95.374 39.0677 89.7201 33.6447C85.7534 29.8398 82.2893 25.2169 80.7865 20.2384C79.1841 14.9291 79.8451 9.03938 84.4975 4.38686C86.6872 2.19723 89.3105 0.761751 92.2358 0.229636C95.1087 -0.292854 97.8981 0.122143 100.399 1.01186C105.26 2.74162 109.666 6.47713 113.237 10.6242C116.925 14.9077 120.297 20.3226 122.684 25.9962C125.071 20.3224 128.444 14.9078 132.132 10.6242C135.703 6.4771 140.109 2.74161 144.97 1.01186ZM96.3764 12.3175C95.3995 11.97 94.7641 11.9671 94.3832 12.0363C94.0547 12.0961 93.5929 12.2622 92.9828 12.8722C92.0356 13.8195 91.6948 14.8501 92.2748 16.7716C92.9549 19.0242 94.8576 21.9447 98.0268 24.9845C102.298 29.0813 107.807 32.4111 112.93 34.1994C111.244 28.8435 108.061 23.0037 104.144 18.4542C101.24 15.0821 98.471 13.063 96.3764 12.3175ZM150.986 12.0363C150.605 11.9671 149.97 11.9699 148.993 12.3175C146.898 13.063 144.129 15.082 141.225 18.4542C137.308 23.0037 134.125 28.8434 132.439 34.1994C137.562 32.4111 143.071 29.0813 147.342 24.9845C150.511 21.9446 152.414 19.0242 153.094 16.7716C153.674 14.8501 153.333 13.8195 152.386 12.8722C151.776 12.2622 151.314 12.0961 150.986 12.0363Z' />
+                                </svg>
+                            </div>
+
+                            {activeProduct.benefits && activeProduct.benefits.length > 0 && (
+                                <div
+                                    className='gh-portal-gift-checkout-card-benefits'
+                                    style={benefitsHeight !== undefined ? {height: benefitsHeight} : undefined}
+                                >
+                                    <div ref={benefitsInnerRef} className='gh-portal-gift-checkout-benefits'>
+                                        {activeProduct.benefits.map((benefit, idx) => {
+                                            const key = benefit?.id || `benefit-${idx}`;
+                                            return (
+                                                <div className='gh-portal-gift-checkout-benefit' key={key}>
+                                                    <CheckmarkIcon alt='' />
+                                                    <span>{benefit.name}</span>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
             </div>
         </>
     );

--- a/apps/portal/src/components/pages/gift-redemption-page.js
+++ b/apps/portal/src/components/pages/gift-redemption-page.js
@@ -5,188 +5,26 @@ import CloseButton from '../common/close-button';
 import InputForm from '../common/input-form';
 import {ValidateInputForm} from '../../utils/form';
 import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
-import {ReactComponent as GiftIcon} from '../../images/icons/gift.svg';
 import {getGiftDurationLabel, getGiftRedemptionErrorMessage} from '../../utils/gift-redemption-notification';
 import {t} from '../../utils/i18n';
 import {hasGiftSubscriptions, removePortalLinkFromUrl} from '../../utils/helpers';
+import useCardTilt from '../../utils/use-card-tilt';
 
 export const GiftRedemptionStyles = `
-    .gh-portal-popup-container.giftRedemption {
-        width: calc(100vw - 24px);
-        max-width: 500px;
-        padding: 0;
-        overflow: hidden;
-        flex-shrink: 0;
-    }
+.gh-portal-gift-redemption-form {
+    margin-top: 24px;
+}
 
-    .gh-portal-popup-container.giftRedemption .gh-portal-closeicon-container {
-        position: absolute;
-        top: 16px;
-        right: 16px;
-        z-index: 5;
-    }
-
-    html[dir="rtl"] .gh-portal-popup-container.giftRedemption .gh-portal-closeicon-container {
-        right: unset;
-        left: 18px;
-    }
-
-    .gh-portal-popup-container.giftRedemption .gh-portal-closeicon {
-        color: rgba(24, 32, 38, 0.14);
-    }
-
-    .gh-portal-popup-container.giftRedemption .gh-portal-closeicon:hover {
-        color: rgba(24, 32, 38, 0.28);
-    }
-
-    .gh-portal-gift-redemption {
-        position: relative;
-        overflow: hidden;
-    }
-
-    .gh-gift-redemption-bg {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 400px;
-        background: linear-gradient(180deg, var(--brandcolor), transparent);
-        opacity: 0.08;
-        pointer-events: none;
-        z-index: 0;
-    }
-
-    .gh-gift-redemption-panel {
-        position: relative;
-        z-index: 1;
-        padding: 40px 32px 32px;
-    }
-
-    .gh-gift-redemption-icon {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 48px;
-        height: 48px;
-        margin: -8px 0 0 -3px;
-        color: var(--brandcolor);
-    }
-
-    html[dir="rtl"] .gh-gift-redemption-icon {
-        margin: -8px -3px 0 0;
-    }
-
-    .gh-gift-redemption-icon svg {
-        width: 52px;
-        height: 52px;
-    }
-
-    .gh-gift-redemption-kicker {
-        margin-top: 0;
-        font-size: 1.3rem;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        text-transform: uppercase;
-        color: var(--brandcolor);
-    }
-
-    .gh-gift-redemption-title {
-        max-width: none;
-        margin: 20px 0 0;
-        font-size: 2.4rem;
-        font-weight: 700;
-        line-height: 1.3;
-        letter-spacing: -0.015em;
-        text-wrap: pretty;
-        color: var(--grey0);
-    }
-
-    .gh-gift-redemption-plan {
-        margin-top: 8px;
-        font-size: 1.5rem;
-        color: var(--grey3);
-    }
-
-    .gh-gift-redemption-tier {
-        font-weight: 700;
-    }
-
-    .gh-gift-redemption-cadence {
-        font-weight: 400;
-    }
-
-    .gh-gift-redemption-benefits {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-        margin-top: 20px;
-    }
-
-    .gh-gift-redemption-form {
-        margin-top: 36px;
-    }
-
-    .gh-gift-redemption-inline-cta {
-        margin-top: 36px;
-    }
-
-    .gh-gift-redemption-benefit {
-        display: flex;
-        align-items: flex-start;
-        gap: 10px;
-        color: var(--grey2);
-        font-size: 1.45rem;
-        line-height: 1.35;
-        text-align: left;
-    }
-
-    .gh-gift-redemption-benefit svg {
-        width: 14px;
-        height: 14px;
-        margin-top: 3px;
-        color: var(--grey1);
-        flex-shrink: 0;
-    }
-
-    html[dir="rtl"] .gh-gift-redemption-benefit {
-        text-align: right;
-        flex-direction: row-reverse;
-    }
-
-    .gh-gift-redemption-submit {
-        width: 100%;
-        height: 44px;
-        margin-top: 20px;
-        font-size: 1.5rem;
-        font-weight: 600;
-    }
-
-    @media (max-width: 480px) {
-        .gh-portal-popup-container.giftRedemption {
-            padding: 0 !important;
-        }
-
-        .gh-gift-redemption-panel {
-            padding: 32px 24px 24px;
-        }
-
-        .gh-gift-redemption-title {
-            font-size: 2.1rem;
-        }
-
-        .gh-gift-redemption-benefit {
-            font-size: 1.4rem;
-        }
-
-        html[dir="rtl"] .gh-gift-redemption-benefit {
-            text-align: right;
-        }
-
-        .gh-gift-redemption-bg {
-            height: 300px;
-        }
-    }
+.gh-portal-gift-redemption-form + .gh-portal-gift-checkout-cta {
+    margin-top: 16px;
+}
 `;
+
+const ChevronIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <polyline points="6 9 12 15 18 9"/>
+    </svg>
+);
 
 // TODO: Add translation strings once copy has been finalised
 const GiftRedemptionPage = () => {
@@ -197,6 +35,8 @@ const GiftRedemptionPage = () => {
     const [name, setName] = useState(member?.name || '');
     const [email, setEmail] = useState(member?.email || '');
     const [errors, setErrors] = useState({});
+    const [showDetails, setShowDetails] = useState(false);
+    const {cardRef, containerProps: cardTiltProps} = useCardTilt();
 
     useEffect(() => {
         setName(member?.name || '');
@@ -316,75 +156,111 @@ const GiftRedemptionPage = () => {
     const buttonLabel = isRedeeming
         ? 'Redeeming gift...' // TODO: Add translation strings once copy has been finalised
         : 'Redeem your membership'; // TODO: Add translation strings once copy has been finalised
-    const siteTitle = site?.title;
+    const siteIcon = site?.icon;
+    const siteTitle = site?.title || '';
     const headerText = siteTitle
         ? `You've been gifted a membership to ${siteTitle}`
         : 'You\'ve been gifted a membership';
+    const benefits = gift.tier.benefits || [];
 
     return (
-        <div className='gh-portal-content gh-portal-gift-redemption'>
+        <>
             <CloseButton />
-            <div className='gh-gift-redemption-bg' />
+            <div className='gh-portal-content giftRedemption'>
+                <div className='gh-portal-gift-checkout'>
+                    <div className='gh-portal-gift-checkout-left'>
+                        <div className='gh-portal-gift-checkout-bg' aria-hidden='true' />
+                        <div className='gh-portal-gift-checkout-inner'>
+                            <header className='gh-portal-gift-checkout-header'>
+                                {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
+                                <h1 className='gh-portal-main-title'>A gift, just for you</h1>
+                                <p className='gh-portal-gift-checkout-subtitle'>{headerText}</p>
+                            </header>
 
-            <div className='gh-gift-redemption-panel'>
-                <div className='gh-gift-redemption-icon'><GiftIcon /></div>
-                <div className='gh-gift-redemption-kicker'>{'Gift membership'}</div>
-                <h1 className='gh-gift-redemption-title'>{headerText}</h1>
-
-                <div className='gh-gift-redemption-plan'>
-                    <span className='gh-gift-redemption-tier'>{gift.tier.name}</span>
-                    <span>&nbsp;&middot;&nbsp;</span>
-                    <span className='gh-gift-redemption-cadence'>{getGiftDurationLabel(gift)}</span>
-                </div>
-
-                {gift.tier.benefits.length > 0 && (
-                    <div className='gh-gift-redemption-benefits'>
-                        {gift.tier.benefits.map((benefit, index) => {
-                            const benefitName = typeof benefit === 'string' ? benefit : benefit?.name;
-                            const benefitKey = typeof benefit === 'string' ? benefit : benefit?.id || `gift-benefit-${index}`;
-
-                            if (!benefitName) {
-                                return null;
-                            }
-
-                            return (
-                                <div className='gh-gift-redemption-benefit' key={benefitKey}>
-                                    <CheckmarkIcon />
-                                    <span>{benefitName}</span>
+                            {!isLoggedIn && (
+                                <div className='gh-portal-gift-redemption-form'>
+                                    <InputForm fields={formFields} onChange={handleFieldChange} onKeyDown={handleKeyDown} />
                                 </div>
-                            );
-                        })}
-                    </div>
-                )}
+                            )}
 
-                {isLoggedIn ? (
-                    <div className='gh-gift-redemption-inline-cta'>
-                        <ActionButton
-                            brandColor={brandColor}
-                            classes='gh-gift-redemption-submit'
-                            label={buttonLabel}
-                            onClick={handleRedeemClick}
-                            style={{width: '100%'}}
-                            disabled={isRedeeming}
-                            isRunning={isRedeeming}
-                        />
+                            <ActionButton
+                                brandColor={brandColor}
+                                classes='gh-portal-gift-checkout-cta'
+                                label={buttonLabel}
+                                onClick={handleRedeemClick}
+                                style={{width: '100%'}}
+                                disabled={isRedeeming}
+                                isRunning={isRedeeming}
+                            />
+                        </div>
                     </div>
-                ) : (
-                    <div className='gh-gift-redemption-form'>
-                        <InputForm fields={formFields} onChange={handleFieldChange} onKeyDown={handleKeyDown} />
-                        <ActionButton
-                            brandColor={brandColor}
-                            classes='gh-gift-redemption-submit'
-                            label={buttonLabel}
-                            onClick={handleRedeemClick}
-                            style={{width: '100%'}}
-                            disabled={isRedeeming}
-                            isRunning={isRedeeming}
-                        />
+
+                    <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
+                        <div className='gh-portal-gift-checkout-card-stack' data-revealing={showDetails}>
+                            <div className='gh-portal-gift-checkout-card-frame'>
+                                <div ref={cardRef} className='gh-portal-gift-checkout-card' aria-hidden='true'>
+                                    <div className='gh-portal-gift-checkout-card-site'>
+                                        {siteIcon && (
+                                            <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
+                                        )}
+                                        <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
+                                    </div>
+                                    <div className='gh-portal-gift-checkout-card-meta'>
+                                        <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel(gift)}</div>
+                                        <div className='gh-portal-gift-checkout-card-tier'>{gift.tier.name}</div>
+                                    </div>
+                                    <div className='gh-portal-gift-checkout-card-ribbon-h' />
+                                    <div className='gh-portal-gift-checkout-card-ribbon-v' />
+                                    <svg className='gh-portal-gift-checkout-card-bow' viewBox='78 -2 90 86' xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='currentColor' fillRule='evenodd' clipRule='evenodd'>
+                                        <path d='M144.97 1.01186C147.471 0.122129 150.26 -0.292891 153.133 0.229636C156.058 0.761757 158.682 2.19718 160.872 4.38686C165.524 9.03938 166.185 14.9291 164.582 20.2384C163.08 25.217 159.616 29.8398 155.649 33.6447C150.07 38.996 142.324 43.8128 134.494 46.1457L156.801 73.8234L147.457 81.3546L122.879 50.8595L98.3012 81.3546L88.9574 73.8234L111.19 46.2384C103.253 43.9422 95.374 39.0677 89.7201 33.6447C85.7534 29.8398 82.2893 25.2169 80.7865 20.2384C79.1841 14.9291 79.8451 9.03938 84.4975 4.38686C86.6872 2.19723 89.3105 0.761751 92.2358 0.229636C95.1087 -0.292854 97.8981 0.122143 100.399 1.01186C105.26 2.74162 109.666 6.47713 113.237 10.6242C116.925 14.9077 120.297 20.3226 122.684 25.9962C125.071 20.3224 128.444 14.9078 132.132 10.6242C135.703 6.4771 140.109 2.74161 144.97 1.01186ZM96.3764 12.3175C95.3995 11.97 94.7641 11.9671 94.3832 12.0363C94.0547 12.0961 93.5929 12.2622 92.9828 12.8722C92.0356 13.8195 91.6948 14.8501 92.2748 16.7716C92.9549 19.0242 94.8576 21.9447 98.0268 24.9845C102.298 29.0813 107.807 32.4111 112.93 34.1994C111.244 28.8435 108.061 23.0037 104.144 18.4542C101.24 15.0821 98.471 13.063 96.3764 12.3175ZM150.986 12.0363C150.605 11.9671 149.97 11.9699 148.993 12.3175C146.898 13.063 144.129 15.082 141.225 18.4542C137.308 23.0037 134.125 28.8434 132.439 34.1994C137.562 32.4111 143.071 29.0813 147.342 24.9845C150.511 21.9446 152.414 19.0242 153.094 16.7716C153.674 14.8501 153.333 13.8195 152.386 12.8722C151.776 12.2622 151.314 12.0961 150.986 12.0363Z' />
+                                    </svg>
+                                </div>
+                            </div>
+
+                            {benefits.length > 0 && (
+                                <>
+                                    <div
+                                        className='gh-portal-gift-checkout-details'
+                                        data-open={showDetails}
+                                        aria-hidden={!showDetails}
+                                    >
+                                        <div className='gh-portal-gift-checkout-details-inner'>
+                                            <div className='gh-portal-gift-checkout-benefits'>
+                                                {benefits.map((benefit, index) => {
+                                                    const benefitName = typeof benefit === 'string' ? benefit : benefit?.name;
+                                                    const benefitKey = typeof benefit === 'string' ? benefit : benefit?.id || `gift-benefit-${index}`;
+
+                                                    if (!benefitName) {
+                                                        return null;
+                                                    }
+
+                                                    return (
+                                                        <div className='gh-portal-gift-checkout-benefit' key={benefitKey}>
+                                                            <CheckmarkIcon alt='' />
+                                                            <span>{benefitName}</span>
+                                                        </div>
+                                                    );
+                                                })}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button
+                                        type='button'
+                                        className={'gh-portal-gift-checkout-details-toggle' + (showDetails ? ' is-open' : '')}
+                                        onClick={() => setShowDetails(s => !s)}
+                                        aria-expanded={showDetails}
+                                    >
+                                        {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
+                                        {showDetails ? 'Hide details' : 'Gift details'}
+                                        <ChevronIcon />
+                                    </button>
+                                </>
+                            )}
+                        </div>
                     </div>
-                )}
+                </div>
             </div>
-        </div>
+        </>
     );
 };
 

--- a/apps/portal/src/components/pages/gift-redemption-page.js
+++ b/apps/portal/src/components/pages/gift-redemption-page.js
@@ -198,7 +198,7 @@ const GiftRedemptionPage = () => {
                     <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
                         <div className='gh-portal-gift-checkout-card-stack' data-revealing={showDetails}>
                             <div className='gh-portal-gift-checkout-card-frame'>
-                                <div ref={cardRef} className='gh-portal-gift-checkout-card' aria-hidden='true'>
+                                <div ref={cardRef} className='gh-portal-gift-checkout-card'>
                                     <div className='gh-portal-gift-checkout-card-site'>
                                         {siteIcon && (
                                             <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
@@ -209,8 +209,8 @@ const GiftRedemptionPage = () => {
                                         <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel(gift)}</div>
                                         <div className='gh-portal-gift-checkout-card-tier'>{gift.tier.name}</div>
                                     </div>
-                                    <div className='gh-portal-gift-checkout-card-ribbon-h' />
-                                    <div className='gh-portal-gift-checkout-card-ribbon-v' />
+                                    <div className='gh-portal-gift-checkout-card-ribbon-h' aria-hidden='true' />
+                                    <div className='gh-portal-gift-checkout-card-ribbon-v' aria-hidden='true' />
                                     <svg className='gh-portal-gift-checkout-card-bow' viewBox='78 -2 90 86' xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='currentColor' fillRule='evenodd' clipRule='evenodd'>
                                         <path d='M144.97 1.01186C147.471 0.122129 150.26 -0.292891 153.133 0.229636C156.058 0.761757 158.682 2.19718 160.872 4.38686C165.524 9.03938 166.185 14.9291 164.582 20.2384C163.08 25.217 159.616 29.8398 155.649 33.6447C150.07 38.996 142.324 43.8128 134.494 46.1457L156.801 73.8234L147.457 81.3546L122.879 50.8595L98.3012 81.3546L88.9574 73.8234L111.19 46.2384C103.253 43.9422 95.374 39.0677 89.7201 33.6447C85.7534 29.8398 82.2893 25.2169 80.7865 20.2384C79.1841 14.9291 79.8451 9.03938 84.4975 4.38686C86.6872 2.19723 89.3105 0.761751 92.2358 0.229636C95.1087 -0.292854 97.8981 0.122143 100.399 1.01186C105.26 2.74162 109.666 6.47713 113.237 10.6242C116.925 14.9077 120.297 20.3226 122.684 25.9962C125.071 20.3224 128.444 14.9078 132.132 10.6242C135.703 6.4771 140.109 2.74161 144.97 1.01186ZM96.3764 12.3175C95.3995 11.97 94.7641 11.9671 94.3832 12.0363C94.0547 12.0961 93.5929 12.2622 92.9828 12.8722C92.0356 13.8195 91.6948 14.8501 92.2748 16.7716C92.9549 19.0242 94.8576 21.9447 98.0268 24.9845C102.298 29.0813 107.807 32.4111 112.93 34.1994C111.244 28.8435 108.061 23.0037 104.144 18.4542C101.24 15.0821 98.471 13.063 96.3764 12.3175ZM150.986 12.0363C150.605 11.9671 149.97 11.9699 148.993 12.3175C146.898 13.063 144.129 15.082 141.225 18.4542C137.308 23.0037 134.125 28.8434 132.439 34.1994C137.562 32.4111 143.071 29.0813 147.342 24.9845C150.511 21.9446 152.414 19.0242 153.094 16.7716C153.674 14.8501 153.333 13.8195 152.386 12.8722C151.776 12.2622 151.314 12.0961 150.986 12.0363Z' />
                                     </svg>

--- a/apps/portal/src/components/pages/gift-success-page.js
+++ b/apps/portal/src/components/pages/gift-success-page.js
@@ -1,114 +1,111 @@
 import {useContext, useState} from 'react';
 import AppContext from '../../app-context';
-import {ReactComponent as GiftIcon} from '../../images/icons/gift.svg';
 import CloseButton from '../common/close-button';
 import copyTextToClipboard from '../../utils/copy-to-clipboard';
+import {getAvailableProducts} from '../../utils/helpers';
+import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
+import useCardTilt from '../../utils/use-card-tilt';
 
 // TODO: wrap strings with t() once copy is finalised
 /* eslint-disable i18next/no-literal-string */
 
 export const GiftSuccessStyle = `
-    .gh-portal-gift-success .gh-portal-signup-header {
-        margin-bottom: 0;
-        padding: 0;
-    }
+.gh-portal-gift-success-link {
+    display: flex;
+    align-items: center;
+    height: 56px;
+    background: color-mix(in srgb, var(--brandcolor) 8%, var(--white));
+    border-radius: 999px;
+    padding: 4px 8px 4px 24px;
+    gap: 8px;
+}
 
-    .gh-portal-gift-success .gh-gift-success-icon {
-        margin: 12px auto 0;
-        text-align: center;
-        color: var(--brandcolor);
-        width: 56px;
-        height: 56px;
-    }
+.gh-portal-gift-success-link-url {
+    flex: 1;
+    font-size: 1.6rem;
+    font-weight: 400;
+    color: var(--brandcolor);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    user-select: all;
+}
 
-    .gh-portal-gift-success .gh-gift-success-icon svg {
-        width: 56px;
-        height: 56px;
-    }
+.gh-portal-gift-success-copy {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    height: 40px;
+    padding: 0 18px;
+    background: var(--brandcolor);
+    color: var(--white);
+    border: none;
+    border-radius: 999px;
+    font-size: 1.4rem;
+    font-weight: 600;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: opacity 0.15s ease;
+    will-change: opacity;
+}
 
-    .gh-portal-gift-success h1.gh-portal-main-title {
-        font-size: 32px;
-        margin-top: 16px;
-    }
+.gh-portal-gift-success-copy:hover {
+    opacity: 0.9;
+}
 
-    .gh-portal-gift-success .gh-portal-main-subtitle {
-        margin-top: 12px;
-    }
+.gh-portal-gift-success-copy svg {
+    width: 14px;
+    height: 14px;
+}
 
-    .gh-portal-gift-success .gh-gift-link-container {
-        display: flex;
-        align-items: center;
-        height: 48px;
-        background-color: #f3f3f3;
-        border-radius: 8px;
-        padding: 6px 6px 6px 12px;
-        margin-top: 24px;
-        gap: 8px;
-    }
-
-    .gh-portal-gift-success .gh-gift-link-url {
-        flex: 1;
-        font-size: 1.5rem;
-        color: var(--grey1);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        min-width: 0;
-        user-select: all;
-    }
-
-    .gh-portal-gift-success .gh-gift-copy-btn {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        height: 36px;
-        background: var(--brandcolor);
-        color: #fff;
-        border: none;
-        border-radius: 6px;
-        padding: 8px 16px 8px 14px;
-        font-size: 14px;
-        font-weight: 500;
-        cursor: pointer;
-        white-space: nowrap;
-        flex-shrink: 0;
-        transition: opacity 0.15s ease;
-        will-change: opacity;
-    }
-
-    .gh-portal-gift-success .gh-gift-copy-btn:hover {
-        opacity: 0.9;
-    }
-
-    .gh-portal-gift-success .gh-gift-footer-text {
-        margin: 36px 0 0;
-        font-size: 1.3rem;
-        color: var(--grey7);
-        text-align: center;
-        line-height: 1.5;
-    }
+.gh-portal-gift-success-footer {
+    margin-top: 24px;
+    margin-bottom: 0;
+    font-size: 1.4rem;
+    color: var(--grey6);
+    line-height: 1.5;
+}
 `;
 
 const CopyIcon = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="14" height="14">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
         <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
     </svg>
 );
 
 const CheckIcon = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{margin: '1px -1px 0 -2px'}} width="16" height="16">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
         <polyline points="20 6 9 17 4 12"/>
     </svg>
 );
 
+const ChevronIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <polyline points="6 9 12 15 18 9"/>
+    </svg>
+);
+
+function getDurationLabel(cadence) {
+    return cadence === 'month' ? '1 month' : '1 year';
+}
+
 const GiftSuccessPage = () => {
     const {site, pageData} = useContext(AppContext);
     const [copied, setCopied] = useState(false);
+    const [showDetails, setShowDetails] = useState(false);
+    const {cardRef, containerProps: cardTiltProps} = useCardTilt();
 
     const token = pageData?.token;
+    const tierId = pageData?.tierId;
+    const cadence = pageData?.cadence;
     const siteUrl = site?.url || '';
+    const siteIcon = site?.icon;
+    const siteTitle = site?.title || '';
     const redeemUrl = `${siteUrl.replace(/\/$/, '')}/gift/${token}`;
+
+    const products = getAvailableProducts({site}).filter(p => p.type === 'paid');
+    const tier = tierId ? products.find(p => p.id === tierId) : null;
 
     const handleCopy = () => {
         copyTextToClipboard(redeemUrl);
@@ -117,29 +114,98 @@ const GiftSuccessPage = () => {
     };
 
     return (
-        <div className='gh-portal-content gh-portal-gift-success'>
+        <>
             <CloseButton />
+            <div className='gh-portal-content giftSuccess'>
+                <div className='gh-portal-gift-checkout'>
+                    <div className='gh-portal-gift-checkout-left'>
+                        <div className='gh-portal-gift-checkout-bg' aria-hidden='true' />
+                        <div className='gh-portal-gift-checkout-inner'>
+                            <header className='gh-portal-gift-checkout-header'>
+                                <h1 className='gh-portal-main-title'>Your gift is ready!</h1>
+                                <p className='gh-portal-gift-checkout-subtitle'>
+                                    Send the link below to share it with whoever you&apos;d like.
+                                </p>
+                            </header>
 
-            <div className="gh-portal-signup-header">
-                <div className="gh-gift-success-icon"><GiftIcon /></div>
-                <h1 className="gh-portal-main-title">Your gift is ready!</h1>
-                <p className="gh-portal-main-subtitle gh-portal-text-center">
-                    Send the link below to share it with whoever you&apos;d like.
-                </p>
+                            <div className='gh-portal-gift-checkout-section'>
+                                <div className='gh-portal-gift-checkout-label'>Shareable link</div>
+                                <div className='gh-portal-gift-success-link'>
+                                    <span className='gh-portal-gift-success-link-url'>{redeemUrl}</span>
+                                    <button className='gh-portal-gift-success-copy' onClick={handleCopy} type='button'>
+                                        {copied ? <CheckIcon /> : <CopyIcon />}
+                                        {copied ? 'Copied' : 'Copy'}
+                                    </button>
+                                </div>
+                            </div>
+
+                            <p className='gh-portal-gift-success-footer'>
+                                Not ready to share? We&apos;ve also emailed a copy to your inbox.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
+                        <div className='gh-portal-gift-checkout-card-stack' data-revealing={showDetails}>
+                            <div className='gh-portal-gift-checkout-card-frame'>
+                                <div ref={cardRef} className='gh-portal-gift-checkout-card' aria-hidden='true'>
+                                    <div className='gh-portal-gift-checkout-card-site'>
+                                        {siteIcon && (
+                                            <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
+                                        )}
+                                        <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
+                                    </div>
+                                    {tier && cadence && (
+                                        <div className='gh-portal-gift-checkout-card-meta'>
+                                            <div className='gh-portal-gift-checkout-card-duration'>{getDurationLabel(cadence)}</div>
+                                            <div className='gh-portal-gift-checkout-card-tier'>{tier.name}</div>
+                                        </div>
+                                    )}
+                                    <div className='gh-portal-gift-checkout-card-ribbon-h' />
+                                    <div className='gh-portal-gift-checkout-card-ribbon-v' />
+                                    <svg className='gh-portal-gift-checkout-card-bow' viewBox='78 -2 90 86' xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='currentColor' fillRule='evenodd' clipRule='evenodd'>
+                                        <path d='M144.97 1.01186C147.471 0.122129 150.26 -0.292891 153.133 0.229636C156.058 0.761757 158.682 2.19718 160.872 4.38686C165.524 9.03938 166.185 14.9291 164.582 20.2384C163.08 25.217 159.616 29.8398 155.649 33.6447C150.07 38.996 142.324 43.8128 134.494 46.1457L156.801 73.8234L147.457 81.3546L122.879 50.8595L98.3012 81.3546L88.9574 73.8234L111.19 46.2384C103.253 43.9422 95.374 39.0677 89.7201 33.6447C85.7534 29.8398 82.2893 25.2169 80.7865 20.2384C79.1841 14.9291 79.8451 9.03938 84.4975 4.38686C86.6872 2.19723 89.3105 0.761751 92.2358 0.229636C95.1087 -0.292854 97.8981 0.122143 100.399 1.01186C105.26 2.74162 109.666 6.47713 113.237 10.6242C116.925 14.9077 120.297 20.3226 122.684 25.9962C125.071 20.3224 128.444 14.9078 132.132 10.6242C135.703 6.4771 140.109 2.74161 144.97 1.01186ZM96.3764 12.3175C95.3995 11.97 94.7641 11.9671 94.3832 12.0363C94.0547 12.0961 93.5929 12.2622 92.9828 12.8722C92.0356 13.8195 91.6948 14.8501 92.2748 16.7716C92.9549 19.0242 94.8576 21.9447 98.0268 24.9845C102.298 29.0813 107.807 32.4111 112.93 34.1994C111.244 28.8435 108.061 23.0037 104.144 18.4542C101.24 15.0821 98.471 13.063 96.3764 12.3175ZM150.986 12.0363C150.605 11.9671 149.97 11.9699 148.993 12.3175C146.898 13.063 144.129 15.082 141.225 18.4542C137.308 23.0037 134.125 28.8434 132.439 34.1994C137.562 32.4111 143.071 29.0813 147.342 24.9845C150.511 21.9446 152.414 19.0242 153.094 16.7716C153.674 14.8501 153.333 13.8195 152.386 12.8722C151.776 12.2622 151.314 12.0961 150.986 12.0363Z' />
+                                    </svg>
+                                </div>
+                            </div>
+
+                            {tier && tier.benefits && tier.benefits.length > 0 && (
+                                <>
+                                    <div
+                                        className='gh-portal-gift-checkout-details'
+                                        data-open={showDetails}
+                                        aria-hidden={!showDetails}
+                                    >
+                                        <div className='gh-portal-gift-checkout-details-inner'>
+                                            <div className='gh-portal-gift-checkout-benefits'>
+                                                {tier.benefits.map((benefit, idx) => {
+                                                    const key = benefit?.id || `benefit-${idx}`;
+                                                    return (
+                                                        <div className='gh-portal-gift-checkout-benefit' key={key}>
+                                                            <CheckmarkIcon alt='' />
+                                                            <span>{benefit.name}</span>
+                                                        </div>
+                                                    );
+                                                })}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button
+                                        type='button'
+                                        className={'gh-portal-gift-checkout-details-toggle' + (showDetails ? ' is-open' : '')}
+                                        onClick={() => setShowDetails(s => !s)}
+                                        aria-expanded={showDetails}
+                                    >
+                                        {showDetails ? 'Hide details' : 'Gift details'}
+                                        <ChevronIcon />
+                                    </button>
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </div>
             </div>
-
-            <div className="gh-gift-link-container">
-                <span className="gh-gift-link-url">{redeemUrl}</span>
-                <button className="gh-gift-copy-btn" onClick={handleCopy} type="button">
-                    {copied ? <CheckIcon /> : <CopyIcon />}
-                    {copied ? 'Copied' : 'Copy'}
-                </button>
-            </div>
-
-            <p className="gh-gift-footer-text">
-                Not ready to share? We&apos;ve also emailed a copy to your inbox.
-            </p>
-        </div>
+        </>
     );
 };
 

--- a/apps/portal/src/components/pages/gift-success-page.js
+++ b/apps/portal/src/components/pages/gift-success-page.js
@@ -148,7 +148,7 @@ const GiftSuccessPage = () => {
                     <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
                         <div className='gh-portal-gift-checkout-card-stack' data-revealing={showDetails}>
                             <div className='gh-portal-gift-checkout-card-frame'>
-                                <div ref={cardRef} className='gh-portal-gift-checkout-card' aria-hidden='true'>
+                                <div ref={cardRef} className='gh-portal-gift-checkout-card'>
                                     <div className='gh-portal-gift-checkout-card-site'>
                                         {siteIcon && (
                                             <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
@@ -161,8 +161,8 @@ const GiftSuccessPage = () => {
                                             <div className='gh-portal-gift-checkout-card-tier'>{tier.name}</div>
                                         </div>
                                     )}
-                                    <div className='gh-portal-gift-checkout-card-ribbon-h' />
-                                    <div className='gh-portal-gift-checkout-card-ribbon-v' />
+                                    <div className='gh-portal-gift-checkout-card-ribbon-h' aria-hidden='true' />
+                                    <div className='gh-portal-gift-checkout-card-ribbon-v' aria-hidden='true' />
                                     <svg className='gh-portal-gift-checkout-card-bow' viewBox='78 -2 90 86' xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='currentColor' fillRule='evenodd' clipRule='evenodd'>
                                         <path d='M144.97 1.01186C147.471 0.122129 150.26 -0.292891 153.133 0.229636C156.058 0.761757 158.682 2.19718 160.872 4.38686C165.524 9.03938 166.185 14.9291 164.582 20.2384C163.08 25.217 159.616 29.8398 155.649 33.6447C150.07 38.996 142.324 43.8128 134.494 46.1457L156.801 73.8234L147.457 81.3546L122.879 50.8595L98.3012 81.3546L88.9574 73.8234L111.19 46.2384C103.253 43.9422 95.374 39.0677 89.7201 33.6447C85.7534 29.8398 82.2893 25.2169 80.7865 20.2384C79.1841 14.9291 79.8451 9.03938 84.4975 4.38686C86.6872 2.19723 89.3105 0.761751 92.2358 0.229636C95.1087 -0.292854 97.8981 0.122143 100.399 1.01186C105.26 2.74162 109.666 6.47713 113.237 10.6242C116.925 14.9077 120.297 20.3226 122.684 25.9962C125.071 20.3224 128.444 14.9078 132.132 10.6242C135.703 6.4771 140.109 2.74161 144.97 1.01186ZM96.3764 12.3175C95.3995 11.97 94.7641 11.9671 94.3832 12.0363C94.0547 12.0961 93.5929 12.2622 92.9828 12.8722C92.0356 13.8195 91.6948 14.8501 92.2748 16.7716C92.9549 19.0242 94.8576 21.9447 98.0268 24.9845C102.298 29.0813 107.807 32.4111 112.93 34.1994C111.244 28.8435 108.061 23.0037 104.144 18.4542C101.24 15.0821 98.471 13.063 96.3764 12.3175ZM150.986 12.0363C150.605 11.9671 149.97 11.9699 148.993 12.3175C146.898 13.063 144.129 15.082 141.225 18.4542C137.308 23.0037 134.125 28.8434 132.439 34.1994C137.562 32.4111 143.071 29.0813 147.342 24.9845C150.511 21.9446 152.414 19.0242 153.094 16.7716C153.674 14.8501 153.333 13.8195 152.386 12.8722C151.776 12.2622 151.314 12.0961 150.986 12.0363Z' />
                                     </svg>

--- a/apps/portal/src/components/pages/magic-link-page.js
+++ b/apps/portal/src/components/pages/magic-link-page.js
@@ -344,7 +344,7 @@ export default class MagicLinkPage extends React.Component {
                         <div className='gh-portal-gift-checkout-right'>
                             <div className='gh-portal-gift-checkout-card-stack' data-revealing={this.state.showDetails}>
                                 <div className='gh-portal-gift-checkout-card-frame'>
-                                    <div className='gh-portal-gift-checkout-card' aria-hidden='true'>
+                                    <div className='gh-portal-gift-checkout-card'>
                                         <div className='gh-portal-gift-checkout-card-site'>
                                             {siteIcon && (
                                                 <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
@@ -355,8 +355,8 @@ export default class MagicLinkPage extends React.Component {
                                             <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel(gift)}</div>
                                             <div className='gh-portal-gift-checkout-card-tier'>{gift.tier?.name}</div>
                                         </div>
-                                        <div className='gh-portal-gift-checkout-card-ribbon-h' />
-                                        <div className='gh-portal-gift-checkout-card-ribbon-v' />
+                                        <div className='gh-portal-gift-checkout-card-ribbon-h' aria-hidden='true' />
+                                        <div className='gh-portal-gift-checkout-card-ribbon-v' aria-hidden='true' />
                                         <svg className='gh-portal-gift-checkout-card-bow' viewBox='78 -2 90 86' xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='currentColor' fillRule='evenodd' clipRule='evenodd'>
                                             <path d='M144.97 1.01186C147.471 0.122129 150.26 -0.292891 153.133 0.229636C156.058 0.761757 158.682 2.19718 160.872 4.38686C165.524 9.03938 166.185 14.9291 164.582 20.2384C163.08 25.217 159.616 29.8398 155.649 33.6447C150.07 38.996 142.324 43.8128 134.494 46.1457L156.801 73.8234L147.457 81.3546L122.879 50.8595L98.3012 81.3546L88.9574 73.8234L111.19 46.2384C103.253 43.9422 95.374 39.0677 89.7201 33.6447C85.7534 29.8398 82.2893 25.2169 80.7865 20.2384C79.1841 14.9291 79.8451 9.03938 84.4975 4.38686C86.6872 2.19723 89.3105 0.761751 92.2358 0.229636C95.1087 -0.292854 97.8981 0.122143 100.399 1.01186C105.26 2.74162 109.666 6.47713 113.237 10.6242C116.925 14.9077 120.297 20.3226 122.684 25.9962C125.071 20.3224 128.444 14.9078 132.132 10.6242C135.703 6.4771 140.109 2.74161 144.97 1.01186ZM96.3764 12.3175C95.3995 11.97 94.7641 11.9671 94.3832 12.0363C94.0547 12.0961 93.5929 12.2622 92.9828 12.8722C92.0356 13.8195 91.6948 14.8501 92.2748 16.7716C92.9549 19.0242 94.8576 21.9447 98.0268 24.9845C102.298 29.0813 107.807 32.4111 112.93 34.1994C111.244 28.8435 108.061 23.0037 104.144 18.4542C101.24 15.0821 98.471 13.063 96.3764 12.3175ZM150.986 12.0363C150.605 11.9671 149.97 11.9699 148.993 12.3175C146.898 13.063 144.129 15.082 141.225 18.4542C137.308 23.0037 134.125 28.8434 132.439 34.1994C137.562 32.4111 143.071 29.0813 147.342 24.9845C150.511 21.9446 152.414 19.0242 153.094 16.7716C153.674 14.8501 153.333 13.8195 152.386 12.8722C151.776 12.2622 151.314 12.0961 150.986 12.0363Z' />
                                         </svg>

--- a/apps/portal/src/components/pages/magic-link-page.js
+++ b/apps/portal/src/components/pages/magic-link-page.js
@@ -4,8 +4,16 @@ import CloseButton from '../common/close-button';
 import InboxLinkButton from '../common/inbox-link-button';
 import AppContext from '../../app-context';
 import {ReactComponent as EnvelopeIcon} from '../../images/icons/envelope.svg';
+import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
 import {isIos} from '../../utils/is-ios';
 import {t} from '../../utils/i18n';
+import {getGiftDurationLabel} from '../../utils/gift-redemption-notification';
+
+const ChevronIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <polyline points="6 9 12 15 18 9"/>
+    </svg>
+);
 
 export const MagicLinkStyles = `
     .gh-portal-icon-envelope {
@@ -85,7 +93,8 @@ export default class MagicLinkPage extends React.Component {
         this.state = {
             [OTC_FIELD_NAME]: '',
             errors: {},
-            isFocused: false
+            isFocused: false,
+            showDetails: false
         };
     }
 
@@ -301,9 +310,114 @@ export default class MagicLinkPage extends React.Component {
         );
     }
 
+    renderGiftLayout(showOTCForm) {
+        const {site, pageData, otcRef} = this.context;
+        const gift = pageData?.gift;
+        const siteIcon = site?.icon;
+        const siteTitle = site?.title || '';
+        const submittedEmailOrInbox = pageData?.email ? pageData.email : t('your inbox');
+        const popupTitle = t('Now check your email!');
+        const popupDescription = this.getTranslatedDescription({
+            lastPage: 'gift',
+            otcRef,
+            submittedEmailOrInbox
+        });
+        const benefits = gift.tier?.benefits || [];
+
+        return (
+            <>
+                <CloseButton />
+                <div className='gh-portal-content giftRedemption'>
+                    <div className='gh-portal-gift-checkout'>
+                        <div className='gh-portal-gift-checkout-left'>
+                            <div className='gh-portal-gift-checkout-bg' aria-hidden='true' />
+                            <div className='gh-portal-gift-checkout-inner'>
+                                <header className='gh-portal-gift-checkout-header'>
+                                    <h1 className='gh-portal-main-title'>{popupTitle}</h1>
+                                    <p className='gh-portal-gift-checkout-subtitle'>{popupDescription}</p>
+                                </header>
+                                <div className='gh-portal-gift-redemption-form'>
+                                    {showOTCForm ? this.renderOTCForm() : this.renderCloseButton()}
+                                </div>
+                            </div>
+                        </div>
+                        <div className='gh-portal-gift-checkout-right'>
+                            <div className='gh-portal-gift-checkout-card-stack' data-revealing={this.state.showDetails}>
+                                <div className='gh-portal-gift-checkout-card-frame'>
+                                    <div className='gh-portal-gift-checkout-card' aria-hidden='true'>
+                                        <div className='gh-portal-gift-checkout-card-site'>
+                                            {siteIcon && (
+                                                <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
+                                            )}
+                                            <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
+                                        </div>
+                                        <div className='gh-portal-gift-checkout-card-meta'>
+                                            <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel(gift)}</div>
+                                            <div className='gh-portal-gift-checkout-card-tier'>{gift.tier?.name}</div>
+                                        </div>
+                                        <div className='gh-portal-gift-checkout-card-ribbon-h' />
+                                        <div className='gh-portal-gift-checkout-card-ribbon-v' />
+                                        <svg className='gh-portal-gift-checkout-card-bow' viewBox='78 -2 90 86' xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='currentColor' fillRule='evenodd' clipRule='evenodd'>
+                                            <path d='M144.97 1.01186C147.471 0.122129 150.26 -0.292891 153.133 0.229636C156.058 0.761757 158.682 2.19718 160.872 4.38686C165.524 9.03938 166.185 14.9291 164.582 20.2384C163.08 25.217 159.616 29.8398 155.649 33.6447C150.07 38.996 142.324 43.8128 134.494 46.1457L156.801 73.8234L147.457 81.3546L122.879 50.8595L98.3012 81.3546L88.9574 73.8234L111.19 46.2384C103.253 43.9422 95.374 39.0677 89.7201 33.6447C85.7534 29.8398 82.2893 25.2169 80.7865 20.2384C79.1841 14.9291 79.8451 9.03938 84.4975 4.38686C86.6872 2.19723 89.3105 0.761751 92.2358 0.229636C95.1087 -0.292854 97.8981 0.122143 100.399 1.01186C105.26 2.74162 109.666 6.47713 113.237 10.6242C116.925 14.9077 120.297 20.3226 122.684 25.9962C125.071 20.3224 128.444 14.9078 132.132 10.6242C135.703 6.4771 140.109 2.74161 144.97 1.01186ZM96.3764 12.3175C95.3995 11.97 94.7641 11.9671 94.3832 12.0363C94.0547 12.0961 93.5929 12.2622 92.9828 12.8722C92.0356 13.8195 91.6948 14.8501 92.2748 16.7716C92.9549 19.0242 94.8576 21.9447 98.0268 24.9845C102.298 29.0813 107.807 32.4111 112.93 34.1994C111.244 28.8435 108.061 23.0037 104.144 18.4542C101.24 15.0821 98.471 13.063 96.3764 12.3175ZM150.986 12.0363C150.605 11.9671 149.97 11.9699 148.993 12.3175C146.898 13.063 144.129 15.082 141.225 18.4542C137.308 23.0037 134.125 28.8434 132.439 34.1994C137.562 32.4111 143.071 29.0813 147.342 24.9845C150.511 21.9446 152.414 19.0242 153.094 16.7716C153.674 14.8501 153.333 13.8195 152.386 12.8722C151.776 12.2622 151.314 12.0961 150.986 12.0363Z' />
+                                        </svg>
+                                    </div>
+                                </div>
+
+                                {benefits.length > 0 && (
+                                    <>
+                                        <div
+                                            className='gh-portal-gift-checkout-details'
+                                            data-open={this.state.showDetails}
+                                            aria-hidden={!this.state.showDetails}
+                                        >
+                                            <div className='gh-portal-gift-checkout-details-inner'>
+                                                <div className='gh-portal-gift-checkout-benefits'>
+                                                    {benefits.map((benefit, index) => {
+                                                        const benefitName = typeof benefit === 'string' ? benefit : benefit?.name;
+                                                        const benefitKey = typeof benefit === 'string' ? benefit : benefit?.id || `gift-benefit-${index}`;
+
+                                                        if (!benefitName) {
+                                                            return null;
+                                                        }
+
+                                                        return (
+                                                            <div className='gh-portal-gift-checkout-benefit' key={benefitKey}>
+                                                                <CheckmarkIcon />
+                                                                <span>{benefitName}</span>
+                                                            </div>
+                                                        );
+                                                    })}
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <button
+                                            type='button'
+                                            className={'gh-portal-gift-checkout-details-toggle' + (this.state.showDetails ? ' is-open' : '')}
+                                            onClick={() => this.setState(s => ({showDetails: !s.showDetails}))}
+                                            aria-expanded={this.state.showDetails}
+                                        >
+                                            {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
+                                            {this.state.showDetails ? 'Hide details' : 'Gift details'}
+                                            <ChevronIcon />
+                                        </button>
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </>
+        );
+    }
+
     render() {
-        const {otcRef} = this.context;
+        const {otcRef, lastPage, pageData} = this.context;
         const showOTCForm = !!otcRef;
+        const isGiftMode = lastPage === 'gift' && !!pageData?.gift;
+
+        if (isGiftMode) {
+            return this.renderGiftLayout(showOTCForm);
+        }
 
         return (
             <div className='gh-portal-content'>

--- a/apps/portal/src/components/popup-modal.js
+++ b/apps/portal/src/components/popup-modal.js
@@ -146,7 +146,7 @@ class PopupContent extends React.Component {
     }
 
     render() {
-        const {page, pageQuery, site, customSiteUrl} = this.context;
+        const {page, pageQuery, site, customSiteUrl, lastPage} = this.context;
         const products = getSiteProducts({site, pageQuery});
         const noOfProducts = products.length;
 
@@ -189,8 +189,17 @@ class PopupContent extends React.Component {
             }
         }
 
-        if (page === 'gift') {
+        if (page === 'gift' || page === 'giftSuccess' || page === 'giftRedemption') {
             pageClass += ' full-size';
+            popupSize = 'full';
+        }
+
+        // Magic link page reached via gift redemption: render in the same
+        // 50/50 layout (gift card stays visible on the right) instead of as
+        // a small centered modal. Reuses the giftRedemption class so the
+        // existing full-size CSS rules apply.
+        if (page === 'magiclink' && lastPage === 'gift') {
+            pageClass += ' full-size giftRedemption';
             popupSize = 'full';
         }
 

--- a/apps/portal/src/utils/use-card-tilt.js
+++ b/apps/portal/src/utils/use-card-tilt.js
@@ -1,0 +1,72 @@
+import {useCallback, useRef} from 'react';
+
+/**
+ * Subtle 3D tilt effect that follows the cursor.
+ *
+ * Returns a `cardRef` to attach to the card element, and `containerProps`
+ * (mouse handlers) to spread onto the surrounding container that defines
+ * the active tracking area.
+ *
+ * Uses requestAnimationFrame to coalesce mousemove updates into one DOM write
+ * per frame, and toggles the transition duration so the card tracks the cursor
+ * responsively while moving and eases back smoothly on leave. Safari is more
+ * sensitive than Chrome to long transitions overlapping rapid style updates,
+ * so without this it feels like the tilt is debounced.
+ */
+export default function useCardTilt({maxTilt = 3, trackTransition = 'transform 80ms linear', restTransition = 'transform 400ms ease-out'} = {}) {
+    const cardRef = useRef(null);
+    const rafIdRef = useRef(null);
+    const targetRef = useRef({x: 0, y: 0});
+    const isHoveringRef = useRef(false);
+
+    const applyFrame = useCallback(() => {
+        rafIdRef.current = null;
+        const card = cardRef.current;
+        if (!card) {
+            return;
+        }
+        if (isHoveringRef.current) {
+            const {x, y} = targetRef.current;
+            card.style.transition = trackTransition;
+            card.style.transform = `perspective(1200px) rotateX(${-y * maxTilt}deg) rotateY(${x * maxTilt}deg)`;
+        } else {
+            card.style.transition = restTransition;
+            card.style.transform = '';
+        }
+    }, [maxTilt, trackTransition, restTransition]);
+
+    const schedule = useCallback(() => {
+        if (rafIdRef.current === null) {
+            rafIdRef.current = requestAnimationFrame(applyFrame);
+        }
+    }, [applyFrame]);
+
+    const onMouseMove = useCallback((event) => {
+        const card = cardRef.current;
+        if (!card) {
+            return;
+        }
+        const rect = card.getBoundingClientRect();
+        const halfWidth = rect.width / 2;
+        const halfHeight = rect.height / 2;
+        if (halfWidth === 0 || halfHeight === 0) {
+            return;
+        }
+        targetRef.current = {
+            x: (event.clientX - rect.left - halfWidth) / halfWidth,
+            y: (event.clientY - rect.top - halfHeight) / halfHeight
+        };
+        isHoveringRef.current = true;
+        schedule();
+    }, [schedule]);
+
+    const onMouseLeave = useCallback(() => {
+        isHoveringRef.current = false;
+        schedule();
+    }, [schedule]);
+
+    return {
+        cardRef,
+        containerProps: {onMouseMove, onMouseLeave}
+    };
+}

--- a/apps/portal/src/utils/use-card-tilt.js
+++ b/apps/portal/src/utils/use-card-tilt.js
@@ -52,9 +52,13 @@ export default function useCardTilt({maxTilt = 3, trackTransition = 'transform 8
         if (halfWidth === 0 || halfHeight === 0) {
             return;
         }
+        // Clamp to ±1: the mouse handlers are attached to the whole column,
+        // so the cursor can be well outside the card bounds — without
+        // clamping the rotation would exceed maxTilt near the column edges.
+        const clamp = value => Math.max(-1, Math.min(1, value));
         targetRef.current = {
-            x: (event.clientX - rect.left - halfWidth) / halfWidth,
-            y: (event.clientY - rect.top - halfHeight) / halfHeight
+            x: clamp((event.clientX - rect.left - halfWidth) / halfWidth),
+            y: clamp((event.clientY - rect.top - halfHeight) / halfHeight)
         };
         isHoveringRef.current = true;
         schedule();

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -189,6 +189,8 @@ class PaymentsService {
         const successUrlObj = new URL(successUrl);
         successUrlObj.searchParams.set('stripe', 'gift-purchase-success');
         successUrlObj.searchParams.set('gift_token', token);
+        successUrlObj.searchParams.set('gift_tier', tier.id.toHexString());
+        successUrlObj.searchParams.set('gift_cadence', cadence);
 
         const data = {
             amount,

--- a/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
@@ -368,7 +368,7 @@ describe('PaymentsService', function () {
             assert.equal(args.metadata.gift_token, 'AbCdEfGhIjKl');
         });
 
-        it('appends gift token to success URL', async function () {
+        it('appends gift token, tier and cadence to success URL', async function () {
             const tier = await createTier({monthlyPrice: 5000, yearlyPrice: 50000});
 
             await service.getGiftPaymentLink({...defaultGiftOptions, tier, cadence: 'year'});
@@ -378,6 +378,8 @@ describe('PaymentsService', function () {
 
             assert.equal(successUrl.searchParams.get('stripe'), 'gift-purchase-success');
             assert.equal(successUrl.searchParams.get('gift_token'), args.metadata.gift_token);
+            assert.equal(successUrl.searchParams.get('gift_tier'), tier.id.toHexString());
+            assert.equal(successUrl.searchParams.get('gift_cadence'), 'year');
         });
 
         it('prevents caller metadata from overwriting gift-specific keys', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3600/design-iteration

Refreshed every screen in the gift subscription flow — selection, confirmation, redemption, and the magic link state when redeeming — with a single shared 50/50 split layout: action on the left, gift card preview on the right.

### What's new

- **Unified gift card preview** across all four screens — same site icon + duration + tier, brand-tinted gradient, cross ribbons, wrapped-bow SVG, subtle cursor-follow tilt.
- **Selection screen**: title + duration toggle + tier radio list + pill CTA on the left; benefits below the card on the right with smooth height animation when switching tiers.
- **Confirmation screen**: shareable link pill with copy button on the left; reused gift card on the right with collapsible "Gift details" toggle.
- **Redemption screen**: title "A gift, just for you" + name/email form + redeem button; same toggle reveals tier benefits with card tilt that makes them look like they're sliding out from behind the card.
- **Magic link in gift mode**: when reached via gift redemption, swaps the centered modal for the same 50/50 layout so the gift card stays put across the form → "Now check your email!" transition.