### PR TITLE
🐛 Improved checks for comped subs in member creation flow

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1954,15 +1954,15 @@ module.exports = class MemberRepository {
             });
         }
 
-        const zeroValuePrices = defaultProduct.stripePrices.filter((price) => {
-            return price.amount === 0;
+        const complimentaryPrices = defaultProduct.stripePrices.filter((price) => {
+            return price.amount === 0 && this.isComplimentaryPlanNickname(price.nickname);
         });
 
         if (activeSubscriptions.length) {
             for (const subscription of activeSubscriptions) {
                 const price = await subscription.related('stripePrice').fetch(options);
 
-                let zeroValuePrice = zeroValuePrices.find((p) => {
+                let zeroValuePrice = complimentaryPrices.find((p) => {
                     return p.currency.toLowerCase() === price.get('currency').toLowerCase();
                 });
 
@@ -1980,9 +1980,9 @@ module.exports = class MemberRepository {
                         }]
                     }, options)).toJSON();
                     zeroValuePrice = product.stripePrices.find((p) => {
-                        return p.currency.toLowerCase() === price.get('currency').toLowerCase() && p.amount === 0;
+                        return p.currency.toLowerCase() === price.get('currency').toLowerCase() && p.amount === 0 && this.isComplimentaryPlanNickname(p.nickname);
                     });
-                    zeroValuePrices.push(zeroValuePrice);
+                    complimentaryPrices.push(zeroValuePrice);
                 }
 
                 const stripeSubscription = await this._stripeAPIService.getSubscription(
@@ -2014,7 +2014,7 @@ module.exports = class MemberRepository {
                 name: stripeCustomer.name
             }, sharedOptions);
 
-            let zeroValuePrice = zeroValuePrices[0];
+            let zeroValuePrice = complimentaryPrices[0];
 
             if (!zeroValuePrice) {
                 const product = (await this._productRepository.update({
@@ -2030,9 +2030,9 @@ module.exports = class MemberRepository {
                     }]
                 }, sharedOptions)).toJSON();
                 zeroValuePrice = product.stripePrices.find((price) => {
-                    return price.currency.toLowerCase() === 'usd' && price.amount === 0;
+                    return price.currency.toLowerCase() === 'usd' && price.amount === 0 && this.isComplimentaryPlanNickname(price.nickname);
                 });
-                zeroValuePrices.push(zeroValuePrice);
+                complimentaryPrices.push(zeroValuePrice);
             }
 
             const subscription = await this._stripeAPIService.createSubscription(

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1982,6 +1982,11 @@ module.exports = class MemberRepository {
                     zeroValuePrice = product.stripePrices.find((p) => {
                         return p.currency.toLowerCase() === price.get('currency').toLowerCase() && p.amount === 0 && this.isComplimentaryPlanNickname(p.nickname);
                     });
+                    if (!zeroValuePrice) {
+                        throw new errors.NotFoundError({
+                            message: `Failed to locate a complimentary (zero-amount, nickname matched by isComplimentaryPlanNickname) Stripe price for currency "${price.get('currency')}" on product ${product.id} after update. Returned stripePrices: ${JSON.stringify(product.stripePrices)}`
+                        });
+                    }
                     complimentaryPrices.push(zeroValuePrice);
                 }
 
@@ -2032,6 +2037,11 @@ module.exports = class MemberRepository {
                 zeroValuePrice = product.stripePrices.find((price) => {
                     return price.currency.toLowerCase() === 'usd' && price.amount === 0 && this.isComplimentaryPlanNickname(price.nickname);
                 });
+                if (!zeroValuePrice) {
+                    throw new errors.NotFoundError({
+                        message: `Failed to locate a complimentary (zero-amount, nickname matched by isComplimentaryPlanNickname) Stripe price for currency "USD" on product ${product.id} after update. Returned stripePrices: ${JSON.stringify(product.stripePrices)}`
+                    });
+                }
                 complimentaryPrices.push(zeroValuePrice);
             }
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -143,6 +143,93 @@ describe('MemberRepository', function () {
                 assert.equal(err.message, 'Could not find Product "default"');
             }
         });
+
+        it('ignores non-complimentary zero-value prices when creating a complimentary subscription', async function () {
+            const member = {
+                id: 'member_id_123',
+                get: sinon.stub().withArgs('email').returns('member@example.com'),
+                related: () => {
+                    return {
+                        fetch: sinon.stub().resolves({
+                            models: []
+                        })
+                    };
+                }
+            };
+            Member.findOne.resolves(member);
+
+            const activeSubscriptionPrice = {
+                stripe_price_id: 'price_active_subscription',
+                nickname: 'Active Subscription',
+                currency: 'usd',
+                amount: 0
+            };
+            const complimentaryPrice = {
+                stripe_price_id: 'price_complimentary',
+                nickname: 'Complimentary',
+                currency: 'usd',
+                amount: 0
+            };
+
+            productRepository = {
+                getDefaultProduct: sinon.stub().resolves({
+                    toJSON: () => {
+                        return {
+                            id: 'product_id_123',
+                            name: 'Default tier',
+                            description: null,
+                            stripePrices: [activeSubscriptionPrice]
+                        };
+                    }
+                }),
+                update: sinon.stub().resolves({
+                    toJSON: () => {
+                        return {
+                            stripePrices: [
+                                activeSubscriptionPrice,
+                                complimentaryPrice
+                            ]
+                        };
+                    }
+                })
+            };
+
+            const stripeAPIService = {
+                configured: true,
+                createCustomer: sinon.stub().resolves({
+                    id: 'cus_123',
+                    email: 'member@example.com',
+                    name: null
+                }),
+                createSubscription: sinon.stub().resolves({
+                    id: 'sub_123',
+                    customer: 'cus_123'
+                })
+            };
+
+            const StripeCustomer = {
+                upsert: sinon.stub().resolves()
+            };
+
+            const repo = new MemberRepository({
+                Member,
+                StripeCustomer,
+                stripeAPIService,
+                productRepository,
+                OfferRedemption: mockOfferRedemption
+            });
+            sinon.stub(repo, 'linkSubscription').resolves();
+
+            await repo.setComplimentarySubscription({
+                id: 'member_id_123'
+            }, {
+                transacting: true
+            });
+
+            sinon.assert.calledOnce(productRepository.update);
+            sinon.assert.calledWith(stripeAPIService.createSubscription, 'cus_123', 'price_complimentary');
+            sinon.assert.neverCalledWith(stripeAPIService.createSubscription, 'cus_123', 'price_active_subscription');
+        });
     });
 
     describe('newsletter subscriptions', function () {


### PR DESCRIPTION
ref INC-280

Fixes comped member creation so Ghost only reuses zero-value Stripe prices that are actually marked as `Complimentary`.

Previously, `setComplimentarySubscription()` selected the first zero-value price on the default paid tier. If a site had another $0 price, Ghost could create the comped subscription with that price and then misclassify the member because later logic only treats `Complimentary` as comped.