### PR TITLE
Dropped some usages of deprecated `url` functions

### DIFF
--- a/ghost/core/core/frontend/utils/images.js
+++ b/ghost/core/core/frontend/utils/images.js
@@ -1,4 +1,3 @@
-const url = require('url');
 const imageTransform = require('@tryghost/image-transform');
 const urlUtils = require('../../shared/url-utils');
 const storageUtils = require('../../server/adapters/storage/utils');
@@ -11,7 +10,7 @@ module.exports.detectInternalImage = function detectInternalImage(requestedImage
     // CASE: imagePath is a "protocol relative" url e.g. "//www.gravatar.com/ava..."
     //       by resolving the the imagePath relative to the blog url, we can then
     //       detect if the imagePath is external, or internal.
-    const isRelativeInternalImage = !isAbsoluteImage && url.resolve(siteUrl, requestedImageUrl).startsWith(siteUrl);
+    const isRelativeInternalImage = !isAbsoluteImage && new URL(requestedImageUrl, siteUrl).toString().startsWith(siteUrl);
 
     return isAbsoluteInternalImage || isRelativeInternalImage;
 };

--- a/ghost/core/core/server/services/auth/members/index.js
+++ b/ghost/core/core/server/services/auth/members/index.js
@@ -6,8 +6,7 @@ const config = require('../../../../shared/config');
 let UNO_MEMBERINO;
 
 async function createMiddleware() {
-    const url = require('url');
-    const {protocol, host} = url.parse(config.get('url'));
+    const {protocol, host} = new URL(config.get('url'));
     const siteOrigin = `${protocol}//${host}`;
 
     const membersConfig = await membersService.api.getPublicConfig();

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
 const supertest = require('supertest');
 const _ = require('lodash');
-const url = require('url');
 const configUtils = require('../../utils/config-utils');
 const config = require('../../../core/shared/config');
 const testUtils = require('../../utils');
@@ -50,9 +49,8 @@ describe('Tags Content API', function () {
             assert.equal(jsonResponse.tags[4].name, 'kitchen sink');
         }
 
-        assertExists(res.body.tags[0].url);
-        assertExists(url.parse(res.body.tags[0].url).protocol);
-        assertExists(url.parse(res.body.tags[0].url).host);
+        assert(new URL(res.body.tags[0].url).protocol);
+        assert(new URL(res.body.tags[0].url).host);
     });
 
     it('Can request tags with limit=all', async function () {

--- a/ghost/core/test/utils/api.js
+++ b/ghost/core/test/utils/api.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const _ = require('lodash');
-const url = require('url');
 const moment = require('moment');
 const DataGenerator = require('./fixtures/data-generator');
 const config = require('../../core/shared/config');
@@ -15,11 +14,11 @@ function getURL() {
 }
 
 function getSigninURL() {
-    return url.resolve(protocol + host + ':' + port, 'ghost/signin/');
+    return new URL('ghost/signin/', protocol + host + ':' + port).toString();
 }
 
 function getAdminURL() {
-    return url.resolve(protocol + host + ':' + port, 'ghost/');
+    return new URL('ghost/', protocol + host + ':' + port).toString();
 }
 
 function isISO8601(date) {


### PR DESCRIPTION
no ref

`url.parse` and `url.resolve` are deprecated. Let's replace a few of them with `URL`. (These are the easy ones.)
