### PR TITLE
[HKG-1738] Experiment: lazy URL routing service

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -119,12 +119,14 @@ async function initCore({ghostServer, config, frontend}) {
     // The URLService is a core part of Ghost, which depends on models.
     debug('Begin: Url Service');
     const urlService = require('./server/services/url');
-    // Note: there is no await here, we do not wait for the url service to finish
-    // We can return, but the site will remain in maintenance mode until this finishes
-    // This is managed on request: https://github.com/TryGhost/Ghost/blob/main/core/app.js#L10
-    urlService.init({
-        urlCache: !frontend // hacky parameter to make the cache initialization kick in as we can't initialize labs before the boot
-    });
+    if (!urlService.facade.isLazy()) {
+        // Note: there is no await here, we do not wait for the url service to finish
+        // We can return, but the site will remain in maintenance mode until this finishes
+        // This is managed on request: https://github.com/TryGhost/Ghost/blob/main/core/app.js#L10
+        urlService.init({
+            urlCache: !frontend // hacky parameter to make the cache initialization kick in as we can't initialize labs before the boot
+        });
+    }
     debug('End: Url Service');
 
     if (ghostServer) {
@@ -154,9 +156,11 @@ async function initCore({ghostServer, config, frontend}) {
         });
         debug('End: Mentions Job Service');
 
-        ghostServer.registerCleanupTask(async () => {
-            await urlService.shutdown();
-        });
+        if (!urlService.facade.isLazy()) {
+            ghostServer.registerCleanupTask(async () => {
+                await urlService.shutdown();
+            });
+        }
     }
 
     debug('End: initCore');

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -248,7 +248,10 @@ async function initExpressApps({frontend, backend, config}) {
 
     if (frontend) {
         // SITE + MEMBERS
-        const urlService = require('./server/services/url');
+        // RouterManager and migrated frontend callers expect the facade
+        // (getUrlForResource / ownsResource), not the raw eager UrlService
+        // (which only exposes the legacy id-based methods).
+        const urlService = require('./server/services/url').facade;
         const frontendApp = require('./server/web/parent/frontend')({urlService});
         parentApp.use(vhost(config.getFrontendMountPath(), frontendApp));
     }

--- a/ghost/core/core/bridge.js
+++ b/ghost/core/core/bridge.js
@@ -122,12 +122,16 @@ class Bridge {
         // re-initialize apps (register app routers, because we have re-initialized the site routers)
         appService.init();
 
-        // connect routers and resources again
-        urlService.queue.start({
-            event: 'init',
-            tolerance: 100,
-            requiredSubscriberCount: 1
-        });
+        if (!urlService.facade.isLazy()) {
+            // connect routers and resources again. The lazy URL service has
+            // nothing to precompute, so this step (and the queue itself) is
+            // skipped in lazy mode.
+            urlService.queue.start({
+                event: 'init',
+                tolerance: 100,
+                requiredSubscriberCount: 1
+            });
+        }
     }
 }
 

--- a/ghost/core/core/bridge.js
+++ b/ghost/core/core/bridge.js
@@ -114,7 +114,7 @@ class Bridge {
 
         const routerConfig = {
             routeSettings: await routeSettings.loadRouteSettings(),
-            urlService
+            urlService: urlService.facade
         };
 
         await siteApp.reload(routerConfig);

--- a/ghost/core/core/frontend/helpers/authors.js
+++ b/ghost/core/core/frontend/helpers/authors.js
@@ -34,7 +34,7 @@ module.exports = function authors(options = {}) {
     function createAuthorsList(authorsList) {
         function processAuthor(author) {
             return autolink ? templates.link({
-                url: urlService.getUrlByResourceId(author.id, {withSubdirectory: true}),
+                url: urlService.facade.getUrlForResource({...author, type: 'authors'}, {withSubdirectory: true}),
                 text: escapeExpression(author.name)
             }) : escapeExpression(author.name);
         }

--- a/ghost/core/core/frontend/helpers/tags.js
+++ b/ghost/core/core/frontend/helpers/tags.js
@@ -27,7 +27,7 @@ module.exports = function tags(options) {
     function createTagList(tagsList) {
         function processTag(tag) {
             return autolink ? templates.link({
-                url: urlService.getUrlByResourceId(tag.id, {withSubdirectory: true}),
+                url: urlService.facade.getUrlForResource({...tag, type: 'tags'}, {withSubdirectory: true}),
                 text: escapeExpression(tag.name)
             }) : escapeExpression(tag.name);
         }

--- a/ghost/core/core/frontend/meta/author-url.js
+++ b/ghost/core/core/frontend/meta/author-url.js
@@ -7,11 +7,11 @@ function getAuthorUrl(data, absolute) {
     const contextObject = getContextObject(data, context);
 
     if (data.author) {
-        return urlService.getUrlByResourceId(data.author.id, {absolute: absolute, withSubdirectory: true});
+        return urlService.facade.getUrlForResource({...data.author, type: 'authors'}, {absolute: absolute, withSubdirectory: true});
     }
 
     if (contextObject && contextObject.primary_author) {
-        return urlService.getUrlByResourceId(contextObject.primary_author.id, {absolute: absolute, withSubdirectory: true});
+        return urlService.facade.getUrlForResource({...contextObject.primary_author, type: 'authors'}, {absolute: absolute, withSubdirectory: true});
     }
 
     return null;

--- a/ghost/core/core/frontend/meta/url.js
+++ b/ghost/core/core/frontend/meta/url.js
@@ -16,15 +16,20 @@ function getUrl(data, absolute) {
          *
          * A long term solution should be part of the final version of Dynamic Routing.
          */
-        if (data.status !== 'published' && urlService.getUrlByResourceId(data.id) === '/404/') {
+        const postResource = {...data, type: 'posts'};
+        if (data.status !== 'published' && urlService.facade.getUrlForResource(postResource) === '/404/') {
             return urlUtils.urlFor({relativeUrl: urlUtils.urlJoin('/p', data.uuid, '/')}, null, absolute);
         }
 
-        return urlService.getUrlByResourceId(data.id, {absolute: absolute, withSubdirectory: true});
+        return urlService.facade.getUrlForResource(postResource, {absolute: absolute, withSubdirectory: true});
     }
 
-    if (checks.isTag(data) || checks.isUser(data)) {
-        return urlService.getUrlByResourceId(data.id, {absolute: absolute, withSubdirectory: true});
+    if (checks.isTag(data)) {
+        return urlService.facade.getUrlForResource({...data, type: 'tags'}, {absolute: absolute, withSubdirectory: true});
+    }
+
+    if (checks.isUser(data)) {
+        return urlService.facade.getUrlForResource({...data, type: 'authors'}, {absolute: absolute, withSubdirectory: true});
     }
 
     if (checks.isNav(data)) {

--- a/ghost/core/core/frontend/services/routing/controllers/collection.js
+++ b/ghost/core/core/frontend/services/routing/controllers/collection.js
@@ -73,7 +73,7 @@ module.exports = function collectionController(req, res, next) {
              * People should always invert their filters to ensure that the database query loads unique posts per collection.
              */
             result.posts = _.filter(result.posts, (post) => {
-                if (routerManager.owns(res.routerOptions.identifier, post.id)) {
+                if (routerManager.ownsResource(res.routerOptions.identifier, post)) {
                     return post;
                 }
 

--- a/ghost/core/core/frontend/services/routing/controllers/email-post.js
+++ b/ghost/core/core/frontend/services/routing/controllers/email-post.js
@@ -48,7 +48,7 @@ module.exports = function emailPostController(req, res, next) {
             }
 
             if (post.status === 'published') {
-                return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
+                return urlUtils.redirect301(res, routerManager.getUrlForResource(post, {withSubdirectory: true}));
             }
 
             return renderer.renderEntry(req, res)(post);

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -51,7 +51,7 @@ module.exports = function previewController(req, res, next) {
 
             // published content should only resolve to /:slug - /p/:uuid is for drafts only in lieu of an actual preview api
             if (post.status === 'published') {
-                return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
+                return urlUtils.redirect301(res, routerManager.getUrlForResource(post, {withSubdirectory: true}));
             }
 
             // once an email-only post has been sent it shouldn't be available via /p/ to avoid leaking members-only content

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -17,21 +17,13 @@ class RouterManager {
         this.registry = registry;
         this.siteRouter = null;
         /**
-         * @type {URLService}
+         * @type {URLServiceFacade}
          */
         this.urlService = null;
     }
 
-    owns(routerId, id) {
-        return this.urlService.owns(routerId, id);
-    }
-
     ownsResource(routerId, resource) {
         return this.urlService.ownsResource(routerId, resource);
-    }
-
-    getUrlByResourceId(id, options) {
-        return this.urlService.getUrlByResourceId(id, options);
     }
 
     getUrlForResource(resource, options) {
@@ -198,7 +190,7 @@ module.exports = RouterManager;
 /**
  * @typedef {Object} RouterConfig
  * @property {RouteSettings} [routeSettings] - JSON config representing routes
- * @property {URLService} urlService - service providing resource URL utility functions such as owns, getUrlByResourceId, and getResourceById
+ * @property {URLServiceFacade} urlService - resource-based URL service facade
  */
 
 /**
@@ -209,10 +201,10 @@ module.exports = RouterManager;
  */
 
 /**
- * @typedef {Object} URLService
- * @property {Function} owns
- * @property {Function} getUrlByResourceId
- * @property {Function} getResourceById
+ * @typedef {Object} URLServiceFacade
+ * @property {Function} getUrlForResource
+ * @property {Function} ownsResource
+ * @property {Function} resolveUrl
  * @property {Function} onRouterAddedType
  * @property {Function} onRouterUpdated
  */

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -26,8 +26,16 @@ class RouterManager {
         return this.urlService.owns(routerId, id);
     }
 
+    ownsResource(routerId, resource) {
+        return this.urlService.ownsResource(routerId, resource);
+    }
+
     getUrlByResourceId(id, options) {
         return this.urlService.getUrlByResourceId(id, options);
+    }
+
+    getUrlForResource(resource, options) {
+        return this.urlService.getUrlForResource(resource, options);
     }
 
     getResourceById(resourceId) {

--- a/ghost/core/core/frontend/services/rss/generate-feed.js
+++ b/ghost/core/core/frontend/services/rss/generate-feed.js
@@ -19,7 +19,7 @@ const generateTags = function generateTags(data) {
 const generateItem = function generateItem(post) {
     const cheerio = require('cheerio');
 
-    const itemUrl = routerManager.getUrlByResourceId(post.id, {absolute: true});
+    const itemUrl = routerManager.getUrlForResource(post, {absolute: true});
     const htmlContent = cheerio.load(post.html || '');
     const item = {
         title: post.title,

--- a/ghost/core/core/frontend/services/sitemap/handler.js
+++ b/ghost/core/core/frontend/services/sitemap/handler.js
@@ -13,7 +13,13 @@ module.exports = function handler(siteApp) {
         next();
     };
 
-    siteApp.get('/sitemap.xml', function sitemapXML(req, res) {
+    siteApp.get('/sitemap.xml', async function sitemapXML(req, res, next) {
+        try {
+            await manager.ensurePopulatedFromDatabase();
+        } catch (err) {
+            return next(err);
+        }
+
         res.set({
             'Cache-Control': 'public, max-age=' + config.get('caching:sitemap:maxAge'),
             'Content-Type': 'text/xml'
@@ -22,10 +28,16 @@ module.exports = function handler(siteApp) {
         res.send(manager.getIndexXml());
     });
 
-    siteApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res) {
+    siteApp.get('/sitemap-:resource.xml', verifyResourceType, async function sitemapResourceXML(req, res, next) {
         const type = req.params.resource.replace(/-\d+$/, '');
         const pageParam = (req.params.resource.match(/-(\d+)$/) || [null, null])[1];
         const page = pageParam ? parseInt(pageParam, 10) : 1;
+
+        try {
+            await manager.ensurePopulatedFromDatabase();
+        } catch (err) {
+            return next(err);
+        }
 
         const content = manager.getSiteMapXml(type, page);
         // Prevent x-1.xml as it is a duplicate of x.xml and empty sitemaps

--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -1,5 +1,7 @@
 const DomainEvents = require('@tryghost/domain-events');
+const config = require('../../../shared/config');
 const {URLResourceUpdatedEvent} = require('../../../shared/events');
+const toPlain = require('../../../server/lib/common/to-plain');
 const IndexMapGenerator = require('./site-map-index-generator');
 const PagesMapGenerator = require('./page-map-generator');
 const PostsMapGenerator = require('./post-map-generator');
@@ -21,6 +23,20 @@ class SiteMapManager {
         this.tags = options.tags || this.createTagsGenerator(options);
         this.index = options.index || this.createIndexGenerator(options);
 
+        // The lazy URL service does not fire url.added / url.removed /
+        // URLResourceUpdatedEvent. When that mode is active the sitemap
+        // populates itself from the database on first request instead.
+        this._lazyRouting = options.lazyRouting === undefined
+            ? config.get('lazyRouting')
+            : options.lazyRouting;
+        this._populated = false;
+        this._populating = null;
+        // Each routers.reset bumps this generation. An in-flight populate
+        // captures the generation it started in; if that generation is no
+        // longer current when the populate settles, its result is discarded
+        // so we don't mark a stale (potentially mid-reset) lookup as ready.
+        this._populationGeneration = 0;
+
         events.on('router.created', (router) => {
             if (router.name === 'StaticRoutesRouter') {
                 this.pages.addUrl(router.getRoute({absolute: true}), {id: router.identifier, staticRoute: true});
@@ -31,23 +47,31 @@ class SiteMapManager {
             }
         });
 
-        DomainEvents.subscribe(URLResourceUpdatedEvent, (event) => {
-            this[event.data.resourceType].updateURL(event.data);
-        });
+        if (!this._lazyRouting) {
+            DomainEvents.subscribe(URLResourceUpdatedEvent, (event) => {
+                this[event.data.resourceType].updateURL(event.data);
+            });
 
-        events.on('url.added', (obj) => {
-            this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
-        });
+            events.on('url.added', (obj) => {
+                this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
+            });
 
-        events.on('url.removed', (obj) => {
-            this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
-        });
+            events.on('url.removed', (obj) => {
+                this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
+            });
+        }
 
         events.on('routers.reset', () => {
             this.pages && this.pages.reset();
             this.posts && this.posts.reset();
             this.users && this.users.reset();
             this.tags && this.tags.reset();
+            // Force the next sitemap request to repopulate from the DB.
+            // Bumping the generation invalidates any populate currently in
+            // flight (its `.then` will see a stale generation and bail).
+            this._populated = false;
+            this._populating = null;
+            this._populationGeneration += 1;
         });
     }
 
@@ -86,6 +110,106 @@ class SiteMapManager {
     getSiteMapXml(type, page) {
         return this[type].getXml(page);
     }
+
+    /**
+     * Populate the sitemap from the database. Used when the lazy URL service
+     * is active and the URL-added/-removed events are not firing. Idempotent;
+     * a second call is a no-op while the first is in flight or has finished.
+     */
+    async ensurePopulatedFromDatabase() {
+        if (!this._lazyRouting || this._populated) {
+            return;
+        }
+        if (this._populating) {
+            return this._populating;
+        }
+        const generation = this._populationGeneration;
+        const populating = this._populateFromDatabase().then(
+            () => {
+                // If a routers.reset happened while we were running, the
+                // generators have been wiped. Don't flip _populated; let the
+                // next request kick off a fresh populate.
+                if (this._populationGeneration === generation) {
+                    this._populated = true;
+                }
+                // Only clear our own handle. routers.reset already nulled
+                // _populating and a successor populate may have replaced it
+                // — clobbering would orphan the successor.
+                if (this._populating === populating) {
+                    this._populating = null;
+                }
+            },
+            (err) => {
+                if (this._populating === populating) {
+                    this._populating = null;
+                }
+                throw err;
+            }
+        );
+        this._populating = populating;
+        return this._populating;
+    }
+
+    async _populateFromDatabase() {
+        const models = require('../../../server/models');
+        const urlService = require('../../../server/services/url');
+        const facade = urlService.facade;
+
+        // Use TagPublic/Author for the shouldHavePosts gate (so tags/users
+        // with no published posts are excluded). The visibility filter is
+        // applied in TYPE_BROWSE_OPTIONS below; together these mirror what
+        // the eager URL service does in services/url/config.js.
+        await Promise.all([
+            this._loadType(models.Post, 'posts', this.posts, facade),
+            this._loadType(models.Post, 'pages', this.pages, facade),
+            this._loadType(models.TagPublic, 'tags', this.tags, facade),
+            this._loadType(models.Author, 'authors', this.users, facade)
+        ]);
+    }
+
+    async _loadType(Model, type, generator, facade) {
+        const baseOptions = browseOptionsFor(type);
+        let page = 1;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const result = await Model.findPage({...baseOptions, page});
+            for (const model of result.data) {
+                const datum = toPlain(model);
+                const url = facade.getUrlForResource({...datum, type}, {absolute: true});
+                if (url && !url.match(/\/404\//)) {
+                    generator.addUrl(url, datum);
+                }
+            }
+            const totalPages = result?.meta?.pagination?.pages;
+            // Guard against unexpected response shapes (missing meta,
+            // empty page) so we don't loop forever.
+            if (!totalPages || page >= totalPages || result.data.length === 0) {
+                break;
+            }
+            page += 1;
+        }
+    }
+}
+
+// Per-router-type browse options for the lazy populate path. Mirrors the
+// eager URL service's resource queries (services/url/config.js): posts/pages
+// filter by published+type, tags/authors by visibility:public.
+//
+// `withRelated: ['tags', 'authors']` for posts: needed so the Bookshelf
+// model's toJSON output includes `primary_tag` and `primary_author`, which
+// custom permalink templates like `/:primary_tag/:slug/` evaluate against.
+// Without this preload the lazy sitemap would emit `/undefined/.../` for
+// any site using a primary_tag/primary_author permalink. Pages exclude
+// these in the eager config so we mirror that.
+const TYPE_BROWSE_OPTIONS = {
+    posts: {limit: 200, status: 'published', filter: 'type:post', withRelated: ['tags', 'authors']},
+    pages: {limit: 200, status: 'published', filter: 'type:page'},
+    tags: {limit: 200, filter: 'visibility:public'},
+    authors: {limit: 200, filter: 'visibility:public'}
+};
+
+function browseOptionsFor(type) {
+    return TYPE_BROWSE_OPTIONS[type] || {limit: 200};
 }
 
 module.exports = SiteMapManager;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
@@ -3,7 +3,11 @@ const urlUtils = require('../../../../../../../shared/url-utils');
 const localUtils = require('../../../index');
 
 const forPost = (id, attrs, frame) => {
-    attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+    // `id` is passed separately because callers may filter `attrs` via
+    // `fields=url`, which strips every attribute except the requested ones.
+    // Without this explicit `id`, the eager facade's id-based fallback hits
+    // /404/ for every post.
+    attrs.url = urlService.facade.getUrlForResource({...attrs, id, type: 'posts'}, {absolute: true});
 
     /**
      * CASE: admin api should serve preview urls
@@ -44,7 +48,7 @@ const forPost = (id, attrs, frame) => {
 
 const forUser = (id, attrs, options) => {
     if (!options.columns || (options.columns && options.columns.includes('url'))) {
-        attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+        attrs.url = urlService.facade.getUrlForResource({...attrs, id, type: 'authors'}, {absolute: true});
     }
 
     return attrs;
@@ -52,7 +56,7 @@ const forUser = (id, attrs, options) => {
 
 const forTag = (id, attrs, options) => {
     if (!options.columns || (options.columns && options.columns.includes('url'))) {
-        attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+        attrs.url = urlService.facade.getUrlForResource({...attrs, id, type: 'tags'}, {absolute: true});
     }
 
     return attrs;

--- a/ghost/core/core/server/lib/common/to-plain.js
+++ b/ghost/core/core/server/lib/common/to-plain.js
@@ -1,0 +1,21 @@
+/**
+ * Normalise a Bookshelf model or plain object to its JSON representation.
+ *
+ * Bookshelf models expose their data via `.toJSON()` and store it on a private
+ * `attributes` map; spreading them with `{...model}` skips the prototype-defined
+ * getters (including `id`) and so silently loses the data. This helper lets
+ * callers accept either shape uniformly:
+ *
+ *   const data = toPlain(post);
+ *   urlService.facade.getUrlForResource({...data, type: 'posts'}, ...)
+ *
+ * @template T
+ * @param {T | {toJSON(): T}} modelOrObj
+ * @returns {T}
+ */
+module.exports = function toPlain(modelOrObj) {
+    if (modelOrObj && typeof modelOrObj.toJSON === 'function') {
+        return modelOrObj.toJSON();
+    }
+    return modelOrObj;
+};

--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
@@ -1,3 +1,5 @@
+const toPlain = require('../../lib/common/to-plain');
+
 class AudienceFeedbackService {
     /** @type URL */
     #baseURL;
@@ -20,13 +22,14 @@ class AudienceFeedbackService {
      * @param {string} key - hashed uuid value
      */
     buildLink(uuid, post, score, key) {
-        let postUrl = this.#urlService.getUrlByResourceId(post.id, {absolute: true});
+        const postData = toPlain(post);
+        let postUrl = this.#urlService.facade.getUrlForResource({...postData, type: 'posts'}, {absolute: true});
 
         if (postUrl.match(/\/404\//)) {
             postUrl = this.#baseURL;
         }
         const url = new URL(postUrl);
-        url.hash = `#/feedback/${post.id}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
+        url.hash = `#/feedback/${postData.id}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
         return url;
     }
 }

--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
@@ -15,18 +15,18 @@ class AudienceFeedbackService {
     }
     /**
      * @param {string} uuid
-     * @param {string} postId
+     * @param {{id: string}} post
      * @param {0 | 1} score
      * @param {string} key - hashed uuid value
      */
-    buildLink(uuid, postId, score, key) {
-        let postUrl = this.#urlService.getUrlByResourceId(postId, {absolute: true});
+    buildLink(uuid, post, score, key) {
+        let postUrl = this.#urlService.getUrlByResourceId(post.id, {absolute: true});
 
         if (postUrl.match(/\/404\//)) {
             postUrl = this.#baseURL;
         }
         const url = new URL(postUrl);
-        url.hash = `#/feedback/${postId}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
+        url.hash = `#/feedback/${post.id}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
         return url;
     }
 }

--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -2,6 +2,7 @@ const moment = require('moment');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const emailService = require('../email-service');
 const CommentsServiceEmailRenderer = require('./comments-service-email-renderer');
+const toPlain = require('../../lib/common/to-plain');
 const {t} = require('../i18n');
 
 class CommentsServiceEmails {
@@ -25,7 +26,8 @@ class CommentsServiceEmails {
      * @returns {string} The post URL with appropriate comment fragment
      */
     getPostUrl(post, commentId) {
-        const baseUrl = this.urlService.getUrlByResourceId(post.id, {absolute: true});
+        const postData = toPlain(post);
+        const baseUrl = this.urlService.facade.getUrlForResource({...postData, type: 'posts'}, {absolute: true});
         return `${baseUrl}#ghost-comments-${commentId}`;
     }
 

--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -20,12 +20,12 @@ class CommentsServiceEmails {
 
     /**
      * Build the post URL with comment fragment for email links
-     * @param {string} postId - The ID of the post
+     * @param {{id: string}} post - The post (model or plain object with `id`)
      * @param {string} commentId - The ID of the comment to link to
      * @returns {string} The post URL with appropriate comment fragment
      */
-    getPostUrl(postId, commentId) {
-        const baseUrl = this.urlService.getUrlByResourceId(postId, {absolute: true});
+    getPostUrl(post, commentId) {
+        const baseUrl = this.urlService.getUrlByResourceId(post.id, {absolute: true});
         return `${baseUrl}#ghost-comments-${commentId}`;
     }
 
@@ -48,7 +48,7 @@ class CommentsServiceEmails {
                 siteUrl: this.urlUtils.getSiteUrl(),
                 siteDomain: this.siteDomain,
                 postTitle: post.get('title'),
-                postUrl: this.getPostUrl(post.get('id'), comment.get('id')),
+                postUrl: this.getPostUrl(post, comment.get('id')),
                 commentHtml: comment.get('html'),
                 commentDate: moment(comment.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),
                 memberName: memberName,
@@ -110,7 +110,7 @@ class CommentsServiceEmails {
             siteUrl: this.urlUtils.getSiteUrl(),
             siteDomain: this.siteDomain,
             postTitle: post.get('title'),
-            postUrl: this.getPostUrl(post.get('id'), reply.get('id')),
+            postUrl: this.getPostUrl(post, reply.get('id')),
             replyHtml: reply.get('html'),
             replyDate: moment(reply.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),
             memberName: memberName,
@@ -158,7 +158,7 @@ class CommentsServiceEmails {
             siteUrl: this.urlUtils.getSiteUrl(),
             siteDomain: this.siteDomain,
             postTitle: post.get('title'),
-            postUrl: this.getPostUrl(post.get('id'), comment.get('id')),
+            postUrl: this.getPostUrl(post, comment.get('id')),
             commentHtml: comment.get('html'),
             commentText: htmlToPlaintext.comment(comment.get('html')),
             commentDate: moment(comment.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1058,13 +1058,13 @@ class EmailRenderer {
         // Audience feedback
         const positiveLink = this.#audienceFeedbackService.buildLink(
             '--uuid--',
-            post.id,
+            post,
             1,
             '--key--'
         ).href.replace('--uuid--', '%%{uuid}%%').replace('--key--', '%%{key}%%');
         const negativeLink = this.#audienceFeedbackService.buildLink(
             '--uuid--',
-            post.id,
+            post,
             0,
             '--key--'
         ).href.replace('--uuid--', '%%{uuid}%%').replace('--key--', '%%{key}%%');

--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -84,7 +84,7 @@ async function ping(post) {
     }
 
     try {
-        const url = urlService.getUrlByResourceId(post.id, {absolute: true});
+        const url = urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
 
         // Get the API key (auto-generated on boot by settings service)
         const key = getApiKey();

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -1,7 +1,9 @@
 /**
  * @typedef {Object} UrlService
- * @prop {(resourceId: string, options) => Object} getResource
- * @prop {{getUrlForResource: (resource: Object, options: Object) => string}} facade
+ * @prop {{
+ *   getUrlForResource: (resource: Object, options: Object) => string,
+ *   resolveUrl: (path: string) => Promise<Object | null>
+ * }} facade
  */
 
 const toPlain = require('../../lib/common/to-plain');
@@ -88,7 +90,7 @@ class UrlTranslator {
         return {
             type: 'url',
             id: null,
-            ...this.getTypeAndIdFromPath(path),
+            ...(await this.getTypeAndIdFromPath(path)),
             url: path
         };
     }
@@ -97,37 +99,37 @@ class UrlTranslator {
      * Get the resource type and ID from a path that was visited on the site
      * @param {string} path (excluding subdirectory)
      */
-    getTypeAndIdFromPath(path) {
-        const resource = this.urlService.getResource(path);
+    async getTypeAndIdFromPath(path) {
+        const resource = await this.urlService.facade.resolveUrl(path);
         if (!resource) {
             return;
         }
 
-        if (resource.config.type === 'posts') {
+        if (resource.type === 'posts') {
             return {
                 type: 'post',
-                id: resource.data.id
+                id: resource.id
             };
         }
 
-        if (resource.config.type === 'pages') {
+        if (resource.type === 'pages') {
             return {
                 type: 'page',
-                id: resource.data.id
+                id: resource.id
             };
         }
 
-        if (resource.config.type === 'tags') {
+        if (resource.type === 'tags') {
             return {
                 type: 'tag',
-                id: resource.data.id
+                id: resource.id
             };
         }
 
-        if (resource.config.type === 'authors') {
+        if (resource.type === 'authors') {
             return {
                 type: 'author',
-                id: resource.data.id
+                id: resource.id
             };
         }
     }

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -1,9 +1,17 @@
 /**
  * @typedef {Object} UrlService
  * @prop {(resourceId: string, options) => Object} getResource
- *  @prop {(resourceId: string, options) => string} getUrlByResourceId
- *
+ * @prop {{getUrlForResource: (resource: Object, options: Object) => string}} facade
  */
+
+const toPlain = require('../../lib/common/to-plain');
+
+const TYPE_TO_RESOURCE = {
+    post: 'posts',
+    page: 'pages',
+    tag: 'tags',
+    author: 'authors'
+};
 
 /**
  * Translate a url into, (id+type), or a resource, and vice versa
@@ -124,10 +132,6 @@ class UrlTranslator {
         }
     }
 
-    getUrlByResourceId(id, options = {absolute: true}) {
-        return this.urlService.getUrlByResourceId(id, options);
-    }
-
     /**
      * Get the URL for a resource, handling email-only posts which have no
      * public URL (the URL service returns /404/ for them).
@@ -138,14 +142,26 @@ class UrlTranslator {
             const emailPath = `/email/${model.get('uuid')}/`;
             return absolute ? this.relativeToAbsolute(emailPath) : emailPath;
         }
-        return this.getUrlByResourceId(id, {absolute});
+        // Lazy URL service evaluates permalink templates against resource fields
+        // (slug, published_at, primary_tag, ...). Caller already loaded the model,
+        // so spread its plain data so those fields reach the facade.
+        const data = toPlain(model);
+        const resource = {...data, id, type: TYPE_TO_RESOURCE[type]};
+        return this.urlService.facade.getUrlForResource(resource, {absolute});
     }
 
     async getResourceById(id, type) {
         switch (type) {
         case 'post':
         case 'page': {
-            const post = await this.models.Post.findOne({id}, {require: false, filter: 'type:[post,page]+status:[published,sent]'});
+            // withRelated: tags+authors so the lazy URL service can evaluate
+            // `:primary_tag` / `:primary_author` permalink templates against
+            // the resource. Mirrors services/url/config.js's posts config.
+            const post = await this.models.Post.findOne({id}, {
+                require: false,
+                filter: 'type:[post,page]+status:[published,sent]',
+                withRelated: ['tags', 'authors']
+            });
             if (!post) {
                 return null;
             }

--- a/ghost/core/core/server/services/mentions/resource-service.js
+++ b/ghost/core/core/server/services/mentions/resource-service.js
@@ -30,17 +30,17 @@ module.exports = class ResourceService {
      */
     async getByURL(url) {
         const path = this.#urlUtils.absoluteToRelative(url.href, {withoutSubdirectory: true});
-        const resource = this.#urlService.getResource(path);
-        if (resource?.config?.type === 'posts') {
+        const resource = await this.#urlService.facade.resolveUrl(path);
+        if (resource?.type === 'posts') {
             return {
                 type: 'post',
-                id: ObjectID.createFromHexString(resource.data.id)
+                id: ObjectID.createFromHexString(resource.id)
             };
         }
-        if (resource?.config?.type === 'pages') {
+        if (resource?.type === 'pages') {
             return {
                 type: 'page',
-                id: ObjectID.createFromHexString(resource.data.id)
+                id: ObjectID.createFromHexString(resource.id)
             };
         }
         return {

--- a/ghost/core/core/server/services/route-settings/route-settings.js
+++ b/ghost/core/core/server/services/route-settings/route-settings.js
@@ -95,10 +95,20 @@ class RouteSettings {
         await this.createBackupFile(this.settingsPath, this.backupPath);
         await this.saveFile(filePath, this.settingsPath);
 
-        urlService.resetGenerators({releaseResourcesOnly: true});
+        const isLazy = urlService.facade.isLazy();
+        const resetUrlState = () => {
+            if (isLazy) {
+                // Drop registered router configs; reloadFrontend re-registers them.
+                urlService.facade.reset();
+            } else {
+                urlService.resetGenerators({releaseResourcesOnly: true});
+            }
+        };
+
+        resetUrlState();
 
         const bringBackValidRoutes = async () => {
-            urlService.resetGenerators({releaseResourcesOnly: true});
+            resetUrlState();
 
             await this.restoreBackupFile(this.settingsPath, this.backupPath);
 
@@ -112,6 +122,12 @@ class RouteSettings {
                 .finally(() => {
                     throw err;
                 });
+        }
+
+        // The lazy URL service has nothing to precompute, so the readiness
+        // poll below is unnecessary; hasFinished() returns true immediately.
+        if (isLazy) {
+            return;
         }
 
         // @TODO: how can we get rid of this from here?

--- a/ghost/core/core/server/services/slack.js
+++ b/ghost/core/core/server/services/slack.js
@@ -56,7 +56,7 @@ function ping(post) {
 
     // If this is a post, we want to send the link of the post
     if (hasPostProperties(post)) {
-        message = urlService.getUrlByResourceId(post.id, {absolute: true});
+        message = urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
         title = post.title ? post.title : null;
         author = post.authors ? post.authors[0] : null;
 
@@ -136,7 +136,7 @@ function ping(post) {
                         fields: [
                             {
                                 title: 'Author',
-                                value: author ? `<${urlService.getUrlByResourceId(author.id, {absolute: true})} | ${author.name}>` : null,
+                                value: author ? `<${urlService.facade.getUrlForResource({...author, type: 'authors'}, {absolute: true})} | ${author.name}>` : null,
                                 short: true
                             }
                         ],

--- a/ghost/core/core/server/services/stats/content-stats-service.js
+++ b/ghost/core/core/server/services/stats/content-stats-service.js
@@ -1,5 +1,14 @@
 const logging = require('@tryghost/logging');
 
+// Pre-migration the resourceType field on this service's response was the
+// raw `data.type` column on the underlying record: 'post' / 'page' for
+// posts and pages, undefined for tags / authors (those tables have no type
+// column). Preserve that contract by only mapping the two singular types.
+const ROUTER_TYPE_TO_SINGULAR = {
+    posts: 'post',
+    pages: 'page'
+};
+
 /**
  * @typedef {Object} TopContentDataItem
  * @property {string} pathname - Page path
@@ -176,27 +185,31 @@ class ContentStatsService {
     /**
      * Get resource title using UrlService
      * @param {string} pathname - Path to look up
-     * @returns {Object|null} Resource title and type, or null if not found
+     * @returns {Promise<Object|null>} Resource title and type, or null if not found
      */
-    getResourceTitle(pathname) {
+    async getResourceTitle(pathname) {
         if (!this.urlService) {
             return null;
         }
 
         try {
-            const resource = this.urlService.getResource(pathname);
+            const resource = await this.urlService.facade.resolveUrl(pathname);
 
-            if (resource && resource.data) {
-                if (resource.data.title) {
+            if (resource) {
+                // resource.type is the routing-level plural form (posts/pages/tags/authors).
+                // Keep singular/undefined here for backwards-compatibility with the previous
+                // data.type semantics (post/page/undefined).
+                const resourceType = ROUTER_TYPE_TO_SINGULAR[resource.type];
+                if (resource.title) {
                     return {
-                        title: resource.data.title,
-                        resourceType: resource.data.type
+                        title: resource.title,
+                        resourceType
                     };
-                } else if (resource.data.name) {
+                } else if (resource.name) {
                     // For authors, tags, etc.
                     return {
-                        title: resource.data.name,
-                        resourceType: resource.data.type
+                        title: resource.name,
+                        resourceType
                     };
                 }
             }
@@ -232,8 +245,8 @@ class ContentStatsService {
             if (this.urlService && item.pathname) {
                 try {
                     // Check if URL service is ready
-                    if (this.urlService.hasFinished && this.urlService.hasFinished()) {
-                        const resource = this.urlService.getResource(item.pathname);
+                    if (this.urlService.facade.hasFinished && this.urlService.facade.hasFinished()) {
+                        const resource = await this.urlService.facade.resolveUrl(item.pathname);
                         urlExists = !!resource; // Convert to boolean
                     }
                     // If URL service isn't ready, we default to true (clickable)
@@ -255,7 +268,7 @@ class ContentStatsService {
             }
 
             // Use UrlService for pages without post_uuid
-            const resourceInfo = this.getResourceTitle(item.pathname);
+            const resourceInfo = await this.getResourceTitle(item.pathname);
             if (resourceInfo) {
                 return {
                     ...item,

--- a/ghost/core/core/server/services/stats/posts-stats-service.js
+++ b/ghost/core/core/server/services/stats/posts-stats-service.js
@@ -213,7 +213,7 @@ class PostsStatsService {
         }
 
         // Transform results and enrich with titles and URL existence validation
-        return results.map((row) => {
+        return Promise.all(results.map(async (row) => {
             const title = row.title || this._generateTitleFromPath(row.attribution_url);
 
             // Check if URL exists using the URL service
@@ -222,8 +222,8 @@ class PostsStatsService {
             if (this.urlService && row.attribution_url) {
                 try {
                     // Check if URL service is ready
-                    if (this.urlService.hasFinished && this.urlService.hasFinished()) {
-                        const resource = this.urlService.getResource(row.attribution_url);
+                    if (this.urlService.facade.hasFinished && this.urlService.facade.hasFinished()) {
+                        const resource = await this.urlService.facade.resolveUrl(row.attribution_url);
                         urlExists = !!resource; // Convert to boolean
                     }
                     // If URL service isn't ready, we default to true (clickable)
@@ -246,7 +246,7 @@ class PostsStatsService {
                 post_type: row.attribution_type === 'post' ? 'post' : (row.attribution_type === 'page' ? 'page' : null),
                 url_exists: urlExists
             };
-        });
+        }));
     }
 
     _generateTitleFromPath(path) {

--- a/ghost/core/core/server/services/url/BENCHMARK.md
+++ b/ghost/core/core/server/services/url/BENCHMARK.md
@@ -1,0 +1,69 @@
+# Lazy URL service benchmark plan
+
+Tracking issue: [HKG-1772](https://linear.app/ghost/issue/HKG-1772/benchmark-lazy-url-resolution).
+
+This file documents the methodology for evaluating the `lazyRouting` flag on
+realistic data. Results live in the Linear project document, not in the repo.
+
+## What we're measuring
+
+| Metric | Tool | Notes |
+| -- | -- | -- |
+| Browse endpoint response time | `autocannon` | `/ghost/api/content/posts/?limit=15` |
+| Single post read | `autocannon` | `/ghost/api/content/posts/slug/<known-slug>/` |
+| Page render | `autocannon` | `/<slug>/` (frontend) |
+| Sitemap generation | one-shot `curl --time` | `/sitemap.xml`, `/sitemap-posts.xml`, etc. |
+| Memory (RSS, heap) | `process.memoryUsage()` sampled every 5s | logged during the autocannon run |
+| Boot time | first `200` response after `pnpm start` | recorded by a wrapper script |
+
+## Dataset
+
+A clone of a large production Ghost(Pro) site (~250K posts). Two
+`routes.yaml` configs are tested:
+
+1. The default config (one unfiltered collection at `/`).
+2. A non-trivial multi-collection config representative of the production
+   site cohort identified in the
+   [routes.yaml analysis](https://linear.app/ghost/document/ghostpro-routesyaml-analysis-de19baaf775e)
+   (≥ 10 collections, mix of `tag:`, `primary_tag:`, `featured:`, and
+   date-based permalinks).
+
+## Procedure
+
+For each `(routes.yaml, lazyRouting on/off)` combination:
+
+1. Restart Ghost (`pnpm dev` or container restart). Record boot time.
+2. Wait 30s for caches to settle.
+3. Run `autocannon -d 60 -c <C>` with `<C>` ∈ {1, 50, 100} for each of the
+   three latency targets above.
+4. Capture median, p95, and p99 latency plus throughput.
+5. Sample memory while step 3 is running.
+6. Issue one cold-cache sitemap request per type (clear HTTP-level cache
+   first), record total time.
+
+Each combination runs three times; we report the median run.
+
+## Acceptable thresholds (working hypothesis)
+
+* Median page render latency increase ≤ 15% under c=100.
+* p99 page render latency increase ≤ 30% under c=100.
+* Per-instance RSS reduction ≥ 50% on the 250K-post dataset (the eager map
+  is the main contributor; if the lazy mode does not free this we have a
+  finding to act on).
+* Sitemap generation ≤ 60s for the 250K-post dataset, served from HTTP cache
+  thereafter.
+
+If the lazy implementation misses any of these, the next step is Approach 2
+from the design doc: layer per-resource memoization onto the lazy service.
+
+## How to run locally
+
+The flag is config-only:
+
+```bash
+echo '{"lazyRouting": true}' > ghost/core/config.local.json
+pnpm dev
+```
+
+`pnpm dev` resolves config from the workspace root; flip the value to switch
+modes between runs.

--- a/ghost/core/core/server/services/url/index.js
+++ b/ghost/core/core/server/services/url/index.js
@@ -1,6 +1,7 @@
 const config = require('../../../shared/config');
 const LocalFileCache = require('./local-file-cache');
 const UrlService = require('./url-service');
+const UrlServiceFacade = require('./url-service-facade');
 
 // NOTE: instead of a path we could give UrlService a "data-resolver" of some sort
 //       so it doesn't have to contain the logic to read data at all. This would be
@@ -21,6 +22,12 @@ if (process.env.NODE_ENV.startsWith('test')){
 
 const cache = new LocalFileCache({storagePath, writeDisabled});
 const urlService = new UrlService({cache});
+const urlServiceFacade = new UrlServiceFacade({urlService});
 
-// Singleton
+// Singleton: default export remains the eager UrlService for backwards
+// compatibility with existing imports. The new facade is exposed alongside
+// it via `urlService.facade` so RouterManager and migrating callers can
+// reach for it without forcing every consumer to update at once.
+urlService.facade = urlServiceFacade;
+
 module.exports = urlService;

--- a/ghost/core/core/server/services/url/index.js
+++ b/ghost/core/core/server/services/url/index.js
@@ -2,6 +2,7 @@ const config = require('../../../shared/config');
 const LocalFileCache = require('./local-file-cache');
 const UrlService = require('./url-service');
 const UrlServiceFacade = require('./url-service-facade');
+const LazyUrlService = require('./lazy-url-service');
 
 // NOTE: instead of a path we could give UrlService a "data-resolver" of some sort
 //       so it doesn't have to contain the logic to read data at all. This would be
@@ -22,7 +23,56 @@ if (process.env.NODE_ENV.startsWith('test')){
 
 const cache = new LocalFileCache({storagePath, writeDisabled});
 const urlService = new UrlService({cache});
-const urlServiceFacade = new UrlServiceFacade({urlService});
+
+// LazyUrlService is only attached to the facade when the lazyRouting flag is
+// on. The eager UrlService stays in the require graph either way so test code
+// and partially-migrated callers continue to work. The model layer is only
+// pulled in when the flag is on so flag-off boot keeps its existing
+// require-graph shape.
+let lazyUrlService = null;
+if (config.get('lazyRouting')) {
+    const models = require('../../models');
+
+    const loadOne = async (Model, query) => {
+        const result = await Model.findOne(query, {require: false});
+        return result ? result.toJSON() : null;
+    };
+
+    const loadPostlike = (Model, query, dbType) => {
+        return loadOne(Model, {...query, type: dbType, status: 'published'});
+    };
+
+    // The eager UrlService only registers URLs for resources matching the
+    // resourceConfig filter (status:published, public visibility). Mirror
+    // that here so reverse lookups can't return drafts / private resources
+    // even though we now hit the DB on demand. We also disambiguate posts
+    // vs pages — both share `models.Post` and a permalink template like
+    // `/:slug/` could otherwise return either record.
+    //
+    // For tags and authors we use the public-facing scoped models
+    // (TagPublic, Author) which carry the shouldHavePosts gate, so reverse
+    // lookups can't return tags/users with no published posts (and in
+    // particular can't expose staff User accounts via a guessed slug).
+    const findResource = (type, query) => {
+        if (type === 'posts') {
+            return loadPostlike(models.Post, query, 'post');
+        }
+        if (type === 'pages') {
+            return loadPostlike(models.Post, query, 'page');
+        }
+        if (type === 'tags') {
+            return loadOne(models.TagPublic, {...query, visibility: 'public'});
+        }
+        if (type === 'authors') {
+            return loadOne(models.Author, {...query, visibility: 'public'});
+        }
+        return Promise.resolve(null);
+    };
+
+    lazyUrlService = new LazyUrlService({findResource});
+}
+
+const urlServiceFacade = new UrlServiceFacade({urlService, lazyUrlService});
 
 // Singleton: default export remains the eager UrlService for backwards
 // compatibility with existing imports. The new facade is exposed alongside

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -1,0 +1,265 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const nql = require('@tryghost/nql');
+const debug = require('@tryghost/debug')('services:url:lazy');
+const localUtils = require('../../../shared/url-utils');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+import type {Resource, UrlOptions, LazyUrlServiceBackend} from './url-service-facade';
+
+// The same expansions used by UrlGenerator so users can write `tag:foo`,
+// `author:jane`, etc. and have them rewritten to the underlying field paths.
+const EXPANSIONS = [
+    {key: 'author', replacement: 'authors.slug'},
+    {key: 'tags', replacement: 'tags.slug'},
+    {key: 'tag', replacement: 'tags.slug'},
+    {key: 'authors', replacement: 'authors.slug'},
+    {key: 'primary_tag', replacement: 'primary_tag.slug'},
+    {key: 'primary_author', replacement: 'primary_author.slug'}
+];
+
+// Same `page:true/false` legacy transformer the UrlGenerator uses, so old
+// routes.yaml configs continue to work.
+const PAGE_TRANSFORMER = nql.utils.mapKeyValues({
+    key: {from: 'page', to: 'type'},
+    values: [
+        {from: false, to: 'post'},
+        {from: true, to: 'page'}
+    ]
+});
+
+// Map a resource's `type` field (whatever the caller passed) onto the plural
+// router resource type. We accept the singular DB column values ('post',
+// 'page') as well as the plural router keys, because the migrated callers
+// are inconsistent: API responses spread `attrs` (singular), but some
+// helpers explicitly tag with the plural router key.
+const TYPE_TO_ROUTER_TYPE: Record<string, string> = {
+    post: 'posts',
+    posts: 'posts',
+    page: 'pages',
+    pages: 'pages',
+    tag: 'tags',
+    tags: 'tags',
+    author: 'authors',
+    authors: 'authors'
+};
+
+interface NqlInstance {
+    queryJSON(record: Record<string, unknown>): unknown;
+}
+
+interface RouterConfig {
+    identifier: string;
+    filter: string | null;
+    resourceType: string;
+    permalink: string;
+    nql: NqlInstance | null;
+}
+
+/**
+ * Async function that resolves a slug (or other params) to a database
+ * record. Injected so the URL service stays pure for forward lookups —
+ * only `resolveUrl` actually hits the DB, and only via this hook.
+ */
+export type FindResource = (
+    routerType: string,
+    params: Record<string, string>
+) => Promise<Record<string, unknown> | null>;
+
+interface LazyUrlServiceDeps {
+    urlUtils?: typeof localUtils;
+    findResource?: FindResource | null;
+}
+
+/**
+ * On-demand URL service. Computes URLs and ownership per-call from the
+ * registered router configs instead of holding a precomputed map of every
+ * resource. Pure for forward lookups; resolveUrl() takes an optional DB
+ * lookup function so reverse lookups stay testable.
+ */
+export class LazyUrlService implements LazyUrlServiceBackend {
+    private urlUtils: typeof localUtils;
+    private findResource: FindResource | null;
+    private routerConfigs: RouterConfig[];
+
+    constructor({urlUtils = localUtils, findResource = null}: LazyUrlServiceDeps = {}) {
+        this.urlUtils = urlUtils;
+        this.findResource = findResource;
+        // Router configs in priority order. Position is the registration order.
+        this.routerConfigs = [];
+    }
+
+    onRouterAddedType(
+        identifier: string,
+        filter: string | null,
+        resourceType: string,
+        permalink: string
+    ): void {
+        debug('onRouterAddedType', identifier, resourceType, permalink, filter);
+        const config: RouterConfig = {identifier, filter, resourceType, permalink, nql: null};
+        if (filter) {
+            config.nql = nql(filter, {expansions: EXPANSIONS, transformer: PAGE_TRANSFORMER});
+        }
+        this.routerConfigs.push(config);
+    }
+
+    onRouterUpdated(): void {
+        // No state to regenerate. The next URL request reads the (possibly new)
+        // router config; in-flight requests that already snapshotted the old
+        // config keep using it, which matches the documented atomic-reload
+        // behaviour.
+    }
+
+    /**
+     * Drop all registered routers. Called when routes.yaml is reloaded.
+     */
+    reset(): void {
+        this.routerConfigs = [];
+    }
+
+    hasFinished(): boolean {
+        return true;
+    }
+
+    getUrlForResource(resource: Resource, options: UrlOptions = {}): string {
+        const routerType = this._routerTypeOf(resource);
+        if (!routerType) {
+            return this._formatPath('/404/', options);
+        }
+        const candidates = this.routerConfigs.filter(c => c.resourceType === routerType);
+        for (const config of candidates) {
+            // NQL filters are evaluated against the original resource (with
+            // its singular DB `type` field intact) because the page:true/false
+            // transformer rewrites to type:'post'/'page'.
+            if (this._matchesFilter(config, resource)) {
+                const path = this.urlUtils.replacePermalink(config.permalink, resource);
+                return this._formatPath(path, options);
+            }
+        }
+        return this._formatPath('/404/', options);
+    }
+
+    ownsResource(routerIdentifier: string, resource: Resource | null): boolean {
+        const config = this.routerConfigs.find(c => c.identifier === routerIdentifier);
+        if (!config || !resource) {
+            return false;
+        }
+        const routerType = this._routerTypeOf(resource);
+        if (config.resourceType !== routerType) {
+            return false;
+        }
+        return this._matchesFilter(config, resource);
+    }
+
+    /**
+     * Translate the resource's `type` field into the plural router resource
+     * type (`'posts'` / `'pages'` / `'tags'` / `'authors'`). Returns `null`
+     * when the type is missing or unrecognised.
+     */
+    private _routerTypeOf(resource: Resource | null | undefined): string | null {
+        if (!resource || !resource.type) {
+            return null;
+        }
+        return TYPE_TO_ROUTER_TYPE[resource.type] || null;
+    }
+
+    /**
+     * Resolve a URL path to a resource record. Iterates router configs in
+     * priority order, pattern-matching the path against each permalink
+     * template, querying the database for a matching resource, and verifying
+     * any NQL filter still matches for posts.
+     */
+    async resolveUrl(urlPath: string): Promise<Resource | null> {
+        if (!this.findResource) {
+            return null;
+        }
+        for (const config of this.routerConfigs) {
+            const params = this._matchPermalink(config.permalink, urlPath);
+            if (!params) {
+                continue;
+            }
+            const resource = await this.findResource(config.resourceType, params);
+            if (!resource) {
+                continue;
+            }
+            // For posts/pages with NQL filters, confirm the DB record still
+            // satisfies the filter. The match runs against the raw record
+            // (with its singular `type` column) because the page:true/false
+            // transformer rewrites to type:'post'/'page'.
+            if (config.nql && !this._matchesFilter(config, resource)) {
+                continue;
+            }
+            return Object.assign({}, resource, {type: config.resourceType}) as Resource;
+        }
+        return null;
+    }
+
+    private _matchesFilter(config: RouterConfig, resource: Record<string, unknown>): boolean {
+        if (!config.nql) {
+            return true;
+        }
+        try {
+            return !!config.nql.queryJSON(resource);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            debug('NQL match failed', config.filter, message);
+            return false;
+        }
+    }
+
+    private _formatPath(path: string, options: UrlOptions): string {
+        if (options.absolute) {
+            return this.urlUtils.createUrl(path, options.absolute);
+        }
+        if (options.withSubdirectory) {
+            return this.urlUtils.createUrl(path, false, true);
+        }
+        return path;
+    }
+
+    /**
+     * Match a Ghost permalink template (e.g. `/:slug/`,
+     * `/:year/:month/:slug/`) against a URL path and extract the named
+     * fields. Ghost's RouteSettings validator rewrites `{field}` placeholders
+     * into `:field` form before they reach the URL service, so this parser
+     * works on the `:field` syntax.
+     *
+     * Implementation: walk the permalink and path one segment at a time.
+     * Each segment must be either a literal match or a single placeholder.
+     * Mixing literals and placeholders inside a segment is unsupported and
+     * not a documented Ghost feature; rejecting it here also keeps us out of
+     * regex-backtracking territory entirely.
+     */
+    private _matchPermalink(permalink: string, urlPath: string): Record<string, string> | null {
+        if (typeof permalink !== 'string' || typeof urlPath !== 'string') {
+            return null;
+        }
+        const permalinkSegments = permalink.split('/');
+        const pathSegments = urlPath.split('/');
+        if (permalinkSegments.length !== pathSegments.length) {
+            return null;
+        }
+        const params: Record<string, string> = {};
+        for (let i = 0; i < permalinkSegments.length; i += 1) {
+            const templateSegment = permalinkSegments[i];
+            const pathSegment = pathSegments[i];
+            if (templateSegment.startsWith(':')) {
+                const fieldName = templateSegment.slice(1);
+                if (!/^\w+$/.test(fieldName) || pathSegment.length === 0) {
+                    return null;
+                }
+                try {
+                    params[fieldName] = decodeURIComponent(pathSegment);
+                } catch {
+                    // Malformed %-escapes (e.g. "/foo%ZZ/") throw URIError;
+                    // treat as a non-match rather than crash the request.
+                    return null;
+                }
+            } else if (templateSegment !== pathSegment) {
+                return null;
+            }
+        }
+        return params;
+    }
+}
+
+module.exports = LazyUrlService;

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -1,0 +1,162 @@
+/**
+ * UrlServiceFacade
+ *
+ * Sits in front of the URL service so callers can use a stable, resource-based
+ * interface regardless of the underlying implementation. The facade can be
+ * built with two backends:
+ *
+ *  - urlService:     the legacy eager UrlService that precomputes a full
+ *                    resource → URL map at boot.
+ *  - lazyUrlService: an on-demand implementation (LazyUrlService) that
+ *                    computes URLs and ownership per call.
+ *
+ * When `lazyUrlService` is provided the facade routes calls to it; otherwise
+ * it delegates to the eager `urlService`. This lets the lazy implementation be
+ * swapped in behind a config flag without touching individual callers.
+ */
+
+/**
+ * Routing-level resource. `type` is one of the plural router keys
+ * ('posts', 'pages', 'tags', 'authors'). Concrete records carry additional
+ * fields (slug, published_at, primary_tag, ...) used by permalink templates.
+ */
+export interface Resource {
+    type: string;
+    id?: string;
+    [key: string]: unknown;
+}
+
+export interface UrlOptions {
+    absolute?: boolean;
+    withSubdirectory?: boolean;
+}
+
+/**
+ * Eager UrlService's resource envelope: `{config: {type}, data: {...}}`.
+ * Returned by `getResourceById`. The `data` field carries the raw record;
+ * `config.type` is the plural router key.
+ */
+export interface LegacyResourceEnvelope {
+    config: {type: string; [key: string]: unknown};
+    data: Record<string, unknown>;
+}
+
+/**
+ * Surface of the eager UrlService that the facade depends on. The full class
+ * has many more methods; only those used here need typing.
+ */
+export interface EagerUrlService {
+    getUrlByResourceId(id: string | undefined, options?: UrlOptions): string;
+    owns(routerId: string, id: string | undefined): boolean;
+    getResource(path: string): {config: {type: string}; data: Record<string, unknown>} | null;
+    getResourceById(id: string): LegacyResourceEnvelope | null;
+    hasFinished(): boolean;
+    onRouterAddedType(...args: unknown[]): unknown;
+    onRouterUpdated(...args: unknown[]): unknown;
+}
+
+export interface LazyUrlServiceBackend {
+    getUrlForResource(resource: Resource, options?: UrlOptions): string;
+    ownsResource(routerId: string, resource: Resource): boolean;
+    resolveUrl(path: string): Promise<Resource | null>;
+    hasFinished(): boolean;
+    onRouterAddedType(...args: unknown[]): unknown;
+    onRouterUpdated(...args: unknown[]): unknown;
+    reset(): void;
+}
+
+export class UrlServiceFacade {
+    private urlService: EagerUrlService;
+    private lazyUrlService: LazyUrlServiceBackend | null;
+
+    constructor({
+        urlService,
+        lazyUrlService = null
+    }: {urlService: EagerUrlService; lazyUrlService?: LazyUrlServiceBackend | null}) {
+        this.urlService = urlService;
+        this.lazyUrlService = lazyUrlService;
+    }
+
+    isLazy(): boolean {
+        return !!this.lazyUrlService;
+    }
+
+    /**
+     * The full resource record is required: the lazy backend evaluates NQL
+     * filters and applies permalink templates against it.
+     */
+    getUrlForResource(resource: Resource, options?: UrlOptions): string {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.getUrlForResource(resource, options);
+        }
+        return this.urlService.getUrlByResourceId(resource.id, options);
+    }
+
+    ownsResource(routerIdentifier: string, resource: Resource): boolean {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.ownsResource(routerIdentifier, resource);
+        }
+        return this.urlService.owns(routerIdentifier, resource.id);
+    }
+
+    /**
+     * Reverse URL lookup. Returns a flat resource shape (e.g. `{type, id, slug}`)
+     * rather than the legacy `{config: {type}, data: {...}}` envelope. Async to
+     * match the lazy implementation's contract.
+     */
+    async resolveUrl(urlPath: string): Promise<Resource | null> {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.resolveUrl(urlPath);
+        }
+        const resource = this.urlService.getResource(urlPath);
+        if (!resource) {
+            return null;
+        }
+        // The routing-level type ('posts', 'pages', 'tags', 'authors') wins
+        // over any DB type field on resource.data so the flat Resource is
+        // unambiguous.
+        return Object.assign({}, resource.data, {type: resource.config.type}) as Resource;
+    }
+
+    /**
+     * Forward lookup of a resource by id. Returns the eager UrlService's
+     * `{config: {type, ...}, data: {...}}` envelope so existing callers
+     * (e.g. the entry controller) can keep using `.config.type`.
+     */
+    getResourceById(resourceId: string): LegacyResourceEnvelope | null {
+        return this.urlService.getResourceById(resourceId);
+    }
+
+    hasFinished(): boolean {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.hasFinished();
+        }
+        return this.urlService.hasFinished();
+    }
+
+    onRouterAddedType(...args: unknown[]): unknown {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.onRouterAddedType(...args);
+        }
+        return this.urlService.onRouterAddedType(...args);
+    }
+
+    onRouterUpdated(...args: unknown[]): unknown {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.onRouterUpdated(...args);
+        }
+        return this.urlService.onRouterUpdated(...args);
+    }
+
+    /**
+     * Reset all router registrations. Used when routes.yaml is reloaded in
+     * lazy mode. In eager mode the URL service handles resets via its queue.
+     */
+    reset(): void {
+        if (this.lazyUrlService) {
+            this.lazyUrlService.reset();
+        }
+    }
+}
+
+module.exports = UrlServiceFacade;

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -1,5 +1,6 @@
 {
     "url": "http://localhost:2368",
+    "lazyRouting": false,
     "server": {
         "host": "127.0.0.1",
         "port": 2368,

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
@@ -6,8 +6,10 @@ const urlUtils = require('../../../../../../../../core/shared/url-utils');
 const urlUtil = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/utils/url');
 
 describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
+    let getUrlForResourceStub;
+
     beforeEach(function () {
-        sinon.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');
+        getUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource').returns('getUrlForResource');
         sinon.stub(urlUtils, 'urlFor').returns('urlFor');
     });
 
@@ -15,7 +17,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
         sinon.restore();
     });
 
-    describe('Ensure calls url service', function () {
+    describe('forPost', function () {
         let pageModel;
 
         beforeEach(function () {
@@ -24,28 +26,89 @@ describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
             };
         });
 
-        it('meta & models & relations', function () {
+        it('passes a posts resource (with id and slug) to the facade', function () {
             const post = pageModel(testUtils.DataGenerator.forKnex.createPost({
                 id: 'id1',
                 mobiledoc: '{}',
-                html: 'html',
-                custom_excerpt: 'customExcerpt',
-                codeinjection_head: 'codeinjectionHead',
-                codeinjection_foot: 'codeinjectionFoot',
-                feature_image: 'featureImage',
-                posts_meta: {
-                    og_image: 'ogImage',
-                    twitter_image: 'twitterImage'
-                },
-                canonical_url: 'canonicalUrl'
+                html: 'html'
             }));
 
             urlUtil.forPost(post.id, post, {options: {}});
 
             assert(Object.hasOwn(post, 'url'));
+            sinon.assert.callCount(getUrlForResourceStub, 1);
+            const [resource, options] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.type, 'posts');
+            assert.equal(resource.id, 'id1');
+            assert.equal(resource.slug, post.slug);
+            assert.deepEqual(options, {absolute: true});
+        });
 
-            sinon.assert.callCount(urlService.getUrlByResourceId, 1);
-            sinon.assert.calledWithExactly(urlService.getUrlByResourceId, 'id1', {absolute: true});
+        it('still passes id when attrs has been stripped (e.g. fields=url)', function () {
+            // Content API request like `?fields=url` runs jsonModel through a
+            // serializer that strips every attribute except `url`. The mapper
+            // calls forPost(model.id, jsonModel, frame) — id is on the model,
+            // not on attrs. Regression: a previous spread `{...attrs, type}`
+            // sent id-less resources, so the eager facade's id-fallback hit
+            // /404/ for every post.
+            const stripped = {};
+
+            urlUtil.forPost('post-id', stripped, {options: {}});
+
+            sinon.assert.calledOnce(getUrlForResourceStub);
+            const [resource] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.id, 'post-id');
+            assert.equal(resource.type, 'posts');
+        });
+    });
+
+    describe('forTag', function () {
+        it('passes a tags resource to the facade when url is requested', function () {
+            const tag = {id: 'tag1', slug: 'food', name: 'Food'};
+
+            urlUtil.forTag(tag.id, tag, {});
+
+            assert.equal(tag.url, 'getUrlForResource');
+            sinon.assert.calledOnce(getUrlForResourceStub);
+            const [resource, options] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.type, 'tags');
+            assert.equal(resource.id, 'tag1');
+            assert.equal(resource.slug, 'food');
+            assert.deepEqual(options, {absolute: true});
+        });
+
+        it('skips url generation when columns excludes url', function () {
+            const tag = {id: 'tag1', slug: 'food'};
+
+            urlUtil.forTag(tag.id, tag, {columns: ['id', 'slug']});
+
+            assert.equal(tag.url, undefined);
+            sinon.assert.notCalled(getUrlForResourceStub);
+        });
+    });
+
+    describe('forUser', function () {
+        it('passes an authors resource to the facade when url is requested', function () {
+            const user = {id: 'user1', slug: 'jane', name: 'Jane'};
+
+            urlUtil.forUser(user.id, user, {});
+
+            assert.equal(user.url, 'getUrlForResource');
+            sinon.assert.calledOnce(getUrlForResourceStub);
+            const [resource, options] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.type, 'authors');
+            assert.equal(resource.id, 'user1');
+            assert.equal(resource.slug, 'jane');
+            assert.deepEqual(options, {absolute: true});
+        });
+
+        it('skips url generation when columns excludes url', function () {
+            const user = {id: 'user1', slug: 'jane'};
+
+            urlUtil.forUser(user.id, user, {columns: ['id', 'slug']});
+
+            assert.equal(user.url, undefined);
+            sinon.assert.notCalled(getUrlForResourceStub);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/authors.test.js
+++ b/ghost/core/test/unit/frontend/helpers/authors.test.js
@@ -6,10 +6,10 @@ const authorsHelper = require('../../../../core/frontend/helpers/authors');
 const testUtils = require('../../../utils');
 
 describe('{{authors}} helper', function () {
-    let urlServiceGetUrlByResourceIdStub;
+    let urlServiceGetUrlForResourceStub;
 
     beforeEach(function () {
-        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
     });
 
     afterEach(function () {
@@ -113,8 +113,8 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url 1');
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[0].id})).returns('author url 1');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url 2');
 
         const rendered = authorsHelper.call({authors: authors});
         assertExists(rendered);
@@ -128,7 +128,7 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url 1');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[0].id})).returns('author url 1');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {limit: '1'}});
         assertExists(rendered);
@@ -142,7 +142,7 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url 2');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2'}});
         assertExists(rendered);
@@ -156,7 +156,7 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[0].id})).returns('author url');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {to: '1'}});
         assertExists(rendered);
@@ -171,8 +171,8 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url 2');
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[2].id).returns('author url 3');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[2].id})).returns('author url 3');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2', to: '3'}});
         assertExists(rendered);
@@ -187,7 +187,7 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url x');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url x');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2', limit: '1'}});
         assertExists(rendered);
@@ -202,9 +202,9 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url a');
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url b');
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[2].id).returns('author url c');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[0].id})).returns('author url a');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url b');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[2].id})).returns('author url c');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '1', to: '3', limit: '2'}});
         assertExists(rendered);

--- a/ghost/core/test/unit/frontend/helpers/tags.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tags.test.js
@@ -6,10 +6,10 @@ const urlService = require('../../../../core/server/services/url');
 const tagsHelper = require('../../../../core/frontend/helpers/tags');
 
 describe('{{tags}} helper', function () {
-    let urlServiceGetUrlByResourceIdStub;
+    let urlServiceGetUrlForResourceStub;
 
     beforeEach(function () {
-        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
     });
 
     afterEach(function () {
@@ -101,8 +101,8 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url 1');
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('tag url 1');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url 2');
 
         const rendered = tagsHelper.call({tags: tags});
         assertExists(rendered);
@@ -116,7 +116,7 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url 1');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('tag url 1');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {limit: '1'}});
         assertExists(rendered);
@@ -130,7 +130,7 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url 2');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2'}});
         assertExists(rendered);
@@ -144,7 +144,7 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url x');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('tag url x');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {to: '1'}});
         assertExists(rendered);
@@ -159,8 +159,8 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url b');
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[2].id).returns('tag url c');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url b');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[2].id})).returns('tag url c');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', to: '3'}});
         assertExists(rendered);
@@ -175,7 +175,7 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url b');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url b');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', limit: '1'}});
         assertExists(rendered);
@@ -190,9 +190,9 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url a');
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url b');
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[2].id).returns('tag url c');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('tag url a');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url b');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[2].id})).returns('tag url c');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '1', to: '3', limit: '2'}});
         assertExists(rendered);
@@ -215,11 +215,11 @@ describe('{{tags}} helper', function () {
         ];
 
         beforeEach(function () {
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('1');
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('2');
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[2].id).returns('3');
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[3].id).returns('4');
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[4].id).returns('5');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('1');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('2');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[2].id})).returns('3');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[3].id})).returns('4');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[4].id})).returns('5');
         });
 
         it('will not output internal tags by default', function () {

--- a/ghost/core/test/unit/frontend/meta/author-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-url.test.js
@@ -7,10 +7,10 @@ const getAuthorUrl = require('../../../../core/frontend/meta/author-url');
 
 describe('getAuthorUrl', function () {
     /** @type {import('sinon').SinonStub} */
-    let urlServiceGetUrlByResourceIdStub;
+    let urlServiceGetUrlForResourceStub;
 
     beforeEach(function () {
-        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
     });
 
     afterEach(function () {
@@ -25,7 +25,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.primary_author.id, type: 'authors'}), {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         assertExists(getAuthorUrl({
@@ -42,7 +42,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: true, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.primary_author.id, type: 'authors'}), {absolute: true, withSubdirectory: true})
             .returns('absolute author url');
 
         assertExists(getAuthorUrl({
@@ -57,7 +57,7 @@ describe('getAuthorUrl', function () {
             slug: 'test-author'
         };
 
-        urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: author.id, type: 'authors'}), {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         assertExists(getAuthorUrl({

--- a/ghost/core/test/unit/frontend/meta/url.test.js
+++ b/ghost/core/test/unit/frontend/meta/url.test.js
@@ -6,11 +6,11 @@ const getUrl = require('../../../../core/frontend/meta/url');
 const testUtils = require('../../../utils');
 
 describe('getUrl', function () {
-    let urlServiceGetUrlByResourceIdStub;
+    let urlServiceGetUrlForResourceStub;
     let urlUtilsUrlForStub;
 
     beforeEach(function () {
-        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
         urlUtilsUrlForStub = sinon.stub(urlUtils, 'urlFor');
     });
 
@@ -21,7 +21,7 @@ describe('getUrl', function () {
     it('should return url for a post', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
-        urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts'}), {absolute: undefined, withSubdirectory: true})
             .returns('post url');
 
         assert.equal(getUrl(post), 'post url');
@@ -30,11 +30,11 @@ describe('getUrl', function () {
     describe('preview url: drafts/scheduled posts', function () {
         it('relative', function () {
             const post = testUtils.DataGenerator.forKnex.createPost({status: 'draft'});
-            urlServiceGetUrlByResourceIdStub.withArgs(post.id).returns('/404/');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts'})).returns('/404/');
             urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined).returns('relative');
             let url = getUrl(post);
 
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledOnce(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined));
 
             assert.equal(url, 'relative');
@@ -42,11 +42,11 @@ describe('getUrl', function () {
 
         it('absolute', function () {
             const post = testUtils.DataGenerator.forKnex.createPost({status: 'draft'});
-            urlServiceGetUrlByResourceIdStub.withArgs(post.id).returns('/404/');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts'})).returns('/404/');
             urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true).returns('absolute');
             let url = getUrl(post, true);
 
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledOnce(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true));
 
             assert.equal(url, 'absolute');
@@ -56,7 +56,7 @@ describe('getUrl', function () {
     it('should return absolute url for a post', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
-        urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: true, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts'}), {absolute: true, withSubdirectory: true})
             .returns('absolute post url');
 
         assert.equal(getUrl(post, true), 'absolute post url');
@@ -70,7 +70,7 @@ describe('getUrl', function () {
         //        the tag object contains a `parent` attribute. the tag model contains a `parent_id` attr.
         tag.parent = null;
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tag.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tag.id, type: 'tags'}), {absolute: undefined, withSubdirectory: true})
             .returns('tag url');
 
         assert.equal(getUrl(tag), 'tag url');
@@ -79,7 +79,7 @@ describe('getUrl', function () {
     it('should return url for a author', function () {
         const author = testUtils.DataGenerator.forKnex.createUser();
 
-        urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: author.id, type: 'authors'}), {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         assert.equal(getUrl(author), 'author url');
@@ -88,7 +88,7 @@ describe('getUrl', function () {
     it('should return absolute url for a author', function () {
         const author = testUtils.DataGenerator.forKnex.createUser();
 
-        urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: true, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: author.id, type: 'authors'}), {absolute: true, withSubdirectory: true})
             .returns('absolute author url');
 
         assert.equal(getUrl(author, true), 'absolute author url');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -16,7 +16,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     let renderStub;
     let posts;
     let postsPerPage;
-    let ownsStub;
+    let ownsResourceStub;
     let next;
 
     beforeEach(function () {
@@ -46,8 +46,8 @@ describe('Unit - services/routing/controllers/collection', function () {
 
         sinon.stub(renderer, 'renderEntries').returns(renderStub);
 
-        ownsStub = sinon.stub(routerManager, 'owns');
-        ownsStub.withArgs('identifier', posts[0].id).returns(true);
+        ownsResourceStub = sinon.stub(routerManager, 'ownsResource');
+        ownsResourceStub.withArgs('identifier', posts[0]).returns(true);
 
         req = {
             path: '/',
@@ -83,7 +83,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -104,7 +104,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -127,7 +127,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -150,7 +150,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
         sinon.assert.notCalled(renderStub);
-        sinon.assert.notCalled(ownsStub);
+        sinon.assert.notCalled(ownsResourceStub);
     });
 
     it('slug param', async function () {
@@ -170,7 +170,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.calledOnce(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -191,7 +191,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -205,11 +205,11 @@ describe('Unit - services/routing/controllers/collection', function () {
 
         res.routerOptions.filter = 'featured:true';
 
-        ownsStub.reset();
-        ownsStub.withArgs('identifier', posts[0].id).returns(false);
-        ownsStub.withArgs('identifier', posts[1].id).returns(true);
-        ownsStub.withArgs('identifier', posts[2].id).returns(false);
-        ownsStub.withArgs('identifier', posts[3].id).returns(false);
+        ownsResourceStub.reset();
+        ownsResourceStub.withArgs('identifier', posts[0]).returns(false);
+        ownsResourceStub.withArgs('identifier', posts[1]).returns(true);
+        ownsResourceStub.withArgs('identifier', posts[2]).returns(false);
+        ownsResourceStub.withArgs('identifier', posts[3]).returns(false);
 
         fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
@@ -228,7 +228,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.callCount(ownsStub, 4);
+        sinon.assert.callCount(ownsResourceStub, 4);
         sinon.assert.notCalled(next);
     });
 });

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -10,7 +10,7 @@ const generateFeed = require('../../../../../core/frontend/services/rss/generate
 describe('RSS: Generate Feed', function () {
     const data = {};
     let baseUrl;
-    let routerManagerGetUrlByResourceIdStub;
+    let routerManagerGetUrlForResourceStub;
 
     // Static set of posts
     let posts;
@@ -45,7 +45,7 @@ describe('RSS: Generate Feed', function () {
     });
 
     beforeEach(function () {
-        routerManagerGetUrlByResourceIdStub = sinon.stub(routerManager, 'getUrlByResourceId');
+        routerManagerGetUrlForResourceStub = sinon.stub(routerManager, 'getUrlForResource');
 
         baseUrl = '/rss/';
 
@@ -91,7 +91,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = posts;
 
             _.each(data.posts, function (post) {
-                routerManagerGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
+                routerManagerGetUrlForResourceStub.withArgs(sinon.match({id: post.id}), {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
             });
 
             const xmlData = await generateFeed(baseUrl, data);
@@ -189,7 +189,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [posts[0]];
 
             _.each(data.posts, function (post) {
-                routerManagerGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
+                routerManagerGetUrlForResourceStub.withArgs(sinon.match({id: post.id}), {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
             });
 
             const xmlData = await generateFeed(baseUrl, data);

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -126,4 +126,295 @@ describe('Unit: sitemap/manager', function () {
             sinon.assert.calledOnce(IndexGenerator.prototype.getXml);
         });
     });
+
+    describe('SiteMapManager (lazyRouting mode)', function () {
+        let lazyEvents;
+
+        before(function () {
+            lazyEvents = {};
+            // Replace the events.on stub for this block so we can capture
+            // subscriptions made by a manager constructed with lazyRouting on.
+            events.on.restore();
+            sinon.stub(events, 'on').callsFake((eventName, callback) => {
+                lazyEvents[eventName] = callback;
+            });
+
+            new SiteMapManager({
+                posts: new PostGenerator(),
+                pages: new PageGenerator(),
+                tags: new TagGenerator(),
+                authors: new UserGenerator(),
+                lazyRouting: true
+            });
+        });
+
+        it('skips url.added and url.removed event subscriptions', function () {
+            assert.equal(lazyEvents['url.added'], undefined);
+            assert.equal(lazyEvents['url.removed'], undefined);
+        });
+
+        it('still subscribes to router.created and routers.reset', function () {
+            assertExists(lazyEvents['router.created']);
+            assertExists(lazyEvents['routers.reset']);
+        });
+
+        it('ensurePopulatedFromDatabase is a no-op when lazyRouting is off', async function () {
+            const eagerManager = new SiteMapManager({
+                posts: new PostGenerator(),
+                pages: new PageGenerator(),
+                tags: new TagGenerator(),
+                authors: new UserGenerator(),
+                lazyRouting: false
+            });
+            // Should resolve without touching the DB.
+            await eagerManager.ensurePopulatedFromDatabase();
+        });
+    });
+
+    // The lazy populate path is the only mechanism that fills the sitemap when
+    // url.added/url.removed events do not fire. These tests exercise it as a
+    // unit: stub the model layer + the URL facade and assert addUrl is called
+    // for the right resources.
+    describe('_populateFromDatabase', function () {
+        let sandbox;
+        let postFindPage;
+        let tagFindPage;
+        let userFindPage;
+        let getUrlForResource;
+
+        const models = require('../../../../../core/server/models');
+        const urlServiceModule = require('../../../../../core/server/services/url');
+
+        // The outer suite stubs PostGenerator.prototype.addUrl globally, so
+        // we can't (re)stub it on a fresh instance. Reset the shared post
+        // stub and use a per-test sandbox for everything else so a partial
+        // beforeEach failure can't leak stubs across cases.
+        beforeEach(function () {
+            sandbox = sinon.createSandbox();
+            postFindPage = sandbox.stub(models.Post, 'findPage');
+            // Sitemap populate uses TagPublic and Author (the scoped models
+            // with shouldHavePosts gating) instead of Tag/User.
+            tagFindPage = sandbox.stub(models.TagPublic, 'findPage');
+            userFindPage = sandbox.stub(models.Author, 'findPage');
+
+            sandbox.stub(PageGenerator.prototype, 'addUrl');
+            sandbox.stub(TagGenerator.prototype, 'addUrl');
+            sandbox.stub(UserGenerator.prototype, 'addUrl');
+            PostGenerator.prototype.addUrl.resetHistory();
+
+            // Method-level stub on the singleton facade method the sitemap
+            // actually reads. Sandbox.restore() puts it back even if a sibling
+            // beforeEach throws partway.
+            getUrlForResource = sandbox.stub(urlServiceModule.facade, 'getUrlForResource');
+        });
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        function paged(rows) {
+            return {
+                data: rows.map(r => ({...r, toJSON: () => r})),
+                meta: {pagination: {pages: 1}}
+            };
+        }
+
+        function makeLazyManager() {
+            return new SiteMapManager({
+                posts: new PostGenerator(),
+                pages: new PageGenerator(),
+                tags: new TagGenerator(),
+                authors: new UserGenerator(),
+                lazyRouting: true
+            });
+        }
+
+        it('feeds non-/404/ URLs into the per-type generators', async function () {
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:post'}))
+                .resolves(paged([{id: 'p1', slug: 'hello', type: 'post'}]));
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:page'}))
+                .resolves(paged([{id: 'pg1', slug: 'about', type: 'page'}]));
+            tagFindPage.resolves(paged([{id: 't1', slug: 'food'}]));
+            userFindPage.resolves(paged([{id: 'u1', slug: 'jane'}]));
+
+            getUrlForResource.callsFake((resource) => {
+                if (resource.id === 'p1') {
+                    return 'http://example.com/hello/';
+                }
+                if (resource.id === 'pg1') {
+                    return 'http://example.com/about/';
+                }
+                if (resource.id === 't1') {
+                    return 'http://example.com/tag/food/';
+                }
+                if (resource.id === 'u1') {
+                    return 'http://example.com/author/jane/';
+                }
+                return '/404/';
+            });
+
+            const manager = makeLazyManager();
+            await manager.ensurePopulatedFromDatabase();
+
+            sinon.assert.calledWith(PostGenerator.prototype.addUrl, 'http://example.com/hello/', sinon.match({id: 'p1'}));
+            sinon.assert.calledWith(PageGenerator.prototype.addUrl, 'http://example.com/about/', sinon.match({id: 'pg1'}));
+            sinon.assert.calledWith(TagGenerator.prototype.addUrl, 'http://example.com/tag/food/', sinon.match({id: 't1'}));
+            sinon.assert.calledWith(UserGenerator.prototype.addUrl, 'http://example.com/author/jane/', sinon.match({id: 'u1'}));
+        });
+
+        it('preloads tags+authors for posts so primary_tag permalinks resolve', async function () {
+            postFindPage.resolves(paged([]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+            getUrlForResource.returns('http://example.com/x/');
+
+            await makeLazyManager().ensurePopulatedFromDatabase();
+
+            // Sites using `/:primary_tag/:slug/` permalinks need
+            // `primary_tag` populated on the resource. Bookshelf only fills
+            // it in toJSON when the `tags` relation is loaded.
+            sinon.assert.calledWith(postFindPage, sinon.match({
+                filter: 'type:post',
+                withRelated: ['tags', 'authors']
+            }));
+        });
+
+        it('queries tags and authors with visibility:public to mirror the eager URL service', async function () {
+            postFindPage.resolves(paged([]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+            getUrlForResource.returns('http://example.com/x/');
+
+            await makeLazyManager().ensurePopulatedFromDatabase();
+
+            // Pin the full options shape so a future drop of `limit` or a
+            // change in the filter expression still fails this test. The
+            // tag schema permits visibility:'internal' and the user schema
+            // defaults to 'public' but doesn't enforce it; without these
+            // filters the lazy sitemap diverges from the eager URL service
+            // (services/url/config.js applies both).
+            sinon.assert.calledWith(tagFindPage, sinon.match({
+                limit: 200,
+                filter: 'visibility:public'
+            }));
+            sinon.assert.calledWith(userFindPage, sinon.match({
+                limit: 200,
+                filter: 'visibility:public'
+            }));
+        });
+
+        it('skips resources whose URL would be /404/', async function () {
+            postFindPage.resolves(paged([
+                {id: 'p1', slug: 'good', type: 'post'},
+                {id: 'p2', slug: 'orphan', type: 'post'}
+            ]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+
+            getUrlForResource.callsFake((resource) => {
+                return resource.id === 'p1' ? 'http://example.com/good/' : '/404/';
+            });
+
+            const manager = makeLazyManager();
+            await manager.ensurePopulatedFromDatabase();
+
+            sinon.assert.calledWith(PostGenerator.prototype.addUrl, 'http://example.com/good/', sinon.match({id: 'p1'}));
+            const p2Calls = PostGenerator.prototype.addUrl.getCalls().filter(c => c.args[1] && c.args[1].id === 'p2');
+            assert.equal(p2Calls.length, 0, 'p2 should be skipped because its URL is /404/');
+        });
+
+        it('a settled stale populate does not clobber a successor populate handle', async function () {
+            // T1 starts populate (slow), T1 awaits DB.
+            // routers.reset fires → _populating cleared, generation bumped.
+            // T2 starts populate (also slow) → owns _populating now.
+            // T1 finally settles. Bug: T1's `.then` would set _populating=null,
+            // orphaning T2 and letting a T3 race in alongside T2.
+            // Fix: only clear _populating if it still points to T1's promise.
+            let unblockT1;
+            let unblockT2;
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:post'}))
+                .onFirstCall().returns(new Promise((resolve) => {
+                    unblockT1 = () => resolve(paged([]));
+                }))
+                .onSecondCall().returns(new Promise((resolve) => {
+                    unblockT2 = () => resolve(paged([]));
+                }));
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:page'}))
+                .resolves(paged([]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+            getUrlForResource.returns('http://example.com/x/');
+
+            const manager = makeLazyManager();
+
+            const t1 = manager.ensurePopulatedFromDatabase();
+            const resetHandlers = events.on
+                .getCalls()
+                .filter(c => c.args[0] === 'routers.reset')
+                .map(c => c.args[1]);
+            resetHandlers.forEach(handler => handler());
+
+            const t2 = manager.ensurePopulatedFromDatabase();
+            assertExists(manager._populating, 'T2 must own the populate handle after reset');
+            const t2Handle = manager._populating;
+
+            // T1 settles before T2. The buggy version null'd _populating here.
+            unblockT1();
+            await t1;
+            assert.equal(
+                manager._populating,
+                t2Handle,
+                'T1 settling must not clobber T2\'s in-flight populate handle'
+            );
+
+            unblockT2();
+            await t2;
+        });
+
+        it('routers.reset during a populate cancels the populate via the generation token', async function () {
+            // The "post" findPage call hangs until we explicitly resolve it,
+            // simulating a slow DB load that races with a routes.yaml reload.
+            let unblockPopulate;
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:post'}))
+                .returns(new Promise((resolve) => {
+                    unblockPopulate = () => resolve(paged([]));
+                }));
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:page'}))
+                .resolves(paged([]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+            getUrlForResource.returns('http://example.com/x/');
+
+            const manager = makeLazyManager();
+
+            const inFlight = manager.ensurePopulatedFromDatabase();
+            // The outer suite has stubbed events.on; the manager registered
+            // its routers.reset handler via that stub. Locate and invoke it.
+            const resetHandlers = events.on
+                .getCalls()
+                .filter(c => c.args[0] === 'routers.reset')
+                .map(c => c.args[1]);
+            resetHandlers.forEach(handler => handler());
+
+            unblockPopulate();
+            await inFlight;
+
+            // Behavioural assertion: a subsequent ensurePopulatedFromDatabase
+            // must re-issue the DB queries because the previous populate's
+            // result was invalidated by the routers.reset. (Asserting on the
+            // private `_populated` flag would couple to internal state.)
+            const callsBefore = postFindPage.callCount;
+            await manager.ensurePopulatedFromDatabase();
+            assert.ok(
+                postFindPage.callCount > callsBefore,
+                'A reset mid-populate must invalidate the in-flight result so the next call re-queries'
+            );
+        });
+    });
 });

--- a/ghost/core/test/unit/server/lib/common/to-plain.test.js
+++ b/ghost/core/test/unit/server/lib/common/to-plain.test.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert/strict');
+const toPlain = require('../../../../../core/server/lib/common/to-plain');
+
+describe('toPlain', function () {
+    it('returns a plain object unchanged', function () {
+        const obj = {id: 'abc', slug: 'hello'};
+        assert.equal(toPlain(obj), obj);
+    });
+
+    it('serialises a Bookshelf-shaped model via toJSON', function () {
+        const model = {
+            // own keys are not the data; only `.toJSON()` produces it.
+            toJSON: () => ({id: 'xyz', slug: 'world'})
+        };
+        assert.deepEqual(toPlain(model), {id: 'xyz', slug: 'world'});
+    });
+
+    it('returns null and undefined unchanged (no toJSON deref)', function () {
+        assert.equal(toPlain(null), null);
+        assert.equal(toPlain(undefined), undefined);
+    });
+
+    it('returns primitives unchanged (they have no toJSON)', function () {
+        assert.equal(toPlain(0), 0);
+        assert.equal(toPlain(''), '');
+        assert.equal(toPlain(false), false);
+    });
+
+    it('returns input unchanged when toJSON is present but not callable', function () {
+        // pins the `typeof === 'function'` guard: a non-function `toJSON`
+        // (e.g. a JSON-serialised payload that already has a `toJSON` field)
+        // must not throw and must round-trip the input.
+        const obj = {id: 'abc', toJSON: 'not-a-fn'};
+        assert.equal(toPlain(obj), obj);
+    });
+});

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
@@ -15,7 +15,9 @@ describe('audienceFeedbackService', function () {
         it('Can build link to post', async function () {
             const instance = new AudienceFeedbackService({
                 urlService: {
-                    getUrlByResourceId: () => `https://localhost:2368/${mockData.postTitle}/`
+                    facade: {
+                        getUrlForResource: () => `https://localhost:2368/${mockData.postTitle}/`
+                    }
                 },
                 config: {
                     baseURL: new URL('https://localhost:2368')
@@ -29,7 +31,9 @@ describe('audienceFeedbackService', function () {
         it('Can build link to home page if post wasn\'t published', async function () {
             const instance = new AudienceFeedbackService({
                 urlService: {
-                    getUrlByResourceId: () => `https://localhost:2368/${mockData.postTitle}/404/`
+                    facade: {
+                        getUrlForResource: () => `https://localhost:2368/${mockData.postTitle}/404/`
+                    }
                 },
                 config: {
                     baseURL: new URL('https://localhost:2368')
@@ -40,13 +44,15 @@ describe('audienceFeedbackService', function () {
             assert.equal(link.href, expectedLink);
         });
 
-        it('Passes post id (not the post object) to the url service', async function () {
-            let receivedId;
+        it('Passes a posts resource (with id) to the facade', async function () {
+            let receivedResource;
             const instance = new AudienceFeedbackService({
                 urlService: {
-                    getUrlByResourceId: (id) => {
-                        receivedId = id;
-                        return `https://localhost:2368/${mockData.postTitle}/`;
+                    facade: {
+                        getUrlForResource: (resource) => {
+                            receivedResource = resource;
+                            return `https://localhost:2368/${mockData.postTitle}/`;
+                        }
                     }
                 },
                 config: {
@@ -54,7 +60,44 @@ describe('audienceFeedbackService', function () {
                 }
             });
             instance.buildLink(mockData.uuid, mockPost, mockData.score, mockData.key);
-            assert.equal(receivedId, mockData.postId);
+            assert.equal(receivedResource.id, mockData.postId);
+            assert.equal(receivedResource.type, 'posts');
+        });
+
+        it('Serialises Bookshelf-model input so spread does not lose the id', async function () {
+            // Real callers (email-renderer) pass a Bookshelf model. Spreading
+            // one with `{...model}` skips prototype getters like `.id`. The
+            // service must call `.toJSON()` first; this test pins that.
+            //
+            // toJSON also returns the DB-level `type: 'post'` (singular). The
+            // service must override that to the routing-level `'posts'`
+            // (plural) before handing the resource to the facade — the
+            // assertion below captures that override explicitly.
+            let receivedResource;
+            const fakeBookshelfModel = {
+                // No own `id` / `slug` properties; only `.toJSON()` exposes them.
+                toJSON: () => ({id: mockData.postId, slug: mockData.postTitle, type: 'post'})
+            };
+            const instance = new AudienceFeedbackService({
+                urlService: {
+                    facade: {
+                        getUrlForResource: (resource) => {
+                            receivedResource = resource;
+                            return `https://localhost:2368/${mockData.postTitle}/`;
+                        }
+                    }
+                },
+                config: {
+                    baseURL: new URL('https://localhost:2368')
+                }
+            });
+            const link = instance.buildLink(mockData.uuid, fakeBookshelfModel, mockData.score, mockData.key);
+            assert.equal(receivedResource.id, mockData.postId);
+            assert.equal(receivedResource.slug, mockData.postTitle);
+            assert.equal(receivedResource.type, 'posts');
+            // The hash fragment also depends on the post id, so the same bug
+            // would surface in the produced URL.
+            assert.match(link.href, new RegExp(`#/feedback/${mockData.postId}/`));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
@@ -9,6 +9,7 @@ describe('audienceFeedbackService', function () {
         score: 1,
         key: 'somekey'
     };
+    const mockPost = {id: mockData.postId};
 
     describe('build link', function () {
         it('Can build link to post', async function () {
@@ -20,7 +21,7 @@ describe('audienceFeedbackService', function () {
                     baseURL: new URL('https://localhost:2368')
                 }
             });
-            const link = instance.buildLink(mockData.uuid, mockData.postId, mockData.score, mockData.key);
+            const link = instance.buildLink(mockData.uuid, mockPost, mockData.score, mockData.key);
             const expectedLink = `https://localhost:2368/${mockData.postTitle}/#/feedback/${mockData.postId}/${mockData.score}/?uuid=${mockData.uuid}&key=somekey`;
             assert.equal(link.href, expectedLink);
         });
@@ -34,9 +35,26 @@ describe('audienceFeedbackService', function () {
                     baseURL: new URL('https://localhost:2368')
                 }
             });
-            const link = instance.buildLink(mockData.uuid, mockData.postId, mockData.score, mockData.key);
+            const link = instance.buildLink(mockData.uuid, mockPost, mockData.score, mockData.key);
             const expectedLink = `https://localhost:2368/#/feedback/${mockData.postId}/${mockData.score}/?uuid=${mockData.uuid}&key=somekey`;
             assert.equal(link.href, expectedLink);
+        });
+
+        it('Passes post id (not the post object) to the url service', async function () {
+            let receivedId;
+            const instance = new AudienceFeedbackService({
+                urlService: {
+                    getUrlByResourceId: (id) => {
+                        receivedId = id;
+                        return `https://localhost:2368/${mockData.postTitle}/`;
+                    }
+                },
+                config: {
+                    baseURL: new URL('https://localhost:2368')
+                }
+            });
+            instance.buildLink(mockData.uuid, mockPost, mockData.score, mockData.key);
+            assert.equal(receivedId, mockData.postId);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -30,9 +30,17 @@ describe('Comments Service: CommentsServiceEmails', function () {
         it('returns post URL with comment permalink', function () {
             const {instance} = createClassInstance({});
 
-            const result = instance.getPostUrl('123', '456');
+            const result = instance.getPostUrl({id: '123'}, '456');
 
             assert.equal(result, 'https://example.com/my-post/#ghost-comments-456');
+        });
+
+        it('passes the post id (not the post object) to the url service', function () {
+            const {instance, urlService} = createClassInstance({});
+
+            instance.getPostUrl({id: '123'}, '456');
+
+            sinon.assert.calledWith(urlService.getUrlByResourceId, '123', {absolute: true});
         });
     });
 
@@ -125,8 +133,9 @@ describe('Comments Service: CommentsServiceEmails', function () {
             sinon.assert.calledOnce(getPostUrlSpy);
             const [postArg, commentIdArg] = getPostUrlSpy.firstCall.args;
             assert.equal(commentIdArg, 'comment-id');
-            // postArg is either the post model or its id; both yield the same URL
-            assert.equal(typeof postArg === 'string' ? postArg : postArg && postArg.id, post.id);
+            assert.equal(postArg.id, post.id);
+            // After this commit's migration the call always passes a model.
+            assert.notEqual(typeof postArg, 'string');
 
             sinon.assert.calledOnce(renderStub);
             const [, templateData] = renderStub.firstCall.args;
@@ -153,7 +162,9 @@ describe('Comments Service: CommentsServiceEmails', function () {
             sinon.assert.calledOnce(getPostUrlSpy);
             const [postArg, commentIdArg] = getPostUrlSpy.firstCall.args;
             assert.equal(commentIdArg, 'comment-id');
-            assert.equal(typeof postArg === 'string' ? postArg : postArg && postArg.id, post.id);
+            assert.equal(postArg.id, post.id);
+            // After this commit's migration the call always passes a model.
+            assert.notEqual(typeof postArg, 'string');
 
             sinon.assert.calledOnce(renderStub);
             const [, templateData] = renderStub.firstCall.args;

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -5,7 +5,9 @@ const CommentsServiceEmails = require('../../../../../core/server/services/comme
 describe('Comments Service: CommentsServiceEmails', function () {
     function createClassInstance({labs = {}}) {
         const urlService = {
-            getUrlByResourceId: sinon.stub().returns('https://example.com/my-post/')
+            facade: {
+                getUrlForResource: sinon.stub().returns('https://example.com/my-post/')
+            }
         };
         const labsStub = {
             isSet: sinon.stub().callsFake(flag => labs[flag] || false)
@@ -35,12 +37,34 @@ describe('Comments Service: CommentsServiceEmails', function () {
             assert.equal(result, 'https://example.com/my-post/#ghost-comments-456');
         });
 
-        it('passes the post id (not the post object) to the url service', function () {
+        it('passes a posts resource to the facade', function () {
             const {instance, urlService} = createClassInstance({});
 
             instance.getPostUrl({id: '123'}, '456');
 
-            sinon.assert.calledWith(urlService.getUrlByResourceId, '123', {absolute: true});
+            sinon.assert.calledWith(
+                urlService.facade.getUrlForResource,
+                sinon.match({id: '123', type: 'posts'}),
+                {absolute: true}
+            );
+        });
+
+        it('serialises Bookshelf-model input so spread does not lose the id', function () {
+            // Real callers (notify*Authors / notifyParentCommentAuthor / notifyReport)
+            // pass a Bookshelf model from Post.findOne. Spreading one with
+            // `{...model}` skips prototype getters like `.id`.
+            const {instance, urlService} = createClassInstance({});
+            const fakeBookshelfModel = {
+                toJSON: () => ({id: '123', slug: 'my-post'})
+            };
+
+            instance.getPostUrl(fakeBookshelfModel, '456');
+
+            sinon.assert.calledWith(
+                urlService.facade.getUrlForResource,
+                sinon.match({id: '123', slug: 'my-post', type: 'posts'}),
+                {absolute: true}
+            );
         });
     });
 
@@ -105,7 +129,9 @@ describe('Comments Service: CommentsServiceEmails', function () {
                 settingsCache: {get: sinon.stub().returns('Test Site')},
                 settingsHelpers: {getMembersSupportAddress: () => 'support@example.com'},
                 urlService: {
-                    getUrlByResourceId: sinon.stub().returns('https://example.com/my-post/')
+                    facade: {
+                        getUrlForResource: sinon.stub().returns('https://example.com/my-post/')
+                    }
                 },
                 urlUtils: {
                     getSiteUrl: () => 'https://example.com/',

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -35,4 +35,129 @@ describe('Comments Service: CommentsServiceEmails', function () {
             assert.equal(result, 'https://example.com/my-post/#ghost-comments-456');
         });
     });
+
+    // Characterisation tests for the three notification entry points. These
+    // exercise the full public path so that future changes to `getPostUrl`'s
+    // signature have to migrate every call site coherently — historically
+    // line 161 of comments-service-emails.js was missed when the helper was
+    // refactored, and the helper-only test above did not catch it.
+    describe('public notification methods invoke getPostUrl', function () {
+        const POST_URL_FOR_COMMENT = 'https://example.com/my-post/#ghost-comments-comment-id';
+
+        function makeModel(attrs, related = {}) {
+            return {
+                id: attrs.id,
+                attributes: attrs,
+                get: key => attrs[key],
+                related: name => related[name]
+            };
+        }
+
+        function makeAuthor(attrs) {
+            return makeModel(Object.assign({comment_notifications: true}, attrs));
+        }
+
+        function buildHarness(opts = {}) {
+            const post = makeModel(
+                Object.assign({id: 'post-id', title: 'My Post'}, opts.post),
+                {
+                    authors: opts.authors !== undefined ? opts.authors : [
+                        makeAuthor({email: 'author@example.com', slug: 'author'})
+                    ]
+                }
+            );
+            const member = makeModel({
+                id: 'member-id',
+                name: 'Reader',
+                email: 'reader@example.com',
+                expertise: ''
+            });
+            const owner = makeModel({email: 'owner@example.com', slug: 'owner'});
+            const comment = makeModel({
+                id: 'comment-id',
+                post_id: 'post-id',
+                member_id: 'member-id',
+                html: '<p>hi</p>',
+                created_at: new Date('2026-04-01T00:00:00Z')
+            });
+
+            const Post = {findOne: sinon.stub().resolves(post)};
+            const Member = {findOne: sinon.stub().resolves(member)};
+            const User = {getOwnerUser: sinon.stub().resolves(owner)};
+            const Comment = {findOne: sinon.stub()};
+
+            const renderStub = sinon.stub().resolves({html: 'h', text: 't'});
+            const mailerSendStub = sinon.stub().resolves();
+
+            const instance = new CommentsServiceEmails({
+                config: {},
+                logging: {warn: sinon.stub()},
+                models: {Post, Member, User, Comment},
+                mailer: {send: mailerSendStub},
+                settingsCache: {get: sinon.stub().returns('Test Site')},
+                settingsHelpers: {getMembersSupportAddress: () => 'support@example.com'},
+                urlService: {
+                    getUrlByResourceId: sinon.stub().returns('https://example.com/my-post/')
+                },
+                urlUtils: {
+                    getSiteUrl: () => 'https://example.com/',
+                    urlFor: () => 'https://example.com/ghost/',
+                    urlJoin: (...parts) => parts.join('')
+                },
+                labs: {isSet: sinon.stub().returns(false)}
+            });
+
+            instance.commentsServiceEmailRenderer.renderEmailTemplate = renderStub;
+            const getPostUrlSpy = sinon.spy(instance, 'getPostUrl');
+
+            return {instance, post, comment, getPostUrlSpy, renderStub};
+        }
+
+        it('notifyPostAuthors: passes the right post arg into getPostUrl and threads the URL into templateData', async function () {
+            const {instance, post, comment, getPostUrlSpy, renderStub} = buildHarness();
+
+            await instance.notifyPostAuthors(comment);
+
+            // The signature on `main` is (postId, commentId). When this test
+            // was written the call site at line 51 passes the string id; the
+            // upcoming HKG-1761 migration will rewrite it to pass the post
+            // model. Either way, the URL must thread through to templateData.
+            sinon.assert.calledOnce(getPostUrlSpy);
+            const [postArg, commentIdArg] = getPostUrlSpy.firstCall.args;
+            assert.equal(commentIdArg, 'comment-id');
+            // postArg is either the post model or its id; both yield the same URL
+            assert.equal(typeof postArg === 'string' ? postArg : postArg && postArg.id, post.id);
+
+            sinon.assert.calledOnce(renderStub);
+            const [, templateData] = renderStub.firstCall.args;
+            assert.equal(templateData.postUrl, POST_URL_FOR_COMMENT);
+        });
+
+        // notifyParentCommentAuthor is intentionally not exercised here: the
+        // function reaches into emailService.renderer.createUnsubscribeUrl,
+        // which is only populated after the email-service module is
+        // initialised, requiring far more setup than the regression scope
+        // justifies. notifyPostAuthors above and notifyReport below cover
+        // the same `getPostUrl` call-shape contract.
+
+        it('notifyReport: threads the post URL through to templateData (regression for the missed line-161 migration)', async function () {
+            const {instance, post, comment, getPostUrlSpy, renderStub} = buildHarness();
+
+            await instance.notifyReport(comment, {name: 'Reporter', email: 'reporter@example.com'});
+
+            // The bug we want to catch: if the helper signature changes
+            // (postId → post) but this notifyReport call site is not
+            // migrated, getPostUrl is invoked with a string and produces
+            // a malformed URL. Pin the URL here so a future regression
+            // surfaces immediately.
+            sinon.assert.calledOnce(getPostUrlSpy);
+            const [postArg, commentIdArg] = getPostUrlSpy.firstCall.args;
+            assert.equal(commentIdArg, 'comment-id');
+            assert.equal(typeof postArg === 'string' ? postArg : postArg && postArg.id, post.id);
+
+            sinon.assert.calledOnce(renderStub);
+            const [, templateData] = renderStub.firstCall.args;
+            assert.equal(templateData.postUrl, POST_URL_FOR_COMMENT);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -412,11 +412,18 @@ describe('IndexNow', function () {
     describe('ping() URL output', function () {
         const ping = indexnow.__get__('ping');
         const POST_URL = 'https://my-blog.example/some-post/';
+        let getUrlForResourceStub;
         let requestStub;
         let resetIndexNow;
 
         beforeEach(function () {
-            sinon.stub(urlService, 'getUrlByResourceId').returns(POST_URL);
+            // Bind the stub to the exact resource shape production passes
+            // (`{...post, type: 'posts'}`) so a regression that drops the
+            // type override or the spread surfaces here.
+            getUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
+            getUrlForResourceStub
+                .withArgs(sinon.match({id: 'abc', type: 'posts'}), {absolute: true})
+                .returns(POST_URL);
 
             requestStub = sinon.stub().resolves({statusCode: 200});
             resetIndexNow = indexnow.__set__('request', requestStub);
@@ -433,6 +440,7 @@ describe('IndexNow', function () {
 
             await ping(post);
 
+            sinon.assert.calledOnce(getUrlForResourceStub);
             sinon.assert.calledOnce(requestStub);
             const indexNowUrl = new URL(requestStub.firstCall.args[0]);
             assert.equal(indexNowUrl.searchParams.get('url'), POST_URL);

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -9,6 +9,7 @@ const events = require('../../../../core/server/lib/common/events');
 const settingsCache = require('../../../../core/shared/settings-cache');
 const labs = require('../../../../core/shared/labs');
 const logging = require('@tryghost/logging');
+const urlService = require('../../../../core/server/services/url');
 
 describe('IndexNow', function () {
     let eventStub;
@@ -399,6 +400,42 @@ describe('IndexNow', function () {
 
             const key = indexnow.getApiKey();
             assert.equal((key === null), true);
+        });
+    });
+
+    // Pin which URL ping() actually sends. The earlier `ping()` block above
+    // uses nock to intercept the HTTP request but never inspects the
+    // `?url=...` query parameter; that's the exact value a future change to
+    // the url-service call shape (e.g. swapping the legacy id-based method
+    // for a resource-based facade method) could regress without anyone
+    // noticing.
+    describe('ping() URL output', function () {
+        const ping = indexnow.__get__('ping');
+        const POST_URL = 'https://my-blog.example/some-post/';
+        let requestStub;
+        let resetIndexNow;
+
+        beforeEach(function () {
+            sinon.stub(urlService, 'getUrlByResourceId').returns(POST_URL);
+
+            requestStub = sinon.stub().resolves({statusCode: 200});
+            resetIndexNow = indexnow.__set__('request', requestStub);
+
+            settingsCacheStub.withArgs('indexnow_api_key').returns('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
+        });
+
+        afterEach(function () {
+            resetIndexNow();
+        });
+
+        it('passes the post URL into the IndexNow request', async function () {
+            const post = {id: 'abc', slug: 'some-post', type: 'post'};
+
+            await ping(post);
+
+            sinon.assert.calledOnce(requestStub);
+            const indexNowUrl = new URL(requestStub.firstCall.args[0]);
+            assert.equal(indexNowUrl.searchParams.get('url'), POST_URL);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
@@ -52,26 +52,15 @@ describe('UrlTranslator', function () {
                     facade: {
                         getUrlForResource: (resource) => {
                             return '/path/' + resource.id;
-                        }
-                    },
-                    getResource: (path) => {
-                        switch (path) {
-                        case '/path/post': return {
-                            config: {type: 'posts'},
-                            data: {id: 'post'}
-                        };
-                        case '/path/tag': return {
-                            config: {type: 'tags'},
-                            data: {id: 'tag'}
-                        };
-                        case '/path/page': return {
-                            config: {type: 'pages'},
-                            data: {id: 'page'}
-                        };
-                        case '/path/author': return {
-                            config: {type: 'authors'},
-                            data: {id: 'author'}
-                        };
+                        },
+                        resolveUrl: async (path) => {
+                            switch (path) {
+                            case '/path/post': return {type: 'posts', id: 'post'};
+                            case '/path/tag': return {type: 'tags', id: 'tag'};
+                            case '/path/page': return {type: 'pages', id: 'page'};
+                            case '/path/author': return {type: 'authors', id: 'author'};
+                            }
+                            return null;
                         }
                     }
                 },
@@ -152,60 +141,51 @@ describe('UrlTranslator', function () {
         before(function () {
             translator = new UrlTranslator({
                 urlService: {
-                    getResource: (path) => {
-                        switch (path) {
-                        case '/post': return {
-                            config: {type: 'posts'},
-                            data: {id: 'post'}
-                        };
-                        case '/tag': return {
-                            config: {type: 'tags'},
-                            data: {id: 'tag'}
-                        };
-                        case '/page': return {
-                            config: {type: 'pages'},
-                            data: {id: 'page'}
-                        };
-                        case '/author': return {
-                            config: {type: 'authors'},
-                            data: {id: 'author'}
-                        };
+                    facade: {
+                        resolveUrl: async (path) => {
+                            switch (path) {
+                            case '/post': return {type: 'posts', id: 'post'};
+                            case '/tag': return {type: 'tags', id: 'tag'};
+                            case '/page': return {type: 'pages', id: 'page'};
+                            case '/author': return {type: 'authors', id: 'author'};
+                            }
+                            return null;
                         }
                     }
                 }
             });
         });
 
-        it('returns posts', function () {
-            assert.deepEqual(translator.getTypeAndIdFromPath('/post'), {
+        it('returns posts', async function () {
+            assert.deepEqual(await translator.getTypeAndIdFromPath('/post'), {
                 type: 'post',
                 id: 'post'
             });
         });
 
-        it('returns pages', function () {
-            assert.deepEqual(translator.getTypeAndIdFromPath('/page'), {
+        it('returns pages', async function () {
+            assert.deepEqual(await translator.getTypeAndIdFromPath('/page'), {
                 type: 'page',
                 id: 'page'
             });
         });
 
-        it('returns authors', function () {
-            assert.deepEqual(translator.getTypeAndIdFromPath('/author'), {
+        it('returns authors', async function () {
+            assert.deepEqual(await translator.getTypeAndIdFromPath('/author'), {
                 type: 'author',
                 id: 'author'
             });
         });
 
-        it('returns tags', function () {
-            assert.deepEqual(translator.getTypeAndIdFromPath('/tag'), {
+        it('returns tags', async function () {
+            assert.deepEqual(await translator.getTypeAndIdFromPath('/tag'), {
                 type: 'tag',
                 id: 'tag'
             });
         });
 
-        it('returns undefined', function () {
-            assert.equal(translator.getTypeAndIdFromPath('/other'), undefined);
+        it('returns undefined', async function () {
+            assert.equal(await translator.getTypeAndIdFromPath('/other'), undefined);
         });
     });
 

--- a/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
@@ -49,8 +49,10 @@ describe('UrlTranslator', function () {
                     }
                 },
                 urlService: {
-                    getUrlByResourceId: (id) => {
-                        return '/path/' + id;
+                    facade: {
+                        getUrlForResource: (resource) => {
+                            return '/path/' + resource.id;
+                        }
                     },
                     getResource: (path) => {
                         switch (path) {
@@ -212,8 +214,8 @@ describe('UrlTranslator', function () {
         before(function () {
             translator = new UrlTranslator({
                 urlService: {
-                    getUrlByResourceId: () => {
-                        return '/path';
+                    facade: {
+                        getUrlForResource: () => '/path'
                     }
                 },
                 models
@@ -258,6 +260,69 @@ describe('UrlTranslator', function () {
 
         it('returns null for not found tag', async function () {
             assert.equal(await translator.getResourceById('invalid', 'tag'), null);
+        });
+    });
+
+    describe('getResourceUrl', function () {
+        // Lazy URL service evaluates permalink templates against resource fields
+        // (slug, published_at, primary_tag, ...). The facade contract requires
+        // the full resource shape, not just `{id, type}`.
+        it('passes the model\'s plain data (slug, etc.) to the facade', function () {
+            let captured;
+            const translator = new UrlTranslator({
+                urlUtils: {
+                    relativeToAbsolute: t => 'https://abs' + t
+                },
+                urlService: {
+                    facade: {
+                        getUrlForResource: (resource) => {
+                            captured = resource;
+                            return '/' + resource.slug + '/';
+                        }
+                    }
+                },
+                models: {}
+            });
+
+            const tag = {
+                get: () => undefined,
+                toJSON: () => ({id: 'abc', slug: 'changelog', visibility: 'public'})
+            };
+
+            const url = translator.getResourceUrl('abc', 'tag', tag, {absolute: false});
+
+            assert.equal(url, '/changelog/');
+            assert.equal(captured.id, 'abc');
+            assert.equal(captured.type, 'tags');
+            assert.equal(captured.slug, 'changelog');
+        });
+
+        it('keeps the email-only short-circuit for sent posts', function () {
+            const translator = new UrlTranslator({
+                urlUtils: {
+                    relativeToAbsolute: t => 'https://abs' + t
+                },
+                urlService: {
+                    facade: {
+                        getUrlForResource: () => {
+                            throw new Error('facade should not be consulted for email-only posts');
+                        }
+                    }
+                },
+                models: {}
+            });
+
+            const post = {
+                get(k) {
+                    return k === 'status' ? 'sent' : 'uuid-123';
+                },
+                toJSON: () => ({id: 'pid', uuid: 'uuid-123', status: 'sent'})
+            };
+
+            assert.equal(
+                translator.getResourceUrl('pid', 'post', post, {absolute: false}),
+                '/email/uuid-123/'
+            );
         });
     });
 

--- a/ghost/core/test/unit/server/services/mentions/resource-service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/resource-service.test.js
@@ -2,32 +2,26 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const ResourceService = require('../../../../../core/server/services/mentions/resource-service');
 const UrlUtils = require('@tryghost/url-utils');
-const UrlService = require('../../../../../core/server/services/url/url-service');
 
-function stubGetResource(urlService) {
-    const getResource = sinon.stub(urlService, 'getResource');
+function buildUrlServiceWithStubbedFacade() {
+    const resolveUrl = sinon.stub();
 
-    getResource.withArgs('/post-resource').returns({
-        config: {
-            type: 'posts'
-        },
-        data: {
-            id: '63ce473f992390b739b00b01'
-        }
+    resolveUrl.withArgs('/post-resource').resolves({
+        type: 'posts',
+        id: '63ce473f992390b739b00b01'
     });
 
-    getResource.withArgs('/tag-resource').returns({
-        config: {
-            type: 'tags'
-        },
-        data: {
-            id: '63ce473f992390b739b00b02'
-        }
+    resolveUrl.withArgs('/tag-resource').resolves({
+        type: 'tags',
+        id: '63ce473f992390b739b00b02'
     });
 
-    getResource.withArgs('/no-resource').returns(null);
+    resolveUrl.withArgs('/no-resource').resolves(null);
 
-    return getResource;
+    return {
+        urlService: {facade: {resolveUrl}},
+        resolveUrl
+    };
 }
 
 describe('ResourceService', function () {
@@ -45,19 +39,17 @@ describe('ResourceService', function () {
                 }
             });
 
-            const urlService = new UrlService();
+            const {urlService, resolveUrl} = buildUrlServiceWithStubbedFacade();
             const resourceService = new ResourceService({
                 urlUtils,
                 urlService
             });
 
-            const getResource = stubGetResource(urlService);
-
             const result = await resourceService.getByURL(
                 new URL('https://site.com/blah/post-resource')
             );
 
-            sinon.assert.calledWithExactly(getResource, '/post-resource');
+            sinon.assert.calledWithExactly(resolveUrl, '/post-resource');
 
             assert.equal(result.type, 'post');
             assert.equal(result.id.toHexString(), '63ce473f992390b739b00b01');
@@ -76,19 +68,17 @@ describe('ResourceService', function () {
                 }
             });
 
-            const urlService = new UrlService();
+            const {urlService, resolveUrl} = buildUrlServiceWithStubbedFacade();
             const resourceService = new ResourceService({
                 urlUtils,
                 urlService
             });
 
-            const getResource = stubGetResource(urlService);
-
             const result = await resourceService.getByURL(
                 new URL('https://site.com/blah/tag-resource')
             );
 
-            sinon.assert.calledWithExactly(getResource, '/tag-resource');
+            sinon.assert.calledWithExactly(resolveUrl, '/tag-resource');
 
             assert.equal(result.type, null);
             assert.equal(result.id, null);
@@ -107,19 +97,17 @@ describe('ResourceService', function () {
                 }
             });
 
-            const urlService = new UrlService();
+            const {urlService, resolveUrl} = buildUrlServiceWithStubbedFacade();
             const resourceService = new ResourceService({
                 urlUtils,
                 urlService
             });
 
-            const getResource = stubGetResource(urlService);
-
             const result = await resourceService.getByURL(
                 new URL('https://site.com/blah/no-resource')
             );
 
-            sinon.assert.calledWithExactly(getResource, '/no-resource');
+            sinon.assert.calledWithExactly(resolveUrl, '/no-resource');
 
             assert.equal(result.type, null);
             assert.equal(result.id, null);

--- a/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const bridge = require('../../../../../core/bridge');
 const RouteSettings = require('../../../../../core/server/services/route-settings/route-settings');
+const urlService = require('../../../../../core/server/services/url');
 
 describe('UNIT > Settings Service DefaultSettingsManager:', function () {
     let fsReadFileStub;
@@ -46,6 +47,96 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             } catch (error) {
                 assert.match(error.message, /YAMLException: bad indentation of a mapping entry/);
             }
+        });
+
+        // Lazy/eager branching for the URL-service reset and the post-reload
+        // readiness poll. The lazy branch is unique to this commit (HKG-1771),
+        // so the test is colocated with the implementation.
+        describe('when lazyRouting is on', function () {
+            const routesSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes.yaml');
+            const backupFilePath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-backup.yaml');
+            const incomingSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-incoming.yaml');
+
+            let facadeResetStub;
+            let resetGeneratorsStub;
+            let hasFinishedStub;
+
+            beforeEach(function () {
+                sinon.stub(urlService.facade, 'isLazy').returns(true);
+                facadeResetStub = sinon.stub(urlService.facade, 'reset');
+                resetGeneratorsStub = sinon.stub(urlService, 'resetGenerators');
+                hasFinishedStub = sinon.stub(urlService, 'hasFinished').returns(true);
+
+                fsReadFileStub.withArgs(routesSettingsPath, 'utf8').resolves('content');
+                fsCopyStub.withArgs(backupFilePath, routesSettingsPath).resolves();
+                fsCopyStub.withArgs(incomingSettingsPath, routesSettingsPath).resolves();
+
+                bridgeReloadFrontendStub.resolves();
+            });
+
+            it('resets via facade.reset and skips eager resetGenerators', async function () {
+                const manager = new RouteSettings({
+                    settingsLoader: {},
+                    settingsPath: routesSettingsPath,
+                    backupPath: backupFilePath
+                });
+
+                await manager.setFromFilePath(incomingSettingsPath);
+
+                sinon.assert.calledOnce(facadeResetStub);
+                sinon.assert.notCalled(resetGeneratorsStub);
+            });
+
+            it('skips the readiness poll', async function () {
+                const manager = new RouteSettings({
+                    settingsLoader: {},
+                    settingsPath: routesSettingsPath,
+                    backupPath: backupFilePath
+                });
+
+                await manager.setFromFilePath(incomingSettingsPath);
+
+                // The readiness loop is the only caller of
+                // urlService.hasFinished() inside setFromFilePath. When the
+                // flag is on, the lazy short-circuit returns early — so it
+                // must never be consulted.
+                sinon.assert.notCalled(hasFinishedStub);
+            });
+        });
+
+        describe('when lazyRouting is off (eager default)', function () {
+            const routesSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes.yaml');
+            const backupFilePath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-backup.yaml');
+            const incomingSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-incoming.yaml');
+
+            let facadeResetStub;
+            let resetGeneratorsStub;
+
+            beforeEach(function () {
+                sinon.stub(urlService.facade, 'isLazy').returns(false);
+                facadeResetStub = sinon.stub(urlService.facade, 'reset');
+                resetGeneratorsStub = sinon.stub(urlService, 'resetGenerators');
+                sinon.stub(urlService, 'hasFinished').returns(true);
+
+                fsReadFileStub.withArgs(routesSettingsPath, 'utf8').resolves('content');
+                fsCopyStub.withArgs(backupFilePath, routesSettingsPath).resolves();
+                fsCopyStub.withArgs(incomingSettingsPath, routesSettingsPath).resolves();
+
+                bridgeReloadFrontendStub.resolves();
+            });
+
+            it('keeps the existing eager resetGenerators path', async function () {
+                const manager = new RouteSettings({
+                    settingsLoader: {},
+                    settingsPath: routesSettingsPath,
+                    backupPath: backupFilePath
+                });
+
+                await manager.setFromFilePath(incomingSettingsPath);
+
+                sinon.assert.called(resetGeneratorsStub);
+                sinon.assert.notCalled(facadeResetStub);
+            });
         });
     });
 });

--- a/ghost/core/test/unit/server/services/slack.test.js
+++ b/ghost/core/test/unit/server/services/slack.test.js
@@ -113,11 +113,11 @@ describe('Slack', function () {
         let settingsCacheStub;
         let slackReset;
         let makeRequestStub;
-        let urlServiceGetUrlByResourceIdStub;
+        let urlServiceGetUrlForResourceStub;
         const ping = slack.__get__('ping');
 
         beforeEach(function () {
-            urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+            urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
 
             settingsCacheStub = sinon.stub(settingsCache, 'get');
 
@@ -142,7 +142,9 @@ describe('Slack', function () {
                 slug: 'webhook-test',
                 html: `<p>Hello World!</p><p>This is a test post.</p><!--members-only--><p>This is members only content.</p>`
             });
-            urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://myblog.com/' + post.slug + '/');
+            urlServiceGetUrlForResourceStub
+                .withArgs(sinon.match({id: post.id, type: 'posts'}), {absolute: true})
+                .returns('http://myblog.com/' + post.slug + '/');
 
             settingsCacheStub.withArgs('slack_url').returns(slackURL);
 
@@ -151,7 +153,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.calledOnce(makeRequestStub);
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
 
             requestUrl = makeRequestStub.firstCall.args[0];
@@ -179,7 +181,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.calledOnce(makeRequestStub);
-            sinon.assert.notCalled(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.notCalled(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
 
             requestUrl = makeRequestStub.firstCall.args[0];
@@ -220,7 +222,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.notCalled(makeRequestStub);
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
         });
 
@@ -233,7 +235,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.notCalled(makeRequestStub);
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
         });
 
@@ -246,7 +248,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.notCalled(makeRequestStub);
-            sinon.assert.called(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.called(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
         });
     });

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -22,8 +22,10 @@ describe('ContentStatsService', function () {
         };
 
         mockUrlService = {
-            getResource: sinon.stub(),
-            hasFinished: sinon.stub().returns(true)
+            facade: {
+                resolveUrl: sinon.stub().resolves(null),
+                hasFinished: sinon.stub().returns(true)
+            }
         };
 
         // Create mock Tinybird client
@@ -160,56 +162,54 @@ describe('ContentStatsService', function () {
     });
 
     describe('getResourceTitle', function () {
-        it('returns null if urlService is not available', function () {
+        it('returns null if urlService is not available', async function () {
             // Create service without urlService
             const serviceNoUrl = new ContentStatsService({
                 knex: mockKnex,
                 urlService: null
             });
 
-            const result = serviceNoUrl.getResourceTitle('/about/');
+            const result = await serviceNoUrl.getResourceTitle('/about/');
             assert.equal(result, null);
         });
 
-        it('returns title from resource with title property', function () {
-            mockUrlService.getResource.withArgs('/about/').returns({
-                data: {
-                    title: 'About Us',
-                    type: 'page'
-                }
+        it('returns title from resource with title property', async function () {
+            mockUrlService.facade.resolveUrl.withArgs('/about/').resolves({
+                title: 'About Us',
+                type: 'pages'
             });
 
-            const result = service.getResourceTitle('/about/');
+            const result = await service.getResourceTitle('/about/');
             assertExists(result);
             assert.equal(result.title, 'About Us');
             assert.equal(result.resourceType, 'page');
         });
 
-        it('returns name from resource with name property (tags, authors)', function () {
-            mockUrlService.getResource.withArgs('/tag/news/').returns({
-                data: {
-                    name: 'News',
-                    type: 'tag'
-                }
+        it('returns name from resource with name property (tags, authors)', async function () {
+            mockUrlService.facade.resolveUrl.withArgs('/tag/news/').resolves({
+                name: 'News',
+                type: 'tags'
             });
 
-            const result = service.getResourceTitle('/tag/news/');
+            const result = await service.getResourceTitle('/tag/news/');
             assertExists(result);
             assert.equal(result.title, 'News');
-            assert.equal(result.resourceType, 'tag');
+            // Pre-migration tags/authors had no `data.type` column so this
+            // surfaced as undefined; keep that contract for API consumers.
+            assert.equal(result.resourceType, undefined);
         });
 
-        it('returns null if resource lookup fails', function () {
-            mockUrlService.getResource.withArgs('/not-found/').throws(new Error('Resource not found'));
+        it('returns null if resource lookup fails', async function () {
+            mockUrlService.facade.resolveUrl.withArgs('/not-found/').rejects(new Error('Resource not found'));
 
-            const result = service.getResourceTitle('/not-found/');
+            const result = await service.getResourceTitle('/not-found/');
             assert.equal(result, null);
         });
 
-        it('returns null if resource has no data or title/name', function () {
-            mockUrlService.getResource.withArgs('/empty/').returns({});
+        it('returns null if resource has no title or name', async function () {
+            mockUrlService.facade.resolveUrl.withArgs('/empty/').resolves({type: 'posts'});
 
-            const result = service.getResourceTitle('/empty/');
+            const result = await service.getResourceTitle('/empty/');
             assert.equal(result, null);
         });
     });
@@ -238,8 +238,8 @@ describe('ContentStatsService', function () {
             ];
 
             // Mock urlService to return resources for these paths
-            mockUrlService.getResource.withArgs('/post-1/').returns({data: {title: 'Post 1'}});
-            mockUrlService.getResource.withArgs('/post-2/').returns({data: {title: 'Post 2'}});
+            mockUrlService.facade.resolveUrl.withArgs('/post-1/').resolves({title: 'Post 1', type: 'posts'});
+            mockUrlService.facade.resolveUrl.withArgs('/post-2/').resolves({title: 'Post 2', type: 'posts'});
 
             const result = await service.enrichTopContentData(data);
 
@@ -262,11 +262,9 @@ describe('ContentStatsService', function () {
                 {pathname: '/about/', visits: 100}
             ];
 
-            mockUrlService.getResource.withArgs('/about/').returns({
-                data: {
-                    title: 'About Us',
-                    type: 'page'
-                }
+            mockUrlService.facade.resolveUrl.withArgs('/about/').resolves({
+                title: 'About Us',
+                type: 'pages'
             });
 
             const result = await service.enrichTopContentData(data);
@@ -286,7 +284,7 @@ describe('ContentStatsService', function () {
                 {pathname: '/unknown-page/', visits: 100}
             ];
 
-            mockUrlService.getResource.withArgs('/unknown-page/').returns(null);
+            mockUrlService.facade.resolveUrl.withArgs('/unknown-page/').resolves(null);
 
             const result = await service.enrichTopContentData(data);
 
@@ -304,7 +302,7 @@ describe('ContentStatsService', function () {
                 {pathname: '/', visits: 100}
             ];
 
-            mockUrlService.getResource.withArgs('/').returns(null);
+            mockUrlService.facade.resolveUrl.withArgs('/').resolves(null);
 
             const result = await service.enrichTopContentData(data);
 

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -316,10 +316,12 @@ describe('PostsStatsService', function () {
 
         // Mock urlService for URL existence checking
         const mockUrlService = {
-            hasFinished: () => true,
-            getResource: () => {
-                // Mock that all URLs exist for testing
-                return {data: {title: 'Mock Title'}};
+            facade: {
+                hasFinished: () => true,
+                resolveUrl: async () => {
+                    // Mock that all URLs exist for testing
+                    return {title: 'Mock Title', type: 'posts'};
+                }
             }
         };
 
@@ -373,14 +375,16 @@ describe('PostsStatsService', function () {
             return new PostsStatsService({
                 knex: db,
                 urlService: {
-                    hasFinished: () => true,
-                    getResource: lookup
+                    facade: {
+                        hasFinished: () => true,
+                        resolveUrl: async path => lookup(path)
+                    }
                 }
             });
         }
 
         it('flags url_exists: true when the URL resolves to a resource', async function () {
-            const svc = svcWithUrlLookup(() => ({data: {title: 'present'}}));
+            const svc = svcWithUrlLookup(() => ({type: 'posts', title: 'present'}));
             const out = await svc._enrichWithTitles([
                 {attribution_url: '/known/', title: 'Known', attribution_type: 'post', attribution_id: 'p', post_id: 'p'}
             ]);

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -364,6 +364,38 @@ describe('PostsStatsService', function () {
         assert.ok(service, 'Service instance should exist');
     });
 
+    // _enrichWithTitles assigns `url_exists` based on the urlService lookup.
+    // The fixtures above always return truthy, so the falsy branch was
+    // unreached. Pin both branches here so the future migration to a
+    // different lookup API has to keep them coherent.
+    describe('_enrichWithTitles url_exists', function () {
+        function svcWithUrlLookup(lookup) {
+            return new PostsStatsService({
+                knex: db,
+                urlService: {
+                    hasFinished: () => true,
+                    getResource: lookup
+                }
+            });
+        }
+
+        it('flags url_exists: true when the URL resolves to a resource', async function () {
+            const svc = svcWithUrlLookup(() => ({data: {title: 'present'}}));
+            const out = await svc._enrichWithTitles([
+                {attribution_url: '/known/', title: 'Known', attribution_type: 'post', attribution_id: 'p', post_id: 'p'}
+            ]);
+            assert.equal(out[0].url_exists, true);
+        });
+
+        it('flags url_exists: false when the URL has no resource', async function () {
+            const svc = svcWithUrlLookup(() => null);
+            const out = await svc._enrichWithTitles([
+                {attribution_url: '/missing/', title: 'Missing', attribution_type: 'post', attribution_id: 'p', post_id: 'p'}
+            ]);
+            assert.equal(out[0].url_exists, false);
+        });
+    });
+
     describe('getTopPosts', function () {
         it('returns all posts with zero stats when no events exist', async function () {
             const result = await service.getTopPosts({});

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -1,0 +1,329 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const LazyUrlService = require('../../../../../core/server/services/url/lazy-url-service');
+
+function makeUrlUtils() {
+    // Just enough of url-utils to satisfy the service. createUrl returns the
+    // path verbatim so tests can assert on the relative form; replacePermalink
+    // does the same substitution Ghost's url-utils does for our limited fields.
+    // Permalinks use the `:field` syntax that Ghost's RouteSettings validator
+    // rewrites all `{field}` placeholders into before they reach the URL
+    // service.
+    return {
+        replacePermalink(permalink, resource) {
+            const datePart = resource.published_at ? new Date(resource.published_at) : null;
+            return permalink
+                .replace(/:slug\b/, resource.slug || '')
+                .replace(/:id\b/, resource.id || '')
+                .replace(/:primary_tag\b/, resource.primary_tag?.slug || '')
+                .replace(/:primary_author\b/, resource.primary_author?.slug || '')
+                .replace(/:year\b/, datePart ? String(datePart.getUTCFullYear()) : '')
+                .replace(/:month\b/, datePart ? String(datePart.getUTCMonth() + 1).padStart(2, '0') : '')
+                .replace(/:day\b/, datePart ? String(datePart.getUTCDate()).padStart(2, '0') : '');
+        },
+        createUrl(path, absolute, withSubdirectory) {
+            if (absolute) {
+                return `https://example.com${path}`;
+            }
+            if (withSubdirectory) {
+                return `/sub${path}`;
+            }
+            return path;
+        }
+    };
+}
+
+describe('LazyUrlService', function () {
+    let urlUtils;
+
+    beforeEach(function () {
+        urlUtils = makeUrlUtils();
+    });
+
+    describe('getUrlForResource', function () {
+        it('returns /404/ when no router has been registered', function () {
+            const service = new LazyUrlService({urlUtils});
+            const url = service.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
+            assert.equal(url, '/404/');
+        });
+
+        it('returns /404/ when called without a resource type', function () {
+            const service = new LazyUrlService({urlUtils});
+            assert.equal(service.getUrlForResource(null), '/404/');
+            assert.equal(service.getUrlForResource({}), '/404/');
+        });
+
+        it('uses the unfiltered collection router for any post', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello'});
+            assert.equal(url, '/hello/');
+        });
+
+        it('respects router priority for filtered collections', function () {
+            const service = new LazyUrlService({urlUtils});
+            // Featured posts go to /featured/, everything else to /:slug/.
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const featured = service.getUrlForResource({type: 'posts', id: 'f', slug: 'hot', featured: true});
+            const ordinary = service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', featured: false});
+
+            assert.equal(featured, '/featured/hot/');
+            assert.equal(ordinary, '/meh/');
+        });
+
+        it('falls back to /404/ when a post matches no collection filter', function () {
+            const service = new LazyUrlService({urlUtils});
+            // Only featured posts are routed.
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+
+            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', featured: false});
+            assert.equal(url, '/404/');
+        });
+
+        it('expands shorthand tag/author filters via the EXPANSIONS table', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('podcast', 'tag:podcast', 'posts', '/podcast/:slug/');
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const podcastPost = service.getUrlForResource({
+                type: 'posts',
+                id: 'p',
+                slug: 'episode-1',
+                tags: [{id: 't1', slug: 'podcast'}, {id: 't2', slug: 'misc'}]
+            });
+            assert.equal(podcastPost, '/podcast/episode-1/');
+        });
+
+        it('matches page:false against the singular DB type field', function () {
+            // The legacy transformer rewrites `page:false` to `type:post` and
+            // evaluates it against the resource's singular DB-style `type`
+            // field. The negative half (a record whose `type` is 'page'
+            // failing the filter) is not directly expressible through this
+            // public API: `_routerTypeOf('page')` returns 'pages', so a
+            // type:'page' resource is routed to the pages collection rather
+            // than reaching this posts router's filter at all. That's why
+            // only the positive match is asserted here.
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('posts-only', 'page:false', 'posts', '/:slug/');
+
+            const post = service.getUrlForResource({type: 'post', id: 'p', slug: 'hello'});
+            assert.equal(post, '/hello/');
+        });
+
+        it('handles deterministic ownership for tags/authors/pages', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('tagsRouter', null, 'tags', '/tag/:slug/');
+            service.onRouterAddedType('authorsRouter', null, 'authors', '/author/:slug/');
+            service.onRouterAddedType('staticPages', null, 'pages', '/:slug/');
+
+            assert.equal(
+                service.getUrlForResource({type: 'tags', id: 't1', slug: 'food'}),
+                '/tag/food/'
+            );
+            assert.equal(
+                service.getUrlForResource({type: 'authors', id: 'a1', slug: 'jane'}),
+                '/author/jane/'
+            );
+            assert.equal(
+                service.getUrlForResource({type: 'pages', id: 'pg1', slug: 'about'}),
+                '/about/'
+            );
+        });
+
+        it('substitutes date-based permalink fields', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('dated', null, 'posts', '/:year/:month/:slug/');
+
+            const url = service.getUrlForResource({
+                type: 'posts',
+                id: 'p',
+                slug: 'hello',
+                published_at: '2026-04-15T10:00:00Z'
+            });
+            assert.equal(url, '/2026/04/hello/');
+        });
+
+        it('honours the absolute and withSubdirectory options', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const post = {type: 'posts', id: 'p', slug: 'hello'};
+            assert.equal(service.getUrlForResource(post, {absolute: true}), 'https://example.com/hello/');
+            assert.equal(service.getUrlForResource(post, {withSubdirectory: true}), '/sub/hello/');
+        });
+    });
+
+    describe('ownsResource', function () {
+        it('returns false for an unknown router identifier', function () {
+            const service = new LazyUrlService({urlUtils});
+            assert.equal(service.ownsResource('unknown', {type: 'posts', id: 'p'}), false);
+        });
+
+        it('returns true for an unfiltered router that matches the resource type', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(service.ownsResource('default', {type: 'posts', id: 'p', slug: 'x'}), true);
+        });
+
+        it('returns false when the resource type does not match the router', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(service.ownsResource('default', {type: 'pages', id: 'p', slug: 'x'}), false);
+        });
+
+        it('evaluates NQL filters against the resource', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+
+            assert.equal(service.ownsResource('featured', {type: 'posts', id: 'a', featured: true}), true);
+            assert.equal(service.ownsResource('featured', {type: 'posts', id: 'b', featured: false}), false);
+        });
+    });
+
+    describe('hasFinished', function () {
+        it('always returns true', function () {
+            assert.equal(new LazyUrlService({urlUtils}).hasFinished(), true);
+        });
+    });
+
+    describe('reset', function () {
+        it('drops all registered router configs', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p'}), '/hello/');
+
+            service.reset();
+            assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p'}), '/404/');
+        });
+    });
+
+    describe('resolveUrl', function () {
+        it('returns null when no findResource hook is configured', async function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(await service.resolveUrl('/hello/'), null);
+        });
+
+        it('extracts slug params and queries the DB by router type', async function () {
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello', title: 'Hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const result = await service.resolveUrl('/hello/');
+            assert.deepEqual(result, {id: 'p1', slug: 'hello', title: 'Hello', type: 'posts'});
+            sinon.assert.calledWith(findResource, 'posts', {slug: 'hello'});
+        });
+
+        it('iterates routers in priority order, picking the first whose template matches', async function () {
+            // Two routers with overlapping templates: a single-segment posts
+            // collection at /:slug/ and a single-segment static-pages
+            // collection at /:slug/. Both can pattern-match `/hello/`. The
+            // posts collection is registered first, so it wins — and the
+            // static pages router is never consulted via findResource.
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('posts', null, 'posts', '/:slug/');
+            service.onRouterAddedType('staticPages', null, 'pages', '/:slug/');
+
+            const result = await service.resolveUrl('/hello/');
+            assert.equal(result.type, 'posts');
+            assert.equal(result.id, 'p1');
+            sinon.assert.neverCalledWith(findResource, 'pages', sinon.match.any);
+        });
+
+        it('verifies NQL filters for filtered post collections', async function () {
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'plain'}).resolves({id: 'p2', slug: 'plain', featured: false});
+            findResource.withArgs('posts', {slug: 'hot'}).resolves({id: 'p3', slug: 'hot', featured: true});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+
+            // 'plain' is found in the DB but its featured filter rejects it.
+            assert.equal(await service.resolveUrl('/featured/plain/'), null);
+            const hot = await service.resolveUrl('/featured/hot/');
+            assert.equal(hot.id, 'p3');
+        });
+
+        it('returns null when no router template matches the URL', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            assert.equal(await service.resolveUrl('/some/other/path/'), null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('matches multi-segment permalinks (e.g. /:primary_tag/:slug/)', async function () {
+            const findResource = sinon.stub();
+            // withArgs binds the resolve to the exact param shape, so a
+            // regression that drops one of the captures (e.g. forgets to
+            // pass `primary_tag`) fails on the resolve, not just on the spy.
+            findResource
+                .withArgs('posts', {primary_tag: 'podcast', slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:primary_tag/:slug/');
+
+            const result = await service.resolveUrl('/podcast/hello/');
+            assert.equal(result.id, 'p1');
+            assert.equal(result.type, 'posts');
+        });
+
+        it('matches date-based permalinks', async function () {
+            const findResource = sinon.stub();
+            findResource
+                .withArgs('posts', {year: '2026', month: '04', slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:year/:month/:slug/');
+
+            const result = await service.resolveUrl('/2026/04/hello/');
+            assert.equal(result.id, 'p1');
+        });
+
+        it('does not throw on malformed %-escapes; returns null instead', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const result = await service.resolveUrl('/foo%ZZ/');
+            assert.equal(result, null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('rejects mixed-literal-and-placeholder segments (no ReDoS surface)', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            // Mixed segments like `/blog-:slug/` are not a documented Ghost
+            // permalink shape; we deliberately don't try to match them.
+            service.onRouterAddedType('default', null, 'posts', '/blog-:slug/');
+
+            assert.equal(await service.resolveUrl('/blog-hello/'), null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('uses the singular DB type field to find posts collections', async function () {
+            const findResource = sinon.stub();
+            findResource.resolves({id: 'p1', slug: 'hello', type: 'post'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            // Caller (e.g. the entry controller / RSS feed) hands the lazy
+            // service a raw DB record with type:'post'. The service should
+            // still match the posts collection.
+            const url = service.getUrlForResource({type: 'post', id: 'p1', slug: 'hello'});
+            assert.equal(url, '/hello/');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -93,4 +93,60 @@ describe('UrlServiceFacade', function () {
             sinon.assert.calledWith(urlService.onRouterUpdated, 'id');
         });
     });
+
+    describe('lazy mode (lazyUrlService backend)', function () {
+        let lazyUrlService;
+        let lazyFacade;
+
+        beforeEach(function () {
+            lazyUrlService = {
+                getUrlForResource: sinon.stub().returns('/lazy/'),
+                ownsResource: sinon.stub().returns(true),
+                resolveUrl: sinon.stub().resolves({type: 'posts', id: 'p1'}),
+                hasFinished: sinon.stub().returns(true),
+                onRouterAddedType: sinon.stub(),
+                onRouterUpdated: sinon.stub(),
+                reset: sinon.stub()
+            };
+            lazyFacade = new UrlServiceFacade({urlService, lazyUrlService});
+        });
+
+        it('isLazy() reports true', function () {
+            assert.equal(lazyFacade.isLazy(), true);
+        });
+
+        it('routes getUrlForResource through the lazy backend', function () {
+            const url = lazyFacade.getUrlForResource({type: 'posts', id: 'a'}, {absolute: true});
+            sinon.assert.calledWith(lazyUrlService.getUrlForResource, {type: 'posts', id: 'a'}, {absolute: true});
+            sinon.assert.notCalled(urlService.getUrlByResourceId);
+            assert.equal(url, '/lazy/');
+        });
+
+        it('routes ownsResource through the lazy backend', function () {
+            lazyFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
+            sinon.assert.calledWith(lazyUrlService.ownsResource, 'routerA', {type: 'posts', id: 'a'});
+            sinon.assert.notCalled(urlService.owns);
+        });
+
+        it('returns the lazy backend resource directly from resolveUrl', async function () {
+            const result = await lazyFacade.resolveUrl('/x/');
+            sinon.assert.calledWith(lazyUrlService.resolveUrl, '/x/');
+            sinon.assert.notCalled(urlService.getResource);
+            assert.deepEqual(result, {type: 'posts', id: 'p1'});
+        });
+
+        it('forwards lifecycle hooks to the lazy backend', function () {
+            lazyFacade.onRouterAddedType('id', 'filter', 'posts', '/{slug}/');
+            lazyFacade.onRouterUpdated('id');
+            sinon.assert.calledWith(lazyUrlService.onRouterAddedType, 'id', 'filter', 'posts', '/{slug}/');
+            sinon.assert.calledWith(lazyUrlService.onRouterUpdated, 'id');
+            sinon.assert.notCalled(urlService.onRouterAddedType);
+            sinon.assert.notCalled(urlService.onRouterUpdated);
+        });
+
+        it('reset() drops registered router configs on the lazy backend', function () {
+            lazyFacade.reset();
+            sinon.assert.calledOnce(lazyUrlService.reset);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -1,0 +1,96 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const UrlServiceFacade = require('../../../../../core/server/services/url/url-service-facade');
+
+describe('UrlServiceFacade', function () {
+    let urlService;
+    let facade;
+
+    beforeEach(function () {
+        urlService = {
+            getUrlByResourceId: sinon.stub().returns('/hello-world/'),
+            owns: sinon.stub().returns(true),
+            getResource: sinon.stub(),
+            getResourceById: sinon.stub(),
+            hasFinished: sinon.stub().returns(true),
+            onRouterAddedType: sinon.stub(),
+            onRouterUpdated: sinon.stub()
+        };
+        facade = new UrlServiceFacade({urlService});
+    });
+
+    describe('getUrlForResource', function () {
+        it('extracts the id from the resource and forwards options', function () {
+            const url = facade.getUrlForResource({id: 'abc', type: 'posts'}, {absolute: true});
+
+            sinon.assert.calledWith(urlService.getUrlByResourceId, 'abc', {absolute: true});
+            assert.equal(url, '/hello-world/');
+        });
+
+        it('forwards an undefined options argument unchanged', function () {
+            facade.getUrlForResource({id: 'abc'});
+
+            sinon.assert.calledWith(urlService.getUrlByResourceId, 'abc', undefined);
+        });
+    });
+
+    describe('ownsResource', function () {
+        it('extracts the id from the resource', function () {
+            const owned = facade.ownsResource('collectionRouter', {id: 'abc'});
+
+            sinon.assert.calledWith(urlService.owns, 'collectionRouter', 'abc');
+            assert.equal(owned, true);
+        });
+    });
+
+    describe('resolveUrl', function () {
+        it('returns null when the underlying lookup misses', async function () {
+            urlService.getResource.returns(null);
+
+            const result = await facade.resolveUrl('/missing/');
+
+            assert.equal(result, null);
+        });
+
+        it('flattens the legacy {config, data} envelope into a Resource', async function () {
+            urlService.getResource.returns({
+                config: {type: 'posts'},
+                data: {id: 'abc', slug: 'hello-world', title: 'Hello'}
+            });
+
+            const result = await facade.resolveUrl('/hello-world/');
+
+            assert.deepEqual(result, {
+                type: 'posts',
+                id: 'abc',
+                slug: 'hello-world',
+                title: 'Hello'
+            });
+        });
+
+        it('returns a promise (the lazy implementation will be async)', function () {
+            urlService.getResource.returns(null);
+            const result = facade.resolveUrl('/x/');
+            assert.ok(result instanceof Promise);
+        });
+    });
+
+    describe('hasFinished', function () {
+        it('delegates to the underlying url service', function () {
+            urlService.hasFinished.returns(false);
+            assert.equal(facade.hasFinished(), false);
+        });
+    });
+
+    describe('lifecycle pass-throughs', function () {
+        it('forwards onRouterAddedType', function () {
+            facade.onRouterAddedType('id', 'filter', 'posts', '/{slug}/');
+            sinon.assert.calledWith(urlService.onRouterAddedType, 'id', 'filter', 'posts', '/{slug}/');
+        });
+
+        it('forwards onRouterUpdated', function () {
+            facade.onRouterUpdated('id');
+            sinon.assert.calledWith(urlService.onRouterUpdated, 'id');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Experimental opt-in lazy URL routing service, gated behind `config.lazyRouting` (default `false`). When the flag is on, the existing eager `UrlService` (which preloads every post/page/tag/author at boot) is replaced by a pure on-demand `LazyUrlService` that resolves URLs from the DB the first time each one is asked for. The flag-off path is the existing eager service unchanged.

This is a multi-issue stack ([HKG-1738](https://linear.app/ghost/issue/HKG-1738)). 15 commits, each independently reviewable. Three of them are pure-tests-on-top-of-main commits inserted before the impl they exercise (TDD discipline + independently mergeable).

## Stack

- HKG-1761 — Pass post objects to audience feedback / comment email services (preceded by a tests-only commit characterising the existing behaviour through the public methods)
- HKG-1762 — Simplify entry controller type check
- HKG-1763 — Introduce `UrlServiceFacade`
- HKG-1764 — Migrate routing controllers to facade
- HKG-1765 — Migrate API output serializer to facade
- HKG-1766 — Migrate frontend helpers and meta to facade
- HKG-1767 — Migrate backend services to facade (preceded by ` test: pin IndexNow ping URL output`)
- HKG-1768 — Migrate reverse-lookup callers to facade (preceded by ` test: pin posts-stats urlExists false branch`)
- HKG-1769 — Migrate sitemap to DB-driven generation when `lazyRouting` is on
- HKG-1770 — Implement `LazyUrlService` class
- HKG-1771 — Wire `LazyUrlService` into the boot/reset lifecycle behind the flag
- HKG-1772 — Document benchmark methodology

## What this changes for flag-off users (default)

Behaviour-preserving migrations only. Backend services and routing controllers now talk to a thin facade (`urlService.facade`) that delegates to the existing eager `UrlService`. No semantic change for any flag-off path; no callers were removed. Two refactor-only patches add a `toPlain()` helper for Bookshelf-or-plain inputs and tighten the entry-controller type check.

## What flips on with `config.lazyRouting: true` (opt-in)

- `UrlServiceFacade` routes through `LazyUrlService` instead of the eager service. Each `getUrlForResource` / `resolveUrl` walks the registered routers' permalink templates against the resource (or `findResource()` for path → resource) on demand.
- `SiteMapManager` populates itself from the DB on first request (per type, paginated) instead of waiting for `url.added`/`url.removed` events. Mirrors the eager URL service's resource queries: posts/pages by `status:published`+`type:`, tags/authors by `visibility:public`. Posts are loaded with `withRelated: ['tags', 'authors']` so `:primary_tag`/`:primary_author` permalinks resolve.
- `bridge.start()` skips `urlService.queue.start` (no more 8-stage URL boot pipeline).
- `route-settings.setFromFilePath` calls `facade.reset()` and skips the readiness poll.

## Production safety

- Flag default is `false`; flag-off path is unchanged. Verified by 4 review passes.
- The two scoped models for the lazy sitemap populate are `models.TagPublic` and `models.Author` (the existing `shouldHavePosts`-gated models) so the sitemap doesn't leak staff-only User accounts. Tags/authors also filtered by `visibility:public` to mirror the eager service.
- `_populateFromDatabase` guards a re-entry race: if `routers.reset` fires mid-populate, the in-flight result is invalidated via a generation token, and a stale settle is prevented from clobbering a successor populate's handle.

## Test plan

- [x] `cd ghost/core && pnpm lint` — 0 errors, 2 pre-existing warnings
- [x] `cd ghost/core && pnpm test:single test/unit/server/services` — 3168 passing
- [x] `cd ghost/core && pnpm test:single test/unit/frontend` — 1769 passing
- [x] Targeted suites at tip: `to-plain.test.js` (5), `lazy-url-service.test.js` (26), `url-service-facade.test.js` (15), sitemap `manager.test.js` (15), `route-settings.test.js`, `url-translator.test.js` (29)
- [ ] CI green
- [ ] Smoke test the lazy path locally (`config.lazyRouting: true`, hit `/`, RSS, sitemap, member-attribution URL)
- [ ] E2E pass

## Reviewer notes

Stacked PR. Read the commits in order — each migration is small and isolated. The two tests-on-top-of-main commits are intentional: they characterise pre-existing behaviour through the public methods that the migrations touch, so they're independently mergeable on top of `main` if the rest of the stack ever changes shape.

Six rounds of multi-agent review (clean-code / production-safety / bug+security / test-quality) prior to opening this PR. CodeRabbit will get the next pass.