### PR TITLE
Improved admin-x settings test request waits

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -268,6 +268,12 @@ export async function mockApi<Requests extends Record<string, MockRequestConfig>
     return {lastApiRequests};
 }
 
+export async function waitForApiRequest<Requests extends Record<string, MockRequestConfig>>(lastApiRequests: {[key in keyof Requests]?: RequestRecord}, requestName: keyof Requests) {
+    await expect.poll(() => lastApiRequests[requestName]).toBeTruthy();
+
+    return lastApiRequests[requestName]!;
+}
+
 export function updatedSettingsResponse(newSettings: Array<{ key: string, value: string | boolean | null, is_read_only?: boolean }>) {
     return {
         ...responseFixtures.settings,

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/test';
-import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
+import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse, waitForApiRequest} from '@tryghost/admin-x-framework/test/acceptance';
 
 // Helper functions to reduce mockApi boilerplate
 const createConfigWithFeatureFlags = (limits?: any) => ({
@@ -97,8 +97,9 @@ test.describe('Analytics settings', async () => {
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        const body = lastApiRequests.editSettings?.body as {settings: Array<{key: string, value: boolean}>} | undefined;
-        const actualSettings = body?.settings || [];
+        const editSettings = await waitForApiRequest(lastApiRequests, 'editSettings');
+        const body = editSettings.body as {settings: Array<{key: string, value: boolean}>};
+        const actualSettings = body.settings || [];
         const expectedSettings = [
             {key: 'web_analytics', value: false},
             {key: 'members_track_sources', value: false},
@@ -129,7 +130,8 @@ test.describe('Analytics settings', async () => {
 
         await section.getByRole('button', {name: 'Post analytics'}).click();
 
-        const hasDownloadUrl = lastApiRequests.postsExport?.url?.includes('/posts/export/?limit=1000');
+        const postsExport = await waitForApiRequest(lastApiRequests, 'postsExport');
+        const hasDownloadUrl = postsExport.url?.includes('/posts/export/?limit=1000');
         expect(hasDownloadUrl).toBe(true);
     });
 
@@ -211,7 +213,8 @@ test.describe('Analytics settings', async () => {
         await webAnalyticsToggle.uncheck();
         await section.getByRole('button', {name: 'Save'}).click();
 
-        expect(lastApiRequests.editSettings?.body).toEqual({
+        const editSettings = await waitForApiRequest(lastApiRequests, 'editSettings');
+        expect(editSettings.body).toEqual({
             settings: [
                 {key: 'web_analytics', value: false}
             ]
@@ -270,7 +273,8 @@ test.describe('Analytics settings', async () => {
         await webAnalyticsToggle.check();
         await section.getByRole('button', {name: 'Save'}).click();
 
-        expect(lastApiRequests.editSettings?.body).toEqual({
+        const editSettings = await waitForApiRequest(lastApiRequests, 'editSettings');
+        expect(editSettings.body).toEqual({
             settings: [
                 {key: 'web_analytics', value: true}
             ]

--- a/apps/admin-x-settings/test/acceptance/membership/stripe.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/stripe.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/test';
-import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
+import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse, waitForApiRequest} from '@tryghost/admin-x-framework/test/acceptance';
 
 test.describe('Stripe settings', async () => {
     test('Supports the Stripe Connect flow', async ({page}) => {
@@ -39,7 +39,8 @@ test.describe('Stripe settings', async () => {
         await expect(section.getByText('Connected to Stripe')).toHaveCount(2);
 
         // We actually do two settings update requests here, this just checks the last one
-        expect(lastApiRequests.editSettings?.body).toEqual({
+        const editSettings = await waitForApiRequest(lastApiRequests, 'editSettings');
+        expect(editSettings.body).toEqual({
             settings: [{
                 key: 'portal_plans',
                 value: '["free","monthly","yearly"]'
@@ -78,7 +79,8 @@ test.describe('Stripe settings', async () => {
         // There's a mobile version of the same button in the DOM
         await expect(section.getByText('Connected to Stripe')).toHaveCount(2);
 
-        expect(lastApiRequests.editSettings?.body).toEqual({
+        const editSettings = await waitForApiRequest(lastApiRequests, 'editSettings');
+        expect(editSettings.body).toEqual({
             settings: [{
                 key: 'stripe_secret_key',
                 value: 'sk_test_123'

--- a/apps/admin-x-settings/test/acceptance/site/design.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/design.test.ts
@@ -4,7 +4,8 @@ import {
     mockApi,
     mockSitePreview,
     responseFixtures,
-    updatedSettingsResponse
+    updatedSettingsResponse,
+    waitForApiRequest
 } from '@tryghost/admin-x-framework/test/acceptance';
 import {expect, test} from '@playwright/test';
 
@@ -140,7 +141,8 @@ test.describe('Design settings', async () => {
         await expect(modal.getByTestId('toggle-unsplash-button')).toBeVisible();
         await modal.getByRole('button', {name: 'Save'}).click();
 
-        expect(lastApiRequests.editSettings?.body).toEqual({
+        const editSettings = await waitForApiRequest(lastApiRequests, 'editSettings');
+        expect(editSettings.body).toEqual({
             settings: [
                 {key: 'accent_color', value: '#cd5786'}
             ]
@@ -186,12 +188,14 @@ test.describe('Design settings', async () => {
         const expectedSettings = {navigation_layout: 'Logo in the middle'};
         const expectedEncoded = new URLSearchParams([['custom', JSON.stringify(expectedSettings)]]).toString();
 
+        await expect.poll(() => previewRequests.find(header => new RegExp(`&${expectedEncoded.replace(/\+/g, '\\+')}`).test(header))).toBeTruthy();
         const matchingHeader = previewRequests.find(header => new RegExp(`&${expectedEncoded.replace(/\+/g, '\\+')}`).test(header));
 
         expect(matchingHeader).toBeDefined();
 
         await modal.getByRole('button', {name: 'Save'}).click();
-        expect(lastApiRequests.editCustomThemeSettings?.body).toMatchObject({
+        const editCustomThemeSettings = await waitForApiRequest(lastApiRequests, 'editCustomThemeSettings');
+        expect(editCustomThemeSettings.body).toMatchObject({
             custom_theme_settings: [
                 {key: 'navigation_layout', value: 'Logo in the middle'}
             ]
@@ -289,6 +293,7 @@ test.describe('Design settings', async () => {
         const expectedSettings = {navigation_layout: 'Logo in the middle', show_featured_posts: null};
         const expectedEncoded = new URLSearchParams([['custom', JSON.stringify(expectedSettings)]]).toString();
 
+        await expect.poll(() => previewRequests.find(header => header.includes(expectedEncoded))).toBeTruthy();
         const matchingHeader = previewRequests.find(header => header.includes(expectedEncoded));
 
         expect(matchingHeader).toBeDefined();
@@ -296,7 +301,8 @@ test.describe('Design settings', async () => {
 
         await modal.getByRole('button', {name: 'Save'}).click();
 
-        expect(lastApiRequests.editCustomThemeSettings?.body).toMatchObject({
+        const editCustomThemeSettings = await waitForApiRequest(lastApiRequests, 'editCustomThemeSettings');
+        expect(editCustomThemeSettings.body).toMatchObject({
             custom_theme_settings: [
                 {key: 'navigation_layout', value: 'Logo in the middle'},
                 {key: 'show_featured_posts', value: 'false'}


### PR DESCRIPTION
## Summary
- added a shared `waitForApiRequest` helper for Playwright acceptance tests that inspect mocked API calls
- updated flaky-prone admin-x settings specs to wait for route-handler captures before asserting request bodies/URLs
- updated design preview assertions to wait for the expected preview header instead of reading the capture synchronously

## Rationale
The stronger signal is that several tests click/save and immediately inspect `lastApiRequests`, which is populated asynchronously by `page.route`. On loaded CI runners that can race. 

## Testing
- `pnpm nx run @tryghost/admin-x-settings:test:acceptance -- test/acceptance/site/design.test.ts test/acceptance/membership/stripe.test.ts test/acceptance/membership/analytics.test.ts --workers=4 --reporter=line`
- lint-staged eslint via commit hook for changed files