### PR TITLE
Harden private site access code checks

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/lib/middleware.js
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/middleware.js
@@ -12,16 +12,27 @@ const privateRoute = '/private/';
 
 const messages = {
     pageNotFound: 'Page not found.',
-    wrongPassword: 'Incorrect password.'
+    wrongAccessCode: 'Incorrect access code.'
 };
 
+function getAccessCode() {
+    const accessCode = settingsCache.get('password');
+    return typeof accessCode === 'string' ? accessCode : '';
+}
+
+function hasAccessCode(accessCode) {
+    return typeof accessCode === 'string' && accessCode.trim().length > 0;
+}
+
 function verifySessionHash(salt, hash) {
-    if (!salt || !hash) {
+    const accessCode = getAccessCode();
+
+    if (!salt || !hash || !hasAccessCode(accessCode)) {
         return false;
     }
 
     let hasher = crypto.createHash('sha256');
-    hasher.update(settingsCache.get('password') + salt, 'utf8');
+    hasher.update(accessCode + salt, 'utf8');
     return hasher.digest('hex') === hash;
 }
 
@@ -152,21 +163,21 @@ const privateBlogging = {
             return next();
         }
 
-        const bodyPass = req.body.password;
-        const pass = settingsCache.get('password');
+        const submittedAccessCode = req.body && req.body.password;
+        const accessCode = getAccessCode();
         const hasher = crypto.createHash('sha256');
         const salt = Date.now().toString();
         const forward = getRedirectUrl(req.query);
 
-        if (pass === bodyPass) {
-            hasher.update(bodyPass + salt, 'utf8');
+        if (hasAccessCode(accessCode) && hasAccessCode(submittedAccessCode) && accessCode === submittedAccessCode) {
+            hasher.update(submittedAccessCode + salt, 'utf8');
             req.session.token = hasher.digest('hex');
             req.session.salt = salt;
 
             return res.redirect(urlUtils.urlFor({relativeUrl: forward}));
         } else {
             res.error = {
-                message: tpl(messages.wrongPassword)
+                message: tpl(messages.wrongAccessCode)
             };
             return next();
         }

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -8,9 +8,9 @@ const settingsCache = require('../../../../../core/shared/settings-cache');
 const config = require('../../../../../core/shared/config');
 const privateBlogging = require('../../../../../core/frontend/apps/private-blogging/lib/middleware');
 
-function hash(password, salt) {
+function hash(accessCode, salt) {
     const hasher = crypto.createHash('sha256');
-    hasher.update(password + salt, 'utf8');
+    hasher.update(accessCode + salt, 'utf8');
     return hasher.digest('hex');
 }
 
@@ -239,15 +239,47 @@ describe('Private Blogging', function () {
                 sinon.assert.called(next);
             });
 
-            it('doLoginToPrivateSite should return next if password is incorrect', function () {
+            it('doLoginToPrivateSite should return next if access code is incorrect', function () {
                 req.body = {password: 'wrongpassword'};
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 assertExists(res.error);
+                assert.equal(res.error.message, 'Incorrect access code.');
                 sinon.assert.called(next);
             });
 
-            it('doLoginToPrivateSite should redirect if password is correct', function () {
+            it('doLoginToPrivateSite should return next if stored access code is empty', function () {
+                settingsStub.withArgs('password').returns('');
+                req.body = {password: ''};
+
+                privateBlogging.doLoginToPrivateSite(req, res, next);
+                assertExists(res.error);
+                assert.equal(res.error.message, 'Incorrect access code.');
+                sinon.assert.notCalled(res.redirect);
+                sinon.assert.called(next);
+            });
+
+            it('doLoginToPrivateSite should return next if submitted access code is empty', function () {
+                req.body = {password: ''};
+
+                privateBlogging.doLoginToPrivateSite(req, res, next);
+                assertExists(res.error);
+                assert.equal(res.error.message, 'Incorrect access code.');
+                sinon.assert.notCalled(res.redirect);
+                sinon.assert.called(next);
+            });
+
+            it('doLoginToPrivateSite should return next if submitted access code is missing', function () {
+                req.body = {};
+
+                privateBlogging.doLoginToPrivateSite(req, res, next);
+                assertExists(res.error);
+                assert.equal(res.error.message, 'Incorrect access code.');
+                sinon.assert.notCalled(res.redirect);
+                sinon.assert.called(next);
+            });
+
+            it('doLoginToPrivateSite should redirect if access code is correct', function () {
                 req.body = {password: 'rightpassword'};
                 req.session = {};
                 res.redirect = sinon.spy();
@@ -321,7 +353,7 @@ describe('Private Blogging', function () {
                 assert.equal(res.redirect.args[0][0], '/');
             });
 
-            describe('Bad Password', function () {
+            describe('Bad access code', function () {
                 beforeEach(function () {
                     req.session = {
                         token: 'wrongpassword',
@@ -356,6 +388,21 @@ describe('Private Blogging', function () {
             it('authenticatePrivateSession should return next', function () {
                 privateBlogging.authenticatePrivateSession(req, res, next);
                 sinon.assert.called(next);
+            });
+
+            it('authenticatePrivateSession should redirect when stored access code is empty', function () {
+                const salt = Date.now().toString();
+                settingsStub.withArgs('password').returns('');
+                req.url = '/welcome';
+                req.session = {
+                    token: hash('', salt),
+                    salt
+                };
+
+                privateBlogging.authenticatePrivateSession(req, res, next);
+                sinon.assert.notCalled(next);
+                sinon.assert.called(res.redirect);
+                sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
             });
 
             it('handle404 should still 404', function () {

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -250,7 +250,7 @@ describe('Private Blogging', function () {
 
             it('doLoginToPrivateSite should return next if stored access code is empty', function () {
                 settingsStub.withArgs('password').returns('');
-                req.body = {password: ''};
+                req.body = {password: 'rightpassword'};
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 assertExists(res.error);

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -259,6 +259,28 @@ describe('Private Blogging', function () {
                 sinon.assert.called(next);
             });
 
+            it('doLoginToPrivateSite should return next if stored access code is undefined', function () {
+                settingsStub.withArgs('password').returns(undefined);
+                req.body = {password: 'rightpassword'};
+
+                privateBlogging.doLoginToPrivateSite(req, res, next);
+                assertExists(res.error);
+                assert.equal(res.error.message, 'Incorrect access code.');
+                sinon.assert.notCalled(res.redirect);
+                sinon.assert.called(next);
+            });
+
+            it('doLoginToPrivateSite should return next if stored access code is null', function () {
+                settingsStub.withArgs('password').returns(null);
+                req.body = {password: 'rightpassword'};
+
+                privateBlogging.doLoginToPrivateSite(req, res, next);
+                assertExists(res.error);
+                assert.equal(res.error.message, 'Incorrect access code.');
+                sinon.assert.notCalled(res.redirect);
+                sinon.assert.called(next);
+            });
+
             it('doLoginToPrivateSite should return next if submitted access code is empty', function () {
                 req.body = {password: ''};
 


### PR DESCRIPTION
## Summary
- Treat private-site authentication as access-code based in middleware naming and user-facing copy.
- Reject empty or missing stored/submitted access codes so blank settings cannot authenticate visitors.
- Add unit coverage for empty-code and terminology cases.

## Testing
- pnpm test:single test/unit/frontend/apps/private-blogging/middleware.test.js