### PR TITLE
Added knip CI job in advisory mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,31 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  job_knip:
+    runs-on: ubuntu-latest
+    needs: [job_setup]
+    name: Unused dependencies (advisory)
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for unused dependencies (knip)
+        run: |
+          set +e
+          pnpm knip
+          code=$?
+          if [ $code -ne 0 ]; then
+            echo "::warning title=Unused dependencies (advisory)::knip exited $code — see logs above. Advisory only; not blocking the merge."
+          fi
+          exit 0
+
   job_i18n:
     runs-on: ubuntu-latest
     needs: [job_setup]


### PR DESCRIPTION
## Summary

Adds a `Knip (advisory)` job to `ci.yml` that runs `pnpm knip` on every PR. The job has `continue-on-error: true` and is **not** in `job_required_tests.needs`, so a knip failure produces a yellow check that surfaces unused-dep regressions but does not block merging.

This is the trial run before flipping it to a required check (a follow-up PR can do that once the team is comfortable with the signal).

## Why

#27716 wired up knip locally and #27720 cleared the genuinely vestigial entries from the baseline. Without a CI step, new vestigial deps will accumulate again — `pnpm audit` doesn't catch them since it only diffs lockfile resolutions against the advisory database.

Running it as advisory first lets the team see what the check would have done on real PRs (false-positive rate on dynamic imports, plugin-resolved deps, runner-invoked binaries) before we treat it as a gate.

## Test plan

- [ ] CI runs the new `Knip (advisory)` job
- [ ] Job exit status is reported but does not block merging (not in `job_required_tests`)
- [ ] When the baseline is clean, the job will be a green check; when it isn't, it'll be yellow (continue-on-error)