### PR TITLE
Bumped moment override to 2.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "@tryghost/errors": "^1.3.7",
       "@tryghost/logging": "4.1.0",
       "jackspeak": "2.3.6",
-      "moment": "2.24.0",
+      "moment": "2.30.1",
       "moment-timezone": "0.5.45",
       "nwsapi": "2.2.23",
       "broccoli-persistent-filter": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   '@tryghost/errors': ^1.3.7
   '@tryghost/logging': 4.1.0
   jackspeak: 2.3.6
-  moment: 2.24.0
+  moment: 2.30.1
   moment-timezone: 0.5.45
   nwsapi: 2.2.23
   broccoli-persistent-filter: ^2.3.1
@@ -857,8 +857,8 @@ importers:
         specifier: 28.1.0
         version: 28.1.0(@noble/hashes@1.8.0)
       moment:
-        specifier: 2.24.0
-        version: 2.24.0
+        specifier: 2.30.1
+        version: 2.30.1
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -969,8 +969,8 @@ importers:
         specifier: 7.14.0
         version: 7.14.0
       moment:
-        specifier: 2.24.0
-        version: 2.24.0
+        specifier: 2.30.1
+        version: 2.30.1
       moment-timezone:
         specifier: 0.5.45
         version: 0.5.45
@@ -1453,8 +1453,8 @@ importers:
         specifier: 7.14.0
         version: 7.14.0
       moment:
-        specifier: 2.24.0
-        version: 2.24.0
+        specifier: 2.30.1
+        version: 2.30.1
       moment-timezone:
         specifier: 0.5.45
         version: 0.5.45
@@ -1840,7 +1840,7 @@ importers:
         version: 4.2.0(@babel/core@7.29.0)(ember-source@3.24.0(@babel/core@7.29.0))
       ember-moment:
         specifier: 10.0.1
-        version: 10.0.1(moment-timezone@0.5.45)(moment@2.24.0)
+        version: 10.0.1(moment-timezone@0.5.45)(moment@2.30.1)
       ember-one-way-select:
         specifier: 4.0.1
         version: 4.0.1
@@ -2376,8 +2376,8 @@ importers:
         specifier: 2.5.3
         version: 2.5.3
       moment:
-        specifier: 2.24.0
-        version: 2.24.0
+        specifier: 2.30.1
+        version: 2.30.1
       moment-timezone:
         specifier: 0.5.45
         version: 0.5.45
@@ -13077,7 +13077,7 @@ packages:
   ember-moment@10.0.1:
     resolution: {integrity: sha512-Es5PaFBRF6djyb0zwmcCMqWjLhyKrCWs5Ug6iaZoKxDgEc8incVCTv3ED2Z4oCcNDY2gKTqXY5VTsP1J9hUPcg==}
     peerDependencies:
-      moment: 2.24.0
+      moment: 2.30.1
       moment-timezone: 0.5.45
     peerDependenciesMeta:
       moment:
@@ -17231,8 +17231,8 @@ packages:
   moment-timezone@0.5.45:
     resolution: {integrity: sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==}
 
-  moment@2.24.0:
-    resolution: {integrity: sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==}
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   moo@0.5.3:
     resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
@@ -30117,7 +30117,7 @@ snapshots:
     dependencies:
       cheerio: 0.22.0
       lodash: 4.18.1
-      moment: 2.24.0
+      moment: 2.30.1
       moment-timezone: 0.5.45
       remark: 11.0.2
       remark-footnotes: 1.0.0
@@ -30127,7 +30127,7 @@ snapshots:
     dependencies:
       cheerio: 1.2.0
       lodash: 4.18.1
-      moment: 2.24.0
+      moment: 2.30.1
       moment-timezone: 0.5.45
       remark: 11.0.2
       remark-footnotes: 1.0.0
@@ -33491,7 +33491,7 @@ snapshots:
   bunyan@1.8.15:
     optionalDependencies:
       dtrace-provider: 0.8.8
-      moment: 2.24.0
+      moment: 2.30.1
       mv: 2.1.1
       safe-json-stringify: 1.2.0
 
@@ -33790,7 +33790,7 @@ snapshots:
   chart.js@2.9.4:
     dependencies:
       chartjs-color: 2.4.1
-      moment: 2.24.0
+      moment: 2.30.1
 
   chartjs-color-string@0.6.0:
     dependencies:
@@ -36441,11 +36441,11 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-moment@10.0.1(moment-timezone@0.5.45)(moment@2.24.0):
+  ember-moment@10.0.1(moment-timezone@0.5.45)(moment@2.30.1):
     dependencies:
       '@embroider/addon-shim': 1.10.2
     optionalDependencies:
-      moment: 2.24.0
+      moment: 2.30.1
       moment-timezone: 0.5.45
     transitivePeerDependencies:
       - supports-color
@@ -38471,7 +38471,7 @@ snapshots:
 
   ghost-storage-base@1.1.2:
     dependencies:
-      moment: 2.24.0
+      moment: 2.30.1
 
   git-hooks-list@1.0.3: {}
 
@@ -40756,7 +40756,7 @@ snapshots:
       debug: 4.4.1
       knex: 2.4.2(mysql2@3.14.1)(sqlite3@5.1.7)
       lodash: 4.18.1
-      moment: 2.24.0
+      moment: 2.30.1
       mysql2: 3.14.1
       nconf: 0.12.1
       resolve: 1.22.8
@@ -42114,9 +42114,9 @@ snapshots:
 
   moment-timezone@0.5.45:
     dependencies:
-      moment: 2.24.0
+      moment: 2.30.1
 
-  moment@2.24.0: {}
+  moment@2.30.1: {}
 
   moo@0.5.3: {}
 
@@ -42464,7 +42464,7 @@ snapshots:
   node-loggly-bulk@3.0.1:
     dependencies:
       json-stringify-safe: 5.0.1
-      moment: 2.24.0
+      moment: 2.30.1
       request: 2.88.2
 
   node-machine-id@1.1.12: {}


### PR DESCRIPTION
## Why

The existing root override pinned `moment` at `2.24.0`, which is itself flagged by two high-severity advisories — path traversal in `moment.locale` (GHSA-8hfj-j24r-96c4, fixed in 2.29.2) and ReDoS (GHSA-wc69-rhjr-hc9g, fixed in 2.29.4). The override was therefore actively masking a regression we'd already accepted.

`2.30.1` matches what `apps/comments-ui` already declares as a direct dep; pinning the override there means one of our public-app callers gets the version it asked for instead of being force-downgraded. ghost/core (~110 import sites) and ghost/admin (~7 import sites) both remain on the same 2.x API surface, so call-site behavior is unchanged.

## Test plan

- [x] `pnpm install` — lockfile updates cleanly
- [x] `pnpm audit` — 61 → 59 findings, 49 → 47 unique GHSAs; both moment advisories cleared
- [x] `pnpm test` — 6283/6283 ghost/core unit tests pass (one pre-existing comments-ui editor markdown flake reproduces on clean main, unrelated)
- [x] `pnpm --filter ghost-admin run build` — exit 0
- [x] `pnpm --filter ghost-admin run test` — 1079/1079 Ember acceptance/integration tests pass
- [ ] CI confirms the same delta against the canonical environment