### PR TITLE
Fixed duplicate staff email when gift members upgrade to paid

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1279,7 +1279,8 @@ module.exports = class MemberRepository {
                         memberId: memberModel.id,
                         subscriptionId: updatedStripeCustomerSubscriptionModel.get('id'),
                         offerId: offerId,
-                        batchId: options.batch_id
+                        batchId: options.batch_id,
+                        previousStatus: memberModel.get('status')
                     });
                     this.dispatchEvent(subscriptionActivatedEvent, options);
                 }
@@ -1367,7 +1368,8 @@ module.exports = class MemberRepository {
                     subscriptionId: newStripeCustomerSubscriptionModel.get('id'),
                     offerId: offerId,
                     attribution: attribution,
-                    batchId: options.batch_id
+                    batchId: options.batch_id,
+                    previousStatus: memberModel.get('status')
                 });
                 this.dispatchEvent(subscriptionActivatedEvent, options);
             }

--- a/ghost/core/core/server/services/staff/staff-service.js
+++ b/ghost/core/core/server/services/staff/staff-service.js
@@ -110,6 +110,11 @@ class StaffService {
                 attribution
             });
         } else if (type === SubscriptionActivatedEvent) {
+            // Suppress for gift→paid upgrades — staff was already notified
+            // when the member redeemed the gift (notifyGiftSubscriptionStarted).
+            if (event.data.previousStatus === 'gift') {
+                return;
+            }
             let attribution;
             if (event.data?.attribution) {
                 attribution = await this.memberAttributionService.fetchResource(event.data.attribution);

--- a/ghost/core/core/shared/events/subscription-activated-event.js
+++ b/ghost/core/core/shared/events/subscription-activated-event.js
@@ -9,6 +9,7 @@
  * @prop {string} subscriptionId
  * @prop {string} attribution
  * @prop {string} offerId
+ * @prop {string} [previousStatus] The member's status immediately before activation (e.g. 'free', 'paid', 'gift'). Used by subscribers to suppress duplicate notifications — e.g. staff was already notified at gift redemption.
  */
 
 module.exports = class SubscriptionActivatedEvent {

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const DomainEvents = require('@tryghost/domain-events');
 const MemberRepository = require('../../../../../../../core/server/services/members/members-api/repositories/member-repository');
-const {SubscriptionCreatedEvent, OfferRedemptionEvent} = require('../../../../../../../core/shared/events');
+const {SubscriptionCreatedEvent, SubscriptionActivatedEvent, OfferRedemptionEvent} = require('../../../../../../../core/shared/events');
 
 const mockOfferRedemption = {
     add: sinon.stub(),
@@ -2111,6 +2111,102 @@ describe('MemberRepository', function () {
             });
 
             sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
+        });
+
+        it('dispatches SubscriptionActivatedEvent with previousStatus="gift" when member status was "gift"', async function () {
+            Member.findOne.resolves({
+                id: 'member_id_123',
+                get: sinon.stub().callsFake((key) => {
+                    const data = {
+                        email: 'test@example.com',
+                        name: 'Test Member',
+                        status: 'gift'
+                    };
+                    return data[key];
+                }),
+                related: (relation) => {
+                    return {
+                        query: sinon.stub().returns({
+                            fetchOne: sinon.stub().resolves({})
+                        }),
+                        toJSON: sinon.stub().returns(relation === 'products' ? [] : {}),
+                        fetch: sinon.stub().resolves({
+                            toJSON: sinon.stub().returns(relation === 'products' ? [] : {}),
+                            models: []
+                        })
+                    };
+                },
+                toJSON: sinon.stub().returns({})
+            });
+
+            const subscriptionActivatedSpy = sinon.spy();
+            DomainEvents.subscribe(SubscriptionActivatedEvent, subscriptionActivatedSpy);
+
+            const repo = new MemberRepository({
+                Member,
+                Outbox,
+                WelcomeEmailAutomationRun,
+                MemberPaidSubscriptionEvent,
+                StripeCustomerSubscription,
+                MemberProductEvent,
+                MemberStatusEvent,
+                stripeAPIService,
+                productRepository,
+                WelcomeEmailAutomation,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
+
+            await repo.linkSubscription({
+                id: 'member_id_123',
+                subscription: subscriptionData
+            }, {
+                transacting: {
+                    executionPromise: Promise.resolve()
+                },
+                context: {}
+            });
+
+            sinon.assert.calledOnce(subscriptionActivatedSpy);
+            const event = subscriptionActivatedSpy.firstCall.args[0];
+            assert.equal(event.data.previousStatus, 'gift');
+        });
+
+        it('dispatches SubscriptionActivatedEvent with previousStatus not equal to "gift" when member status was not "gift"', async function () {
+            // Default Member.findOne stub returns no status, simulating a non-gift member
+            const subscriptionActivatedSpy = sinon.spy();
+            DomainEvents.subscribe(SubscriptionActivatedEvent, subscriptionActivatedSpy);
+
+            const repo = new MemberRepository({
+                Member,
+                Outbox,
+                WelcomeEmailAutomationRun,
+                MemberPaidSubscriptionEvent,
+                StripeCustomerSubscription,
+                MemberProductEvent,
+                MemberStatusEvent,
+                stripeAPIService,
+                productRepository,
+                WelcomeEmailAutomation,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
+
+            await repo.linkSubscription({
+                id: 'member_id_123',
+                subscription: subscriptionData
+            }, {
+                transacting: {
+                    executionPromise: Promise.resolve()
+                },
+                context: {}
+            });
+
+            sinon.assert.calledOnce(subscriptionActivatedSpy);
+            const event = subscriptionActivatedSpy.firstCall.args[0];
+            assert.notEqual(event.data.previousStatus, 'gift');
         });
     });
 

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -406,6 +406,23 @@ describe('StaffService', function () {
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Direct')));
             });
 
+            it('skips paid subscription started email when previousStatus is "gift"', async function () {
+                await service.handleEvent(SubscriptionActivatedEvent, {
+                    data: {
+                        source: 'member',
+                        memberId: 'member-1',
+                        subscriptionId: 'sub-1',
+                        offerId: 'offer-1',
+                        tierId: 'tier-1',
+                        previousStatus: 'gift'
+                    }
+                });
+
+                sinon.assert.notCalled(service.memberAttributionService.getSubscriptionCreatedAttribution);
+                sinon.assert.notCalled(service.memberAttributionService.fetchResource);
+                sinon.assert.neverCalledWith(mailStub, sinon.match({subject: '💸 Paid subscription started: Jamie'}));
+            });
+
             it('handles paid member cancellation event', async function () {
                 await service.handleEvent(SubscriptionCancelledEvent, {
                     data: {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3608

## Summary

When a gift member upgrades to a real paid subscription, Ghost was sending staff two near-identical "Paid subscription started" emails:

1. `🎁 Paid subscription started: <name>` — at gift redemption (correct)
2. `💸 Paid subscription started: <name>` — when the member later starts a paid subscription (redundant)

This PR suppresses (2) for the gift→paid path.

Staff already know the member is paying — they were notified at gift redemption. The second email is redundant noise and slightly confusing because it looks like a fresh signup when it isn't.

## Changes

Followed the precedent already established for the **paid welcome email** at [`member-repository.js:1540`](https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/server/services/members/members-api/repositories/member-repository.js#L1540), which uses `_previousAttributes.status !== 'gift'` to skip a duplicate welcome email for previously-gifted members.

The staff notification fires off `SubscriptionActivatedEvent`. We can't suppress the event itself because `gift-service-wrapper` also subscribes to it to consume the redeemed gift. So instead:

1. **Carry an `isFromGift` flag on the event.** Set at the dispatch site in `member-repository.linkSubscription` based on `memberModel.get('status') === 'gift'` — at that point the member's status field still reflects the pre-update value, the same invariant the welcome-email check relies on one level up the call stack. Both dispatch sites (the `incomplete → active` 3D-Secure path and the `new + immediately active` path — the common one for gift→paid) are updated.
2. **Staff service short-circuits when the flag is set.** Early-return in `staff-service.handleEvent` before fetching attribution and calling `notifyPaidSubscriptionStarted`.
3. **Gift consumption is unchanged.** The event still fires; `gift-service-wrapper` still consumes the gift; only the staff email is suppressed.

This keeps the suppression decision colocated with the data (no extra DB query in the staff service), avoids the race where the gift may already be consumed by the parallel subscriber by the time the staff handler runs, and keeps the staff service decoupled from the gift service.

## Tests

- New unit test in `staff-service.test.js`: verifies `notifyPaidSubscriptionStarted` is **not** called when `event.data.isFromGift === true`.
- New unit tests in `member-repository.test.js`: verify the dispatched `SubscriptionActivatedEvent` carries `isFromGift: true` for a `status: 'gift'` member, and `isFromGift: false` otherwise.

All existing unit tests still pass (46 staff-service, 54 member-repository), lint clean.

## Manual verification

1. Enable `paid_subscription_started_notification` for the staff user (default on).
2. Buy + redeem a gift as a new member — confirm the `🎁` email arrives in Mailpit.
3. While that member has `status = 'gift'`, complete a paid subscription checkout — confirm **no** `💸` email arrives.
4. Verify the gift row is `consumed`, member is `paid`, subscription is active.
5. Sanity check the inverse: a non-gift member subscribing still triggers the `💸` email.
