### PR TITLE
Fixed landing on blank `/setup/done` route after site setup

### DIFF
--- a/e2e/tests/admin/onboarding.test.ts
+++ b/e2e/tests/admin/onboarding.test.ts
@@ -7,9 +7,9 @@ type ChecklistState = 'pending' | 'started' | 'completed' | 'dismissed';
 const allSteps = ['customize-design', 'first-post', 'build-audience', 'share-publication'];
 const activeStartedAt = '2026-05-01T00:00:00.000Z';
 const navigationSteps: Array<[string, RegExp]> = [
-    ['customize-design', /\/ghost\/#\/settings\/design\/edit\?ref=setup/],
-    ['first-post', /\/ghost\/#\/editor\/post/],
-    ['build-audience', /\/ghost\/#\/members/]
+    ['customize-design', /\/ghost\/(?:\?[^#]*)?#\/settings\/design\/edit\?ref=setup/],
+    ['first-post', /\/ghost\/(?:\?[^#]*)?#\/editor\/post/],
+    ['build-audience', /\/ghost\/(?:\?[^#]*)?#\/members/]
 ];
 
 test.use({isolation: 'per-test'});
@@ -72,14 +72,15 @@ async function startOnboarding(page: Page) {
 }
 
 test.describe('Ghost Admin - Onboarding Checklist', () => {
-    test('new owner setup flow lands on onboarding', async ({page}) => {
+    test('firstStart root redirect lands on onboarding', async ({page}) => {
         await setOnboardingState(page, 'pending', ['customize-design']);
 
-        await page.goto('/ghost/#/setup/done');
+        await page.goto('/ghost/#/?firstStart=true&sr_id=test-site&ssts=1778061878&ssml=test-signature');
 
         const onboardingPage = new OnboardingPage(page);
         await expect(onboardingPage.checklist).toBeVisible();
         await expectOnboardingRoute(page);
+        await expect(page).not.toHaveURL(/\/ghost\/#\/setup\/done/);
 
         const preferences = await getOnboardingPreferences(page);
         expect(preferences).toMatchObject({

--- a/ghost/admin/app/routes/setup/done.js
+++ b/ghost/admin/app/routes/setup/done.js
@@ -9,7 +9,7 @@ export default class SetupFinishingTouchesRoute extends AuthenticatedRoute {
     @service session;
     @service settings;
 
-    async beforeModel() {
+    async beforeModel(transition) {
         await super.beforeModel(...arguments);
 
         if (this.session.user.isOwnerOnly) {
@@ -18,6 +18,7 @@ export default class SetupFinishingTouchesRoute extends AuthenticatedRoute {
 
         if (this.session.user?.isAdmin) {
             // The React admin app owns /setup/onboarding, so hand off via hash navigation.
+            transition.abort();
             window.location.hash = '/setup/onboarding?returnTo=/analytics';
         }
     }

--- a/ghost/admin/tests/acceptance/onboarding-test.js
+++ b/ghost/admin/tests/acceptance/onboarding-test.js
@@ -13,6 +13,15 @@ describe('Acceptance: Onboarding', function () {
     
     // Helper selectors for better readability
     const checklist = () => find('[data-test-dashboard="onboarding-checklist"]');
+    async function visitSetupDoneRedirect() {
+        try {
+            await visit('/setup/done');
+        } catch (error) {
+            if (error?.message !== 'TransitionAborted') {
+                throw error;
+            }
+        }
+    }
 
     beforeEach(async function () {
         mockAnalyticsApps();
@@ -47,7 +56,7 @@ describe('Acceptance: Onboarding', function () {
         // the React analytics app, not Ember.
 
         it('setup/done starts onboarding and redirects to the React onboarding route', async function () {
-            await visit('/setup/done');
+            await visitSetupDoneRedirect();
 
             await waitUntil(() => window.location.hash === '#/setup/onboarding?returnTo=/analytics');
             expect(window.location.hash).to.equal('#/setup/onboarding?returnTo=/analytics');
@@ -76,7 +85,7 @@ describe('Acceptance: Onboarding', function () {
         });
 
         it('setup/done redirects to the React onboarding route without starting onboarding', async function () {
-            await visit('/setup/done');
+            await visitSetupDoneRedirect();
 
             await waitUntil(() => window.location.hash === '#/setup/onboarding?returnTo=/analytics');
             expect(window.location.hash).to.equal('#/setup/onboarding?returnTo=/analytics');


### PR DESCRIPTION
## Summary

- aborts the Ember `setup.done` transition before handing off to the React onboarding hash route
- updates onboarding E2E coverage to exercise the production-shaped `firstStart=true` root redirect
- allows onboarding step navigation assertions to tolerate query params before the hash

## Root cause

The hosted setup flow enters Admin at `#/?firstStart=true...`, then Ember redirects through `setup.done` to start onboarding. The route set `window.location.hash` for the React onboarding screen, but allowed the original Ember transition to finish. That could leave the app settled on the empty `#/setup/done` route instead of rendering onboarding.
