### PR TITLE
Disable HTML escaping for site titles in signup success notifications

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.33",
+  "version": "2.68.34",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/notification.js
+++ b/apps/portal/src/components/notification.js
@@ -68,7 +68,7 @@ const NotificationText = ({type, status, message, context}) => {
                     mapping={{
                         strong: <strong />
                     }}
-                    string={t('You\'ve successfully subscribed to <strong>{siteTitle}</strong>', {siteTitle: context.site.title})}
+                    string={t('You\'ve successfully subscribed to <strong>{siteTitle}</strong>', {siteTitle: context.site.title, interpolation: {escapeValue: false}})}
                 />
             </p>
         );
@@ -79,7 +79,7 @@ const NotificationText = ({type, status, message, context}) => {
                     mapping={{
                         strong: <strong />
                     }}
-                    string={t('You\'ve successfully subscribed to <strong>{siteTitle}</strong>', {siteTitle: context.site.title})}
+                    string={t('You\'ve successfully subscribed to <strong>{siteTitle}</strong>', {siteTitle: context.site.title, interpolation: {escapeValue: false}})}
                 />
             </p>
         );

--- a/apps/portal/test/unit/components/notification.test.js
+++ b/apps/portal/test/unit/components/notification.test.js
@@ -206,6 +206,38 @@ describe('Notification', () => {
         });
     });
 
+    test('renders site titles with special characters without HTML escaping in signup success toast', async () => {
+        NotificationParser.mockReturnValue({
+            type: 'signup',
+            status: 'success',
+            autoHide: true,
+            duration: 5000
+        });
+
+        const site = {
+            url: 'https://example.com',
+            title: 'Fabien O\'Carroll'
+        };
+
+        const {getByText} = render(
+            <AppContext.Provider value={{
+                site,
+                member: null,
+                brandColor: '#000000',
+                showPopup: false,
+                doAction: vi.fn(),
+                notification: null
+            }}
+            >
+                <Notification />
+            </AppContext.Provider>
+        );
+
+        await waitFor(() => {
+            expect(getByText('Fabien O\'Carroll')).toBeInTheDocument();
+        });
+    });
+
     test('renders title and subtitle from a gift redemption error message object', async () => {
         NotificationParser.mockReturnValue({
             type: 'giftRedeem',

--- a/apps/portal/test/unit/components/notification.test.js
+++ b/apps/portal/test/unit/components/notification.test.js
@@ -216,7 +216,7 @@ describe('Notification', () => {
 
         const site = {
             url: 'https://example.com',
-            title: 'Fabien O\'Carroll'
+            title: 'Quentin O\'Apostrophe'
         };
 
         const {getByText} = render(
@@ -234,7 +234,7 @@ describe('Notification', () => {
         );
 
         await waitFor(() => {
-            expect(getByText('Fabien O\'Carroll')).toBeInTheDocument();
+            expect(getByText('Quentin O\'Apostrophe')).toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1708

Site titles containing special characters (like apostrophes) were being HTML-escaped in signup success notifications, causing them to display incorrectly to users. For example, `Quentin O'Apostrophe` would render in the toast as `Quentin O&#39;Apostrophe`.

We now disable HTML escaping for the `siteTitle` interpolation variable in the signup success and signup-paid success notifications by passing `interpolation: {escapeValue: false}` to the `t()` call.

The same opt-out is already used in `apps/portal/src/components/pages/recommendations-page.js` and `apps/portal/src/components/pages/offer-page.js` for the same reason.

## Why this is not an XSS risk

Disabling `escapeValue` only matters if the unescaped value can reach the DOM as raw HTML. In this code path it cannot:

1. The interpolated string is passed to `@doist/react-interpolate`, which only converts the explicitly-mapped `<strong>` tag into a real React element. Any other tag in the value (e.g. `<script>` smuggled into a site title) is left as-is in the output text.
2. That output is then rendered by React as a text node. React always escapes text nodes, so any HTML-looking content is rendered as literal characters rather than parsed as markup.
3. Nowhere in this flow is `dangerouslySetInnerHTML` used with the site title.

So the title is treated as plain text end-to-end, regardless of i18next's escaping setting. Removing the i18next pre-escape just stops the redundant entity encoding from leaking into the visible string.
