### PR TITLE
Fixed flaky OTC magic-link assertion matching token digits

### DIFF
--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -768,14 +768,19 @@ describe('sendMagicLink', function () {
         function assertNoOTCInEmailContent(mail) {
             const otcRegex = /\d{6}|\scode\s|\sotc\s/i;
 
+            // Magic-link tokens are random alphanumerics and can incidentally
+            // contain six consecutive digits, which would false-positive the
+            // \d{6} check. Strip URLs from any text we're scanning.
+            const stripUrls = string => string.replace(/https?:\/\/\S+/g, '');
+
             const subjectMatch = mail.subject.match(otcRegex);
             assert(!subjectMatch, `Email subject should not contain OTC. Found: "${subjectMatch?.[0]}" in subject: "${mail.subject}"`);
 
-            const textMatch = mail.text.match(otcRegex);
-            assert(!textMatch, `Email text should not contain OTC. Found: "${textMatch?.[0]}" near: "${mail.text.substring(mail.text.search(otcRegex) - 50, mail.text.search(otcRegex) + 100)}"`);
+            const text = stripUrls(mail.text);
+            const textMatch = text.match(otcRegex);
+            assert(!textMatch, `Email text should not contain OTC. Found: "${textMatch?.[0]}" near: "${text.substring(text.search(otcRegex) - 50, text.search(otcRegex) + 100)}"`);
 
-            // It's possible that there's an OTC-like in an href, so only check the rendered text.
-            const htmlText = cheerio.load(mail.html).text();
+            const htmlText = stripUrls(cheerio.load(mail.html).text());
             const htmlMatch = htmlText.match(otcRegex);
             assert(!htmlMatch, `Email HTML should not contain OTC. Found: "${htmlMatch?.[0]}" near: "${htmlText.substring(htmlText.search(otcRegex) - 50, htmlText.search(otcRegex) + 100)}"`);
         }

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -770,8 +770,10 @@ describe('sendMagicLink', function () {
 
             // Magic-link tokens are random alphanumerics and can incidentally
             // contain six consecutive digits, which would false-positive the
-            // \d{6} check. Strip URLs from any text we're scanning.
-            const stripUrls = string => string.replace(/https?:\/\/\S+/g, '');
+            // \d{6} check. Replace URLs with whitespace before scanning so a
+            // URL in one text node can't merge with a real OTC in the next
+            // when cheerio concatenates without separators.
+            const stripUrls = string => string.replace(/https?:\/\/\S+/g, ' ');
 
             const subjectMatch = mail.subject.match(otcRegex);
             assert(!subjectMatch, `Email subject should not contain OTC. Found: "${subjectMatch?.[0]}" in subject: "${mail.subject}"`);
@@ -780,7 +782,14 @@ describe('sendMagicLink', function () {
             const textMatch = text.match(otcRegex);
             assert(!textMatch, `Email text should not contain OTC. Found: "${textMatch?.[0]}" near: "${text.substring(text.search(otcRegex) - 50, text.search(otcRegex) + 100)}"`);
 
-            const htmlText = stripUrls(cheerio.load(mail.html).text());
+            // Per text node, so a URL in one node can't merge with digits
+            // in the next via cheerio's separator-less .text().
+            const $ = cheerio.load(mail.html);
+            const htmlText = $('*').contents()
+                .toArray()
+                .filter(n => n.type === 'text')
+                .map(n => stripUrls(n.data))
+                .join(' ');
             const htmlMatch = htmlText.match(otcRegex);
             assert(!htmlMatch, `Email HTML should not contain OTC. Found: "${htmlMatch?.[0]}" near: "${htmlText.substring(htmlText.search(otcRegex) - 50, htmlText.search(otcRegex) + 100)}"`);
         }

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -768,11 +768,7 @@ describe('sendMagicLink', function () {
         function assertNoOTCInEmailContent(mail) {
             const otcRegex = /\d{6}|\scode\s|\sotc\s/i;
 
-            // Magic-link tokens are random alphanumerics and can incidentally
-            // contain six consecutive digits, which would false-positive the
-            // \d{6} check. Replace URLs with whitespace before scanning so a
-            // URL in one text node can't merge with a real OTC in the next
-            // when cheerio concatenates without separators.
+            // \d{6} would otherwise match digits inside the magic-link token.
             const stripUrls = string => string.replace(/https?:\/\/\S+/g, ' ');
 
             const subjectMatch = mail.subject.match(otcRegex);
@@ -782,8 +778,8 @@ describe('sendMagicLink', function () {
             const textMatch = text.match(otcRegex);
             assert(!textMatch, `Email text should not contain OTC. Found: "${textMatch?.[0]}" near: "${text.substring(text.search(otcRegex) - 50, text.search(otcRegex) + 100)}"`);
 
-            // Per text node, so a URL in one node can't merge with digits
-            // in the next via cheerio's separator-less .text().
+            // Per text node — cheerio's .text() concatenates without
+            // separators, so URLs could otherwise merge with adjacent digits.
             const $ = cheerio.load(mail.html);
             const htmlText = $('*').contents()
                 .toArray()


### PR DESCRIPTION
## Summary

`assertNoOTCInEmailContent` in `send-magic-link.test.js` uses `/\d{6}/` to verify no one-time code appears in the email, but `mail.text` and the rendered HTML text both contain the magic-link URL — and the URL's random token can incidentally contain six consecutive digits, false-positiving the assertion.

The fix strips `http(s)://...` URLs from the scanned text before applying the regex. Subject is left alone since URLs don't appear there.

## Why

The token is alphanumeric over ~62 characters. For a ~24-char token, the chance of six consecutive digits anywhere is ~4×10⁻⁴ per call. The helper is invoked four times per CI run (two `forEach` × two email types), so the per-run flake rate compounds. Two main runs hit it today on different random token slices: `…536961…` ([25372072813](https://github.com/TryGhost/Ghost/actions/runs/25372072813)) and `…923759…` ([25394896963](https://github.com/TryGhost/Ghost/actions/runs/25394896963)).

The non-`\d{6}` alternatives (`\scode\s`, `\sotc\s`) require literal whitespace boundaries and aren't affected. A real OTC, rendered outside any URL, is still caught.

## Test plan

- [x] Full `send-magic-link.test.js` suite passes locally (44 passing).
- [x] ESLint clean.