### PR TITLE
Changed default dev command to skip public apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ Two categories of apps:
 ```bash
 corepack enable pnpm           # Enable corepack to use the correct pnpm version
 pnpm run setup                 # First-time setup (installs deps + submodules)
-pnpm dev                       # Start development (Docker backend + host frontend dev servers)
+pnpm dev                       # Start development (Docker backend + admin frontend dev servers)
+pnpm dev:apps                  # Start Ghost, admin, and public app dev servers
 ```
 
 ### Building
@@ -104,13 +105,16 @@ The `pnpm dev` command uses a **hybrid Docker + host development** setup:
 - Caddy gateway/reverse proxy
 
 **What runs on host:**
-- Frontend dev servers (Admin, Portal, Comments UI, etc.) in watch mode with HMR
+- Admin frontend dev servers in watch mode with HMR
 - Foundation libraries (shade, admin-x-framework, etc.)
 
 **Setup:**
 ```bash
-# Start everything (Docker + frontend dev servers)
+# Start Ghost + admin app dev servers
 pnpm dev
+
+# Start Ghost, admin, and public app dev servers when working on visitor-facing widgets
+pnpm dev:apps
 
 # With optional services (uses Docker Compose file composition)
 pnpm dev:analytics             # Include Tinybird analytics

--- a/apps/announcement-bar/README.md
+++ b/apps/announcement-bar/README.md
@@ -7,14 +7,12 @@
 - Run `pnpm` in Ghost monorepo root
 - Run `pnpm` in this directory
 
-### Running via Ghost `pnpm dev` in root folder
+### Running from the monorepo root
 
-Announcement Bar runs automatically when using Ghost's development command from the monorepo root:
+Run Ghost with the public app dev servers from the monorepo root when working on Announcement Bar:
 ```bash
-pnpm dev
+pnpm dev:apps
 ```
-
-This starts all frontend apps (including Announcement Bar.)
 
 ## Release
 

--- a/apps/comments-ui/README.md
+++ b/apps/comments-ui/README.md
@@ -8,11 +8,11 @@ Comments widget that is embedded at the bottom of posts in Ghost.
 
 - Run `pnpm` in Ghost monorepo root
 
-### Running via Ghost `pnpm dev` in root folder
+### Running from the monorepo root
 
-Comments UI runs automatically when using Ghost's development command from the monorepo root:
+Run Ghost with the public app dev servers from the monorepo root when working on Comments UI:
 ```bash
-pnpm dev
+pnpm dev:apps
 ```
 
 ## Release

--- a/apps/portal/README.md
+++ b/apps/portal/README.md
@@ -44,12 +44,10 @@ Refer the [docs](https://ghost.org/help/setup-members/#customize-portal-settings
 
 ## Develop
 
-Portal runs automatically when using Ghost's development command from the monorepo root:
+Run Ghost with the public app dev servers from the monorepo root when working on Portal:
 ```
-pnpm dev
+pnpm dev:apps
 ```
-
-This starts all frontend apps (including Portal.)
 ---
 
 To run Portal in a standalone fashion, use `pnpm preview` and open [http://localhost:3000](http://localhost:3000).

--- a/apps/signup-form/README.md
+++ b/apps/signup-form/README.md
@@ -9,14 +9,12 @@ Embed a Ghost signup form on any site.
 - Run `pnpm` in Ghost monorepo root
 - Run `pnpm` in this directory
 
-### Running via Ghost `pnpm dev` in root folder
+### Running from the monorepo root
 
-Signup Form runs automatically when using Ghost's development command from the monorepo root:
+Run Ghost with the public app dev servers from the monorepo root when working on Signup Form:
 ```bash
-pnpm dev
+pnpm dev:apps
 ```
-
-This starts all frontend apps (including Signup Form.)
 
 ### Running the development version only
 

--- a/apps/sodo-search/README.md
+++ b/apps/sodo-search/README.md
@@ -7,14 +7,12 @@
 - Run `pnpm` in Ghost monorepo root
 - Run `pnpm` in this directory
 
-### Running via Ghost `pnpm dev` in root folder
+### Running from the monorepo root
 
-Sodo Search runs automatically when using Ghost's development command from the monorepo root:
+Run Ghost with the public app dev servers from the monorepo root when working on Sodo Search:
 ```bash
-pnpm dev
+pnpm dev:apps
 ```
-
-This starts all frontend apps (including Sodo Search.)
 
 ## Release
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ pnpm run setup
 #### 3. Start Ghost
 
 ```bash
-# Start development (runs Docker backend services + frontend dev servers)
+# Start development (runs Docker backend services + admin frontend dev servers)
 pnpm dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:clean": "nx reset && rimraf -g 'ghost/*/build' && rimraf -g 'ghost/*/tsconfig.tsbuildinfo'",
     "clean:hard": "node ./.github/scripts/clean.js",
     "dev": "pnpm nx run ghost-monorepo:docker:dev",
+    "dev:apps": "pnpm nx run ghost-monorepo:docker:dev:apps",
     "dev:sqlite": "DEV_COMPOSE_FILES='-f compose.dev.sqlite.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:mailgun": "DEV_COMPOSE_FILES='-f compose.dev.mailgun.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:lexical": "EDITOR_URL=http://localhost:2368/ghost/assets/koenig-lexical/ pnpm dev",
@@ -173,6 +174,23 @@
         }
       },
       "docker:dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "trap 'docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down' EXIT; docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} logs -f"
+        },
+        "dependsOn": [
+          "docker:up",
+          {
+            "target": "dev",
+            "projects": [
+              "@tryghost/admin",
+              "@tryghost/parse-email-address"
+            ]
+          }
+        ]
+      },
+      "docker:dev:apps": {
         "continuous": true,
         "executor": "nx:run-commands",
         "options": {


### PR DESCRIPTION
## Summary

- changed the default pnpm dev stack to run Ghost and admin app dev servers only
- added pnpm dev:apps for the previous full stack with public app dev servers
- updated contributor and public app docs to describe the new commands