### PR TITLE
Fixed HTML entities appearing in Portal toast and heading text

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.33",
+  "version": "2.68.34",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/offer-page.js
+++ b/apps/portal/src/components/pages/offer-page.js
@@ -523,7 +523,7 @@ export default class OfferPage extends React.Component {
         };
 
         const originalPrice = this.getOriginalPrice({offer, product});
-        const renewsLabel = t(`Renews at {price}.`, {price: originalPrice, interpolation: {escapeValue: false}});
+        const renewsLabel = t(`Renews at {price}.`, {price: originalPrice});
 
         let offerLabel = '';
         let useRenewsLabel = false;
@@ -546,8 +546,7 @@ export default class OfferPage extends React.Component {
             return (
                 <p className="footnote" data-testid="offer-message">{t('Try free for {amount} days, then {originalPrice}.', {
                     amount: offer.amount,
-                    originalPrice: originalPrice,
-                    interpolation: {escapeValue: false}
+                    originalPrice: originalPrice
                 })} <span className="gh-portal-cancel">{t('Cancel anytime.')}</span></p>
             );
         }

--- a/apps/portal/src/components/pages/recommendations-page.js
+++ b/apps/portal/src/components/pages/recommendations-page.js
@@ -323,7 +323,7 @@ const RecommendationsPage = () => {
         return <LoadingPage/>;
     }
 
-    const heading = pageData && pageData.signup ? t('Welcome to {siteTitle}', {siteTitle: title, interpolation: {escapeValue: false}}) : t('Recommendations');
+    const heading = pageData && pageData.signup ? t('Welcome to {siteTitle}', {siteTitle: title}) : t('Recommendations');
 
     /* Possible cases:
     - no recommendations found - subhead says no recommendations are available.

--- a/ghost/i18n/lib/i18n.js
+++ b/ghost/i18n/lib/i18n.js
@@ -111,7 +111,7 @@ module.exports = (lng = 'en', ns = 'portal', options = {}) => {
         prefix: '{',
         suffix: '}'
     };
-    if (ns === 'theme') {
+    if (ns === 'theme' || ns === 'portal') {
         interpolation.escapeValue = false;
     }
     let resources;


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1368/handle-apostrophes-in-names-in-portal, https://linear.app/ghost/issue/DES-1359/newsletter-names-with-and-display-incorrectly-in-popups

i18next was escaping apostrophes and ampersands in interpolated values, mangling things like the subscribe toast. Disabled escaping for the portal namespace and removed three older per-call workarounds.

| Before | After |
|--------|--------|
| <img width="553" height="693" alt="Screenshot 2026-05-07 at 22 55 08" src="https://github.com/user-attachments/assets/f289f29d-6f31-4eef-a427-9f7407b253e2" /> | <img width="549" height="697" alt="Screenshot 2026-05-07 at 22 53 49" src="https://github.com/user-attachments/assets/bd0c0dcd-5549-4f81-9788-7b00c77fd7c0" /> |
| <img width="412" height="106" alt="Screenshot 2026-05-07 at 22 54 49" src="https://github.com/user-attachments/assets/cfa8c2a1-6143-480a-b0d7-8e6a41af7a46" /> | <img width="415" height="108" alt="Screenshot 2026-05-07 at 22 54 31" src="https://github.com/user-attachments/assets/1774d71a-e66d-470b-9111-b2af2f229ef4" /> | 