### PR TITLE
Refactored ShareModal to use slot-based composition

### DIFF
--- a/apps/admin/src/onboarding/components/share-publication-dialog.tsx
+++ b/apps/admin/src/onboarding/components/share-publication-dialog.tsx
@@ -1,5 +1,6 @@
 import {Button} from "@tryghost/shade/components";
 import {ShareModal, type ShareModalSocialLink} from "@tryghost/shade/patterns";
+import {LucideIcon} from "@tryghost/shade/utils";
 
 interface SharePublicationDialogProps {
     description: string;
@@ -47,37 +48,52 @@ export function SharePublicationDialog({
     ];
 
     return (
-        <ShareModal
-            actionsLayout="footer"
-            closeButtonId="ob-close-share-modal"
-            contentProps={{
-                className: "dark:bg-surface-elevated",
-                "data-testid": "onboarding-share-modal",
-            }}
-            copyButtonId="ob-copy-publication-link"
-            copyButtonTestId="onboarding-copy-link"
-            copyLabel="Copy link"
-            copyURL={siteUrl}
-            guidance={(
+        <ShareModal.Root
+            open={open}
+            onOpenChange={onOpenChange}
+        >
+            <ShareModal.Content
+                className="dark:bg-surface-elevated"
+                data-test-modal="onboarding-share"
+                data-testid="onboarding-share-modal"
+            >
+                <ShareModal.Header className="flex-row items-center justify-between gap-4 space-y-0 text-left">
+                    <ShareModal.Title className="text-2xl">Share your publication</ShareModal.Title>
+                    <ShareModal.CloseButton id="ob-close-share-modal" onClick={() => onOpenChange(false)} />
+                </ShareModal.Header>
+                <ShareModal.Preview className="rounded-lg bg-card" href={siteUrl}>
+                    {imageUrl ?
+                        <div className="aspect-video bg-cover bg-center" style={{backgroundImage: `url(${imageUrl})`}}></div>
+                        :
+                        <div className="flex aspect-video items-center justify-center bg-muted text-muted-foreground">
+                            <LucideIcon.Image className="size-8" />
+                        </div>
+                    }
+                    <div className="p-5">
+                        <div className="text-lg font-semibold">{siteTitle}</div>
+                        {description && (
+                            <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+                        )}
+                    </div>
+                </ShareModal.Preview>
                 <p className="text-sm text-muted-foreground">
                     Set your publication&apos;s cover image and description in{" "}
                     <Button asChild className="h-auto p-0 align-baseline text-sm text-green hover:text-green/90" variant="link">
                         <a href="#/settings/design/edit?ref=setup" id="ob-share-modal-design-settings">Design settings</a>
                     </Button>.
                 </p>
-            )}
-            open={open}
-            preview={{
-                description,
-                imageURL: imageUrl,
-                title: siteTitle,
-                url: siteUrl,
-            }}
-            socialLinks={socialLinks}
-            title="Share your publication"
-            variant="publication"
-            onClose={() => onOpenChange(false)}
-            onOpenChange={onOpenChange}
-        />
+                <ShareModal.Footer>
+                    <ShareModal.SocialLinks links={socialLinks} />
+                    <ShareModal.CopyButton
+                        className="ml-0! grow cursor-pointer"
+                        copyURL={siteUrl}
+                        data-testid="onboarding-copy-link"
+                        icon="link"
+                        id="ob-copy-publication-link"
+                        label="Copy link"
+                    />
+                </ShareModal.Footer>
+            </ShareModal.Content>
+        </ShareModal.Root>
     );
 }

--- a/apps/shade/src/components/features/post-share-modal/post-share-modal.tsx
+++ b/apps/shade/src/components/features/post-share-modal/post-share-modal.tsx
@@ -1,4 +1,5 @@
 import ShareModal, {type ShareModalSocialLink} from '@/components/features/share-modal/share-modal';
+import {H3} from '@/components/layout/heading';
 import {Button} from '@/components/ui/button';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import React from 'react';
@@ -62,40 +63,65 @@ const PostShareModal: React.FC<PostShareModalProps> = ({
     ];
 
     return (
-        <ShareModal
-            actionsLayout="footer"
-            copyURL={postURL}
-            description={description}
-            footerAction={emailOnly ? (
-                <Button className="cursor-pointer" type="button" onClick={onClose}>
-                    Close
-                </Button>
-            ) : undefined}
-            preview={{
-                description: postExcerpt,
-                imageURL: featureImageURL,
-                meta: (
-                    <div className="mt-2 flex items-start gap-2">
-                        <div className="mt-0.5 size-4 bg-cover bg-center" style={{backgroundImage: `url(${faviconURL})`}}></div>
-                        <div className="flex gap-1">
-                            <strong>{siteTitle}</strong>
-                            <span>&bull;</span>
-                            <span>{author}</span>
+        <ShareModal.Root {...props}>
+            {children && (
+                <ShareModal.Trigger>
+                    {children}
+                </ShareModal.Trigger>
+            )}
+            <ShareModal.Content>
+                <div className="sticky top-0 ml-auto size-0">
+                    <ShareModal.CloseButton className="absolute -top-5 -right-5" onClick={onClose} />
+                </div>
+                <ShareModal.Header className="relative -mt-5">
+                    <ShareModal.Title className="text-3xl leading-[1.15em] font-bold">
+                        {primaryTitle && <span className="text-state-success">{primaryTitle}</span>}
+                        {primaryTitle && secondaryTitle && <br />}
+                        {secondaryTitle && <span>{secondaryTitle}</span>}
+                    </ShareModal.Title>
+                    {description && (
+                        <ShareModal.Description className="mb-0 pt-1 pb-0 text-lg text-foreground">
+                            {description}
+                        </ShareModal.Description>
+                    )}
+                </ShareModal.Header>
+                <ShareModal.Preview className="rounded-md" href={postURL}>
+                    {featureImageURL && (
+                        <div className="aspect-video bg-cover bg-center" style={{backgroundImage: `url(${featureImageURL})`}}></div>
+                    )}
+                    <div className="p-6 pt-5">
+                        <H3>{postTitle}</H3>
+                        {postExcerpt && (
+                            <p>{postExcerpt}</p>
+                        )}
+                        <div className="mt-2 flex items-start gap-2">
+                            <div className="mt-0.5 size-4 bg-cover bg-center" style={{backgroundImage: `url(${faviconURL})`}}></div>
+                            <div className="flex gap-1">
+                                <strong>{siteTitle}</strong>
+                                <span>&bull;</span>
+                                <span>{author}</span>
+                            </div>
                         </div>
                     </div>
-                ),
-                title: postTitle,
-                url: postURL
-            }}
-            primaryTitle={primaryTitle}
-            secondaryTitle={secondaryTitle}
-            socialLinks={socialLinks}
-            variant="post"
-            onClose={onClose}
-            {...props}
-        >
-            {children}
-        </ShareModal>
+                </ShareModal.Preview>
+                <ShareModal.Footer>
+                    {emailOnly ? (
+                        <Button className="cursor-pointer" type="button" onClick={onClose}>
+                            Close
+                        </Button>
+                    ) : (
+                        <>
+                            <ShareModal.SocialLinks links={socialLinks} />
+                            <ShareModal.CopyButton
+                                className="ml-0! grow cursor-pointer"
+                                copyURL={postURL}
+                                icon="link"
+                            />
+                        </>
+                    )}
+                </ShareModal.Footer>
+            </ShareModal.Content>
+        </ShareModal.Root>
     );
 };
 

--- a/apps/shade/src/components/features/share-modal/index.ts
+++ b/apps/shade/src/components/features/share-modal/index.ts
@@ -1,2 +1,2 @@
 export {default} from './share-modal';
-export type {ShareModalSocialLink} from './share-modal';
+export type {ShareModalPreviewProps, ShareModalSocialLink} from './share-modal';

--- a/apps/shade/src/components/features/share-modal/share-modal.stories.tsx
+++ b/apps/shade/src/components/features/share-modal/share-modal.stories.tsx
@@ -1,20 +1,14 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {useState} from 'react';
+import {H3} from '@/components/layout/heading';
 import {Button} from '@/components/ui/button';
 import ShareModal, {type ShareModalSocialLink} from './share-modal';
 
 const meta = {
     title: 'Features / Share Modal',
-    component: ShareModal,
-    tags: ['autodocs'],
-    argTypes: {
-        children: {
-            table: {
-                disable: true
-            }
-        }
-    }
-} satisfies Meta<typeof ShareModal>;
+    component: ShareModal.Root,
+    tags: ['autodocs']
+} satisfies Meta<typeof ShareModal.Root>;
 
 export default meta;
 
@@ -74,149 +68,145 @@ const publicationSocialLinks: ShareModalSocialLink[] = [
     }
 ];
 
-const postArgs = {
-    copyURL: postUrl,
-    description: <>
-        Your post was published on your site and sent to <strong>3 subscribers</strong> of <strong>Ghost Blog</strong>, on <strong>June 13th</strong> at <strong>12:02</strong>.
-    </>,
-    preview: {
-        description: 'A comprehensive guide to implementing copy-to-clipboard functionality in React applications with proper error handling and user feedback.',
-        imageURL: 'https://picsum.photos/800/600?random=1',
-        meta: (
-            <div className="mt-2 flex items-start gap-2">
-                <div className="mt-0.5 size-4 bg-cover bg-center" style={{backgroundImage: 'url(https://www.google.com/s2/favicons?domain=ghost.org&sz=64)'}}></div>
-                <div className="flex gap-1">
-                    <strong>Ghost Blog</strong>
-                    <span>&bull;</span>
-                    <span>Jane Smith</span>
-                </div>
+const postPreview = {
+    description: 'A comprehensive guide to implementing copy-to-clipboard functionality in React applications with proper error handling and user feedback.',
+    imageURL: 'https://picsum.photos/800/600?random=1',
+    meta: (
+        <div className="mt-2 flex items-start gap-2">
+            <div className="mt-0.5 size-4 bg-cover bg-center" style={{backgroundImage: 'url(https://www.google.com/s2/favicons?domain=ghost.org&sz=64)'}}></div>
+            <div className="flex gap-1">
+                <strong>Ghost Blog</strong>
+                <span>&bull;</span>
+                <span>Jane Smith</span>
             </div>
-        ),
-        title: 'Copy to Clipboard in React: Complete Guide',
-        url: postUrl
-    },
-    primaryTitle: 'Your post is published.',
-    secondaryTitle: 'Spread the word!',
-    socialLinks: postSocialLinks,
-    variant: 'post' as const
+        </div>
+    ),
+    title: 'Copy to Clipboard in React: Complete Guide',
+    url: postUrl
 };
 
-const publicationArgs = {
-    actionsLayout: 'footer' as const,
-    copyURL: publicationUrl,
-    guidance: (
-        <p className="text-sm text-muted-foreground">
-            Set your publication&apos;s cover image and description in <Button className="h-auto p-0 align-baseline text-sm text-green hover:text-green/90" variant="link" asChild><a href="#/settings/design/edit?ref=setup">Design settings</a></Button>.
-        </p>
-    ),
-    preview: {
-        description: 'Thoughts, stories and ideas.',
-        imageURL: 'https://picsum.photos/800/600?random=2',
-        title: 'Ghostbusters',
-        url: publicationUrl
-    },
-    socialLinks: publicationSocialLinks,
-    title: 'Share your publication',
-    variant: 'publication' as const
+const publicationPreview = {
+    description: 'Thoughts, stories and ideas.',
+    imageURL: 'https://picsum.photos/800/600?random=2',
+    title: 'Ghost Journal',
+    url: publicationUrl
 };
+
+function PostPreview() {
+    return (
+        <ShareModal.Preview className="rounded-md" href={postPreview.url}>
+            <div className="aspect-video bg-cover bg-center" style={{backgroundImage: `url(${postPreview.imageURL})`}}></div>
+            <div className="p-6 pt-5">
+                <H3>{postPreview.title}</H3>
+                <p>{postPreview.description}</p>
+                {postPreview.meta}
+            </div>
+        </ShareModal.Preview>
+    );
+}
+
+function PublicationPreview() {
+    return (
+        <ShareModal.Preview className="rounded-lg bg-card" href={publicationPreview.url}>
+            <div className="aspect-video bg-cover bg-center" style={{backgroundImage: `url(${publicationPreview.imageURL})`}}></div>
+            <div className="p-5">
+                <div className="text-lg font-semibold">{publicationPreview.title}</div>
+                <p className="mt-1 text-sm text-muted-foreground">{publicationPreview.description}</p>
+            </div>
+        </ShareModal.Preview>
+    );
+}
 
 const postSource = `const [isOpen, setIsOpen] = useState(false);
 
-const postUrl = 'https://example.com/copy-clipboard-react-guide';
-const encodedPostTitle = encodeURIComponent('Copy to Clipboard in React: Complete Guide');
-const encodedPostUrl = encodeURIComponent(postUrl);
-
-<ShareModal
-    copyURL={postUrl}
-    description={<>Your post was published on your site and sent to <strong>3 subscribers</strong>.</>}
-    open={isOpen}
-    preview={{
-        description: 'A comprehensive guide to implementing copy-to-clipboard functionality in React applications.',
-        imageURL: 'https://picsum.photos/800/600?random=1',
-        meta: (
-            <div className="mt-2 flex items-start gap-2">
-                <div className="mt-0.5 size-4 bg-cover bg-center" style={{backgroundImage: 'url(https://www.google.com/s2/favicons?domain=ghost.org&sz=64)'}} />
-                <div className="flex gap-1">
-                    <strong>Ghost Blog</strong>
-                    <span>&bull;</span>
-                    <span>Jane Smith</span>
-                </div>
+<ShareModal.Root open={isOpen} onOpenChange={setIsOpen}>
+    <ShareModal.Trigger>
+        <Button onClick={() => setIsOpen(true)}>Share post</Button>
+    </ShareModal.Trigger>
+    <ShareModal.Content>
+        <div className="sticky top-0 ml-auto size-0">
+            <ShareModal.CloseButton className="absolute -top-5 -right-5" onClick={() => setIsOpen(false)} />
+        </div>
+        <ShareModal.Header className="relative -mt-5">
+            <ShareModal.Title className="text-3xl leading-[1.15em] font-bold">
+                <span className="text-state-success">Your post is published.</span><br />
+                <span>Spread the word!</span>
+            </ShareModal.Title>
+            <ShareModal.Description className="mb-0 pt-1 pb-0 text-lg text-foreground">
+                Your post was published on your site and sent to <strong>3 subscribers</strong>.
+            </ShareModal.Description>
+        </ShareModal.Header>
+        <ShareModal.Preview className="rounded-md" href={postUrl}>
+            <div className="aspect-video bg-cover bg-center" style={{backgroundImage: \`url(\${imageURL})\`}} />
+            <div className="p-6 pt-5">
+                <H3>Copy to Clipboard in React: Complete Guide</H3>
+                <p>A comprehensive guide to implementing copy-to-clipboard functionality in React applications.</p>
             </div>
-        ),
-        title: 'Copy to Clipboard in React: Complete Guide',
-        url: postUrl
-    }}
-    primaryTitle="Your post is published."
-    secondaryTitle="Spread the word!"
-    socialLinks={[
-        {
-            href: \`https://twitter.com/intent/tweet?text=\${encodedPostTitle}%0A\${encodedPostUrl}\`,
-            label: 'Share on X',
-            service: 'x'
-        }
-    ]}
-    variant="post"
-    onClose={() => setIsOpen(false)}
-    onOpenChange={setIsOpen}
->
-    <Button onClick={() => setIsOpen(true)}>Share post</Button>
-</ShareModal>`;
+        </ShareModal.Preview>
+        <ShareModal.Footer>
+            <ShareModal.SocialLinks links={socialLinks} />
+            <ShareModal.CopyButton className="ml-0! grow cursor-pointer" copyURL={postUrl} />
+        </ShareModal.Footer>
+    </ShareModal.Content>
+</ShareModal.Root>`;
 
 const publicationSource = `const [isOpen, setIsOpen] = useState(false);
 
-const publicationUrl = 'https://ghost.org';
-const encodedPublicationUrl = encodeURIComponent(publicationUrl);
-
-<ShareModal
-    actionsLayout="footer"
-    copyURL={publicationUrl}
-    guidance={(
-        <p className="text-sm text-muted-foreground">
-            Set your publication's cover image and description in{' '}
-            <Button className="h-auto p-0 align-baseline text-sm text-green hover:text-green/90" variant="link" asChild>
-                <a href="#/settings/design/edit?ref=setup">Design settings</a>
-            </Button>.
-        </p>
-    )}
-    open={isOpen}
-    preview={{
-        description: 'Thoughts, stories and ideas.',
-        imageURL: 'https://picsum.photos/800/600?random=2',
-        title: 'Ghostbusters',
-        url: publicationUrl
-    }}
-    socialLinks={[
-        {
-            href: \`https://threads.net/intent/post?text=\${encodedPublicationUrl}\`,
-            label: 'Share your publication on Threads',
-            service: 'threads'
-        }
-    ]}
-    title="Share your publication"
-    variant="publication"
-    onClose={() => setIsOpen(false)}
-    onOpenChange={setIsOpen}
->
-    <Button onClick={() => setIsOpen(true)}>Share publication</Button>
-</ShareModal>`;
+<ShareModal.Root open={isOpen} onOpenChange={setIsOpen}>
+    <ShareModal.Trigger>
+        <Button onClick={() => setIsOpen(true)}>Share publication</Button>
+    </ShareModal.Trigger>
+    <ShareModal.Content data-testid="publication-share-modal">
+        <ShareModal.Header className="flex-row items-center justify-between gap-4 space-y-0 text-left">
+            <ShareModal.Title className="text-2xl">Share your publication</ShareModal.Title>
+            <ShareModal.CloseButton onClick={() => setIsOpen(false)} />
+        </ShareModal.Header>
+        <ShareModal.Preview className="rounded-lg bg-card" href={publicationUrl}>
+            <div className="aspect-video bg-cover bg-center" style={{backgroundImage: \`url(\${imageURL})\`}} />
+            <div className="p-5">
+                <div className="text-lg font-semibold">Ghost Journal</div>
+                <p className="mt-1 text-sm text-muted-foreground">Thoughts, stories and ideas.</p>
+            </div>
+        </ShareModal.Preview>
+        <p className="text-sm text-muted-foreground">Set your publication's cover image and description in Design settings.</p>
+        <ShareModal.Footer>
+            <ShareModal.SocialLinks links={socialLinks} />
+            <ShareModal.CopyButton className="ml-0! grow cursor-pointer" copyURL={publicationUrl} />
+        </ShareModal.Footer>
+    </ShareModal.Content>
+</ShareModal.Root>`;
 
 export const Post: Story = {
-    args: {
-        ...postArgs
-    },
-    render: (args) => {
+    render: () => {
         const PostExample = () => {
             const [isOpen, setIsOpen] = useState(false);
 
             return (
-                <ShareModal
-                    {...args}
-                    open={isOpen}
-                    onClose={() => setIsOpen(false)}
-                    onOpenChange={setIsOpen}
-                >
-                    <Button onClick={() => setIsOpen(true)}>Share post</Button>
-                </ShareModal>
+                <ShareModal.Root open={isOpen} onOpenChange={setIsOpen}>
+                    <ShareModal.Trigger>
+                        <Button onClick={() => setIsOpen(true)}>Share post</Button>
+                    </ShareModal.Trigger>
+                    <ShareModal.Content>
+                        <div className="sticky top-0 ml-auto size-0">
+                            <ShareModal.CloseButton className="absolute -top-5 -right-5" onClick={() => setIsOpen(false)} />
+                        </div>
+                        <ShareModal.Header className="relative -mt-5">
+                            <ShareModal.Title className="text-3xl leading-[1.15em] font-bold">
+                                <span className="text-state-success">Your post is published.</span>
+                                <br />
+                                <span>Spread the word!</span>
+                            </ShareModal.Title>
+                            <ShareModal.Description className="mb-0 pt-1 pb-0 text-lg text-foreground">
+                                Your post was published on your site and sent to <strong>3 subscribers</strong> of <strong>Ghost Blog</strong>, on <strong>June 13th</strong> at <strong>12:02</strong>.
+                            </ShareModal.Description>
+                        </ShareModal.Header>
+                        <PostPreview />
+                        <ShareModal.Footer>
+                            <ShareModal.SocialLinks links={postSocialLinks} />
+                            <ShareModal.CopyButton className="ml-0! grow cursor-pointer" copyURL={postUrl} />
+                        </ShareModal.Footer>
+                    </ShareModal.Content>
+                </ShareModal.Root>
             );
         };
 
@@ -232,22 +222,30 @@ export const Post: Story = {
 };
 
 export const Publication: Story = {
-    args: {
-        ...publicationArgs
-    },
-    render: (args) => {
+    render: () => {
         const PublicationExample = () => {
             const [isOpen, setIsOpen] = useState(false);
 
             return (
-                <ShareModal
-                    {...args}
-                    open={isOpen}
-                    onClose={() => setIsOpen(false)}
-                    onOpenChange={setIsOpen}
-                >
-                    <Button onClick={() => setIsOpen(true)}>Share publication</Button>
-                </ShareModal>
+                <ShareModal.Root open={isOpen} onOpenChange={setIsOpen}>
+                    <ShareModal.Trigger>
+                        <Button onClick={() => setIsOpen(true)}>Share publication</Button>
+                    </ShareModal.Trigger>
+                    <ShareModal.Content data-testid="publication-share-modal">
+                        <ShareModal.Header className="flex-row items-center justify-between gap-4 space-y-0 text-left">
+                            <ShareModal.Title className="text-2xl">Share your publication</ShareModal.Title>
+                            <ShareModal.CloseButton onClick={() => setIsOpen(false)} />
+                        </ShareModal.Header>
+                        <PublicationPreview />
+                        <p className="text-sm text-muted-foreground">
+                            Set your publication&apos;s cover image and description in <Button className="h-auto p-0 align-baseline text-sm text-green hover:text-green/90" variant="link" asChild><a href="#/settings/design/edit?ref=setup">Design settings</a></Button>.
+                        </p>
+                        <ShareModal.Footer>
+                            <ShareModal.SocialLinks links={publicationSocialLinks} />
+                            <ShareModal.CopyButton className="ml-0! grow cursor-pointer" copyURL={publicationUrl} />
+                        </ShareModal.Footer>
+                    </ShareModal.Content>
+                </ShareModal.Root>
             );
         };
 
@@ -262,39 +260,36 @@ export const Publication: Story = {
     }
 };
 
-export const ControlledPublication: Story = {
-    args: {
-        copyURL: publicationUrl,
-        preview: {
-            title: 'Ghostbusters',
-            url: publicationUrl
-        }
-    },
-    parameters: {
-        docs: {
-            source: {
-                code: publicationSource.replace('Share publication', 'Open publication share modal')
-            }
-        }
-    },
+export const StackedActions: Story = {
     render: () => {
-        const ControlledExample = () => {
+        const StackedExample = () => {
             const [isOpen, setIsOpen] = useState(false);
 
             return (
-                <ShareModal
-                    {...publicationArgs}
-                    open={isOpen}
-                    onClose={() => setIsOpen(false)}
-                    onOpenChange={setIsOpen}
-                >
-                    <Button onClick={() => setIsOpen(true)}>
-                        Open publication share modal
-                    </Button>
-                </ShareModal>
+                <ShareModal.Root open={isOpen} onOpenChange={setIsOpen}>
+                    <ShareModal.Trigger>
+                        <Button onClick={() => setIsOpen(true)}>Open stacked share modal</Button>
+                    </ShareModal.Trigger>
+                    <ShareModal.Content>
+                        <ShareModal.Header className="flex-row items-center justify-between gap-4 space-y-0 text-left">
+                            <ShareModal.Title className="text-2xl">Share your publication</ShareModal.Title>
+                            <ShareModal.CloseButton onClick={() => setIsOpen(false)} />
+                        </ShareModal.Header>
+                        <PublicationPreview />
+                        <ShareModal.CopyURLBox copyURL={publicationUrl}>
+                            <ShareModal.CopyButton
+                                copyURL={publicationUrl}
+                                icon="copy"
+                                size="sm"
+                                variant="outline"
+                            />
+                        </ShareModal.CopyURLBox>
+                        <ShareModal.SocialLinks layout="stacked" links={publicationSocialLinks} />
+                    </ShareModal.Content>
+                </ShareModal.Root>
             );
         };
 
-        return <ControlledExample />;
+        return <StackedExample />;
     }
 };

--- a/apps/shade/src/components/features/share-modal/share-modal.tsx
+++ b/apps/shade/src/components/features/share-modal/share-modal.tsx
@@ -1,10 +1,9 @@
-import {H3} from '@/components/layout/heading';
-import {Button} from '@/components/ui/button';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import {Check, Copy, Link, X} from 'lucide-react';
+import React, {useState} from 'react';
+import {Button, type ButtonProps} from '@/components/ui/button';
 import {Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger} from '@/components/ui/dialog';
 import {cn} from '@/lib/utils';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import {Check, Copy, Image as ImageIcon, Link, X} from 'lucide-react';
-import React, {useState} from 'react';
 
 type ShareService = 'x' | 'threads' | 'facebook' | 'linkedin';
 
@@ -16,35 +15,9 @@ export type ShareModalSocialLink = {
     title?: string;
 };
 
-interface ShareModalPreview {
-    description?: React.ReactNode;
-    imageURL?: string;
-    meta?: React.ReactNode;
-    title: React.ReactNode;
-    url: string;
-}
-
-interface ShareModalProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root> {
-    actionsLayout?: 'footer' | 'stacked';
-    children?: React.ReactNode;
-    closeButtonId?: string;
-    copyButtonId?: string;
-    copyButtonTestId?: string;
-    copyLabel?: string;
-    copySuccessLabel?: string;
-    copyURL: string;
-    contentProps?: React.ComponentPropsWithoutRef<typeof DialogContent> & Record<`data-${string}`, string | undefined>;
-    description?: React.ReactNode;
-    footerAction?: React.ReactNode;
-    guidance?: React.ReactNode;
-    onClose?: () => void;
-    preview: ShareModalPreview;
-    primaryTitle?: React.ReactNode;
-    secondaryTitle?: React.ReactNode;
-    socialLinks?: ShareModalSocialLink[];
-    title?: React.ReactNode;
-    variant?: 'post' | 'publication';
-}
+export type ShareModalPreviewProps = {
+    href: string;
+} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 async function copyTextToClipboard(text: string) {
     if (navigator.clipboard?.writeText) {
@@ -67,6 +40,98 @@ async function copyTextToClipboard(text: string) {
     document.execCommand('copy');
     document.body.removeChild(textarea);
 }
+
+function Root(props: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root>) {
+    return <Dialog {...props} />;
+}
+
+const Trigger = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Trigger>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>
+>(({asChild = true, className, ...props}, ref) => (
+    <DialogTrigger
+        ref={ref}
+        asChild={asChild}
+        className={cn('cursor-pointer', className)}
+        {...props}
+    />
+));
+Trigger.displayName = 'ShareModal.Trigger';
+
+const Content = React.forwardRef<
+    React.ElementRef<typeof DialogContent>,
+    React.ComponentPropsWithoutRef<typeof DialogContent>
+>(({className, ...props}, ref) => (
+    <DialogContent
+        ref={ref}
+        className={cn('max-h-[calc(100vh-16vmin)] max-w-[540px] overflow-y-auto p-8', className)}
+        {...props}
+    />
+));
+Content.displayName = 'ShareModal.Content';
+
+function Header({className, ...props}: React.ComponentPropsWithoutRef<typeof DialogHeader>) {
+    return <DialogHeader className={className} {...props} />;
+}
+
+function Title({className, ...props}: React.ComponentPropsWithoutRef<typeof DialogTitle>) {
+    return <DialogTitle className={className} {...props} />;
+}
+
+function Description({className, ...props}: React.ComponentPropsWithoutRef<typeof DialogDescription>) {
+    return <DialogDescription className={className} {...props} />;
+}
+
+type CloseButtonProps = ButtonProps;
+
+const CloseButton = React.forwardRef<HTMLButtonElement, CloseButtonProps>(({
+    children,
+    className,
+    size = 'lg',
+    title = 'Close',
+    variant = 'link',
+    ...props
+}, ref) => (
+    <Button
+        ref={ref}
+        className={cn(
+            '-mr-2 cursor-pointer p-2 text-muted-foreground hover:text-foreground [&_svg]:size-6!',
+            className
+        )}
+        size={size}
+        title={title}
+        variant={variant}
+        {...props}
+    >
+        {children || (
+            <>
+                <X size={24} strokeWidth={1} />
+                <span className="sr-only">Close</span>
+            </>
+        )}
+    </Button>
+));
+CloseButton.displayName = 'ShareModal.CloseButton';
+
+const Preview = React.forwardRef<HTMLAnchorElement, ShareModalPreviewProps>(({
+    className,
+    href,
+    rel = 'noopener noreferrer',
+    target = '_blank',
+    ...props
+}, ref) => {
+    return (
+        <a
+            ref={ref}
+            className={cn('flex flex-col items-stretch overflow-hidden border transition-all hover:border-muted-foreground/40', className)}
+            href={href}
+            rel={rel}
+            target={target}
+            {...props}
+        />
+    );
+});
+Preview.displayName = 'ShareModal.Preview';
 
 function SocialIcon({service}: {service: ShareService}) {
     if (service === 'threads') {
@@ -92,10 +157,15 @@ function SocialIcon({service}: {service: ShareService}) {
     );
 }
 
-function SocialLinks({layout, links}: {layout: 'footer' | 'stacked'; links: ShareModalSocialLink[]}) {
+interface SocialLinksProps extends React.HTMLAttributes<HTMLDivElement> {
+    layout?: 'footer' | 'stacked';
+    links: ShareModalSocialLink[];
+}
+
+function SocialLinks({className, layout = 'footer', links, ...props}: SocialLinksProps) {
     if (layout === 'stacked') {
         return (
-            <div className="flex gap-2">
+            <div className={cn('flex gap-2', className)} {...props}>
                 {links.map(link => (
                     <Button key={link.id ?? link.href} className="flex-1" id={link.id} variant="outline" asChild>
                         <a aria-label={link.label} href={link.href} rel="noreferrer" target="_blank" title={link.title || link.label}>
@@ -109,7 +179,7 @@ function SocialLinks({layout, links}: {layout: 'footer' | 'stacked'; links: Shar
     }
 
     return (
-        <div className="flex items-center gap-2">
+        <div className={cn('flex items-center gap-2', className)} {...props}>
             {links.map(link => (
                 <a key={link.id ?? link.href} aria-label={link.label} className="flex h-(--control-height) w-14 items-center justify-center rounded-xs bg-muted px-3 hover:bg-muted-foreground/20 [&_svg]:h-4" href={link.href} rel="noopener noreferrer" target="_blank" title={link.title || link.label}>
                     <SocialIcon service={link.service} />
@@ -119,151 +189,93 @@ function SocialLinks({layout, links}: {layout: 'footer' | 'stacked'; links: Shar
     );
 }
 
-const ShareModal: React.FC<ShareModalProps> = ({
-    actionsLayout = 'footer',
+interface CopyButtonProps extends ButtonProps {
+    copyURL: string;
+    icon?: 'copy' | 'link';
+    label?: string;
+    successLabel?: string;
+}
+
+function CopyButton({
     children,
-    closeButtonId,
-    copyButtonId,
-    copyButtonTestId,
-    copyLabel = 'Copy link',
-    copySuccessLabel = 'Copied!',
     copyURL,
-    contentProps,
-    description,
-    footerAction,
-    guidance,
-    onClose = () => {},
-    preview,
-    primaryTitle,
-    secondaryTitle,
-    socialLinks = [],
-    title,
-    variant = 'post',
+    disabled,
+    icon = 'link',
+    label = 'Copy link',
+    onClick,
+    successLabel = 'Copied!',
     ...props
-}) => {
+}: CopyButtonProps) {
     const [isCopied, setIsCopied] = useState(false);
 
-    const handleCopyLink = async () => {
+    const handleCopyLink = async (event: React.MouseEvent<HTMLButtonElement>) => {
+        onClick?.(event);
+
+        if (event.defaultPrevented) {
+            return;
+        }
+
         await copyTextToClipboard(copyURL);
         setIsCopied(true);
         setTimeout(() => setIsCopied(false), 2000);
     };
 
-    const showPostHeader = variant === 'post';
-    const {className: contentClassName, ...dialogContentProps} = contentProps || {};
-    const content = (
-        <DialogContent className={cn('max-h-[calc(100vh-16vmin)] max-w-[540px] overflow-y-auto p-8', contentClassName)} {...dialogContentProps}>
-            {showPostHeader && (
-                <div className="sticky top-0 ml-auto size-0">
-                    <Button className="absolute -top-5 -right-5 cursor-pointer p-2 text-muted-foreground hover:text-foreground [&_svg]:size-6!" id={closeButtonId} size="lg" title="Close" variant="link" onClick={onClose}>
-                        <X size={24} strokeWidth={1} />
-                        <span className="sr-only">Close</span>
-                    </Button>
-                </div>
-            )}
-            <DialogHeader className={showPostHeader ? 'relative -mt-5' : 'flex-row items-center justify-between gap-4 space-y-0 text-left'}>
-                {showPostHeader ?
-                    <DialogTitle className="text-3xl leading-[1.15em] font-bold">
-                        {primaryTitle && <span className="text-state-success">{primaryTitle}</span>}
-                        {primaryTitle && secondaryTitle && <br />}
-                        {secondaryTitle && <span>{secondaryTitle}</span>}
-                    </DialogTitle>
-                    :
-                    <DialogTitle className="text-2xl">{title}</DialogTitle>
-                }
-                {!showPostHeader && (
-                    <Button className="-mr-2 cursor-pointer p-2 text-muted-foreground hover:text-foreground [&_svg]:size-6!" id={closeButtonId} size="lg" title="Close" variant="link" onClick={onClose}>
-                        <X size={24} strokeWidth={1} />
-                        <span className="sr-only">Close</span>
-                    </Button>
-                )}
-                {description &&
-                    <DialogDescription className={showPostHeader ? 'mb-0 pt-1 pb-0 text-lg text-foreground' : 'sr-only'}>
-                        {description}
-                    </DialogDescription>
-                }
-            </DialogHeader>
-
-            <a className={cn('flex flex-col items-stretch overflow-hidden border transition-all hover:border-muted-foreground/40', showPostHeader ? 'rounded-md' : 'rounded-lg bg-card')} href={preview.url} rel="noopener noreferrer" target="_blank">
-                {preview.imageURL ?
-                    <div className="aspect-video bg-cover bg-center" style={{backgroundImage: `url(${preview.imageURL})`}}></div>
-                    :
-                    !showPostHeader && (
-                        <div className="flex aspect-video items-center justify-center bg-muted text-muted-foreground">
-                            <ImageIcon className="size-8" />
-                        </div>
-                    )
-                }
-                <div className={showPostHeader ? 'p-6 pt-5' : 'p-5'}>
-                    {showPostHeader ?
-                        <H3>{preview.title}</H3>
-                        :
-                        <div className="text-lg font-semibold">{preview.title}</div>
-                    }
-                    {preview.description && (
-                        <p className={showPostHeader ? undefined : 'mt-1 text-sm text-muted-foreground'}>{preview.description}</p>
-                    )}
-                    {preview.meta}
-                </div>
-            </a>
-
-            {guidance}
-
-            {actionsLayout === 'stacked' ?
-                <>
-                    <div className="flex items-center gap-2 rounded-md border bg-muted p-2">
-                        <span className="min-w-0 flex-1 truncate px-2 text-sm">{copyURL}</span>
-                        <Button
-                            data-testid={copyButtonTestId}
-                            id={copyButtonId}
-                            size="sm"
-                            type="button"
-                            variant="outline"
-                            onClick={() => {
-                                void handleCopyLink();
-                            }}
-                        >
-                            {isCopied ? <Check /> : <Copy />}
-                            {isCopied ? copySuccessLabel : copyLabel}
-                        </Button>
-                    </div>
-                    <SocialLinks layout={actionsLayout} links={socialLinks} />
-                </>
-                :
-                <DialogFooter className="justify-between gap-6">
-                    {footerAction || (
-                        <>
-                            <SocialLinks layout={actionsLayout} links={socialLinks} />
-                            <Button
-                                className="ml-0! grow cursor-pointer"
-                                disabled={!copyURL}
-                                type="button"
-                                onClick={() => {
-                                    void handleCopyLink();
-                                }}
-                            >
-                                {isCopied ? <Check /> : <Link />}
-                                {isCopied ? copySuccessLabel : copyLabel}
-                            </Button>
-                        </>
-                    )}
-                </DialogFooter>
-            }
-        </DialogContent>
-    );
+    const Icon = icon === 'copy' ? Copy : Link;
 
     return (
-        <Dialog {...props}>
-            {children ?
-                <DialogTrigger className="cursor-pointer" asChild>
-                    {children}
-                </DialogTrigger>
-                :
-                null
-            }
-            {content}
-        </Dialog>
+        <Button
+            disabled={disabled || !copyURL}
+            type="button"
+            onClick={(event) => {
+                void handleCopyLink(event);
+            }}
+            {...props}
+        >
+            {children || (
+                <>
+                    {isCopied ? <Check /> : <Icon />}
+                    {isCopied ? successLabel : label}
+                </>
+            )}
+        </Button>
     );
+}
+
+interface CopyURLBoxProps extends React.HTMLAttributes<HTMLDivElement> {
+    copyURL: string;
+}
+
+function CopyURLBox({children, className, copyURL, ...props}: CopyURLBoxProps) {
+    return (
+        <div className={cn('flex items-center gap-2 rounded-md border bg-muted p-2', className)} {...props}>
+            <span className="min-w-0 flex-1 truncate px-2 text-sm">{copyURL}</span>
+            {children}
+        </div>
+    );
+}
+
+function Footer({className, ...props}: React.ComponentPropsWithoutRef<typeof DialogFooter>) {
+    return (
+        <DialogFooter
+            className={cn('justify-between gap-6', className)}
+            {...props}
+        />
+    );
+}
+
+const ShareModal = {
+    CloseButton,
+    Content,
+    CopyButton,
+    CopyURLBox,
+    Description,
+    Footer,
+    Header,
+    Preview,
+    Root,
+    SocialLinks,
+    Title,
+    Trigger
 };
 
 export default ShareModal;

--- a/apps/shade/src/patterns.ts
+++ b/apps/shade/src/patterns.ts
@@ -4,7 +4,7 @@ export {default as ColorPicker} from './components/features/color-picker/color-p
 export type {ColorPickerProps} from './components/features/color-picker/color-picker';
 export {default as PostShareModal} from './components/features/post-share-modal';
 export {default as ShareModal} from './components/features/share-modal';
-export type {ShareModalSocialLink} from './components/features/share-modal';
+export type {ShareModalPreviewProps, ShareModalSocialLink} from './components/features/share-modal';
 export * from './components/features/table-filter-tabs/table-filter-tabs';
 export * from './components/features/utm-campaign-tabs/utm-campaign-tabs';
 export type {CampaignType, TabType} from './components/features/utm-campaign-tabs/utm-campaign-tabs';


### PR DESCRIPTION
no issue

## Summary

- changed ShareModal from a monolithic props API into slot components for Root, Trigger, Content, headers, preview, actions, social links, and copy controls
- updated PostShareModal and the onboarding share publication dialog to compose the new slots directly
- moved data attributes onto ShareModal.Content so callers use normal JSX attributes instead of narrow prop bags
- updated ShareModal stories and exported the preview props type

## Why

The previous contentProps escape hatch leaked internal DialogContent details and required narrow type patches for data attributes. The slot API gives future share modal use-cases direct access to the DOM surfaces they need without growing a long list of pass-through props.