### PR TITLE
Removed redundant vite plugin declarations from admin-x consumers

### DIFF
--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -74,15 +74,12 @@
     "@types/react": "18.3.28",
     "@types/react-dom": "18.3.7",
     "@types/validator": "13.15.10",
-    "@vitejs/plugin-react": "4.7.0",
     "eslint": "catalog:",
     "eslint-plugin-react-hooks": "4.6.2",
     "eslint-plugin-react-refresh": "0.4.24",
     "eslint-plugin-tailwindcss": "4.0.0-beta.0",
     "tailwindcss": "^4.2.2",
     "vite": "7.3.2",
-    "vite-plugin-css-injected-by-js": "3.5.2",
-    "vite-plugin-svgr": "4.5.0",
     "vitest": "4.1.2"
   },
   "nx": {

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -81,7 +81,6 @@
     "sinon": "^21.1.1",
     "tailwindcss": "3.4.18",
     "vite": "5.4.21",
-    "vite-plugin-css-injected-by-js": "3.5.2",
     "vite-plugin-svgr": "3.3.0",
     "vitest": "1.6.1"
   },

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -49,7 +49,6 @@
         "@types/react": "18.3.28",
         "@types/react-svg-map": "2.1.4",
         "@vitest/coverage-v8": "^4.1.2",
-        "@vitejs/plugin-react": "4.7.0",
         "dotenv": "17.3.1",
         "eslint": "catalog:",
         "eslint-plugin-react-hooks": "4.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,9 +692,6 @@ importers:
       '@types/validator':
         specifier: 13.15.10
         version: 13.15.10
-      '@vitejs/plugin-react':
-        specifier: 4.7.0
-        version: 4.7.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -713,12 +710,6 @@ importers:
       vite:
         specifier: 7.3.2
         version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-css-injected-by-js:
-        specifier: 3.5.2
-        version: 3.5.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      vite-plugin-svgr:
-        specifier: 4.5.0
-        version: 4.5.0(rollup@4.60.0)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@22.19.17)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -871,9 +862,6 @@ importers:
       vite:
         specifier: 5.4.21
         version: 5.4.21(@types/node@25.6.0)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)
-      vite-plugin-css-injected-by-js:
-        specifier: 3.5.2
-        version: 3.5.2(vite@5.4.21(@types/node@25.6.0)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
       vite-plugin-svgr:
         specifier: 3.3.0
         version: 3.3.0(rollup@4.60.0)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
@@ -1444,9 +1432,6 @@ importers:
       '@types/react-svg-map':
         specifier: 2.1.4
         version: 2.1.4
-      '@vitejs/plugin-react':
-        specifier: 4.7.0
-        version: 4.7.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.2
         version: 4.1.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@22.19.17)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
@@ -31077,18 +31062,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -47188,10 +47161,6 @@ snapshots:
   vite-plugin-css-injected-by-js@3.5.2(vite@5.4.21(@types/node@25.6.0)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)):
     dependencies:
       vite: 5.4.21(@types/node@25.6.0)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)
-
-  vite-plugin-css-injected-by-js@3.5.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-plugin-css-injected-by-js@3.5.2(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Five vite-plugin declarations in three workspaces were redundant. Each consumer's `vite.config.*` either delegates to `@tryghost/admin-x-framework/vite` (which already imports the plugins itself) or doesn't import the plugin at all. Removing the duplicate `package.json` entries makes the dep contract honest and removes ~25 lines from the lockfile.

## What's removed

| Workspace | Removed devDeps | Why safe |
|---|---|---|
| `apps/admin-x-settings` | `@vitejs/plugin-react`, `vite-plugin-css-injected-by-js`, `vite-plugin-svgr` | `vite.config.mjs` is pure delegation to `adminXViteConfig` from `@tryghost/admin-x-framework/vite`; no direct plugin imports |
| `apps/stats` | `@vitejs/plugin-react` | `vite.config.mjs` delegates to `adminXViteConfig`; only `vite-plugin-svgr` is imported directly (kept) |
| `apps/comments-ui` | `vite-plugin-css-injected-by-js` | Not imported anywhere in `src/`, `test/`, or `vite.config.mts` |

`tailwindcss` declarations in these workspaces are kept — they're consumed by `eslint-plugin-tailwindcss` at lint time, which knip can't see (genuinely un-knip-able pattern).

## Why it's safe under strict isolation

`admin-x-framework` declares all the affected plugins in its own devDependencies (and declares `vite` and `vitest` so they resolve against the consumer's runtime versions). Consumers depend on `@tryghost/admin-x-framework: workspace:*`, so pnpm's symlink farm makes the framework's transitive plugins reachable when the framework's vite helper imports them at config time. The duplicate consumer declarations were never doing anything useful.

Single-version-source benefit: today, if `apps/stats` pinned `@vitejs/plugin-react@4.7.0` while the framework moved to `5.x`, you'd get two copies of the plugin in the same vite graph and weird HMR/SSR symptoms. Removing the duplicates eliminates that risk.

Versions in `admin-x-framework` exactly match what consumers had (`@vitejs/plugin-react@4.7.0`, `vite-plugin-css-injected-by-js@3.5.2`, `vite-plugin-svgr@3.3.0`), so no behavior change.

## Workspace version bumps

- `apps/comments-ui`: `1.4.11` → `1.4.12` (non-private; only published workspace touched)
- `apps/admin-x-settings` and `apps/stats` are private — no bump needed

## Test plan

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm --filter @tryghost/comments-ui build` — UMD bundle has 0 instances of runtime `require("@tryghost/debug")` externalization
- [x] `pnpm --filter @tryghost/stats build` — passes
- [x] `pnpm --filter @tryghost/admin-x-settings build` — fails on a `waitForApiRequest` TS error that **also fails on `main`**; unrelated to this PR (admin-x-framework needs to be built first for the export to be visible to the test config; CI's Nx-driven build handles this correctly)

## Note on overlap with #27731

#27731 (security vite/vitest bump) is currently open and bumps `vite-plugin-svgr` to `4.5.0` in `apps/admin-x-settings`. This PR removes that line entirely. Whichever PR lands first, the other rebases — the conflict resolution is mechanical (the line goes away because the declaration shouldn't be there).