### PR TITLE
✨ Added relative date filters to the members page

### DIFF
--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -27,7 +27,7 @@
         "dev": "vite build --watch",
         "dev:start": "vite",
         "build": "tsc && vite build",
-        "test:unit": "vitest run test/unit",
+        "test:unit": "vitest run",
         "lint": "pnpm run lint:code && pnpm run lint:test",
         "lint:code": "eslint --ext .js,.ts,.cjs,.tsx --cache src",
         "lint:code:fix": "eslint --ext .js,.ts,.cjs,.tsx --cache --fix src",

--- a/apps/posts/src/nql-lang.d.ts
+++ b/apps/posts/src/nql-lang.d.ts
@@ -1,6 +1,10 @@
 declare module '@tryghost/nql-lang' {
+    interface ParseOptions {
+        preserveRelativeDates?: boolean;
+    }
+
     const nql: {
-        parse(input: string): unknown;
+        parse(input: string, options?: ParseOptions): unknown;
     };
 
     export default nql;

--- a/apps/posts/src/views/comments/comment-fields.ts
+++ b/apps/posts/src/views/comments/comment-fields.ts
@@ -2,6 +2,7 @@ import {DATE_FILTER_OPERATORS, DEFAULT_DATE_OPERATOR} from '../filters/filter-da
 import {dateCodec, scalarCodec, textCodec} from '../filters/filter-codecs';
 import {defineFields} from '../filters/filter-types';
 import {extractComparator} from '../filters/filter-ast';
+import {withPastRelativeOperator} from '../filters/filter-relative-date';
 import type {FilterCodec} from '../filters/filter-types';
 
 const reportedCodec: FilterCodec = {
@@ -64,7 +65,7 @@ export const commentFields = defineFields({
         ],
         codec: scalarCodec()
     },
-    created_at: {
+    created_at: withPastRelativeOperator({
         operators: DATE_FILTER_OPERATORS,
         ui: {
             label: 'Date',
@@ -72,7 +73,7 @@ export const commentFields = defineFields({
             type: 'date'
         },
         codec: dateCodec()
-    },
+    }),
     body: {
         operators: ['contains', 'does-not-contain'],
         parseKeys: ['html'],

--- a/apps/posts/src/views/comments/comment-filter-query.ts
+++ b/apps/posts/src/views/comments/comment-filter-query.ts
@@ -1,9 +1,15 @@
 import {commentFields} from './comment-fields';
 import {dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates, stampPredicates} from '../filters/filter-query-core';
+import {resolveField} from '../filters/resolve-field';
 import type {AstNode} from '../filters/filter-ast';
 import type {FilterPredicate, ParsedPredicate} from '../filters/filter-types';
 
 const TIMEZONE_SENSITIVE_COMMENT_FIELDS = getFieldKeysByType(commentFields, 'date');
+
+function isPredicateEnabled(predicate: ParsedPredicate): boolean {
+    const resolved = resolveField(commentFields, predicate.field, 'UTC');
+    return resolved?.definition.operators.includes(predicate.operator) ?? false;
+}
 
 function parseCommentNode(node: AstNode, timezone: string): ParsedPredicate[] {
     if (Array.isArray(node.$and)) {
@@ -20,7 +26,7 @@ export function parseCommentFilter(filter: string | undefined, timezone: string)
         return [];
     }
 
-    return stampPredicates(parseCommentNode(ast, timezone));
+    return stampPredicates(parseCommentNode(ast, timezone).filter(isPredicateEnabled));
 }
 
 export function hasTimezoneSensitiveCommentFilter(filter: string | undefined): boolean {
@@ -34,5 +40,5 @@ export function hasTimezoneSensitiveCommentFilter(filter: string | undefined): b
 }
 
 export function serializeCommentFilters(predicates: FilterPredicate[], timezone: string): string | undefined {
-    return serializePredicates(predicates, commentFields, timezone);
+    return serializePredicates(predicates.filter(isPredicateEnabled), commentFields, timezone);
 }

--- a/apps/posts/src/views/comments/use-comment-filter-fields.ts
+++ b/apps/posts/src/views/comments/use-comment-filter-fields.ts
@@ -2,6 +2,7 @@ import React, {useMemo} from 'react';
 import {DATE_OPERATOR_LABELS} from '../filters/filter-date';
 import {FilterFieldConfig, ValueSource} from '@tryghost/shade/patterns';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {RELATIVE_DATE_OPERATOR_LABELS, createRelativeDateRenderer, fieldHasRelativeOperator} from '../filters/filter-relative-date';
 import {commentFields} from './comment-fields';
 import {createOperatorOptions} from '../filters/filter-operator-options';
 import {getTodayInTimezone} from '../filters/filter-normalization';
@@ -13,6 +14,11 @@ interface UseCommentFilterFieldsOptions {
 }
 
 const COMMENT_FIELD_ORDER = ['author', 'post', 'body', 'status', 'reported', 'created_at'] as const;
+
+const COMMENT_OPERATOR_LABELS = {
+    ...DATE_OPERATOR_LABELS,
+    ...RELATIVE_DATE_OPERATOR_LABELS
+};
 
 function getFieldIcon(key: string) {
     switch (key) {
@@ -43,14 +49,20 @@ export function useCommentFilterFields({
 
         return COMMENT_FIELD_ORDER.map((key) => {
             const field = commentFields[key];
+            const dateConfig = key === 'created_at'
+                ? {
+                    defaultValue: today,
+                    ...(fieldHasRelativeOperator(field) ? {customRenderer: createRelativeDateRenderer(today)} : {})
+                }
+                : {};
 
             return {
                 key,
                 ...field.ui,
                 icon: getFieldIcon(key),
-                operators: createOperatorOptions(field.operators, {labels: DATE_OPERATOR_LABELS}),
+                operators: createOperatorOptions(field.operators, {labels: COMMENT_OPERATOR_LABELS}),
                 ...('options' in field && field.options ? {options: field.options} : {}),
-                ...(key === 'created_at' ? {defaultValue: today} : {}),
+                ...dateConfig,
                 ...(key === 'author' ? {valueSource: memberValueSource} : {}),
                 ...(key === 'post' ? {valueSource: postValueSource} : {})
             };

--- a/apps/posts/src/views/filters/filter-codecs.ts
+++ b/apps/posts/src/views/filters/filter-codecs.ts
@@ -332,13 +332,62 @@ export function numberCodec(config?: CodecConfig): FilterCodec {
     };
 }
 
+interface RelativeDateTag {
+    $relativeDate: {
+        op: 'sub' | 'add';
+        amount: number;
+        unit: string;
+    };
+}
+
+function isRelativeDateTag(value: unknown): value is RelativeDateTag {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const tag = (value as Record<string, unknown>).$relativeDate;
+
+    if (!tag || typeof tag !== 'object') {
+        return false;
+    }
+
+    const {op, amount, unit} = tag as Record<string, unknown>;
+
+    return (op === 'sub' || op === 'add')
+        && typeof amount === 'number' && Number.isSafeInteger(amount) && amount > 0
+        && typeof unit === 'string';
+}
+
 export function dateCodec(config?: CodecConfig): FilterCodec {
     return {
         parse(node, ctx) {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field || typeof comparator.value !== 'string') {
+            if (!comparator || comparator.field !== field) {
+                return null;
+            }
+
+            // Relative dates flow through as `{$gte: {$relativeDate: ...}}`
+            // when the parse caller opted in via `preserveRelativeDates: true`
+            // — we currently only render relative day counts in the UI, so any
+            // other unit (weeks, months, ...) falls through to absolute-date
+            // handling below.
+            if (isRelativeDateTag(comparator.value) && comparator.value.$relativeDate.unit === 'days') {
+                const {op, amount} = comparator.value.$relativeDate;
+                const isPast = op === 'sub' && comparator.operator === '$gte';
+                const isFuture = op === 'add' && comparator.operator === '$lte';
+
+                if (isPast || isFuture) {
+                    return {
+                        field: ctx.key,
+                        operator: isPast ? 'in-the-last' : 'in-the-next',
+                        values: [amount]
+                    };
+                }
+            }
+
+            if (typeof comparator.value !== 'string') {
                 return null;
             }
 
@@ -356,8 +405,22 @@ export function dateCodec(config?: CodecConfig): FilterCodec {
             };
         },
         serialize(predicate, ctx) {
-            const rawValue = predicate.values[0];
             const field = getCodecField(config, ctx.key);
+
+            if (predicate.operator === 'in-the-last' || predicate.operator === 'in-the-next') {
+                const days = predicate.values[0];
+
+                if (typeof days !== 'number' || !Number.isSafeInteger(days) || days <= 0) {
+                    return null;
+                }
+
+                const sign = predicate.operator === 'in-the-last' ? '-' : '+';
+                const op = predicate.operator === 'in-the-last' ? '>=' : '<=';
+
+                return [`${field}:${op}now${sign}${days}d`];
+            }
+
+            const rawValue = predicate.values[0];
 
             if (typeof rawValue !== 'string' || rawValue === '') {
                 return null;

--- a/apps/posts/src/views/filters/filter-query-core.ts
+++ b/apps/posts/src/views/filters/filter-query-core.ts
@@ -9,7 +9,7 @@ export function parseFilterToAst(filter: string): AstNode | undefined {
     }
 
     try {
-        return nql.parse(filter) as AstNode;
+        return nql.parse(filter, {preserveRelativeDates: true}) as AstNode;
     } catch {
         return undefined;
     }

--- a/apps/posts/src/views/filters/filter-relative-date.test.tsx
+++ b/apps/posts/src/views/filters/filter-relative-date.test.tsx
@@ -1,0 +1,57 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {createRelativeDateRenderer, formatRelativeDateTooltip} from './filter-relative-date';
+import {render, screen} from '@testing-library/react';
+import type {FilterFieldConfig} from '@tryghost/shade/patterns';
+
+const dateField: FilterFieldConfig = {
+    key: 'created_at',
+    label: 'Created',
+    type: 'date',
+    operators: [
+        {value: 'is-or-less', label: 'on or before'},
+        {value: 'in-the-last', label: 'in the last'}
+    ]
+};
+
+describe('createRelativeDateRenderer', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('uses the Shade date picker for non-relative date operators', () => {
+        const renderer = createRelativeDateRenderer('2026-05-09');
+
+        render(<>{renderer({
+            field: dateField,
+            operator: 'is-or-less',
+            values: ['2026-05-07'],
+            onChange: vi.fn()
+        })}</>);
+
+        const input = screen.getByPlaceholderText('YYYY-MM-DD') as HTMLInputElement;
+
+        expect(input.type).toBe('text');
+        expect(screen.getByRole('button', {name: 'Open calendar'})).toBeInTheDocument();
+    });
+
+    it('formats relative date tooltips with the browser locale', () => {
+        vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('fr-FR');
+
+        expect(formatRelativeDateTooltip('2026-05-09', -7)).toBe('2 mai 2026');
+    });
+
+    it('does not rewrite hydrated relative date amounts above one year', () => {
+        const renderer = createRelativeDateRenderer('2026-05-09');
+        const onChange = vi.fn();
+
+        render(<>{renderer({
+            field: dateField,
+            operator: 'in-the-last',
+            values: [730],
+            onChange
+        })}</>);
+
+        expect(screen.getByLabelText('Relative date amount')).toHaveValue(730);
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/apps/posts/src/views/filters/filter-relative-date.tsx
+++ b/apps/posts/src/views/filters/filter-relative-date.tsx
@@ -1,15 +1,15 @@
 import React, {useEffect, useRef, useState} from 'react';
+import {type CustomRendererProps, FilterDatePicker, type FilterFieldConfig} from '@tryghost/shade/patterns';
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {cn} from '@tryghost/shade/utils';
-import type {CustomRendererProps, FilterFieldConfig} from '@tryghost/shade/patterns';
 import type {FilterField} from './filter-types';
 
 /**
  * The relative-date operator family — "in the last N days" / "in the next N
  * days" — plus the bits any view needs to use them: labels, a type guard,
  * variant builders that attach them to a date field, and the day-count input
- * renderer. Domains decide when to attach them (typically gated on a labs
- * flag); this file just provides the pieces.
+ * renderer. Domains decide when to attach them; this file just provides the
+ * pieces.
  */
 
 export const RELATIVE_PAST_OPERATOR = 'in-the-last';
@@ -39,7 +39,7 @@ export function withFutureRelativeOperator<T extends FilterField>(field: T): T {
 }
 
 /** The day-count input shown when a relative-date operator is selected. */
-export function createRelativeDateRenderer(fallbackDate: string): FilterFieldConfig['customRenderer'] {
+export function createRelativeDateRenderer(fallbackDate: string): NonNullable<FilterFieldConfig['customRenderer']> {
     const renderer = (props: CustomRendererProps) => React.createElement(RelativeDateFilter, {
         ...props,
         fallbackDate
@@ -53,7 +53,6 @@ export function createRelativeDateRenderer(fallbackDate: string): FilterFieldCon
 // ---------------------------------------------------------------------------
 
 const DEFAULT_AMOUNT = 7;
-const MAX_AMOUNT = 365;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 const inputClass = 'w-full bg-transparent outline-hidden dark:!bg-transparent';
@@ -71,8 +70,8 @@ const RelativeDateFilter: React.FC<RelativeDateFilterProps> = ({
 }) => {
     const isRelative = isRelativeDateOperator(operator);
     const rawAmount = values[0];
-    const amount = typeof rawAmount === 'number' && Number.isInteger(rawAmount) && rawAmount > 0
-        ? Math.min(rawAmount, MAX_AMOUNT)
+    const amount = typeof rawAmount === 'number' && Number.isSafeInteger(rawAmount) && rawAmount > 0
+        ? rawAmount
         : DEFAULT_AMOUNT;
     const dateValue = typeof rawAmount === 'string' && DATE_PATTERN.test(rawAmount) ? rawAmount : fallbackDate;
 
@@ -103,7 +102,7 @@ const RelativeDateFilter: React.FC<RelativeDateFilterProps> = ({
 
     if (isRelative) {
         const tooltipPrefix = operator === RELATIVE_PAST_OPERATOR ? 'Since' : 'Until';
-        const tooltipDate = shiftAndFormatDate(fallbackDate, operator === RELATIVE_PAST_OPERATOR ? -amount : amount);
+        const tooltipDate = formatRelativeDateTooltip(fallbackDate, operator === RELATIVE_PAST_OPERATOR ? -amount : amount);
 
         return (
             <TooltipProvider>
@@ -114,14 +113,13 @@ const RelativeDateFilter: React.FC<RelativeDateFilterProps> = ({
                                 aria-label="Relative date amount"
                                 className={cn(inputClass, 'min-w-[1ch] tabular-nums [field-sizing:content] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none')}
                                 data-slot="filters-input"
-                                max={MAX_AMOUNT}
                                 min={1}
                                 type="number"
                                 value={draft}
                                 onBlur={() => {
                                     const n = Number(draft);
 
-                                    if (!Number.isInteger(n) || n <= 0 || n > MAX_AMOUNT) {
+                                    if (!Number.isSafeInteger(n) || n <= 0) {
                                         setDraft(String(amount));
                                     }
                                 }}
@@ -130,7 +128,7 @@ const RelativeDateFilter: React.FC<RelativeDateFilterProps> = ({
                                     setDraft(next);
                                     const n = Number(next);
 
-                                    if (Number.isInteger(n) && n > 0 && n <= MAX_AMOUNT) {
+                                    if (Number.isSafeInteger(n) && n > 0) {
                                         onChange([n]);
                                     }
                                 }}
@@ -145,32 +143,37 @@ const RelativeDateFilter: React.FC<RelativeDateFilterProps> = ({
     }
 
     return (
-        <div className={cn('flex w-full items-center', field.className)} data-slot="filters-input-wrapper">
-            <input
-                aria-label={typeof field.label === 'string' ? field.label : 'Date'}
-                className={inputClass}
-                data-slot="filters-input"
-                type="date"
-                value={dateValue}
-                onChange={e => onChange([e.target.value])}
-            />
-        </div>
+        <FilterDatePicker
+            className={field.className}
+            embedded={true}
+            field={field}
+            value={dateValue}
+            onChange={value => onChange([value])}
+        />
     );
 };
 
 // `yyyymmdd` is a calendar date in the site's timezone. We construct a Date in the
 // browser's local zone purely to do calendar arithmetic — only the y/m/d fields are
 // read back via Intl, so the local-timezone Date is fine for display.
-function shiftAndFormatDate(yyyymmdd: string, dayOffset: number): string {
+export function formatRelativeDateTooltip(yyyymmdd: string, dayOffset: number): string {
     const [year, month, day] = yyyymmdd.split('-').map(Number);
     const date = new Date(year, month - 1, day);
     date.setDate(date.getDate() + dayOffset);
 
-    return new Intl.DateTimeFormat('en-US', {
+    return new Intl.DateTimeFormat(getPreferredLocale(), {
         month: 'short',
         day: 'numeric',
         year: 'numeric'
     }).format(date);
+}
+
+function getPreferredLocale(): string {
+    if (typeof navigator === 'undefined') {
+        return 'en-US';
+    }
+
+    return navigator.language || 'en-US';
 }
 
 function valuesMatch(actual: unknown[], expected: unknown[]): boolean {

--- a/apps/posts/src/views/filters/filter-relative-date.tsx
+++ b/apps/posts/src/views/filters/filter-relative-date.tsx
@@ -1,0 +1,188 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {cn} from '@tryghost/shade/utils';
+import type {CustomRendererProps, FilterFieldConfig} from '@tryghost/shade/patterns';
+import type {FilterField} from './filter-types';
+
+/**
+ * The relative-date operator family — "in the last N days" / "in the next N
+ * days" — plus the bits any view needs to use them: labels, a type guard,
+ * variant builders that attach them to a date field, and the day-count input
+ * renderer. Domains decide when to attach them (typically gated on a labs
+ * flag); this file just provides the pieces.
+ */
+
+export const RELATIVE_PAST_OPERATOR = 'in-the-last';
+export const RELATIVE_FUTURE_OPERATOR = 'in-the-next';
+
+export const RELATIVE_DATE_OPERATOR_LABELS: Record<string, string> = {
+    [RELATIVE_PAST_OPERATOR]: 'in the last',
+    [RELATIVE_FUTURE_OPERATOR]: 'in the next'
+};
+
+export function isRelativeDateOperator(operator: string): boolean {
+    return operator === RELATIVE_PAST_OPERATOR || operator === RELATIVE_FUTURE_OPERATOR;
+}
+
+export function fieldHasRelativeOperator(field: FilterField): boolean {
+    return field.operators.some(isRelativeDateOperator);
+}
+
+/** Returns the field with the past-leaning relative operator appended. */
+export function withPastRelativeOperator<T extends FilterField>(field: T): T {
+    return {...field, operators: [...field.operators, RELATIVE_PAST_OPERATOR]};
+}
+
+/** Returns the field with the future-leaning relative operator appended. */
+export function withFutureRelativeOperator<T extends FilterField>(field: T): T {
+    return {...field, operators: [...field.operators, RELATIVE_FUTURE_OPERATOR]};
+}
+
+/** The day-count input shown when a relative-date operator is selected. */
+export function createRelativeDateRenderer(fallbackDate: string): FilterFieldConfig['customRenderer'] {
+    const renderer = (props: CustomRendererProps) => React.createElement(RelativeDateFilter, {
+        ...props,
+        fallbackDate
+    });
+
+    return Object.assign(renderer, {displayName: 'RelativeDateRenderer'});
+}
+
+// ---------------------------------------------------------------------------
+// Renderer component
+// ---------------------------------------------------------------------------
+
+const DEFAULT_AMOUNT = 7;
+const MAX_AMOUNT = 365;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const inputClass = 'w-full bg-transparent outline-hidden dark:!bg-transparent';
+
+interface RelativeDateFilterProps extends CustomRendererProps<unknown> {
+    fallbackDate: string;
+}
+
+const RelativeDateFilter: React.FC<RelativeDateFilterProps> = ({
+    field,
+    values,
+    onChange,
+    operator,
+    fallbackDate
+}) => {
+    const isRelative = isRelativeDateOperator(operator);
+    const rawAmount = values[0];
+    const amount = typeof rawAmount === 'number' && Number.isInteger(rawAmount) && rawAmount > 0
+        ? Math.min(rawAmount, MAX_AMOUNT)
+        : DEFAULT_AMOUNT;
+    const dateValue = typeof rawAmount === 'string' && DATE_PATTERN.test(rawAmount) ? rawAmount : fallbackDate;
+
+    // Normalize values when the operator switches between date and relative-day modes.
+    // Stored in a ref so this only fires on operator transitions, not on every render —
+    // which would risk a parent/child onChange ping-pong.
+    const lastNormalizedOperatorRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (lastNormalizedOperatorRef.current === operator) {
+            return;
+        }
+
+        lastNormalizedOperatorRef.current = operator;
+
+        const expected: unknown[] = isRelative ? [amount] : [dateValue];
+
+        if (!valuesMatch(values, expected)) {
+            onChange(expected);
+        }
+    }, [operator, isRelative, amount, dateValue, values, onChange]);
+
+    const [draft, setDraft] = useState<string>(() => String(amount));
+
+    useEffect(() => {
+        setDraft(String(amount));
+    }, [amount]);
+
+    if (isRelative) {
+        const tooltipPrefix = operator === RELATIVE_PAST_OPERATOR ? 'Since' : 'Until';
+        const tooltipDate = shiftAndFormatDate(fallbackDate, operator === RELATIVE_PAST_OPERATOR ? -amount : amount);
+
+        return (
+            <TooltipProvider>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <div className="flex w-full items-center gap-2" data-slot="filters-input-wrapper">
+                            <input
+                                aria-label="Relative date amount"
+                                className={cn(inputClass, 'min-w-[1ch] tabular-nums [field-sizing:content] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none')}
+                                data-slot="filters-input"
+                                max={MAX_AMOUNT}
+                                min={1}
+                                type="number"
+                                value={draft}
+                                onBlur={() => {
+                                    const n = Number(draft);
+
+                                    if (!Number.isInteger(n) || n <= 0 || n > MAX_AMOUNT) {
+                                        setDraft(String(amount));
+                                    }
+                                }}
+                                onChange={(e) => {
+                                    const next = e.target.value;
+                                    setDraft(next);
+                                    const n = Number(next);
+
+                                    if (Number.isInteger(n) && n > 0 && n <= MAX_AMOUNT) {
+                                        onChange([n]);
+                                    }
+                                }}
+                            />
+                            <span className="shrink-0 text-muted-foreground select-none">{amount === 1 ? 'day' : 'days'}</span>
+                        </div>
+                    </TooltipTrigger>
+                    <TooltipContent>{tooltipPrefix} {tooltipDate}</TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
+        );
+    }
+
+    return (
+        <div className={cn('flex w-full items-center', field.className)} data-slot="filters-input-wrapper">
+            <input
+                aria-label={typeof field.label === 'string' ? field.label : 'Date'}
+                className={inputClass}
+                data-slot="filters-input"
+                type="date"
+                value={dateValue}
+                onChange={e => onChange([e.target.value])}
+            />
+        </div>
+    );
+};
+
+// `yyyymmdd` is a calendar date in the site's timezone. We construct a Date in the
+// browser's local zone purely to do calendar arithmetic — only the y/m/d fields are
+// read back via Intl, so the local-timezone Date is fine for display.
+function shiftAndFormatDate(yyyymmdd: string, dayOffset: number): string {
+    const [year, month, day] = yyyymmdd.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    date.setDate(date.getDate() + dayOffset);
+
+    return new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+    }).format(date);
+}
+
+function valuesMatch(actual: unknown[], expected: unknown[]): boolean {
+    if (actual.length !== expected.length) {
+        return false;
+    }
+
+    for (let i = 0; i < actual.length; i += 1) {
+        if (actual[i] !== expected[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -70,6 +70,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const emailTrackClicks = getSettingValue<boolean>(settings, 'email_track_clicks') === true;
     const siteTimezone = getSiteTimezone(settings);
     const giftSubscriptionsEnabled = configData?.config?.labs?.giftSubscriptions === true;
+    const labs = configData?.config?.labs;
 
     const tiers = tiersData?.tiers || [];
     const newsletters = newslettersData?.newsletters || [];
@@ -118,7 +119,8 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         emailTrackOpens,
         emailTrackClicks,
         siteTimezone,
-        giftSubscriptionsEnabled
+        giftSubscriptionsEnabled,
+        labs
     });
 
     const hasFilters = filters.length > 0;

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -70,7 +70,6 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const emailTrackClicks = getSettingValue<boolean>(settings, 'email_track_clicks') === true;
     const siteTimezone = getSiteTimezone(settings);
     const giftSubscriptionsEnabled = configData?.config?.labs?.giftSubscriptions === true;
-    const labs = configData?.config?.labs;
 
     const tiers = tiersData?.tiers || [];
     const newsletters = newslettersData?.newsletters || [];
@@ -119,8 +118,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         emailTrackOpens,
         emailTrackClicks,
         siteTimezone,
-        giftSubscriptionsEnabled,
-        labs
+        giftSubscriptionsEnabled
     });
 
     const hasFilters = filters.length > 0;

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.ts
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.ts
@@ -1,7 +1,9 @@
 import {Filter} from '@tryghost/shade/patterns';
-import {hasTimezoneSensitiveMemberFilter, parseMemberFilter, serializeMemberFilters} from '../member-filter-query';
+import {getMemberFields} from '../member-fields';
+import {hasTimezoneSensitiveMemberFilter, isPredicateEnabled, parseMemberFilter, serializeMemberFilters} from '../member-filter-query';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useSearchParams} from 'react-router';
+import type {Labs, MemberFields} from '../member-fields';
 
 interface SetFiltersOptions {
     replace?: boolean;
@@ -23,19 +25,33 @@ interface ToSearchParamsOptions {
     filters: Filter[];
     search: string;
     timezone: string;
+    fields: MemberFields;
 }
 
+interface UseMembersFilterStateOptions {
+    labs?: Labs;
+}
+
+/**
+ * Should the page hold off parsing the URL filter until more data is in?
+ *
+ * Parsing a date-sensitive filter needs the timezone (from settings) AND the
+ * labs-flag state (from config) to be available. If we parse without them,
+ * the writeback effect will rewrite the URL to an absolute date before the
+ * flag arrives, losing `now-30d`-style relative forms.
+ */
 export function shouldDelayMembersDateFilterHydration(
     filterParam: string | undefined,
-    hasResolvedTimezone: boolean,
-    isSettingsLoading: boolean = !hasResolvedTimezone
+    hasResolvedDependencies: boolean,
+    isLoadingDependencies: boolean = !hasResolvedDependencies
 ): boolean {
-    return Boolean(filterParam) && isSettingsLoading && !hasResolvedTimezone && hasTimezoneSensitiveMemberFilter(filterParam);
+    return Boolean(filterParam) && isLoadingDependencies && !hasResolvedDependencies && hasTimezoneSensitiveMemberFilter(filterParam);
 }
 
-function toSearchParams({baseSearchParams, filters, search, timezone}: ToSearchParamsOptions): URLSearchParams {
+function toSearchParams({baseSearchParams, filters, search, timezone, fields}: ToSearchParamsOptions): URLSearchParams {
     const params = new URLSearchParams(baseSearchParams);
-    const filter = serializeMemberFilters(filters, timezone);
+    const enabled = filters.filter(predicate => isPredicateEnabled(predicate, fields));
+    const filter = serializeMemberFilters(enabled, timezone);
 
     params.delete('filter');
     params.delete('search');
@@ -51,15 +67,17 @@ function toSearchParams({baseSearchParams, filters, search, timezone}: ToSearchP
     return params;
 }
 
-export function useMembersFilterState(timezone: string): UseMembersFilterStateReturn {
+export function useMembersFilterState(timezone: string, options: UseMembersFilterStateOptions = {}): UseMembersFilterStateReturn {
+    const {labs} = options;
+    const fields = useMemo(() => getMemberFields(labs), [labs]);
     const [searchParams, setSearchParams] = useSearchParams();
     const lastWrittenQueryRef = useRef<string | null>(null);
     const filterParam = useMemo(() => searchParams.get('filter') ?? undefined, [searchParams]);
     const currentQuery = useMemo(() => searchParams.toString(), [searchParams]);
 
     const parsedFilters = useMemo(() => {
-        return parseMemberFilter(filterParam, timezone);
-    }, [filterParam, timezone]);
+        return parseMemberFilter(filterParam, timezone).filter(predicate => isPredicateEnabled(predicate, fields));
+    }, [filterParam, timezone, fields]);
     const [filters, setDraftFilters] = useState<Filter[]>(parsedFilters);
 
     const search = useMemo(() => {
@@ -67,8 +85,9 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
     }, [searchParams]);
 
     const nql = useMemo(() => {
-        return serializeMemberFilters(filters, timezone);
-    }, [filters, timezone]);
+        const enabled = filters.filter(predicate => isPredicateEnabled(predicate, fields));
+        return serializeMemberFilters(enabled, timezone);
+    }, [filters, timezone, fields]);
 
     useEffect(() => {
         if (currentQuery !== lastWrittenQueryRef.current) {
@@ -86,7 +105,8 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
             baseSearchParams: searchParams,
             filters,
             search,
-            timezone
+            timezone,
+            fields
         });
         const nextQuery = nextParams.toString();
 
@@ -94,60 +114,64 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
             lastWrittenQueryRef.current = nextQuery;
             setSearchParams(nextParams, {replace: true});
         }
-    }, [currentQuery, filters, search, searchParams, setSearchParams, timezone]);
+    }, [currentQuery, filters, search, searchParams, setSearchParams, timezone, fields]);
 
-    const setFilters = useCallback((nextFilters: Filter[], options: SetFiltersOptions = {}) => {
-        const replace = options.replace ?? true;
+    const setFilters = useCallback((nextFilters: Filter[], setOptions: SetFiltersOptions = {}) => {
+        const replace = setOptions.replace ?? true;
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters: nextFilters,
             search,
-            timezone
+            timezone,
+            fields
         });
 
         setDraftFilters(nextFilters);
         lastWrittenQueryRef.current = nextParams.toString();
         setSearchParams(nextParams, {replace});
-    }, [search, searchParams, setSearchParams, timezone]);
+    }, [search, searchParams, setSearchParams, timezone, fields]);
 
-    const setSearch = useCallback((nextSearch: string, options: SetFiltersOptions = {}) => {
-        const replace = options.replace ?? true;
+    const setSearch = useCallback((nextSearch: string, setOptions: SetFiltersOptions = {}) => {
+        const replace = setOptions.replace ?? true;
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters,
             search: nextSearch,
-            timezone
+            timezone,
+            fields
         });
 
         lastWrittenQueryRef.current = nextParams.toString();
         setSearchParams(nextParams, {replace});
-    }, [filters, searchParams, setSearchParams, timezone]);
+    }, [filters, searchParams, setSearchParams, timezone, fields]);
 
     const clearFilters = useCallback(({replace = true}: SetFiltersOptions = {}) => {
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters: [],
             search,
-            timezone
+            timezone,
+            fields
         });
 
         setDraftFilters([]);
         lastWrittenQueryRef.current = nextParams.toString();
         setSearchParams(nextParams, {replace});
-    }, [search, searchParams, setSearchParams, timezone]);
+    }, [search, searchParams, setSearchParams, timezone, fields]);
 
     const clearAll = useCallback(({replace = true}: SetFiltersOptions = {}) => {
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters: [],
             search: '',
-            timezone
+            timezone,
+            fields
         });
 
         setDraftFilters([]);
         lastWrittenQueryRef.current = nextParams.toString();
         setSearchParams(nextParams, {replace});
-    }, [searchParams, setSearchParams, timezone]);
+    }, [searchParams, setSearchParams, timezone, fields]);
 
     return {
         filters,

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.ts
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.ts
@@ -3,7 +3,7 @@ import {getMemberFields} from '../member-fields';
 import {hasTimezoneSensitiveMemberFilter, isPredicateEnabled, parseMemberFilter, serializeMemberFilters} from '../member-filter-query';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useSearchParams} from 'react-router';
-import type {Labs, MemberFields} from '../member-fields';
+import type {MemberFields} from '../member-fields';
 
 interface SetFiltersOptions {
     replace?: boolean;
@@ -28,17 +28,12 @@ interface ToSearchParamsOptions {
     fields: MemberFields;
 }
 
-interface UseMembersFilterStateOptions {
-    labs?: Labs;
-}
-
 /**
  * Should the page hold off parsing the URL filter until more data is in?
  *
- * Parsing a date-sensitive filter needs the timezone (from settings) AND the
- * labs-flag state (from config) to be available. If we parse without them,
- * the writeback effect will rewrite the URL to an absolute date before the
- * flag arrives, losing `now-30d`-style relative forms.
+ * Parsing a date-sensitive filter needs the timezone from settings. If we parse
+ * before it resolves, the writeback effect can round-trip the date in UTC
+ * instead of site time.
  */
 export function shouldDelayMembersDateFilterHydration(
     filterParam: string | undefined,
@@ -67,9 +62,8 @@ function toSearchParams({baseSearchParams, filters, search, timezone, fields}: T
     return params;
 }
 
-export function useMembersFilterState(timezone: string, options: UseMembersFilterStateOptions = {}): UseMembersFilterStateReturn {
-    const {labs} = options;
-    const fields = useMemo(() => getMemberFields(labs), [labs]);
+export function useMembersFilterState(timezone: string): UseMembersFilterStateReturn {
+    const fields = useMemo(() => getMemberFields(), []);
     const [searchParams, setSearchParams] = useSearchParams();
     const lastWrittenQueryRef = useRef<string | null>(null);
     const filterParam = useMemo(() => searchParams.get('filter') ?? undefined, [searchParams]);

--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {memberFields} from './member-fields';
+import {getMemberFields, memberFields} from './member-fields';
 import type {CodecContext, FilterPredicate} from '../filters/filter-types';
 
 const dateContext: CodecContext = {
@@ -55,12 +55,35 @@ describe('memberFields', () => {
             'is-greater',
             'is-less'
         ]);
-        expect(memberFields.created_at.operators).toEqual([
-            'is-less',
-            'is-or-less',
-            'is-greater',
-            'is-or-greater'
-        ]);
+        const dateOperators = ['is-less', 'is-or-less', 'is-greater', 'is-or-greater'];
+
+        expect(memberFields.created_at.operators).toEqual(dateOperators);
+        expect(memberFields.last_seen_at.operators).toEqual(dateOperators);
+        expect(memberFields['subscriptions.start_date'].operators).toEqual(dateOperators);
+        expect(memberFields['subscriptions.current_period_end'].operators).toEqual(dateOperators);
+    });
+
+    it('appends the past/future relative operator to date fields when the flag is on', () => {
+        const fields = getMemberFields({membersRelativeDateFilters: true});
+
+        expect(fields.created_at.operators).toContain('in-the-last');
+        expect(fields.last_seen_at.operators).toContain('in-the-last');
+        expect(fields['subscriptions.start_date'].operators).toContain('in-the-last');
+        expect(fields['subscriptions.current_period_end'].operators).toContain('in-the-next');
+    });
+
+    it('leaves date fields without relative operators when the flag is off', () => {
+        const fields = getMemberFields({membersRelativeDateFilters: false});
+
+        expect(fields.created_at.operators).not.toContain('in-the-last');
+        expect(fields['subscriptions.current_period_end'].operators).not.toContain('in-the-next');
+    });
+
+    it('leaves date fields without relative operators when no labs object is given', () => {
+        const fields = getMemberFields();
+
+        expect(fields.created_at.operators).not.toContain('in-the-last');
+        expect(fields['subscriptions.current_period_end'].operators).not.toContain('in-the-next');
     });
 
     it('keeps the expected subscription status options', () => {

--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -55,35 +55,22 @@ describe('memberFields', () => {
             'is-greater',
             'is-less'
         ]);
-        const dateOperators = ['is-less', 'is-or-less', 'is-greater', 'is-or-greater'];
+        const pastDateOperators = ['is-less', 'is-or-less', 'is-greater', 'is-or-greater', 'in-the-last'];
+        const futureDateOperators = ['is-less', 'is-or-less', 'is-greater', 'is-or-greater', 'in-the-next'];
 
-        expect(memberFields.created_at.operators).toEqual(dateOperators);
-        expect(memberFields.last_seen_at.operators).toEqual(dateOperators);
-        expect(memberFields['subscriptions.start_date'].operators).toEqual(dateOperators);
-        expect(memberFields['subscriptions.current_period_end'].operators).toEqual(dateOperators);
+        expect(memberFields.created_at.operators).toEqual(pastDateOperators);
+        expect(memberFields.last_seen_at.operators).toEqual(pastDateOperators);
+        expect(memberFields['subscriptions.start_date'].operators).toEqual(pastDateOperators);
+        expect(memberFields['subscriptions.current_period_end'].operators).toEqual(futureDateOperators);
     });
 
-    it('appends the past/future relative operator to date fields when the flag is on', () => {
-        const fields = getMemberFields({membersRelativeDateFilters: true});
+    it('always appends the past/future relative operator to member date fields', () => {
+        const fields = getMemberFields();
 
         expect(fields.created_at.operators).toContain('in-the-last');
         expect(fields.last_seen_at.operators).toContain('in-the-last');
         expect(fields['subscriptions.start_date'].operators).toContain('in-the-last');
         expect(fields['subscriptions.current_period_end'].operators).toContain('in-the-next');
-    });
-
-    it('leaves date fields without relative operators when the flag is off', () => {
-        const fields = getMemberFields({membersRelativeDateFilters: false});
-
-        expect(fields.created_at.operators).not.toContain('in-the-last');
-        expect(fields['subscriptions.current_period_end'].operators).not.toContain('in-the-next');
-    });
-
-    it('leaves date fields without relative operators when no labs object is given', () => {
-        const fields = getMemberFields();
-
-        expect(fields.created_at.operators).not.toContain('in-the-last');
-        expect(fields['subscriptions.current_period_end'].operators).not.toContain('in-the-next');
     });
 
     it('keeps the expected subscription status options', () => {

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -2,7 +2,13 @@ import {DATE_FILTER_OPERATORS, DEFAULT_DATE_OPERATOR} from '../filters/filter-da
 import {dateCodec, numberCodec, scalarCodec, setCodec, textCodec} from '../filters/filter-codecs';
 import {defineFields} from '../filters/filter-types';
 import {escapeNqlString} from '../filters/filter-normalization';
+import {withFutureRelativeOperator, withPastRelativeOperator} from '../filters/filter-relative-date';
 import type {FilterCodec} from '../filters/filter-types';
+
+/** Shape of the labs flags map (from `useBrowseConfig().config.labs`). */
+export type Labs = Record<string, boolean>;
+
+const MEMBERS_RELATIVE_DATE_FLAG = 'membersRelativeDateFilters';
 
 const TEXT_OPERATORS = ['is', 'contains', 'does-not-contain', 'starts-with', 'ends-with'] as const;
 const NUMBER_OPERATORS = ['is', 'is-greater', 'is-less'] as const;
@@ -90,7 +96,7 @@ const feedbackCodec: FilterCodec = {
     }
 };
 
-export const memberFields = defineFields({
+const baseMemberFields = defineFields({
     name: {
         operators: TEXT_OPERATORS,
         ui: {
@@ -398,3 +404,32 @@ export const memberFields = defineFields({
         codec: setCodec({quoteStrings: true, serializeSingletonAsScalar: true})
     }
 });
+
+export type MemberFields = typeof baseMemberFields;
+
+/**
+ * Returns the member field set under the current labs flags. The relative-date
+ * operators are attached to date fields when `membersRelativeDateFilters` is
+ * on. All consumers (parser, serializer, UI hook) call this with the current
+ * labs so they agree on which operators are actually advertised.
+ */
+export function getMemberFields(labs?: Labs): MemberFields {
+    if (!labs?.[MEMBERS_RELATIVE_DATE_FLAG]) {
+        return baseMemberFields;
+    }
+
+    return {
+        ...baseMemberFields,
+        last_seen_at: withPastRelativeOperator(baseMemberFields.last_seen_at),
+        created_at: withPastRelativeOperator(baseMemberFields.created_at),
+        'subscriptions.start_date': withPastRelativeOperator(baseMemberFields['subscriptions.start_date']),
+        'subscriptions.current_period_end': withFutureRelativeOperator(baseMemberFields['subscriptions.current_period_end'])
+    };
+}
+
+/**
+ * Flag-agnostic field set. Use this for static lookups (e.g. deriving the
+ * set of date-typed field keys) where the operator list isn't relevant.
+ * Use `getMemberFields(labs)` for anything that consults `.operators`.
+ */
+export const memberFields = baseMemberFields;

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -5,11 +5,6 @@ import {escapeNqlString} from '../filters/filter-normalization';
 import {withFutureRelativeOperator, withPastRelativeOperator} from '../filters/filter-relative-date';
 import type {FilterCodec} from '../filters/filter-types';
 
-/** Shape of the labs flags map (from `useBrowseConfig().config.labs`). */
-export type Labs = Record<string, boolean>;
-
-const MEMBERS_RELATIVE_DATE_FLAG = 'membersRelativeDateFilters';
-
 const TEXT_OPERATORS = ['is', 'contains', 'does-not-contain', 'starts-with', 'ends-with'] as const;
 const NUMBER_OPERATORS = ['is', 'is-greater', 'is-less'] as const;
 const SCALAR_OPERATORS = ['is', 'is-not'] as const;
@@ -405,31 +400,16 @@ const baseMemberFields = defineFields({
     }
 });
 
-export type MemberFields = typeof baseMemberFields;
+export const memberFields = defineFields({
+    ...baseMemberFields,
+    last_seen_at: withPastRelativeOperator(baseMemberFields.last_seen_at),
+    created_at: withPastRelativeOperator(baseMemberFields.created_at),
+    'subscriptions.start_date': withPastRelativeOperator(baseMemberFields['subscriptions.start_date']),
+    'subscriptions.current_period_end': withFutureRelativeOperator(baseMemberFields['subscriptions.current_period_end'])
+});
 
-/**
- * Returns the member field set under the current labs flags. The relative-date
- * operators are attached to date fields when `membersRelativeDateFilters` is
- * on. All consumers (parser, serializer, UI hook) call this with the current
- * labs so they agree on which operators are actually advertised.
- */
-export function getMemberFields(labs?: Labs): MemberFields {
-    if (!labs?.[MEMBERS_RELATIVE_DATE_FLAG]) {
-        return baseMemberFields;
-    }
+export type MemberFields = typeof memberFields;
 
-    return {
-        ...baseMemberFields,
-        last_seen_at: withPastRelativeOperator(baseMemberFields.last_seen_at),
-        created_at: withPastRelativeOperator(baseMemberFields.created_at),
-        'subscriptions.start_date': withPastRelativeOperator(baseMemberFields['subscriptions.start_date']),
-        'subscriptions.current_period_end': withFutureRelativeOperator(baseMemberFields['subscriptions.current_period_end'])
-    };
+export function getMemberFields(): MemberFields {
+    return memberFields;
 }
-
-/**
- * Flag-agnostic field set. Use this for static lookups (e.g. deriving the
- * set of date-typed field keys) where the operator list isn't relevant.
- * Use `getMemberFields(labs)` for anything that consults `.operators`.
- */
-export const memberFields = baseMemberFields;

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from 'vitest';
-import {parseMemberFilter, serializeMemberFilters} from './member-filter-query';
+import {getMemberFields} from './member-fields';
+import {hasTimezoneSensitiveMemberFilter, isPredicateEnabled, parseMemberFilter, serializeMemberFilters} from './member-filter-query';
 import type {FilterPredicate} from '../filters/filter-types';
 
 function stripIds(predicates: FilterPredicate[]) {
@@ -188,5 +189,142 @@ describe('member-filter-query', () => {
 
     it('drops invalid member date values during parse', () => {
         expect(parseMemberFilter('created_at:<=\'not-a-date\'', 'UTC')).toEqual([]);
+    });
+
+    it('parses relative past-date filters into in-the-last predicates for every supported field', () => {
+        expect(stripIds(parseMemberFilter('created_at:>=now-7d', 'UTC'))).toEqual([
+            {field: 'created_at', operator: 'in-the-last', values: [7]}
+        ]);
+
+        expect(stripIds(parseMemberFilter('last_seen_at:>=now-30d', 'UTC'))).toEqual([
+            {field: 'last_seen_at', operator: 'in-the-last', values: [30]}
+        ]);
+
+        expect(stripIds(parseMemberFilter('subscriptions.start_date:>=now-90d', 'UTC'))).toEqual([
+            {field: 'subscriptions.start_date', operator: 'in-the-last', values: [90]}
+        ]);
+    });
+
+    it('parses relative future-date filters into in-the-next predicates', () => {
+        expect(stripIds(parseMemberFilter('subscriptions.current_period_end:<=now+14d', 'UTC'))).toEqual([
+            {field: 'subscriptions.current_period_end', operator: 'in-the-next', values: [14]}
+        ]);
+    });
+
+    it('serializes in-the-last and in-the-next predicates with the relative now token', () => {
+        expect(serializeMemberFilters(
+            [{id: '1', field: 'created_at', operator: 'in-the-last', values: [7]}],
+            'UTC'
+        )).toBe('created_at:>=now-7d');
+
+        expect(serializeMemberFilters(
+            [{id: '1', field: 'subscriptions.current_period_end', operator: 'in-the-next', values: [14]}],
+            'UTC'
+        )).toBe('subscriptions.current_period_end:<=now+14d');
+    });
+
+    it('round-trips relative created_at predicates alongside other clauses', () => {
+        const filter = 'created_at:>=now-30d+status:paid';
+        const parsed = parseMemberFilter(filter, 'UTC');
+
+        expect(stripIds(parsed)).toEqual([
+            {field: 'created_at', operator: 'in-the-last', values: [30]},
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+
+        expect(serializeMemberFilters(parsed, 'UTC')).toBe('created_at:>=now-30d+status:paid');
+    });
+
+    it('drops invalid relative date predicates on serialize', () => {
+        expect(serializeMemberFilters(
+            [{id: '1', field: 'created_at', operator: 'in-the-last', values: [0]}],
+            'UTC'
+        )).toBeUndefined();
+
+        expect(serializeMemberFilters(
+            [{id: '1', field: 'created_at', operator: 'in-the-last', values: ['7']}],
+            'UTC'
+        )).toBeUndefined();
+    });
+
+    it('drops the entire filter when a relative-date clause is mixed into a top-level OR', () => {
+        // Top-level OR isn't flattened by parseMemberNode, so every clause —
+        // including the non-relative `status:paid` — is dropped. Pinned to
+        // catch silent regressions if OR support is added later.
+        const parsed = parseMemberFilter('created_at:>=now-7d,status:paid', 'UTC');
+
+        expect(stripIds(parsed)).toEqual([]);
+    });
+
+    it('drops the degenerate now-0d form', () => {
+        // The codec only accepts a relative-day count > 0 — both directions
+        // (parse and serialize) defend the same predicate-shape invariant.
+        expect(parseMemberFilter('created_at:>=now-0d', 'UTC')).toEqual([]);
+    });
+
+    it('rejects relative day counts outside the safe-integer range on parse', () => {
+        expect(parseMemberFilter('created_at:>=now-9999999999999999d', 'UTC')).toEqual([]);
+    });
+
+    it('reports relative-date filters as timezone-sensitive', () => {
+        // `now` resolves in the user's timezone, so a relative-date clause
+        // must wait for timezone resolution just like an absolute date clause.
+        expect(hasTimezoneSensitiveMemberFilter('created_at:>=now-7d')).toBe(true);
+        expect(hasTimezoneSensitiveMemberFilter('subscriptions.current_period_end:<=now+14d')).toBe(true);
+        expect(hasTimezoneSensitiveMemberFilter('created_at:>=now-7d+status:paid')).toBe(true);
+    });
+
+    it('does not report non-date filters as timezone-sensitive', () => {
+        expect(hasTimezoneSensitiveMemberFilter('status:paid')).toBe(false);
+        expect(hasTimezoneSensitiveMemberFilter('')).toBe(false);
+        expect(hasTimezoneSensitiveMemberFilter(undefined)).toBe(false);
+    });
+});
+
+describe('isPredicateEnabled', () => {
+    const flagOnFields = getMemberFields({membersRelativeDateFilters: true});
+    const flagOffFields = getMemberFields();
+
+    it('returns true for predicates whose operator is declared by the variant', () => {
+        expect(isPredicateEnabled(
+            {field: 'created_at', operator: 'in-the-last', values: [7]},
+            flagOnFields
+        )).toBe(true);
+
+        expect(isPredicateEnabled(
+            {field: 'status', operator: 'is', values: ['paid']},
+            flagOffFields
+        )).toBe(true);
+    });
+
+    it('returns false for relative operators when the labs flag is off', () => {
+        // The flag-off variant doesn't declare in-the-last/in-the-next, so
+        // a relative predicate from a stored URL would be dropped before it
+        // reaches the UI or the rewritten URL.
+        expect(isPredicateEnabled(
+            {field: 'created_at', operator: 'in-the-last', values: [7]},
+            flagOffFields
+        )).toBe(false);
+
+        expect(isPredicateEnabled(
+            {field: 'subscriptions.current_period_end', operator: 'in-the-next', values: [14]},
+            flagOffFields
+        )).toBe(false);
+    });
+
+    it('returns false for a relative operator on a field that does not advertise that direction', () => {
+        // `subscriptions.current_period_end` is future-only — its variant
+        // never includes `in-the-last`, regardless of labs state.
+        expect(isPredicateEnabled(
+            {field: 'subscriptions.current_period_end', operator: 'in-the-last', values: [7]},
+            flagOnFields
+        )).toBe(false);
+    });
+
+    it('returns false for unknown fields', () => {
+        expect(isPredicateEnabled(
+            {field: 'not_a_real_field', operator: 'is', values: ['anything']},
+            flagOnFields
+        )).toBe(false);
     });
 });

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -282,49 +282,32 @@ describe('member-filter-query', () => {
 });
 
 describe('isPredicateEnabled', () => {
-    const flagOnFields = getMemberFields({membersRelativeDateFilters: true});
-    const flagOffFields = getMemberFields();
+    const fields = getMemberFields();
 
-    it('returns true for predicates whose operator is declared by the variant', () => {
+    it('returns true for predicates whose operator is declared by the field map', () => {
         expect(isPredicateEnabled(
             {field: 'created_at', operator: 'in-the-last', values: [7]},
-            flagOnFields
+            fields
         )).toBe(true);
 
         expect(isPredicateEnabled(
             {field: 'status', operator: 'is', values: ['paid']},
-            flagOffFields
+            fields
         )).toBe(true);
     });
 
-    it('returns false for relative operators when the labs flag is off', () => {
-        // The flag-off variant doesn't declare in-the-last/in-the-next, so
-        // a relative predicate from a stored URL would be dropped before it
-        // reaches the UI or the rewritten URL.
-        expect(isPredicateEnabled(
-            {field: 'created_at', operator: 'in-the-last', values: [7]},
-            flagOffFields
-        )).toBe(false);
-
-        expect(isPredicateEnabled(
-            {field: 'subscriptions.current_period_end', operator: 'in-the-next', values: [14]},
-            flagOffFields
-        )).toBe(false);
-    });
-
     it('returns false for a relative operator on a field that does not advertise that direction', () => {
-        // `subscriptions.current_period_end` is future-only — its variant
-        // never includes `in-the-last`, regardless of labs state.
+        // `subscriptions.current_period_end` is future-only.
         expect(isPredicateEnabled(
             {field: 'subscriptions.current_period_end', operator: 'in-the-last', values: [7]},
-            flagOnFields
+            fields
         )).toBe(false);
     });
 
     it('returns false for unknown fields', () => {
         expect(isPredicateEnabled(
             {field: 'not_a_real_field', operator: 'is', values: ['anything']},
-            flagOnFields
+            fields
         )).toBe(false);
     });
 });

--- a/apps/posts/src/views/members/member-filter-query.ts
+++ b/apps/posts/src/views/members/member-filter-query.ts
@@ -1,10 +1,26 @@
 import {dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates, stampPredicates} from '../filters/filter-query-core';
 import {memberFields} from './member-fields';
+import {resolveField} from '../filters/resolve-field';
 import type {AstNode} from '../filters/filter-ast';
 import type {FilterPredicate, ParsedPredicate} from '../filters/filter-types';
+import type {MemberFields} from './member-fields';
 
 type CompoundMatcher = (node: AstNode) => ParsedPredicate | null;
 const TIMEZONE_SENSITIVE_MEMBER_FIELDS = getFieldKeysByType(memberFields, 'date');
+
+/**
+ * Is this predicate's operator one the field currently advertises?
+ *
+ * Pass a flag-aware field set (from `getMemberFields(labs)`) and this returns
+ * `false` for predicates the user can't reach in the UI right now — either
+ * the field never declares the operator, or the labs-off variant omits it.
+ * Hooks call this to drop unreachable predicates before serializing or after
+ * parsing. The parser/serializer themselves stay pure.
+ */
+export function isPredicateEnabled(predicate: ParsedPredicate, fields: MemberFields): boolean {
+    const resolved = resolveField(fields, predicate.field, 'UTC');
+    return resolved?.definition.operators.includes(predicate.operator) ?? false;
+}
 
 function getCompoundChildren(node: AstNode): {operator: '$and' | '$or'; children: AstNode[]} | null {
     if (Array.isArray(node.$and)) {
@@ -192,6 +208,11 @@ function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
     return dispatchSimpleNodes([node], memberFields, timezone);
 }
 
+/**
+ * Parses NQL into predicates. Pure: doesn't know about labs flags or
+ * variants. Callers are responsible for filtering the output via
+ * `isPredicateEnabled` against the variant they want to enforce.
+ */
 export function parseMemberFilter(filter: string | undefined, timezone: string): FilterPredicate[] {
     const ast = parseFilterToAst(filter ?? '');
 
@@ -212,6 +233,11 @@ export function hasTimezoneSensitiveMemberFilter(filter: string | undefined): bo
     return hasFieldKey(ast, TIMEZONE_SENSITIVE_MEMBER_FIELDS);
 }
 
+/**
+ * Serializes predicates back to NQL. Pure: doesn't filter by labs/variant.
+ * Callers should pre-filter via `isPredicateEnabled` if they need to drop
+ * predicates the current variant doesn't advertise.
+ */
 export function serializeMemberFilters(predicates: FilterPredicate[], timezone: string): string | undefined {
     return serializePredicates(predicates, memberFields, timezone);
 }

--- a/apps/posts/src/views/members/member-filter-query.ts
+++ b/apps/posts/src/views/members/member-filter-query.ts
@@ -11,11 +11,10 @@ const TIMEZONE_SENSITIVE_MEMBER_FIELDS = getFieldKeysByType(memberFields, 'date'
 /**
  * Is this predicate's operator one the field currently advertises?
  *
- * Pass a flag-aware field set (from `getMemberFields(labs)`) and this returns
- * `false` for predicates the user can't reach in the UI right now — either
- * the field never declares the operator, or the labs-off variant omits it.
- * Hooks call this to drop unreachable predicates before serializing or after
- * parsing. The parser/serializer themselves stay pure.
+ * This returns `false` for predicates the user can't reach in the UI because
+ * the field never declares the operator. Hooks call this to drop unreachable
+ * predicates before serializing or after parsing. The parser/serializer
+ * themselves stay pure.
  */
 export function isPredicateEnabled(predicate: ParsedPredicate, fields: MemberFields): boolean {
     const resolved = resolveField(fields, predicate.field, 'UTC');
@@ -209,9 +208,8 @@ function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
 }
 
 /**
- * Parses NQL into predicates. Pure: doesn't know about labs flags or
- * variants. Callers are responsible for filtering the output via
- * `isPredicateEnabled` against the variant they want to enforce.
+ * Parses NQL into predicates. Pure: callers are responsible for filtering the
+ * output via `isPredicateEnabled` against the field map they want to enforce.
  */
 export function parseMemberFilter(filter: string | undefined, timezone: string): FilterPredicate[] {
     const ast = parseFilterToAst(filter ?? '');
@@ -234,9 +232,9 @@ export function hasTimezoneSensitiveMemberFilter(filter: string | undefined): bo
 }
 
 /**
- * Serializes predicates back to NQL. Pure: doesn't filter by labs/variant.
- * Callers should pre-filter via `isPredicateEnabled` if they need to drop
- * predicates the current variant doesn't advertise.
+ * Serializes predicates back to NQL. Pure: callers should pre-filter via
+ * `isPredicateEnabled` if they need to drop predicates the field map doesn't
+ * advertise.
  */
 export function serializeMemberFilters(predicates: FilterPredicate[], timezone: string): string | undefined {
     return serializePredicates(predicates, memberFields, timezone);

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -221,6 +221,48 @@ describe('useMemberFilterFields', () => {
 
         expect(offerField?.customValueRenderer?.(['offer_month_1'], offerField.options || [])).toBe('Retention A');
     });
+
+    it('omits relative operators and the renderer on date fields when the flag is off', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            paidMembersEnabled: true,
+            siteTimezone: 'UTC'
+        }));
+
+        const basicFields = result.current.find(group => group.group === 'Basic')?.fields ?? [];
+        const subscriptionFields = result.current.find(group => group.group === 'Subscription')?.fields ?? [];
+        const dateFields = [
+            basicFields.find(field => field.key === 'created_at'),
+            basicFields.find(field => field.key === 'last_seen_at'),
+            subscriptionFields.find(field => field.key === 'subscriptions.start_date'),
+            subscriptionFields.find(field => field.key === 'subscriptions.current_period_end')
+        ];
+
+        for (const field of dateFields) {
+            expect(field).toBeDefined();
+            expect(field?.customRenderer).toBeUndefined();
+            expect(field?.operators?.map(op => op.value)).not.toContain('in-the-last');
+            expect(field?.operators?.map(op => op.value)).not.toContain('in-the-next');
+        }
+    });
+
+    it('includes relative operators and the renderer on date fields when the flag is on', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            paidMembersEnabled: true,
+            siteTimezone: 'UTC',
+            labs: {membersRelativeDateFilters: true}
+        }));
+
+        const basicFields = result.current.find(group => group.group === 'Basic')?.fields ?? [];
+        const subscriptionFields = result.current.find(group => group.group === 'Subscription')?.fields ?? [];
+        const createdAt = basicFields.find(field => field.key === 'created_at');
+        const periodEnd = subscriptionFields.find(field => field.key === 'subscriptions.current_period_end');
+
+        expect(createdAt?.customRenderer).toBeTypeOf('function');
+        expect(createdAt?.operators?.map(op => op.value)).toContain('in-the-last');
+
+        expect(periodEnd?.customRenderer).toBeTypeOf('function');
+        expect(periodEnd?.operators?.map(op => op.value)).toContain('in-the-next');
+    });
 });
 
 describe('retention offer helpers', () => {

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -222,7 +222,7 @@ describe('useMemberFilterFields', () => {
         expect(offerField?.customValueRenderer?.(['offer_month_1'], offerField.options || [])).toBe('Retention A');
     });
 
-    it('omits relative operators and the renderer on date fields when the flag is off', () => {
+    it('includes relative operators and the renderer on date fields', () => {
         const {result} = renderHook(() => useMemberFilterFields({
             paidMembersEnabled: true,
             siteTimezone: 'UTC'
@@ -239,24 +239,11 @@ describe('useMemberFilterFields', () => {
 
         for (const field of dateFields) {
             expect(field).toBeDefined();
-            expect(field?.customRenderer).toBeUndefined();
-            expect(field?.operators?.map(op => op.value)).not.toContain('in-the-last');
-            expect(field?.operators?.map(op => op.value)).not.toContain('in-the-next');
+            expect(field?.customRenderer).toBeTypeOf('function');
         }
-    });
 
-    it('includes relative operators and the renderer on date fields when the flag is on', () => {
-        const {result} = renderHook(() => useMemberFilterFields({
-            paidMembersEnabled: true,
-            siteTimezone: 'UTC',
-            labs: {membersRelativeDateFilters: true}
-        }));
-
-        const basicFields = result.current.find(group => group.group === 'Basic')?.fields ?? [];
-        const subscriptionFields = result.current.find(group => group.group === 'Subscription')?.fields ?? [];
         const createdAt = basicFields.find(field => field.key === 'created_at');
         const periodEnd = subscriptionFields.find(field => field.key === 'subscriptions.current_period_end');
-
         expect(createdAt?.customRenderer).toBeTypeOf('function');
         expect(createdAt?.operators?.map(op => op.value)).toContain('in-the-last');
 

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -3,9 +3,11 @@ import {DATE_OPERATOR_LABELS} from '../filters/filter-date';
 import {FilterFieldConfig, FilterFieldGroup, FilterOption, ValueSource} from '@tryghost/shade/patterns';
 import {LabelFilterRenderer} from '@src/components/label-picker';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {RELATIVE_DATE_OPERATOR_LABELS, createRelativeDateRenderer, fieldHasRelativeOperator} from '../filters/filter-relative-date';
 import {createOperatorOptions} from '../filters/filter-operator-options';
+import {getMemberFields} from './member-fields';
 import {getTodayInTimezone} from '../filters/filter-normalization';
-import {memberFields} from './member-fields';
+import type {Labs} from './member-fields';
 import type {Offer} from '@tryghost/admin-x-framework/api/offers';
 
 interface UseMemberFilterFieldsOptions {
@@ -24,6 +26,7 @@ interface UseMemberFilterFieldsOptions {
     emailTrackClicks?: boolean;
     siteTimezone?: string;
     giftSubscriptionsEnabled?: boolean;
+    labs?: Labs;
 }
 
 type OfferOption = FilterOption<string>;
@@ -34,6 +37,7 @@ const MEMBER_OPERATOR_LABELS: Record<string, string> = {
     'is-not-any': 'is none of',
     'does-not-contain': 'does not contain',
     ...DATE_OPERATOR_LABELS,
+    ...RELATIVE_DATE_OPERATOR_LABELS,
     1: 'More like this',
     0: 'Less like this'
 };
@@ -92,29 +96,6 @@ function getFieldIcon(key: string) {
 
         return undefined;
     }
-}
-
-function createFieldConfig(
-    key: string,
-    overrides: Partial<FilterFieldConfig> = {},
-    operatorLabels: Record<string, string> = MEMBER_OPERATOR_LABELS
-): FilterFieldConfig {
-    const field = key.startsWith('newsletters.')
-        ? memberFields['newsletters.:slug']
-        : memberFields[key as keyof typeof memberFields];
-
-    return {
-        key,
-        ...field.ui,
-        icon: getFieldIcon(key),
-        operators: createOperatorOptions(field.operators, {labels: operatorLabels}),
-        ...('options' in field && field.options ? {options: field.options} : {}),
-        ...overrides
-    };
-}
-
-function createDateFieldConfig(key: string, defaultValue: string) {
-    return createFieldConfig(key, {defaultValue});
 }
 
 function createSearchableFieldOverrides(
@@ -276,9 +257,45 @@ export function useMemberFilterFields({
     emailTrackOpens = false,
     emailTrackClicks = false,
     siteTimezone = 'UTC',
-    giftSubscriptionsEnabled = false
+    giftSubscriptionsEnabled = false,
+    labs
 }: UseMemberFilterFieldsOptions): FilterFieldGroup[] {
     return useMemo(() => {
+        const fields = getMemberFields(labs);
+        type MemberFieldKey = keyof typeof fields;
+
+        function createFieldConfig(
+            key: string,
+            overrides: Partial<FilterFieldConfig> = {},
+            operatorLabels: Record<string, string> = MEMBER_OPERATOR_LABELS
+        ): FilterFieldConfig {
+            const field = key.startsWith('newsletters.')
+                ? fields['newsletters.:slug']
+                : fields[key as MemberFieldKey];
+
+            return {
+                key,
+                ...field.ui,
+                icon: getFieldIcon(key),
+                operators: createOperatorOptions(field.operators, {labels: operatorLabels}),
+                ...('options' in field && field.options ? {options: field.options} : {}),
+                ...overrides
+            };
+        }
+
+        function createDateFieldConfig(
+            key: string,
+            today: string,
+            overrides: Partial<FilterFieldConfig> = {}
+        ): FilterFieldConfig {
+            const field = fields[key as MemberFieldKey];
+            const config = createFieldConfig(key, {defaultValue: today, ...overrides});
+
+            return fieldHasRelativeOperator(field)
+                ? {...config, customRenderer: createRelativeDateRenderer(today)}
+                : config;
+        }
+
         const groups: FilterFieldGroup[] = [];
         const activeNewsletters = newsletters.filter(newsletter => newsletter.status !== 'archived');
         const activeNewsletterSlugs = new Set(activeNewsletters.map(newsletter => newsletter.slug));
@@ -367,7 +384,7 @@ export function useMemberFilterFields({
 
             subscriptionFields.push(
                 createFieldConfig('status', giftSubscriptionsEnabled ? {
-                    options: [...memberFields.status.options, {value: 'gift', label: 'Gift subscription'}]
+                    options: [...fields.status.options, {value: 'gift', label: 'Gift subscription'}]
                 } : {}),
                 createFieldConfig('subscriptions.plan_interval'),
                 createFieldConfig('subscriptions.status'),
@@ -445,6 +462,7 @@ export function useMemberFilterFields({
         paidMembersEnabled,
         postValueSource,
         siteTimezone,
-        tierValueSource
+        tierValueSource,
+        labs
     ]);
 }

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -7,7 +7,6 @@ import {RELATIVE_DATE_OPERATOR_LABELS, createRelativeDateRenderer, fieldHasRelat
 import {createOperatorOptions} from '../filters/filter-operator-options';
 import {getMemberFields} from './member-fields';
 import {getTodayInTimezone} from '../filters/filter-normalization';
-import type {Labs} from './member-fields';
 import type {Offer} from '@tryghost/admin-x-framework/api/offers';
 
 interface UseMemberFilterFieldsOptions {
@@ -26,7 +25,6 @@ interface UseMemberFilterFieldsOptions {
     emailTrackClicks?: boolean;
     siteTimezone?: string;
     giftSubscriptionsEnabled?: boolean;
-    labs?: Labs;
 }
 
 type OfferOption = FilterOption<string>;
@@ -257,11 +255,10 @@ export function useMemberFilterFields({
     emailTrackOpens = false,
     emailTrackClicks = false,
     siteTimezone = 'UTC',
-    giftSubscriptionsEnabled = false,
-    labs
+    giftSubscriptionsEnabled = false
 }: UseMemberFilterFieldsOptions): FilterFieldGroup[] {
     return useMemo(() => {
-        const fields = getMemberFields(labs);
+        const fields = getMemberFields();
         type MemberFieldKey = keyof typeof fields;
 
         function createFieldConfig(
@@ -462,7 +459,6 @@ export function useMemberFilterFields({
         paidMembersEnabled,
         postValueSource,
         siteTimezone,
-        tierValueSource,
-        labs
+        tierValueSource
     ]);
 }

--- a/apps/posts/test/unit/views/comments/comment-fields.test.ts
+++ b/apps/posts/test/unit/views/comments/comment-fields.test.ts
@@ -42,7 +42,8 @@ describe('commentFields', () => {
             'is-less',
             'is-or-less',
             'is-greater',
-            'is-or-greater'
+            'is-or-greater',
+            'in-the-last'
         ]);
         expect(commentFields.body.operators).toEqual(['contains', 'does-not-contain']);
         expect(commentFields.post.operators).toEqual(['is', 'is-not']);
@@ -89,6 +90,19 @@ describe('commentFields', () => {
                 operator: 'is-greater',
                 values: ['2024-01-01']
             });
+        });
+
+        it('serializes relative date predicates with the relative now token', () => {
+            const predicate: FilterPredicate = {
+                id: '1',
+                field: 'created_at',
+                operator: 'in-the-last',
+                values: [7]
+            };
+
+            expect(commentFields.created_at.codec.serialize(predicate, createdAtContext)).toEqual([
+                'created_at:>=now-7d'
+            ]);
         });
     });
 

--- a/apps/posts/test/unit/views/comments/comment-filter-query.test.ts
+++ b/apps/posts/test/unit/views/comments/comment-filter-query.test.ts
@@ -46,6 +46,38 @@ describe('comment-filter-query', () => {
         );
     });
 
+    it('round-trips relative created_at filters', () => {
+        const parsed = parseCommentFilter('created_at:>=now-7d+status:published', 'UTC');
+
+        expect(stripIds(parsed)).toEqual([
+            {
+                field: 'created_at',
+                operator: 'in-the-last',
+                values: [7]
+            },
+            {
+                field: 'status',
+                operator: 'is',
+                values: ['published']
+            }
+        ]);
+
+        expect(serializeCommentFilters(parsed, 'UTC')).toBe('created_at:>=now-7d+status:published');
+    });
+
+    it('drops unsupported future relative created_at filters', () => {
+        const parsed = parseCommentFilter('created_at:<=now+14d+status:published', 'UTC');
+
+        expect(stripIds(parsed)).toEqual([
+            {
+                field: 'status',
+                operator: 'is',
+                values: ['published']
+            }
+        ]);
+        expect(serializeCommentFilters(parsed, 'UTC')).toBe('status:published');
+    });
+
     it('round-trips comment filters in a non-UTC site timezone', () => {
         const parsed = parseCommentFilter(
             'created_at:>=\'2024-01-01T05:00:00.000Z\'+created_at:<=\'2024-01-02T04:59:59.999Z\'+member_id:member_123+status:published',

--- a/apps/posts/test/unit/views/comments/use-comment-filter-fields.test.tsx
+++ b/apps/posts/test/unit/views/comments/use-comment-filter-fields.test.tsx
@@ -36,8 +36,10 @@ describe('useCommentFilterFields', () => {
                 {value: 'is-less', label: 'before'},
                 {value: 'is-or-less', label: 'on or before'},
                 {value: 'is-greater', label: 'after'},
-                {value: 'is-or-greater', label: 'on or after'}
-            ]
+                {value: 'is-or-greater', label: 'on or after'},
+                {value: 'in-the-last', label: 'in the last'}
+            ],
+            customRenderer: expect.any(Function)
         });
     });
 });

--- a/apps/shade/src/components/patterns/filters.tsx
+++ b/apps/shade/src/components/patterns/filters.tsx
@@ -689,21 +689,23 @@ const formatFilterDateValue = (date: Date | undefined): string => {
     return `${year}-${month}-${day}`;
 };
 
-interface FilterDatePickerProps<T = unknown> {
+export interface FilterDatePickerProps<T = unknown> {
     field?: FilterFieldConfig<T>;
     value: string;
     onChange: (value: string) => void;
     className?: string;
+    embedded?: boolean;
 }
 
 // Composes a text input for YYYY-MM-DD values with a Shade Calendar popover.
 // Avoid using <input type="date"> here: Safari opens its native date picker
 // from clicks inside the text area even when the calendar indicator is hidden.
-function FilterDatePicker<T = unknown>({
+export function FilterDatePicker<T = unknown>({
     field,
     value,
     onChange,
-    className
+    className,
+    embedded = false
 }: FilterDatePickerProps<T>) {
     const context = useFilterContext();
     const [open, setOpen] = useState(false);
@@ -804,8 +806,9 @@ function FilterDatePicker<T = unknown>({
     return (
         <div
             className={cn(
-                'w-32',
-                filterInputVariants({variant: context.variant, size: context.size, cursorPointer: false}),
+                embedded
+                    ? 'flex w-full min-w-0 items-center'
+                    : cn('w-32', filterInputVariants({variant: context.variant, size: context.size, cursorPointer: false})),
                 className
             )}
             data-slot="filters-input-wrapper"

--- a/apps/shade/src/components/patterns/filters.tsx
+++ b/apps/shade/src/components/patterns/filters.tsx
@@ -387,13 +387,24 @@ const filterFieldLabelVariants = cva(
 const filterFieldValueVariants = cva(
     [
         'relative flex min-w-0 shrink items-center gap-1 text-foreground transition focus-visible:z-1',
-        'focus-visible:ring-1 focus-visible:ring-focus-ring focus-visible:outline-hidden'
+        'focus-visible:ring-1 focus-visible:ring-focus-ring focus-visible:outline-hidden',
+        'has-[[data-slot=filters-input]:focus-visible]:ring-focus-ring/30',
+        'has-[[data-slot=filters-input]:focus-visible]:border-focus-ring',
+        'has-[[data-slot=filters-input]:focus-visible]:outline-hidden',
+        'has-[[data-slot=filters-input]:focus-visible]:ring-[3px]',
+        'has-[[data-slot=filters-input]:focus-visible]:z-1',
+        'has-[[data-slot=filters-input][aria-invalid=true]]:border',
+        'has-[[data-slot=filters-input][aria-invalid=true]]:border-solid',
+        'has-[[data-slot=filters-input][aria-invalid=true]]:border-destructive/60',
+        'has-[[data-slot=filters-input][aria-invalid=true]]:ring-destructive/10',
+        'dark:has-[[data-slot=filters-input][aria-invalid=true]]:border-destructive',
+        'dark:has-[[data-slot=filters-input][aria-invalid=true]]:ring-destructive/20'
     ],
     {
         variants: {
             variant: {
                 solid: 'bg-secondary',
-                outline: 'border border-border bg-background hover:bg-secondary has-[[data-slot=switch]]:hover:bg-transparent'
+                outline: 'border border-border bg-background hover:bg-secondary has-[[data-slot=switch]]:hover:bg-transparent has-[>[data-slot=filters-input-wrapper]]:hover:bg-background'
             },
             size: {
                 lg: 'h-10 gap-1.5 px-4 text-sm [&_svg:not([class*=size-])]:size-4',
@@ -401,7 +412,7 @@ const filterFieldValueVariants = cva(
                 sm: 'h-8 gap-0.5 px-2.5 text-xs [&_svg:not([class*=size-])]:size-3.5'
             },
             cursorPointer: {
-                true: 'cursor-pointer has-[[data-slot=switch]]:cursor-default',
+                true: 'cursor-pointer has-[[data-slot=switch]]:cursor-default has-[>[data-slot=filters-input-wrapper]]:cursor-text',
                 false: ''
             }
         },

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -28,6 +28,7 @@ Object {
       "lexicalIndicators": true,
       "llmsTxt": true,
       "members": true,
+      "membersRelativeDateFilters": true,
       "pictureImageFormats": true,
       "smarterCounts": true,
       "stripeAutomaticTax": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -28,7 +28,6 @@ Object {
       "lexicalIndicators": true,
       "llmsTxt": true,
       "members": true,
-      "membersRelativeDateFilters": true,
       "pictureImageFormats": true,
       "smarterCounts": true,
       "stripeAutomaticTax": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,11 +61,11 @@ catalogs:
       specifier: 1.5.5
       version: 1.5.5
     '@tryghost/nql':
-      specifier: 0.12.10
-      version: 0.12.10
+      specifier: 0.12.11
+      version: 0.12.11
     '@tryghost/nql-lang':
-      specifier: 0.6.4
-      version: 0.6.4
+      specifier: 0.6.5
+      version: 0.6.5
     '@tryghost/string':
       specifier: 0.3.4
       version: 0.3.4
@@ -881,7 +881,7 @@ importers:
         version: 1.5.5
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.12.10
+        version: 0.12.11
       '@tryghost/timezone-data':
         specifier: 'catalog:'
         version: 0.4.20
@@ -1082,7 +1082,7 @@ importers:
         version: link:../../ghost/i18n
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.12.10
+        version: 0.12.11
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 4.7.0(vite@7.3.2(@types/node@25.9.1)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -1224,7 +1224,7 @@ importers:
         version: 1.8.1
       '@tryghost/nql-lang':
         specifier: 'catalog:'
-        version: 0.6.4
+        version: 0.6.5
       '@tryghost/shade':
         specifier: workspace:*
         version: link:../shade
@@ -1905,7 +1905,7 @@ importers:
         version: 1.5.5
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.12.10
+        version: 0.12.11
       '@tryghost/string':
         specifier: 'catalog:'
         version: 0.3.4
@@ -2322,10 +2322,10 @@ importers:
         version: 2.2.2(babel-core@6.26.3)(handlebars@4.7.9)(lodash@4.18.1)(underscore@1.13.8)
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.12.10
+        version: 0.12.11
       '@tryghost/nql-lang':
         specifier: 'catalog:'
-        version: 0.6.4
+        version: 0.6.5
       '@tryghost/parse-email-address':
         specifier: workspace:*
         version: link:../parse-email-address
@@ -8641,8 +8641,14 @@ packages:
   '@tryghost/mongo-knex@0.9.4':
     resolution: {integrity: sha512-R5mqpuQ1nN4qWAii9Tvg5POZ0nLO7Voy7QaQF+95sseUpfe4XEUsr3+mm4HYPC8MNKginlUm/unLf5QFzFQl5w==}
 
+  '@tryghost/mongo-knex@0.9.5':
+    resolution: {integrity: sha512-etO6Kz8a1dgMV6yapD2C2JsoeLrUjkIoIUdXrkV9ELHQsMjMhtI2SAUnMV9AcLhxv0P7h8UWWD2rlNBwo8JJig==}
+
   '@tryghost/mongo-utils@0.6.3':
     resolution: {integrity: sha512-BOgflEMywUXnTxXqOPuppFRD50IuIERAt06UEsyGTLRI6GSuO18BDygo72UpMHtM+NspGM0jPc1eQOeVvUJNAw==}
+
+  '@tryghost/mongo-utils@0.6.4':
+    resolution: {integrity: sha512-4ZGl9QXoMTQb9qb5HGjMjVLkV39FO0F/0cM4Z3i/9gUXXfdmGZwPdcAMBRT7oRhqng3/4uSRpvQ/Rk0oASM+kg==}
 
   '@tryghost/mw-error-handler@1.0.13':
     resolution: {integrity: sha512-qDRjyiOkF5UNGgMHUDdFKTY0Mcwnxo5N9m71pliwVI+HfYvw77k/GxEIGc8mgikxjCuZkgC+IUnJjWCLuzCvKQ==}
@@ -8656,8 +8662,14 @@ packages:
   '@tryghost/nql-lang@0.6.4':
     resolution: {integrity: sha512-m984kPFEexS3N1j/LeG51ChTJCplN/+IWoBP6/vsBxz0cnneY87J7rwr96gTmNR+s1xDzuQOpj3heoFD9Dw+7A==}
 
+  '@tryghost/nql-lang@0.6.5':
+    resolution: {integrity: sha512-13Loz2yH7GCMAfpVawD6KNWNPIVTc4STnP+MeCwbrWg8htv/CPOB0u+i9Eap0qEi8h6TC2aoOvbQV0EvjidQaQ==}
+
   '@tryghost/nql@0.12.10':
     resolution: {integrity: sha512-kpj2ICTBmkz5Uet7Z/J61C/EEBTfa55np6LnbqW6N8g33uvCh9NkAsM2WgV1NK2lffpQT3Cs/qA2ymzHAguvoA==}
+
+  '@tryghost/nql@0.12.11':
+    resolution: {integrity: sha512-8Cb10OpQWT+v0Xvfrov9IkBwzyPlARsjF1EIC8f3ET/JZD3G+ARoQ3GEBQ7XeW6YcUd7MIh3zqJTv5ST+aDjZA==}
 
   '@tryghost/pretty-cli@3.2.0':
     resolution: {integrity: sha512-ddd/Zw8WNIXHMz9pAYcI8mT53586YnS9l9aCM7nvvXtIUdOvVBwtmQcAdq8Sqc8WcwzHCXWXsDa6Khe6zV2kDg==}
@@ -28824,7 +28836,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tryghost/mongo-knex@0.9.5':
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      lodash: 4.18.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@tryghost/mongo-utils@0.6.3':
+    dependencies:
+      lodash: 4.18.1
+
+  '@tryghost/mongo-utils@0.6.4':
     dependencies:
       lodash: 4.18.1
 
@@ -28909,11 +28932,25 @@ snapshots:
     dependencies:
       date-fns: 2.30.0
 
+  '@tryghost/nql-lang@0.6.5':
+    dependencies:
+      date-fns: 2.30.0
+
   '@tryghost/nql@0.12.10':
     dependencies:
       '@tryghost/mongo-knex': 0.9.4
       '@tryghost/mongo-utils': 0.6.3
       '@tryghost/nql-lang': 0.6.4
+      lodash: 4.18.1
+      mingo: 2.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tryghost/nql@0.12.11':
+    dependencies:
+      '@tryghost/mongo-knex': 0.9.5
+      '@tryghost/mongo-utils': 0.6.4
+      '@tryghost/nql-lang': 0.6.5
       lodash: 4.18.1
       mingo: 2.5.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,8 +44,8 @@ catalog:
   '@tryghost/koenig-lexical': 1.8.1
   '@tryghost/limit-service': 1.5.5
   '@tryghost/logging': 4.2.1
-  '@tryghost/nql': 0.12.10
-  '@tryghost/nql-lang': 0.6.4
+  '@tryghost/nql': 0.12.11
+  '@tryghost/nql-lang': 0.6.5
   '@tryghost/string': 0.3.4
   '@tryghost/timezone-data': 0.4.20
   '@types/express': 4.17.25
@@ -165,6 +165,11 @@ packageExtensions:
     dependencies:
       lodash: ^4.18.0
 minimumReleaseAgeExclude:
+  # Intentional same-day NQL release required for relative date parsing
+  - "@tryghost/mongo-knex@0.9.5"
+  - "@tryghost/mongo-utils@0.6.4"
+  - "@tryghost/nql-lang@0.6.5"
+  - "@tryghost/nql@0.12.11"
   # Renovate security update: @number-flow/react@0.6.0
   - "@number-flow/react@0.6.0"
   # Renovate security update: @aws-sdk/client-s3@3.1053.0


### PR DESCRIPTION
## Problem

Date filters only supported absolute dates like "created on or before May 1, 2026". Admins who want to monitor recent activity — new signups in the last week, members not seen in the last 30 days, subscriptions ending in the next 14 days, or recent comments in moderation — had to redo calendar math every time they visited the page. Saved views with these queries also drifted out of date.

## Solution

Add relative date operators to date-typed member filters:

- **In the last N days** for created date, last seen, and paid start date — the dates admins typically track backwards from today.
- **In the next N days** for next billing date — the future-leaning member date in the schema.

Add the same relative date behavior to comment moderation's created date filter with **In the last N days**.

The filter UI shows a single "days" input for relative operators and keeps using Shade's calendar-backed date picker for absolute date operators. Saved views that store relative ranges resolve against "now" each time the page loads, so they stay accurate without manual updates.

## Dependency

This now uses the stable NQL releases:

- `@tryghost/nql@0.12.11`
- `@tryghost/nql-lang@0.6.5`

ref https://linear.app/ghost/issue/BER-3621/add-relative-date-filters-to-the-members-page
