### PR TITLE
Removed unnecessary `URL` imports

### DIFF
--- a/ghost/core/core/frontend/web/middleware/cors.js
+++ b/ghost/core/core/frontend/web/middleware/cors.js
@@ -1,4 +1,3 @@
-const {URL} = require('url');
 const cors = require('cors');
 const errors = require('@tryghost/errors');
 const config = require('../../../shared/config');

--- a/ghost/core/core/server/services/members/members-config-provider.js
+++ b/ghost/core/core/server/services/members/members-config-provider.js
@@ -1,5 +1,4 @@
 const logging = require('@tryghost/logging');
-const {URL} = require('url');
 const createKeypair = require('keypair');
 
 class MembersConfigProvider {

--- a/ghost/core/core/server/services/members/stripe-connect.js
+++ b/ghost/core/core/server/services/members/stripe-connect.js
@@ -2,7 +2,6 @@ const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const {Buffer} = require('buffer');
 const {randomBytes} = require('crypto');
-const {URL} = require('url');
 
 const config = require('../../../shared/config');
 const urlUtils = require('../../../shared/url-utils');

--- a/ghost/core/core/server/web/members/middleware/cors.js
+++ b/ghost/core/core/server/web/members/middleware/cors.js
@@ -1,4 +1,3 @@
-const {URL} = require('url');
 const cors = require('cors');
 const config = require('../../../../shared/config');
 


### PR DESCRIPTION
no ref

We don't need to import `URL` from `url` any more.
