### PR TITLE
Cleaned up CORS middleware exports

### DIFF
--- a/ghost/core/core/server/web/api/middleware/cors.js
+++ b/ghost/core/core/server/web/api/middleware/cors.js
@@ -87,7 +87,7 @@ function corsOptionsDelegate(req, cb) {
  * @param {Express.Response} res
  * @param {Function} next
  */
-const handleCaching = function handleCaching(req, res, next) {
+const corsCaching = function corsCaching(req, res, next) {
     const method = req.method && req.method.toUpperCase && req.method.toUpperCase();
     if (method === 'OPTIONS') {
         // @NOTE: try to add native support for dynamic 'vary' header value in 'cors' module
@@ -96,7 +96,5 @@ const handleCaching = function handleCaching(req, res, next) {
     next();
 };
 
-module.exports = [
-    handleCaching,
-    cors(corsOptionsDelegate)
-];
+exports.corsMiddleware = cors(corsOptionsDelegate);
+exports.corsCaching = corsCaching;

--- a/ghost/core/core/server/web/api/middleware/index.js
+++ b/ghost/core/core/server/web/api/middleware/index.js
@@ -1,5 +1,10 @@
+const {corsCaching, corsMiddleware} = require('./cors');
+
 module.exports = {
-    cors: require('./cors'),
+    cors: [
+        corsCaching,
+        corsMiddleware
+    ],
     updateUserLastSeen: require('./update-user-last-seen'),
     upload: require('./upload')
 };

--- a/ghost/core/test/unit/server/web/api/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/cors.test.js
@@ -3,8 +3,8 @@ const sinon = require('sinon');
 const rewire = require('rewire');
 const configUtils = require('../../../../../utils/config-utils');
 
-let cors = rewire('../../../../../../core/server/web/api/middleware/cors')[1];
-let corsCaching = rewire('../../../../../../core/server/web/api/middleware/cors')[0];
+let cors = rewire('../../../../../../core/server/web/api/middleware/cors').corsMiddleware;
+const {corsCaching} = rewire('../../../../../../core/server/web/api/middleware/cors');
 
 describe('cors', function () {
     let res;
@@ -37,7 +37,7 @@ describe('cors', function () {
     afterEach(async function () {
         sinon.restore();
         await configUtils.restore();
-        cors = rewire('../../../../../../core/server/web/api/middleware/cors')[1];
+        cors = rewire('../../../../../../core/server/web/api/middleware/cors').corsMiddleware;
     });
 
     it('should not be enabled without a request origin header', function (done) {


### PR DESCRIPTION
no ref

1. Renamed an export with a clearer name
2. Used named exports instead of exporting an array