### PR TITLE
Added trial days to new paid subscription staff notification

### DIFF
--- a/ghost/core/core/server/services/staff/email-templates/new-paid-started.hbs
+++ b/ghost/core/core/server/services/staff/email-templates/new-paid-started.hbs
@@ -16,7 +16,7 @@
             <!-- START CENTERED CONTAINER -->
             {{#> preview}}
               {{#*inline "content"}}
-                {{tierData.name}}: {{tierData.details}} {{#if offerData}}- Offer: {{offerData.name}} - {{offerData.details}}{{/if}}
+                {{tierData.name}}: {{tierData.details}}{{#if tierData.trialDays}} - {{tierData.trialDays}} days free{{/if}} {{#if offerData}}- Offer: {{offerData.name}} - {{offerData.details}}{{/if}}
               {{/inline}}
             {{/preview}}
 
@@ -44,7 +44,7 @@
                                       <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Name</p>
                                       <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{memberData.name}}{{#if memberData.showEmail}} ({{memberData.email}}){{/if}}</p>
                                       <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Tier</p>
-                                      <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{tierData.name}}{{#if tierData.details}} &bull; {{tierData.details}}{{/if}}</p>
+                                      <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{tierData.name}}{{#if tierData.details}} &bull; {{tierData.details}}{{/if}}{{#if tierData.trialDays}} &bull; <span style="color: {{accentColor}};">{{tierData.trialDays}} days free</span>{{/if}}</p>
                                       {{#if offerData}}
                                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; margin: 0; padding-bottom: 4px; color: #15171A; font-weight: 700;">Offer</p>
                                         <p class="text-link large" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; margin: 0; padding-bottom: 24px; color: #15171A; font-weight: 400;">{{offerData.name}} &bull; <span style="color: {{accentColor}};">{{offerData.details}}</span></p>

--- a/ghost/core/core/server/services/staff/staff-service-emails.js
+++ b/ghost/core/core/server/services/staff/staff-service-emails.js
@@ -79,7 +79,8 @@ class StaffServiceEmails {
             const interval = subscription?.interval || '';
             const tierData = {
                 name: tier?.name || '',
-                details: `${formattedAmount}/${interval}`
+                details: `${formattedAmount}/${interval}`,
+                trialDays: null
             };
 
             const subscriptionData = {
@@ -87,6 +88,15 @@ class StaffServiceEmails {
             };
 
             let offerData = this.getOfferData(offer);
+
+            if (!offerData && subscription?.trialEnd) {
+                const trialEnd = moment(subscription.trialEnd);
+                const trialStart = subscription.trialStart ? moment(subscription.trialStart) : moment();
+                const days = trialEnd.diff(trialStart, 'days');
+                if (days > 0) {
+                    tierData.trialDays = days;
+                }
+            }
 
             let attributionTitle = attribution?.title || '';
             // In case of a homepage attribution, we want to show the title as "Homepage" on email

--- a/ghost/core/core/server/services/staff/staff-service.js
+++ b/ghost/core/core/server/services/staff/staff-service.js
@@ -45,7 +45,9 @@ class StaffService {
                 currency: subscription.plan?.currency,
                 startDate: subscription.start_date,
                 cancelAt: subscription.current_period_end,
-                cancellationReason: subscription.cancellation_reason
+                cancellationReason: subscription.cancellation_reason,
+                trialStart: subscription.trial_start_at,
+                trialEnd: subscription.trial_end_at
             } : null,
             member: member ? {
                 id: member.id,

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -565,7 +565,7 @@ describe('StaffService', function () {
                 testCommonPaidSubMailData({...stubs, member});
 
                 assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', 'Offer')
+                    sinon.match.has('html', sinon.match('Offer'))
                 ), false);
             });
 
@@ -580,7 +580,7 @@ describe('StaffService', function () {
                 testCommonPaidSubMailData({...stubs, member: memberData});
 
                 assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', 'Offer')
+                    sinon.match.has('html', sinon.match('Offer'))
                 ), false);
 
                 // check preview text
@@ -656,6 +656,56 @@ describe('StaffService', function () {
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Free week')));
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('7 days free')));
             });
+
+            it('sends paid subscription start alert with gift-derived trial period', async function () {
+                const trialStart = new Date('2022-08-01T07:30:39.882Z');
+                const trialEnd = new Date('2022-08-31T07:30:39.882Z');
+                const trialSubscription = {
+                    ...subscription,
+                    trialStart,
+                    trialEnd
+                };
+
+                await service.emails.notifyPaidSubscriptionStarted({member, offer: null, tier, subscription: trialSubscription}, options);
+
+                sinon.assert.calledOnce(mailStub);
+                testCommonPaidSubMailData({...stubs, member});
+
+                // Trial appears inline on the Tier line, not as a separate Offer block
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('30 days free')));
+                assert.equal(mailStub.calledWith(
+                    sinon.match.has('html', sinon.match('Offer'))
+                ), false);
+
+                // check preview text — trial appended to tier line
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Test Tier: $50.00/month - 30 days free')));
+            });
+
+            it('does not show inline trial on tier line when a trial offer is present', async function () {
+                offer = {
+                    name: 'Free week',
+                    duration: 'trial',
+                    type: 'trial',
+                    amount: 7
+                };
+                const trialSubscription = {
+                    ...subscription,
+                    trialStart: new Date('2022-08-01T07:30:39.882Z'),
+                    trialEnd: new Date('2022-08-08T07:30:39.882Z')
+                };
+
+                await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription: trialSubscription}, options);
+
+                sinon.assert.calledOnce(mailStub);
+                testCommonPaidSubMailData({...stubs, member});
+
+                // The Offer block renders "7 days free" but the Tier line should NOT also show it
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Free week')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('7 days free')));
+                assert.equal(mailStub.calledWith(
+                    sinon.match.has('html', sinon.match('Test Tier: $50.00/month - 7 days free'))
+                ), false);
+            });
         });
 
         describe('notifyPaidSubscriptionCancel', function () {
@@ -704,7 +754,7 @@ describe('StaffService', function () {
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('5 Sep 2024')));
 
                 assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', 'Offer')
+                    sinon.match.has('html', sinon.match('Offer'))
                 ), false);
 
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Cancellation reason')));
@@ -750,7 +800,7 @@ describe('StaffService', function () {
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('5 Sep 2024')));
 
                 assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', 'Offer')
+                    sinon.match.has('html', sinon.match('Offer'))
                 ), false);
 
                 sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Cancellation reason')));


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3618

When a gift member upgrades to a paid subscription, Ghost converts their remaining gift days into a Stripe trial period (see [`payments-service.js`](https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/server/services/members/members-api/services/payments-service.js)). Until now, that trial period was invisible in the **💸 Paid subscription started** staff email — staff saw "Premium • $6.00/month" with no indication that the new member wouldn't be charged for N days.

This PR surfaces the trial days inline on the Tier line, mirroring the visual treatment we already use for trial offers:

> Premium • $6.00/month • **3 days free**

…with `3 days free` rendered in the site's accent color.

### How it works
- `staff-service.js` now serialises `trial_start_at` / `trial_end_at` (already present on the `StripeCustomerSubscription` model) into the subscription payload passed to the email assembler.
- `staff-service-emails.js` computes `tierData.trialDays` from those timestamps when the subscription has a trial *and* no offer is attached. The `!offerData` guard avoids duplicating "X days free" alongside an active trial offer, which already renders that text in the Offer block.
- The template appends an accent-coloured `{{tierData.trialDays}} days free` to the existing Tier line.

The approach is source-agnostic — it also surfaces tier-default trial days (`tier.trialDays`), not only gift-derived trials — which felt like a natural side benefit rather than a bug. No event-payload changes needed; we reuse data already on the model.

## Test plan
- [x] Unit tests added in `staff-service.test.js`:
    - happy path: gift-derived trial period renders "30 days free" inline on the Tier line
    - guard: trial offer + trial period on subscription does *not* duplicate "X days free" on the Tier line
- [x] All existing `notifyPaidSubscriptionStarted` tests still pass
- [x] Manual: gift member upgrades to paid via Portal → verify Mailpit shows the trial days on the Tier line in the staff email
- [x] Manual: tier-based trial signup shows the trial days on the Tier line
- [x] Manual: trial-offer signup still renders only the Offer block (no duplication)
- [x] Manual: regular paid signup (no trial, no offer) renders unchanged