### PR TITLE
Fixed apps/admin TypeScript build for ShareModal contentProps

### DIFF
--- a/apps/admin/src/onboarding/components/share-publication-dialog.tsx
+++ b/apps/admin/src/onboarding/components/share-publication-dialog.tsx
@@ -52,7 +52,6 @@ export function SharePublicationDialog({
             closeButtonId="ob-close-share-modal"
             contentProps={{
                 className: "dark:bg-surface-elevated",
-                "data-test-modal": "onboarding-share",
                 "data-testid": "onboarding-share-modal",
             }}
             copyButtonId="ob-copy-publication-link"

--- a/apps/shade/src/components/features/share-modal/share-modal.tsx
+++ b/apps/shade/src/components/features/share-modal/share-modal.tsx
@@ -33,7 +33,7 @@ interface ShareModalProps extends React.ComponentPropsWithoutRef<typeof DialogPr
     copyLabel?: string;
     copySuccessLabel?: string;
     copyURL: string;
-    contentProps?: React.ComponentPropsWithoutRef<typeof DialogContent>;
+    contentProps?: React.ComponentPropsWithoutRef<typeof DialogContent> & Record<`data-${string}`, string | undefined>;
     description?: React.ReactNode;
     footerAction?: React.ReactNode;
     guidance?: React.ReactNode;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3587/

Follow-up to #27625 — the apps/admin build was failing with a TS2353 error because Radix's `DialogContentProps` type does not include an index signature for `data-*` attributes, so passing `data-testid` (or any `data-*` attr) as a literal in `contentProps` failed strict excess-property checks.

- widened `ShareModal`'s `contentProps` type to additionally accept arbitrary `data-*` keys, matching how the attribute is consumed on the rendered DOM element
- removed the vestigial `data-test-modal` attribute from the onboarding share dialog; nothing references it (the e2e helper uses the `data-testid` selector)