### PR TITLE
Removed `6.x` branch from CodeRabbit auto-review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,6 +6,3 @@ reviews:
   sequence_diagrams: false
   estimate_code_review_effort: false
   poem: false
-  auto_review:
-    base_branches:
-      - 6.x


### PR DESCRIPTION
ref https://docs.coderabbit.ai/configuration/auto-review#base_branches
ref https://github.com/TryGhost/Ghost/tree/6.x

By default, CodeRabbit only reviews PRs against `main`. We previously added `6.x` to this list. But Ghost v6 has been out awhile, so we can remove this rule. (The `6.x` branch hasn't been updated for almost a year.)
