### PR TITLE
Rewrote Shade Storybook docs in conversational prose, added Terms section

### DIFF
--- a/apps/shade/src/docs/architecture.mdx
+++ b/apps/shade/src/docs/architecture.mdx
@@ -4,245 +4,143 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <div className="sb-doc">
 
-# System Architecture
+# How Shade is organized
 
-<p className="excerpt">Shade is built as a layered system, with each layer building upon the previous to create a complete design system. This document outlines how these layers work together.</p>
+<p className="excerpt">Shade is a layered system. Each layer has a job, and code belongs in exactly one. Once you understand the layers and their boundaries, the rest of the design system answers itself: where to put new code, what to import, when to compose vs. when to add a new abstraction.</p>
 
-## Read This First (60 seconds)
+## The five-second mental model
 
-If you are not sure where code belongs, use this:
+From the bottom up:
 
-- `tokens`: visual values only (color, type, radius, motion)
-- `primitives`: layout structure only (`Stack`, `Inline`, `Box`, `Container`, `Grid`, `Text`)
-- `components`: reusable generic controls (button, input, dialog)
-- `patterns`: repeated product workflows (filters, resource flows)
-- `app`: app shell and transitional domain exports
-- `utils`: design-system-safe generic helpers only
+**Tokens** are the raw visual values — a color, a radius, a font size, a duration. They have no shape, no behavior, no markup. Just values that other layers consume.
 
-Fast decision rule:
+**Primitives** turn tokens into structure. They're the layout vocabulary: `Stack`, `Inline`, `Box`, `Grid`, `Container`, `Text`. Primitives don't know about buttons or dialogs; they know about rows, columns, padding, and gaps.
 
-- If it changes spacing/alignment/layout, use `primitives`.
-- If it is a generic control, use `components`.
-- If it encodes product workflow, use `patterns`.
+**Components** are generic, reusable controls — Button, Input, Dialog, Tabs. They have visual styling and accessible behavior, but they don't know anything about Ghost's product. A Shade Button is the same Button whether it sits inside Stats, Settings, or the post editor.
 
-## File Structure
+**Recipes** sit alongside components in a separate sidebar group called Foundations. A recipe is a small, shared visual rule that several components consume — for example `inputSurface`, the border + background + focus ring used by every Input, Textarea, InputGroup, and Select trigger. Recipes are utilities, not components; they have no JSX of their own.
+
+**Features** (sometimes called Patterns) are the product-shaped layer. This is where Ghost-specific compositions live: KPI cards, the area chart on Stats, the filter builder on the Members list. Features compose primitives and components together with knowledge of how Ghost actually uses them.
+
+That's the whole hierarchy. Tokens → primitives → components & recipes → features. Each layer is allowed to use anything below it. The reverse is forbidden: a Button can't reach into a feature, a primitive can't reach into a component.
+
+## Terms
+
+A few words get used a lot in Shade and they're worth defining clearly.
+
+### Token
+
+A named visual value. `--color-foreground`, `--radius-md`, `--text-base`, `--duration-fast`. Tokens are CSS custom properties exposed via Tailwind v4's `@theme` block. They flip between light and dark mode automatically. You consume them through Tailwind utility classes (`bg-background`, `text-foreground`, `rounded-md`) or directly via CSS variables in stylesheets.
+
+When you find yourself reaching for a hardcoded color or pixel value, that's a sign you should be using a token instead.
+
+### Primitive
+
+A small layout building block with no domain meaning. The full set: `Stack` (vertical grouping), `Inline` (horizontal grouping), `Box` (padding / radius framing), `Container` (width-constrained shells), `Grid` (multi-column layouts), `Text` (typographic element). Primitives accept semantic spacing and alignment props (`gap="lg"`, `align="center"`) instead of raw Tailwind classes.
+
+Primitives replace the long `flex flex-col gap-4 items-start` strings that made every layout look the same to humans and robots alike.
+
+### Component
+
+A generic, reusable UI control. Button, Input, Dialog, Tabs, Card, DropdownMenu, and so on. Components are styled, accessible, and themed — but they have no product-specific behavior. A Shade `Button` accepts `variant="destructive"` because "destructive" is a generic visual intent. It does not accept `isMembersPage`, because that's a product concern leaking into a generic control.
+
+If a component starts collecting product-specific props or branches, that's a signal to extract a Feature wrapper instead.
+
+### Recipe
+
+A small, named visual rule reused by several components — without being a component itself. The canonical example is `inputSurface`: a function that returns the shared border, background, radius, and focus-ring class string used by every form control surface in Shade. `Input`, `Textarea`, `InputGroup`, and the `Select` trigger all consume it.
+
+Recipes are useful when several components need to look identical along one dimension (chrome, focus state, density) but have different shapes otherwise. They live in `components/ui/` next to the components they support, and they show up in Storybook under the **Foundations** group.
+
+### Layout
+
+A reusable page shell. `Page`, `Header`, `ListHeader`, `ViewHeader`, `Heading`. Layouts compose primitives and components into the structural skeleton of a screen, but they don't carry product logic. They're shared scaffolding.
+
+### Feature (also called Pattern)
+
+A product-shaped composition. Examples in Shade today: `KpiCardHeader`, `KpiTabValue`, `GhAreaChart`, `Filters`. Features know that Ghost has KPIs, area charts with diff tooltips, filterable Members lists. They compose components, primitives, and recipes with that knowledge baked in.
+
+There's a small terminology mismatch worth knowing: in the file system, this layer lives in `components/features/`, but the package entrypoint that exposes them is called `@tryghost/shade/patterns`. Both names refer to the same thing — features are patterns and vice versa. You'll see both used.
+
+### App
+
+The wrapper layer for context, providers, and a small set of transitional helpers. `ShadeApp` lives here, along with utilities that bridge between the design system and Ghost-specific concerns during ongoing migrations.
+
+## Choosing the right layer
+
+When you're about to write something new, the layer choice is usually obvious if you ask: *what is this thing actually doing?*
+
+If it changes spacing, alignment, or layout structure, it's a primitive concern. Reach for `Stack`, `Inline`, `Box`, `Grid`, or `Container` rather than writing flex utilities by hand.
+
+If it's a generic interactive control, it's a component. Use the existing one (Button, Input, Dialog, etc.) or, if you genuinely have a new generic control nobody has built yet, add it to `components/ui/`.
+
+If several components share the same chrome, focus ring, or visual rule, that's a recipe. Extract it to a small utility function in `components/ui/`. Don't try to make it a component if it doesn't have its own markup.
+
+If the thing knows about Ghost — KPIs, members, posts, newsletters, analytics — it's a feature. Put it in `components/features/<feature-name>/`.
+
+The fast version: **if it has a Ghost-shaped name, it's a feature; if it has a generic name, it's a component or primitive.**
+
+## When to add code to Shade at all
+
+The default is to **keep code local first**. A component used in one place doesn't belong in a design system. Build it in your app, ship it, and leave it there. When you find yourself building the same thing a second time in a different surface, that's when you start considering Shade. By the third time, the case is clear.
+
+Premature abstractions in a design system are expensive — the API gets tuned for too few use cases, and changing it later means hunting through every consumer. Patience pays.
+
+## Layered package entrypoints
+
+Shade exposes itself through several import paths instead of one giant barrel. This keeps consumer bundles small and makes intent clear at the call site:
+
+| Import | What's in it |
+| --- | --- |
+| `@tryghost/shade/tokens` | Token names and helpers (CSS variable definitions in `@tryghost/shade/tokens.css`) |
+| `@tryghost/shade/primitives` | Layout primitives + legacy layout shells |
+| `@tryghost/shade/components` | Generic controls, recipes, and visual assets |
+| `@tryghost/shade/patterns` | Features (product compositions) |
+| `@tryghost/shade/app` | `ShadeApp`, providers, transitional helpers |
+| `@tryghost/shade/utils` | Generic DS-safe helpers, `LucideIcon`, `Recharts` |
+
+The bare `@tryghost/shade` import is a compatibility lane that re-exports the main DS layers. New code should import from a specific subpath. The migration deadline is documented in the [Root Imports Migration](?path=/docs/migration-root-imports--docs) page.
+
+## File layout
+
+The repository structure mirrors the layer model:
 
 ```
-/apps/shade/
-├── src/
-│   ├── components/
-│   │   ├── ui/           # Base ShadCN components
-│   │   ├── layout/       # Composed, reusable layout components
-│   │   └── features/     # Feature-specific, higher-level components
-│   ├── hooks/            # Custom React hooks
-│   ├── providers/        # Context providers
-│   ├── lib/ds-utils.ts   # DS-safe utilities
-│   ├── lib/app-utils.ts  # Transitional domain utilities
-│   └── docs/             # Documentation
-├── .storybook/          # Storybook configuration
-├── styles.css           # Tailwind imports + runtime variables
-└── tailwind.theme.css   # CSS-first token definitions (@theme)
+apps/shade/src/
+├── components/
+│   ├── ui/              Generic controls and recipes
+│   ├── layout/          Page shells (Page, ListHeader, ViewHeader)
+│   └── features/        Product compositions (KPI, charts, filters)
+├── docs/                MDX documentation rendered in Storybook
+├── hooks/               Generic React hooks
+├── lib/
+│   ├── ds-utils.ts      DS-safe utilities
+│   └── app-utils.ts     Transitional domain utilities
+└── providers/           Context providers
 ```
 
-## Export Entrypoints
+`components.ts`, `primitives.ts`, `patterns.ts` and friends are the entrypoint barrels — they re-export from their respective folders for the corresponding `@tryghost/shade/*` import path.
 
-Shade now uses layered package entrypoints:
+## Conventions worth knowing
 
-- `@tryghost/shade/tokens` and `@tryghost/shade/tokens.css`
-- `@tryghost/shade/primitives`
-- `@tryghost/shade/components`
-- `@tryghost/shade/patterns`
-- `@tryghost/shade/app`
-- `@tryghost/shade/utils`
+**File names are kebab-case** (`dropdown-menu.tsx`). This matches what the ShadCN CLI generates, so we accept the inconsistency with PascalCase exports.
 
-The root `@tryghost/shade` entrypoint remains a compatibility lane during migration, but new code should import from a layer-specific subpath.
-The root entrypoint now keeps compatibility for DS layers only (`tokens`, `primitives`, `components`, `patterns`).
-`app` and `utils` are intentionally subpath-only.
+**Components are PascalCase**, hooks/functions/types are camelCase.
 
-## Layer Ownership Rules
+**Stories live next to their component** as `<name>.stories.tsx`. The Storybook title puts each story in the right sidebar group: `Foundations / X`, `Primitives / X`, `Components / X`, `Layout / X`, `Features / X`.
 
-- `tokens`: token definitions and helpers only (CSS variables, token names, token lookup helpers).
-- `primitives`: structure/layout building blocks with no product/domain behavior.
-- `components`: reusable UI controls and visual assets/icons.
-- `patterns`: feature-level reusable compositions and interaction rules.
-- `app`: app shell/provider/context APIs and transitional domain exports.
-- `utils`: DS-safe helpers, generic hooks, and third-party namespaces.
+**Use `cn()` to merge classes** (combines `clsx` + `tailwind-merge`). Always merge through `cn()` rather than concatenating strings — it handles Tailwind class conflicts correctly.
 
-## Human and AI Decision Protocol
+**Use `cva()` for variants** when a component has multiple visual modes. It gives type-safe variant props and a single place to define the styles.
 
-Run this order before implementing UI:
+**Always forward `className`** so consumers can extend a component without wrapping it.
 
-1. Choose the layer (`tokens` -> `primitives` -> `components` -> `patterns`).
-2. Reuse existing API first.
-3. If no fit, keep code local and add it to Shade only after repeated use.
-4. Keep shared APIs product-agnostic.
+## When to stop and think
 
-Stop and re-evaluate when:
+A few situations should make you pause:
 
-- a shared component needs workflow-specific props
-- a layout abstraction starts carrying business logic
-- ownership between `components` and `patterns` is unclear
-
-When to add code to Shade:
-
-- Keep code local first, then add it to Shade when it is reused across surfaces.
-- Add to `primitives` when the abstraction is structural.
-- Add to `components` when the abstraction is a reusable control.
-- Add to `patterns` when repeated product workflows emerge.
-- Do not place domain/product helpers in `utils`; route them through `app` during migration and then toward app-local/pattern ownership.
-
-## Primitive Composition Rules and Guarantees
-
-Primitive composition has these fixed rules:
-
-- Primitive set: `Stack`, `Inline`, `Box`, `Container`, `Grid`, `Text`.
-- Spacing API: semantic steps `none | xs | sm | md | lg | xl | 2xl`.
-- Text depth: minimal `Text` primitive with compatibility heading wrappers (`H1`-`H4`, `HTable`).
-- Migration scope: `apps/shade/src/components/layout/*` only.
-- Compatibility policy: keep existing `@tryghost/shade/primitives` exports available during migration and deprecate without hard removals.
-
-## Component Rules and Guarantees Layer
-
-This layer keeps shared control APIs explicit and stable in `components/ui`:
-
-- Define explicit API and state rules for Wave A controls (`Button`, `Input`, `Field`, `Select`, `Tabs`, `Table`, `Dialog`, `DropdownMenu`, `Card`).
-- Keep shared controls product-agnostic.
-- Preserve compatibility through deprecation notes, not hard removals.
-
-## Component Types
-
-### Base Components (UI)
-Located in `/src/components/ui/`:
-- Built on ShadCN/UI primitives
-- Use RadixUI for accessibility
-- Follow composable pattern
-- Examples: Button, Input, Card
-
-### Layout Components (Composed)
-Located in `/src/components/layout/`:
-- Compose base UI into reusable layout primitives (Page, Header, Heading, ViewHeader)
-- Shared across surfaces; no product logic
-- Follow same patterns as base components
-
-### Feature Components
-Located in `/src/components/features/`:
-- Higher-level, feature-specific compositions (e.g., PostShareModal, SourceTabs)
-- May bundle multiple UI and layout parts for a specific workflow
-- Still reusable across apps when the feature exists
-
-## Dependencies
-
-### Core Dependencies
-- **React**: UI library
-- **TailwindCSS**: Utility-first styling
-- **ShadCN/UI**: Component primitives
-- **RadixUI**: Accessible primitives
-- **Lucide**: Default icon system
-
-> ⚠️ Note: When using third-party libraries that might have naming conflicts (like Recharts), we alias all exports (e.g., `export * as Recharts from "recharts"`).
-
-## Component Implementation
-
-### Naming Conventions
-
-- Filenames: ShadCN-generated files keep kebab-case; file-scoped components live alongside their stories
-- Components: `PascalCase`
-- Functions/vars/types: `camelCase`
-
-> ⚠️ Note: ShadCN/UI CLI creates files in kebab-case. We accept this inconsistency due to case-sensitivity issues.
-
-### Component Structure
-
-```tsx
-// Basic component structure
-import { cn } from "@/lib/utils"
-import { cva } from "class-variance-authority"
-
-const componentVariants = cva(
-    "base-styles",
-    {
-        variants: {
-            variant: {
-                default: "variant-styles",
-                // Add variants...
-            }
-        },
-        defaultVariants: {
-            variant: "default"
-        }
-    }
-)
-
-export interface ComponentProps {
-    className?: string;
-    // Other props...
-}
-
-export function Component({ className, ...props }: ComponentProps) {
-    return (
-        <div className={cn(componentVariants(), className)} {...props} />
-    )
-}
-```
-
-### Component API
-
-- Use RadixUI primitives for accessibility
-- Expose RadixUI props when available
-- Always include `className` prop
-- Use Class Variance Authority for variants
-
-## Icons
-
-Shade defaults to using Lucide icons. Since all exports are aliased as `LucideIcon` in `index.ts`, the way to use icons in apps happens through referencing the LucideIcon package:
-
-   ```tsx
-   import { LucideIcon } from 'lucide-react';
-
-   <LucideIcon.Search size={16} />
-   ```
-
-## ShadCN/UI Configuration
-
-Key configuration in `components.json`:
-```json
-{
-    "style": "new-york",
-    "baseColor": "gray",
-    "cssVariables": true
-}
-```
-
-## Best Practices
-
-### Component Design
-- Create composable, not configurable components
-- Keep components focused and single-purpose
-- Maintain consistent prop patterns
-- Document all variants and props
-
-### Styling
-- Use design tokens via Tailwind classes sourced from CSS-first `@theme` tokens
-- Always merge className prop using cn utility
-- Maintain dark mode support
-- Follow responsive design patterns
-
-### Implementation Flow
-
-1. **Start with ShadCN/UI**
-   - Install via CLI if available
-   - Customize implementation
-   - Add/modify variants
-
-2. **Add Documentation**
-   - Create stories
-   - Document variants
-   - Show usage examples
-
-3. **Export Component**
-   ```ts
-   // index.ts
-   export * from './components/ui/component';
-   ```
+- A shared component is starting to grow workflow-specific props (`isMembersPage`, `showInPostEditor`). That's a sign the abstraction is wrong; extract a Feature wrapper instead.
+- A primitive is sprouting business logic (an `if` branch that knows about specific data). Move that logic up into the consumer or a Feature.
+- You can't tell whether something belongs in `components` or `features`. Use the rule: generic name → component, Ghost-shaped name → feature. If still unclear, ask — that ambiguity is usually a real design question.
 
 </div>

--- a/apps/shade/src/docs/component-contracts.mdx
+++ b/apps/shade/src/docs/component-contracts.mdx
@@ -4,86 +4,61 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <div className="sb-doc">
 
-# Component Rules and Guarantees
+# What you can rely on from a Shade component
 
-<p className="excerpt">This page defines clear rules and guarantees for shared controls: what they do, what they do not do, and which states must always work.</p>
+<p className="excerpt">When you reach for a Shade component, there are some things you should be able to count on without reading the source. This page describes those guarantees, and what we promise about them when the component changes over time.</p>
 
-## Plain-English Definition
+## The rules in one paragraph
 
-In this doc, “contract” means “rules and guarantees”.
-Those rules answer 5 questions:
+A shared component in `components/ui/` does one job, has a public API you can use without surprises, and works in four states (default, hover, focus-visible, disabled) before anything else. It doesn't know about specific product surfaces, and it doesn't accept props that hint at one. When we change it, we tell you what changed and what stayed the same.
 
-- What problem does this component solve?
-- What API can consumers use safely?
-- Which states must always work?
-- What is intentionally out of scope?
-- What compatibility promise do we make?
+If those things aren't true, the component isn't ready to be shared yet — it's still a draft.
 
-If these answers are missing, teams guess. Guessing causes component drift.
+## Why bother with rules
 
-## Why This Matters
+For humans, clear rules make code reviews faster (less back-and-forth about whether a prop is appropriate) and reuse decisions less anxious (you can tell from the API whether a component fits your situation).
 
-For humans:
+For AI agents, the rules are even more important. An agent generating UI code is constantly making choices: which component to use, which prop, which variant. Predictable, narrow component APIs let the agent pick the right tool without inventing components or making up props. Loose APIs invite the agent to guess.
 
-- Faster code reviews (less ambiguity)
-- Easier reuse decisions (`components` vs `patterns`)
-- Fewer accidental breaking changes
+## What "shared" means
 
-For AI agents:
+The current target for documented rules is the set of foundational controls in `components/ui/`:
 
-- Reliable constraints for code generation
-- Fewer invented props and variants
-- Predictable output shape across components
+`Button`, `Input`, `Field`, `Select`, `Tabs`, `Table`, `Dialog`, `DropdownMenu`, `Card`.
 
-## Scope (Wave A)
+Other things in `components/ui/` (recipes like `inputSurface`, smaller helpers, primitives like `TrendBadge` and `MetricValue`) follow the same spirit but don't yet have formal rule documents.
 
-Current Wave A rules coverage targets:
+Some surfaces deliberately sit outside this list — `sidebar`, `multi-select-combobox`, the chart variants. They're large and mix layout, behavior, and styling in ways that the simple rules don't fit cleanly. They're documented at the component level instead.
 
-- `Button`
-- `Input`
-- `Field`
-- `Select`
-- `Tabs`
-- `Table`
-- `Dialog`
-- `DropdownMenu`
-- `Card`
+## What the rules answer
 
-Out of scope for Wave A:
+Five questions, in this order:
 
-- workflow-level compositions (`filters`, app-specific orchestration)
-- very large mixed-behavior surfaces (`sidebar`, `multi-select-combobox`, chart variants)
+**What problem does this component solve?** A one- or two-sentence answer. If the answer takes a paragraph, the component is probably doing too much.
 
-## Human Workflow (Fast)
+**What's the public API?** Props, slots, and variants you can rely on. Things explicitly out of scope (so consumers don't accidentally lean on internal implementation details).
 
-Use this when adding or changing a shared component:
+**Which states must always work?** Default, hover, focus-visible, disabled at minimum. Optional ones (active, loading, error, empty) are documented when they apply.
 
-1. Write a 1-2 sentence purpose and non-goals.
-2. List public props and slots.
-3. Confirm required states: `default`, `hover`, `focus-visible`, `disabled`.
-4. Add Storybook stories that prove those states.
-5. Add compatibility notes if API changed.
+**What's intentionally out of scope?** Workflow-specific behavior, product-specific styling, things that belong in a Feature wrapper instead.
 
-If you cannot explain a prop in one sentence, the API is probably too broad.
+**What's the compatibility promise?** Backward-compatible additions, breaking changes (with migration notes), deprecation timelines if a prop is going away.
 
-## AI Agent Workflow (Deterministic)
+## When you're adding or changing a shared component
 
-When generating or editing a shared component, produce this structure first, then implement:
+The minimum loop:
 
-1. `Component scope`
-2. `Public API`
-3. `State matrix`
-4. `Compatibility policy`
-5. `Deprecation plan` (if needed)
+1. Write a one-sentence purpose statement and a list of explicit non-goals.
+2. List the public props and any slots/subcomponents.
+3. Implement the four required states (default, hover, focus-visible, disabled).
+4. Add Storybook stories that prove those states work.
+5. If you changed an existing API, write a short note about what's different and what stayed the same.
 
-Hard rules for agents:
+If you can't explain a prop in one sentence, the API is probably trying to do too much. Split it.
 
-- Do not add product-specific props in shared `components`.
-- Do not skip required states.
-- Do not remove existing public API without compatibility notes.
-- If behavior is workflow-specific, move it to `patterns`.
+## When you're an AI agent generating a shared component
 
-## Rules Template
+Produce this structure first, then implement:
 
 ```md
 ## Component scope
@@ -92,63 +67,78 @@ Hard rules for agents:
 
 ## Public API
 - Props:
-- Slots/subcomponents:
+- Slots / subcomponents:
 - Variants:
-- Events/callbacks:
+- Events / callbacks:
 
 ## State matrix
 - default:
 - hover:
 - focus-visible:
 - disabled:
-- optional states (if applicable): active/loading/error/empty
+- optional states (if applicable): active / loading / error / empty
 
 ## Compatibility policy
 - Backward-compatible additions:
 - Breaking changes:
 - Migration notes:
 
-## Deprecation plan
+## Deprecation plan (if applicable)
 - Alias period:
 - Removal target:
 ```
 
-## Good vs Bad Example
+The hard rules for agents:
 
-Good:
+- No product-specific props in shared components. `variant="destructive"` is fine; `isMembersPage` is not.
+- Don't skip required states. A component without a focus-visible style isn't done.
+- Don't remove existing public API without explicit compatibility notes.
+- If behavior is workflow-specific, route it to `features/`, not into the base component.
 
-- `variant="destructive"`: visual intent is explicit and reusable.
-- `size="sm|md|lg"`: bounded scale.
+## A worked example: good vs bad props
 
-Bad:
+Good props are visual or interactive intents that make sense in any context:
 
-- `isMembersPage`: product-specific in a shared control.
-- `layoutMode="toolbarWithFilterAndStats"`: workflow logic leaking into base component.
+- `variant="destructive"` — clear visual intent, reusable across surfaces.
+- `size="sm | md | lg"` — bounded scale, no hidden behavior.
+- `loading={true}` — generic state.
 
-## Required State Coverage
+Bad props leak product or workflow knowledge into a generic control:
 
-For each required state, define:
+- `isMembersPage` — the component shouldn't know which page it's on.
+- `layoutMode="toolbarWithFilterAndStats"` — that's a workflow shape, not a component variant.
 
-- visuals (semantic tokens)
-- interaction behavior
-- accessibility semantics
+When you see yourself reaching for the second kind, stop and ask: is this really a generic control, or is it a Feature wrapper trying to hide as a Button?
 
-Missing required states is a blocker.
+## State coverage in detail
 
-## Ownership Rules
+For each required state, the component should define three things:
 
-Choose `components` when the abstraction is a generic reusable control.
-Choose `patterns` when the abstraction encodes product workflow semantics.
+**Visuals**: which semantic tokens drive the appearance (background, border, text, ring).
 
-If a shared control starts accumulating workflow props, stop and extract a pattern wrapper.
+**Interaction behavior**: what happens when the user does the thing (clicks, types, presses Tab).
 
-## Review Checklist
+**Accessibility semantics**: ARIA roles, labels, focus management, keyboard support.
 
-Before merge:
+Missing required states is a blocker. We don't ship a Button without a focus ring and we don't ship a Dialog without escape-to-close.
 
-- [ ] Rules and guarantees are documented and match implementation.
-- [ ] Required states are implemented and visible in stories.
-- [ ] API remains product-agnostic.
-- [ ] Compatibility/deprecation notes are present for API changes.
+## Components vs. features: the dividing line
+
+The honest answer is: pick `components` when the abstraction is genuinely generic, and `features` when it encodes product workflow.
+
+The smell test: if the component name reads like English you'd use in any web app (Button, Input, Tabs), it's a component. If it reads like Ghost-specific jargon (KpiCardHeader, GhAreaChart, FilterBuilder), it's a feature.
+
+When a shared control starts collecting workflow-specific props, that's the signal to extract a Feature wrapper instead of growing the base API.
+
+## Review checklist
+
+Before merging a change to a shared component:
+
+- The rules and guarantees match the implementation.
+- Required states are implemented and visible in stories.
+- The API stays product-agnostic.
+- Compatibility / deprecation notes exist for any API changes.
+
+If any of those isn't true, the change isn't ready yet.
 
 </div>

--- a/apps/shade/src/docs/contributing.mdx
+++ b/apps/shade/src/docs/contributing.mdx
@@ -6,232 +6,189 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Contributing to Shade
 
-<p className="excerpt">This guide explains how to contribute to the Shade design system, including adding or modifying components and documentation.</p>
+<p className="excerpt">This is the practical guide for adding to or changing the design system: where files go, how to write stories, what stops you from accidentally breaking everything downstream.</p>
 
-## Quick Start (Humans and Agents)
+## Before you write any code
 
-Use this sequence before writing code:
+The first decision is always which layer your change belongs in. The [Architecture](?path=/docs/architecture--docs) page has the full breakdown, but the quick rule:
 
-1. Pick the right layer (`tokens`, `primitives`, `components`, `patterns`).
-2. Reuse existing APIs first.
-3. If no good fit exists, keep code local first.
-4. Add shared abstractions to Shade only after clear repetition.
-5. Add stories that prove intended usage and states.
+- Visual values (colors, sizes, durations) → **Tokens**
+- Layout structure → **Primitives**
+- Generic UI controls → **Components**
+- Shared visual rules used by several components → **Recipes** (alongside components, surfaced under Foundations)
+- Product-shaped compositions → **Features**
 
-If unsure between `components` and `patterns`:
+If you're not sure between Components and Features, the smell test is: does the thing's name sound like Ghost or like the open web? `KpiCardHeader` is Ghost-y, `Button` is web-y.
 
-- choose `components` for generic controls
-- choose `patterns` for product workflow composition
+The second decision is whether the change belongs in Shade at all. The default is to keep code local to your app first. Build it where you need it, ship it, and only consider promoting it to Shade once you find yourself building the same thing again somewhere else. Premature design system additions are expensive — once an abstraction has consumers, changing it gets harder fast.
 
-## Repository Layout
-
-```
-/apps/shade/
-  .storybook/                 # Storybook config
-  src/
-    components/
-      ui/                     # Base ShadCN/UI primitives
-      layout/                 # Composed, reusable layout components
-      features/               # Feature-specific, higher-level components
-    docs/                     # System docs rendered in Storybook
-```
-
-## Import From Layered Entrypoints
-
-For new code, import from a layer-specific Shade subpath instead of the root barrel:
-
-- `@tryghost/shade/tokens` (+ `@tryghost/shade/tokens.css` for CSS token consumption)
-- `@tryghost/shade/primitives`
-- `@tryghost/shade/components`
-- `@tryghost/shade/patterns`
-- `@tryghost/shade/app`
-- `@tryghost/shade/utils`
-
-Use the root `@tryghost/shade` entrypoint only for DS-layer compatibility (`tokens`/`primitives`/`components`/`patterns`).
-Do not import `utils` or `app` symbols from root.
-
-## Ownership and "Add to Shade" Rules
-
-- Put token names/helpers and CSS token definitions in `tokens`.
-- Put layout/structure-only abstractions in `primitives`.
-- Put reusable controls and visual assets in `components`.
-- Put reusable feature-level compositions/rules in `patterns`.
-- Put app shell/provider/context APIs in `app`.
-- Keep `utils` design-system-safe only (generic helpers/hooks + third-party namespaces).
-- Do not add new domain/product helpers to `utils`; place them in app-local code or transitional `app` exports.
-
-## Primitive Composition Guardrails
-
-- Prefer `Stack`, `Inline`, `Box`, `Container`, `Grid`, and `Text` over anonymous wrappers that only carry layout utility classes.
-- Layout-shell migration scope is limited to `apps/shade/src/components/layout/*`.
-- Keep existing `@tryghost/shade/primitives` consumers compatible during migration; do not remove legacy exports during compatibility windows.
-- Use semantic spacing props (`none | xs | sm | md | lg | xl | 2xl`) for primitive composition APIs.
-
-## Component Rules and Guarantees
-
-- Shared controls in `apps/shade/src/components/ui/*` must be product-agnostic.
-- Define explicit public API and state rules before expanding variants.
-- Required interactive states for shared controls: `default`, `hover`, `focus-visible`, `disabled`.
-- If behavior becomes workflow-specific, move it into a `patterns` wrapper instead of growing the base control API.
-
-## AI Agent Output Format
-
-When an AI agent proposes or changes a shared component, include:
-
-1. `Scope` (purpose + non-goals)
-2. `Public API` (props, slots, variants)
-3. `States` (`default`, `hover`, `focus-visible`, `disabled` at minimum)
-4. `Compatibility notes` (what changed, what remains stable)
-
-## Naming Conventions
-
-- **File names:** kebab-case, e.g. `dropdown-menu.tsx` (ShadCN-generated files keep kebab-case)
-  ```
-  dropdown-menu.tsx
-  dropdown-menu.stories.tsx
-  # optional extras below
-  dropdown-menu.mdx
-  dropdown-menu.meta.json
-  fixtures/dropdown-menu.fixtures.ts
-  ```
-- **Storybook titles:**
-  - UI primitives: `Components / <Name>` (e.g., `Components / Button`)
-  - Layout: `Layout / <Name>` (e.g., `Layout / Page`)
-  - Features: `Features / <Name>` (e.g., `Features / Post Share Modal`)
-- **Component folders:**
-  - ShadCN primitives under `/apps/shade/src/components/ui/`
-  - Composed layout components under `/apps/shade/src/components/layout/`
-  - Feature components under `/apps/shade/src/components/features/`
-
-## File Set Per Component
-
-Each documented component requires:
+## Repo layout
 
 ```
-/apps/shade/src/components/ui/button.tsx          # Component (source)
-/apps/shade/src/components/ui/button.stories.tsx  # Stories (CSF)
-/apps/shade/src/components/ui/button.mdx          # (optional) component docs (MDX)
-
-# Optional metadata & fixtures
-/apps/shade/src/components/ui/button.meta.json    # Machine-readable metadata
-/apps/shade/src/components/ui/fixtures/button.fixtures.ts
+apps/shade/
+├── .storybook/                Storybook config
+└── src/
+    ├── components/
+    │   ├── ui/                Generic controls + recipes
+    │   ├── layout/            Page shells (Page, ListHeader, etc.)
+    │   └── features/          Product compositions
+    └── docs/                  These MDX pages
 ```
 
-## Component Documentation in Storybook
+Entrypoint barrels live one level up: `components.ts`, `primitives.ts`, `patterns.ts`, etc. They re-export from the folders above.
 
-We document components through concise stories that show real use cases. Each story should have a one‑line description explaining when to use that variant/state. Prefer multiple focused stories over long prose.
+## Importing from Shade
 
-Required for every component:
-- A colocated `*.stories.tsx` using CSF with:
-  - `title` under the right section (Components / Layout / Features)
-  - `tags: ['autodocs']`
-  - An overview via `parameters.docs.description.component`
-  - Stories covering key variants and states with `parameters.docs.description.story`
+Use a layer-specific subpath, not the root barrel:
 
-Example:
+```ts
+// Good
+import {Button} from '@tryghost/shade/components';
+import {Stack} from '@tryghost/shade/primitives';
+import {createFilter} from '@tryghost/shade/patterns';
+import {cn} from '@tryghost/shade/utils';
+import {ShadeApp} from '@tryghost/shade/app';
+
+// Avoid (compatibility lane only)
+import {Button, Stack} from '@tryghost/shade';
+```
+
+The full migration story is on the [Root Imports Migration](?path=/docs/migration-root-imports--docs) page.
+
+Inside Shade itself, use the `@/` path alias for cross-file imports. Don't worry about the alias leaking into emitted `.d.ts` files — `tsc-alias` rewrites them to relative paths at build time so consumer apps resolve them correctly.
+
+## File names and Storybook titles
+
+File names are kebab-case (`dropdown-menu.tsx`), matching what the ShadCN CLI generates. Components are PascalCase (`DropdownMenu`), hooks and functions are camelCase.
+
+Each component file ships alongside its story:
+
+```
+button.tsx              The component
+button.stories.tsx      Stories (CSF format)
+button.mdx              Optional component-specific docs
+```
+
+Storybook titles follow the layer convention so the sidebar groups make sense:
+
+| Layer | Title prefix |
+| --- | --- |
+| Recipe / visual rule | `Foundations / X` |
+| Layout primitive | `Primitives / X` |
+| Generic control | `Components / X` |
+| Page shell | `Layout / X` |
+| Product composition | `Features / X` |
+
+## Writing stories
+
+Every documented component needs a `.stories.tsx` file with:
+
+- A `title` under the right sidebar group.
+- `tags: ['autodocs']` so Storybook generates the docs page.
+- An overview via `parameters.docs.description.component`.
+- A handful of focused stories that cover the key variants and states, each with a one-line `parameters.docs.description.story` explaining when to use that variant.
+
+A typical Button story:
 
 ```tsx
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {Button} from './button';
 
 const meta: Meta<typeof Button> = {
-  title: 'Components / Button',
-  component: Button,
-  tags: ['autodocs'],
-  parameters: {
-    docs: {
-      description: {
-        component: 'Reusable button for actions. Choose variant/size by context.'
-      }
+    title: 'Components / Button',
+    component: Button,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Reusable button for actions. Pick a variant and size based on context.'
+            }
+        }
     }
-  }
 };
 export default meta;
+
 type Story = StoryObj<typeof Button>;
 
 export const Default: Story = {
-  args: {children: 'Continue'},
-  parameters: {
-    docs: {description: {story: 'Primary call‑to‑action with default styling.'}}
-  }
+    args: {children: 'Continue'},
+    parameters: {docs: {description: {story: 'Primary call to action with default styling.'}}}
 };
 
 export const Destructive: Story = {
-  args: {variant: 'destructive', children: 'Delete'},
-  parameters: {
-    docs: {description: {story: 'Use for dangerous or irreversible actions.'}}
-  }
+    args: {variant: 'destructive', children: 'Delete'},
+    parameters: {docs: {description: {story: 'Use for dangerous or irreversible actions.'}}}
 };
 ```
 
-## Component Implementation
+The general pattern: prefer many small focused stories with a one-line "when to use" description over long prose. Storybook is a gallery, not a textbook.
 
-### Using ShadCN/UI
+## Implementing a component
 
-1. **Install Component**
-   ```bash
-   npx shadcn@latest add button
-   ```
+### Use ShadCN as a starting point
 
-2. **Customize Implementation**
+When the thing you're building maps onto a ShadCN primitive (Button, Dialog, Select, etc.), install it via the CLI:
 
-   > ⚠️ Always use the `cn` utility to combine classNames and `cva` for component variants. This ensures consistent class merging and variant handling across the design system.
+```bash
+npx shadcn@latest add button
+```
 
-   ```tsx
-   import { cn } from "@/lib/utils"
-   import { cva, type VariantProps } from "class-variance-authority"
+A few guardrails when running the CLI:
 
-   // Define variants using cva
-   const buttonVariants = cva(
-       // Base styles applied to all variants
-       "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors",
-       {
-           variants: {
-               variant: {
-                   solid: "bg-primary text-primary-foreground hover:bg-primary/90",
-                   outline: "border border-input bg-background hover:bg-accent",
-                   ghost: "hover:bg-accent hover:text-accent-foreground"
-               },
-               size: {
-                   sm: "h-9 px-3",
-                   md: "h-10 px-4",
-                   lg: "h-11 px-8"
-               }
-           },
-           defaultVariants: {
-               variant: "solid",
-               size: "md"
-           }
-       }
-   );
+- **Never overwrite existing Shade components.** When the prompt asks, choose "No" — we may have customizations the CLI doesn't know about.
+- **Run on a fresh branch.** It's much easier to review what the CLI did when the diff is clean.
+- **If the component already exists**, generate into a scratch repo and manually port the parts you actually want.
+- **After integrating**, run `pnpm lint`, `pnpm test`, and verify in Storybook.
 
-   // Extract variant props type
-   interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-       VariantProps<typeof buttonVariants> {}
+### Pattern for variants
 
-   // Use cn to combine variants with custom classes
-   export function Button({ className, variant, size, ...props }: ButtonProps) {
-       return (
-           <button
-               className={cn(buttonVariants({ variant, size }), className)}
-               {...props}
-           />
-       );
-   }
-   ```
+Use `cva()` for variants and `cn()` for class merging. They're not optional — they're the reason classes don't conflict in unexpected ways.
 
-   **Key Points:**
-   - Use `cn` to merge component variants with custom className props
-   - Define variants with `cva` for type-safe variant combinations
-   - Extract variant props using `VariantProps` type
-   - Always provide sensible default variants
-   - Include hover/focus states in variant definitions
+```tsx
+import {cn} from '@/lib/utils';
+import {cva, type VariantProps} from 'class-variance-authority';
 
-### Prefer Compound Subcomponents
+const buttonVariants = cva(
+    'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors',
+    {
+        variants: {
+            variant: {
+                solid: 'bg-primary text-primary-foreground hover:bg-primary/90',
+                outline: 'border border-input bg-background hover:bg-accent',
+                ghost: 'hover:bg-accent hover:text-accent-foreground'
+            },
+            size: {
+                sm: 'h-9 px-3',
+                md: 'h-10 px-4',
+                lg: 'h-11 px-8'
+            }
+        },
+        defaultVariants: {
+            variant: 'solid',
+            size: 'md'
+        }
+    }
+);
 
-When a component has multiple meaningful regions (title, meta, actions, etc.), prefer a compound subcomponents API over many props. This keeps the API composable and flexible.
+interface ButtonProps
+    extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+        VariantProps<typeof buttonVariants> {}
 
-Example (Header):
+export function Button({className, variant, size, ...props}: ButtonProps) {
+    return (
+        <button
+            className={cn(buttonVariants({variant, size}), className)}
+            {...props}
+        />
+    );
+}
+```
+
+Three things to notice: the base styles go in the first `cva` argument, variants in the object, defaults in `defaultVariants`. The component always merges its computed className with the consumer's via `cn()` so consumers can extend without wrapping.
+
+### Compound subcomponents over heavy props
+
+When a component has multiple meaningful regions (a title, a meta line, an actions row), prefer compound subcomponents over a forest of props. It keeps the API composable and the consumer code readable:
 
 ```tsx
 function Header(props) { /* ... */ }
@@ -244,87 +201,62 @@ Header.Meta = HeaderMeta;
 Header.Actions = HeaderActions;
 
 export {Header};
+```
 
-// Usage
+Used like:
+
+```tsx
 <Header>
-  <Header.Title>Members</Header.Title>
-  <Header.Meta>42,102 total</Header.Meta>
-  <Header.Actions><Button>New member</Button></Header.Actions>
-  {/* ... */}
+    <Header.Title>Members</Header.Title>
+    <Header.Meta>42,102 total</Header.Meta>
+    <Header.Actions>
+        <Button>New member</Button>
+    </Header.Actions>
 </Header>
 ```
 
-Tips:
-- Attach parts as static properties and export them as named exports for convenience.
-- Keep parts small and focused; forward and merge `className`.
-- Demonstrate parts usage in stories (e.g., “With actions”, “With meta”).
+Each part stays small, accepts and forwards `className`, and gets demonstrated in stories ("With actions", "With meta").
 
-### Creating Custom Components
+### Custom components without ShadCN
 
-1. **File Structure**
-   ```
-   # Layout component
-   src/components/layout/
-   ├── custom-component.tsx
-   ├── custom-component.stories.tsx
-   └── custom-component.mdx
+For things that don't have a ShadCN starting point, the structure is the same — just simpler:
 
-   # Feature component
-   src/components/features/
-   ├── custom-component.tsx
-   ├── custom-component.stories.tsx
-   └── custom-component.mdx
-   ```
+```tsx
+import {cn} from '@/lib/utils';
 
-2. **Implementation Pattern**
-   ```tsx
-   import { cn } from "@/lib/utils"
+interface CustomComponentProps {
+    className?: string;
+}
 
-   interface CustomComponentProps {
-       className?: string;
-   }
+export function CustomComponent({className, ...props}: CustomComponentProps) {
+    return (
+        <div className={cn('base-styles', className)} {...props} />
+    );
+}
+```
 
-   export function CustomComponent({ className }: CustomComponentProps) {
-       return (
-           <div className={cn("base-styles", className)}>
-               {/* Component content */}
-           </div>
-       );
-   }
-   ```
+## Acceptance checklist
 
-## Acceptance Checklist
+Before you mark a component done:
 
-For each component:
+- It does one thing well, and the API reflects that one thing.
+- Multi-region components use compound subcomponents.
+- The `.stories.tsx` covers the key variants and states.
+- Each story has a short "when to use" description.
+- Accessibility is considered: labels, focus management, disabled state, keyboard support.
+- `className` is forwarded.
 
-- [ ] Component follows design system principles
-- [ ] Prefer compound subcomponents for multi‑region components
-- [ ] `*.stories.tsx` includes: overview + key variants and states
-- [ ] Each story has a short “when to use” description
-- [ ] Accessibility is considered (labels, focus, disabled) and reflected in stories/args
-- [ ] Slots are listed in Anatomy and demonstrated
-- [ ] Accessibility items include keyboard, ARIA, and contrast
-- [ ] (Optional) `*.meta.json` present and valid
+## What to do when something feels wrong
 
-## ShadCN Installation Guardrails
+A few situations should make you stop and reconsider before pushing through:
 
-- Never overwrite existing Shade components during `npx shadcn@latest add <name>` prompts — choose “No”.
-- Work on a fresh branch before running the installer: `git checkout -b chore/shadcn-add-<name>`.
-- If a component already exists, generate into a scratch repo and manually diff; port only the desired changes.
-- After integrating, run `yarn lint`, `yarn test`, and verify in Storybook.
+- The shared component is starting to grow product-specific props. Extract a Feature wrapper instead.
+- The API is requiring three or four optional props to do anything useful. Split or simplify.
+- A primitive is sprouting business logic. Move that logic up.
+- You can't decide between `components` and `features`. The decision is probably real — ask before guessing.
 
-## Utilities
+## Repo conventions
 
-- Import utilities from `@/lib/utils`.
-- Always forward and merge `className` with `cn(...)` and prefer CVA for variants when useful.
-
-## Agents & Repo Conventions
-
-Refer to `AGENTS.md` at the repository root for additional, repo-specific guidance used by both humans and agents. It covers:
-- Project structure and module organization
-- Build, test, and development commands
-- Coding style, naming conventions, and Tailwind scoping
-- Adding new components and ShadCN guardrails
-- Testing expectations and commit/PR guidelines
+For broader conventions across the Ghost monorepo (build commands, test expectations, commit and PR style), see `AGENTS.md` in the repo root.
 
 </div>

--- a/apps/shade/src/docs/introduction.mdx
+++ b/apps/shade/src/docs/introduction.mdx
@@ -4,112 +4,83 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <div className="sb-doc">
 
-# Shade Design System
+# Welcome to Shade
 
-<p className="excerpt">Shade is Ghost's design system for product design. Built on ShadCN/UI and TailwindCSS, it provides a complete set of components and patterns for building consistent user experiences.</p>
+<p className="excerpt">Shade is the design system that powers Ghost's product surfaces. It exists so that engineers, designers, and AI agents can build admin UI quickly without reinventing the same components, spacing decisions, or color choices each time.</p>
 
-## Overview
+## What Shade gives you
 
-Shade is built on three powerful foundations:
-- [ShadCN/UI](https://ui.shadcn.com/) - Reusable components built with Radix UI
-- [TailwindCSS](https://tailwindcss.com/) - Utility-first CSS framework
-- [Radix UI](https://www.radix-ui.com/) - Accessible component primitives
+If you're shipping admin features, Shade gives you four things:
 
-### Scope & Reuse
+A **set of visual values** (color, type, spacing, radius, motion) that automatically work in light and dark mode.
 
-Shade contains reusable, system-wide components and patterns. Keep one-off, app-specific components in the consuming application rather than adding them to Shade.
+A **set of layout primitives** (`Stack`, `Inline`, `Box`, `Grid`, `Container`, `Text`) that replace the endless `flex flex-col gap-4` strings with something readable.
 
-### Target Audience
+A **library of generic UI controls** (Button, Input, Dialog, Tabs, and so on) built on Radix and ShadCN, accessible by default.
 
-- **Designers**: Understand our design language and component capabilities
-- **Engineers**: Find implementation details and integration examples
-- **AI Agents**: Access machine-readable metadata for automation
+A **smaller set of product-shaped compositions** for things Ghost does over and over — KPI cards, filter builders, the area chart on Stats — where the generic controls aren't enough.
 
-### Core Surfaces
+The line between those four layers is the most important thing to understand about Shade. We cover it in detail on the [Architecture](?path=/docs/architecture--docs) page, including a glossary of terms.
 
-Shade components are used across:
-- Admin interfaces
-- Settings panels
-- Portal experiences
-- Email templates
-- Documentation sites
+## Who it's for
 
-## Getting Started
+**Designers** working in code use Shade to compose screens fast. The primitives and components do the heavy lifting; you focus on the structure and content of the surface you're designing.
 
-### Installation
+**Engineers** use it as a reliable substrate. If a control already exists in Shade, use it — it's accessible, themed, and tested. If it doesn't, the design system tells you which layer to build into.
 
-```bash
-# Install Shade
-yarn add @tryghost/shade
+**AI agents** generating UI code use Shade as a constraint. The layer rules and the typed component APIs let the agent pick the right tool without inventing components or making up tokens.
 
-# Install peer dependencies
-yarn add react react-dom tailwindcss
-```
+## Getting set up
 
-> Note: The package is currently private and primarily consumed internally in the monorepo. The snippet above reflects usage once published.
-
-### Basic Usage
+Shade lives in the Ghost monorepo (`apps/shade`) and is consumed by the React admin apps via `@tryghost/shade/*` entrypoints. There's nothing to install separately — just import:
 
 ```tsx
 import {Button} from '@tryghost/shade/components';
 
 function MyComponent() {
-    return (
-        <Button variant="solid">
-            Continue
-        </Button>
-    );
+    return <Button>Continue</Button>;
 }
 ```
 
-### Configure Styles (CSS-first)
-
-Import Shade's styles in your app entry CSS:
+To pick up Shade's CSS in your app, import its stylesheet once at your entry point:
 
 ```css
 @import "@tryghost/shade/styles.css";
 ```
 
-For Tailwind v4 utility generation, scan both your app files and Shade component usage paths with `@source`.
+If you're using Tailwind v4, add Shade's source paths to your `@source` directives so utility generation picks up classes used inside Shade components.
 
-### Scope Styles & Dark Mode
+## Light and dark mode
 
-Shade scopes all styles to a `.shade` container and toggles dark mode with a `.dark` class inside that scope.
-
-Use `ShadeApp` to handle scoping and provide context:
+Every Shade component is themed. To toggle modes, wrap your tree in `ShadeApp`:
 
 ```tsx
 import {ShadeApp} from '@tryghost/shade/app';
 import {Button} from '@tryghost/shade/components';
 
 export default function App() {
-    // Toggle dark mode by switching the `darkMode` prop
     return (
         <ShadeApp darkMode={false}>
-            <div>
-                <Button>Continue</Button>
-            </div>
+            <Button>Continue</Button>
         </ShadeApp>
     );
 }
 ```
 
-Alternatively, wrap your UI in a div with `className="shade"` and toggle a nested `.dark` class when needed.
+`ShadeApp` adds a `.shade` scope to your tree and toggles a `.dark` class inside it. If you'd rather not use the wrapper, you can apply those two classes manually — the components will respond.
 
-## Documentation Structure
+## Where to go next
 
-Our documentation is organized into:
+If you're new here, read the [Architecture](?path=/docs/architecture--docs) page next. It explains the layers (tokens, primitives, components, recipes, features) with a glossary so the vocabulary makes sense, and a short decision rule for choosing where new code belongs.
 
-1. **Components** - Individual UI elements with variants and usage
-2. **Patterns** - Common UI patterns and compositions
-3. **Tokens** - Design tokens via TailwindCSS
-4. **Guidelines** - Best practices and standards
+If you already know your way around and just want to ship, browse:
 
-## Resources
+- **Foundations** — visual recipes like `inputSurface` that shape every form control's chrome.
+- **Primitives** — `Stack`, `Inline`, `Box`, `Grid`, `Container`, `Text`. The structural vocabulary.
+- **Components** — generic controls (Button, Input, Dialog, etc.).
+- **Layout** — page shells (Page, ListHeader, ViewHeader).
+- **Features** — product compositions (KPI cards, charts, filters).
 
-- [GitHub Repository](https://github.com/TryGhost/Ghost)
-- [ShadCN/UI Documentation](https://ui.shadcn.com)
-- [TailwindCSS Documentation](https://tailwindcss.com/docs)
-- [Radix UI Documentation](https://www.radix-ui.com/docs/primitives)
+Each section's pages have a description, props, and live examples.
 
 </div>

--- a/apps/shade/src/docs/primitives-guide.mdx
+++ b/apps/shade/src/docs/primitives-guide.mdx
@@ -4,39 +4,48 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <div className="sb-doc">
 
-# Primitives Guide
+# Working with primitives
 
-<p className="excerpt">Use primitives to make layout intent explicit. This page explains when to use each primitive, which props matter, and how to migrate from raw layout classes.</p>
+<p className="excerpt">Primitives are how Shade replaces the endless string of `flex flex-col gap-4 items-start` utilities with something a human can read and an AI agent can generate consistently. This page is a practical guide to the six primitives, their props, and how to migrate existing layouts.</p>
 
-## Why Primitives
+## Why primitives exist
 
-Primitives solve a simple problem: repeated `flex/grid/gap` class strings hide intent.
+Most layout code in any React codebase looks the same: a `<div>` with five Tailwind layout utilities. After a while it becomes invisible. Reviewers stop reading those classes; agents glue together their own variants of "vertical stack with medium gap"; small spacing inconsistencies accumulate across the product.
 
-Use primitives so that:
+Primitives solve that by giving the structural concepts names. Instead of inferring "this is a vertical stack" from `flex flex-col gap-4`, you write `<Stack gap="md">` and the intent is right there.
 
-- humans can read structure quickly
-- AI agents can generate consistent layout trees
-- spacing/alignment decisions stay explicit
+The benefits are practical:
 
-## Primitive Selection
+- A reviewer skimming a screen can tell in one second what its structure is.
+- An AI agent generating UI doesn't have to re-derive flex syntax every time.
+- Spacing decisions become semantic (`gap="lg"`) rather than numeric (`gap-6`), so we can tune the spacing scale without touching every component.
 
-- `Stack`: vertical grouping and vertical spacing
-- `Inline`: horizontal grouping, action rows, wrapped inline controls
-- `Box`: padding and radius framing without layout semantics
-- `Container`: width constraints and horizontal page padding
-- `Grid`: two-dimensional column layout
-- `Text`: semantic text element + typography rules
+## The six primitives
 
-Fast rule:
+You only need to remember six. They cover essentially every layout situation that doesn't involve writing a custom component.
 
-- vertical composition -> `Stack`
-- horizontal composition -> `Inline`
-- framed region -> `Box`
-- max width shell -> `Container`
-- columns/cards -> `Grid`
-- copy/headings/labels -> `Text`
+**`Stack`** is for vertical groupings. Use it whenever you have a column of children that need consistent spacing between them.
 
-## Prop Reference
+**`Inline`** is for horizontal groupings — toolbars, action rows, sequences of inline controls.
+
+**`Box`** is a framing primitive. Use it when you want padding or radius without imposing a layout direction.
+
+**`Container`** constrains width — for page shells where content shouldn't span the full viewport.
+
+**`Grid`** is for actual two-dimensional grids: card grids, multi-column lists.
+
+**`Text`** is the typographic primitive. Use it for paragraphs, headings, labels, captions — anything that's "rendered text".
+
+The fast version of when to reach for each:
+
+- Vertical composition? `Stack`.
+- Horizontal composition? `Inline`.
+- A framed region? `Box`.
+- A page shell with a max width? `Container`.
+- Cards or columns? `Grid`.
+- Words on the screen? `Text`.
+
+## Props at a glance
 
 ### Stack
 
@@ -51,10 +60,10 @@ Fast rule:
 | Prop | Type | Default | Purpose |
 | --- | --- | --- | --- |
 | `as` | `div|header|section|footer|nav|span` | `div` | Render element |
-| `gap` | `none|xs|sm|md|lg|xl|2xl` | `md` | Horizontal spacing |
+| `gap` | `none|xs|sm|md|lg|xl|2xl` | `md` | Horizontal spacing between children |
 | `align` | `start|center|end|stretch|baseline` | `center` | Cross-axis alignment |
 | `justify` | `start|center|end|between|around|evenly` | `start` | Main-axis distribution |
-| `wrap` | `boolean` | `false` | Wrap items to multiple rows |
+| `wrap` | `boolean` | `false` | Wrap children to multiple rows |
 
 ### Box
 
@@ -91,11 +100,11 @@ Fast rule:
 | `weight` | `regular|medium|semibold|bold` | `regular` | Font weight |
 | `tone` | `primary|secondary|tertiary|inverse` | `primary` | Text tone token |
 | `leading` | `none|snug|normal|relaxed|tight|tighter|supertight|body|heading` | `body` | Line-height token |
-| `truncate` | `boolean` | `false` | Single-line truncation |
+| `truncate` | `boolean` | `false` | Single-line truncation with ellipsis |
 
-## Composition Examples
+## Putting them together
 
-### Page Shell
+A typical page shell, all primitives:
 
 ```tsx
 import {Button} from '@tryghost/shade/components';
@@ -109,18 +118,17 @@ import {Container, Inline, Stack, Text} from '@tryghost/shade/primitives';
         </Inline>
 
         <Stack gap="md">
-            <Text tone="secondary">Core content goes here.</Text>
+            <Text tone="secondary">Manage your audience.</Text>
         </Stack>
     </Stack>
 </Container>
 ```
 
-### Header Shell
+Read that out loud and it tells you what's there: a page-width container; vertically stacked content; the top row is a horizontal inline split with the title on the left and the action button on the right; the body below is another vertical stack of text.
+
+A header with actions and a count:
 
 ```tsx
-import {Button} from '@tryghost/shade/components';
-import {Inline, Stack, Text} from '@tryghost/shade/primitives';
-
 <Stack gap="sm">
     <Text as="h2" size="xl" weight="semibold" leading="heading">Posts</Text>
     <Inline justify="between" align="center" wrap>
@@ -133,11 +141,9 @@ import {Inline, Stack, Text} from '@tryghost/shade/primitives';
 </Stack>
 ```
 
-### List Shell
+A list of framed rows:
 
 ```tsx
-import {Box, Grid, Stack, Text} from '@tryghost/shade/primitives';
-
 <Stack gap="sm">
     <Text as="h3" size="lg" weight="semibold">Drafts</Text>
     <Grid columns={1} gap="sm">
@@ -151,9 +157,9 @@ import {Box, Grid, Stack, Text} from '@tryghost/shade/primitives';
 </Stack>
 ```
 
-## Migration Examples
+## Migrating existing layouts
 
-### Before -> After: Vertical Layout
+The migration is mechanical, and almost always shorter:
 
 ```tsx
 // Before
@@ -175,7 +181,7 @@ import {Box, Grid, Stack, Text} from '@tryghost/shade/primitives';
 </Stack>
 ```
 
-### Before -> After: Framed Grid
+Or for a card grid:
 
 ```tsx
 // Before
@@ -193,10 +199,14 @@ import {Box, Grid, Stack, Text} from '@tryghost/shade/primitives';
 </Grid>
 ```
 
-## Practical Guardrails
+## Things to avoid
 
-- Do not add anonymous wrappers that only carry `flex/grid/gap` utilities.
-- Prefer semantic spacing (`sm`, `md`, `lg`) over ad-hoc spacing choices.
-- Keep primitives layout-focused; do not put product workflow logic in primitives.
+Don't add anonymous `<div>` wrappers that only carry `flex/grid/gap` utilities. If you need that structure, reach for a primitive instead.
+
+Don't use raw spacing numbers (`gap-6`, `p-3`) in primitive APIs. Use the semantic scale (`gap="lg"`, `padding="sm"`) — it's what the spacing tokens are for.
+
+Don't put product workflow logic inside a primitive. Primitives are layout vocabulary; if a component is starting to know about Ghost-specific data, it belongs in a Feature, not a primitive.
+
+Don't reach for `Box` when `Stack` or `Inline` would do. `Box` is the right tool when you genuinely don't want a layout direction — just framing.
 
 </div>

--- a/apps/shade/src/docs/tokens.mdx
+++ b/apps/shade/src/docs/tokens.mdx
@@ -4,222 +4,138 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <div className="sb-doc">
 
-# Design Tokens
+# Design tokens
 
-<p className="excerpt">Shade's design tokens are implemented through CSS-first Tailwind v4 tokens (`@theme` + CSS variables). This document outlines our token system and how to use it effectively.</p>
+<p className="excerpt">Tokens are the smallest unit of the design system — a color, a size, a duration. Every other layer (primitives, components, features) ultimately resolves down to tokens. This page explains how they're defined, which families exist, and how to consume them.</p>
 
-## Color System
+## What a token is
 
-### Base Colors
+In Shade, a token is a CSS custom property exposed through Tailwind v4's `@theme` block. So `bg-background`, `text-foreground`, and `rounded-md` are all backed by tokens that flip automatically when dark mode is on.
 
-Our color system includes semantic colors and a comprehensive neutral palette:
+There are two kinds of token in practice:
 
-```css
-@theme {
-    // Base colors
-    --color-transparent: transparent;
-    --color-current: currentColor;
-    --color-ghostaccent: var(--accent-color, #ff0095);
-    --color-white: #FFF;
-    --color-black: #15171A;
+**Raw tokens** are concrete values — `--color-gray-500`, `--text-base`, `--spacing`. They never change between modes; they just exist.
 
-    // Gray scale (note: we use 'gray', not 'grey')
-    --color-gray-50: #FAFAFB;
-    --color-gray-100: #F4F5F6;
-    // ... more shades
-    --color-gray-900: #394047;
-    --color-gray: #ABB4BE;
+**Semantic tokens** are named by purpose, not value. `--background`, `--foreground`, `--border-default`, `--surface-elevated`. They reference raw tokens (or specific values) and they're allowed to flip between light and dark mode. **You should almost always reach for the semantic token, not the raw one.** That way the same component renders correctly in both modes without any work from you.
 
-    // Brand colors
-    --color-green-100: #E1F9E4;
-    --color-green-400: #58DA67;
-    --color-green-500: #30CF43;
-    --color-green-600: #2AB23A;
-    --color-green: #30CF43;
-    // ... more colors
-}
-```
+## Where they're defined
 
-> ⚠️ Note: While both `grey` and `gray` token aliases exist for legacy compatibility, use `gray` for new components following TailwindCSS conventions.
+Two files do the heavy lifting:
 
-### Semantic Tokens
+**`theme-variables.css`** holds the runtime values for every semantic token, including the dark-mode overrides. This is where `--background` becomes `hsl(0 0% 100%)` in light and `hsl(216 11% 9%)` in dark.
 
-Theme-aware colors using CSS variables:
+**`tailwind.theme.css`** is the Tailwind `@theme` block. It exposes both the raw token catalogue (the gray scale, the brand colors, the type ramp, the spacing unit) and the bindings that make `bg-background` resolve to `var(--background)`.
 
-```css
-@theme {
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --color-primary: var(--primary);
-    --color-primary-foreground: var(--primary-foreground);
-    // ... more semantic colors
-}
-```
+If you want to know what a Tailwind class is actually doing, search `tailwind.theme.css` first.
 
-### Semantic Contract
+## Color
 
-The semantic visual rules and guarantees are defined in:
+Shade uses a small semantic palette layered on top of a larger raw palette.
 
-- `theme-variables.css` (runtime values + dark mode overrides)
-- `tailwind.theme.css` (Tailwind aliases)
+### Semantic color families
 
-Current semantic families:
+Color tokens are grouped by what they're for, not by their RGB value. The current families are:
 
-- Surface: `surface-page`, `surface-panel`, `surface-elevated`, `surface-overlay`, `surface-inverse`
-- Text: `text-primary`, `text-secondary`, `text-tertiary`, `text-inverse`
-- Border/focus: `border-subtle`, `border-default`, `border-strong`, `focus-ring`
-- State: `state-info`, `state-success`, `state-warning`, `state-danger`
+- **Surface** — `surface-page`, `surface-panel`, `surface-elevated`, `surface-overlay`, `surface-inverse`. Backgrounds with intent: "the page itself", "a card sitting on the page", "a popover floating above everything".
+- **Text** — `text-primary`, `text-secondary`, `text-tertiary`, `text-inverse`. Use these instead of the foreground variants when you want explicit hierarchy.
+- **Border / focus** — `border-subtle`, `border-default`, `border-strong`, `focus-ring`. Three weights of border plus the focus ring color.
+- **State** — `state-info`, `state-success`, `state-warning`, `state-danger`. Plus matching `-foreground` variants for text on those backgrounds.
 
-Semantic typography/radius/motion families:
+Every one of these flips between light and dark mode. You don't have to do anything for that to work.
 
-- Typography: `font-body`, `font-heading`, `font-code`, `text-body-{sm|md|lg}`, `leading-{body|heading}`
-- Sizing: `--control-height` (shared medium control height, currently `34px`)
-- Radius: `radius-control`, `radius-surface`, `radius-badge`, `radius-pill`
-- Motion: `duration-{fast|base|slow}`, `ease-{standard|emphasized}`
+### Raw color palette
+
+If you genuinely need a specific shade rather than a semantic token, the raw palette is also available — `gray-50` through `gray-900`, the brand greens, plus chart colors (`--chart-1` through `--chart-5` and named accents like `--chart-purple`, `--chart-rose`).
+
+A note on spelling: both `grey` and `gray` work as token aliases for legacy reasons, but `gray` is the convention going forward — it matches Tailwind.
+
+### Picking the right color
+
+The default move is the semantic token: `bg-background`, `text-foreground`, `border-border-default`. Reach for raw colors when the semantic vocabulary doesn't fit (chart series, brand logos, illustrations).
+
+What you should not do is hardcode hex or `hsl()` values, even temporarily. They don't theme, they don't dark-mode, and they don't show up in design audits.
 
 ## Typography
 
-### Font Families
+### Font families
 
-```css
-@theme {
-    --font-sans: Inter, -apple-system, ...;  /* Default UI font */
-    --font-serif: Georgia, serif;            /* Editorial content */
-    --font-mono: Consolas, ...;              /* Code */
-    // Additional web fonts available
-}
-```
+Three faces are available via `--font-sans` (Inter, the default UI face), `--font-serif` (Georgia, for editorial content), and `--font-mono` (Consolas, for code).
 
-### Font Sizes
+### Font sizes
 
-A comprehensive scale from 2xs to 9xl:
+The type ramp runs from `--text-2xs` (1.0rem) up to `--text-9xl` (12.8rem). Use the semantic `text-base` for body copy. Larger sizes have line-height variables baked in (`--text-9xl--line-height: 1`) so headlines don't get awkward leading.
 
-```css
-@theme {
-    --text-2xs: 1.0rem;
-    --text-base: 1.4rem;
-    --text-xs: 1.2rem;
-    // ... more sizes
-    --text-9xl: 12.8rem;
-    --text-9xl--line-height: 1;
-}
-```
+### Line height
 
-### Line Heights
-
-```css
-@theme {
-    --leading-base: 1.5em;
-    --leading-tight: 1.35em;
-    --leading-tighter: 1.25em;
-    --leading-supertight: 1.1em;
-}
-```
+`--leading-base` (1.5em) is the default. `--leading-tight`, `--leading-tighter`, `--leading-supertight` exist for headings and dense type.
 
 ## Spacing
 
-Our spacing system uses a 0.4rem (4px) base unit:
+Shade's spacing scale is built on a 4px base (`--spacing: 0.4rem`). Tailwind utilities like `p-4`, `gap-2`, `mt-3` derive from that base — `p-4` is `4 × 0.4rem = 1.6rem`.
+
+For primitives (`Stack`, `Inline`, `Box`), use the semantic spacing scale instead of the raw Tailwind numbers: `gap="md"` rather than `gap-4`. The named values map onto the same underlying base unit but make intent readable: "a medium gap" instead of "the number four".
+
+The semantic scale: `none | xs | sm | md | lg | xl | 2xl`.
+
+## Sizing
+
+A few size tokens exist for shared dimensions:
+
+- `--control-height` (currently `34px`) — the height of a medium form control. Used by Input, Select trigger, the "medium" Button size, etc.
+
+If you need a control to match the others vertically, reach for this token rather than re-deriving it.
+
+## Radius
+
+Border radius has both a numeric scale (`--radius`, `--radius-sm`, `--radius-md`, `--radius-lg`) and semantic aliases (`radius-control` for form controls, `radius-surface` for cards, `radius-badge` for pills, `radius-pill` for fully rounded).
+
+Prefer the semantic version when it fits — it'll keep visual rhythm consistent if we ever shift the radius vocabulary.
+
+## Motion
+
+`--duration-fast`, `--duration-base`, `--duration-slow` for timing. `--ease-standard` and `--ease-emphasized` for curves. There's also a set of pre-built named animations (`--animate-fade-in`, `--animate-toaster-in`, etc.) for common interactions.
+
+## Shadows and breakpoints
+
+Standard shadows live on `--shadow`, `--shadow-xs`, `--shadow-sm`, `--shadow-md`, `--shadow-lg`. Breakpoints are defined as `--breakpoint-sm` through `--breakpoint-xxxl`, plus a few specials (`--breakpoint-sidebar`, `--breakpoint-sidebarlg`, `--breakpoint-tablet`).
+
+## How to consume tokens
+
+Most of the time, you consume tokens through Tailwind utility classes:
+
+```tsx
+// Good — semantic, themed
+<div className="bg-background text-foreground border-border-default rounded-md">
+    Hello
+</div>
+
+// Bad — hardcoded, breaks in dark mode
+<div style={{background: '#fff', color: '#000', border: '1px solid #eee'}}>
+    Hello
+</div>
+```
+
+Inside a stylesheet (rare in Shade, but it happens), use the CSS variables directly:
 
 ```css
-@theme {
-    --spacing: 0.4rem; /* Base unit */
-    // Utilities are derived as calc(var(--spacing) * n)
+.something {
+    background: var(--surface-elevated);
+    color: var(--surface-elevated-foreground);
 }
 ```
 
-## Breakpoints
+Don't double-wrap variables in `hsl()` — they already contain `hsl(...)`. Writing `hsl(var(--background))` produces nonsense.
 
-```css
-@theme {
-    --breakpoint-sm: 480px;
-    --breakpoint-md: 640px;
-    --breakpoint-sidebar: 800px;
-    --breakpoint-lg: 1024px;
-    --breakpoint-sidebarlg: 1240px;
-    --breakpoint-xl: 1320px;
-    --breakpoint-xxl: 1440px;
-    --breakpoint-xxxl: 1600px;
-    --breakpoint-tablet: 860px;
-}
-```
+## Dark mode
 
-## Shadows
+Dark mode is handled by toggling a `.dark` class on a Shade-scoped ancestor (`ShadeApp` does this for you). The CSS custom variant in `theme-variables.css` flips every semantic token under that class, so `bg-background`, `text-foreground`, etc. all switch automatically.
 
-```css
-@theme {
-    --shadow: 0 0 1px rgba(0,0,0,.05), 0 5px 18px rgba(0,0,0,.08);
-    --shadow-xs: 0 0 1px rgba(0,0,0,0.04), ...;
-    // ... more shadow values
-}
-```
+You don't write `dark:` variants in component code. The tokens do that work.
 
-## Border Radius
+The exception is when a component genuinely needs a different layout or asset between modes (a logo, a custom illustration). For those rare cases, `dark:` Tailwind variants are fine. But for color and surface decisions, stick to semantic tokens and let them flip.
 
-```css
-@theme {
-    --radius: 0.4rem;
-    --radius-sm: 0.4rem;
-    --radius-md: 0.6rem;
-    --radius-lg: 0.8rem;
-    // ... more radius values
-}
-```
+## Reset
 
-## Animations
-
-Pre-defined animations for common interactions:
-
-```css
-@theme {
-    --animate-toaster-in: toasterIn 0.8s cubic-bezier(...);
-    --animate-fade-in: fadeIn 0.15s ease forwards;
-    // ... more animations
-}
-```
-
-## Usage Guidelines
-
-### Best Practices
-
-1. **Use Semantic Tokens**
-   ```js
-   // ✅ Good
-   className="bg-background text-foreground"
-
-   // ❌ Avoid
-   className="bg-white text-black"
-   ```
-
-2. **Spacing Consistency**
-   ```js
-   // ✅ Good
-   className="p-4 gap-2"
-
-   // ❌ Avoid
-   style={{padding: '16px', gap: '8px'}}
-   ```
-
-3. **Typography Scale**
-   ```js
-   // ✅ Good
-   className="text-2xl font-sans"
-
-   // ❌ Avoid
-   style={{fontSize: '22px'}}
-   ```
-
-### Dark Mode
-
-Dark mode uses a CSS custom variant:
-```css
-@custom-variant dark (&:is(.dark *):not(.light *));
-```
-
-### CSS Reset
-
-Shade uses a scoped CSS reset:
-```css
-@import "./preflight.css"; /* Custom scoped reset provided */
-```
+Shade ships its own scoped CSS reset (`preflight.css`) so it doesn't fight whatever reset the rest of the app might use. You don't need to do anything to get it — it's imported by `styles.css`.
 
 </div>


### PR DESCRIPTION
## Summary

Rewrites the Shade Storybook documentation pages so they read like prose written by a human, not bullet points generated by a machine. Adds a proper **Terms** section to the Architecture page that defines the words we throw around (tokens, primitives, components, recipes, layouts, features, app).

ref https://linear.app/tryghost/issue/DES-1343

## What changed

Six docs rewritten:

- **introduction.mdx** — Welcome page. What Shade is, who it's for, getting set up.
- **architecture.mdx** — How the layered system works. **New Terms section** defining each layer with examples. Includes the file-system-vs-entrypoint mismatch (`features/` on disk vs `@tryghost/shade/patterns`) that's been a quiet source of confusion.
- **tokens.mdx** — What tokens are, how they're defined, how to consume them.
- **primitives-guide.mdx** — Why primitives exist, when to reach for each, prop reference, migration examples.
- **component-contracts.mdx** — What you can rely on from a Shade component (rules and guarantees).
- **contributing.mdx** — Practical guide for adding to or changing Shade.

One doc left alone:

- **migration-root-imports.mdx** — Already a tight reference table; that's the right format for it.

## Why

The previous docs read as defensive, robotic, and bullet-heavy. Workable as machine-readable reference, frustrating to learn from. Storybook is meant to be the source of truth for the design system, and humans need it as much as agents do.

The rewrites:

- **Lead with prose**, weave examples into the text instead of dropping them after definitions.
- **Use a POV voice** ("you", "we") so it reads like a colleague explaining the system.
- **Keep bullet lists** for genuinely list-like content (prop tables, the migration table, acceptance checklists). Drop them when they're just a list of sentences.
- **Don't lose context** — every rule, prop reference, and example from the old docs is preserved, just in a more readable shape.

Still useful for AI agents: the Terms section is now an explicit glossary an agent can ground its choices in, and the layer rules are stated plainly enough that "which layer does this belong in" has an answerable rule.