### PR TITLE
Added eslint declarations to workspaces missing them

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.16",
+  "version": "3.1.18",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,6 +42,7 @@
     "@types/jest": "29.5.14",
     "@types/react": "18.3.28",
     "@types/react-dom": "18.3.7",
+    "eslint": "catalog:",
     "jest": "29.7.0",
     "tailwindcss": "^4.2.2",
     "vite": "5.4.21",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/announcement-bar",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -83,6 +83,7 @@
     "@vitest/coverage-v8": "~3.2.4",
     "concurrently": "8.2.2",
     "cross-fetch": "4.1.0",
+    "eslint": "catalog:",
     "jsdom": "28.1.0",
     "vite": "5.4.21",
     "vite-plugin-svgr": "3.3.0",

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -45,6 +45,7 @@
         "@types/jest": "29.5.14",
         "@types/react": "18.3.28",
         "@vitest/coverage-v8": "^1.6.1",
+        "eslint": "catalog:",
         "msw": "2.12.14",
         "tailwindcss": "^4.2.2",
         "vite": "5.4.21",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/sodo-search",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -101,6 +101,7 @@
     "@vitest/coverage-v8": "~3.2.4",
     "concurrently": "8.2.2",
     "cross-fetch": "4.1.0",
+    "eslint": "catalog:",
     "jsdom": "28.1.0",
     "nock": "13.5.6",
     "tailwindcss": "3.4.18",

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -50,6 +50,7 @@
         "@vitest/coverage-v8": "^1.6.1",
         "@vitejs/plugin-react": "4.7.0",
         "dotenv": "17.3.1",
+        "eslint": "catalog:",
         "tailwindcss": "^4.2.2",
         "vite": "5.4.21",
         "vite-plugin-svgr": "4.5.0",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -270,6 +270,7 @@
     "cli-progress": "3.12.0",
     "cssnano": "7.1.1",
     "esbuild": "0.25.12",
+    "eslint": "catalog:",
     "expect": "29.7.0",
     "form-data": "4.0.5",
     "html-minifier": "4.0.0",

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -32,6 +32,7 @@
   ],
   "devDependencies": {
     "c8": "10.1.3",
+    "eslint": "catalog:",
     "fs-extra": "11.3.4",
     "glob": "^13.0.6",
     "i18next-parser": "9.3.0",

--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@types/node": "25.6.0",
     "c8": "10.1.3",
+    "eslint": "catalog:",
     "mocha": "11.7.5",
     "tsx": "4.21.0",
     "typescript": "5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.2(@swc/core@1.15.21(@swc/helpers@0.5.21))(@types/node@25.6.0)(typescript@5.9.3))
@@ -726,6 +729,9 @@ importers:
       cross-fetch:
         specifier: 4.1.0
         version: 4.1.0(encoding@0.1.13)
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
       jsdom:
         specifier: 28.1.0
         version: 28.1.0(@noble/hashes@1.8.0)
@@ -996,6 +1002,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^1.6.1
         version: 1.6.1(vitest@1.6.1(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
       msw:
         specifier: 2.12.14
         version: 2.12.14(@types/node@25.6.0)(typescript@5.9.3)
@@ -1326,6 +1335,9 @@ importers:
       cross-fetch:
         specifier: 4.1.0
         version: 4.1.0(encoding@0.1.13)
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
       jsdom:
         specifier: 28.1.0
         version: 28.1.0(@noble/hashes@1.8.0)
@@ -1405,6 +1417,9 @@ importers:
       dotenv:
         specifier: 17.3.1
         version: 17.3.1
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -2403,6 +2418,9 @@ importers:
       esbuild:
         specifier: 0.25.12
         version: 0.25.12
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
       expect:
         specifier: 29.7.0
         version: 29.7.0
@@ -2489,6 +2507,9 @@ importers:
       c8:
         specifier: 10.1.3
         version: 10.1.3
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
       fs-extra:
         specifier: 11.3.4
         version: 11.3.4
@@ -2514,6 +2535,9 @@ importers:
       c8:
         specifier: 10.1.3
         version: 10.1.3
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
       mocha:
         specifier: 11.7.5
         version: 11.7.5
@@ -9388,6 +9412,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react-swc@4.1.0':
     resolution: {integrity: sha512-Ff690TUck0Anlh7wdIcnsVMhofeEVgm44Y4OYdeeEEPSKyZHzDI9gfVBvySEhDfXtBp8tLCbfsVKPWEMEjq8/g==}


### PR DESCRIPTION
## Summary

Eight workspaces invoke `eslint` from their `lint` scripts but don't declare `eslint` in `package.json`. Under pnpm strict isolation that means no workspace-local `node_modules/.bin/eslint`, and the binary resolves to whatever pnpm hoists at root level — currently `apps/admin`'s `catalog:eslint9` (9.37.0). Their legacy `.eslintrc.cjs` configs aren't compatible with ESLint 9, so `pnpm --filter <workspace> lint` from the repo root fails locally with `ESLint couldn't find an eslint.config.js file`.

This PR adds `"eslint": "catalog:"` (resolves to `8.57.1`) to each affected workspace's devDeps so the local `.bin/eslint` shim is correct.

## Affected workspaces

| Workspace | Version bump |
|---|---|
| `apps/activitypub` | 3.1.16 → 3.1.18 (patch) |
| `apps/announcement-bar` | 1.1.19 → 1.1.20 (patch) |
| `apps/posts` | n/a (private) |
| `apps/sodo-search` | 1.8.16 → 1.8.17 (patch) |
| `apps/stats` | n/a (private) |
| `ghost/core` | n/a (release-managed) |
| `ghost/i18n` | n/a (private) |
| `ghost/parse-email-address` | n/a (private) |

## Why CI doesn't already catch this

Ghost's CI runs `pnpm nx run-many -t lint`. Nx invokes each workspace's lint script in a per-workspace shell that uses `pnpm exec` semantics, so the binary resolves correctly through the pnpm symlink farm even without a local declaration. The CI Lint job is green on `main`.

The local `pnpm --filter <pkg> lint` invocation is a **different code path** — it runs the workspace's `lint` script directly, with PATH-based binary resolution. That's where the wrong-eslint-binary leaks through. This is also the path that affects developer ergonomics (running a single workspace's lint locally before pushing).

## Why #27724 didn't fix this

#27724 fixed lint-staged hook routing — the `git commit` flow. Different invocation path; doesn't affect `pnpm --filter` lint.

## Note on `catalog:`

Three of the affected workspaces are published to npm (activitypub, announcement-bar, sodo-search). Using `catalog:` matches the existing convention in published workspaces like `comments-ui`, `portal`, `signup-form`. There is a pre-existing wart that `catalog:` leaks literally into published `package.json` metadata on npm (Ghost's release flow doesn't seem to expand it the way `pnpm publish` would), which would break anyone trying to clone a single app and `pnpm install` outside the monorepo. That's a real issue but pre-existing and contained to devDependencies (not pulled by `npm install` for end users). Worth fixing separately; doesn't block this PR.

See [`docs/lint-standalone-invocation-gap.md`](docs/lint-standalone-invocation-gap.md) for the full write-up of the gap.

## Test plan

- [x] `pnpm install --frozen-lockfile` — clean
- [x] For each affected workspace, `pnpm --filter <pkg> exec eslint --version` reports `v8.57.1`
- [x] For each affected workspace, `pnpm --filter <pkg> lint` runs successfully (only pre-existing warnings, no `ESLint 9` config errors)
- [x] `pnpm --filter ghost run lint:server` — passes (2 pre-existing warnings, 0 errors)
- [x] CI Lint job continues to pass