### PR TITLE
Added `GET automations/:id` route with placeholder static payload

### DIFF
--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -16,7 +16,7 @@
           {
             "name": "credential in URL query string",
             "patterns": [
-              "/[?&](?:token|api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|secret|password)=(?<CREDENTIAL>(?!p\\.)[^&\\s\"'<>]{16,})/i"
+              "/[?&](?:token|api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|secret|password)=(?<CREDENTIAL>(?!p\\.|\\$\\{)[^&\\s\"'<>]{16,})/i"
             ]
           },
           {

--- a/ghost/core/core/server/api/endpoints/automations.js
+++ b/ghost/core/core/server/api/endpoints/automations.js
@@ -43,9 +43,9 @@ const controller = {
                 updated_at: '2026-05-05T00:00:00.000Z',
                 actions: [{
                     id: '67f3f3f3f3f3f3f3f3f3f3f4',
-                    type: 'wait',
+                    type: 'delay',
                     data: {
-                        wait_hours: 24
+                        delay_hours: 24
                     }
                 }, {
                     id: '67f3f3f3f3f3f3f3f3f3f3f5',

--- a/ghost/core/core/server/api/endpoints/automations.js
+++ b/ghost/core/core/server/api/endpoints/automations.js
@@ -36,10 +36,7 @@ const controller = {
             return {
                 id: frame.data.id,
                 name: 'Welcome email',
-                description: 'Onboard new free members with a short welcome email.',
-                status: 'active',
-                trigger_type: 'member_signs_up',
-                trigger_mode: 'free'
+                status: 'active'
             };
         }
     },

--- a/ghost/core/core/server/api/endpoints/automations.js
+++ b/ghost/core/core/server/api/endpoints/automations.js
@@ -35,8 +35,33 @@ const controller = {
         query(frame) {
             return {
                 id: frame.data.id,
+                slug: 'member-welcome-email-free',
                 name: 'Welcome email',
-                status: 'active'
+                status: 'active',
+                created_at: '2026-05-05T00:00:00.000Z',
+                updated_at: '2026-05-05T00:00:00.000Z',
+                actions: [{
+                    id: '67f3f3f3f3f3f3f3f3f3f3f4',
+                    type: 'wait',
+                    data: {
+                        wait_hours: 24
+                    }
+                }, {
+                    id: '67f3f3f3f3f3f3f3f3f3f3f5',
+                    type: 'send email',
+                    data: {
+                        email_subject: 'Welcome!',
+                        email_lexical: '{"root":{"children":[]}}',
+                        email_sender_name: null,
+                        email_sender_email: null,
+                        email_sender_reply_to: null,
+                        email_design_setting_id: '680000000000000000000001'
+                    }
+                }],
+                edges: [{
+                    source_action_id: '67f3f3f3f3f3f3f3f3f3f3f4',
+                    target_action_id: '67f3f3f3f3f3f3f3f3f3f3f5'
+                }]
             };
         }
     },

--- a/ghost/core/core/server/api/endpoints/automations.js
+++ b/ghost/core/core/server/api/endpoints/automations.js
@@ -24,6 +24,26 @@ const controller = {
         }
     },
 
+    read: {
+        headers: {
+            cacheInvalidate: false
+        },
+        data: [
+            'id'
+        ],
+        permissions: true,
+        query(frame) {
+            return {
+                id: frame.data.id,
+                name: 'Welcome email',
+                description: 'Onboard new free members with a short welcome email.',
+                status: 'active',
+                trigger_type: 'member_signs_up',
+                trigger_mode: 'free'
+            };
+        }
+    },
+
     poll: {
         statusCode: 204,
         headers: {

--- a/ghost/core/core/server/api/endpoints/automations.js
+++ b/ghost/core/core/server/api/endpoints/automations.js
@@ -33,6 +33,7 @@ const controller = {
         ],
         permissions: true,
         query(frame) {
+            // TODO: NY-1265 - replace this static payload with persisted automation data.
             return {
                 id: frame.data.id,
                 slug: 'member-welcome-email-free',

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -187,6 +187,7 @@ module.exports = function apiRoutes() {
 
     // ## Automations
     router.get('/automations', mw.authAdminApi, http(api.automations.browse));
+    router.get('/automations/:id', mw.authAdminApi, http(api.automations.read));
     router.put('/automations/poll', mw.authAdminApiWithUrl, http(api.automations.poll));
 
     // ## Automated Emails

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
@@ -80,10 +80,10 @@ Object {
       "actions": Array [
         Object {
           "data": Object {
-            "wait_hours": 24,
+            "delay_hours": 24,
           },
           "id": "67f3f3f3f3f3f3f3f3f3f3f4",
-          "type": "wait",
+          "type": "delay",
         },
         Object {
           "data": Object {
@@ -119,7 +119,7 @@ exports[`Automations API read returns a placeholder automation for the requested
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "666",
+  "content-length": "668",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
@@ -72,3 +72,58 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Automations API read returns a placeholder automation for the requested id 1: [body] 1`] = `
+Object {
+  "automations": Array [
+    Object {
+      "actions": Array [
+        Object {
+          "data": Object {
+            "wait_hours": 24,
+          },
+          "id": "67f3f3f3f3f3f3f3f3f3f3f4",
+          "type": "wait",
+        },
+        Object {
+          "data": Object {
+            "email_design_setting_id": "680000000000000000000001",
+            "email_lexical": "{\\"root\\":{\\"children\\":[]}}",
+            "email_sender_email": null,
+            "email_sender_name": null,
+            "email_sender_reply_to": null,
+            "email_subject": "Welcome!",
+          },
+          "id": "67f3f3f3f3f3f3f3f3f3f3f5",
+          "type": "send email",
+        },
+      ],
+      "created_at": "2026-05-05T00:00:00.000Z",
+      "edges": Array [
+        Object {
+          "source_action_id": "67f3f3f3f3f3f3f3f3f3f3f4",
+          "target_action_id": "67f3f3f3f3f3f3f3f3f3f3f5",
+        },
+      ],
+      "id": "67f3f3f3f3f3f3f3f3f3f3f3",
+      "name": "Welcome email",
+      "slug": "member-welcome-email-free",
+      "status": "active",
+      "updated_at": "2026-05-05T00:00:00.000Z",
+    },
+  ],
+}
+`;
+
+exports[`Automations API read returns a placeholder automation for the requested id 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "666",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -85,10 +85,7 @@ describe('Automations API', function () {
             assert.deepEqual(body.automations, [{
                 id: automationId,
                 name: 'Welcome email',
-                description: 'Onboard new free members with a short welcome email.',
-                status: 'active',
-                trigger_type: 'member_signs_up',
-                trigger_mode: 'free'
+                status: 'active'
             }]);
         });
     });

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -73,6 +73,26 @@ describe('Automations API', function () {
         });
     });
 
+    describe('read', function () {
+        it('returns a placeholder automation for the requested id', async function () {
+            const automationId = '67f3f3f3f3f3f3f3f3f3f3f3';
+
+            const {body} = await agent
+                .get(`automations/${automationId}`)
+                .expectStatus(200)
+                .expect(cacheInvalidateHeaderNotSet());
+
+            assert.deepEqual(body.automations, [{
+                id: automationId,
+                name: 'Welcome email',
+                description: 'Onboard new free members with a short welcome email.',
+                status: 'active',
+                trigger_type: 'member_signs_up',
+                trigger_mode: 'free'
+            }]);
+        });
+    });
+
     describe('poll', function () {
         /** @type {sinon.SinonStub} */
         let dispatchStub;

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -77,16 +77,15 @@ describe('Automations API', function () {
         it('returns a placeholder automation for the requested id', async function () {
             const automationId = '67f3f3f3f3f3f3f3f3f3f3f3';
 
-            const {body} = await agent
+            await agent
                 .get(`automations/${automationId}`)
                 .expectStatus(200)
-                .expect(cacheInvalidateHeaderNotSet());
-
-            assert.deepEqual(body.automations, [{
-                id: automationId,
-                name: 'Welcome email',
-                status: 'active'
-            }]);
+                .expect(cacheInvalidateHeaderNotSet())
+                .matchBodySnapshot()
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
         });
     });
 

--- a/ghost/core/test/unit/api/endpoints/automations.test.js
+++ b/ghost/core/test/unit/api/endpoints/automations.test.js
@@ -79,9 +79,9 @@ describe('Automations controller', function () {
                 updated_at: '2026-05-05T00:00:00.000Z',
                 actions: [{
                     id: '67f3f3f3f3f3f3f3f3f3f3f4',
-                    type: 'wait',
+                    type: 'delay',
                     data: {
-                        wait_hours: 24
+                        delay_hours: 24
                     }
                 }, {
                     id: '67f3f3f3f3f3f3f3f3f3f3f5',

--- a/ghost/core/test/unit/api/endpoints/automations.test.js
+++ b/ghost/core/test/unit/api/endpoints/automations.test.js
@@ -62,6 +62,25 @@ describe('Automations controller', function () {
         });
     });
 
+    describe('read', function () {
+        it('returns a placeholder automation for the requested id', function () {
+            const result = automationsController.read.query({
+                data: {
+                    id: '67f3f3f3f3f3f3f3f3f3f3f3'
+                }
+            });
+
+            assert.deepEqual(result, {
+                id: '67f3f3f3f3f3f3f3f3f3f3f3',
+                name: 'Welcome email',
+                description: 'Onboard new free members with a short welcome email.',
+                status: 'active',
+                trigger_type: 'member_signs_up',
+                trigger_mode: 'free'
+            });
+        });
+    });
+
     describe('poll', function () {
         it('dispatches a StartAutomationsPollEvent', function () {
             const result = automationsController.poll.query({});

--- a/ghost/core/test/unit/api/endpoints/automations.test.js
+++ b/ghost/core/test/unit/api/endpoints/automations.test.js
@@ -72,8 +72,33 @@ describe('Automations controller', function () {
 
             assert.deepEqual(result, {
                 id: '67f3f3f3f3f3f3f3f3f3f3f3',
+                slug: 'member-welcome-email-free',
                 name: 'Welcome email',
-                status: 'active'
+                status: 'active',
+                created_at: '2026-05-05T00:00:00.000Z',
+                updated_at: '2026-05-05T00:00:00.000Z',
+                actions: [{
+                    id: '67f3f3f3f3f3f3f3f3f3f3f4',
+                    type: 'wait',
+                    data: {
+                        wait_hours: 24
+                    }
+                }, {
+                    id: '67f3f3f3f3f3f3f3f3f3f3f5',
+                    type: 'send email',
+                    data: {
+                        email_subject: 'Welcome!',
+                        email_lexical: '{"root":{"children":[]}}',
+                        email_sender_name: null,
+                        email_sender_email: null,
+                        email_sender_reply_to: null,
+                        email_design_setting_id: '680000000000000000000001'
+                    }
+                }],
+                edges: [{
+                    source_action_id: '67f3f3f3f3f3f3f3f3f3f3f4',
+                    target_action_id: '67f3f3f3f3f3f3f3f3f3f3f5'
+                }]
             });
         });
     });

--- a/ghost/core/test/unit/api/endpoints/automations.test.js
+++ b/ghost/core/test/unit/api/endpoints/automations.test.js
@@ -73,10 +73,7 @@ describe('Automations controller', function () {
             assert.deepEqual(result, {
                 id: '67f3f3f3f3f3f3f3f3f3f3f3',
                 name: 'Welcome email',
-                description: 'Onboard new free members with a short welcome email.',
-                status: 'active',
-                trigger_type: 'member_signs_up',
-                trigger_mode: 'free'
+                status: 'active'
             });
         });
     });


### PR DESCRIPTION
refs https://linear.app/ghost/issue/NY-1265/create-endpoint-for-reading-a-single-automation

This adds the scaffolding for the GET `automations/:id` endpoint in the Admin API, with a hardcoded payload. The intent here is simply to unblock development of the frontend, while we iron out the rest of the schema. This will eventually be updated to return automations from the database, once the schema is in place. 