### PR TITLE
Fixed flaky timeout-threshold tests racing real setTimeout

### DIFF
--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -565,9 +565,7 @@ describe('{{#get}} helper', function () {
                 const result = await resultPromise;
 
                 assert(result.toString().includes('data-aborted-get-helper'));
-                // A log message will be output
                 sinon.assert.calledOnce(logging.error);
-                // The get helper gets called with an empty array of results
                 sinon.assert.calledOnce(fn);
                 const args = fn.firstCall.args[0];
                 assert(args && typeof args === 'object');

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -560,8 +560,7 @@ describe('{{#get}} helper', function () {
                     'posts',
                     {hash: {}, data: locals, fn: fn, inverse: inverse}
                 );
-                // Advance past the 1ms threshold but not the stub's 5ms timer,
-                // so the helper's timeout branch wins deterministically.
+                // 2 > threshold (1), < stub's 5 — fires only the helper's timer.
                 await clock.tickAsync(2);
                 const result = await resultPromise;
 

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -551,23 +551,32 @@ describe('{{#get}} helper', function () {
         });
 
         it('should log an error and return safely if it hits the timeout threshold', async function () {
-            configUtils.set('optimization:getHelper:timeout:threshold', 1);
+            const clock = sinon.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']});
+            try {
+                configUtils.set('optimization:getHelper:timeout:threshold', 1);
 
-            const result = await get.call(
-                {},
-                'posts',
-                {hash: {}, data: locals, fn: fn, inverse: inverse}
-            );
+                const resultPromise = get.call(
+                    {},
+                    'posts',
+                    {hash: {}, data: locals, fn: fn, inverse: inverse}
+                );
+                // Advance past the 1ms threshold but not the stub's 5ms timer,
+                // so the helper's timeout branch wins deterministically.
+                await clock.tickAsync(2);
+                const result = await resultPromise;
 
-            assert(result.toString().includes('data-aborted-get-helper'));
-            // A log message will be output
-            sinon.assert.calledOnce(logging.error);
-            // The get helper gets called with an empty array of results
-            sinon.assert.calledOnce(fn);
-            const args = fn.firstCall.args[0];
-            assert(args && typeof args === 'object');
-            assert('posts' in args);
-            assert.deepEqual(args.posts, []);
+                assert(result.toString().includes('data-aborted-get-helper'));
+                // A log message will be output
+                sinon.assert.calledOnce(logging.error);
+                // The get helper gets called with an empty array of results
+                sinon.assert.calledOnce(fn);
+                const args = fn.firstCall.args[0];
+                assert(args && typeof args === 'object');
+                assert('posts' in args);
+                assert.deepEqual(args.posts, []);
+            } finally {
+                clock.restore();
+            }
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -145,6 +145,8 @@ describe('{{#recommendations}} helper', function () {
     });
 
     describe('when timeout is exceeded', function () {
+        let clock;
+
         before(function () {
             sinon.stub(api, 'recommendationsPublic').get(() => {
                 return {
@@ -158,6 +160,15 @@ describe('{{#recommendations}} helper', function () {
                 };
             });
         });
+
+        beforeEach(function () {
+            clock = sinon.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']});
+        });
+
+        afterEach(function () {
+            clock.restore();
+        });
+
         after(async function () {
             await configUtils.restore();
         });
@@ -165,9 +176,13 @@ describe('{{#recommendations}} helper', function () {
         it('should log an error and return safely if it hits the timeout threshold', async function () {
             configUtils.set('optimization:getHelper:timeout:threshold', 1);
 
-            const response = await recommendations.call(
+            const responsePromise = recommendations.call(
                 'recommendations'
             );
+            // Advance past the 1ms threshold but not the stub's 5ms timer,
+            // so the helper's timeout branch wins deterministically.
+            await clock.tickAsync(2);
+            const response = await responsePromise;
 
             // An error message is logged
             sinon.assert.calledOnce(logging.error);

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -179,8 +179,7 @@ describe('{{#recommendations}} helper', function () {
             const responsePromise = recommendations.call(
                 'recommendations'
             );
-            // Advance past the 1ms threshold but not the stub's 5ms timer,
-            // so the helper's timeout branch wins deterministically.
+            // 2 > threshold (1), < stub's 5 — fires only the helper's timer.
             await clock.tickAsync(2);
             const response = await responsePromise;
 


### PR DESCRIPTION
## Summary

The `{{#get}}` and `{{#recommendations}}` "timeout threshold" tests asserted that the helper's `setTimeout(threshold=1ms)` fires before the API stub's `setTimeout(5ms)`. That's a Node scheduler race, not a behavior assertion.

Switch each test to `sinon.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']})`, kick off the helper, then `clock.tickAsync(2)` — fires the 1ms threshold timer but not the 5ms stub timer, so the timeout branch wins deterministically.

## Why

Under CI load both timers can land in the same macrotask and the ordering becomes unreliable. Recent hits:

- `recommendations.test.js:173` — run [25404408183](https://github.com/TryGhost/Ghost/actions/runs/25404408183) (main)
- `get.test.js:562` — run [25399938361](https://github.com/TryGhost/Ghost/actions/runs/25399938361) (renovate-vite)

The pattern dates back to commit `270f288c48` for `get.test.js`; PR #27571 tried to harden the recommendations variant on 2026-04-27 by awaiting `cachePartials`, but that fixed setup, not the timer race.

`toFake` is scoped to `setTimeout`/`clearTimeout` so `Date` and other clocks aren't affected — the `notify` test in the same file still relies on real `Date.now()` and is unchanged (it isn't a race; it just measures elapsed time after the API resolves).

## Test plan

- [x] Each rewritten suite passes locally 25/25 in a stress loop.
- [x] Full `recommendations.test.js` (4 passing) and `get.test.js` (47 passing) clean.
- [x] ESLint clean.