### PR TITLE
Improved Ember dev server startup

### DIFF
--- a/ghost/admin/config/environment.js
+++ b/ghost/admin/config/environment.js
@@ -49,7 +49,8 @@ module.exports = function (environment) {
 
         // Enable mirage here in order to mock API endpoints during development
         ENV['ember-cli-mirage'] = {
-            enabled: false
+            enabled: false,
+            excludeFilesFromBuild: process.env.EMBER_INCLUDE_TESTS !== 'true'
         };
     }
 

--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -14,6 +14,7 @@ const environment = EmberApp.env();
 const isDevelopment = environment === 'development';
 const isProduction = environment === 'production';
 const isTesting = environment === 'test';
+const includeTestAssets = !isProduction && (isTesting || process.env.EMBER_INCLUDE_TESTS === 'true');
 
 const postcssImport = require('postcss-import');
 const postcssCustomProperties = require('postcss-custom-properties');
@@ -58,7 +59,7 @@ const codemirrorAssets = function () {
     };
 
     // put the files in vendor ready for importing into the test-support file
-    if (environment === 'development') {
+    if (environment === 'development' && includeTestAssets) {
         config.vendor = codemirrorFiles;
     }
 
@@ -83,6 +84,9 @@ if (isTesting) {
 module.exports = function (defaults) {
     let app = new EmberApp(defaults, {
         addons: {denylist},
+        tests: includeTestAssets,
+        hinting: includeTestAssets,
+        trees: includeTestAssets ? {} : {tests: false},
         babel: {
             plugins: [
                 require.resolve('babel-plugin-transform-react-jsx')
@@ -261,11 +265,11 @@ module.exports = function (defaults) {
 
     // pull things we rely on via lazy-loading into the test-support.js file so
     // that tests don't break when running via http://localhost:4200/tests
-    if (app.env === 'development') {
+    if (app.env === 'development' && includeTestAssets) {
         app.import('vendor/codemirror/lib/codemirror.js', {type: 'test'});
     }
 
-    if (app.env === 'development' || app.env === 'test') {
+    if (includeTestAssets) {
         // pull dynamic imports into the assets folder so that they can be lazy-loaded in tests
         // also done in development env so http://localhost:4200/tests works
         app.import('node_modules/@tryghost/koenig-lexical/dist/koenig-lexical.umd.js', {outputFile: 'ghost/assets/koenig-lexical/koenig-lexical.umd.js'});

--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -14,7 +14,8 @@ const environment = EmberApp.env();
 const isDevelopment = environment === 'development';
 const isProduction = environment === 'production';
 const isTesting = environment === 'test';
-const includeTestAssets = !isProduction && (isTesting || process.env.EMBER_INCLUDE_TESTS === 'true');
+const shouldIncludeTestAssets = buildEnvironment => buildEnvironment !== 'production' && (buildEnvironment === 'test' || process.env.EMBER_INCLUDE_TESTS === 'true');
+const includeTestAssets = shouldIncludeTestAssets(environment);
 
 const postcssImport = require('postcss-import');
 const postcssCustomProperties = require('postcss-custom-properties');
@@ -265,11 +266,13 @@ module.exports = function (defaults) {
 
     // pull things we rely on via lazy-loading into the test-support.js file so
     // that tests don't break when running via http://localhost:4200/tests
-    if (app.env === 'development' && includeTestAssets) {
+    const includeAppTestAssets = shouldIncludeTestAssets(app.env);
+
+    if (app.env === 'development' && includeAppTestAssets) {
         app.import('vendor/codemirror/lib/codemirror.js', {type: 'test'});
     }
 
-    if (includeTestAssets) {
+    if (includeAppTestAssets) {
         // pull dynamic imports into the assets folder so that they can be lazy-loaded in tests
         // also done in development env so http://localhost:4200/tests works
         app.import('node_modules/@tryghost/koenig-lexical/dist/koenig-lexical.umd.js', {outputFile: 'ghost/assets/koenig-lexical/koenig-lexical.umd.js'});


### PR DESCRIPTION
## Summary

- Skip Ember test and hinting trees during normal development builds.
- Exclude Mirage files from normal development builds unless explicitly opted in.
- Keep `/tests` support available with `EMBER_INCLUDE_TESTS=true`.

## Why

`ember serve` was building test and Mirage assets by default in development, pulling large dev-only dependencies such as Faker into the default startup path. This keeps the normal dev server focused on the app graph while preserving explicit test-server support.

## Validation

- Ran isolated `ember serve --port 4210 --live-reload false` profiling before and after the change.
- Before: ~31.4s Ember build, 777 Broccoli steps, ~2.85 GB max RSS, 16.6 MiB Faker/Mirage webpack chunk.
- After: server reached `Build successful`, ~19.8s profiled Ember build, 716 Broccoli steps, ~1.68 GB max RSS.
- Commit hooks ran eslint and secret scanning successfully.