### PR TITLE
🐛 Fixed 500 error when updating members with nameless labels

### DIFF
--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -326,8 +326,12 @@ const Member = ghostBookshelf.Model.extend({
             //  and deduplicate upper/lowercase tags
             _.each(this.get('labels'), function each(item) {
                 item.name = item.name && item.name.trim();
+                // CASE: skip labels without a name to avoid downstream `.toLowerCase()` errors
+                if (!item.name) {
+                    return;
+                }
                 for (let i = 0; i < labelsToSave.length; i = i + 1) {
-                    if (labelsToSave[i].name && item.name && labelsToSave[i].name.toLocaleLowerCase() === item.name.toLocaleLowerCase()) {
+                    if (labelsToSave[i].name && labelsToSave[i].name.toLocaleLowerCase() === item.name.toLocaleLowerCase()) {
                         return;
                     }
                 }
@@ -348,7 +352,8 @@ const Member = ghostBookshelf.Model.extend({
             .then((labels) => {
                 labelsToSave.forEach((label) => {
                     let existingLabel = labels.find((lab) => {
-                        return label.name.toLowerCase() === lab.get('name').toLowerCase();
+                        const existingName = lab.get('name');
+                        return label.name && existingName && label.name.toLowerCase() === existingName.toLowerCase();
                     });
                     label.name = (existingLabel && existingLabel.get('name')) || label.name;
                     label.id = (existingLabel && existingLabel.id) || label.id;

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -312,36 +312,29 @@ const Member = ghostBookshelf.Model.extend({
     },
 
     onSaving: function onSaving(model, attr, options) {
-        let labelsToSave = [];
+        const rawLabels = this.get('labels');
 
-        if (_.isUndefined(this.get('labels'))) {
+        if (_.isUndefined(rawLabels)) {
             this.unset('labels');
             return;
         }
 
-        // CASE: detect lowercase/uppercase label slugs
-        if (!_.isUndefined(this.get('labels')) && !_.isNull(this.get('labels'))) {
-            labelsToSave = [];
+        // CASE: trim, drop nameless, and dedupe by case-insensitive name (first wins)
+        const seen = new Set();
+        const labelsToSave = (rawLabels || []).filter((item) => {
+            item.name = item.name && item.name.trim();
+            if (!item.name) {
+                return false;
+            }
+            const key = item.name.toLowerCase();
+            if (seen.has(key)) {
+                return false;
+            }
+            seen.add(key);
+            return true;
+        });
 
-            //  and deduplicate upper/lowercase tags
-            _.each(this.get('labels'), function each(item) {
-                item.name = item.name && item.name.trim();
-                // CASE: skip labels without a name to avoid downstream `.toLowerCase()` errors
-                if (!item.name) {
-                    return;
-                }
-                for (let i = 0; i < labelsToSave.length; i = i + 1) {
-                    if (labelsToSave[i].name && labelsToSave[i].name.toLocaleLowerCase() === item.name.toLocaleLowerCase()) {
-                        return;
-                    }
-                }
-
-                labelsToSave.push(item);
-            });
-
-            this.set('labels', labelsToSave);
-        }
-
+        this.set('labels', labelsToSave);
         this.handleAttachedModels(model);
 
         // CASE: Detect existing labels with same case-insensitive name and replace
@@ -350,13 +343,20 @@ const Member = ghostBookshelf.Model.extend({
                 columns: ['id', 'name']
             }, _.pick(options, 'transacting')))
             .then((labels) => {
+                const existingByName = new Map();
+                for (const lab of labels.models) {
+                    const name = lab.get('name');
+                    if (name) {
+                        existingByName.set(name.toLowerCase(), lab);
+                    }
+                }
+
                 labelsToSave.forEach((label) => {
-                    let existingLabel = labels.find((lab) => {
-                        const existingName = lab.get('name');
-                        return label.name && existingName && label.name.toLowerCase() === existingName.toLowerCase();
-                    });
-                    label.name = (existingLabel && existingLabel.get('name')) || label.name;
-                    label.id = (existingLabel && existingLabel.id) || label.id;
+                    const match = existingByName.get(label.name.toLowerCase());
+                    if (match) {
+                        label.name = match.get('name');
+                        label.id = match.id;
+                    }
                 });
 
                 model.set('labels', labelsToSave);

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -66,7 +66,7 @@ describe('Unit: models/member', function () {
                 get: key => (key === 'name' ? 'Existing' : 'existing-1')
             }];
             const findAllStub = sinon.stub(models.Label, 'findAll').resolves({
-                find: predicate => existingLabels.find(predicate)
+                models: existingLabels
             });
 
             await memberModel.onSaving(memberModel, memberModel.attributes, {});

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -48,6 +48,36 @@ describe('Unit: models/member', function () {
         });
     });
 
+    describe('onSaving', function () {
+        it('skips labels without a name instead of throwing', async function () {
+            const memberModel = new models.Member({email: 'test@example.com'});
+            // Simulate input from API where one label is missing `name`
+            memberModel.set('labels', [
+                {name: 'Newsletter'},
+                {id: 'abc123'}, // no name
+                {name: '   '}, // whitespace only -> trimmed to ''
+                {name: 'newsletter'} // case-insensitive duplicate
+            ]);
+
+            // Stub Label.findAll to return a collection with a pre-existing label
+            // so the buggy `.toLowerCase()` path on member.js:351 is exercised.
+            const existingLabels = [{
+                id: 'existing-1',
+                get: key => (key === 'name' ? 'Existing' : 'existing-1')
+            }];
+            const findAllStub = sinon.stub(models.Label, 'findAll').resolves({
+                find: predicate => existingLabels.find(predicate)
+            });
+
+            await memberModel.onSaving(memberModel, memberModel.attributes, {});
+
+            const finalLabels = memberModel.get('labels');
+            assert.equal(finalLabels.length, 1, 'only the valid label should remain');
+            assert.equal(finalLabels[0].name, 'Newsletter');
+            sinon.assert.calledOnce(findAllStub);
+        });
+    });
+
     describe('updateTierExpiry', function () {
         let memberModel;
         let updatePivot;


### PR DESCRIPTION
## Problem

Updating a member through the Admin API would return a 500 error if the request body contained a label without a name. The crash surfaced as `Cannot read properties of undefined (reading 'toLowerCase')` and was reported via Sentry.

## Solution

The member-saving logic now skips labels that have no name when deduplicating, instead of attempting to compare against an undefined value. This brings the dedup pass in line with the rest of the loop's existing handling of empty/falsy names.

refs https://linear.app/ghost/issue/BER-3560