### PR TITLE
Added no-cache handling for preview requests

### DIFF
--- a/ghost/core/core/frontend/web/middleware/frontend-caching.js
+++ b/ghost/core/core/frontend/web/middleware/frontend-caching.js
@@ -4,6 +4,7 @@
 const config = require('../../../shared/config');
 const shared = require('../../../server/web/shared');
 const {api} = require('../../services/proxy');
+const preview = require('../../services/theme-engine/preview');
 
 /**
  * Calculate the member's active tier.
@@ -43,6 +44,10 @@ const getMiddleware = async (getFreeTier = async () => {
      * @param {import('express').NextFunction} next
      */
     function setFrontendCacheHeadersMiddleware(req, res, next) {
+        if (req.header?.(preview._PREVIEW_HEADER_NAME)) {
+            return shared.middleware.cacheControl('noCache')(req, res, next);
+        }
+
         // Caching member's content is an experimental feature, enabled via config
         const shouldCacheMembersContent = config.get('cacheMembersContent:enabled');
         // CASE: Never cache if the blog is set to private

--- a/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
@@ -73,6 +73,15 @@ describe('frontendCaching', function () {
         sinon.assert.calledWith(res.set, {'Cache-Control': testUtils.cacheRules.noCache});
     });
 
+    it('should set cache control to no-cache if the request includes preview data', function () {
+        req.header = sinon.stub().withArgs('x-ghost-preview').returns('c=%23ff0000');
+
+        middleware(req, res, next);
+
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': testUtils.cacheRules.noCache});
+    });
+
     describe('calculateMemberTier', function () {
         it('should return null if the member has more than one active subscription', function () {
             const member = {


### PR DESCRIPTION
no ref

Preview requests can include request-specific theme data, so these responses should not be stored or reused by frontend caches.