### PR TITLE
Moved Docker registry mirror setup before Buildx in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -968,6 +968,9 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Setup Docker Registry Mirrors
+        uses: ./.github/actions/setup-docker-registry-mirrors
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -1175,6 +1178,9 @@ jobs:
       - name: Extract public app artifacts
         run: tar -xzf e2e-public-apps.tar.gz
 
+      - name: Setup Docker Registry Mirrors
+        uses: ./.github/actions/setup-docker-registry-mirrors
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:
@@ -1275,6 +1281,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Docker Registry Mirrors
+        uses: ./.github/actions/setup-docker-registry-mirrors
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -1297,9 +1306,6 @@ jobs:
           use-artifact: ${{ needs.job_build_e2e_image.outputs.use-artifact }}
           image-tags: ${{ needs.job_build_e2e_image.outputs.image-tags }}
           artifact-name: docker-image-e2e
-
-      - name: Setup Docker Registry Mirrors
-        uses: ./.github/actions/setup-docker-registry-mirrors
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6


### PR DESCRIPTION
## Summary

- `setup-buildx-action` (default `docker-container` driver) bootstraps by pulling `moby/buildkit:buildx-stable-1` from Docker Hub. Intermittent Docker Hub auth timeouts (`auth.docker.io` deadline exceeded) have been taking down e2e shards before any tests run.
- The `job_e2e_tests` job already configured `mirror.gcr.io` via the `setup-docker-registry-mirrors` action, but the step ran *after* Buildx — too late to help with the failing pull. The other two Buildx-using jobs (`job_build_artifacts`, `job_build_e2e_image`) had no mirror at all.
- This PR moves the mirror step ahead of Buildx in all three jobs so the buildkit pull (and every subsequent Docker Hub pull in the job) is routed through the GCR pull-through cache, taking Docker Hub off the critical path.

## Test plan

- [ ] CI runs to green; `Set up Docker Buildx` completes without contacting `auth.docker.io`
- [ ] No regression in `job_build_artifacts` or `job_build_e2e_image` image builds