### PR TITLE
Updated email filters on members page

### DIFF
--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -389,8 +389,7 @@ export const memberFields = defineFields({
         ui: {
             label: 'Emails sent (all time)',
             type: 'number',
-            defaultOperator: 'is',
-            defaultValue: 0,
+            defaultOperator: 'is-greater',
             min: 0,
             className: 'w-24'
         },
@@ -401,8 +400,7 @@ export const memberFields = defineFields({
         ui: {
             label: 'Emails opened (all time)',
             type: 'number',
-            defaultOperator: 'is',
-            defaultValue: 0,
+            defaultOperator: 'is-greater',
             min: 0,
             className: 'w-24'
         },
@@ -413,8 +411,7 @@ export const memberFields = defineFields({
         ui: {
             label: 'Open rate (all time)',
             type: 'number',
-            defaultOperator: 'is',
-            defaultValue: 0,
+            defaultOperator: 'is-greater',
             min: 0,
             max: 100,
             suffix: '%',


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/BER-3609/open-rate-filter-applies-empty-exact-match-immediately

Switches is to is greater than and removes the default value for all email filters.
