### PR TITLE
Introduced UrlServiceFacade and migrated callers

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -248,7 +248,10 @@ async function initExpressApps({frontend, backend, config}) {
 
     if (frontend) {
         // SITE + MEMBERS
-        const urlService = require('./server/services/url');
+        // RouterManager and migrated frontend callers expect the facade
+        // (getUrlForResource / ownsResource), not the raw eager UrlService
+        // (which only exposes the legacy id-based methods).
+        const urlService = require('./server/services/url').facade;
         const frontendApp = require('./server/web/parent/frontend')({urlService});
         parentApp.use(vhost(config.getFrontendMountPath(), frontendApp));
     }

--- a/ghost/core/core/bridge.js
+++ b/ghost/core/core/bridge.js
@@ -114,7 +114,7 @@ class Bridge {
 
         const routerConfig = {
             routeSettings: await routeSettings.loadRouteSettings(),
-            urlService
+            urlService: urlService.facade
         };
 
         await siteApp.reload(routerConfig);

--- a/ghost/core/core/frontend/helpers/authors.js
+++ b/ghost/core/core/frontend/helpers/authors.js
@@ -34,7 +34,7 @@ module.exports = function authors(options = {}) {
     function createAuthorsList(authorsList) {
         function processAuthor(author) {
             return autolink ? templates.link({
-                url: urlService.getUrlByResourceId(author.id, {withSubdirectory: true}),
+                url: urlService.facade.getUrlForResource({...author, type: 'authors'}, {withSubdirectory: true}),
                 text: escapeExpression(author.name)
             }) : escapeExpression(author.name);
         }

--- a/ghost/core/core/frontend/helpers/tags.js
+++ b/ghost/core/core/frontend/helpers/tags.js
@@ -27,7 +27,7 @@ module.exports = function tags(options) {
     function createTagList(tagsList) {
         function processTag(tag) {
             return autolink ? templates.link({
-                url: urlService.getUrlByResourceId(tag.id, {withSubdirectory: true}),
+                url: urlService.facade.getUrlForResource({...tag, type: 'tags'}, {withSubdirectory: true}),
                 text: escapeExpression(tag.name)
             }) : escapeExpression(tag.name);
         }

--- a/ghost/core/core/frontend/meta/author-url.js
+++ b/ghost/core/core/frontend/meta/author-url.js
@@ -7,11 +7,11 @@ function getAuthorUrl(data, absolute) {
     const contextObject = getContextObject(data, context);
 
     if (data.author) {
-        return urlService.getUrlByResourceId(data.author.id, {absolute: absolute, withSubdirectory: true});
+        return urlService.facade.getUrlForResource({...data.author, type: 'authors'}, {absolute: absolute, withSubdirectory: true});
     }
 
     if (contextObject && contextObject.primary_author) {
-        return urlService.getUrlByResourceId(contextObject.primary_author.id, {absolute: absolute, withSubdirectory: true});
+        return urlService.facade.getUrlForResource({...contextObject.primary_author, type: 'authors'}, {absolute: absolute, withSubdirectory: true});
     }
 
     return null;

--- a/ghost/core/core/frontend/meta/url.js
+++ b/ghost/core/core/frontend/meta/url.js
@@ -16,15 +16,20 @@ function getUrl(data, absolute) {
          *
          * A long term solution should be part of the final version of Dynamic Routing.
          */
-        if (data.status !== 'published' && urlService.getUrlByResourceId(data.id) === '/404/') {
+        const postResource = {...data, type: 'posts'};
+        if (data.status !== 'published' && urlService.facade.getUrlForResource(postResource) === '/404/') {
             return urlUtils.urlFor({relativeUrl: urlUtils.urlJoin('/p', data.uuid, '/')}, null, absolute);
         }
 
-        return urlService.getUrlByResourceId(data.id, {absolute: absolute, withSubdirectory: true});
+        return urlService.facade.getUrlForResource(postResource, {absolute: absolute, withSubdirectory: true});
     }
 
-    if (checks.isTag(data) || checks.isUser(data)) {
-        return urlService.getUrlByResourceId(data.id, {absolute: absolute, withSubdirectory: true});
+    if (checks.isTag(data)) {
+        return urlService.facade.getUrlForResource({...data, type: 'tags'}, {absolute: absolute, withSubdirectory: true});
+    }
+
+    if (checks.isUser(data)) {
+        return urlService.facade.getUrlForResource({...data, type: 'authors'}, {absolute: absolute, withSubdirectory: true});
     }
 
     if (checks.isNav(data)) {

--- a/ghost/core/core/frontend/services/routing/controllers/collection.js
+++ b/ghost/core/core/frontend/services/routing/controllers/collection.js
@@ -73,7 +73,7 @@ module.exports = function collectionController(req, res, next) {
              * People should always invert their filters to ensure that the database query loads unique posts per collection.
              */
             result.posts = _.filter(result.posts, (post) => {
-                if (routerManager.owns(res.routerOptions.identifier, post.id)) {
+                if (routerManager.ownsResource(res.routerOptions.identifier, post)) {
                     return post;
                 }
 

--- a/ghost/core/core/frontend/services/routing/controllers/email-post.js
+++ b/ghost/core/core/frontend/services/routing/controllers/email-post.js
@@ -48,7 +48,7 @@ module.exports = function emailPostController(req, res, next) {
             }
 
             if (post.status === 'published') {
-                return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
+                return urlUtils.redirect301(res, routerManager.getUrlForResource(post, {withSubdirectory: true}));
             }
 
             return renderer.renderEntry(req, res)(post);

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -51,7 +51,7 @@ module.exports = function previewController(req, res, next) {
 
             // published content should only resolve to /:slug - /p/:uuid is for drafts only in lieu of an actual preview api
             if (post.status === 'published') {
-                return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
+                return urlUtils.redirect301(res, routerManager.getUrlForResource(post, {withSubdirectory: true}));
             }
 
             // once an email-only post has been sent it shouldn't be available via /p/ to avoid leaking members-only content

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -17,21 +17,13 @@ class RouterManager {
         this.registry = registry;
         this.siteRouter = null;
         /**
-         * @type {URLService}
+         * @type {URLServiceFacade}
          */
         this.urlService = null;
     }
 
-    owns(routerId, id) {
-        return this.urlService.owns(routerId, id);
-    }
-
     ownsResource(routerId, resource) {
         return this.urlService.ownsResource(routerId, resource);
-    }
-
-    getUrlByResourceId(id, options) {
-        return this.urlService.getUrlByResourceId(id, options);
     }
 
     getUrlForResource(resource, options) {
@@ -198,7 +190,7 @@ module.exports = RouterManager;
 /**
  * @typedef {Object} RouterConfig
  * @property {RouteSettings} [routeSettings] - JSON config representing routes
- * @property {URLService} urlService - service providing resource URL utility functions such as owns, getUrlByResourceId, and getResourceById
+ * @property {URLServiceFacade} urlService - resource-based URL service facade
  */
 
 /**
@@ -209,10 +201,10 @@ module.exports = RouterManager;
  */
 
 /**
- * @typedef {Object} URLService
- * @property {Function} owns
- * @property {Function} getUrlByResourceId
- * @property {Function} getResourceById
+ * @typedef {Object} URLServiceFacade
+ * @property {Function} getUrlForResource
+ * @property {Function} ownsResource
+ * @property {Function} resolveUrl
  * @property {Function} onRouterAddedType
  * @property {Function} onRouterUpdated
  */

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -26,8 +26,16 @@ class RouterManager {
         return this.urlService.owns(routerId, id);
     }
 
+    ownsResource(routerId, resource) {
+        return this.urlService.ownsResource(routerId, resource);
+    }
+
     getUrlByResourceId(id, options) {
         return this.urlService.getUrlByResourceId(id, options);
+    }
+
+    getUrlForResource(resource, options) {
+        return this.urlService.getUrlForResource(resource, options);
     }
 
     getResourceById(resourceId) {

--- a/ghost/core/core/frontend/services/rss/generate-feed.js
+++ b/ghost/core/core/frontend/services/rss/generate-feed.js
@@ -19,7 +19,7 @@ const generateTags = function generateTags(data) {
 const generateItem = function generateItem(post) {
     const cheerio = require('cheerio');
 
-    const itemUrl = routerManager.getUrlByResourceId(post.id, {absolute: true});
+    const itemUrl = routerManager.getUrlForResource(post, {absolute: true});
     const htmlContent = cheerio.load(post.html || '');
     const item = {
         title: post.title,

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
@@ -3,7 +3,16 @@ const urlUtils = require('../../../../../../../shared/url-utils');
 const localUtils = require('../../../index');
 
 const forPost = (id, attrs, frame) => {
-    attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+    // `forPost` is shared between the posts and pages mappers (pages.js
+    // delegates to posts.js). The router-level resource type therefore has
+    // to be derived from `attrs.type` ('post' / 'page') rather than hardcoded
+    // — otherwise the facade would dispatch a page record against the posts
+    // router. `id` is passed separately because callers may filter `attrs`
+    // via `fields=url`, which strips every attribute except the requested
+    // ones; without the explicit `id`, the eager facade's id-based fallback
+    // hits /404/ for every record.
+    const type = attrs.type === 'page' ? 'pages' : 'posts';
+    attrs.url = urlService.facade.getUrlForResource({...attrs, id, type}, {absolute: true});
 
     /**
      * CASE: admin api should serve preview urls
@@ -44,7 +53,7 @@ const forPost = (id, attrs, frame) => {
 
 const forUser = (id, attrs, options) => {
     if (!options.columns || (options.columns && options.columns.includes('url'))) {
-        attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+        attrs.url = urlService.facade.getUrlForResource({...attrs, id, type: 'authors'}, {absolute: true});
     }
 
     return attrs;
@@ -52,7 +61,7 @@ const forUser = (id, attrs, options) => {
 
 const forTag = (id, attrs, options) => {
     if (!options.columns || (options.columns && options.columns.includes('url'))) {
-        attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+        attrs.url = urlService.facade.getUrlForResource({...attrs, id, type: 'tags'}, {absolute: true});
     }
 
     return attrs;

--- a/ghost/core/core/server/lib/common/to-plain.js
+++ b/ghost/core/core/server/lib/common/to-plain.js
@@ -1,0 +1,21 @@
+/**
+ * Normalise a Bookshelf model or plain object to its JSON representation.
+ *
+ * Bookshelf models expose their data via `.toJSON()` and store it on a private
+ * `attributes` map; spreading them with `{...model}` skips the prototype-defined
+ * getters (including `id`) and so silently loses the data. This helper lets
+ * callers accept either shape uniformly:
+ *
+ *   const data = toPlain(post);
+ *   urlService.facade.getUrlForResource({...data, type: 'posts'}, ...)
+ *
+ * @template T
+ * @param {T | {toJSON(): T}} modelOrObj
+ * @returns {T}
+ */
+module.exports = function toPlain(modelOrObj) {
+    if (modelOrObj && typeof modelOrObj.toJSON === 'function') {
+        return modelOrObj.toJSON();
+    }
+    return modelOrObj;
+};

--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
@@ -1,3 +1,5 @@
+const toPlain = require('../../lib/common/to-plain');
+
 class AudienceFeedbackService {
     /** @type URL */
     #baseURL;
@@ -20,13 +22,14 @@ class AudienceFeedbackService {
      * @param {string} key - hashed uuid value
      */
     buildLink(uuid, post, score, key) {
-        let postUrl = this.#urlService.getUrlByResourceId(post.id, {absolute: true});
+        const postData = toPlain(post);
+        let postUrl = this.#urlService.facade.getUrlForResource({...postData, type: 'posts'}, {absolute: true});
 
         if (postUrl.match(/\/404\//)) {
             postUrl = this.#baseURL;
         }
         const url = new URL(postUrl);
-        url.hash = `#/feedback/${post.id}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
+        url.hash = `#/feedback/${postData.id}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
         return url;
     }
 }

--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
@@ -15,18 +15,18 @@ class AudienceFeedbackService {
     }
     /**
      * @param {string} uuid
-     * @param {string} postId
+     * @param {{id: string}} post
      * @param {0 | 1} score
      * @param {string} key - hashed uuid value
      */
-    buildLink(uuid, postId, score, key) {
-        let postUrl = this.#urlService.getUrlByResourceId(postId, {absolute: true});
+    buildLink(uuid, post, score, key) {
+        let postUrl = this.#urlService.getUrlByResourceId(post.id, {absolute: true});
 
         if (postUrl.match(/\/404\//)) {
             postUrl = this.#baseURL;
         }
         const url = new URL(postUrl);
-        url.hash = `#/feedback/${postId}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
+        url.hash = `#/feedback/${post.id}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
         return url;
     }
 }

--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -2,6 +2,7 @@ const moment = require('moment');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const emailService = require('../email-service');
 const CommentsServiceEmailRenderer = require('./comments-service-email-renderer');
+const toPlain = require('../../lib/common/to-plain');
 const {t} = require('../i18n');
 
 class CommentsServiceEmails {
@@ -25,7 +26,8 @@ class CommentsServiceEmails {
      * @returns {string} The post URL with appropriate comment fragment
      */
     getPostUrl(post, commentId) {
-        const baseUrl = this.urlService.getUrlByResourceId(post.id, {absolute: true});
+        const postData = toPlain(post);
+        const baseUrl = this.urlService.facade.getUrlForResource({...postData, type: 'posts'}, {absolute: true});
         return `${baseUrl}#ghost-comments-${commentId}`;
     }
 

--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -20,12 +20,12 @@ class CommentsServiceEmails {
 
     /**
      * Build the post URL with comment fragment for email links
-     * @param {string} postId - The ID of the post
+     * @param {{id: string}} post - The post (model or plain object with `id`)
      * @param {string} commentId - The ID of the comment to link to
      * @returns {string} The post URL with appropriate comment fragment
      */
-    getPostUrl(postId, commentId) {
-        const baseUrl = this.urlService.getUrlByResourceId(postId, {absolute: true});
+    getPostUrl(post, commentId) {
+        const baseUrl = this.urlService.getUrlByResourceId(post.id, {absolute: true});
         return `${baseUrl}#ghost-comments-${commentId}`;
     }
 
@@ -48,7 +48,7 @@ class CommentsServiceEmails {
                 siteUrl: this.urlUtils.getSiteUrl(),
                 siteDomain: this.siteDomain,
                 postTitle: post.get('title'),
-                postUrl: this.getPostUrl(post.get('id'), comment.get('id')),
+                postUrl: this.getPostUrl(post, comment.get('id')),
                 commentHtml: comment.get('html'),
                 commentDate: moment(comment.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),
                 memberName: memberName,
@@ -110,7 +110,7 @@ class CommentsServiceEmails {
             siteUrl: this.urlUtils.getSiteUrl(),
             siteDomain: this.siteDomain,
             postTitle: post.get('title'),
-            postUrl: this.getPostUrl(post.get('id'), reply.get('id')),
+            postUrl: this.getPostUrl(post, reply.get('id')),
             replyHtml: reply.get('html'),
             replyDate: moment(reply.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),
             memberName: memberName,
@@ -158,7 +158,7 @@ class CommentsServiceEmails {
             siteUrl: this.urlUtils.getSiteUrl(),
             siteDomain: this.siteDomain,
             postTitle: post.get('title'),
-            postUrl: this.getPostUrl(post.get('id'), comment.get('id')),
+            postUrl: this.getPostUrl(post, comment.get('id')),
             commentHtml: comment.get('html'),
             commentText: htmlToPlaintext.comment(comment.get('html')),
             commentDate: moment(comment.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1058,13 +1058,13 @@ class EmailRenderer {
         // Audience feedback
         const positiveLink = this.#audienceFeedbackService.buildLink(
             '--uuid--',
-            post.id,
+            post,
             1,
             '--key--'
         ).href.replace('--uuid--', '%%{uuid}%%').replace('--key--', '%%{key}%%');
         const negativeLink = this.#audienceFeedbackService.buildLink(
             '--uuid--',
-            post.id,
+            post,
             0,
             '--key--'
         ).href.replace('--uuid--', '%%{uuid}%%').replace('--key--', '%%{key}%%');

--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -84,7 +84,7 @@ async function ping(post) {
     }
 
     try {
-        const url = urlService.getUrlByResourceId(post.id, {absolute: true});
+        const url = urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
 
         // Get the API key (auto-generated on boot by settings service)
         const key = getApiKey();

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -1,7 +1,9 @@
 /**
  * @typedef {Object} UrlService
- * @prop {(resourceId: string, options) => Object} getResource
- * @prop {{getUrlForResource: (resource: Object, options: Object) => string}} facade
+ * @prop {{
+ *   getUrlForResource: (resource: Object, options: Object) => string,
+ *   resolveUrl: (path: string) => Promise<Object | null>
+ * }} facade
  */
 
 const toPlain = require('../../lib/common/to-plain');
@@ -88,7 +90,7 @@ class UrlTranslator {
         return {
             type: 'url',
             id: null,
-            ...this.getTypeAndIdFromPath(path),
+            ...(await this.getTypeAndIdFromPath(path)),
             url: path
         };
     }
@@ -97,37 +99,37 @@ class UrlTranslator {
      * Get the resource type and ID from a path that was visited on the site
      * @param {string} path (excluding subdirectory)
      */
-    getTypeAndIdFromPath(path) {
-        const resource = this.urlService.getResource(path);
+    async getTypeAndIdFromPath(path) {
+        const resource = await this.urlService.facade.resolveUrl(path);
         if (!resource) {
             return;
         }
 
-        if (resource.config.type === 'posts') {
+        if (resource.type === 'posts') {
             return {
                 type: 'post',
-                id: resource.data.id
+                id: resource.id
             };
         }
 
-        if (resource.config.type === 'pages') {
+        if (resource.type === 'pages') {
             return {
                 type: 'page',
-                id: resource.data.id
+                id: resource.id
             };
         }
 
-        if (resource.config.type === 'tags') {
+        if (resource.type === 'tags') {
             return {
                 type: 'tag',
-                id: resource.data.id
+                id: resource.id
             };
         }
 
-        if (resource.config.type === 'authors') {
+        if (resource.type === 'authors') {
             return {
                 type: 'author',
-                id: resource.data.id
+                id: resource.id
             };
         }
     }

--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -1,9 +1,17 @@
 /**
  * @typedef {Object} UrlService
  * @prop {(resourceId: string, options) => Object} getResource
- *  @prop {(resourceId: string, options) => string} getUrlByResourceId
- *
+ * @prop {{getUrlForResource: (resource: Object, options: Object) => string}} facade
  */
+
+const toPlain = require('../../lib/common/to-plain');
+
+const TYPE_TO_RESOURCE = {
+    post: 'posts',
+    page: 'pages',
+    tag: 'tags',
+    author: 'authors'
+};
 
 /**
  * Translate a url into, (id+type), or a resource, and vice versa
@@ -124,10 +132,6 @@ class UrlTranslator {
         }
     }
 
-    getUrlByResourceId(id, options = {absolute: true}) {
-        return this.urlService.getUrlByResourceId(id, options);
-    }
-
     /**
      * Get the URL for a resource, handling email-only posts which have no
      * public URL (the URL service returns /404/ for them).
@@ -138,14 +142,26 @@ class UrlTranslator {
             const emailPath = `/email/${model.get('uuid')}/`;
             return absolute ? this.relativeToAbsolute(emailPath) : emailPath;
         }
-        return this.getUrlByResourceId(id, {absolute});
+        // Lazy URL service evaluates permalink templates against resource fields
+        // (slug, published_at, primary_tag, ...). Caller already loaded the model,
+        // so spread its plain data so those fields reach the facade.
+        const data = toPlain(model);
+        const resource = {...data, id, type: TYPE_TO_RESOURCE[type]};
+        return this.urlService.facade.getUrlForResource(resource, {absolute});
     }
 
     async getResourceById(id, type) {
         switch (type) {
         case 'post':
         case 'page': {
-            const post = await this.models.Post.findOne({id}, {require: false, filter: 'type:[post,page]+status:[published,sent]'});
+            // withRelated: tags+authors so the lazy URL service can evaluate
+            // `:primary_tag` / `:primary_author` permalink templates against
+            // the resource. Mirrors services/url/config.js's posts config.
+            const post = await this.models.Post.findOne({id}, {
+                require: false,
+                filter: 'type:[post,page]+status:[published,sent]',
+                withRelated: ['tags', 'authors']
+            });
             if (!post) {
                 return null;
             }

--- a/ghost/core/core/server/services/mentions/resource-service.js
+++ b/ghost/core/core/server/services/mentions/resource-service.js
@@ -30,17 +30,17 @@ module.exports = class ResourceService {
      */
     async getByURL(url) {
         const path = this.#urlUtils.absoluteToRelative(url.href, {withoutSubdirectory: true});
-        const resource = this.#urlService.getResource(path);
-        if (resource?.config?.type === 'posts') {
+        const resource = await this.#urlService.facade.resolveUrl(path);
+        if (resource?.type === 'posts') {
             return {
                 type: 'post',
-                id: ObjectID.createFromHexString(resource.data.id)
+                id: ObjectID.createFromHexString(resource.id)
             };
         }
-        if (resource?.config?.type === 'pages') {
+        if (resource?.type === 'pages') {
             return {
                 type: 'page',
-                id: ObjectID.createFromHexString(resource.data.id)
+                id: ObjectID.createFromHexString(resource.id)
             };
         }
         return {

--- a/ghost/core/core/server/services/slack.js
+++ b/ghost/core/core/server/services/slack.js
@@ -56,7 +56,7 @@ function ping(post) {
 
     // If this is a post, we want to send the link of the post
     if (hasPostProperties(post)) {
-        message = urlService.getUrlByResourceId(post.id, {absolute: true});
+        message = urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
         title = post.title ? post.title : null;
         author = post.authors ? post.authors[0] : null;
 
@@ -136,7 +136,7 @@ function ping(post) {
                         fields: [
                             {
                                 title: 'Author',
-                                value: author ? `<${urlService.getUrlByResourceId(author.id, {absolute: true})} | ${author.name}>` : null,
+                                value: author ? `<${urlService.facade.getUrlForResource({...author, type: 'authors'}, {absolute: true})} | ${author.name}>` : null,
                                 short: true
                             }
                         ],

--- a/ghost/core/core/server/services/stats/content-stats-service.js
+++ b/ghost/core/core/server/services/stats/content-stats-service.js
@@ -1,5 +1,14 @@
 const logging = require('@tryghost/logging');
 
+// Pre-migration the resourceType field on this service's response was the
+// raw `data.type` column on the underlying record: 'post' / 'page' for
+// posts and pages, undefined for tags / authors (those tables have no type
+// column). Preserve that contract by only mapping the two singular types.
+const ROUTER_TYPE_TO_SINGULAR = {
+    posts: 'post',
+    pages: 'page'
+};
+
 /**
  * @typedef {Object} TopContentDataItem
  * @property {string} pathname - Page path
@@ -176,27 +185,31 @@ class ContentStatsService {
     /**
      * Get resource title using UrlService
      * @param {string} pathname - Path to look up
-     * @returns {Object|null} Resource title and type, or null if not found
+     * @returns {Promise<Object|null>} Resource title and type, or null if not found
      */
-    getResourceTitle(pathname) {
+    async getResourceTitle(pathname) {
         if (!this.urlService) {
             return null;
         }
 
         try {
-            const resource = this.urlService.getResource(pathname);
+            const resource = await this.urlService.facade.resolveUrl(pathname);
 
-            if (resource && resource.data) {
-                if (resource.data.title) {
+            if (resource) {
+                // resource.type is the routing-level plural form (posts/pages/tags/authors).
+                // Keep singular/undefined here for backwards-compatibility with the previous
+                // data.type semantics (post/page/undefined).
+                const resourceType = ROUTER_TYPE_TO_SINGULAR[resource.type];
+                if (resource.title) {
                     return {
-                        title: resource.data.title,
-                        resourceType: resource.data.type
+                        title: resource.title,
+                        resourceType
                     };
-                } else if (resource.data.name) {
+                } else if (resource.name) {
                     // For authors, tags, etc.
                     return {
-                        title: resource.data.name,
-                        resourceType: resource.data.type
+                        title: resource.name,
+                        resourceType
                     };
                 }
             }
@@ -232,8 +245,8 @@ class ContentStatsService {
             if (this.urlService && item.pathname) {
                 try {
                     // Check if URL service is ready
-                    if (this.urlService.hasFinished && this.urlService.hasFinished()) {
-                        const resource = this.urlService.getResource(item.pathname);
+                    if (this.urlService.facade.hasFinished && this.urlService.facade.hasFinished()) {
+                        const resource = await this.urlService.facade.resolveUrl(item.pathname);
                         urlExists = !!resource; // Convert to boolean
                     }
                     // If URL service isn't ready, we default to true (clickable)
@@ -255,7 +268,7 @@ class ContentStatsService {
             }
 
             // Use UrlService for pages without post_uuid
-            const resourceInfo = this.getResourceTitle(item.pathname);
+            const resourceInfo = await this.getResourceTitle(item.pathname);
             if (resourceInfo) {
                 return {
                     ...item,

--- a/ghost/core/core/server/services/stats/posts-stats-service.js
+++ b/ghost/core/core/server/services/stats/posts-stats-service.js
@@ -213,7 +213,7 @@ class PostsStatsService {
         }
 
         // Transform results and enrich with titles and URL existence validation
-        return results.map((row) => {
+        return Promise.all(results.map(async (row) => {
             const title = row.title || this._generateTitleFromPath(row.attribution_url);
 
             // Check if URL exists using the URL service
@@ -222,8 +222,8 @@ class PostsStatsService {
             if (this.urlService && row.attribution_url) {
                 try {
                     // Check if URL service is ready
-                    if (this.urlService.hasFinished && this.urlService.hasFinished()) {
-                        const resource = this.urlService.getResource(row.attribution_url);
+                    if (this.urlService.facade.hasFinished && this.urlService.facade.hasFinished()) {
+                        const resource = await this.urlService.facade.resolveUrl(row.attribution_url);
                         urlExists = !!resource; // Convert to boolean
                     }
                     // If URL service isn't ready, we default to true (clickable)
@@ -246,7 +246,7 @@ class PostsStatsService {
                 post_type: row.attribution_type === 'post' ? 'post' : (row.attribution_type === 'page' ? 'page' : null),
                 url_exists: urlExists
             };
-        });
+        }));
     }
 
     _generateTitleFromPath(path) {

--- a/ghost/core/core/server/services/url/index.js
+++ b/ghost/core/core/server/services/url/index.js
@@ -1,6 +1,7 @@
 const config = require('../../../shared/config');
 const LocalFileCache = require('./local-file-cache');
 const UrlService = require('./url-service');
+const UrlServiceFacade = require('./url-service-facade');
 
 // NOTE: instead of a path we could give UrlService a "data-resolver" of some sort
 //       so it doesn't have to contain the logic to read data at all. This would be
@@ -21,6 +22,12 @@ if (process.env.NODE_ENV.startsWith('test')){
 
 const cache = new LocalFileCache({storagePath, writeDisabled});
 const urlService = new UrlService({cache});
+const urlServiceFacade = new UrlServiceFacade({urlService});
 
-// Singleton
+// Singleton: default export remains the eager UrlService for backwards
+// compatibility with existing imports. The new facade is exposed alongside
+// it via `urlService.facade` so RouterManager and migrating callers can
+// reach for it without forcing every consumer to update at once.
+urlService.facade = urlServiceFacade;
+
 module.exports = urlService;

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -1,0 +1,166 @@
+/**
+ * UrlServiceFacade
+ *
+ * Sits in front of the URL service so callers can use a stable, resource-based
+ * interface regardless of the underlying implementation. The facade can be
+ * built with two backends:
+ *
+ *  - urlService:     the legacy eager UrlService that precomputes a full
+ *                    resource → URL map at boot.
+ *  - lazyUrlService: an on-demand implementation (LazyUrlService) that
+ *                    computes URLs and ownership per call.
+ *
+ * When `lazyUrlService` is provided the facade routes calls to it; otherwise
+ * it delegates to the eager `urlService`. This lets the lazy implementation be
+ * swapped in behind a config flag without touching individual callers.
+ */
+
+/**
+ * Routing-level resource. `type` is one of the plural router keys
+ * ('posts', 'pages', 'tags', 'authors'). Concrete records carry additional
+ * fields (slug, published_at, primary_tag, ...) used by permalink templates.
+ *
+ * `id` is required: the eager backend's URL lookup is id-based, so a missing
+ * `id` would silently return `/404/`. Every in-tree caller already passes an
+ * id; the type makes that mandatory.
+ */
+export interface Resource {
+    type: string;
+    id: string;
+    [key: string]: unknown;
+}
+
+export interface UrlOptions {
+    absolute?: boolean;
+    withSubdirectory?: boolean;
+}
+
+/**
+ * Eager UrlService's resource envelope: `{config: {type}, data: {...}}`.
+ * Returned by `getResourceById`. The `data` field carries the raw record;
+ * `config.type` is the plural router key.
+ */
+export interface LegacyResourceEnvelope {
+    config: {type: string; [key: string]: unknown};
+    data: Record<string, unknown>;
+}
+
+/**
+ * Surface of the eager UrlService that the facade depends on. The full class
+ * has many more methods; only those used here need typing.
+ */
+export interface EagerUrlService {
+    getUrlByResourceId(id: string, options?: UrlOptions): string;
+    owns(routerId: string, id: string): boolean;
+    getResource(path: string): {config: {type: string}; data: Record<string, unknown>} | null;
+    getResourceById(id: string): LegacyResourceEnvelope | null;
+    hasFinished(): boolean;
+    onRouterAddedType(...args: unknown[]): unknown;
+    onRouterUpdated(...args: unknown[]): unknown;
+}
+
+export interface LazyUrlServiceBackend {
+    getUrlForResource(resource: Resource, options?: UrlOptions): string;
+    ownsResource(routerId: string, resource: Resource): boolean;
+    resolveUrl(path: string): Promise<Resource | null>;
+    hasFinished(): boolean;
+    onRouterAddedType(...args: unknown[]): unknown;
+    onRouterUpdated(...args: unknown[]): unknown;
+    reset(): void;
+}
+
+export class UrlServiceFacade {
+    private urlService: EagerUrlService;
+    private lazyUrlService: LazyUrlServiceBackend | null;
+
+    constructor({
+        urlService,
+        lazyUrlService = null
+    }: {urlService: EagerUrlService; lazyUrlService?: LazyUrlServiceBackend | null}) {
+        this.urlService = urlService;
+        this.lazyUrlService = lazyUrlService;
+    }
+
+    isLazy(): boolean {
+        return !!this.lazyUrlService;
+    }
+
+    /**
+     * The full resource record is required: the lazy backend evaluates NQL
+     * filters and applies permalink templates against it.
+     */
+    getUrlForResource(resource: Resource, options?: UrlOptions): string {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.getUrlForResource(resource, options);
+        }
+        return this.urlService.getUrlByResourceId(resource.id, options);
+    }
+
+    ownsResource(routerIdentifier: string, resource: Resource): boolean {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.ownsResource(routerIdentifier, resource);
+        }
+        return this.urlService.owns(routerIdentifier, resource.id);
+    }
+
+    /**
+     * Reverse URL lookup. Returns a flat resource shape (e.g. `{type, id, slug}`)
+     * rather than the legacy `{config: {type}, data: {...}}` envelope. Async to
+     * match the lazy implementation's contract.
+     */
+    async resolveUrl(urlPath: string): Promise<Resource | null> {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.resolveUrl(urlPath);
+        }
+        const resource = this.urlService.getResource(urlPath);
+        if (!resource) {
+            return null;
+        }
+        // The routing-level type ('posts', 'pages', 'tags', 'authors') wins
+        // over any DB type field on resource.data so the flat Resource is
+        // unambiguous.
+        return Object.assign({}, resource.data, {type: resource.config.type}) as Resource;
+    }
+
+    /**
+     * Forward lookup of a resource by id. Returns the eager UrlService's
+     * `{config: {type, ...}, data: {...}}` envelope so existing callers
+     * (e.g. the entry controller) can keep using `.config.type`.
+     */
+    getResourceById(resourceId: string): LegacyResourceEnvelope | null {
+        return this.urlService.getResourceById(resourceId);
+    }
+
+    hasFinished(): boolean {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.hasFinished();
+        }
+        return this.urlService.hasFinished();
+    }
+
+    onRouterAddedType(...args: unknown[]): unknown {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.onRouterAddedType(...args);
+        }
+        return this.urlService.onRouterAddedType(...args);
+    }
+
+    onRouterUpdated(...args: unknown[]): unknown {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.onRouterUpdated(...args);
+        }
+        return this.urlService.onRouterUpdated(...args);
+    }
+
+    /**
+     * Reset all router registrations. Used when routes.yaml is reloaded in
+     * lazy mode. In eager mode the URL service handles resets via its queue.
+     */
+    reset(): void {
+        if (this.lazyUrlService) {
+            this.lazyUrlService.reset();
+        }
+    }
+}
+
+module.exports = UrlServiceFacade;

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
@@ -6,8 +6,10 @@ const urlUtils = require('../../../../../../../../core/shared/url-utils');
 const urlUtil = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/utils/url');
 
 describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
+    let getUrlForResourceStub;
+
     beforeEach(function () {
-        sinon.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');
+        getUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource').returns('getUrlForResource');
         sinon.stub(urlUtils, 'urlFor').returns('urlFor');
     });
 
@@ -15,7 +17,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
         sinon.restore();
     });
 
-    describe('Ensure calls url service', function () {
+    describe('forPost', function () {
         let pageModel;
 
         beforeEach(function () {
@@ -24,28 +26,105 @@ describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
             };
         });
 
-        it('meta & models & relations', function () {
+        it('passes a posts resource (with id and slug) to the facade', function () {
             const post = pageModel(testUtils.DataGenerator.forKnex.createPost({
                 id: 'id1',
                 mobiledoc: '{}',
-                html: 'html',
-                custom_excerpt: 'customExcerpt',
-                codeinjection_head: 'codeinjectionHead',
-                codeinjection_foot: 'codeinjectionFoot',
-                feature_image: 'featureImage',
-                posts_meta: {
-                    og_image: 'ogImage',
-                    twitter_image: 'twitterImage'
-                },
-                canonical_url: 'canonicalUrl'
+                html: 'html'
             }));
 
             urlUtil.forPost(post.id, post, {options: {}});
 
             assert(Object.hasOwn(post, 'url'));
+            sinon.assert.callCount(getUrlForResourceStub, 1);
+            const [resource, options] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.type, 'posts');
+            assert.equal(resource.id, 'id1');
+            assert.equal(resource.slug, post.slug);
+            assert.deepEqual(options, {absolute: true});
+        });
 
-            sinon.assert.callCount(urlService.getUrlByResourceId, 1);
-            sinon.assert.calledWithExactly(urlService.getUrlByResourceId, 'id1', {absolute: true});
+        it('still passes id when attrs has been stripped (e.g. fields=url)', function () {
+            // Content API request like `?fields=url` runs jsonModel through a
+            // serializer that strips every attribute except `url`. The mapper
+            // calls forPost(model.id, jsonModel, frame) — id is on the model,
+            // not on attrs. Regression: a previous spread `{...attrs, type}`
+            // sent id-less resources, so the eager facade's id-fallback hit
+            // /404/ for every post.
+            const stripped = {};
+
+            urlUtil.forPost('post-id', stripped, {options: {}});
+
+            sinon.assert.calledOnce(getUrlForResourceStub);
+            const [resource] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.id, 'post-id');
+            assert.equal(resource.type, 'posts');
+        });
+
+        it('routes pages through the pages router type', function () {
+            // The pages mapper delegates to the posts mapper, which calls
+            // forPost. Regression: a previous version hardcoded
+            // `type: 'posts'`, which would route page records against the
+            // posts router in lazy mode (eager mode is unaffected because
+            // the facade only reads `id` in its eager fallback).
+            const page = {id: 'page-id', slug: 'about', type: 'page'};
+
+            urlUtil.forPost(page.id, page, {options: {}});
+
+            sinon.assert.calledOnce(getUrlForResourceStub);
+            const [resource] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.id, 'page-id');
+            assert.equal(resource.type, 'pages');
+        });
+    });
+
+    describe('forTag', function () {
+        it('passes a tags resource to the facade when url is requested', function () {
+            const tag = {id: 'tag1', slug: 'food', name: 'Food'};
+
+            urlUtil.forTag(tag.id, tag, {});
+
+            assert.equal(tag.url, 'getUrlForResource');
+            sinon.assert.calledOnce(getUrlForResourceStub);
+            const [resource, options] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.type, 'tags');
+            assert.equal(resource.id, 'tag1');
+            assert.equal(resource.slug, 'food');
+            assert.deepEqual(options, {absolute: true});
+        });
+
+        it('skips url generation when columns excludes url', function () {
+            const tag = {id: 'tag1', slug: 'food'};
+
+            urlUtil.forTag(tag.id, tag, {columns: ['id', 'slug']});
+
+            assert.equal(tag.url, undefined);
+            sinon.assert.notCalled(getUrlForResourceStub);
+        });
+    });
+
+    describe('forUser', function () {
+        it('passes an authors resource to the facade when url is requested', function () {
+            const user = {id: 'user1', slug: 'jane', name: 'Jane'};
+
+            urlUtil.forUser(user.id, user, {});
+
+            assert.equal(user.url, 'getUrlForResource');
+            sinon.assert.calledOnce(getUrlForResourceStub);
+            const [resource, options] = getUrlForResourceStub.firstCall.args;
+            assert.equal(resource.type, 'authors');
+            assert.equal(resource.id, 'user1');
+            assert.equal(resource.slug, 'jane');
+            assert.deepEqual(options, {absolute: true});
+        });
+
+        it('skips url generation when columns excludes url', function () {
+            const user = {id: 'user1', slug: 'jane'};
+
+            urlUtil.forUser(user.id, user, {columns: ['id', 'slug']});
+
+            assert.equal(user.url, undefined);
+            sinon.assert.notCalled(getUrlForResourceStub);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/authors.test.js
+++ b/ghost/core/test/unit/frontend/helpers/authors.test.js
@@ -6,10 +6,10 @@ const authorsHelper = require('../../../../core/frontend/helpers/authors');
 const testUtils = require('../../../utils');
 
 describe('{{authors}} helper', function () {
-    let urlServiceGetUrlByResourceIdStub;
+    let urlServiceGetUrlForResourceStub;
 
     beforeEach(function () {
-        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
     });
 
     afterEach(function () {
@@ -113,8 +113,8 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url 1');
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[0].id})).returns('author url 1');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url 2');
 
         const rendered = authorsHelper.call({authors: authors});
         assertExists(rendered);
@@ -128,7 +128,7 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url 1');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[0].id})).returns('author url 1');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {limit: '1'}});
         assertExists(rendered);
@@ -142,7 +142,7 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url 2');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2'}});
         assertExists(rendered);
@@ -156,7 +156,7 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[0].id})).returns('author url');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {to: '1'}});
         assertExists(rendered);
@@ -171,8 +171,8 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url 2');
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[2].id).returns('author url 3');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[2].id})).returns('author url 3');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2', to: '3'}});
         assertExists(rendered);
@@ -187,7 +187,7 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url x');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url x');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2', limit: '1'}});
         assertExists(rendered);
@@ -202,9 +202,9 @@ describe('{{authors}} helper', function () {
             testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url a');
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url b');
-        urlServiceGetUrlByResourceIdStub.withArgs(authors[2].id).returns('author url c');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[0].id})).returns('author url a');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[1].id})).returns('author url b');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: authors[2].id})).returns('author url c');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '1', to: '3', limit: '2'}});
         assertExists(rendered);

--- a/ghost/core/test/unit/frontend/helpers/tags.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tags.test.js
@@ -6,10 +6,10 @@ const urlService = require('../../../../core/server/services/url');
 const tagsHelper = require('../../../../core/frontend/helpers/tags');
 
 describe('{{tags}} helper', function () {
-    let urlServiceGetUrlByResourceIdStub;
+    let urlServiceGetUrlForResourceStub;
 
     beforeEach(function () {
-        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
     });
 
     afterEach(function () {
@@ -101,8 +101,8 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url 1');
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('tag url 1');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url 2');
 
         const rendered = tagsHelper.call({tags: tags});
         assertExists(rendered);
@@ -116,7 +116,7 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url 1');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('tag url 1');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {limit: '1'}});
         assertExists(rendered);
@@ -130,7 +130,7 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url 2');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url 2');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2'}});
         assertExists(rendered);
@@ -144,7 +144,7 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url x');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('tag url x');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {to: '1'}});
         assertExists(rendered);
@@ -159,8 +159,8 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url b');
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[2].id).returns('tag url c');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url b');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[2].id})).returns('tag url c');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', to: '3'}});
         assertExists(rendered);
@@ -175,7 +175,7 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url b');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url b');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', limit: '1'}});
         assertExists(rendered);
@@ -190,9 +190,9 @@ describe('{{tags}} helper', function () {
             testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
         ];
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url a');
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url b');
-        urlServiceGetUrlByResourceIdStub.withArgs(tags[2].id).returns('tag url c');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('tag url a');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('tag url b');
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[2].id})).returns('tag url c');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '1', to: '3', limit: '2'}});
         assertExists(rendered);
@@ -215,11 +215,11 @@ describe('{{tags}} helper', function () {
         ];
 
         beforeEach(function () {
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('1');
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('2');
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[2].id).returns('3');
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[3].id).returns('4');
-            urlServiceGetUrlByResourceIdStub.withArgs(tags[4].id).returns('5');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[0].id})).returns('1');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[1].id})).returns('2');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[2].id})).returns('3');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[3].id})).returns('4');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tags[4].id})).returns('5');
         });
 
         it('will not output internal tags by default', function () {

--- a/ghost/core/test/unit/frontend/meta/author-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-url.test.js
@@ -7,10 +7,10 @@ const getAuthorUrl = require('../../../../core/frontend/meta/author-url');
 
 describe('getAuthorUrl', function () {
     /** @type {import('sinon').SinonStub} */
-    let urlServiceGetUrlByResourceIdStub;
+    let urlServiceGetUrlForResourceStub;
 
     beforeEach(function () {
-        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
     });
 
     afterEach(function () {
@@ -25,7 +25,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.primary_author.id, type: 'authors'}), {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         assertExists(getAuthorUrl({
@@ -42,7 +42,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: true, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.primary_author.id, type: 'authors'}), {absolute: true, withSubdirectory: true})
             .returns('absolute author url');
 
         assertExists(getAuthorUrl({
@@ -57,7 +57,7 @@ describe('getAuthorUrl', function () {
             slug: 'test-author'
         };
 
-        urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: author.id, type: 'authors'}), {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         assertExists(getAuthorUrl({

--- a/ghost/core/test/unit/frontend/meta/url.test.js
+++ b/ghost/core/test/unit/frontend/meta/url.test.js
@@ -6,11 +6,11 @@ const getUrl = require('../../../../core/frontend/meta/url');
 const testUtils = require('../../../utils');
 
 describe('getUrl', function () {
-    let urlServiceGetUrlByResourceIdStub;
+    let urlServiceGetUrlForResourceStub;
     let urlUtilsUrlForStub;
 
     beforeEach(function () {
-        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
         urlUtilsUrlForStub = sinon.stub(urlUtils, 'urlFor');
     });
 
@@ -21,7 +21,7 @@ describe('getUrl', function () {
     it('should return url for a post', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
-        urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts'}), {absolute: undefined, withSubdirectory: true})
             .returns('post url');
 
         assert.equal(getUrl(post), 'post url');
@@ -30,11 +30,11 @@ describe('getUrl', function () {
     describe('preview url: drafts/scheduled posts', function () {
         it('relative', function () {
             const post = testUtils.DataGenerator.forKnex.createPost({status: 'draft'});
-            urlServiceGetUrlByResourceIdStub.withArgs(post.id).returns('/404/');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts'})).returns('/404/');
             urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined).returns('relative');
             let url = getUrl(post);
 
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledOnce(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined));
 
             assert.equal(url, 'relative');
@@ -42,11 +42,11 @@ describe('getUrl', function () {
 
         it('absolute', function () {
             const post = testUtils.DataGenerator.forKnex.createPost({status: 'draft'});
-            urlServiceGetUrlByResourceIdStub.withArgs(post.id).returns('/404/');
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts'})).returns('/404/');
             urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true).returns('absolute');
             let url = getUrl(post, true);
 
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledOnce(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true));
 
             assert.equal(url, 'absolute');
@@ -56,7 +56,7 @@ describe('getUrl', function () {
     it('should return absolute url for a post', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
-        urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: true, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts'}), {absolute: true, withSubdirectory: true})
             .returns('absolute post url');
 
         assert.equal(getUrl(post, true), 'absolute post url');
@@ -70,7 +70,7 @@ describe('getUrl', function () {
         //        the tag object contains a `parent` attribute. the tag model contains a `parent_id` attr.
         tag.parent = null;
 
-        urlServiceGetUrlByResourceIdStub.withArgs(tag.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: tag.id, type: 'tags'}), {absolute: undefined, withSubdirectory: true})
             .returns('tag url');
 
         assert.equal(getUrl(tag), 'tag url');
@@ -79,7 +79,7 @@ describe('getUrl', function () {
     it('should return url for a author', function () {
         const author = testUtils.DataGenerator.forKnex.createUser();
 
-        urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: author.id, type: 'authors'}), {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         assert.equal(getUrl(author), 'author url');
@@ -88,7 +88,7 @@ describe('getUrl', function () {
     it('should return absolute url for a author', function () {
         const author = testUtils.DataGenerator.forKnex.createUser();
 
-        urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: true, withSubdirectory: true})
+        urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: author.id, type: 'authors'}), {absolute: true, withSubdirectory: true})
             .returns('absolute author url');
 
         assert.equal(getUrl(author, true), 'absolute author url');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -16,7 +16,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     let renderStub;
     let posts;
     let postsPerPage;
-    let ownsStub;
+    let ownsResourceStub;
     let next;
 
     beforeEach(function () {
@@ -46,8 +46,8 @@ describe('Unit - services/routing/controllers/collection', function () {
 
         sinon.stub(renderer, 'renderEntries').returns(renderStub);
 
-        ownsStub = sinon.stub(routerManager, 'owns');
-        ownsStub.withArgs('identifier', posts[0].id).returns(true);
+        ownsResourceStub = sinon.stub(routerManager, 'ownsResource');
+        ownsResourceStub.withArgs('identifier', posts[0]).returns(true);
 
         req = {
             path: '/',
@@ -83,7 +83,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -104,7 +104,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -127,7 +127,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -150,7 +150,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
         sinon.assert.notCalled(renderStub);
-        sinon.assert.notCalled(ownsStub);
+        sinon.assert.notCalled(ownsResourceStub);
     });
 
     it('slug param', async function () {
@@ -170,7 +170,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.calledOnce(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -191,7 +191,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.calledOnce(ownsStub);
+        sinon.assert.calledOnce(ownsResourceStub);
         sinon.assert.notCalled(next);
     });
 
@@ -205,11 +205,11 @@ describe('Unit - services/routing/controllers/collection', function () {
 
         res.routerOptions.filter = 'featured:true';
 
-        ownsStub.reset();
-        ownsStub.withArgs('identifier', posts[0].id).returns(false);
-        ownsStub.withArgs('identifier', posts[1].id).returns(true);
-        ownsStub.withArgs('identifier', posts[2].id).returns(false);
-        ownsStub.withArgs('identifier', posts[3].id).returns(false);
+        ownsResourceStub.reset();
+        ownsResourceStub.withArgs('identifier', posts[0]).returns(false);
+        ownsResourceStub.withArgs('identifier', posts[1]).returns(true);
+        ownsResourceStub.withArgs('identifier', posts[2]).returns(false);
+        ownsResourceStub.withArgs('identifier', posts[3]).returns(false);
 
         fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
@@ -228,7 +228,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.calledOnce(themeEngine.getActive);
         sinon.assert.notCalled(security.string.safe);
         sinon.assert.calledOnce(fetchDataStub);
-        sinon.assert.callCount(ownsStub, 4);
+        sinon.assert.callCount(ownsResourceStub, 4);
         sinon.assert.notCalled(next);
     });
 });

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -10,7 +10,7 @@ const generateFeed = require('../../../../../core/frontend/services/rss/generate
 describe('RSS: Generate Feed', function () {
     const data = {};
     let baseUrl;
-    let routerManagerGetUrlByResourceIdStub;
+    let routerManagerGetUrlForResourceStub;
 
     // Static set of posts
     let posts;
@@ -45,7 +45,7 @@ describe('RSS: Generate Feed', function () {
     });
 
     beforeEach(function () {
-        routerManagerGetUrlByResourceIdStub = sinon.stub(routerManager, 'getUrlByResourceId');
+        routerManagerGetUrlForResourceStub = sinon.stub(routerManager, 'getUrlForResource');
 
         baseUrl = '/rss/';
 
@@ -91,7 +91,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = posts;
 
             _.each(data.posts, function (post) {
-                routerManagerGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
+                routerManagerGetUrlForResourceStub.withArgs(sinon.match({id: post.id}), {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
             });
 
             const xmlData = await generateFeed(baseUrl, data);
@@ -189,7 +189,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [posts[0]];
 
             _.each(data.posts, function (post) {
-                routerManagerGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
+                routerManagerGetUrlForResourceStub.withArgs(sinon.match({id: post.id}), {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
             });
 
             const xmlData = await generateFeed(baseUrl, data);

--- a/ghost/core/test/unit/server/lib/common/to-plain.test.js
+++ b/ghost/core/test/unit/server/lib/common/to-plain.test.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert/strict');
+const toPlain = require('../../../../../core/server/lib/common/to-plain');
+
+describe('toPlain', function () {
+    it('returns a plain object unchanged', function () {
+        const obj = {id: 'abc', slug: 'hello'};
+        assert.equal(toPlain(obj), obj);
+    });
+
+    it('serialises a Bookshelf-shaped model via toJSON', function () {
+        const model = {
+            // own keys are not the data; only `.toJSON()` produces it.
+            toJSON: () => ({id: 'xyz', slug: 'world'})
+        };
+        assert.deepEqual(toPlain(model), {id: 'xyz', slug: 'world'});
+    });
+
+    it('returns null and undefined unchanged (no toJSON deref)', function () {
+        assert.equal(toPlain(null), null);
+        assert.equal(toPlain(undefined), undefined);
+    });
+
+    it('returns primitives unchanged (they have no toJSON)', function () {
+        assert.equal(toPlain(0), 0);
+        assert.equal(toPlain(''), '');
+        assert.equal(toPlain(false), false);
+    });
+
+    it('returns input unchanged when toJSON is present but not callable', function () {
+        // pins the `typeof === 'function'` guard: a non-function `toJSON`
+        // (e.g. a JSON-serialised payload that already has a `toJSON` field)
+        // must not throw and must round-trip the input.
+        const obj = {id: 'abc', toJSON: 'not-a-fn'};
+        assert.equal(toPlain(obj), obj);
+    });
+});

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
@@ -15,7 +15,9 @@ describe('audienceFeedbackService', function () {
         it('Can build link to post', async function () {
             const instance = new AudienceFeedbackService({
                 urlService: {
-                    getUrlByResourceId: () => `https://localhost:2368/${mockData.postTitle}/`
+                    facade: {
+                        getUrlForResource: () => `https://localhost:2368/${mockData.postTitle}/`
+                    }
                 },
                 config: {
                     baseURL: new URL('https://localhost:2368')
@@ -29,7 +31,9 @@ describe('audienceFeedbackService', function () {
         it('Can build link to home page if post wasn\'t published', async function () {
             const instance = new AudienceFeedbackService({
                 urlService: {
-                    getUrlByResourceId: () => `https://localhost:2368/${mockData.postTitle}/404/`
+                    facade: {
+                        getUrlForResource: () => `https://localhost:2368/${mockData.postTitle}/404/`
+                    }
                 },
                 config: {
                     baseURL: new URL('https://localhost:2368')
@@ -40,13 +44,15 @@ describe('audienceFeedbackService', function () {
             assert.equal(link.href, expectedLink);
         });
 
-        it('Passes post id (not the post object) to the url service', async function () {
-            let receivedId;
+        it('Passes a posts resource (with id) to the facade', async function () {
+            let receivedResource;
             const instance = new AudienceFeedbackService({
                 urlService: {
-                    getUrlByResourceId: (id) => {
-                        receivedId = id;
-                        return `https://localhost:2368/${mockData.postTitle}/`;
+                    facade: {
+                        getUrlForResource: (resource) => {
+                            receivedResource = resource;
+                            return `https://localhost:2368/${mockData.postTitle}/`;
+                        }
                     }
                 },
                 config: {
@@ -54,7 +60,44 @@ describe('audienceFeedbackService', function () {
                 }
             });
             instance.buildLink(mockData.uuid, mockPost, mockData.score, mockData.key);
-            assert.equal(receivedId, mockData.postId);
+            assert.equal(receivedResource.id, mockData.postId);
+            assert.equal(receivedResource.type, 'posts');
+        });
+
+        it('Serialises Bookshelf-model input so spread does not lose the id', async function () {
+            // Real callers (email-renderer) pass a Bookshelf model. Spreading
+            // one with `{...model}` skips prototype getters like `.id`. The
+            // service must call `.toJSON()` first; this test pins that.
+            //
+            // toJSON also returns the DB-level `type: 'post'` (singular). The
+            // service must override that to the routing-level `'posts'`
+            // (plural) before handing the resource to the facade — the
+            // assertion below captures that override explicitly.
+            let receivedResource;
+            const fakeBookshelfModel = {
+                // No own `id` / `slug` properties; only `.toJSON()` exposes them.
+                toJSON: () => ({id: mockData.postId, slug: mockData.postTitle, type: 'post'})
+            };
+            const instance = new AudienceFeedbackService({
+                urlService: {
+                    facade: {
+                        getUrlForResource: (resource) => {
+                            receivedResource = resource;
+                            return `https://localhost:2368/${mockData.postTitle}/`;
+                        }
+                    }
+                },
+                config: {
+                    baseURL: new URL('https://localhost:2368')
+                }
+            });
+            const link = instance.buildLink(mockData.uuid, fakeBookshelfModel, mockData.score, mockData.key);
+            assert.equal(receivedResource.id, mockData.postId);
+            assert.equal(receivedResource.slug, mockData.postTitle);
+            assert.equal(receivedResource.type, 'posts');
+            // The hash fragment also depends on the post id, so the same bug
+            // would surface in the produced URL.
+            assert.match(link.href, new RegExp(`#/feedback/${mockData.postId}/`));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
@@ -9,6 +9,7 @@ describe('audienceFeedbackService', function () {
         score: 1,
         key: 'somekey'
     };
+    const mockPost = {id: mockData.postId};
 
     describe('build link', function () {
         it('Can build link to post', async function () {
@@ -20,7 +21,7 @@ describe('audienceFeedbackService', function () {
                     baseURL: new URL('https://localhost:2368')
                 }
             });
-            const link = instance.buildLink(mockData.uuid, mockData.postId, mockData.score, mockData.key);
+            const link = instance.buildLink(mockData.uuid, mockPost, mockData.score, mockData.key);
             const expectedLink = `https://localhost:2368/${mockData.postTitle}/#/feedback/${mockData.postId}/${mockData.score}/?uuid=${mockData.uuid}&key=somekey`;
             assert.equal(link.href, expectedLink);
         });
@@ -34,9 +35,26 @@ describe('audienceFeedbackService', function () {
                     baseURL: new URL('https://localhost:2368')
                 }
             });
-            const link = instance.buildLink(mockData.uuid, mockData.postId, mockData.score, mockData.key);
+            const link = instance.buildLink(mockData.uuid, mockPost, mockData.score, mockData.key);
             const expectedLink = `https://localhost:2368/#/feedback/${mockData.postId}/${mockData.score}/?uuid=${mockData.uuid}&key=somekey`;
             assert.equal(link.href, expectedLink);
+        });
+
+        it('Passes post id (not the post object) to the url service', async function () {
+            let receivedId;
+            const instance = new AudienceFeedbackService({
+                urlService: {
+                    getUrlByResourceId: (id) => {
+                        receivedId = id;
+                        return `https://localhost:2368/${mockData.postTitle}/`;
+                    }
+                },
+                config: {
+                    baseURL: new URL('https://localhost:2368')
+                }
+            });
+            instance.buildLink(mockData.uuid, mockPost, mockData.score, mockData.key);
+            assert.equal(receivedId, mockData.postId);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -30,9 +30,17 @@ describe('Comments Service: CommentsServiceEmails', function () {
         it('returns post URL with comment permalink', function () {
             const {instance} = createClassInstance({});
 
-            const result = instance.getPostUrl('123', '456');
+            const result = instance.getPostUrl({id: '123'}, '456');
 
             assert.equal(result, 'https://example.com/my-post/#ghost-comments-456');
+        });
+
+        it('passes the post id (not the post object) to the url service', function () {
+            const {instance, urlService} = createClassInstance({});
+
+            instance.getPostUrl({id: '123'}, '456');
+
+            sinon.assert.calledWith(urlService.getUrlByResourceId, '123', {absolute: true});
         });
     });
 
@@ -133,8 +141,9 @@ describe('Comments Service: CommentsServiceEmails', function () {
             sinon.assert.calledOnce(getPostUrlSpy);
             const [postArg, commentIdArg] = getPostUrlSpy.firstCall.args;
             assert.equal(commentIdArg, 'comment-id');
-            // postArg is either the post model or its id; both yield the same URL
-            assert.equal(typeof postArg === 'string' ? postArg : postArg && postArg.id, post.id);
+            assert.equal(postArg.id, post.id);
+            // After this commit's migration the call always passes a model.
+            assert.notEqual(typeof postArg, 'string');
 
             // End-to-end pin: getUrlByResourceId must receive the post's id,
             // not whatever shape happens to render to a string. The stub
@@ -167,7 +176,9 @@ describe('Comments Service: CommentsServiceEmails', function () {
             sinon.assert.calledOnce(getPostUrlSpy);
             const [postArg, commentIdArg] = getPostUrlSpy.firstCall.args;
             assert.equal(commentIdArg, 'comment-id');
-            assert.equal(typeof postArg === 'string' ? postArg : postArg && postArg.id, post.id);
+            assert.equal(postArg.id, post.id);
+            // After this commit's migration the call always passes a model.
+            assert.notEqual(typeof postArg, 'string');
 
             sinon.assert.calledWith(urlService.getUrlByResourceId, 'post-id');
 

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -5,7 +5,9 @@ const CommentsServiceEmails = require('../../../../../core/server/services/comme
 describe('Comments Service: CommentsServiceEmails', function () {
     function createClassInstance({labs = {}}) {
         const urlService = {
-            getUrlByResourceId: sinon.stub().returns('https://example.com/my-post/')
+            facade: {
+                getUrlForResource: sinon.stub().returns('https://example.com/my-post/')
+            }
         };
         const labsStub = {
             isSet: sinon.stub().callsFake(flag => labs[flag] || false)
@@ -35,12 +37,34 @@ describe('Comments Service: CommentsServiceEmails', function () {
             assert.equal(result, 'https://example.com/my-post/#ghost-comments-456');
         });
 
-        it('passes the post id (not the post object) to the url service', function () {
+        it('passes a posts resource to the facade', function () {
             const {instance, urlService} = createClassInstance({});
 
             instance.getPostUrl({id: '123'}, '456');
 
-            sinon.assert.calledWith(urlService.getUrlByResourceId, '123', {absolute: true});
+            sinon.assert.calledWith(
+                urlService.facade.getUrlForResource,
+                sinon.match({id: '123', type: 'posts'}),
+                {absolute: true}
+            );
+        });
+
+        it('serialises Bookshelf-model input so spread does not lose the id', function () {
+            // Real callers (notify*Authors / notifyParentCommentAuthor / notifyReport)
+            // pass a Bookshelf model from Post.findOne. Spreading one with
+            // `{...model}` skips prototype getters like `.id`.
+            const {instance, urlService} = createClassInstance({});
+            const fakeBookshelfModel = {
+                toJSON: () => ({id: '123', slug: 'my-post'})
+            };
+
+            instance.getPostUrl(fakeBookshelfModel, '456');
+
+            sinon.assert.calledWith(
+                urlService.facade.getUrlForResource,
+                sinon.match({id: '123', slug: 'my-post', type: 'posts'}),
+                {absolute: true}
+            );
         });
     });
 
@@ -97,15 +121,15 @@ describe('Comments Service: CommentsServiceEmails', function () {
             const renderStub = sinon.stub().resolves({html: 'h', text: 't'});
             const mailerSendStub = sinon.stub().resolves();
 
-            // Stub `getUrlByResourceId` with a withArgs match: the URL only
-            // resolves when the post's id is passed. Anything else returns
-            // undefined, so a regression that drops `post.id` somewhere
-            // between notifyX and the URL service surfaces as a bad URL
-            // landing in templateData.
-            const getUrlByResourceIdStub = sinon.stub().returns(undefined);
-            getUrlByResourceIdStub.withArgs('post-id', sinon.match.any)
+            // Stub the facade's getUrlForResource with a withArgs match:
+            // the URL only resolves when a resource carrying the post's id
+            // is passed. Anything else returns undefined, so a regression
+            // that drops `post.id` somewhere between notifyX and the URL
+            // service surfaces as a bad URL landing in templateData.
+            const getUrlForResourceStub = sinon.stub().returns(undefined);
+            getUrlForResourceStub.withArgs(sinon.match({id: 'post-id'}), sinon.match.any)
                 .returns('https://example.com/my-post/');
-            const urlService = {getUrlByResourceId: getUrlByResourceIdStub};
+            const urlService = {facade: {getUrlForResource: getUrlForResourceStub}};
 
             const instance = new CommentsServiceEmails({
                 config: {},
@@ -145,11 +169,11 @@ describe('Comments Service: CommentsServiceEmails', function () {
             // After this commit's migration the call always passes a model.
             assert.notEqual(typeof postArg, 'string');
 
-            // End-to-end pin: getUrlByResourceId must receive the post's id,
-            // not whatever shape happens to render to a string. The stub
-            // only returns the canonical URL for 'post-id', so a regression
-            // that drops the id somewhere in the chain surfaces here.
-            sinon.assert.calledWith(urlService.getUrlByResourceId, 'post-id');
+            // End-to-end pin: the facade must receive a resource carrying
+            // the post's id. The stub only returns the canonical URL for
+            // {id: 'post-id'}, so a regression that drops the id somewhere
+            // in the chain surfaces here.
+            sinon.assert.calledWith(urlService.facade.getUrlForResource, sinon.match({id: 'post-id'}));
 
             sinon.assert.calledOnce(renderStub);
             const [, templateData] = renderStub.firstCall.args;
@@ -180,7 +204,7 @@ describe('Comments Service: CommentsServiceEmails', function () {
             // After this commit's migration the call always passes a model.
             assert.notEqual(typeof postArg, 'string');
 
-            sinon.assert.calledWith(urlService.getUrlByResourceId, 'post-id');
+            sinon.assert.calledWith(urlService.facade.getUrlForResource, sinon.match({id: 'post-id'}));
 
             sinon.assert.calledOnce(renderStub);
             const [, templateData] = renderStub.firstCall.args;

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -412,11 +412,18 @@ describe('IndexNow', function () {
     describe('ping() URL output', function () {
         const ping = indexnow.__get__('ping');
         const POST_URL = 'https://my-blog.example/some-post/';
+        let getUrlForResourceStub;
         let requestStub;
         let resetIndexNow;
 
         beforeEach(function () {
-            sinon.stub(urlService, 'getUrlByResourceId').returns(POST_URL);
+            // Bind the stub to the exact resource shape production passes
+            // (`{...post, type: 'posts'}`) so a regression that drops the
+            // type override or the spread surfaces here.
+            getUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
+            getUrlForResourceStub
+                .withArgs(sinon.match({id: 'abc', type: 'posts'}), {absolute: true})
+                .returns(POST_URL);
 
             requestStub = sinon.stub().resolves({statusCode: 200});
             resetIndexNow = indexnow.__set__('request', requestStub);
@@ -433,6 +440,7 @@ describe('IndexNow', function () {
 
             await ping(post);
 
+            sinon.assert.calledOnce(getUrlForResourceStub);
             sinon.assert.calledOnce(requestStub);
             const indexNowUrl = new URL(requestStub.firstCall.args[0]);
             assert.equal(indexNowUrl.searchParams.get('url'), POST_URL);

--- a/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
@@ -52,26 +52,15 @@ describe('UrlTranslator', function () {
                     facade: {
                         getUrlForResource: (resource) => {
                             return '/path/' + resource.id;
-                        }
-                    },
-                    getResource: (path) => {
-                        switch (path) {
-                        case '/path/post': return {
-                            config: {type: 'posts'},
-                            data: {id: 'post'}
-                        };
-                        case '/path/tag': return {
-                            config: {type: 'tags'},
-                            data: {id: 'tag'}
-                        };
-                        case '/path/page': return {
-                            config: {type: 'pages'},
-                            data: {id: 'page'}
-                        };
-                        case '/path/author': return {
-                            config: {type: 'authors'},
-                            data: {id: 'author'}
-                        };
+                        },
+                        resolveUrl: async (path) => {
+                            switch (path) {
+                            case '/path/post': return {type: 'posts', id: 'post'};
+                            case '/path/tag': return {type: 'tags', id: 'tag'};
+                            case '/path/page': return {type: 'pages', id: 'page'};
+                            case '/path/author': return {type: 'authors', id: 'author'};
+                            }
+                            return null;
                         }
                     }
                 },
@@ -152,60 +141,51 @@ describe('UrlTranslator', function () {
         before(function () {
             translator = new UrlTranslator({
                 urlService: {
-                    getResource: (path) => {
-                        switch (path) {
-                        case '/post': return {
-                            config: {type: 'posts'},
-                            data: {id: 'post'}
-                        };
-                        case '/tag': return {
-                            config: {type: 'tags'},
-                            data: {id: 'tag'}
-                        };
-                        case '/page': return {
-                            config: {type: 'pages'},
-                            data: {id: 'page'}
-                        };
-                        case '/author': return {
-                            config: {type: 'authors'},
-                            data: {id: 'author'}
-                        };
+                    facade: {
+                        resolveUrl: async (path) => {
+                            switch (path) {
+                            case '/post': return {type: 'posts', id: 'post'};
+                            case '/tag': return {type: 'tags', id: 'tag'};
+                            case '/page': return {type: 'pages', id: 'page'};
+                            case '/author': return {type: 'authors', id: 'author'};
+                            }
+                            return null;
                         }
                     }
                 }
             });
         });
 
-        it('returns posts', function () {
-            assert.deepEqual(translator.getTypeAndIdFromPath('/post'), {
+        it('returns posts', async function () {
+            assert.deepEqual(await translator.getTypeAndIdFromPath('/post'), {
                 type: 'post',
                 id: 'post'
             });
         });
 
-        it('returns pages', function () {
-            assert.deepEqual(translator.getTypeAndIdFromPath('/page'), {
+        it('returns pages', async function () {
+            assert.deepEqual(await translator.getTypeAndIdFromPath('/page'), {
                 type: 'page',
                 id: 'page'
             });
         });
 
-        it('returns authors', function () {
-            assert.deepEqual(translator.getTypeAndIdFromPath('/author'), {
+        it('returns authors', async function () {
+            assert.deepEqual(await translator.getTypeAndIdFromPath('/author'), {
                 type: 'author',
                 id: 'author'
             });
         });
 
-        it('returns tags', function () {
-            assert.deepEqual(translator.getTypeAndIdFromPath('/tag'), {
+        it('returns tags', async function () {
+            assert.deepEqual(await translator.getTypeAndIdFromPath('/tag'), {
                 type: 'tag',
                 id: 'tag'
             });
         });
 
-        it('returns undefined', function () {
-            assert.equal(translator.getTypeAndIdFromPath('/other'), undefined);
+        it('returns undefined', async function () {
+            assert.equal(await translator.getTypeAndIdFromPath('/other'), undefined);
         });
     });
 

--- a/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
@@ -49,8 +49,10 @@ describe('UrlTranslator', function () {
                     }
                 },
                 urlService: {
-                    getUrlByResourceId: (id) => {
-                        return '/path/' + id;
+                    facade: {
+                        getUrlForResource: (resource) => {
+                            return '/path/' + resource.id;
+                        }
                     },
                     getResource: (path) => {
                         switch (path) {
@@ -212,8 +214,8 @@ describe('UrlTranslator', function () {
         before(function () {
             translator = new UrlTranslator({
                 urlService: {
-                    getUrlByResourceId: () => {
-                        return '/path';
+                    facade: {
+                        getUrlForResource: () => '/path'
                     }
                 },
                 models
@@ -258,6 +260,69 @@ describe('UrlTranslator', function () {
 
         it('returns null for not found tag', async function () {
             assert.equal(await translator.getResourceById('invalid', 'tag'), null);
+        });
+    });
+
+    describe('getResourceUrl', function () {
+        // Lazy URL service evaluates permalink templates against resource fields
+        // (slug, published_at, primary_tag, ...). The facade contract requires
+        // the full resource shape, not just `{id, type}`.
+        it('passes the model\'s plain data (slug, etc.) to the facade', function () {
+            let captured;
+            const translator = new UrlTranslator({
+                urlUtils: {
+                    relativeToAbsolute: t => 'https://abs' + t
+                },
+                urlService: {
+                    facade: {
+                        getUrlForResource: (resource) => {
+                            captured = resource;
+                            return '/' + resource.slug + '/';
+                        }
+                    }
+                },
+                models: {}
+            });
+
+            const tag = {
+                get: () => undefined,
+                toJSON: () => ({id: 'abc', slug: 'changelog', visibility: 'public'})
+            };
+
+            const url = translator.getResourceUrl('abc', 'tag', tag, {absolute: false});
+
+            assert.equal(url, '/changelog/');
+            assert.equal(captured.id, 'abc');
+            assert.equal(captured.type, 'tags');
+            assert.equal(captured.slug, 'changelog');
+        });
+
+        it('keeps the email-only short-circuit for sent posts', function () {
+            const translator = new UrlTranslator({
+                urlUtils: {
+                    relativeToAbsolute: t => 'https://abs' + t
+                },
+                urlService: {
+                    facade: {
+                        getUrlForResource: () => {
+                            throw new Error('facade should not be consulted for email-only posts');
+                        }
+                    }
+                },
+                models: {}
+            });
+
+            const post = {
+                get(k) {
+                    return k === 'status' ? 'sent' : 'uuid-123';
+                },
+                toJSON: () => ({id: 'pid', uuid: 'uuid-123', status: 'sent'})
+            };
+
+            assert.equal(
+                translator.getResourceUrl('pid', 'post', post, {absolute: false}),
+                '/email/uuid-123/'
+            );
         });
     });
 

--- a/ghost/core/test/unit/server/services/mentions/resource-service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/resource-service.test.js
@@ -2,32 +2,26 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const ResourceService = require('../../../../../core/server/services/mentions/resource-service');
 const UrlUtils = require('@tryghost/url-utils');
-const UrlService = require('../../../../../core/server/services/url/url-service');
 
-function stubGetResource(urlService) {
-    const getResource = sinon.stub(urlService, 'getResource');
+function buildUrlServiceWithStubbedFacade() {
+    const resolveUrl = sinon.stub();
 
-    getResource.withArgs('/post-resource').returns({
-        config: {
-            type: 'posts'
-        },
-        data: {
-            id: '63ce473f992390b739b00b01'
-        }
+    resolveUrl.withArgs('/post-resource').resolves({
+        type: 'posts',
+        id: '63ce473f992390b739b00b01'
     });
 
-    getResource.withArgs('/tag-resource').returns({
-        config: {
-            type: 'tags'
-        },
-        data: {
-            id: '63ce473f992390b739b00b02'
-        }
+    resolveUrl.withArgs('/tag-resource').resolves({
+        type: 'tags',
+        id: '63ce473f992390b739b00b02'
     });
 
-    getResource.withArgs('/no-resource').returns(null);
+    resolveUrl.withArgs('/no-resource').resolves(null);
 
-    return getResource;
+    return {
+        urlService: {facade: {resolveUrl}},
+        resolveUrl
+    };
 }
 
 describe('ResourceService', function () {
@@ -45,19 +39,17 @@ describe('ResourceService', function () {
                 }
             });
 
-            const urlService = new UrlService();
+            const {urlService, resolveUrl} = buildUrlServiceWithStubbedFacade();
             const resourceService = new ResourceService({
                 urlUtils,
                 urlService
             });
 
-            const getResource = stubGetResource(urlService);
-
             const result = await resourceService.getByURL(
                 new URL('https://site.com/blah/post-resource')
             );
 
-            sinon.assert.calledWithExactly(getResource, '/post-resource');
+            sinon.assert.calledWithExactly(resolveUrl, '/post-resource');
 
             assert.equal(result.type, 'post');
             assert.equal(result.id.toHexString(), '63ce473f992390b739b00b01');
@@ -76,19 +68,17 @@ describe('ResourceService', function () {
                 }
             });
 
-            const urlService = new UrlService();
+            const {urlService, resolveUrl} = buildUrlServiceWithStubbedFacade();
             const resourceService = new ResourceService({
                 urlUtils,
                 urlService
             });
 
-            const getResource = stubGetResource(urlService);
-
             const result = await resourceService.getByURL(
                 new URL('https://site.com/blah/tag-resource')
             );
 
-            sinon.assert.calledWithExactly(getResource, '/tag-resource');
+            sinon.assert.calledWithExactly(resolveUrl, '/tag-resource');
 
             assert.equal(result.type, null);
             assert.equal(result.id, null);
@@ -107,19 +97,17 @@ describe('ResourceService', function () {
                 }
             });
 
-            const urlService = new UrlService();
+            const {urlService, resolveUrl} = buildUrlServiceWithStubbedFacade();
             const resourceService = new ResourceService({
                 urlUtils,
                 urlService
             });
 
-            const getResource = stubGetResource(urlService);
-
             const result = await resourceService.getByURL(
                 new URL('https://site.com/blah/no-resource')
             );
 
-            sinon.assert.calledWithExactly(getResource, '/no-resource');
+            sinon.assert.calledWithExactly(resolveUrl, '/no-resource');
 
             assert.equal(result.type, null);
             assert.equal(result.id, null);

--- a/ghost/core/test/unit/server/services/slack.test.js
+++ b/ghost/core/test/unit/server/services/slack.test.js
@@ -113,11 +113,11 @@ describe('Slack', function () {
         let settingsCacheStub;
         let slackReset;
         let makeRequestStub;
-        let urlServiceGetUrlByResourceIdStub;
+        let urlServiceGetUrlForResourceStub;
         const ping = slack.__get__('ping');
 
         beforeEach(function () {
-            urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
+            urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
 
             settingsCacheStub = sinon.stub(settingsCache, 'get');
 
@@ -142,7 +142,9 @@ describe('Slack', function () {
                 slug: 'webhook-test',
                 html: `<p>Hello World!</p><p>This is a test post.</p><!--members-only--><p>This is members only content.</p>`
             });
-            urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://myblog.com/' + post.slug + '/');
+            urlServiceGetUrlForResourceStub
+                .withArgs(sinon.match({id: post.id, type: 'posts'}), {absolute: true})
+                .returns('http://myblog.com/' + post.slug + '/');
 
             settingsCacheStub.withArgs('slack_url').returns(slackURL);
 
@@ -151,7 +153,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.calledOnce(makeRequestStub);
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
 
             requestUrl = makeRequestStub.firstCall.args[0];
@@ -179,7 +181,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.calledOnce(makeRequestStub);
-            sinon.assert.notCalled(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.notCalled(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
 
             requestUrl = makeRequestStub.firstCall.args[0];
@@ -220,7 +222,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.notCalled(makeRequestStub);
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
         });
 
@@ -233,7 +235,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.notCalled(makeRequestStub);
-            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
         });
 
@@ -246,7 +248,7 @@ describe('Slack', function () {
 
             // assertions
             sinon.assert.notCalled(makeRequestStub);
-            sinon.assert.called(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.called(urlServiceGetUrlForResourceStub);
             sinon.assert.calledWith(settingsCacheStub, 'slack_url');
         });
     });

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -22,8 +22,10 @@ describe('ContentStatsService', function () {
         };
 
         mockUrlService = {
-            getResource: sinon.stub(),
-            hasFinished: sinon.stub().returns(true)
+            facade: {
+                resolveUrl: sinon.stub().resolves(null),
+                hasFinished: sinon.stub().returns(true)
+            }
         };
 
         // Create mock Tinybird client
@@ -160,56 +162,54 @@ describe('ContentStatsService', function () {
     });
 
     describe('getResourceTitle', function () {
-        it('returns null if urlService is not available', function () {
+        it('returns null if urlService is not available', async function () {
             // Create service without urlService
             const serviceNoUrl = new ContentStatsService({
                 knex: mockKnex,
                 urlService: null
             });
 
-            const result = serviceNoUrl.getResourceTitle('/about/');
+            const result = await serviceNoUrl.getResourceTitle('/about/');
             assert.equal(result, null);
         });
 
-        it('returns title from resource with title property', function () {
-            mockUrlService.getResource.withArgs('/about/').returns({
-                data: {
-                    title: 'About Us',
-                    type: 'page'
-                }
+        it('returns title from resource with title property', async function () {
+            mockUrlService.facade.resolveUrl.withArgs('/about/').resolves({
+                title: 'About Us',
+                type: 'pages'
             });
 
-            const result = service.getResourceTitle('/about/');
+            const result = await service.getResourceTitle('/about/');
             assertExists(result);
             assert.equal(result.title, 'About Us');
             assert.equal(result.resourceType, 'page');
         });
 
-        it('returns name from resource with name property (tags, authors)', function () {
-            mockUrlService.getResource.withArgs('/tag/news/').returns({
-                data: {
-                    name: 'News',
-                    type: 'tag'
-                }
+        it('returns name from resource with name property (tags, authors)', async function () {
+            mockUrlService.facade.resolveUrl.withArgs('/tag/news/').resolves({
+                name: 'News',
+                type: 'tags'
             });
 
-            const result = service.getResourceTitle('/tag/news/');
+            const result = await service.getResourceTitle('/tag/news/');
             assertExists(result);
             assert.equal(result.title, 'News');
-            assert.equal(result.resourceType, 'tag');
+            // Pre-migration tags/authors had no `data.type` column so this
+            // surfaced as undefined; keep that contract for API consumers.
+            assert.equal(result.resourceType, undefined);
         });
 
-        it('returns null if resource lookup fails', function () {
-            mockUrlService.getResource.withArgs('/not-found/').throws(new Error('Resource not found'));
+        it('returns null if resource lookup fails', async function () {
+            mockUrlService.facade.resolveUrl.withArgs('/not-found/').rejects(new Error('Resource not found'));
 
-            const result = service.getResourceTitle('/not-found/');
+            const result = await service.getResourceTitle('/not-found/');
             assert.equal(result, null);
         });
 
-        it('returns null if resource has no data or title/name', function () {
-            mockUrlService.getResource.withArgs('/empty/').returns({});
+        it('returns null if resource has no title or name', async function () {
+            mockUrlService.facade.resolveUrl.withArgs('/empty/').resolves({type: 'posts'});
 
-            const result = service.getResourceTitle('/empty/');
+            const result = await service.getResourceTitle('/empty/');
             assert.equal(result, null);
         });
     });
@@ -238,8 +238,8 @@ describe('ContentStatsService', function () {
             ];
 
             // Mock urlService to return resources for these paths
-            mockUrlService.getResource.withArgs('/post-1/').returns({data: {title: 'Post 1'}});
-            mockUrlService.getResource.withArgs('/post-2/').returns({data: {title: 'Post 2'}});
+            mockUrlService.facade.resolveUrl.withArgs('/post-1/').resolves({title: 'Post 1', type: 'posts'});
+            mockUrlService.facade.resolveUrl.withArgs('/post-2/').resolves({title: 'Post 2', type: 'posts'});
 
             const result = await service.enrichTopContentData(data);
 
@@ -262,11 +262,9 @@ describe('ContentStatsService', function () {
                 {pathname: '/about/', visits: 100}
             ];
 
-            mockUrlService.getResource.withArgs('/about/').returns({
-                data: {
-                    title: 'About Us',
-                    type: 'page'
-                }
+            mockUrlService.facade.resolveUrl.withArgs('/about/').resolves({
+                title: 'About Us',
+                type: 'pages'
             });
 
             const result = await service.enrichTopContentData(data);
@@ -286,7 +284,7 @@ describe('ContentStatsService', function () {
                 {pathname: '/unknown-page/', visits: 100}
             ];
 
-            mockUrlService.getResource.withArgs('/unknown-page/').returns(null);
+            mockUrlService.facade.resolveUrl.withArgs('/unknown-page/').resolves(null);
 
             const result = await service.enrichTopContentData(data);
 
@@ -304,7 +302,7 @@ describe('ContentStatsService', function () {
                 {pathname: '/', visits: 100}
             ];
 
-            mockUrlService.getResource.withArgs('/').returns(null);
+            mockUrlService.facade.resolveUrl.withArgs('/').resolves(null);
 
             const result = await service.enrichTopContentData(data);
 

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -316,10 +316,12 @@ describe('PostsStatsService', function () {
 
         // Mock urlService for URL existence checking
         const mockUrlService = {
-            hasFinished: () => true,
-            getResource: () => {
-                // Mock that all URLs exist for testing
-                return {data: {title: 'Mock Title'}};
+            facade: {
+                hasFinished: () => true,
+                resolveUrl: async () => {
+                    // Mock that all URLs exist for testing
+                    return {title: 'Mock Title', type: 'posts'};
+                }
             }
         };
 
@@ -373,14 +375,16 @@ describe('PostsStatsService', function () {
             return new PostsStatsService({
                 knex: db,
                 urlService: {
-                    hasFinished: () => true,
-                    getResource: lookup
+                    facade: {
+                        hasFinished: () => true,
+                        resolveUrl: async path => lookup(path)
+                    }
                 }
             });
         }
 
         it('flags url_exists: true when the URL resolves to a resource', async function () {
-            const svc = svcWithUrlLookup(() => ({data: {title: 'present'}}));
+            const svc = svcWithUrlLookup(() => ({type: 'posts', title: 'present'}));
             const out = await svc._enrichWithTitles([
                 {attribution_url: '/known/', title: 'Known', attribution_type: 'post', attribution_id: 'p', post_id: 'p'}
             ]);

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -1,0 +1,96 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const UrlServiceFacade = require('../../../../../core/server/services/url/url-service-facade');
+
+describe('UrlServiceFacade', function () {
+    let urlService;
+    let facade;
+
+    beforeEach(function () {
+        urlService = {
+            getUrlByResourceId: sinon.stub().returns('/hello-world/'),
+            owns: sinon.stub().returns(true),
+            getResource: sinon.stub(),
+            getResourceById: sinon.stub(),
+            hasFinished: sinon.stub().returns(true),
+            onRouterAddedType: sinon.stub(),
+            onRouterUpdated: sinon.stub()
+        };
+        facade = new UrlServiceFacade({urlService});
+    });
+
+    describe('getUrlForResource', function () {
+        it('extracts the id from the resource and forwards options', function () {
+            const url = facade.getUrlForResource({id: 'abc', type: 'posts'}, {absolute: true});
+
+            sinon.assert.calledWith(urlService.getUrlByResourceId, 'abc', {absolute: true});
+            assert.equal(url, '/hello-world/');
+        });
+
+        it('forwards an undefined options argument unchanged', function () {
+            facade.getUrlForResource({id: 'abc'});
+
+            sinon.assert.calledWith(urlService.getUrlByResourceId, 'abc', undefined);
+        });
+    });
+
+    describe('ownsResource', function () {
+        it('extracts the id from the resource', function () {
+            const owned = facade.ownsResource('collectionRouter', {id: 'abc'});
+
+            sinon.assert.calledWith(urlService.owns, 'collectionRouter', 'abc');
+            assert.equal(owned, true);
+        });
+    });
+
+    describe('resolveUrl', function () {
+        it('returns null when the underlying lookup misses', async function () {
+            urlService.getResource.returns(null);
+
+            const result = await facade.resolveUrl('/missing/');
+
+            assert.equal(result, null);
+        });
+
+        it('flattens the legacy {config, data} envelope into a Resource', async function () {
+            urlService.getResource.returns({
+                config: {type: 'posts'},
+                data: {id: 'abc', slug: 'hello-world', title: 'Hello'}
+            });
+
+            const result = await facade.resolveUrl('/hello-world/');
+
+            assert.deepEqual(result, {
+                type: 'posts',
+                id: 'abc',
+                slug: 'hello-world',
+                title: 'Hello'
+            });
+        });
+
+        it('returns a promise (the lazy implementation will be async)', function () {
+            urlService.getResource.returns(null);
+            const result = facade.resolveUrl('/x/');
+            assert.ok(result instanceof Promise);
+        });
+    });
+
+    describe('hasFinished', function () {
+        it('delegates to the underlying url service', function () {
+            urlService.hasFinished.returns(false);
+            assert.equal(facade.hasFinished(), false);
+        });
+    });
+
+    describe('lifecycle pass-throughs', function () {
+        it('forwards onRouterAddedType', function () {
+            facade.onRouterAddedType('id', 'filter', 'posts', '/{slug}/');
+            sinon.assert.calledWith(urlService.onRouterAddedType, 'id', 'filter', 'posts', '/{slug}/');
+        });
+
+        it('forwards onRouterUpdated', function () {
+            facade.onRouterUpdated('id');
+            sinon.assert.calledWith(urlService.onRouterUpdated, 'id');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Introduces `UrlServiceFacade` — a resource-based abstraction in front of the eager `UrlService` — and migrates every in-tree caller across. Behaviour-preserving; no flag, no functional change. Eager URL service is unchanged underneath.

**Stacked on #27712** (the test PRs land first to provide regression safety nets for commits 1, 6, and 7 of this stack).

ref https://linear.app/ghost/issue/HKG-1738/

## Why

This is the preparatory refactor for an opt-in lazy URL routing experiment (#27714, stacked on this PR). The existing eager `UrlService` precomputes a full resource → URL map at boot through an 8-stage pipeline; we want to be able to swap in an on-demand backend without touching individual callers, but the call sites today are inconsistent — some use `getUrlByResourceId(id)`, others use `getResource(path)` with a different envelope shape.

This PR introduces a thin resource-based facade in front of the eager service and migrates every in-tree caller across, so a single backend boundary exists when the lazy implementation lands.

It also resolves an inconsistency in the resolved-resource shape: the routing-level type (`'posts'`/`'pages'`/`'tags'`/`'authors'`) now wins over any DB type field on the underlying record.

## What it does

- Adds `core/server/services/url/url-service-facade.ts` (new TS file). Exposes `getUrlForResource(resource, opts)`, `ownsResource(routerId, resource)`, `resolveUrl(path)`, `getResourceById(id)`, `hasFinished()`, and lifecycle pass-throughs.
- Migrates every caller of `urlService.getUrlByResourceId(id)` and `urlService.getResource(path)` to the new facade.
- Switches `audience-feedback` and `comments` URL helpers from id-only to taking a post object, so the helpers carry the full record into the URL service. Adds a small `toPlain(modelOrObj)` helper for callers that may have either a Bookshelf model or a plain hash.
- Includes a regression fix for `?fields=url` Content API requests: the API output URL serializer now passes `id` explicitly into the resource (the `attrs` spread alone wouldn't have it after `fields=url` strips everything but `url`, and the eager id-fallback would return `/404/` for every record).

## How to review

**Please review commit-by-commit** (the GitHub Commits tab). The full diff is a sweep across ~10 files, but each commit is small and isolated:

1. **Changed audience-feedback and comment URL helpers to take a post object** — preparatory signature change + `toPlain()` helper.
2. **Added `UrlServiceFacade`** (TS) — facade class only, no callers yet.
3. **Migrated routing controllers and RouterManager to UrlServiceFacade** — first batch.
4. **Migrated API output URL serializer to UrlServiceFacade** — `output/utils/url.js`. Includes the `?fields=url` regression fix and a regression test for it.
5. **Migrated frontend helpers and meta to UrlServiceFacade** — `{{tags}}`, `{{authors}}`, `meta/url`, `meta/author-url`.
6. **Migrated slack/indexnow/comments/audience-feedback to UrlServiceFacade** — last forward-lookup callers.
7. **Migrated reverse URL lookups to facade.resolveUrl** — `getResource(path)` → `facade.resolveUrl(path)`. `url-translator.getTypeAndIdFromPath` and `content-stats-service.getResourceTitle` become async; the ripple stops at their existing async callers.

Three pinning tests in earlier PRs in this stack (#27710, #27711, #27712); they catch regressions in commits 1, 6, and 7 specifically.

## Test plan

- [x] Lint clean
- [x] `pnpm test:unit` passes
- [x] CI green (Acceptance, Legacy, E2E across the previous umbrella PR)
- [ ] Local smoke: `/`, RSS, sitemap, comment notification email