### PR TITLE
Fix comment analytics overview review issues

### DIFF
--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -4,6 +4,7 @@ import CommentsFilters from './components/comments-filters';
 import CommentsHeader from './components/comments-header';
 import CommentsLayout from './components/comments-layout';
 import CommentsList from './components/comments-list';
+import CommentsSidebar from './components/comments-sidebar';
 import React, {useCallback} from 'react';
 import {Button, EmptyIndicator, LoadingIndicator} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
@@ -44,19 +45,8 @@ const Comments: React.FC = () => {
     // If we are fetching comments, but not fetching the next page and not refetching, we should show the loading indicator
     const shouldShowLoading = isFetching && !isFetchingNextPage && !isRefetching;
 
-    const rail = analyticsEnabled ? (
-        <CommentsAnalytics
-            dateFrom={dateFrom}
-            dateTo={dateTo}
-            range={range}
-            setRange={setRange}
-            timezone={timezone}
-            onAddFilter={handleAddFilter}
-        />
-    ) : undefined;
-
-    return (
-        <CommentsLayout rail={rail}>
+    const commentsContent = (
+        <>
             <CommentsHeader>
                 {!isSingleIdFilter && (
                     <CommentsFilters
@@ -112,6 +102,28 @@ const Comments: React.FC = () => {
                     </>
                 )}
             </CommentsContent>
+        </>
+    );
+
+    return (
+        <CommentsLayout>
+            {analyticsEnabled ? (
+                <div className='block grow lg:grid lg:grid-cols-[minmax(0,1fr)_460px]'>
+                    <CommentsSidebar>
+                        <CommentsAnalytics
+                            dateFrom={dateFrom}
+                            dateTo={dateTo}
+                            range={range}
+                            setRange={setRange}
+                            timezone={timezone}
+                            onAddFilter={handleAddFilter}
+                        />
+                    </CommentsSidebar>
+                    <div className='flex min-w-0 flex-col lg:col-start-1 lg:row-start-1 lg:[&_.prose]:max-w-[70ch]'>
+                        {commentsContent}
+                    </div>
+                </div>
+            ) : commentsContent}
         </CommentsLayout>
     );
 };

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -8,11 +8,11 @@ import CommentsSidebar from './components/comments-sidebar';
 import React, {useCallback} from 'react';
 import {Button, EmptyIndicator, LoadingIndicator} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
-import {createFilter} from '@tryghost/shade/patterns';
+import {upsertCommentFilters, useFilterState} from './hooks/use-filter-state';
 import {useBrowseComments} from '@tryghost/admin-x-framework/api/comments';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
-import {useFilterState} from './hooks/use-filter-state';
 import {useOverviewRange} from './hooks/use-overview-range';
+import type {CommentFilterUpdate} from './hooks/use-filter-state';
 
 const Comments: React.FC = () => {
     const {filters, nql, setFilters, clearFilters, isSingleIdFilter} = useFilterState();
@@ -21,14 +21,15 @@ const Comments: React.FC = () => {
 
     const {range, setRange, dateFrom, dateTo, timezone} = useOverviewRange();
 
-    const handleAddFilter = useCallback((field: string, value: string, operator: string = 'is') => {
+    const handleAddFilters = useCallback((updates: CommentFilterUpdate[]) => {
         setFilters((prevFilters) => {
-            // Remove any existing filter for the same field
-            const filtered = prevFilters.filter(f => f.field !== field);
-            // Add the new filter
-            return [...filtered, createFilter(field, operator, [value])];
+            return upsertCommentFilters(prevFilters, updates);
         }, {replace: false});
     }, [setFilters]);
+
+    const handleAddFilter = useCallback((field: string, value: string, operator: string = 'is') => {
+        handleAddFilters([{field, value, operator}]);
+    }, [handleAddFilters]);
 
     const {
         data,
@@ -116,7 +117,7 @@ const Comments: React.FC = () => {
                             range={range}
                             setRange={setRange}
                             timezone={timezone}
-                            onAddFilter={handleAddFilter}
+                            onAddFilters={handleAddFilters}
                         />
                     </CommentsSidebar>
                     <div className='flex min-w-0 flex-col lg:col-start-1 lg:row-start-1 lg:[&_.prose]:max-w-[70ch]'>

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -46,8 +46,8 @@ const Comments: React.FC = () => {
     // If we are fetching comments, but not fetching the next page and not refetching, we should show the loading indicator
     const shouldShowLoading = isFetching && !isFetchingNextPage && !isRefetching;
 
-    const commentsContent = (
-        <>
+    return (
+        <CommentsLayout>
             <CommentsHeader>
                 {!isSingleIdFilter && (
                     <CommentsFilters
@@ -103,28 +103,18 @@ const Comments: React.FC = () => {
                     </>
                 )}
             </CommentsContent>
-        </>
-    );
-
-    return (
-        <CommentsLayout>
             {analyticsEnabled ? (
-                <div className='block grow lg:grid lg:grid-cols-[minmax(0,1fr)_460px]'>
-                    <CommentsSidebar>
-                        <CommentsAnalytics
-                            dateFrom={dateFrom}
-                            dateTo={dateTo}
-                            range={range}
-                            setRange={setRange}
-                            timezone={timezone}
-                            onAddFilters={handleAddFilters}
-                        />
-                    </CommentsSidebar>
-                    <div className='flex min-w-0 flex-col lg:col-start-1 lg:row-start-1 lg:[&_.prose]:max-w-[70ch]'>
-                        {commentsContent}
-                    </div>
-                </div>
-            ) : commentsContent}
+                <CommentsSidebar>
+                    <CommentsAnalytics
+                        dateFrom={dateFrom}
+                        dateTo={dateTo}
+                        range={range}
+                        setRange={setRange}
+                        timezone={timezone}
+                        onAddFilters={handleAddFilters}
+                    />
+                </CommentsSidebar>
+            ) : null}
         </CommentsLayout>
     );
 };

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -4,6 +4,7 @@ import CommentsFilters from './components/comments-filters';
 import CommentsHeader from './components/comments-header';
 import CommentsLayout from './components/comments-layout';
 import CommentsList from './components/comments-list';
+import CommentsMain from './components/comments-main';
 import CommentsSidebar from './components/comments-sidebar';
 import React, {useCallback} from 'react';
 import {Button, EmptyIndicator, LoadingIndicator} from '@tryghost/shade/components';
@@ -48,61 +49,63 @@ const Comments: React.FC = () => {
 
     return (
         <CommentsLayout>
-            <CommentsHeader>
-                {!isSingleIdFilter && (
-                    <CommentsFilters
-                        filters={filters}
-                        onFiltersChange={setFilters}
-                    />
-                )}
-            </CommentsHeader>
-            <CommentsContent>
-                {shouldShowLoading ? (
-                    <div className="flex h-full items-center justify-center">
-                        <LoadingIndicator size="lg" />
-                    </div>
-                ) : isError ? (
-                    <div className="mb-16 flex h-full flex-col items-center justify-center">
-                        <h2 className="mb-2 text-xl font-medium">
-                            Error loading comments
-                        </h2>
-                        <p className="mb-4 text-muted-foreground">
-                            Please reload the page to try again
-                        </p>
-                        <Button onClick={() => window.location.reload()}>
-                            Reload page
-                        </Button>
-                    </div>
-                ) : !data?.comments.length ? (
-                    <div className="flex h-full items-center justify-center">
-                        <EmptyIndicator
-                            title="No comments yet"
-                        >
-                            <LucideIcon.MessageSquare />
-                        </EmptyIndicator>
-                    </div>
-                ) : (
-                    <>
-                        <CommentsList
-                            fetchNextPage={fetchNextPage}
-                            hasNextPage={hasNextPage}
-                            isFetchingNextPage={isFetchingNextPage}
-                            isLoading={isFetching && !isFetchingNextPage}
-                            items={data?.comments ?? []}
-                            resetKey={nql ?? ''}
-                            totalItems={data?.meta?.pagination?.total ?? 0}
-                            onAddFilter={handleAddFilter}
+            <CommentsMain>
+                <CommentsHeader>
+                    {!isSingleIdFilter && (
+                        <CommentsFilters
+                            filters={filters}
+                            onFiltersChange={setFilters}
                         />
-                        {isSingleIdFilter && (
-                            <div className="flex justify-center py-8">
-                                <Button variant="outline" onClick={() => clearFilters({replace: false})}>
-                                    Show all comments
-                                </Button>
-                            </div>
-                        )}
-                    </>
-                )}
-            </CommentsContent>
+                    )}
+                </CommentsHeader>
+                <CommentsContent>
+                    {shouldShowLoading ? (
+                        <div className="flex h-full items-center justify-center">
+                            <LoadingIndicator size="lg" />
+                        </div>
+                    ) : isError ? (
+                        <div className="mb-16 flex h-full flex-col items-center justify-center">
+                            <h2 className="mb-2 text-xl font-medium">
+                                Error loading comments
+                            </h2>
+                            <p className="mb-4 text-muted-foreground">
+                                Please reload the page to try again
+                            </p>
+                            <Button onClick={() => window.location.reload()}>
+                                Reload page
+                            </Button>
+                        </div>
+                    ) : !data?.comments.length ? (
+                        <div className="flex h-full items-center justify-center">
+                            <EmptyIndicator
+                                title="No comments yet"
+                            >
+                                <LucideIcon.MessageSquare />
+                            </EmptyIndicator>
+                        </div>
+                    ) : (
+                        <>
+                            <CommentsList
+                                fetchNextPage={fetchNextPage}
+                                hasNextPage={hasNextPage}
+                                isFetchingNextPage={isFetchingNextPage}
+                                isLoading={isFetching && !isFetchingNextPage}
+                                items={data?.comments ?? []}
+                                resetKey={nql ?? ''}
+                                totalItems={data?.meta?.pagination?.total ?? 0}
+                                onAddFilter={handleAddFilter}
+                            />
+                            {isSingleIdFilter && (
+                                <div className="flex justify-center py-8">
+                                    <Button variant="outline" onClick={() => clearFilters({replace: false})}>
+                                        Show all comments
+                                    </Button>
+                                </div>
+                            )}
+                        </>
+                    )}
+                </CommentsContent>
+            </CommentsMain>
             {analyticsEnabled ? (
                 <CommentsSidebar>
                     <CommentsAnalytics

--- a/apps/posts/src/views/comments/components/comments-analytics.tsx
+++ b/apps/posts/src/views/comments/components/comments-analytics.tsx
@@ -3,7 +3,9 @@ import OverviewKpiTabs from './overview-kpi-tabs';
 import OverviewTopMembers from './overview-top-members';
 import OverviewTopPosts from './overview-top-posts';
 import React, {useMemo} from 'react';
+import {Button} from '@tryghost/shade/components';
 import {CommentsOverview as CommentsOverviewPayload, CommentsOverviewResponseType, useCommentsOverview} from '@tryghost/admin-x-framework/api/stats';
+import type {CommentFilterUpdate} from '../hooks/use-filter-state';
 
 interface CommentsAnalyticsProps {
     range: number;
@@ -15,7 +17,7 @@ interface CommentsAnalyticsProps {
      * Applies a filter to the moderation list rendered alongside this rail.
      * Used by top-posts/commenters row clicks and chart bar clicks.
      */
-    onAddFilter: (field: string, value: string, operator?: string) => void;
+    onAddFilters: (filters: CommentFilterUpdate[]) => void;
 }
 
 const EMPTY_OVERVIEW: CommentsOverviewPayload = {
@@ -26,16 +28,18 @@ const EMPTY_OVERVIEW: CommentsOverviewPayload = {
     topMembers: []
 };
 
-const CommentsAnalytics: React.FC<CommentsAnalyticsProps> = ({range, setRange, dateFrom, dateTo, timezone, onAddFilter}) => {
+const CommentsAnalytics: React.FC<CommentsAnalyticsProps> = ({range, setRange, dateFrom, dateTo, timezone, onAddFilters}) => {
     const searchParams = useMemo(() => ({
         date_from: dateFrom,
         date_to: dateTo,
         timezone
     }), [dateFrom, dateTo, timezone]);
 
-    const {data, isLoading} = useCommentsOverview({searchParams}) as {
+    const {data, isError, isLoading, refetch} = useCommentsOverview({searchParams, defaultErrorHandler: false}) as {
         data: CommentsOverviewResponseType | undefined;
+        isError: boolean;
         isLoading: boolean;
+        refetch: () => void;
     };
 
     const overview = data?.stats?.[0] ?? EMPTY_OVERVIEW;
@@ -46,26 +50,38 @@ const CommentsAnalytics: React.FC<CommentsAnalyticsProps> = ({range, setRange, d
                 <h2 className='text-lg font-semibold tracking-tight'>Analytics</h2>
                 <OverviewDateRange range={range} onRangeChange={setRange} />
             </div>
-            <OverviewKpiTabs
-                isLoading={isLoading}
-                previousTotals={data ? overview.previousTotals : undefined}
-                range={range}
-                series={data ? overview.series : undefined}
-                totals={data ? overview.totals : undefined}
-                onAddFilter={onAddFilter}
-            />
-            <OverviewTopPosts
-                isLoading={isLoading}
-                posts={data ? overview.topPosts : undefined}
-                range={range}
-                onRowClick={postId => onAddFilter('post', postId)}
-            />
-            <OverviewTopMembers
-                isLoading={isLoading}
-                members={data ? overview.topMembers : undefined}
-                range={range}
-                onRowClick={memberId => onAddFilter('author', memberId)}
-            />
+            {isError ? (
+                <div className='rounded-md border border-border bg-background p-4 text-sm'>
+                    <div className='font-medium text-foreground'>Could not load analytics</div>
+                    <div className='mt-1 text-muted-foreground'>Try again, or reload the page if the problem continues.</div>
+                    <Button className='mt-3' size='sm' variant='outline' onClick={() => refetch()}>
+                        Retry
+                    </Button>
+                </div>
+            ) : (
+                <>
+                    <OverviewKpiTabs
+                        isLoading={isLoading}
+                        previousTotals={data ? overview.previousTotals : undefined}
+                        range={range}
+                        series={data ? overview.series : undefined}
+                        totals={data ? overview.totals : undefined}
+                        onAddFilters={onAddFilters}
+                    />
+                    <OverviewTopPosts
+                        isLoading={isLoading}
+                        posts={data ? overview.topPosts : undefined}
+                        range={range}
+                        onRowClick={postId => onAddFilters([{field: 'post', value: postId}])}
+                    />
+                    <OverviewTopMembers
+                        isLoading={isLoading}
+                        members={data ? overview.topMembers : undefined}
+                        range={range}
+                        onRowClick={memberId => onAddFilters([{field: 'author', value: memberId}])}
+                    />
+                </>
+            )}
         </div>
     );
 };

--- a/apps/posts/src/views/comments/components/comments-layout.tsx
+++ b/apps/posts/src/views/comments/components/comments-layout.tsx
@@ -5,7 +5,7 @@ const CommentsLayout: React.FC<{children: React.ReactNode}> = ({children}) => {
     return (
         <MainLayout>
             <div className='grid w-full grow'>
-                <div className='flex h-full flex-col lg:has-[>aside]:grid lg:has-[>aside]:grid-cols-[minmax(0,1fr)_460px] lg:has-[>aside]:[&_.prose]:max-w-[70ch] lg:has-[>aside]:[&>*:not(aside)]:col-start-1 lg:has-[>aside]:[&>*:not(aside)]:min-w-0' data-testid='comments-page'>
+                <div className='flex h-full flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_auto]' data-testid='comments-page'>
                     {children}
                 </div>
             </div>

--- a/apps/posts/src/views/comments/components/comments-layout.tsx
+++ b/apps/posts/src/views/comments/components/comments-layout.tsx
@@ -5,7 +5,7 @@ const CommentsLayout: React.FC<{children: React.ReactNode}> = ({children}) => {
     return (
         <MainLayout>
             <div className='grid w-full grow'>
-                <div className='flex h-full flex-col' data-testid='comments-page'>
+                <div className='flex h-full flex-col lg:has-[>aside]:grid lg:has-[>aside]:grid-cols-[minmax(0,1fr)_460px] lg:has-[>aside]:[&_.prose]:max-w-[70ch] lg:has-[>aside]:[&>*:not(aside)]:col-start-1 lg:has-[>aside]:[&>*:not(aside)]:min-w-0' data-testid='comments-page'>
                     {children}
                 </div>
             </div>

--- a/apps/posts/src/views/comments/components/comments-layout.tsx
+++ b/apps/posts/src/views/comments/components/comments-layout.tsx
@@ -1,34 +1,12 @@
 import MainLayout from '@components/layout/main-layout';
 import React from 'react';
 
-interface CommentsLayoutProps {
-    children: React.ReactNode;
-    /**
-     * Optional right-side column rendered alongside the main content on `lg+`.
-     * On smaller viewports it collapses above the main column so the analytics
-     * overview still appears at the top of the page.
-     */
-    rail?: React.ReactNode;
-}
-
-const CommentsLayout: React.FC<CommentsLayoutProps> = ({children, rail}) => {
-    const body = rail ? (
-        <div className='block grow lg:grid lg:grid-cols-[minmax(0,1fr)_460px]'>
-            {/* `self-start` is required for sticky — grid cells otherwise stretch to the row's height. */}
-            <aside className='px-4 pt-4 lg:sticky lg:top-0 lg:col-start-2 lg:row-start-1 lg:max-h-screen lg:self-start lg:overflow-y-auto lg:border-l lg:border-border lg:px-8 lg:pt-8'>
-                {rail}
-            </aside>
-            <div className='flex min-w-0 flex-col lg:col-start-1 lg:row-start-1 lg:[&_.prose]:max-w-[70ch]'>
-                {children}
-            </div>
-        </div>
-    ) : children;
-
+const CommentsLayout: React.FC<{children: React.ReactNode}> = ({children}) => {
     return (
         <MainLayout>
             <div className='grid w-full grow'>
                 <div className='flex h-full flex-col' data-testid='comments-page'>
-                    {body}
+                    {children}
                 </div>
             </div>
         </MainLayout>

--- a/apps/posts/src/views/comments/components/comments-main.tsx
+++ b/apps/posts/src/views/comments/components/comments-main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const CommentsMain: React.FC<React.PropsWithChildren> = ({children}) => {
+    return (
+        <main className='flex min-w-0 flex-col lg:col-start-1 lg:[&_.prose]:max-w-[70ch]'>
+            {children}
+        </main>
+    );
+};
+
+export default CommentsMain;

--- a/apps/posts/src/views/comments/components/comments-sidebar.tsx
+++ b/apps/posts/src/views/comments/components/comments-sidebar.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const CommentsSidebar: React.FC<React.PropsWithChildren> = ({children}) => {
+    return (
+        <aside className='px-4 pt-4 lg:sticky lg:top-0 lg:col-start-2 lg:row-start-1 lg:max-h-screen lg:self-start lg:overflow-y-auto lg:border-l lg:border-border lg:px-8 lg:pt-8'>
+            {children}
+        </aside>
+    );
+};
+
+export default CommentsSidebar;

--- a/apps/posts/src/views/comments/components/comments-sidebar.tsx
+++ b/apps/posts/src/views/comments/components/comments-sidebar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const CommentsSidebar: React.FC<React.PropsWithChildren> = ({children}) => {
     return (
-        <aside className='px-4 pt-4 lg:sticky lg:top-0 lg:col-start-2 lg:row-start-1 lg:max-h-screen lg:self-start lg:overflow-y-auto lg:border-l lg:border-border lg:px-8 lg:pt-8'>
+        <aside className='px-4 pt-4 lg:sticky lg:top-0 lg:col-start-2 lg:row-start-1 lg:max-h-screen lg:w-[460px] lg:self-start lg:overflow-y-auto lg:border-l lg:border-border lg:px-8 lg:pt-8'>
             {children}
         </aside>
     );

--- a/apps/posts/src/views/comments/components/overview-kpi-tabs.tsx
+++ b/apps/posts/src/views/comments/components/overview-kpi-tabs.tsx
@@ -5,6 +5,7 @@ import {LucideIcon, Recharts, formatNumber, formatPercentage} from '@tryghost/sh
 import {STATS_RANGES} from '@src/utils/constants';
 import {formatDisplayDateWithRange, sanitizeChartData} from '@tryghost/shade/app';
 import {getPreviousPeriodText} from '../utils/period-text';
+import type {CommentFilterUpdate} from '../hooks/use-filter-state';
 
 type MetricKey = 'comments' | 'commenters' | 'reported';
 
@@ -26,7 +27,7 @@ interface OverviewKpiTabsProps {
      * Clicking a bar filters the moderation list to comments from that date.
      * On the Reported tab, also applies `reported=true`.
      */
-    onAddFilter: (field: string, value: string, operator?: string) => void;
+    onAddFilters: (filters: CommentFilterUpdate[]) => void;
 }
 
 const TAB_CONFIG: Record<MetricKey, {label: string; color: string; seriesField: 'count' | 'commenters' | 'reported'; totalsField: keyof CommentsOverviewTotals}> = {
@@ -82,7 +83,11 @@ const buildDiffTooltip = (
     );
 };
 
-const OverviewKpiTabs: React.FC<OverviewKpiTabsProps> = ({totals, previousTotals, series, range, isLoading, onAddFilter}) => {
+export const shouldHideDiffs = (range: number) => (
+    range === STATS_RANGES.ALL_TIME.value || range === STATS_RANGES.YEAR_TO_DATE.value
+);
+
+const OverviewKpiTabs: React.FC<OverviewKpiTabsProps> = ({totals, previousTotals, series, range, isLoading, onAddFilters}) => {
     const [currentTab, setCurrentTab] = useState<MetricKey>('comments');
 
     const config = TAB_CONFIG[currentTab];
@@ -97,10 +102,11 @@ const OverviewKpiTabs: React.FC<OverviewKpiTabsProps> = ({totals, previousTotals
         if (!isDailyAggregation || !payload?.date) {
             return;
         }
-        onAddFilter('created_at', payload.date, 'is');
+        const filters: CommentFilterUpdate[] = [{field: 'created_at', value: payload.date, operator: 'is'}];
         if (currentTab === 'reported') {
-            onAddFilter('reported', 'true', 'is');
+            filters.push({field: 'reported', value: 'true', operator: 'is'});
         }
+        onAddFilters(filters);
     };
 
     const chartData = useMemo(() => {
@@ -122,8 +128,8 @@ const OverviewKpiTabs: React.FC<OverviewKpiTabsProps> = ({totals, previousTotals
         value: {label: config.label, color: config.color}
     };
 
-    // No prior period to compare against on "All time" — hide the diff.
-    const diffsHidden = range === STATS_RANGES.ALL_TIME.value;
+    // No meaningful prior period to compare against on "All time" or YTD.
+    const diffsHidden = shouldHideDiffs(range);
     const diffs = useMemo(() => {
         if (diffsHidden || !totals || !previousTotals) {
             return null;

--- a/apps/posts/src/views/comments/hooks/use-filter-state.ts
+++ b/apps/posts/src/views/comments/hooks/use-filter-state.ts
@@ -1,4 +1,4 @@
-import {Filter} from '@tryghost/shade/patterns';
+import {Filter, createFilter} from '@tryghost/shade/patterns';
 import {useCallback, useMemo} from 'react';
 import {useSearchParams} from '@tryghost/admin-x-framework';
 
@@ -8,6 +8,20 @@ import {useSearchParams} from '@tryghost/admin-x-framework';
 export const COMMENT_FILTER_FIELDS = ['id', 'status', 'created_at', 'body', 'post', 'author', 'reported'] as const;
 
 export type CommentFilterField = typeof COMMENT_FILTER_FIELDS[number];
+
+export interface CommentFilterUpdate {
+    field: string;
+    value: string;
+    operator?: string;
+}
+
+export function upsertCommentFilters(filters: Filter[], updates: CommentFilterUpdate[]): Filter[] {
+    const fieldsToUpdate = new Set(updates.map(update => update.field));
+    const filtered = filters.filter(filter => !fieldsToUpdate.has(filter.field));
+    const newFilters = updates.map(update => createFilter(update.field, update.operator || 'is', [update.value]));
+
+    return [...filtered, ...newFilters];
+}
 
 export function buildNqlFilter(filters: Filter[]): string | undefined {
     const parts: string[] = [];

--- a/apps/posts/src/views/comments/hooks/use-overview-range.ts
+++ b/apps/posts/src/views/comments/hooks/use-overview-range.ts
@@ -4,11 +4,12 @@ import {useMemo, useState} from 'react';
 
 const DEFAULT_RANGE = STATS_RANGES.LAST_30_DAYS.value;
 
-export const useOverviewRange = () => {
-    const [range, setRange] = useState<number>(DEFAULT_RANGE);
+export const useOverviewRange = (initialRange: number = DEFAULT_RANGE) => {
+    const [range, setRange] = useState<number>(initialRange);
 
     const {dateFrom, dateTo, timezone} = useMemo(() => {
-        const {startDate, endDate, timezone: tz} = getRangeDates(range);
+        const queryRange = range === STATS_RANGES.YEAR_TO_DATE.value ? -1 : range;
+        const {startDate, endDate, timezone: tz} = getRangeDates(queryRange);
         return {
             dateFrom: formatQueryDate(startDate),
             dateTo: formatQueryDate(endDate),

--- a/apps/posts/test/unit/hooks/use-overview-range.test.tsx
+++ b/apps/posts/test/unit/hooks/use-overview-range.test.tsx
@@ -1,0 +1,20 @@
+import {STATS_RANGES} from '@src/utils/constants';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@testing-library/react';
+import {useOverviewRange} from '@src/views/comments/hooks/use-overview-range';
+
+describe('useOverviewRange', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('uses Jan 1 through today for year to date', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-05-06T12:00:00.000Z'));
+
+        const {result} = renderHook(() => useOverviewRange(STATS_RANGES.YEAR_TO_DATE.value));
+
+        expect(result.current.dateFrom).toBe('2026-01-01');
+        expect(result.current.dateTo).toBe('2026-05-06');
+    });
+});

--- a/apps/posts/test/unit/views/comments/comment-filter-state.test.ts
+++ b/apps/posts/test/unit/views/comments/comment-filter-state.test.ts
@@ -1,0 +1,32 @@
+import {describe, expect, it} from 'vitest';
+import {upsertCommentFilters} from '@src/views/comments/hooks/use-filter-state';
+
+describe('upsertCommentFilters', () => {
+    it('applies multiple filter updates atomically', () => {
+        const result = upsertCommentFilters([], [
+            {field: 'created_at', value: '2026-05-05', operator: 'is'},
+            {field: 'reported', value: 'true', operator: 'is'}
+        ]);
+
+        expect(result).toMatchObject([
+            {field: 'created_at', operator: 'is', values: ['2026-05-05']},
+            {field: 'reported', operator: 'is', values: ['true']}
+        ]);
+    });
+
+    it('replaces existing filters for updated fields without dropping other fields', () => {
+        const result = upsertCommentFilters([
+            {id: 'post', field: 'post', operator: 'is', values: ['post-1']},
+            {id: 'reported', field: 'reported', operator: 'is', values: ['false']}
+        ], [
+            {field: 'reported', value: 'true', operator: 'is'},
+            {field: 'created_at', value: '2026-05-05', operator: 'is'}
+        ]);
+
+        expect(result).toMatchObject([
+            {field: 'post', operator: 'is', values: ['post-1']},
+            {field: 'reported', operator: 'is', values: ['true']},
+            {field: 'created_at', operator: 'is', values: ['2026-05-05']}
+        ]);
+    });
+});

--- a/apps/posts/test/unit/views/comments/overview-kpi-tabs.test.ts
+++ b/apps/posts/test/unit/views/comments/overview-kpi-tabs.test.ts
@@ -1,0 +1,15 @@
+import {STATS_RANGES} from '@src/utils/constants';
+import {describe, expect, it} from 'vitest';
+import {shouldHideDiffs} from '@src/views/comments/components/overview-kpi-tabs';
+
+describe('shouldHideDiffs', () => {
+    it('hides diffs for all time and year to date', () => {
+        expect(shouldHideDiffs(STATS_RANGES.ALL_TIME.value)).toBe(true);
+        expect(shouldHideDiffs(STATS_RANGES.YEAR_TO_DATE.value)).toBe(true);
+    });
+
+    it('shows diffs for bounded trailing ranges', () => {
+        expect(shouldHideDiffs(STATS_RANGES.LAST_7_DAYS.value)).toBe(false);
+        expect(shouldHideDiffs(STATS_RANGES.LAST_30_DAYS.value)).toBe(false);
+    });
+});

--- a/ghost/core/core/server/services/comments/comments-stats-service.js
+++ b/ghost/core/core/server/services/comments/comments-stats-service.js
@@ -73,7 +73,11 @@ module.exports = class CommentsStatsService {
     }
 
     _resolveRange(dateFrom, dateTo, timezone) {
-        return getDateBoundaries({date_from: dateFrom, date_to: dateTo, timezone});
+        const tz = timezone || 'UTC';
+        return {
+            ...getDateBoundaries({date_from: dateFrom, date_to: dateTo, timezone: tz}),
+            timezone: tz
+        };
     }
 
     _resolvePreviousRange(dateFrom, dateTo, timezone) {
@@ -93,7 +97,7 @@ module.exports = class CommentsStatsService {
         }
         const prevDateTo = startOfFrom.clone().subtract(1, 'day').format('YYYY-MM-DD');
         const prevDateFrom = startOfFrom.clone().subtract(lengthDays, 'days').format('YYYY-MM-DD');
-        return getDateBoundaries({date_from: prevDateFrom, date_to: prevDateTo, timezone: tz});
+        return this._resolveRange(prevDateFrom, prevDateTo, tz);
     }
 
     _applyRange(query, column, {dateFrom, dateTo}) {
@@ -125,50 +129,56 @@ module.exports = class CommentsStatsService {
     async _getSeries(knex, range) {
         const commentsQuery = knex('comments')
             .where('status', 'published')
-            .select(knex.raw('DATE(created_at) as date'))
-            .count({count: '*'})
-            .countDistinct({commenters: 'member_id'})
-            .groupByRaw('DATE(created_at)')
-            .orderByRaw('DATE(created_at) ASC');
+            .select('created_at', 'member_id');
         this._applyRange(commentsQuery, 'comments.created_at', range);
 
         const reportsQuery = knex('comment_reports')
-            .select(knex.raw('DATE(created_at) as date'))
-            .countDistinct({reported: 'comment_id'})
-            .groupByRaw('DATE(created_at)')
-            .orderByRaw('DATE(created_at) ASC');
+            .select('created_at', 'comment_id');
         this._applyRange(reportsQuery, 'comment_reports.created_at', range);
 
         const [commentsRows, reportsRows] = await Promise.all([commentsQuery, reportsQuery]);
 
         const byDate = new Map();
         for (const row of commentsRows) {
-            const date = typeof row.date === 'string' ? row.date : this._formatDate(row.date);
-            byDate.set(date, {
-                date,
-                count: Number(row.count) || 0,
-                commenters: Number(row.commenters) || 0,
-                reported: 0
-            });
+            const date = this._formatBucketDate(row.created_at, range.timezone);
+            const existing = this._getSeriesBucket(byDate, date);
+            existing.count += 1;
+            if (row.member_id) {
+                existing.commenterIds.add(row.member_id);
+            }
         }
         for (const row of reportsRows) {
-            const date = typeof row.date === 'string' ? row.date : this._formatDate(row.date);
-            const existing = byDate.get(date) || {date, count: 0, commenters: 0, reported: 0};
-            existing.reported = Number(row.reported) || 0;
-            byDate.set(date, existing);
+            const date = this._formatBucketDate(row.created_at, range.timezone);
+            const existing = this._getSeriesBucket(byDate, date);
+            if (row.comment_id) {
+                existing.reportedCommentIds.add(row.comment_id);
+            }
         }
 
-        return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+        return [...byDate.values()]
+            .map(row => ({
+                date: row.date,
+                count: row.count,
+                commenters: row.commenterIds.size,
+                reported: row.reportedCommentIds.size
+            }))
+            .sort((a, b) => a.date.localeCompare(b.date));
     }
 
-    _formatDate(value) {
-        if (!(value instanceof Date)) {
-            return String(value);
+    _getSeriesBucket(byDate, date) {
+        if (!byDate.has(date)) {
+            byDate.set(date, {
+                date,
+                count: 0,
+                commenterIds: new Set(),
+                reportedCommentIds: new Set()
+            });
         }
-        const year = value.getUTCFullYear();
-        const month = String(value.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(value.getUTCDate()).padStart(2, '0');
-        return `${year}-${month}-${day}`;
+        return byDate.get(date);
+    }
+
+    _formatBucketDate(value, timezone) {
+        return moment.utc(value).tz(timezone || 'UTC').format('YYYY-MM-DD');
     }
 
     async _getTopPosts(knex, range, limit = 25) {

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -379,8 +379,9 @@ describe('Stats API', function () {
 
     describe('Comments overview', function () {
         beforeEach(async function () {
-            await db.knex('comment_reports').truncate();
-            await db.knex('comments').truncate();
+            await db.knex('comment_likes').delete();
+            await db.knex('comment_reports').delete();
+            await db.knex('comments').delete();
         });
 
         function post(index = 0) {

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -2,6 +2,8 @@ const {agentProvider, fixtureManager, matchers, mockManager} = require('../../ut
 const {mockStripe, stripeMocker} = require('../../utils/e2e-framework-mock-manager');
 const {anyContentVersion, anyEtag, anyISODate, anyObjectId, anyContentLength} = matchers;
 const assert = require('node:assert/strict');
+const ObjectId = require('bson-objectid').default;
+const db = require('../../../core/server/data/db');
 
 let agent;
 
@@ -376,6 +378,44 @@ describe('Stats API', function () {
     });
 
     describe('Comments overview', function () {
+        beforeEach(async function () {
+            await db.knex('comment_reports').truncate();
+            await db.knex('comments').truncate();
+        });
+
+        function post(index = 0) {
+            return fixtureManager.get('posts', index);
+        }
+
+        function member(index = 0) {
+            return fixtureManager.get('members', index);
+        }
+
+        async function addComment({postIndex = 0, memberIndex = 0, createdAt, status = 'published'} = {}) {
+            const id = ObjectId().toHexString();
+            await db.knex('comments').insert({
+                id,
+                post_id: post(postIndex).id,
+                member_id: member(memberIndex).id,
+                html: '<p>Comment</p>',
+                status,
+                created_at: createdAt,
+                updated_at: createdAt
+            });
+
+            return {id};
+        }
+
+        async function addReport(comment, memberIndex = 1, createdAt) {
+            await db.knex('comment_reports').insert({
+                id: ObjectId().toHexString(),
+                comment_id: comment.id,
+                member_id: member(memberIndex).id,
+                created_at: createdAt,
+                updated_at: createdAt
+            });
+        }
+
         it('returns the overview payload with expected shape', async function () {
             const {body} = await agent
                 .get('/stats/comments/')
@@ -404,6 +444,59 @@ describe('Stats API', function () {
             await agent
                 .get('/stats/comments/?date_from=2026-01-01&date_to=2026-12-31')
                 .expectStatus(200);
+        });
+
+        it('returns seeded comment analytics through the Admin API', async function () {
+            await addComment({createdAt: '2026-04-29T10:00:00.000Z', memberIndex: 0});
+            await addComment({createdAt: '2026-04-30T10:00:00.000Z', memberIndex: 1});
+
+            const first = await addComment({createdAt: '2026-05-01T10:00:00.000Z', memberIndex: 0, postIndex: 0});
+            const second = await addComment({createdAt: '2026-05-01T12:00:00.000Z', memberIndex: 0, postIndex: 0});
+            await addComment({createdAt: '2026-05-02T10:00:00.000Z', memberIndex: 1, postIndex: 1});
+            await addComment({createdAt: '2026-05-02T11:00:00.000Z', memberIndex: 2, postIndex: 1, status: 'hidden'});
+
+            await addReport(first, 1, '2026-05-01T13:00:00.000Z');
+            await addReport(first, 2, '2026-05-01T14:00:00.000Z');
+            await addReport(second, 2, '2026-05-02T14:00:00.000Z');
+
+            const {body} = await agent
+                .get('/stats/comments/?date_from=2026-05-01&date_to=2026-05-02&timezone=UTC')
+                .expectStatus(200);
+
+            const overview = body.stats[0];
+            assert.deepEqual(overview.totals, {comments: 3, commenters: 2, reported: 2});
+            assert.deepEqual(overview.previousTotals, {comments: 2, commenters: 2, reported: 0});
+            assert.deepEqual(overview.series, [
+                {date: '2026-05-01', count: 2, commenters: 1, reported: 1},
+                {date: '2026-05-02', count: 1, commenters: 1, reported: 1}
+            ]);
+            assert.deepEqual(overview.topPosts.slice(0, 2), [
+                {id: post(0).id, title: post(0).title, slug: post(0).slug, count: 2},
+                {id: post(1).id, title: post(1).title, slug: post(1).slug, count: 1}
+            ]);
+            assert.deepEqual(overview.topMembers.slice(0, 2), [
+                {id: member(0).id, name: member(0).name ?? null, email: member(0).email, count: 2},
+                {id: member(1).id, name: member(1).name ?? null, email: member(1).email, count: 1}
+            ]);
+        });
+
+        it('buckets comment series by the requested timezone through the Admin API', async function () {
+            const comment = await addComment({
+                createdAt: '2026-05-06T06:30:00.000Z',
+                memberIndex: 0,
+                postIndex: 0
+            });
+            await addReport(comment, 1, '2026-05-06T06:45:00.000Z');
+
+            const {body} = await agent
+                .get('/stats/comments/?date_from=2026-05-05&date_to=2026-05-05&timezone=America/Los_Angeles')
+                .expectStatus(200);
+
+            const overview = body.stats[0];
+            assert.deepEqual(overview.totals, {comments: 1, commenters: 1, reported: 1});
+            assert.deepEqual(overview.series, [
+                {date: '2026-05-05', count: 1, commenters: 1, reported: 1}
+            ]);
         });
     });
 });

--- a/ghost/core/test/integration/services/comments-stats-service.test.js
+++ b/ghost/core/test/integration/services/comments-stats-service.test.js
@@ -1,0 +1,104 @@
+const assert = require('node:assert/strict');
+const ObjectId = require('bson-objectid').default;
+const testUtils = require('../../utils');
+const CommentsStatsService = require('../../../core/server/services/comments/comments-stats-service');
+const db = require('../../../core/server/data/db');
+
+describe('CommentsStatsService', function () {
+    before(testUtils.teardownDb);
+    before(testUtils.setup('users:roles', 'posts', 'members'));
+
+    beforeEach(async function () {
+        await testUtils.truncate('comment_reports');
+        await testUtils.truncate('comments');
+    });
+
+    const service = new CommentsStatsService({db});
+
+    function post(index = 0) {
+        return testUtils.DataGenerator.forKnex.posts[index];
+    }
+
+    function member(index = 0) {
+        return testUtils.DataGenerator.forKnex.members[index];
+    }
+
+    async function addComment({postIndex = 0, memberIndex = 0, createdAt, status = 'published', html = '<p>Comment</p>'} = {}) {
+        const id = ObjectId().toHexString();
+        await db.knex('comments').insert({
+            id,
+            post_id: post(postIndex).id,
+            member_id: member(memberIndex).id,
+            html,
+            status,
+            created_at: createdAt,
+            updated_at: createdAt
+        });
+
+        return {id};
+    }
+
+    async function addReport(comment, memberIndex = 1, createdAt) {
+        await db.knex('comment_reports').insert({
+            id: ObjectId().toHexString(),
+            comment_id: comment.id,
+            member_id: member(memberIndex).id,
+            created_at: createdAt,
+            updated_at: createdAt
+        });
+    }
+
+    it('aggregates totals, previous totals, top posts and top members from real tables', async function () {
+        await addComment({createdAt: '2026-04-29T10:00:00.000Z', memberIndex: 0});
+        await addComment({createdAt: '2026-04-30T10:00:00.000Z', memberIndex: 1});
+
+        const first = await addComment({createdAt: '2026-05-01T10:00:00.000Z', memberIndex: 0, postIndex: 0});
+        const second = await addComment({createdAt: '2026-05-01T12:00:00.000Z', memberIndex: 0, postIndex: 0});
+        await addComment({createdAt: '2026-05-02T10:00:00.000Z', memberIndex: 1, postIndex: 1});
+        await addComment({createdAt: '2026-05-02T11:00:00.000Z', memberIndex: 2, postIndex: 1, status: 'hidden'});
+
+        await addReport(first, 1, '2026-05-01T13:00:00.000Z');
+        await addReport(first, 2, '2026-05-01T14:00:00.000Z');
+        await addReport(second, 2, '2026-05-02T14:00:00.000Z');
+
+        const result = await service.getOverview({
+            dateFrom: '2026-05-01',
+            dateTo: '2026-05-02',
+            timezone: 'UTC'
+        });
+
+        assert.deepEqual(result.totals, {comments: 3, commenters: 2, reported: 2});
+        assert.deepEqual(result.previousTotals, {comments: 2, commenters: 2, reported: 0});
+        assert.deepEqual(result.series, [
+            {date: '2026-05-01', count: 2, commenters: 1, reported: 1},
+            {date: '2026-05-02', count: 1, commenters: 1, reported: 1}
+        ]);
+        assert.deepEqual(result.topPosts.map(item => ({id: item.id, count: item.count})), [
+            {id: post(0).id, count: 2},
+            {id: post(1).id, count: 1}
+        ]);
+        assert.deepEqual(result.topMembers.map(item => ({id: item.id, count: item.count})), [
+            {id: member(0).id, count: 2},
+            {id: member(1).id, count: 1}
+        ]);
+    });
+
+    it('buckets series rows by the requested timezone', async function () {
+        const comment = await addComment({
+            createdAt: '2026-05-06T06:30:00.000Z',
+            memberIndex: 0,
+            postIndex: 0
+        });
+        await addReport(comment, 1, '2026-05-06T06:45:00.000Z');
+
+        const result = await service.getOverview({
+            dateFrom: '2026-05-05',
+            dateTo: '2026-05-05',
+            timezone: 'America/Los_Angeles'
+        });
+
+        assert.deepEqual(result.series, [
+            {date: '2026-05-05', count: 1, commenters: 1, reported: 1}
+        ]);
+    });
+});

--- a/ghost/core/test/integration/services/comments-stats-service.test.js
+++ b/ghost/core/test/integration/services/comments-stats-service.test.js
@@ -9,8 +9,9 @@ describe('CommentsStatsService', function () {
     before(testUtils.setup('users:roles', 'posts', 'members'));
 
     beforeEach(async function () {
-        await testUtils.truncate('comment_reports');
-        await testUtils.truncate('comments');
+        await db.knex('comment_likes').delete();
+        await db.knex('comment_reports').delete();
+        await db.knex('comments').delete();
     });
 
     const service = new CommentsStatsService({db});

--- a/ghost/core/test/unit/server/services/comments/comments-stats-service.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-stats-service.test.js
@@ -37,6 +37,10 @@ function createService({tableResults = {}} = {}) {
     };
 }
 
+function isSeriesQuery(builder) {
+    return builder.select.called && !builder.count.called && !builder.countDistinct.called && !builder.join.called;
+}
+
 describe('CommentsStatsService', function () {
     afterEach(function () {
         sinon.restore();
@@ -47,13 +51,13 @@ describe('CommentsStatsService', function () {
             const {service} = createService({
                 tableResults: {
                     comments: (builder) => {
-                        if (builder.groupByRaw.called || builder.join.called) {
+                        if (isSeriesQuery(builder) || builder.join.called) {
                             return [];
                         }
                         return [{count: 0, commenters: 0}];
                     },
                     comment_reports: (builder) => {
-                        if (builder.groupByRaw.called) {
+                        if (isSeriesQuery(builder)) {
                             return [];
                         }
                         return [{reported: 0}];
@@ -73,14 +77,16 @@ describe('CommentsStatsService', function () {
             assert.deepEqual(result.topMembers, []);
         });
 
-        it('maps aggregate rows into the expected shape', async function () {
+        it('buckets series detail rows into the expected shape', async function () {
             const {service} = createService({
                 tableResults: {
                     comments: (builder) => {
-                        if (builder.groupByRaw.called) {
+                        if (isSeriesQuery(builder)) {
                             return [
-                                {date: '2026-01-10', count: '5', commenters: '4'},
-                                {date: '2026-01-11', count: '7', commenters: '5'}
+                                {created_at: new Date('2026-01-10T10:00:00.000Z'), member_id: 'mem-1'},
+                                {created_at: new Date('2026-01-10T11:00:00.000Z'), member_id: 'mem-1'},
+                                {created_at: new Date('2026-01-10T12:00:00.000Z'), member_id: 'mem-2'},
+                                {created_at: new Date('2026-01-11T10:00:00.000Z'), member_id: 'mem-3'}
                             ];
                         }
                         if (builder.join.called) {
@@ -101,8 +107,12 @@ describe('CommentsStatsService', function () {
                         return [{count: '42', commenters: '11'}];
                     },
                     comment_reports: (builder) => {
-                        if (builder.groupByRaw.called) {
-                            return [{date: '2026-01-11', reported: '2'}];
+                        if (isSeriesQuery(builder)) {
+                            return [
+                                {created_at: new Date('2026-01-11T10:00:00.000Z'), comment_id: 'comment-1'},
+                                {created_at: new Date('2026-01-11T11:00:00.000Z'), comment_id: 'comment-1'},
+                                {created_at: new Date('2026-01-11T12:00:00.000Z'), comment_id: 'comment-2'}
+                            ];
                         }
                         return [{reported: '3'}];
                     }
@@ -117,8 +127,8 @@ describe('CommentsStatsService', function () {
                 reported: 3
             });
             assert.deepEqual(result.series, [
-                {date: '2026-01-10', count: 5, commenters: 4, reported: 0},
-                {date: '2026-01-11', count: 7, commenters: 5, reported: 2}
+                {date: '2026-01-10', count: 3, commenters: 2, reported: 0},
+                {date: '2026-01-11', count: 1, commenters: 1, reported: 2}
             ]);
             assert.deepEqual(result.topPosts[0], {
                 id: 'post-1', title: 'Post One', slug: 'post-one', count: 20
@@ -132,14 +142,19 @@ describe('CommentsStatsService', function () {
             const {service} = createService({
                 tableResults: {
                     comments: (builder) => {
-                        if (builder.groupByRaw.called || builder.join.called) {
+                        if (isSeriesQuery(builder) || builder.join.called) {
                             return [];
                         }
                         return [{count: 0, commenters: 0}];
                     },
                     comment_reports: (builder) => {
-                        if (builder.groupByRaw.called) {
-                            return [{date: '2026-02-15', reported: '4'}];
+                        if (isSeriesQuery(builder)) {
+                            return [
+                                {created_at: new Date('2026-02-15T10:00:00.000Z'), comment_id: 'comment-1'},
+                                {created_at: new Date('2026-02-15T11:00:00.000Z'), comment_id: 'comment-2'},
+                                {created_at: new Date('2026-02-15T12:00:00.000Z'), comment_id: 'comment-3'},
+                                {created_at: new Date('2026-02-15T13:00:00.000Z'), comment_id: 'comment-4'}
+                            ];
                         }
                         return [{reported: '4'}];
                     }
@@ -169,7 +184,7 @@ describe('CommentsStatsService', function () {
             const {service} = createService({
                 tableResults: {
                     comments: (builder) => {
-                        if (builder.groupByRaw.called || builder.join.called) {
+                        if (isSeriesQuery(builder) || builder.join.called) {
                             return [];
                         }
                         return isCurrentRange(builder)
@@ -177,7 +192,7 @@ describe('CommentsStatsService', function () {
                             : [{count: '20', commenters: '8'}];
                     },
                     comment_reports: (builder) => {
-                        if (builder.groupByRaw.called) {
+                        if (isSeriesQuery(builder)) {
                             return [];
                         }
                         return isCurrentRange(builder)
@@ -200,7 +215,7 @@ describe('CommentsStatsService', function () {
             const {service} = createService({
                 tableResults: {
                     comments: (builder) => {
-                        if (builder.groupByRaw.called || builder.join.called) {
+                        if (isSeriesQuery(builder) || builder.join.called) {
                             return [];
                         }
                         const from = builder.where.getCalls().find(c => c.args[1] === '>=')?.args[2];
@@ -227,13 +242,13 @@ describe('CommentsStatsService', function () {
             const {service} = createService({
                 tableResults: {
                     comments: (builder) => {
-                        if (builder.groupByRaw.called || builder.join.called) {
+                        if (isSeriesQuery(builder) || builder.join.called) {
                             return [];
                         }
                         return [{count: 0, commenters: 0}];
                     },
                     comment_reports: (builder) => {
-                        if (builder.groupByRaw.called) {
+                        if (isSeriesQuery(builder)) {
                             return [];
                         }
                         return [{reported: 0}];
@@ -246,12 +261,12 @@ describe('CommentsStatsService', function () {
             assert.equal(result.previousTotals, null);
         });
 
-        it('formats Date instances in series rows into YYYY-MM-DD strings', async function () {
+        it('buckets series rows by the requested timezone', async function () {
             const {service} = createService({
                 tableResults: {
                     comments: (builder) => {
-                        if (builder.groupByRaw.called) {
-                            return [{date: new Date('2026-03-07T00:00:00.000Z'), count: 4, commenters: 3}];
+                        if (isSeriesQuery(builder)) {
+                            return [{created_at: new Date('2026-03-07T06:30:00.000Z'), member_id: 'mem-1'}];
                         }
                         if (builder.join.called) {
                             return [];
@@ -259,17 +274,17 @@ describe('CommentsStatsService', function () {
                         return [{count: 0, commenters: 0}];
                     },
                     comment_reports: (builder) => {
-                        if (builder.groupByRaw.called) {
-                            return [];
+                        if (isSeriesQuery(builder)) {
+                            return [{created_at: new Date('2026-03-07T06:45:00.000Z'), comment_id: 'comment-1'}];
                         }
                         return [{reported: 0}];
                     }
                 }
             });
 
-            const result = await service.getOverview({});
+            const result = await service.getOverview({timezone: 'America/Los_Angeles'});
 
-            assert.deepEqual(result.series, [{date: '2026-03-07', count: 4, commenters: 3, reported: 0}]);
+            assert.deepEqual(result.series, [{date: '2026-03-06', count: 1, commenters: 1, reported: 1}]);
         });
     });
 });


### PR DESCRIPTION
## Summary

Draft PR stacked on top of `comment-analytics-overview`.

This addresses review follow-ups for the comment analytics overview:

- refactors the comments page composition so `CommentsLayout`, `CommentsMain`, `CommentsSidebar`, and `CommentsAnalytics` have clearer layout/content boundaries
- fixes reported-bar filter updates so date and reported filters are applied atomically
- fixes year-to-date range handling and hides comparison deltas where the copy would be misleading
- adds a compact analytics error state with retry
- buckets comment analytics series by the requested timezone instead of raw SQL `DATE(created_at)`
- adds real DB integration coverage and stronger Admin API e2e assertions for analytics totals, previous totals, top posts, top commenters, reports, hidden filtering, and timezone-local buckets

## Validation

- `pnpm --filter @tryghost/posts test:unit`
- `pnpm --filter @tryghost/posts lint:code` (passes with existing unrelated `use-post-success-modal.ts` warning)
- `pnpm --dir ghost/core test:single test/integration/services/comments-stats-service.test.js`
- `pnpm --dir ghost/core test:single test/e2e-api/admin/stats.test.js`
- `git diff --check origin/main...HEAD`

## Notes

`gh auth status` reports an invalid local token, so this PR was created via the GitHub connector after pushing the branch over SSH.