### PR TITLE
Fixed pre-commit lint hook routing for all workspaces

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,69 +1,50 @@
 const path = require('path');
+const fs = require('fs');
 
-const SCOPED_WORKSPACES = [
-    'e2e',
-    'apps/admin',
-    'apps/posts',
-    'apps/shade'
-];
+const ROOT = process.cwd();
 
-function normalize(file) {
-    return file.split(path.sep).join('/');
-}
-
-function isInWorkspace(file, workspace) {
-    const normalizedFile = normalize(path.relative(process.cwd(), file));
-    const normalizedWorkspace = normalize(workspace);
-
-    return normalizedFile === normalizedWorkspace || normalizedFile.startsWith(`${normalizedWorkspace}/`);
+function normalize(p) {
+    return p.split(path.sep).join('/');
 }
 
 function shellQuote(value) {
     return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function buildScopedEslintCommand(workspace, files) {
-    if (files.length === 0) {
-        return null;
+function findWorkspace(file) {
+    let dir = path.dirname(path.resolve(file));
+    while (dir.startsWith(ROOT) && dir !== ROOT) {
+        if (fs.existsSync(path.join(dir, 'package.json'))) {
+            return normalize(path.relative(ROOT, dir));
+        }
+        dir = path.dirname(dir);
     }
-
-    const relativeFiles = files
-        .map(file => normalize(path.relative(workspace, file)))
-        .map(shellQuote)
-        .join(' ');
-
-    return `pnpm --dir ${shellQuote(workspace)} exec eslint --cache ${relativeFiles}`;
+    return null;
 }
 
-function buildRootEslintCommand(files) {
-    if (files.length === 0) {
-        return null;
-    }
-
-    const quotedFiles = files.map(file => shellQuote(normalize(file))).join(' ');
-    return `eslint --cache ${quotedFiles}`;
+function buildCommand(workspace, files) {
+    const base = workspace ? path.join(ROOT, workspace) : ROOT;
+    const relativeFiles = files
+        .map(file => normalize(path.relative(base, file)))
+        .map(shellQuote)
+        .join(' ');
+    const dirArg = workspace ? `--dir ${shellQuote(workspace)} ` : '';
+    return `pnpm ${dirArg}exec eslint --cache ${relativeFiles}`;
 }
 
 module.exports = {
     '*.{js,ts,tsx,jsx,cjs}': (files) => {
-        const workspaceGroups = new Map(SCOPED_WORKSPACES.map(workspace => [workspace, []]));
-        const rootFiles = [];
-
+        const groups = new Map();
         for (const file of files) {
-            const workspace = SCOPED_WORKSPACES.find(candidate => isInWorkspace(file, candidate));
-
-            if (workspace) {
-                workspaceGroups.get(workspace).push(file);
-            } else {
-                rootFiles.push(file);
+            const workspace = findWorkspace(file);
+            const key = workspace ?? '';
+            if (!groups.has(key)) {
+                groups.set(key, []);
             }
+            groups.get(key).push(file);
         }
-
-        return [
-            ...SCOPED_WORKSPACES
-                .map(workspace => buildScopedEslintCommand(workspace, workspaceGroups.get(workspace)))
-                .filter(Boolean),
-            buildRootEslintCommand(rootFiles)
-        ].filter(Boolean);
+        return [...groups.entries()].map(([workspace, wsFiles]) =>
+            buildCommand(workspace || null, wsFiles)
+        );
     }
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -11,11 +11,69 @@ function shellQuote(value) {
     return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+// Parse the `packages:` list from pnpm-workspace.yaml. We only need the simple
+// glob shapes pnpm allows here (`apps/*`, `ghost/*`, `e2e`); anything fancier
+// would warrant a real YAML parser.
+function loadWorkspacePatterns() {
+    const yaml = fs.readFileSync(path.join(ROOT, 'pnpm-workspace.yaml'), 'utf8');
+    const lines = yaml.split('\n');
+    const start = lines.findIndex(line => /^packages:\s*$/.test(line));
+    if (start === -1) {
+        return [];
+    }
+    const patterns = [];
+    for (let i = start + 1; i < lines.length; i++) {
+        const line = lines[i];
+        if (/^\s+-\s+/.test(line)) {
+            const match = line.match(/^\s+-\s+['"]?([^'"\s]+)['"]?\s*$/);
+            if (match) {
+                patterns.push(match[1]);
+            }
+        } else if (line.trim() !== '' && !/^\s/.test(line)) {
+            break;
+        }
+    }
+    return patterns;
+}
+
+function expandPattern(pattern) {
+    const segments = pattern.split('/');
+    let candidates = [''];
+    for (const segment of segments) {
+        const next = [];
+        for (const base of candidates) {
+            const dir = base ? path.join(ROOT, base) : ROOT;
+            if (segment === '*') {
+                if (!fs.existsSync(dir)) {
+                    continue;
+                }
+                for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+                    if (entry.isDirectory()) {
+                        next.push(base ? `${base}/${entry.name}` : entry.name);
+                    }
+                }
+            } else {
+                const candidate = base ? `${base}/${segment}` : segment;
+                if (fs.existsSync(path.join(ROOT, candidate))) {
+                    next.push(candidate);
+                }
+            }
+        }
+        candidates = next;
+    }
+    return candidates;
+}
+
+const WORKSPACES = new Set(
+    loadWorkspacePatterns().flatMap(expandPattern)
+);
+
 function findWorkspace(file) {
     let dir = path.dirname(path.resolve(file));
     while (dir.startsWith(ROOT) && dir !== ROOT) {
-        if (fs.existsSync(path.join(dir, 'package.json'))) {
-            return normalize(path.relative(ROOT, dir));
+        const rel = normalize(path.relative(ROOT, dir));
+        if (WORKSPACES.has(rel)) {
+            return rel;
         }
         dir = path.dirname(dir);
     }
@@ -29,7 +87,7 @@ function buildCommand(workspace, files) {
         .map(shellQuote)
         .join(' ');
     const dirArg = workspace ? `--dir ${shellQuote(workspace)} ` : '';
-    return `pnpm ${dirArg}exec eslint --cache ${relativeFiles}`;
+    return `pnpm ${dirArg}exec eslint --cache -- ${relativeFiles}`;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- `.lintstagedrc.cjs` previously maintained a manual `SCOPED_WORKSPACES` allowlist; files outside the listed workspaces fell through to a root `eslint` invocation.
- That root path fails for workspaces whose eslint configs enable `eslint-plugin-tailwindcss`. The plugin resolves tailwindcss via `local-pkg.getPackageInfoSync("tailwindcss")` from `process.cwd()`, and tailwindcss is not a root dependency. Result: `Error: Could not find tailwindcss`.
- The allowlist was only extended reactively (e.g. `apps/posts` / `apps/shade` in #26970 when Tailwind v4 + plugin v4-beta surfaced the failure). Seven other workspaces have been latently broken for local commits ever since: `apps/activitypub`, `apps/admin-x-design-system`, `apps/admin-x-framework`, `apps/admin-x-settings`, `apps/comments-ui`, `apps/signup-form`, `apps/stats`. CI doesn't notice because `.github/hooks/pre-commit.bash` exits early under `$CI`.
- Replaced the allowlist with auto-discovery: walk up from each staged file to its nearest `package.json` and run `pnpm --dir <ws> exec eslint`. New workspaces and new tailwindcss-plugin adopters are picked up automatically; the dichotomy between "scoped" and "root" eslint goes away.
- Every workspace in the repo has an eslint config (either `.eslintrc.*` / `eslint.config.*` or an inline `eslintConfig` in `package.json`), so scoped runs always find a config.

## Why not other approaches

- **Extending the allowlist** — fixes today's symptoms; will silently break again next time a workspace adopts the tailwindcss plugin or a new workspace lands.
- **Hoisting `tailwindcss` to root** (`public-hoist-pattern[]=tailwindcss`) — one-line change but masks phantom-dep usage repo-wide and runs root eslint against every workspace's files, which isn't what each workspace's config necessarily wants.
- **Adding a root eslint config** — workspace `.eslintrc`s are `root: true`, so a root config wouldn't be inherited by them anyway. Doesn't address the cwd-based tailwindcss resolution.

## Test plan

- [x] Reproduced the original failure on `main`: `pnpm exec eslint --cache 'apps/activitypub/src/api/activitypub.ts'` → `Could not find tailwindcss`.
- [x] After the change, dry-ran `pnpm lint-staged --relative` with a staged edit in `apps/activitypub/src/api/activitypub.ts` → routes to `pnpm --dir 'apps/activitypub' exec eslint`, exits 0.
- [x] Cross-workspace dry-run with staged edits in `apps/activitypub` and `ghost/core` simultaneously → both scoped commands run, exit 0.
- [x] Verified routing for representative files across every workspace (apps/* and ghost/*) plus root-level files (`scripts/`, top-level configs) routes correctly.
- [x] Pre-commit hook on this PR's own commit ran lint-staged successfully against `.lintstagedrc.cjs` itself (root-level file → unscoped `pnpm exec eslint`).