### PR TITLE
🐛 Fixed product card rating clicks being silently swallowed after sibling card focus change

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -76,7 +76,7 @@
         "@playwright/test": "1.59.1",
         "@testing-library/jest-dom": "5.17.0",
         "@testing-library/react": "14.3.1",
-        "@tryghost/koenig-lexical": "1.8.1",
+        "@tryghost/koenig-lexical": "1.8.2-pr1882.0",
         "@types/react": "18.3.28",
         "@types/react-dom": "18.3.7",
         "@vitejs/plugin-react": "4.7.0",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -16,7 +16,7 @@
     "@tryghost/activitypub": "workspace:*",
     "@tryghost/admin-x-framework": "workspace:*",
     "@tryghost/admin-x-settings": "workspace:*",
-    "@tryghost/koenig-lexical": "1.8.1",
+    "@tryghost/koenig-lexical": "1.8.2-pr1882.0",
     "@tryghost/posts": "workspace:*",
     "@tryghost/shade": "workspace:*",
     "@tryghost/stats": "workspace:*",

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -50,7 +50,7 @@
     "@tryghost/helpers": "1.1.103",
     "@tryghost/kg-clean-basic-html": "4.3.1",
     "@tryghost/kg-converters": "1.2.1",
-    "@tryghost/koenig-lexical": "1.8.1",
+    "@tryghost/koenig-lexical": "1.8.2-pr1882.0",
     "@tryghost/limit-service": "1.5.2",
     "@tryghost/nql": "0.12.10",
     "@tryghost/string": "0.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,8 +224,8 @@ importers:
         specifier: workspace:*
         version: link:../admin-x-settings
       '@tryghost/koenig-lexical':
-        specifier: 1.8.1
-        version: 1.8.1
+        specifier: 1.8.2-pr1882.0
+        version: 1.8.2-pr1882.0
       '@tryghost/posts':
         specifier: workspace:*
         version: link:../posts
@@ -539,8 +539,8 @@ importers:
         specifier: 14.3.1
         version: 14.3.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tryghost/koenig-lexical':
-        specifier: 1.8.1
-        version: 1.8.1
+        specifier: 1.8.2-pr1882.0
+        version: 1.8.2-pr1882.0
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
@@ -1602,8 +1602,8 @@ importers:
         specifier: 1.2.1
         version: 1.2.1
       '@tryghost/koenig-lexical':
-        specifier: 1.8.1
-        version: 1.8.1
+        specifier: 1.8.2-pr1882.0
+        version: 1.8.2-pr1882.0
       '@tryghost/limit-service':
         specifier: 1.5.2
         version: 1.5.2
@@ -8757,17 +8757,14 @@ packages:
   '@tryghost/kg-utils@1.1.1':
     resolution: {integrity: sha512-qUEQwA4RB0DXwBKaxWknRGiYFdzpW/LYugsgFyhxSZ4k/EX8eWmZSUNaLK0LodCr+I5+VNuFoCllngvM1IhR6A==}
 
-  '@tryghost/koenig-lexical@1.8.1':
-    resolution: {integrity: sha512-cVIM2Iknhz/cZFiczgpX6oBWmeJwo0MIkG6NR6VLxncS6QnF+EJloHGrjQW7j2Uge3ly2BpRWHsJP4YV0PtpzA==}
+  '@tryghost/koenig-lexical@1.8.2-pr1882.0':
+    resolution: {integrity: sha512-h5kySd+bjmy/lUz4S0WRVnaV/ybwSnxwXjKA22H5iVsBgpYKk7sD8Y5UFUa6tTc1dOA6HpTGR1UI7Gw7RllMQA==}
 
   '@tryghost/limit-service@1.5.2':
     resolution: {integrity: sha512-BTSnMpVMRauSkxi0yL/V2qVy9nRlAL9maALFAe5MDNTSCvg4zjV2b2S4o6+tgCyGDRkMPeePfrgSuH2YTTbD5Q==}
 
   '@tryghost/logging@4.1.0':
     resolution: {integrity: sha512-M8tNHRDSGLtAydgNbGRsN4zgUZpprOgXalEcK1112TODmEQMdIUxCjf1Eys3AhOyZZAeQyvonyuqJqDgJDrmww==}
-
-  '@tryghost/members-csv@2.0.5':
-    resolution: {integrity: sha512-5BMzhWSoJg+pOQuXdO8ygHDxLFcwZLob903NX7lprWQtooLPD8FAWwdFql/ZA7gPG5Bq9lV7TyUFK3hWVtvIlw==}
 
   '@tryghost/members-csv@2.0.7':
     resolution: {integrity: sha512-RnpaY2jKXC2waJTH4tI34vW541YBoDu7rX3NPZeHIdzoRP1102NCrzhPrFB/edmcyJ9fMMj5XpcvoQWw7FR/5A==}
@@ -29943,7 +29940,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  '@tryghost/koenig-lexical@1.8.1': {}
+  '@tryghost/koenig-lexical@1.8.2-pr1882.0': {}
 
   '@tryghost/limit-service@1.5.2':
     dependencies:
@@ -29969,13 +29966,6 @@ snapshots:
     transitivePeerDependencies:
       - '@75lb/nature'
       - supports-color
-
-  '@tryghost/members-csv@2.0.5':
-    dependencies:
-      fs-extra: 11.3.0
-      lodash: 4.18.1
-      papaparse: 5.3.2
-      pump: 3.0.2
 
   '@tryghost/members-csv@2.0.7':
     dependencies:


### PR DESCRIPTION
## Problem

Editing a post with a product card immediately following a file card: clicking a rating star on the product card after uploading a file to the file card silently does nothing. The card still appears interactive (settings panel visible, green selection border) but the click never registers.

This was reported in 2023 and has been open in BER triage. Ticket reproducible end-to-end with the `pr-1882` Koenig alpha installed by this PR.

## Solution

Bumps `@tryghost/koenig-lexical` from `1.8.1` to `1.8.2-pr1882.0`. The actual fix lives in TryGhost/Koenig#1882; this PR just pulls it in.

The Koenig change makes `KoenigCardWrapper`'s mousedown handler early-return for clickthrough-marked elements (rather than dispatching `SELECT_CARD_COMMAND`, which was synchronously deselecting sibling cards and causing a layout shift between mousedown and mouseup), and promotes the rating widget to that contract — clicking a star now both updates the rating AND puts the card back into editing state in a single gesture.

This PR will be repointed to the real `1.8.2` (or whichever version) once Koenig#1882 merges and publishes.

refs https://linear.app/ghost/issue/BER-3595
refs https://github.com/TryGhost/Koenig/pull/1882