### PR TITLE
Removed dead password reset brute-force stub

### DIFF
--- a/ghost/core/core/server/api/endpoints/authentication.js
+++ b/ghost/core/core/server/api/endpoints/authentication.js
@@ -167,8 +167,7 @@ const controller = {
         ],
         async query(frame) {
             await auth.setup.assertSetupCompleted(true)();
-            const params = await auth.passwordreset.extractTokenParts(frame);
-            const {options, tokenParts} = await auth.passwordreset.protectBruteForce(params);
+            const {options, tokenParts} = await auth.passwordreset.extractTokenParts(frame);
             const internalOptions = Object.assign(options, {context: {internal: true}});
 
             const doResetParams = await auth.passwordreset.doReset(internalOptions, tokenParts, api.settings);

--- a/ghost/core/core/server/services/auth/passwordreset.js
+++ b/ghost/core/core/server/services/auth/passwordreset.js
@@ -10,7 +10,6 @@ const mail = require('../mail');
 
 const messages = {
     userNotFound: 'User not found.',
-    tokenLocked: 'Token locked',
     resetPassword: 'Reset Password',
     expired: {
         message: 'Cannot reset password.',
@@ -28,8 +27,6 @@ const messages = {
         help: 'Check if password reset link has been fully copied or request new password reset via the login form.'
     }
 };
-
-const tokenSecurity = {};
 
 function generateToken(email, settingsAPI, transaction) {
     const options = {context: {internal: true}, transacting: transaction};
@@ -73,18 +70,6 @@ function extractTokenParts(options) {
             message: tpl(messages.corruptedToken.message),
             context: tpl(messages.corruptedToken.context),
             help: tpl(messages.corruptedToken.help)
-        }));
-    }
-
-    return Promise.resolve({options, tokenParts});
-}
-
-// @TODO: use brute force middleware (see https://github.com/TryGhost/Ghost/pull/7579)
-function protectBruteForce({options, tokenParts}) {
-    if (tokenSecurity[`${tokenParts.email}+${tokenParts.expires}`] &&
-        tokenSecurity[`${tokenParts.email}+${tokenParts.expires}`].count >= 10) {
-        return Promise.reject(new errors.NoPermissionError({
-            message: tpl(messages.tokenLocked)
         }));
     }
 
@@ -187,7 +172,6 @@ async function sendResetNotification(data, mailAPI) {
 module.exports = {
     generateToken,
     extractTokenParts,
-    protectBruteForce,
     doReset,
     sendResetNotification
 };


### PR DESCRIPTION
## Summary

- Removed the unreachable `protectBruteForce` stub in `services/auth/passwordreset.js`. It read a `tokenSecurity[key].count` value that was never assigned anywhere in the file, so the `count >= 10` guard was always false and the in-file rate limit never triggered.
- Removed the matching `tokenSecurity` constant, the `tokenLocked` message, the `// @TODO` comment pointing at #7579 (2016), and the now-unused `protectBruteForce` export.
- Dropped the awaited call from `api/endpoints/authentication.js` since the function only forwarded `{options, tokenParts}` unchanged on the success path.

## Why

The actual brute-force protection for the password reset flow already lives at the route layer in `web/api/endpoints/admin/routes.js`:

- `PUT /authentication/password_reset` is wrapped by `shared.middleware.brute.globalBlock` (express-brute, DB-persisted in the `brute` table, 50 attempts/IP/hour by default — configurable via `spam.global_block`).
- `POST /authentication/password_reset` adds `globalReset` (per-IP) and `userReset` (per-username).

The TODO predated that middleware being wired up to this route, which is why the in-file counter was never finished — the protection landed at the route layer instead. The stub had no tests covering it (`grep` across `ghost/core/test` returns nothing), wasn't called from any other consumer, and recently caused a false-positive in a security report. Deleting it removes a misleading code path without changing behavior.
