### PR TITLE
🐛 Fixed members API timing out on sites with large email_recipients tables

### DIFF
--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -349,10 +349,6 @@ module.exports = class MemberBREADService {
             withRelated.add('productEvents');
         }
 
-        if (withRelated.has('email_recipients')) {
-            withRelated.add('email_recipients.email');
-        }
-
         const model = await this.memberRepository.get(data, {
             ...options,
             withRelated: Array.from(withRelated)
@@ -608,10 +604,6 @@ module.exports = class MemberBREADService {
 
         if (!withRelated.has('productEvents')) {
             withRelated.add('productEvents');
-        }
-
-        if (withRelated.has('email_recipients')) {
-            withRelated.add('email_recipients.email');
         }
 
         //option param to skip distinct from count query, distinct adds a lot of latency and in this case the result set will always be unique.

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -394,6 +394,24 @@ describe('MemberBreadService', function () {
             assert.deepEqual(member.subscriptions, subscriptionsJSON);
         });
 
+        it('does not eager-load the embedded email when email_recipients is included', async function () {
+            // Including ?include=email_recipients should fetch the recipient
+            // metadata only — not bolt on the joined email row, which used
+            // to ship multi-MB LONGTEXT bodies and crash JSON.stringify on
+            // high-volume sites. Clients that want the email itself should
+            // call /emails/:id.
+            memberRepositoryStub.get.resolves(memberModelStub);
+
+            const memberBreadService = getService();
+            await memberBreadService.read({id: MEMBER_ID}, {withRelated: ['email_recipients']});
+
+            const passedWithRelated = memberRepositoryStub.get.lastCall.args[1].withRelated;
+
+            assert.ok(passedWithRelated.includes('email_recipients'), 'email_recipients itself should still be eager-loaded');
+            assert.ok(!passedWithRelated.includes('email_recipients.email'), 'email_recipients.email must not be eager-loaded');
+            assert.ok(!passedWithRelated.some(item => typeof item === 'object' && item !== null && 'email_recipients.email' in item), 'email_recipients.email must not be eager-loaded via object form either');
+        });
+
         it('returns a member with subscriptions that only have a price', async function () {
             const subscriptionsJSON = [
                 {


### PR DESCRIPTION
## Problem

`/admin/members/?include=email_recipients` returns HTTP 500 with `RangeError: Invalid string length` on high-volume sites. The DB query succeeds in 6–7 seconds; what fails is `JSON.stringify` on the response.

The bread service silently bolts an `email_recipients.email` eager-load onto `withRelated` whenever a client asks for `?include=email_recipients`. The joined `email` row carries the `html`, `plaintext`, and `source` LONGTEXT fields — for one site with 256k members and 193M `email_recipients` rows, a five-row page produces ~1GB of JSON and exceeds Node's string-length limit.

## Solution

Drop the silent `email_recipients.email` eager-load. The included `email_recipients[]` entries still carry the recipient delivery metadata (`processed_at`, `delivered_at`, `opened_at`, `failed_at`, `member_email`, `batch_id`, `email_id`, etc.). Clients that need the email content can call `/emails/:id` directly using the `email_id`.

## Why this is the right fix (history + audit)

**Why was the eager-load added?** Commit `c1d66f0b01` (Kevin Ansfield, Dec 2020), introducing `?include=email_recipients`:

> "appends `email_recipients.email` to the `withRelated` array when `email_recipients` is included so that we have data available for **email subject and html/plaintext for previews**"

The intent was to power a per-member email activity timeline in Ghost-Admin (refs `TryGhost/Ghost-Admin/pull/1796`).

**Is that consumer still alive?** No. Ghost-Admin's member activity timeline now consumes the dedicated `member_events` API — see `ghost/admin/app/helpers/parse-member-event.js` and `ghost/admin/app/utils/member-event-types.js`, which switch on `email_sent_event`, `email_opened_event`, `email_delivered_event`, `email_failed_event`, `email_complaint_event`, etc. The `email_recipients.email` shape is vestigial — left over from the 2020 design that has since been replaced.

**First-party consumers of `recipient.email.*`?** I grepped the entire monorepo for any access to the embedded `email` object — `ghost/core/`, `ghost/admin/`, `ghost/i18n/`, every package under `apps/`, the e2e suite. Zero hits outside of:

- this PR's own test (asserting it isn't there)
- fixture data setting `email_id` (the FK column on `email_recipients` itself, not the joined model)

The `recipient.email` references that show up in `email-analytics`, `mailgun-email-provider`, `sending-service`, etc. are all `recipient.email` as a string (an email address), not the joined `email` object — different code paths.

**Existing API contract?** None. The endpoint's `allowedIncludes` is `['email_recipients', 'products', 'tiers']`. There is no `email_recipients.email` in the include allowlist, no input-serializer step that requests it, and the e2e snapshot at `members.test.js:884` shows `"email_recipients": Array []` for the test fixture, so it pins down nothing about the embedded shape.

## Breaking change

External integrations that were reading `email_recipients[].email.*` must call `/emails/:id` (or one of the other email endpoints) instead.

The known affected consumer (the bot reported in BER-3547) is already getting HTTP 500s on this path, so any integration currently working against it on a large site is already broken — there's no graceful-degradation case being lost here.

refs https://linear.app/ghost/issue/BER-3547