### PR TITLE
Fixed adapter-manager misreporting missing deps as missing adapter

### DIFF
--- a/ghost/core/core/server/services/adapter-manager/adapter-manager.js
+++ b/ghost/core/core/server/services/adapter-manager/adapter-manager.js
@@ -135,8 +135,11 @@ module.exports = class AdapterManager {
                     throw new errors.IncorrectUsageError({err});
                 }
 
-                // Catch missing dependencies BUT NOT missing adapter
-                if (!err.message.includes(pathToAdapter)) {
+                // Catch missing dependencies BUT NOT missing adapter.
+                // Only check the first line — Node appends a "Require stack"
+                // that includes the adapter's own path, which would false-positive.
+                const firstLine = err.message.split('\n')[0];
+                if (!firstLine.includes(pathToAdapter)) {
                     throw new errors.IncorrectUsageError({
                         message: `You are missing dependencies in your adapter ${pathToAdapter}`,
                         err

--- a/ghost/core/test/unit/server/services/adapter-manager/adapter-manager.test.js
+++ b/ghost/core/test/unit/server/services/adapter-manager/adapter-manager.test.js
@@ -1,4 +1,7 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const sinon = require('sinon');
 const AdapterManager = require('../../../../../core/server/services/adapter-manager/adapter-manager');
 
@@ -80,6 +83,33 @@ describe('AdapterManager', function () {
         });
 
         sinon.assert.calledWith(loadAdapterFromPath, 'some-node-module-adapter');
+    });
+
+    it('Throws missing-dependency error when adapter exists but requires a missing package', function () {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-adapter-test-'));
+        const adapterDir = path.join(tmpDir, 'scheduling');
+        fs.mkdirSync(adapterDir, {recursive: true});
+        fs.writeFileSync(
+            path.join(adapterDir, 'BrokenAdapter.js'),
+            `require('this-package-does-not-exist-at-all');\nmodule.exports = class {};`
+        );
+
+        try {
+            const adapterManager = new AdapterManager({
+                loadAdapterFromPath: require,
+                pathsToAdapters: [tmpDir]
+            });
+            adapterManager.registerAdapter('scheduling', BaseMailAdapter);
+
+            assert.throws(() => {
+                adapterManager.getAdapter('scheduling', 'BrokenAdapter', {});
+            }, {
+                errorType: 'IncorrectUsageError',
+                message: /missing dependencies/
+            });
+        } finally {
+            fs.rmSync(tmpDir, {recursive: true, force: true});
+        }
     });
 
     it('Loads registered adapters in the order defined by the paths', function () {


### PR DESCRIPTION
Node's `MODULE_NOT_FOUND` errors include a "Require stack" that lists
the calling file's path. The existing heuristic checked whether the
adapter path appeared _anywhere_ in `err.message` to distinguish
"adapter not found" from "adapter found but has a missing dependency."

Because the adapter's own path always appears in the require stack, the
check always matched, causing missing-dep errors to be silently
swallowed and replaced with a misleading "Unable to find adapter"
message.

Restricting the check to the first line of the error message fixes the
false positive.