### PR TITLE
Removed unused eslint-plugin-react-hooks and eslint-plugin-react-refresh declarations

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -73,8 +73,6 @@
     "concurrently": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-i18next": "6.1.4",
-    "eslint-plugin-react-hooks": "4.6.2",
-    "eslint-plugin-react-refresh": "catalog:",
     "eslint-plugin-tailwindcss": "3.18.2",
     "jsdom": "catalog:",
     "moment": "2.30.1",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/signup-form",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -48,8 +48,6 @@
     "autoprefixer": "10.4.21",
     "concurrently": "catalog:",
     "eslint": "catalog:",
-    "eslint-plugin-react-hooks": "4.6.2",
-    "eslint-plugin-react-refresh": "catalog:",
     "eslint-plugin-tailwindcss": "3.18.2",
     "jsdom": "catalog:",
     "postcss": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1029,12 +1029,6 @@ importers:
       eslint-plugin-i18next:
         specifier: 6.1.4
         version: 6.1.4
-      eslint-plugin-react-hooks:
-        specifier: 4.6.2
-        version: 4.6.2(eslint@8.57.1)
-      eslint-plugin-react-refresh:
-        specifier: 'catalog:'
-        version: 0.4.24(eslint@8.57.1)
       eslint-plugin-tailwindcss:
         specifier: 3.18.2
         version: 3.18.2(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.3))
@@ -1501,12 +1495,6 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
-      eslint-plugin-react-hooks:
-        specifier: 4.6.2
-        version: 4.6.2(eslint@8.57.1)
-      eslint-plugin-react-refresh:
-        specifier: 'catalog:'
-        version: 0.4.24(eslint@8.57.1)
       eslint-plugin-tailwindcss:
         specifier: 3.18.2
         version: 3.18.2(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.3))


### PR DESCRIPTION
## Summary

Two of the eslint plugins in `apps/comments-ui` and `apps/signup-form` are vestigial — declared in `package.json` but not referenced in either workspace's `.eslintrc` config or anywhere else. Removing them clears 4 entries from the knip baseline.

## Verification

`apps/comments-ui/.eslintrc.js`:
- `extends:` — `plugin:ghost/ts`, `plugin:react/recommended`, `plugin:i18next/recommended`
- `plugins:` — `ghost`, `tailwindcss`, `i18next`
- No `react-hooks` or `react-refresh` reference anywhere.

`apps/signup-form/.eslintrc.cjs`:
- `extends:` — `plugin:ghost/ts`, `plugin:react/recommended`
- `plugins:` — `ghost`, `tailwindcss`
- Same — no `react-hooks` or `react-refresh` reference.

`grep -rEn "react-hooks|react-refresh"` across both workspaces only matches the two `package.json` declaration lines themselves. No source, test, config, or script references.

## What's removed

| Workspace | Removed |
|---|---|
| `apps/comments-ui` | `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh` |
| `apps/signup-form` | `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh` |

## Test plan

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm --filter @tryghost/comments-ui lint` — 41 pre-existing warnings, 0 errors
- [x] `pnpm --filter @tryghost/comments-ui build` — passes
- [x] `pnpm --filter @tryghost/signup-form lint` — passes
- [x] `pnpm --filter @tryghost/signup-form build` — passes