### PR TITLE
Updated copy and setting for gift redemption staff notification

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/users/email-notifications-tab.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/email-notifications-tab.tsx
@@ -107,8 +107,8 @@ const EmailNotificationsInputs: React.FC<{ user: User; setUserData: (user: User)
                             align='center'
                             checked={user.gift_subscription_purchase_notification}
                             direction='rtl'
-                            hint='Every time someone purchases a gift subscription'
-                            label='Gift subscription purchases'
+                            hint='Every time someone purchases or redeems a gift subscription'
+                            label='Gift subscriptions'
                             onChange={(e) => {
                                 setUserData?.({...user, gift_subscription_purchase_notification: e.target.checked});
                             }}

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -61,6 +61,7 @@ User = ghostBookshelf.Model.extend({
 
     defaults: function defaults() {
         return {
+            // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
             password: security.identifier.uid(50),
             visibility: 'public',
             status: 'active',
@@ -513,7 +514,7 @@ User = ghostBookshelf.Model.extend({
             filter += '+donation_notifications:true';
         } else if (type === 'recommendation-received') {
             filter += '+recommendation_notifications:true';
-        } else if (type === 'gift-subscription-purchased') {
+        } else if (type === 'gift-subscriptions') {
             filter += '+gift_subscription_purchase_notification:true';
         }
         const updatedOptions = Object.assign({}, options, {filter, withRelated: ['roles']});

--- a/ghost/core/core/server/services/staff/email-templates/gift.hbs
+++ b/ghost/core/core/server/services/staff/email-templates/gift.hbs
@@ -28,7 +28,7 @@
                     {{/if}}
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
-                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">Someone purchased a gift&nbsp;subscription!</h1>
+                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">Someone purchased a gift&nbsp;subscription</h1>
                         <table width="100" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background: #F4F5F6; border-radius: 8px;">
                           <tbody>
                             <tr>

--- a/ghost/core/core/server/services/staff/email-templates/gift.txt.js
+++ b/ghost/core/core/server/services/staff/email-templates/gift.txt.js
@@ -1,7 +1,7 @@
 module.exports = function giftText(data) {
     // Be careful when you indent the email, because whitespaces are visible in emails!
     return `
-Someone purchased a gift subscription!
+Someone purchased a gift subscription
 
 From: ${data.gift.name}
 Tier: ${data.gift.tierName} • ${data.gift.cadenceLabel}

--- a/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.hbs
+++ b/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.hbs
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>🎁 Paid subscription started: {{memberData.name}}</title>
+    <title>🎁 Gift subscription redeemed: {{memberData.name}}</title>
     {{> styles}}
   </head>
   <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
@@ -16,7 +16,7 @@
             <!-- START CENTERED CONTAINER -->
             {{#> preview}}
               {{#*inline "content"}}
-                New paid subscriber: {{memberData.name}}
+                Gift subscription redeemed: {{memberData.name}}
               {{/inline}}
             {{/preview}}
 
@@ -33,7 +33,7 @@
                     {{/if}}
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
-                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">You have a new paid&nbsp;subscriber</h1>
+                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">Someone redeemed a gift&nbsp;subscription</h1>
                         <table width="100" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background: #F4F5F6; border-radius: 8px;">
                           <tbody>
                             <tr>

--- a/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.txt.js
+++ b/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.txt.js
@@ -1,10 +1,9 @@
 module.exports = function (data) {
     // Be careful when you indent the email, because whitespaces are visible in emails!
     return `
-Congratulations!
+Someone redeemed a gift subscription
 
-You have a new paid member: ${data.memberData.name}
-
+Member: ${data.memberData.name}
 Tier: ${data.tierData.name}${data.tierData.details ? ` • ${data.tierData.details}` : ''}
 Gifted by: ${data.giftedByEmail}
 

--- a/ghost/core/core/server/services/staff/staff-service-emails.js
+++ b/ghost/core/core/server/services/staff/staff-service-emails.js
@@ -308,7 +308,7 @@ class StaffServiceEmails {
      * @returns {Promise<void>}
      */
     async notifyGiftReceived({name, email, memberId, amount, currency, tierName, cadence, duration}) {
-        const users = await this.models.User.getEmailAlertUsers('gift-subscription-purchased');
+        const users = await this.models.User.getEmailAlertUsers('gift-subscriptions');
         const formattedAmount = this.getFormattedAmount({currency, amount: amount / 100});
 
         const displayName = name ?? email;
@@ -338,13 +338,13 @@ class StaffServiceEmails {
     }
 
     async notifyGiftSubscriptionStarted({memberId, memberName, memberEmail, tierName, cadence, duration, buyerEmail}, options = {}) {
-        const users = await this.models.User.getEmailAlertUsers('paid-started', options);
+        const users = await this.models.User.getEmailAlertUsers('gift-subscriptions', options);
         const memberData = this.getMemberData({
             id: memberId,
             name: memberName ?? null,
             email: memberEmail
         });
-        const subject = `🎁 Paid subscription started: ${memberData.name}`;
+        const subject = `🎁 Gift subscription redeemed: ${memberData.name}`;
         const cadenceLabel = duration === 1 ? `1 ${cadence}` : `${duration} ${cadence}s`;
 
         await this.sendToStaff({

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -636,7 +636,7 @@ describe('Gift Subscriptions', function () {
 
                 // Verify staff notification email was sent
                 mockManager.assert.sentEmail({
-                    subject: /paid subscription started/i,
+                    subject: /gift subscription redeemed/i,
                     to: 'jbloggs@example.com'
                 });
             });
@@ -832,10 +832,10 @@ describe('Gift Subscriptions', function () {
                             'Should enqueue the paid welcome email automation, not the free one'
                         );
 
-                        // Verify gift subscription started staff notification was sent,
+                        // Verify gift subscription redeemed staff notification was sent,
                         // and that no other unwanted staff notifications were sent (i.e. no "Free member signup" email)
                         mockManager.assert.sentEmail({
-                            subject: /paid subscription started/i,
+                            subject: /gift subscription redeemed/i,
                             to: 'jbloggs@example.com'
                         });
                         mockManager.assert.sentEmailCount(1);
@@ -970,9 +970,9 @@ describe('Gift Subscriptions', function () {
                             'Should enqueue the paid welcome email automation, not the free one'
                         );
 
-                        // Verify gift subscription started staff notification was sent
+                        // Verify gift subscription redeemed staff notification was sent
                         mockManager.assert.sentEmail({
-                            subject: /paid subscription started/i,
+                            subject: /gift subscription redeemed/i,
                             to: 'jbloggs@example.com'
                         });
 

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -987,7 +987,7 @@ describe('StaffService', function () {
                     duration: 1
                 });
 
-                sinon.assert.calledWith(getEmailAlertUsersStub, 'gift-subscription-purchased');
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'gift-subscriptions');
                 sinon.assert.calledOnce(mailStub);
                 sinon.assert.calledWith(mailStub, sinon.match.has('subject', sinon.match('Gift subscription purchased: $60.00 from Alice')));
             });
@@ -1102,9 +1102,9 @@ describe('StaffService', function () {
                     buyerEmail: 'gifter@example.com'
                 });
 
-                sinon.assert.calledWith(getEmailAlertUsersStub, 'paid-started');
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'gift-subscriptions');
                 sinon.assert.calledOnce(mailStub);
-                sinon.assert.calledWith(mailStub, sinon.match.has('subject', sinon.match('🎁 Paid subscription started: Jamie')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('subject', sinon.match('🎁 Gift subscription redeemed: Jamie')));
             });
 
             it('includes the tier and cadence in HTML and plain text', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3616

When a recipient redeems a gift subscription, Ghost sends staff a notification email. Today it reuses the *paid subscription started* copy and the *New paid members* email-preference toggle.

We've decided to differentiate the gift redemption staff notification more clearly from the new paid members one. This PR changes the copy of the gift redemption staff notification and moves it under the "Gift subscriptions" email-preference toggle.

## Changes

**Email copy** — `notifyGiftSubscriptionStarted`:
- Subject: `🎁 Paid subscription started: <name>` → `🎁 Gift subscription redeemed: <name>`
- Headline: `You have a new paid subscriber` → `A gift subscription was redeemed`
- Plaintext body line updated to match
- Preview text updated to match

**Notification preference** — gift redemptions now go through the existing **Gift subscriptions** toggle (Stripe + `giftSubscriptions` feature flag), instead of *New paid members*:
- Toggle label: `Gift subscription purchases` → `Gift subscriptions`
- Description: `Every time someone purchases a gift subscription` → `Every time someone purchases or redeems a gift subscription`

**Pre-commit hygiene:**
- Added a targeted `secretlint-disable-next-line` on the random-password-generator default in `user.js` — the new secret-scanning hook (added in #27609) flags `password: security.identifier.uid(50)` as a credential-assignment false-positive, blocking any future change to this file. The line generates a random password placeholder; it isn't a real credential.
