### PR TITLE
Added experimental lazy URL routing service behind config flag

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -119,12 +119,14 @@ async function initCore({ghostServer, config, frontend}) {
     // The URLService is a core part of Ghost, which depends on models.
     debug('Begin: Url Service');
     const urlService = require('./server/services/url');
-    // Note: there is no await here, we do not wait for the url service to finish
-    // We can return, but the site will remain in maintenance mode until this finishes
-    // This is managed on request: https://github.com/TryGhost/Ghost/blob/main/core/app.js#L10
-    urlService.init({
-        urlCache: !frontend // hacky parameter to make the cache initialization kick in as we can't initialize labs before the boot
-    });
+    if (!urlService.facade.isLazy()) {
+        // Note: there is no await here, we do not wait for the url service to finish
+        // We can return, but the site will remain in maintenance mode until this finishes
+        // This is managed on request: https://github.com/TryGhost/Ghost/blob/main/core/app.js#L10
+        urlService.init({
+            urlCache: !frontend // hacky parameter to make the cache initialization kick in as we can't initialize labs before the boot
+        });
+    }
     debug('End: Url Service');
 
     if (ghostServer) {
@@ -154,9 +156,11 @@ async function initCore({ghostServer, config, frontend}) {
         });
         debug('End: Mentions Job Service');
 
-        ghostServer.registerCleanupTask(async () => {
-            await urlService.shutdown();
-        });
+        if (!urlService.facade.isLazy()) {
+            ghostServer.registerCleanupTask(async () => {
+                await urlService.shutdown();
+            });
+        }
     }
 
     debug('End: initCore');

--- a/ghost/core/core/bridge.js
+++ b/ghost/core/core/bridge.js
@@ -122,12 +122,16 @@ class Bridge {
         // re-initialize apps (register app routers, because we have re-initialized the site routers)
         appService.init();
 
-        // connect routers and resources again
-        urlService.queue.start({
-            event: 'init',
-            tolerance: 100,
-            requiredSubscriberCount: 1
-        });
+        if (!urlService.facade.isLazy()) {
+            // connect routers and resources again. The lazy URL service has
+            // nothing to precompute, so this step (and the queue itself) is
+            // skipped in lazy mode.
+            urlService.queue.start({
+                event: 'init',
+                tolerance: 100,
+                requiredSubscriberCount: 1
+            });
+        }
     }
 }
 

--- a/ghost/core/core/frontend/services/sitemap/handler.js
+++ b/ghost/core/core/frontend/services/sitemap/handler.js
@@ -13,7 +13,13 @@ module.exports = function handler(siteApp) {
         next();
     };
 
-    siteApp.get('/sitemap.xml', function sitemapXML(req, res) {
+    siteApp.get('/sitemap.xml', async function sitemapXML(req, res, next) {
+        try {
+            await manager.ensurePopulatedFromDatabase();
+        } catch (err) {
+            return next(err);
+        }
+
         res.set({
             'Cache-Control': 'public, max-age=' + config.get('caching:sitemap:maxAge'),
             'Content-Type': 'text/xml'
@@ -22,10 +28,16 @@ module.exports = function handler(siteApp) {
         res.send(manager.getIndexXml());
     });
 
-    siteApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res) {
+    siteApp.get('/sitemap-:resource.xml', verifyResourceType, async function sitemapResourceXML(req, res, next) {
         const type = req.params.resource.replace(/-\d+$/, '');
         const pageParam = (req.params.resource.match(/-(\d+)$/) || [null, null])[1];
         const page = pageParam ? parseInt(pageParam, 10) : 1;
+
+        try {
+            await manager.ensurePopulatedFromDatabase();
+        } catch (err) {
+            return next(err);
+        }
 
         const content = manager.getSiteMapXml(type, page);
         // Prevent x-1.xml as it is a duplicate of x.xml and empty sitemaps

--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -1,5 +1,7 @@
 const DomainEvents = require('@tryghost/domain-events');
+const config = require('../../../shared/config');
 const {URLResourceUpdatedEvent} = require('../../../shared/events');
+const toPlain = require('../../../server/lib/common/to-plain');
 const IndexMapGenerator = require('./site-map-index-generator');
 const PagesMapGenerator = require('./page-map-generator');
 const PostsMapGenerator = require('./post-map-generator');
@@ -21,6 +23,20 @@ class SiteMapManager {
         this.tags = options.tags || this.createTagsGenerator(options);
         this.index = options.index || this.createIndexGenerator(options);
 
+        // The lazy URL service does not fire url.added / url.removed /
+        // URLResourceUpdatedEvent. When that mode is active the sitemap
+        // populates itself from the database on first request instead.
+        this._lazyRouting = options.lazyRouting === undefined
+            ? config.get('lazyRouting')
+            : options.lazyRouting;
+        this._populated = false;
+        this._populating = null;
+        // Each routers.reset bumps this generation. An in-flight populate
+        // captures the generation it started in; if that generation is no
+        // longer current when the populate settles, its result is discarded
+        // so we don't mark a stale (potentially mid-reset) lookup as ready.
+        this._populationGeneration = 0;
+
         events.on('router.created', (router) => {
             if (router.name === 'StaticRoutesRouter') {
                 this.pages.addUrl(router.getRoute({absolute: true}), {id: router.identifier, staticRoute: true});
@@ -31,23 +47,31 @@ class SiteMapManager {
             }
         });
 
-        DomainEvents.subscribe(URLResourceUpdatedEvent, (event) => {
-            this[event.data.resourceType].updateURL(event.data);
-        });
+        if (!this._lazyRouting) {
+            DomainEvents.subscribe(URLResourceUpdatedEvent, (event) => {
+                this[event.data.resourceType].updateURL(event.data);
+            });
 
-        events.on('url.added', (obj) => {
-            this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
-        });
+            events.on('url.added', (obj) => {
+                this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
+            });
 
-        events.on('url.removed', (obj) => {
-            this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
-        });
+            events.on('url.removed', (obj) => {
+                this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
+            });
+        }
 
         events.on('routers.reset', () => {
             this.pages && this.pages.reset();
             this.posts && this.posts.reset();
             this.users && this.users.reset();
             this.tags && this.tags.reset();
+            // Force the next sitemap request to repopulate from the DB.
+            // Bumping the generation invalidates any populate currently in
+            // flight (its `.then` will see a stale generation and bail).
+            this._populated = false;
+            this._populating = null;
+            this._populationGeneration += 1;
         });
     }
 
@@ -86,6 +110,106 @@ class SiteMapManager {
     getSiteMapXml(type, page) {
         return this[type].getXml(page);
     }
+
+    /**
+     * Populate the sitemap from the database. Used when the lazy URL service
+     * is active and the URL-added/-removed events are not firing. Idempotent;
+     * a second call is a no-op while the first is in flight or has finished.
+     */
+    async ensurePopulatedFromDatabase() {
+        if (!this._lazyRouting || this._populated) {
+            return;
+        }
+        if (this._populating) {
+            return this._populating;
+        }
+        const generation = this._populationGeneration;
+        const populating = this._populateFromDatabase().then(
+            () => {
+                // If a routers.reset happened while we were running, the
+                // generators have been wiped. Don't flip _populated; let the
+                // next request kick off a fresh populate.
+                if (this._populationGeneration === generation) {
+                    this._populated = true;
+                }
+                // Only clear our own handle. routers.reset already nulled
+                // _populating and a successor populate may have replaced it
+                // — clobbering would orphan the successor.
+                if (this._populating === populating) {
+                    this._populating = null;
+                }
+            },
+            (err) => {
+                if (this._populating === populating) {
+                    this._populating = null;
+                }
+                throw err;
+            }
+        );
+        this._populating = populating;
+        return this._populating;
+    }
+
+    async _populateFromDatabase() {
+        const models = require('../../../server/models');
+        const urlService = require('../../../server/services/url');
+        const facade = urlService.facade;
+
+        // Use TagPublic/Author for the shouldHavePosts gate (so tags/users
+        // with no published posts are excluded). The visibility filter is
+        // applied in TYPE_BROWSE_OPTIONS below; together these mirror what
+        // the eager URL service does in services/url/config.js.
+        await Promise.all([
+            this._loadType(models.Post, 'posts', this.posts, facade),
+            this._loadType(models.Post, 'pages', this.pages, facade),
+            this._loadType(models.TagPublic, 'tags', this.tags, facade),
+            this._loadType(models.Author, 'authors', this.users, facade)
+        ]);
+    }
+
+    async _loadType(Model, type, generator, facade) {
+        const baseOptions = browseOptionsFor(type);
+        let page = 1;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const result = await Model.findPage({...baseOptions, page});
+            for (const model of result.data) {
+                const datum = toPlain(model);
+                const url = facade.getUrlForResource({...datum, type}, {absolute: true});
+                if (url && !url.match(/\/404\//)) {
+                    generator.addUrl(url, datum);
+                }
+            }
+            const totalPages = result?.meta?.pagination?.pages;
+            // Guard against unexpected response shapes (missing meta,
+            // empty page) so we don't loop forever.
+            if (!totalPages || page >= totalPages || result.data.length === 0) {
+                break;
+            }
+            page += 1;
+        }
+    }
+}
+
+// Per-router-type browse options for the lazy populate path. Mirrors the
+// eager URL service's resource queries (services/url/config.js): posts/pages
+// filter by published+type, tags/authors by visibility:public.
+//
+// `withRelated: ['tags', 'authors']` for posts: needed so the Bookshelf
+// model's toJSON output includes `primary_tag` and `primary_author`, which
+// custom permalink templates like `/:primary_tag/:slug/` evaluate against.
+// Without this preload the lazy sitemap would emit `/undefined/.../` for
+// any site using a primary_tag/primary_author permalink. Pages exclude
+// these in the eager config so we mirror that.
+const TYPE_BROWSE_OPTIONS = {
+    posts: {limit: 200, status: 'published', filter: 'type:post', withRelated: ['tags', 'authors']},
+    pages: {limit: 200, status: 'published', filter: 'type:page'},
+    tags: {limit: 200, filter: 'visibility:public'},
+    authors: {limit: 200, filter: 'visibility:public'}
+};
+
+function browseOptionsFor(type) {
+    return TYPE_BROWSE_OPTIONS[type] || {limit: 200};
 }
 
 module.exports = SiteMapManager;

--- a/ghost/core/core/server/services/route-settings/route-settings.js
+++ b/ghost/core/core/server/services/route-settings/route-settings.js
@@ -95,10 +95,20 @@ class RouteSettings {
         await this.createBackupFile(this.settingsPath, this.backupPath);
         await this.saveFile(filePath, this.settingsPath);
 
-        urlService.resetGenerators({releaseResourcesOnly: true});
+        const isLazy = urlService.facade.isLazy();
+        const resetUrlState = () => {
+            if (isLazy) {
+                // Drop registered router configs; reloadFrontend re-registers them.
+                urlService.facade.reset();
+            } else {
+                urlService.resetGenerators({releaseResourcesOnly: true});
+            }
+        };
+
+        resetUrlState();
 
         const bringBackValidRoutes = async () => {
-            urlService.resetGenerators({releaseResourcesOnly: true});
+            resetUrlState();
 
             await this.restoreBackupFile(this.settingsPath, this.backupPath);
 
@@ -112,6 +122,12 @@ class RouteSettings {
                 .finally(() => {
                     throw err;
                 });
+        }
+
+        // The lazy URL service has nothing to precompute, so the readiness
+        // poll below is unnecessary; hasFinished() returns true immediately.
+        if (isLazy) {
+            return;
         }
 
         // @TODO: how can we get rid of this from here?

--- a/ghost/core/core/server/services/url/index.js
+++ b/ghost/core/core/server/services/url/index.js
@@ -2,6 +2,7 @@ const config = require('../../../shared/config');
 const LocalFileCache = require('./local-file-cache');
 const UrlService = require('./url-service');
 const UrlServiceFacade = require('./url-service-facade');
+const LazyUrlService = require('./lazy-url-service');
 
 // NOTE: instead of a path we could give UrlService a "data-resolver" of some sort
 //       so it doesn't have to contain the logic to read data at all. This would be
@@ -22,7 +23,21 @@ if (process.env.NODE_ENV.startsWith('test')){
 
 const cache = new LocalFileCache({storagePath, writeDisabled});
 const urlService = new UrlService({cache});
-const urlServiceFacade = new UrlServiceFacade({urlService});
+
+// LazyUrlService is only attached to the facade when the lazyRouting flag is
+// on. The eager UrlService stays in the require graph either way so test code
+// and partially-migrated callers continue to work. The model layer is only
+// pulled in when the flag is on so flag-off boot keeps its existing
+// require-graph shape.
+let lazyUrlService = null;
+if (config.get('lazyRouting')) {
+    const models = require('../../models');
+    const {createFindResource} = require('./lazy-find-resource');
+
+    lazyUrlService = new LazyUrlService({findResource: createFindResource(models)});
+}
+
+const urlServiceFacade = new UrlServiceFacade({urlService, lazyUrlService});
 
 // Singleton: default export remains the eager UrlService for backwards
 // compatibility with existing imports. The new facade is exposed alongside

--- a/ghost/core/core/server/services/url/lazy-find-resource.ts
+++ b/ghost/core/core/server/services/url/lazy-find-resource.ts
@@ -1,0 +1,62 @@
+import type {FindResource} from './lazy-url-service';
+
+interface BookshelfModel {
+    findOne(query: Record<string, unknown>, options?: Record<string, unknown>): Promise<{toJSON(): Record<string, unknown>} | null>;
+}
+
+interface Models {
+    Post: BookshelfModel;
+    TagPublic: BookshelfModel;
+    Author: BookshelfModel;
+}
+
+/**
+ * Builds the on-demand DB lookup hook used by LazyUrlService.resolveUrl.
+ *
+ * The eager UrlService only registers URLs for resources matching the
+ * resourceConfig filter (status:published, public visibility). Mirror that
+ * here so reverse lookups can't return drafts / private resources even though
+ * we now hit the DB on demand. We also disambiguate posts vs pages — both
+ * share `models.Post` and a permalink template like `/:slug/` could otherwise
+ * return either record.
+ *
+ * For tags and authors we use the public-facing scoped models (TagPublic,
+ * Author) which carry the shouldHavePosts gate, so reverse lookups can't
+ * return tags/users with no published posts (and in particular can't expose
+ * staff User accounts via a guessed slug).
+ */
+export function createFindResource(models: Models): FindResource {
+    const loadOne = async (Model: BookshelfModel, query: Record<string, unknown>, options: Record<string, unknown> = {}) => {
+        const result = await Model.findOne(query, {require: false, ...options});
+        return result ? result.toJSON() : null;
+    };
+
+    // Posts and pages need their tags/authors relations loaded so NQL
+    // filters like `tag:news` / `author:jane` can be evaluated against the
+    // returned record (LazyUrlService re-checks the route's filter after
+    // the DB lookup). Without these, every tag- or author-filtered route
+    // would silently 404.
+    const POSTLIKE_RELATIONS = ['tags', 'authors'];
+
+    const loadPostlike = (Model: BookshelfModel, query: Record<string, unknown>, dbType: string) => {
+        return loadOne(Model, {...query, type: dbType, status: 'published'}, {withRelated: POSTLIKE_RELATIONS});
+    };
+
+    return (type: string, query: Record<string, string>) => {
+        if (type === 'posts') {
+            return loadPostlike(models.Post, query, 'post');
+        }
+        if (type === 'pages') {
+            return loadPostlike(models.Post, query, 'page');
+        }
+        if (type === 'tags') {
+            return loadOne(models.TagPublic, {...query, visibility: 'public'});
+        }
+        if (type === 'authors') {
+            return loadOne(models.Author, {...query, visibility: 'public'});
+        }
+        return Promise.resolve(null);
+    };
+}
+
+module.exports = {createFindResource};

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -1,0 +1,265 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const nql = require('@tryghost/nql');
+const debug = require('@tryghost/debug')('services:url:lazy');
+const localUtils = require('../../../shared/url-utils');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+import type {Resource, UrlOptions, LazyUrlServiceBackend} from './url-service-facade';
+
+// The same expansions used by UrlGenerator so users can write `tag:foo`,
+// `author:jane`, etc. and have them rewritten to the underlying field paths.
+const EXPANSIONS = [
+    {key: 'author', replacement: 'authors.slug'},
+    {key: 'tags', replacement: 'tags.slug'},
+    {key: 'tag', replacement: 'tags.slug'},
+    {key: 'authors', replacement: 'authors.slug'},
+    {key: 'primary_tag', replacement: 'primary_tag.slug'},
+    {key: 'primary_author', replacement: 'primary_author.slug'}
+];
+
+// Same `page:true/false` legacy transformer the UrlGenerator uses, so old
+// routes.yaml configs continue to work.
+const PAGE_TRANSFORMER = nql.utils.mapKeyValues({
+    key: {from: 'page', to: 'type'},
+    values: [
+        {from: false, to: 'post'},
+        {from: true, to: 'page'}
+    ]
+});
+
+// Map a resource's `type` field (whatever the caller passed) onto the plural
+// router resource type. We accept the singular DB column values ('post',
+// 'page') as well as the plural router keys, because the migrated callers
+// are inconsistent: API responses spread `attrs` (singular), but some
+// helpers explicitly tag with the plural router key.
+const TYPE_TO_ROUTER_TYPE: Record<string, string> = {
+    post: 'posts',
+    posts: 'posts',
+    page: 'pages',
+    pages: 'pages',
+    tag: 'tags',
+    tags: 'tags',
+    author: 'authors',
+    authors: 'authors'
+};
+
+interface NqlInstance {
+    queryJSON(record: Record<string, unknown>): unknown;
+}
+
+interface RouterConfig {
+    identifier: string;
+    filter: string | null;
+    resourceType: string;
+    permalink: string;
+    nql: NqlInstance | null;
+}
+
+/**
+ * Async function that resolves a slug (or other params) to a database
+ * record. Injected so the URL service stays pure for forward lookups —
+ * only `resolveUrl` actually hits the DB, and only via this hook.
+ */
+export type FindResource = (
+    routerType: string,
+    params: Record<string, string>
+) => Promise<Record<string, unknown> | null>;
+
+interface LazyUrlServiceDeps {
+    urlUtils?: typeof localUtils;
+    findResource?: FindResource | null;
+}
+
+/**
+ * On-demand URL service. Computes URLs and ownership per-call from the
+ * registered router configs instead of holding a precomputed map of every
+ * resource. Pure for forward lookups; resolveUrl() takes an optional DB
+ * lookup function so reverse lookups stay testable.
+ */
+export class LazyUrlService implements LazyUrlServiceBackend {
+    private urlUtils: typeof localUtils;
+    private findResource: FindResource | null;
+    private routerConfigs: RouterConfig[];
+
+    constructor({urlUtils = localUtils, findResource = null}: LazyUrlServiceDeps = {}) {
+        this.urlUtils = urlUtils;
+        this.findResource = findResource;
+        // Router configs in priority order. Position is the registration order.
+        this.routerConfigs = [];
+    }
+
+    onRouterAddedType(
+        identifier: string,
+        filter: string | null,
+        resourceType: string,
+        permalink: string
+    ): void {
+        debug('onRouterAddedType', identifier, resourceType, permalink, filter);
+        const config: RouterConfig = {identifier, filter, resourceType, permalink, nql: null};
+        if (filter) {
+            config.nql = nql(filter, {expansions: EXPANSIONS, transformer: PAGE_TRANSFORMER});
+        }
+        this.routerConfigs.push(config);
+    }
+
+    onRouterUpdated(): void {
+        // No state to regenerate. The next URL request reads the (possibly new)
+        // router config; in-flight requests that already snapshotted the old
+        // config keep using it, which matches the documented atomic-reload
+        // behaviour.
+    }
+
+    /**
+     * Drop all registered routers. Called when routes.yaml is reloaded.
+     */
+    reset(): void {
+        this.routerConfigs = [];
+    }
+
+    hasFinished(): boolean {
+        return true;
+    }
+
+    getUrlForResource(resource: Resource, options: UrlOptions = {}): string {
+        const routerType = this._routerTypeOf(resource);
+        if (!routerType) {
+            return this._formatPath('/404/', options);
+        }
+        const candidates = this.routerConfigs.filter(c => c.resourceType === routerType);
+        for (const config of candidates) {
+            // NQL filters are evaluated against the original resource (with
+            // its singular DB `type` field intact) because the page:true/false
+            // transformer rewrites to type:'post'/'page'.
+            if (this._matchesFilter(config, resource)) {
+                const path = this.urlUtils.replacePermalink(config.permalink, resource);
+                return this._formatPath(path, options);
+            }
+        }
+        return this._formatPath('/404/', options);
+    }
+
+    ownsResource(routerIdentifier: string, resource: Resource | null): boolean {
+        const config = this.routerConfigs.find(c => c.identifier === routerIdentifier);
+        if (!config || !resource) {
+            return false;
+        }
+        const routerType = this._routerTypeOf(resource);
+        if (config.resourceType !== routerType) {
+            return false;
+        }
+        return this._matchesFilter(config, resource);
+    }
+
+    /**
+     * Translate the resource's `type` field into the plural router resource
+     * type (`'posts'` / `'pages'` / `'tags'` / `'authors'`). Returns `null`
+     * when the type is missing or unrecognised.
+     */
+    private _routerTypeOf(resource: Resource | null | undefined): string | null {
+        if (!resource || !resource.type) {
+            return null;
+        }
+        return TYPE_TO_ROUTER_TYPE[resource.type] || null;
+    }
+
+    /**
+     * Resolve a URL path to a resource record. Iterates router configs in
+     * priority order, pattern-matching the path against each permalink
+     * template, querying the database for a matching resource, and verifying
+     * any NQL filter still matches for posts.
+     */
+    async resolveUrl(urlPath: string): Promise<Resource | null> {
+        if (!this.findResource) {
+            return null;
+        }
+        for (const config of this.routerConfigs) {
+            const params = this._matchPermalink(config.permalink, urlPath);
+            if (!params) {
+                continue;
+            }
+            const resource = await this.findResource(config.resourceType, params);
+            if (!resource) {
+                continue;
+            }
+            // For posts/pages with NQL filters, confirm the DB record still
+            // satisfies the filter. The match runs against the raw record
+            // (with its singular `type` column) because the page:true/false
+            // transformer rewrites to type:'post'/'page'.
+            if (config.nql && !this._matchesFilter(config, resource)) {
+                continue;
+            }
+            return Object.assign({}, resource, {type: config.resourceType}) as Resource;
+        }
+        return null;
+    }
+
+    private _matchesFilter(config: RouterConfig, resource: Record<string, unknown>): boolean {
+        if (!config.nql) {
+            return true;
+        }
+        try {
+            return !!config.nql.queryJSON(resource);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            debug('NQL match failed', config.filter, message);
+            return false;
+        }
+    }
+
+    private _formatPath(path: string, options: UrlOptions): string {
+        if (options.absolute) {
+            return this.urlUtils.createUrl(path, options.absolute);
+        }
+        if (options.withSubdirectory) {
+            return this.urlUtils.createUrl(path, false, true);
+        }
+        return path;
+    }
+
+    /**
+     * Match a Ghost permalink template (e.g. `/:slug/`,
+     * `/:year/:month/:slug/`) against a URL path and extract the named
+     * fields. Ghost's RouteSettings validator rewrites `{field}` placeholders
+     * into `:field` form before they reach the URL service, so this parser
+     * works on the `:field` syntax.
+     *
+     * Implementation: walk the permalink and path one segment at a time.
+     * Each segment must be either a literal match or a single placeholder.
+     * Mixing literals and placeholders inside a segment is unsupported and
+     * not a documented Ghost feature; rejecting it here also keeps us out of
+     * regex-backtracking territory entirely.
+     */
+    private _matchPermalink(permalink: string, urlPath: string): Record<string, string> | null {
+        if (typeof permalink !== 'string' || typeof urlPath !== 'string') {
+            return null;
+        }
+        const permalinkSegments = permalink.split('/');
+        const pathSegments = urlPath.split('/');
+        if (permalinkSegments.length !== pathSegments.length) {
+            return null;
+        }
+        const params: Record<string, string> = {};
+        for (let i = 0; i < permalinkSegments.length; i += 1) {
+            const templateSegment = permalinkSegments[i];
+            const pathSegment = pathSegments[i];
+            if (templateSegment.startsWith(':')) {
+                const fieldName = templateSegment.slice(1);
+                if (!/^\w+$/.test(fieldName) || pathSegment.length === 0) {
+                    return null;
+                }
+                try {
+                    params[fieldName] = decodeURIComponent(pathSegment);
+                } catch {
+                    // Malformed %-escapes (e.g. "/foo%ZZ/") throw URIError;
+                    // treat as a non-match rather than crash the request.
+                    return null;
+                }
+            } else if (templateSegment !== pathSegment) {
+                return null;
+            }
+        }
+        return params;
+    }
+}
+
+module.exports = LazyUrlService;

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -1,5 +1,6 @@
 {
     "url": "http://localhost:2368",
+    "lazyRouting": false,
     "server": {
         "host": "127.0.0.1",
         "port": 2368,

--- a/ghost/core/test/integration/url-service.test.js
+++ b/ghost/core/test/integration/url-service.test.js
@@ -300,3 +300,69 @@ describe('Integration: services/url/UrlService', function () {
         });
     });
 });
+
+describe('Integration: services/url/createFindResource', function () {
+    // The lazy URL service evaluates routes.yaml NQL filters (e.g.
+    // `tag:news`, `author:jane`) against records returned by findResource.
+    // EXPANSIONS rewrite those to `tags.slug:news` / `authors.slug:jane`,
+    // so the loaded record must carry its tags and authors relations or
+    // every tag- or author-filtered route silently 404s. These tests pin
+    // that contract against real models.
+    const models = require('../../core/server/models');
+    const {createFindResource} = require('../../core/server/services/url/lazy-find-resource');
+    const LazyUrlService = require('../../core/server/services/url/lazy-url-service');
+
+    let findResource;
+
+    before(testUtils.teardownDb);
+    before(testUtils.setup('users:roles', 'posts'));
+    before(function () {
+        findResource = createFindResource(models);
+    });
+    after(testUtils.teardownDb);
+
+    it('populates tags on a published post', async function () {
+        // posts[0] (html-ipsum) is bound to tags[0] (kitchen-sink) and
+        // tags[1] (bacon) in the posts_tags fixture mapping.
+        const post = await findResource('posts', {slug: 'html-ipsum'});
+
+        assert.ok(post, 'fixture post should be findable');
+        assert.ok(Array.isArray(post.tags) && post.tags.length > 0, 'tags must be loaded');
+        const slugs = post.tags.map(t => t.slug);
+        assert.ok(slugs.includes('kitchen-sink'), `expected kitchen-sink tag, got ${slugs.join(',')}`);
+    });
+
+    it('populates authors on a published post', async function () {
+        const post = await findResource('posts', {slug: 'html-ipsum'});
+
+        assert.ok(post);
+        assert.ok(Array.isArray(post.authors) && post.authors.length > 0, 'authors must be loaded');
+        assert.ok(post.authors[0].slug, 'each author must carry a slug');
+    });
+
+    it('returns null for an unpublished slug (mirrors the eager filter)', async function () {
+        // posts[2] (short-and-sweet) is owned by the eager service's
+        // `featured:false` collection — confirms findResource itself
+        // matches the eager service's status:published gate.
+        const draft = await findResource('posts', {slug: 'unfinished'});
+        assert.equal(draft, null);
+    });
+
+    it('resolves a tag-filtered route end-to-end through LazyUrlService', async function () {
+        const lazy = new LazyUrlService({findResource});
+        lazy.onRouterAddedType('kitchen', 'tag:kitchen-sink', 'posts', '/:slug/');
+
+        const resource = await lazy.resolveUrl('/html-ipsum/');
+        assert.ok(resource, 'tag-filtered post must resolve, not 404');
+        assert.equal(resource.slug, 'html-ipsum');
+    });
+
+    it('rejects a tag-filtered route when the post does not match the filter', async function () {
+        const lazy = new LazyUrlService({findResource});
+        // posts[0] has kitchen-sink and bacon; not pollo.
+        lazy.onRouterAddedType('pollo', 'tag:pollo', 'posts', '/:slug/');
+
+        const resource = await lazy.resolveUrl('/html-ipsum/');
+        assert.equal(resource, null);
+    });
+});

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -126,4 +126,295 @@ describe('Unit: sitemap/manager', function () {
             sinon.assert.calledOnce(IndexGenerator.prototype.getXml);
         });
     });
+
+    describe('SiteMapManager (lazyRouting mode)', function () {
+        let lazyEvents;
+
+        before(function () {
+            lazyEvents = {};
+            // Replace the events.on stub for this block so we can capture
+            // subscriptions made by a manager constructed with lazyRouting on.
+            events.on.restore();
+            sinon.stub(events, 'on').callsFake((eventName, callback) => {
+                lazyEvents[eventName] = callback;
+            });
+
+            new SiteMapManager({
+                posts: new PostGenerator(),
+                pages: new PageGenerator(),
+                tags: new TagGenerator(),
+                authors: new UserGenerator(),
+                lazyRouting: true
+            });
+        });
+
+        it('skips url.added and url.removed event subscriptions', function () {
+            assert.equal(lazyEvents['url.added'], undefined);
+            assert.equal(lazyEvents['url.removed'], undefined);
+        });
+
+        it('still subscribes to router.created and routers.reset', function () {
+            assertExists(lazyEvents['router.created']);
+            assertExists(lazyEvents['routers.reset']);
+        });
+
+        it('ensurePopulatedFromDatabase is a no-op when lazyRouting is off', async function () {
+            const eagerManager = new SiteMapManager({
+                posts: new PostGenerator(),
+                pages: new PageGenerator(),
+                tags: new TagGenerator(),
+                authors: new UserGenerator(),
+                lazyRouting: false
+            });
+            // Should resolve without touching the DB.
+            await eagerManager.ensurePopulatedFromDatabase();
+        });
+    });
+
+    // The lazy populate path is the only mechanism that fills the sitemap when
+    // url.added/url.removed events do not fire. These tests exercise it as a
+    // unit: stub the model layer + the URL facade and assert addUrl is called
+    // for the right resources.
+    describe('_populateFromDatabase', function () {
+        let sandbox;
+        let postFindPage;
+        let tagFindPage;
+        let userFindPage;
+        let getUrlForResource;
+
+        const models = require('../../../../../core/server/models');
+        const urlServiceModule = require('../../../../../core/server/services/url');
+
+        // The outer suite stubs PostGenerator.prototype.addUrl globally, so
+        // we can't (re)stub it on a fresh instance. Reset the shared post
+        // stub and use a per-test sandbox for everything else so a partial
+        // beforeEach failure can't leak stubs across cases.
+        beforeEach(function () {
+            sandbox = sinon.createSandbox();
+            postFindPage = sandbox.stub(models.Post, 'findPage');
+            // Sitemap populate uses TagPublic and Author (the scoped models
+            // with shouldHavePosts gating) instead of Tag/User.
+            tagFindPage = sandbox.stub(models.TagPublic, 'findPage');
+            userFindPage = sandbox.stub(models.Author, 'findPage');
+
+            sandbox.stub(PageGenerator.prototype, 'addUrl');
+            sandbox.stub(TagGenerator.prototype, 'addUrl');
+            sandbox.stub(UserGenerator.prototype, 'addUrl');
+            PostGenerator.prototype.addUrl.resetHistory();
+
+            // Method-level stub on the singleton facade method the sitemap
+            // actually reads. Sandbox.restore() puts it back even if a sibling
+            // beforeEach throws partway.
+            getUrlForResource = sandbox.stub(urlServiceModule.facade, 'getUrlForResource');
+        });
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        function paged(rows) {
+            return {
+                data: rows.map(r => ({...r, toJSON: () => r})),
+                meta: {pagination: {pages: 1}}
+            };
+        }
+
+        function makeLazyManager() {
+            return new SiteMapManager({
+                posts: new PostGenerator(),
+                pages: new PageGenerator(),
+                tags: new TagGenerator(),
+                authors: new UserGenerator(),
+                lazyRouting: true
+            });
+        }
+
+        it('feeds non-/404/ URLs into the per-type generators', async function () {
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:post'}))
+                .resolves(paged([{id: 'p1', slug: 'hello', type: 'post'}]));
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:page'}))
+                .resolves(paged([{id: 'pg1', slug: 'about', type: 'page'}]));
+            tagFindPage.resolves(paged([{id: 't1', slug: 'food'}]));
+            userFindPage.resolves(paged([{id: 'u1', slug: 'jane'}]));
+
+            getUrlForResource.callsFake((resource) => {
+                if (resource.id === 'p1') {
+                    return 'http://example.com/hello/';
+                }
+                if (resource.id === 'pg1') {
+                    return 'http://example.com/about/';
+                }
+                if (resource.id === 't1') {
+                    return 'http://example.com/tag/food/';
+                }
+                if (resource.id === 'u1') {
+                    return 'http://example.com/author/jane/';
+                }
+                return '/404/';
+            });
+
+            const manager = makeLazyManager();
+            await manager.ensurePopulatedFromDatabase();
+
+            sinon.assert.calledWith(PostGenerator.prototype.addUrl, 'http://example.com/hello/', sinon.match({id: 'p1'}));
+            sinon.assert.calledWith(PageGenerator.prototype.addUrl, 'http://example.com/about/', sinon.match({id: 'pg1'}));
+            sinon.assert.calledWith(TagGenerator.prototype.addUrl, 'http://example.com/tag/food/', sinon.match({id: 't1'}));
+            sinon.assert.calledWith(UserGenerator.prototype.addUrl, 'http://example.com/author/jane/', sinon.match({id: 'u1'}));
+        });
+
+        it('preloads tags+authors for posts so primary_tag permalinks resolve', async function () {
+            postFindPage.resolves(paged([]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+            getUrlForResource.returns('http://example.com/x/');
+
+            await makeLazyManager().ensurePopulatedFromDatabase();
+
+            // Sites using `/:primary_tag/:slug/` permalinks need
+            // `primary_tag` populated on the resource. Bookshelf only fills
+            // it in toJSON when the `tags` relation is loaded.
+            sinon.assert.calledWith(postFindPage, sinon.match({
+                filter: 'type:post',
+                withRelated: ['tags', 'authors']
+            }));
+        });
+
+        it('queries tags and authors with visibility:public to mirror the eager URL service', async function () {
+            postFindPage.resolves(paged([]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+            getUrlForResource.returns('http://example.com/x/');
+
+            await makeLazyManager().ensurePopulatedFromDatabase();
+
+            // Pin the full options shape so a future drop of `limit` or a
+            // change in the filter expression still fails this test. The
+            // tag schema permits visibility:'internal' and the user schema
+            // defaults to 'public' but doesn't enforce it; without these
+            // filters the lazy sitemap diverges from the eager URL service
+            // (services/url/config.js applies both).
+            sinon.assert.calledWith(tagFindPage, sinon.match({
+                limit: 200,
+                filter: 'visibility:public'
+            }));
+            sinon.assert.calledWith(userFindPage, sinon.match({
+                limit: 200,
+                filter: 'visibility:public'
+            }));
+        });
+
+        it('skips resources whose URL would be /404/', async function () {
+            postFindPage.resolves(paged([
+                {id: 'p1', slug: 'good', type: 'post'},
+                {id: 'p2', slug: 'orphan', type: 'post'}
+            ]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+
+            getUrlForResource.callsFake((resource) => {
+                return resource.id === 'p1' ? 'http://example.com/good/' : '/404/';
+            });
+
+            const manager = makeLazyManager();
+            await manager.ensurePopulatedFromDatabase();
+
+            sinon.assert.calledWith(PostGenerator.prototype.addUrl, 'http://example.com/good/', sinon.match({id: 'p1'}));
+            const p2Calls = PostGenerator.prototype.addUrl.getCalls().filter(c => c.args[1] && c.args[1].id === 'p2');
+            assert.equal(p2Calls.length, 0, 'p2 should be skipped because its URL is /404/');
+        });
+
+        it('a settled stale populate does not clobber a successor populate handle', async function () {
+            // T1 starts populate (slow), T1 awaits DB.
+            // routers.reset fires → _populating cleared, generation bumped.
+            // T2 starts populate (also slow) → owns _populating now.
+            // T1 finally settles. Bug: T1's `.then` would set _populating=null,
+            // orphaning T2 and letting a T3 race in alongside T2.
+            // Fix: only clear _populating if it still points to T1's promise.
+            let unblockT1;
+            let unblockT2;
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:post'}))
+                .onFirstCall().returns(new Promise((resolve) => {
+                    unblockT1 = () => resolve(paged([]));
+                }))
+                .onSecondCall().returns(new Promise((resolve) => {
+                    unblockT2 = () => resolve(paged([]));
+                }));
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:page'}))
+                .resolves(paged([]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+            getUrlForResource.returns('http://example.com/x/');
+
+            const manager = makeLazyManager();
+
+            const t1 = manager.ensurePopulatedFromDatabase();
+            const resetHandlers = events.on
+                .getCalls()
+                .filter(c => c.args[0] === 'routers.reset')
+                .map(c => c.args[1]);
+            resetHandlers.forEach(handler => handler());
+
+            const t2 = manager.ensurePopulatedFromDatabase();
+            assertExists(manager._populating, 'T2 must own the populate handle after reset');
+            const t2Handle = manager._populating;
+
+            // T1 settles before T2. The buggy version null'd _populating here.
+            unblockT1();
+            await t1;
+            assert.equal(
+                manager._populating,
+                t2Handle,
+                'T1 settling must not clobber T2\'s in-flight populate handle'
+            );
+
+            unblockT2();
+            await t2;
+        });
+
+        it('routers.reset during a populate cancels the populate via the generation token', async function () {
+            // The "post" findPage call hangs until we explicitly resolve it,
+            // simulating a slow DB load that races with a routes.yaml reload.
+            let unblockPopulate;
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:post'}))
+                .returns(new Promise((resolve) => {
+                    unblockPopulate = () => resolve(paged([]));
+                }));
+            postFindPage
+                .withArgs(sinon.match({filter: 'type:page'}))
+                .resolves(paged([]));
+            tagFindPage.resolves(paged([]));
+            userFindPage.resolves(paged([]));
+            getUrlForResource.returns('http://example.com/x/');
+
+            const manager = makeLazyManager();
+
+            const inFlight = manager.ensurePopulatedFromDatabase();
+            // The outer suite has stubbed events.on; the manager registered
+            // its routers.reset handler via that stub. Locate and invoke it.
+            const resetHandlers = events.on
+                .getCalls()
+                .filter(c => c.args[0] === 'routers.reset')
+                .map(c => c.args[1]);
+            resetHandlers.forEach(handler => handler());
+
+            unblockPopulate();
+            await inFlight;
+
+            // Behavioural assertion: a subsequent ensurePopulatedFromDatabase
+            // must re-issue the DB queries because the previous populate's
+            // result was invalidated by the routers.reset. (Asserting on the
+            // private `_populated` flag would couple to internal state.)
+            const callsBefore = postFindPage.callCount;
+            await manager.ensurePopulatedFromDatabase();
+            assert.ok(
+                postFindPage.callCount > callsBefore,
+                'A reset mid-populate must invalidate the in-flight result so the next call re-queries'
+            );
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const bridge = require('../../../../../core/bridge');
 const RouteSettings = require('../../../../../core/server/services/route-settings/route-settings');
+const urlService = require('../../../../../core/server/services/url');
 
 describe('UNIT > Settings Service DefaultSettingsManager:', function () {
     let fsReadFileStub;
@@ -46,6 +47,96 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             } catch (error) {
                 assert.match(error.message, /YAMLException: bad indentation of a mapping entry/);
             }
+        });
+
+        // Lazy/eager branching for the URL-service reset and the post-reload
+        // readiness poll. The lazy branch is unique to this commit (HKG-1771),
+        // so the test is colocated with the implementation.
+        describe('when lazyRouting is on', function () {
+            const routesSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes.yaml');
+            const backupFilePath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-backup.yaml');
+            const incomingSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-incoming.yaml');
+
+            let facadeResetStub;
+            let resetGeneratorsStub;
+            let hasFinishedStub;
+
+            beforeEach(function () {
+                sinon.stub(urlService.facade, 'isLazy').returns(true);
+                facadeResetStub = sinon.stub(urlService.facade, 'reset');
+                resetGeneratorsStub = sinon.stub(urlService, 'resetGenerators');
+                hasFinishedStub = sinon.stub(urlService, 'hasFinished').returns(true);
+
+                fsReadFileStub.withArgs(routesSettingsPath, 'utf8').resolves('content');
+                fsCopyStub.withArgs(backupFilePath, routesSettingsPath).resolves();
+                fsCopyStub.withArgs(incomingSettingsPath, routesSettingsPath).resolves();
+
+                bridgeReloadFrontendStub.resolves();
+            });
+
+            it('resets via facade.reset and skips eager resetGenerators', async function () {
+                const manager = new RouteSettings({
+                    settingsLoader: {},
+                    settingsPath: routesSettingsPath,
+                    backupPath: backupFilePath
+                });
+
+                await manager.setFromFilePath(incomingSettingsPath);
+
+                sinon.assert.calledOnce(facadeResetStub);
+                sinon.assert.notCalled(resetGeneratorsStub);
+            });
+
+            it('skips the readiness poll', async function () {
+                const manager = new RouteSettings({
+                    settingsLoader: {},
+                    settingsPath: routesSettingsPath,
+                    backupPath: backupFilePath
+                });
+
+                await manager.setFromFilePath(incomingSettingsPath);
+
+                // The readiness loop is the only caller of
+                // urlService.hasFinished() inside setFromFilePath. When the
+                // flag is on, the lazy short-circuit returns early — so it
+                // must never be consulted.
+                sinon.assert.notCalled(hasFinishedStub);
+            });
+        });
+
+        describe('when lazyRouting is off (eager default)', function () {
+            const routesSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes.yaml');
+            const backupFilePath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-backup.yaml');
+            const incomingSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-incoming.yaml');
+
+            let facadeResetStub;
+            let resetGeneratorsStub;
+
+            beforeEach(function () {
+                sinon.stub(urlService.facade, 'isLazy').returns(false);
+                facadeResetStub = sinon.stub(urlService.facade, 'reset');
+                resetGeneratorsStub = sinon.stub(urlService, 'resetGenerators');
+                sinon.stub(urlService, 'hasFinished').returns(true);
+
+                fsReadFileStub.withArgs(routesSettingsPath, 'utf8').resolves('content');
+                fsCopyStub.withArgs(backupFilePath, routesSettingsPath).resolves();
+                fsCopyStub.withArgs(incomingSettingsPath, routesSettingsPath).resolves();
+
+                bridgeReloadFrontendStub.resolves();
+            });
+
+            it('keeps the existing eager resetGenerators path', async function () {
+                const manager = new RouteSettings({
+                    settingsLoader: {},
+                    settingsPath: routesSettingsPath,
+                    backupPath: backupFilePath
+                });
+
+                await manager.setFromFilePath(incomingSettingsPath);
+
+                sinon.assert.called(resetGeneratorsStub);
+                sinon.assert.notCalled(facadeResetStub);
+            });
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/lazy-find-resource.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-find-resource.test.js
@@ -1,0 +1,115 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const {createFindResource} = require('../../../../../core/server/services/url/lazy-find-resource');
+
+function fakeModel() {
+    return {findOne: sinon.stub()};
+}
+
+function record(attrs) {
+    return {toJSON: () => attrs};
+}
+
+describe('createFindResource', function () {
+    let models;
+    let findResource;
+
+    beforeEach(function () {
+        models = {Post: fakeModel(), TagPublic: fakeModel(), Author: fakeModel()};
+        findResource = createFindResource(models);
+    });
+
+    it('queries Post with type:post and status:published for posts', async function () {
+        models.Post.findOne.resolves(record({id: 'p1', slug: 'hello'}));
+
+        await findResource('posts', {slug: 'hello'});
+
+        sinon.assert.calledWith(
+            models.Post.findOne,
+            sinon.match({slug: 'hello', type: 'post', status: 'published'}),
+            sinon.match.has('require', false)
+        );
+    });
+
+    it('queries Post with type:page and status:published for pages', async function () {
+        models.Post.findOne.resolves(record({id: 'pg1', slug: 'about'}));
+
+        await findResource('pages', {slug: 'about'});
+
+        sinon.assert.calledWith(
+            models.Post.findOne,
+            sinon.match({slug: 'about', type: 'page', status: 'published'}),
+            sinon.match.has('require', false)
+        );
+    });
+
+    it('asks Post.findOne to load the tags and authors relations on posts', async function () {
+        // Locks the contract that exposed HKG-1738: tag/author NQL filters
+        // (e.g. routes.yaml `filter: tag:news`) evaluate against
+        // `tags.slug` / `authors.slug` on the loaded record. Without
+        // withRelated the record has no `.tags` / `.authors`, every
+        // tag-filtered route silently 404s.
+        models.Post.findOne.resolves(record({id: 'p1'}));
+
+        await findResource('posts', {slug: 'hello'});
+
+        sinon.assert.calledWith(
+            models.Post.findOne,
+            sinon.match.any,
+            sinon.match({withRelated: sinon.match.array.contains(['tags', 'authors'])})
+        );
+    });
+
+    it('asks Post.findOne to load tags and authors on pages too', async function () {
+        models.Post.findOne.resolves(record({id: 'pg1'}));
+
+        await findResource('pages', {slug: 'about'});
+
+        sinon.assert.calledWith(
+            models.Post.findOne,
+            sinon.match.any,
+            sinon.match({withRelated: sinon.match.array.contains(['tags', 'authors'])})
+        );
+    });
+
+    it('queries TagPublic with visibility:public for tags', async function () {
+        models.TagPublic.findOne.resolves(record({id: 't1', slug: 'news'}));
+
+        await findResource('tags', {slug: 'news'});
+
+        sinon.assert.calledWith(
+            models.TagPublic.findOne,
+            sinon.match({slug: 'news', visibility: 'public'}),
+            sinon.match.any
+        );
+    });
+
+    it('queries Author with visibility:public for authors', async function () {
+        models.Author.findOne.resolves(record({id: 'a1', slug: 'jane'}));
+
+        await findResource('authors', {slug: 'jane'});
+
+        sinon.assert.calledWith(
+            models.Author.findOne,
+            sinon.match({slug: 'jane', visibility: 'public'}),
+            sinon.match.any
+        );
+    });
+
+    it('returns the toJSON result on hit, null on miss', async function () {
+        models.Post.findOne.onFirstCall().resolves(record({id: 'p1', slug: 'hello'}));
+        models.Post.findOne.onSecondCall().resolves(null);
+
+        assert.deepEqual(await findResource('posts', {slug: 'hello'}), {id: 'p1', slug: 'hello'});
+        assert.equal(await findResource('posts', {slug: 'missing'}), null);
+    });
+
+    it('returns null for unknown router types without touching any model', async function () {
+        const result = await findResource('unknown', {slug: 'anything'});
+
+        assert.equal(result, null);
+        sinon.assert.notCalled(models.Post.findOne);
+        sinon.assert.notCalled(models.TagPublic.findOne);
+        sinon.assert.notCalled(models.Author.findOne);
+    });
+});

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -252,6 +252,47 @@ describe('LazyUrlService', function () {
             assert.equal(hot.id, 'p3');
         });
 
+        // The next two tests pin the contract for findResource: tag/author
+        // filters expand to `tags.slug` / `authors.slug` lookups via
+        // EXPANSIONS, and NQL evaluates them against the loaded record. If
+        // findResource returns posts without their tags/authors relations,
+        // every tag- or author-filtered collection silently 404s.
+        it('returns null for a tag-filtered router when findResource omits the tags relation', async function () {
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('news', 'tag:news', 'posts', '/:slug/');
+
+            assert.equal(await service.resolveUrl('/hello/'), null);
+        });
+
+        it('resolves a tag-filtered router when findResource populates the tags relation', async function () {
+            const findResource = sinon.stub();
+            findResource
+                .withArgs('posts', {slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello', tags: [{slug: 'news'}]});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('news', 'tag:news', 'posts', '/:slug/');
+
+            const result = await service.resolveUrl('/hello/');
+            assert.equal(result.id, 'p1');
+        });
+
+        it('resolves an author-filtered router when findResource populates the authors relation', async function () {
+            const findResource = sinon.stub();
+            findResource
+                .withArgs('posts', {slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello', authors: [{slug: 'jane'}]});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('jane', 'author:jane', 'posts', '/:slug/');
+
+            const result = await service.resolveUrl('/hello/');
+            assert.equal(result.id, 'p1');
+        });
+
         it('returns null when no router template matches the URL', async function () {
             const findResource = sinon.stub();
             const service = new LazyUrlService({urlUtils, findResource});

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -1,0 +1,329 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const LazyUrlService = require('../../../../../core/server/services/url/lazy-url-service');
+
+function makeUrlUtils() {
+    // Just enough of url-utils to satisfy the service. createUrl returns the
+    // path verbatim so tests can assert on the relative form; replacePermalink
+    // does the same substitution Ghost's url-utils does for our limited fields.
+    // Permalinks use the `:field` syntax that Ghost's RouteSettings validator
+    // rewrites all `{field}` placeholders into before they reach the URL
+    // service.
+    return {
+        replacePermalink(permalink, resource) {
+            const datePart = resource.published_at ? new Date(resource.published_at) : null;
+            return permalink
+                .replace(/:slug\b/, resource.slug || '')
+                .replace(/:id\b/, resource.id || '')
+                .replace(/:primary_tag\b/, resource.primary_tag?.slug || '')
+                .replace(/:primary_author\b/, resource.primary_author?.slug || '')
+                .replace(/:year\b/, datePart ? String(datePart.getUTCFullYear()) : '')
+                .replace(/:month\b/, datePart ? String(datePart.getUTCMonth() + 1).padStart(2, '0') : '')
+                .replace(/:day\b/, datePart ? String(datePart.getUTCDate()).padStart(2, '0') : '');
+        },
+        createUrl(path, absolute, withSubdirectory) {
+            if (absolute) {
+                return `https://example.com${path}`;
+            }
+            if (withSubdirectory) {
+                return `/sub${path}`;
+            }
+            return path;
+        }
+    };
+}
+
+describe('LazyUrlService', function () {
+    let urlUtils;
+
+    beforeEach(function () {
+        urlUtils = makeUrlUtils();
+    });
+
+    describe('getUrlForResource', function () {
+        it('returns /404/ when no router has been registered', function () {
+            const service = new LazyUrlService({urlUtils});
+            const url = service.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
+            assert.equal(url, '/404/');
+        });
+
+        it('returns /404/ when called without a resource type', function () {
+            const service = new LazyUrlService({urlUtils});
+            assert.equal(service.getUrlForResource(null), '/404/');
+            assert.equal(service.getUrlForResource({}), '/404/');
+        });
+
+        it('uses the unfiltered collection router for any post', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello'});
+            assert.equal(url, '/hello/');
+        });
+
+        it('respects router priority for filtered collections', function () {
+            const service = new LazyUrlService({urlUtils});
+            // Featured posts go to /featured/, everything else to /:slug/.
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const featured = service.getUrlForResource({type: 'posts', id: 'f', slug: 'hot', featured: true});
+            const ordinary = service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', featured: false});
+
+            assert.equal(featured, '/featured/hot/');
+            assert.equal(ordinary, '/meh/');
+        });
+
+        it('falls back to /404/ when a post matches no collection filter', function () {
+            const service = new LazyUrlService({urlUtils});
+            // Only featured posts are routed.
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+
+            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', featured: false});
+            assert.equal(url, '/404/');
+        });
+
+        it('expands shorthand tag/author filters via the EXPANSIONS table', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('podcast', 'tag:podcast', 'posts', '/podcast/:slug/');
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const podcastPost = service.getUrlForResource({
+                type: 'posts',
+                id: 'p',
+                slug: 'episode-1',
+                tags: [{id: 't1', slug: 'podcast'}, {id: 't2', slug: 'misc'}]
+            });
+            assert.equal(podcastPost, '/podcast/episode-1/');
+        });
+
+        it('matches page:false against the singular DB type field', function () {
+            // The legacy transformer rewrites `page:false` to `type:post` and
+            // evaluates it against the resource's singular DB-style `type`
+            // field. The negative half (a record whose `type` is 'page'
+            // failing the filter) is not directly expressible through this
+            // public API: `_routerTypeOf('page')` returns 'pages', so a
+            // type:'page' resource is routed to the pages collection rather
+            // than reaching this posts router's filter at all. That's why
+            // only the positive match is asserted here.
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('posts-only', 'page:false', 'posts', '/:slug/');
+
+            const post = service.getUrlForResource({type: 'post', id: 'p', slug: 'hello'});
+            assert.equal(post, '/hello/');
+        });
+
+        it('handles deterministic ownership for tags/authors/pages', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('tagsRouter', null, 'tags', '/tag/:slug/');
+            service.onRouterAddedType('authorsRouter', null, 'authors', '/author/:slug/');
+            service.onRouterAddedType('staticPages', null, 'pages', '/:slug/');
+
+            assert.equal(
+                service.getUrlForResource({type: 'tags', id: 't1', slug: 'food'}),
+                '/tag/food/'
+            );
+            assert.equal(
+                service.getUrlForResource({type: 'authors', id: 'a1', slug: 'jane'}),
+                '/author/jane/'
+            );
+            assert.equal(
+                service.getUrlForResource({type: 'pages', id: 'pg1', slug: 'about'}),
+                '/about/'
+            );
+        });
+
+        it('substitutes date-based permalink fields', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('dated', null, 'posts', '/:year/:month/:slug/');
+
+            const url = service.getUrlForResource({
+                type: 'posts',
+                id: 'p',
+                slug: 'hello',
+                published_at: '2026-04-15T10:00:00Z'
+            });
+            assert.equal(url, '/2026/04/hello/');
+        });
+
+        it('honours the absolute and withSubdirectory options', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const post = {type: 'posts', id: 'p', slug: 'hello'};
+            assert.equal(service.getUrlForResource(post, {absolute: true}), 'https://example.com/hello/');
+            assert.equal(service.getUrlForResource(post, {withSubdirectory: true}), '/sub/hello/');
+        });
+    });
+
+    describe('ownsResource', function () {
+        it('returns false for an unknown router identifier', function () {
+            const service = new LazyUrlService({urlUtils});
+            assert.equal(service.ownsResource('unknown', {type: 'posts', id: 'p'}), false);
+        });
+
+        it('returns true for an unfiltered router that matches the resource type', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(service.ownsResource('default', {type: 'posts', id: 'p', slug: 'x'}), true);
+        });
+
+        it('returns false when the resource type does not match the router', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(service.ownsResource('default', {type: 'pages', id: 'p', slug: 'x'}), false);
+        });
+
+        it('evaluates NQL filters against the resource', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+
+            assert.equal(service.ownsResource('featured', {type: 'posts', id: 'a', featured: true}), true);
+            assert.equal(service.ownsResource('featured', {type: 'posts', id: 'b', featured: false}), false);
+        });
+    });
+
+    describe('hasFinished', function () {
+        it('always returns true', function () {
+            assert.equal(new LazyUrlService({urlUtils}).hasFinished(), true);
+        });
+    });
+
+    describe('reset', function () {
+        it('drops all registered router configs', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p'}), '/hello/');
+
+            service.reset();
+            assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p'}), '/404/');
+        });
+    });
+
+    describe('resolveUrl', function () {
+        it('returns null when no findResource hook is configured', async function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(await service.resolveUrl('/hello/'), null);
+        });
+
+        it('extracts slug params and queries the DB by router type', async function () {
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello', title: 'Hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const result = await service.resolveUrl('/hello/');
+            assert.deepEqual(result, {id: 'p1', slug: 'hello', title: 'Hello', type: 'posts'});
+            sinon.assert.calledWith(findResource, 'posts', {slug: 'hello'});
+        });
+
+        it('iterates routers in priority order, picking the first whose template matches', async function () {
+            // Two routers with overlapping templates: a single-segment posts
+            // collection at /:slug/ and a single-segment static-pages
+            // collection at /:slug/. Both can pattern-match `/hello/`. The
+            // posts collection is registered first, so it wins — and the
+            // static pages router is never consulted via findResource.
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('posts', null, 'posts', '/:slug/');
+            service.onRouterAddedType('staticPages', null, 'pages', '/:slug/');
+
+            const result = await service.resolveUrl('/hello/');
+            assert.equal(result.type, 'posts');
+            assert.equal(result.id, 'p1');
+            sinon.assert.neverCalledWith(findResource, 'pages', sinon.match.any);
+        });
+
+        it('verifies NQL filters for filtered post collections', async function () {
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'plain'}).resolves({id: 'p2', slug: 'plain', featured: false});
+            findResource.withArgs('posts', {slug: 'hot'}).resolves({id: 'p3', slug: 'hot', featured: true});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+
+            // 'plain' is found in the DB but its featured filter rejects it.
+            assert.equal(await service.resolveUrl('/featured/plain/'), null);
+            const hot = await service.resolveUrl('/featured/hot/');
+            assert.equal(hot.id, 'p3');
+        });
+
+        it('returns null when no router template matches the URL', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            assert.equal(await service.resolveUrl('/some/other/path/'), null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('matches multi-segment permalinks (e.g. /:primary_tag/:slug/)', async function () {
+            const findResource = sinon.stub();
+            // withArgs binds the resolve to the exact param shape, so a
+            // regression that drops one of the captures (e.g. forgets to
+            // pass `primary_tag`) fails on the resolve, not just on the spy.
+            findResource
+                .withArgs('posts', {primary_tag: 'podcast', slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:primary_tag/:slug/');
+
+            const result = await service.resolveUrl('/podcast/hello/');
+            assert.equal(result.id, 'p1');
+            assert.equal(result.type, 'posts');
+        });
+
+        it('matches date-based permalinks', async function () {
+            const findResource = sinon.stub();
+            findResource
+                .withArgs('posts', {year: '2026', month: '04', slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:year/:month/:slug/');
+
+            const result = await service.resolveUrl('/2026/04/hello/');
+            assert.equal(result.id, 'p1');
+        });
+
+        it('does not throw on malformed %-escapes; returns null instead', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const result = await service.resolveUrl('/foo%ZZ/');
+            assert.equal(result, null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('rejects mixed-literal-and-placeholder segments (no ReDoS surface)', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            // Mixed segments like `/blog-:slug/` are not a documented Ghost
+            // permalink shape; we deliberately don't try to match them.
+            service.onRouterAddedType('default', null, 'posts', '/blog-:slug/');
+
+            assert.equal(await service.resolveUrl('/blog-hello/'), null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('uses the singular DB type field to find posts collections', async function () {
+            const findResource = sinon.stub();
+            findResource.resolves({id: 'p1', slug: 'hello', type: 'post'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            // Caller (e.g. the entry controller / RSS feed) hands the lazy
+            // service a raw DB record with type:'post'. The service should
+            // still match the posts collection.
+            const url = service.getUrlForResource({type: 'post', id: 'p1', slug: 'hello'});
+            assert.equal(url, '/hello/');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -93,4 +93,60 @@ describe('UrlServiceFacade', function () {
             sinon.assert.calledWith(urlService.onRouterUpdated, 'id');
         });
     });
+
+    describe('lazy mode (lazyUrlService backend)', function () {
+        let lazyUrlService;
+        let lazyFacade;
+
+        beforeEach(function () {
+            lazyUrlService = {
+                getUrlForResource: sinon.stub().returns('/lazy/'),
+                ownsResource: sinon.stub().returns(true),
+                resolveUrl: sinon.stub().resolves({type: 'posts', id: 'p1'}),
+                hasFinished: sinon.stub().returns(true),
+                onRouterAddedType: sinon.stub(),
+                onRouterUpdated: sinon.stub(),
+                reset: sinon.stub()
+            };
+            lazyFacade = new UrlServiceFacade({urlService, lazyUrlService});
+        });
+
+        it('isLazy() reports true', function () {
+            assert.equal(lazyFacade.isLazy(), true);
+        });
+
+        it('routes getUrlForResource through the lazy backend', function () {
+            const url = lazyFacade.getUrlForResource({type: 'posts', id: 'a'}, {absolute: true});
+            sinon.assert.calledWith(lazyUrlService.getUrlForResource, {type: 'posts', id: 'a'}, {absolute: true});
+            sinon.assert.notCalled(urlService.getUrlByResourceId);
+            assert.equal(url, '/lazy/');
+        });
+
+        it('routes ownsResource through the lazy backend', function () {
+            lazyFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
+            sinon.assert.calledWith(lazyUrlService.ownsResource, 'routerA', {type: 'posts', id: 'a'});
+            sinon.assert.notCalled(urlService.owns);
+        });
+
+        it('returns the lazy backend resource directly from resolveUrl', async function () {
+            const result = await lazyFacade.resolveUrl('/x/');
+            sinon.assert.calledWith(lazyUrlService.resolveUrl, '/x/');
+            sinon.assert.notCalled(urlService.getResource);
+            assert.deepEqual(result, {type: 'posts', id: 'p1'});
+        });
+
+        it('forwards lifecycle hooks to the lazy backend', function () {
+            lazyFacade.onRouterAddedType('id', 'filter', 'posts', '/{slug}/');
+            lazyFacade.onRouterUpdated('id');
+            sinon.assert.calledWith(lazyUrlService.onRouterAddedType, 'id', 'filter', 'posts', '/{slug}/');
+            sinon.assert.calledWith(lazyUrlService.onRouterUpdated, 'id');
+            sinon.assert.notCalled(urlService.onRouterAddedType);
+            sinon.assert.notCalled(urlService.onRouterUpdated);
+        });
+
+        it('reset() drops registered router configs on the lazy backend', function () {
+            lazyFacade.reset();
+            sinon.assert.calledOnce(lazyUrlService.reset);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Experimental opt-in lazy URL routing service behind `config.lazyRouting` (default `false`). When the flag is on, the existing eager `UrlService` is replaced by an on-demand `LazyUrlService` that resolves URLs from the DB the first time each one is asked for.

**Stacked on #27713 — that PR must merge first.**

ref https://linear.app/ghost/issue/HKG-1738/

## Why

The eager URL service preloads every post / page / tag / author URL at boot through an 8-stage pipeline. On large sites that's a non-trivial chunk of cold-start time and resident memory. The hypothesis: an on-demand implementation can be fast enough in production while shrinking boot time and RSS.

This PR ships the implementation gated by a flag so we can measure against real traffic before deciding whether to default it on.

## What flips on with `config.lazyRouting: true`

- `UrlServiceFacade` routes through `LazyUrlService` instead of the eager service.
- `SiteMapManager` populates from the DB on first sitemap request (per type, paginated). Mirrors the eager URL service's resource queries: posts/pages by `status:published+type:`, tags/authors by `visibility:public`, plus `withRelated: ['tags', 'authors']` for posts so `:primary_tag`/`:primary_author` permalinks resolve.
- `bridge.start()` skips `urlService.queue.start` (no precompute).
- `route-settings.setFromFilePath` skips the readiness poll, since the lazy service is always finished.

Default-off. Flag-off path is unchanged from `main` after #27713.

## How to review

**Please review commit-by-commit.** Each commit is independently reviewable:

1. **Added DB-driven sitemap population for the lazyRouting flag** — sitemap can't subscribe to the `url.added` / `url.removed` events the lazy backend doesn't fire, so it populates from the DB on first request. Includes a generation-token guard against `routers.reset`-mid-populate races.
2. **Added LazyUrlService class for on-demand URL resolution** (TS) — pure for forward lookups; one injected `findResource` hook for reverse lookups. Same NQL `EXPANSIONS` table and `page:true|false` transformer as the eager `UrlGenerator`.
3. **Added config.lazyRouting flag to swap in LazyUrlService at boot** — wires the lazy backend into the facade and skips the eager init / shutdown when the flag is on.

## Test plan

- [x] Unit tests pass for both flag states
- [x] CI green on the previous umbrella PR
- [ ] Smoke test with `lazyRouting: true` locally
- [ ] Run benchmarks against a 250K-post production clone (tracked in the Linear project document, not in this repo)