### PR TITLE
Added regression test pinning posts-stats urlExists false branch

### DIFF
--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -364,6 +364,38 @@ describe('PostsStatsService', function () {
         assert.ok(service, 'Service instance should exist');
     });
 
+    // _enrichWithTitles assigns `url_exists` based on the urlService lookup.
+    // The fixtures above always return truthy, so the falsy branch was
+    // unreached. Pin both branches here so the future migration to a
+    // different lookup API has to keep them coherent.
+    describe('_enrichWithTitles url_exists', function () {
+        function svcWithUrlLookup(lookup) {
+            return new PostsStatsService({
+                knex: db,
+                urlService: {
+                    hasFinished: () => true,
+                    getResource: lookup
+                }
+            });
+        }
+
+        it('flags url_exists: true when the URL resolves to a resource', async function () {
+            const svc = svcWithUrlLookup(() => ({data: {title: 'present'}}));
+            const out = await svc._enrichWithTitles([
+                {attribution_url: '/known/', title: 'Known', attribution_type: 'post', attribution_id: 'p', post_id: 'p'}
+            ]);
+            assert.equal(out[0].url_exists, true);
+        });
+
+        it('flags url_exists: false when the URL has no resource', async function () {
+            const svc = svcWithUrlLookup(() => null);
+            const out = await svc._enrichWithTitles([
+                {attribution_url: '/missing/', title: 'Missing', attribution_type: 'post', attribution_id: 'p', post_id: 'p'}
+            ]);
+            assert.equal(out[0].url_exists, false);
+        });
+    });
+
     describe('getTopPosts', function () {
         it('returns all posts with zero stats when no events exist', async function () {
             const result = await service.getTopPosts({});


### PR DESCRIPTION
## Summary

Adds a unit test pinning the falsy branch of `posts-stats-service._enrichWithTitles`. Stubs `getResource()` to return `undefined`, runs `_enrichWithTitles`, and asserts the enriched row records `url_exists === false`.

## Why

We're about to migrate this lookup from `urlService.getResource(path)` (sync) to `facade.resolveUrl(path)` (async, returning a flat resource shape). The existing tests only exercise the truthy branch — `_enrichWithTitles` returning a valid title for a known URL. The falsy branch (path doesn't resolve) is the one most likely to regress when the call signature changes from sync to async.

This test lands on top of `main` and is independently mergeable — no production change.

**Stacked on #27711** because the broader refactor that follows modifies test files introduced by both PRs.

ref https://linear.app/ghost/issue/HKG-1768/

## Test plan

- [x] New test passes
- [x] No production code changes