### PR TITLE
🐛 Fixed second label filter creating duplicate filters on each toggle

### DIFF
--- a/apps/shade/src/components/features/filters/filters.tsx
+++ b/apps/shade/src/components/features/filters/filters.tsx
@@ -2422,16 +2422,23 @@ export function Filters<T = unknown>({
                             )}
                         >
                             {selectedFieldForOptions ? (
-                                // Show original select/multiselect rendering without back button
-                                // SelectOptionsPopover renders its own Command component when inline={true}
+                                // In multi-filter mode, override the field's type to 'select' so
+                                // the inline picker behaves as single-pick: one click commits a
+                                // new single-value filter and the picker closes. Further
+                                // multi-value editing happens through the filter row's own
+                                // picker. In single-filter mode the picker stays multi-select and
+                                // accumulates values into one filter (handled in
+                                // addFilterWithOption).
                                 <SelectOptionsPopover<T>
-                                    field={selectedFieldForOptions}
+                                    field={
+                                        allowMultiple && selectedFieldForOptions.type === 'multiselect'
+                                            ? {...selectedFieldForOptions, type: 'select'}
+                                            : selectedFieldForOptions
+                                    }
                                     inline={true}
                                     values={tempSelectedValues as T[]}
                                     onChange={(values) => {
-                                        // For multiselect, create filter immediately but keep popover open
-                                        // For single select, create filter and close popover
-                                        const shouldClosePopover = selectedFieldForOptions.type === 'select';
+                                        const shouldClosePopover = allowMultiple || selectedFieldForOptions.type === 'select';
                                         addFilterWithOption(selectedFieldForOptions, values as unknown[], shouldClosePopover);
                                     }}
                                     onClose={closeFilterPopover}

--- a/apps/shade/src/components/features/filters/filters.tsx
+++ b/apps/shade/src/components/features/filters/filters.tsx
@@ -2234,15 +2234,7 @@ export function Filters<T = unknown>({
             // For select and multiselect types, show the options popover
             if (field.type === 'select' || field.type === 'multiselect') {
                 setSelectedFieldKeyForOptions(field.key);
-
-                // When editing an existing filter (single-filter mode), pre-populate with its values
-                if (!allowMultiple && field.type === 'multiselect') {
-                    const existingFilter = filters.find(f => f.field === fieldKey);
-                    setTempSelectedValues(existingFilter ? existingFilter.values : []);
-                } else {
-                    setTempSelectedValues([]);
-                }
-
+                setTempSelectedValues([]);
                 return;
             }
 
@@ -2271,37 +2263,19 @@ export function Filters<T = unknown>({
     );
 
     const addFilterWithOption = useCallback(
-        (field: FilterFieldConfig<T>, values: unknown[], closePopover: boolean = true) => {
+        (field: FilterFieldConfig<T>, values: unknown[]) => {
             if (!field.key) {
                 return;
             }
 
-            // In single-filter mode, update the existing filter for this field if one exists
-            if (!allowMultiple) {
-                const existingFilter = filters.find(f => f.field === field.key);
-                if (existingFilter) {
-                    onChange(filters.map(f => (f.id === existingFilter.id ? {...f, values: values as T[]} : f)));
-                    setTempSelectedValues(values as T[]);
-
-                    if (closePopover) {
-                        closeFilterPopover();
-                    }
-                    return;
-                }
-            }
-
-            // Create a new filter
+            // Every commit creates a new filter. Multi-value editing of an existing
+            // filter happens through the filter row's own picker, not here.
             const defaultOperator = field.defaultOperator || (field.type === 'multiselect' ? 'is_any_of' : 'is');
             const newFilter = createFilter<T>(field.key, defaultOperator, values as T[]);
             onChange([...filters, newFilter]);
-
-            if (closePopover) {
-                closeFilterPopover();
-            } else {
-                setTempSelectedValues(values as unknown[]);
-            }
+            closeFilterPopover();
         },
-        [allowMultiple, closeFilterPopover, filters, onChange]
+        [closeFilterPopover, filters, onChange]
     );
 
     const selectableFields = useMemo(() => {
@@ -2422,25 +2396,21 @@ export function Filters<T = unknown>({
                             )}
                         >
                             {selectedFieldForOptions ? (
-                                // In multi-filter mode, override the field's type to 'select' so
-                                // the inline picker behaves as single-pick: one click commits a
-                                // new single-value filter and the picker closes. Further
-                                // multi-value editing happens through the filter row's own
-                                // picker. In single-filter mode the picker stays multi-select and
-                                // accumulates values into one filter (handled in
-                                // addFilterWithOption).
+                                // The inline "add filter" picker always commits one filter per
+                                // pick and closes — for both `select` and `multiselect` fields.
+                                // We override `multiselect` → `select` so SelectOptionsPopover
+                                // renders the single-pick UI (one click → onChange + onClose).
+                                // Multi-value editing of an existing filter happens through the
+                                // filter row's own picker, not here.
                                 <SelectOptionsPopover<T>
                                     field={
-                                        allowMultiple && selectedFieldForOptions.type === 'multiselect'
+                                        selectedFieldForOptions.type === 'multiselect'
                                             ? {...selectedFieldForOptions, type: 'select'}
                                             : selectedFieldForOptions
                                     }
                                     inline={true}
                                     values={tempSelectedValues as T[]}
-                                    onChange={(values) => {
-                                        const shouldClosePopover = allowMultiple || selectedFieldForOptions.type === 'select';
-                                        addFilterWithOption(selectedFieldForOptions, values as unknown[], shouldClosePopover);
-                                    }}
+                                    onChange={values => addFilterWithOption(selectedFieldForOptions, values as unknown[])}
                                     onClose={closeFilterPopover}
                                 />
                             ) : (

--- a/apps/shade/test/unit/components/ui/filters.test.tsx
+++ b/apps/shade/test/unit/components/ui/filters.test.tsx
@@ -1,7 +1,7 @@
 import {useMemo, useState} from 'react';
 import {act, fireEvent, render, screen, waitFor} from '../../utils/test-utils';
 import {afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
-import {createFilter, FilterFieldConfig, Filters, ValueSource} from '../../../../src/components/features/filters/filters';
+import {createFilter, Filter, FilterFieldConfig, Filters, ValueSource} from '../../../../src/components/features/filters/filters';
 
 type TestOption = {
     value: string;
@@ -212,5 +212,90 @@ describe('Filters ValueSource', () => {
         rerender(<StaticLoadingFilters isLoading={true} options={ALL_OPTIONS} />);
         expect(await screen.findByPlaceholderText('Search status...')).toBeDefined();
         expect(document.querySelector('.animate-spin')).toBeTruthy();
+    });
+});
+
+describe('Filters allowMultiple multiselect', () => {
+    beforeAll(() => {
+        global.ResizeObserver = class {
+            observe() {
+                return undefined;
+            }
+
+            unobserve() {
+                return undefined;
+            }
+
+            disconnect() {
+                return undefined;
+            }
+        } as unknown as typeof ResizeObserver;
+        HTMLElement.prototype.scrollIntoView = vi.fn();
+    });
+
+    function MultiselectTestFilters({initialFilters, onChangeSpy}: Readonly<{
+        initialFilters: Filter<string>[];
+        // eslint-disable-next-line no-unused-vars
+        onChangeSpy: (filters: Filter<string>[]) => void;
+    }>) {
+        const [filters, setFilters] = useState<Filter<string>[]>(initialFilters);
+        const fields = useMemo<FilterFieldConfig<string>[]>(() => ([
+            {
+                key: 'label',
+                label: 'Label',
+                type: 'multiselect',
+                searchable: false,
+                operators: [{value: 'is-any', label: 'is any of'}],
+                defaultOperator: 'is-any',
+                options: [
+                    {value: 'vip', label: 'VIP'},
+                    {value: 'premium', label: 'Premium'},
+                    {value: 'gold', label: 'Gold'}
+                ]
+            }
+        ]), []);
+
+        return (
+            <Filters
+                addButtonText="Add filter"
+                allowMultiple={true}
+                fields={fields}
+                filters={filters}
+                showSearchInput={false}
+                onChange={(next) => {
+                    onChangeSpy(next);
+                    setFilters(next);
+                }}
+            />
+        );
+    }
+
+    it('commits a new single-value label filter and closes the picker after one selection', async () => {
+        const onChangeSpy = vi.fn();
+        const initial = [createFilter<string>('label', 'is-any', ['vip'])];
+
+        render(<MultiselectTestFilters initialFilters={initial} onChangeSpy={onChangeSpy} />);
+
+        fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+        const labelMenuItem = await screen.findByRole('option', {name: 'Label'});
+        fireEvent.click(labelMenuItem);
+
+        const premiumOption = await screen.findByRole('option', {name: 'Premium'});
+        fireEvent.click(premiumOption);
+
+        await waitFor(() => {
+            const lastCall = onChangeSpy.mock.calls.at(-1);
+            expect(lastCall).toBeDefined();
+            const finalFilters = lastCall![0] as Filter<string>[];
+            expect(finalFilters).toHaveLength(2);
+            expect(finalFilters[0].field).toBe('label');
+            expect(finalFilters[0].values).toEqual(['vip']);
+            expect(finalFilters[1].field).toBe('label');
+            expect(finalFilters[1].values).toEqual(['premium']);
+        });
+
+        // Picker should have closed — no more option role elements visible.
+        expect(screen.queryByRole('option', {name: 'Gold'})).toBeNull();
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3591/adding-a-second-label-filter-does-not-work

## Problem

In the React members list, opening the filter popover and picking "Label" (or any multiselect field) opened an inline multi-select picker that stayed open after each click and spawned a new filter on every commit. Picking a single value worked correctly, but the picker invited the user to click more — and each additional click left a stranded filter behind with stale single-value selections, while a fresh filter was created with the latest cumulative selection.

The same code path applied to every multiselect field in the members filter: `label`, `tier_id` (Membership tier), and `offer_redemptions` (Offer).

## Solution

The add-filter inline picker is now always single-pick: pick one value → commit a new single-value filter → close. Multi-value editing is the responsibility of the filter row's own picker (`LabelFilterRenderer` for label, non-inline `SelectOptionsPopover` for tier/offer), which already supports live multi-select with count updates.

While in the area, several `allowMultiple` branches were either unreachable in production or redundant after the unified picker behaviour, so they were cleaned up:

- The "update existing filter" branch in `addFilterWithOption` was unreachable. Audited all three consumers: members uses `allowMultiple=true` (skips that branch), comments only has `select` fields (closes after one pick), stats's only multiselect field sets `autoCloseOnSelect: true` (same effect). Removed.
- Dropped the `closePopover` parameter — every commit now closes the popover.
- Dropped the `shouldClosePopover` conditional and the dead `addFilter` pre-populate that read from a hidden field.

After the cleanup, `allowMultiple` does exactly one thing: gates whether fields with an existing filter are hidden from the "Add filter" field list (members shows them so users can stack same-field filters; comments and stats hide them so users get one filter per field). All other behaviour is uniform across both modes.

## Test plan

- [x] Unit test in `apps/shade/test/unit/components/ui/filters.test.tsx` covering the add-filter flow with `allowMultiple={true}`
- [x] Manual verification in browser for all three multiselect fields:
  - `label` — pick Blue Consultant, then add second filter Lime Orchestrator → 2 separate filters; chip dropdown adds Magenta to filter 2 in place
  - `tier_id` — pick Silver, then add second filter Gold → 2 separate filters; chip dropdown adds Bronze to filter 2 in place
  - `offer_redemptions` — pick Black Friday, then add second filter Free Trial → 2 separate filters
- [x] Manual verification of `allowMultiple={false}` consumers:
  - Comments — picking Status → Published commits one filter, picker closes; "Add filter" no longer offers Status
- [x] `pnpm --filter=@tryghost/shade test` (213 passing)
- [x] `pnpm --filter=@tryghost/posts test` (165 passing)
- [x] `pnpm --filter=@tryghost/shade lint`