### PR TITLE
Pinned vitest pool to forks in createVitestConfig

### DIFF
--- a/apps/admin-x-framework/src/test/vitest-config.ts
+++ b/apps/admin-x-framework/src/test/vitest-config.ts
@@ -42,6 +42,11 @@ export function createVitestConfig(options: VitestConfigOptions = {}) {
         test: {
             globals: true,
             environment: 'jsdom',
+            // Forks over threads (vitest#1494) — threads pool shares the
+            // V8 isolate, and jsdom + testing-library + MSW corrupt across
+            // workers under that.
+            pool: 'forks',
+            isolate: true,
             setupFiles,
             include,
             silent,

--- a/apps/admin-x-framework/src/test/vitest-config.ts
+++ b/apps/admin-x-framework/src/test/vitest-config.ts
@@ -42,9 +42,8 @@ export function createVitestConfig(options: VitestConfigOptions = {}) {
         test: {
             globals: true,
             environment: 'jsdom',
-            // Forks over threads (vitest#1494) — threads pool shares the
-            // V8 isolate, and jsdom + testing-library + MSW corrupt across
-            // workers under that.
+            // pool: 'forks' for process-level isolation in jsdom-heavy
+            // React suites; sidesteps Vitest threads-pool edge cases.
             pool: 'forks',
             isolate: true,
             setupFiles,


### PR DESCRIPTION
## Summary

Switch the shared `createVitestConfig` from Vitest's default `threads` pool to `forks`. Forks runs each worker as a separate child process, giving stronger isolation than threads (which run in separate V8 isolates but still share the Node process — and therefore process-scoped state).

## Why

Two modest motivations:

1. **Process isolation in jsdom-heavy suites.** `apps/posts`, `apps/stats`, and `apps/admin-x-settings` use jsdom + `@testing-library/react` + MSW. All three mutate process-scoped state (DOM globals, module registries, fetch). Under threads, anything that's process-scoped (rather than isolate-scoped) leaks across workers; forks gives each worker its own process, so they can't.

2. **Sidestep documented Vitest threads-pool edge cases.** Vitest's docs call out threads-specific quirks (native modules, fetch worker termination) and recommend `pool: 'forks'` as the workaround.

I'm being deliberately careful **not** to claim this fixes the `apps/posts:build` TS2339 jest-dom failure documented in `docs/ci-flakiness-jest-dom-types.md`. That failure happens in `tsc` during the build step, before any Vitest worker runs — the pool change literally cannot affect it. That leg remains under investigation; this PR addresses the runtime-isolation half only.

Trade-off: forks has slower worker IPC than threads. Our suites are jsdom-bound (boot dominates), so the practical hit is small.

## Test plan

- [x] `posts` unit suite (130 tests) green
- [x] `stats` unit suite (237 tests) green
- [x] `admin-x-settings` unit suite (153 tests) green