### PR TITLE
✨ Added email_disabled to Members export and import

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -31,6 +31,7 @@ const CSV_HEADERS = [
     'name',
     'note',
     'subscribed_to_emails',
+    'email_disabled',
     'complimentary_plan',
     'stripe_customer_id',
     'created_at',
@@ -71,12 +72,16 @@ function formatMemberForCSV(member) {
     // Convert subscribed boolean to string representation
     const subscribedToEmails = member.subscribed === true ? 'true' : 'false';
 
+    // Convert email_disabled boolean to string representation
+    const emailDisabled = member.email_disabled === true ? 'true' : 'false';
+
     return {
         id: member.id,
         email: member.email,
         name: member.name,
         note: member.note,
         subscribed_to_emails: subscribedToEmails,
+        email_disabled: emailDisabled,
         complimentary_plan: complimentaryPlan,
         stripe_customer_id: member.stripe_customer_id,
         created_at: member.created_at,

--- a/ghost/core/core/server/services/members/exporter/query.js
+++ b/ghost/core/core/server/services/members/exporter/query.js
@@ -175,7 +175,7 @@ async function createExportStream(options) {
 
     // Create a query stream for members
     const membersQuery = knex('members')
-        .select('id', 'email', 'name', 'note', 'status', 'created_at');
+        .select('id', 'email', 'name', 'note', 'status', 'created_at', 'email_disabled');
     
     if (hasFilter) {
         membersQuery.whereIn('id', ids);

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -33,6 +33,7 @@ const DEFAULT_CSV_HEADER_MAPPING = {
     note: 'note',
     subscribed_to_emails: 'subscribed',
     created_at: 'created_at',
+    email_disabled: 'email_disabled',
     complimentary_plan: 'complimentary_plan',
     stripe_customer_id: 'stripe_customer_id',
     labels: 'labels',
@@ -176,7 +177,7 @@ module.exports = class MembersCSVImporter {
                 // Members created in the future will not appear in admin members list
                 // Refs https://github.com/TryGhost/Team/issues/2793
                 const createdAt = moment(row.created_at).isAfter(moment()) ? moment().toDate() : row.created_at;
-                const memberValues = {
+                let memberValues = {
                     email: row.email,
                     name: row.name,
                     note: row.note,
@@ -184,6 +185,12 @@ module.exports = class MembersCSVImporter {
                     created_at: createdAt,
                     labels: row.labels
                 };
+                // Apply email_disabled only if values are present, old CSV files did not have this header
+                const hasEmailDisabled = row.email_disabled !== undefined && row.email_disabled !== null && row.email_disabled !== '';
+                if (hasEmailDisabled) {
+                    memberValues.email_disabled = row.email_disabled;
+                }
+                
                 const existingMember = await membersRepository.get({email: memberValues.email}, {
                     ...options,
                     withRelated: ['labels', 'newsletters']

--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -52,7 +52,7 @@ async function testOutput(member, asserts, filters = []) {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,email_disabled,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
 
         let csv = Papa.parse(res.text, {header: true});
         let row = csv.data.find(r => r.id === member.id);

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2751,7 +2751,7 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,email_disabled,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
 
         const csv = Papa.parse(res.text, {header: true});
         assertExists(csv.data.find(row => row.name === 'Mr Egg'));
@@ -2772,7 +2772,7 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,email_disabled,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id/);
 
         const csv = Papa.parse(res.text, {header: true});
         assertExists(csv.data.find(row => row.name === 'Mr Egg'));

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/member-csv-export.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/member-csv-export.csv
@@ -1,3 +1,3 @@
-id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers
-634e48e056ef99c6a7af5850,member_complimentary_test@example.com,"bobby tables","a note",true,true,,2022-10-18T06:34:08.000Z,,"user import label",This is a Bronze Tier
-634e566dde68acf282cd311e,member_stripe_test@example.com,"stirpey beaver","testing notes",false,,cus_MdR9tqW6bAreiq,2022-10-18T07:31:57.000Z,,,This is a Premium Tier
+id,email,name,note,subscribed_to_emails,email_disabled,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers
+634e48e056ef99c6a7af5850,member_complimentary_test@example.com,"bobby tables","a note",true,false,true,,2022-10-18T06:34:08.000Z,,"user import label",This is a Bronze Tier
+634e566dde68acf282cd311e,member_stripe_test@example.com,"stirpey beaver","testing notes",false,false,,cus_MdR9tqW6bAreiq,2022-10-18T07:31:57.000Z,,,This is a Premium Tier

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/subscribed-to-emails-cases.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/subscribed-to-emails-cases.csv
@@ -1,16 +1,16 @@
-email,name,note,subscribed_to_emails,stripe_customer_id,complimentary_plan,labels,created_at
-member_subscribed_true@example.com,Test Email,This is a test template for importing your members list to Ghost,true,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_subscribed_false@example.com,Test Email,This is a test template for importing your members list to Ghost,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_subscribed_null@example.com,Test Email,This is a test template for importing your members list to Ghost,null,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_subscribed_empty@example.com,Test Email,This is a test template for importing your members list to Ghost,,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_subscribed_invalid@example.com,Test Email,This is a test template for importing your members list to Ghost,asdfasdf,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_not_subscribed_true@example.com,Test Email,This is a test template for importing your members list to Ghost,true,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_not_subscribed_false@example.com,Test Email,This is a test template for importing your members list to Ghost,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_not_subscribed_null@example.com,Test Email,This is a test template for importing your members list to Ghost,null,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_not_subscribed_empty@example.com,Test Email,This is a test template for importing your members list to Ghost,,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-member_not_subscribed_invalid@example.com,Test Email,This is a test template for importing your members list to Ghost,asdfasdf,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-new_member_true@example.com,Test Email,This is a test template for importing your members list to Ghost,true,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-new_member_false@example.com,Test Email,This is a test template for importing your members list to Ghost,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-new_member_null@example.com,Test Email,This is a test template for importing your members list to Ghost,null,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-new_member_empty@example.com,Test Email,This is a test template for importing your members list to Ghost,,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
-new_member_invalid@example.com,Test Email,This is a test template for importing your members list to Ghost,asdfasdf,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+email,name,note,subscribed_to_emails,email_disabled,stripe_customer_id,complimentary_plan,labels,created_at
+member_subscribed_true@example.com,Test Email,This is a test template for importing your members list to Ghost,true,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_subscribed_false@example.com,Test Email,This is a test template for importing your members list to Ghost,false,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_subscribed_null@example.com,Test Email,This is a test template for importing your members list to Ghost,null,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_subscribed_empty@example.com,Test Email,This is a test template for importing your members list to Ghost,,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_subscribed_invalid@example.com,Test Email,This is a test template for importing your members list to Ghost,asdfasdf,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_not_subscribed_true@example.com,Test Email,This is a test template for importing your members list to Ghost,true,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_not_subscribed_false@example.com,Test Email,This is a test template for importing your members list to Ghost,false,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_not_subscribed_null@example.com,Test Email,This is a test template for importing your members list to Ghost,null,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_not_subscribed_empty@example.com,Test Email,This is a test template for importing your members list to Ghost,,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+member_not_subscribed_invalid@example.com,Test Email,This is a test template for importing your members list to Ghost,asdfasdf,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+new_member_true@example.com,Test Email,This is a test template for importing your members list to Ghost,true,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+new_member_false@example.com,Test Email,This is a test template for importing your members list to Ghost,false,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+new_member_null@example.com,Test Email,This is a test template for importing your members list to Ghost,null,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+new_member_empty@example.com,Test Email,This is a test template for importing your members list to Ghost,,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z
+new_member_invalid@example.com,Test Email,This is a test template for importing your members list to Ghost,asdfasdf,false,Example: cus_GdsYH4fZbHx9hF,false,"vip,promotion",2019-10-30T14:52:08.000Z

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -24,6 +24,7 @@ describe('MembersCSVImporter', function () {
         note: 'note',
         subscribed_to_emails: 'subscribed_to_emails',
         created_at: 'created_at',
+        email_disabled: 'email_disabled',
         complimentary_plan: 'complimentary_plan',
         stripe_customer_id: 'stripe_customer_id',
         labels: 'labels',
@@ -185,7 +186,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
 
-            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.create.args[0][0].id, undefined, 'id field should not be taken from the user input');
             assert.equal(membersRepositoryStub.create.args[0][0].email, 'member_complimentary_test@example.com');
             assert.equal(membersRepositoryStub.create.args[0][0].name, 'bobby tables');
@@ -197,7 +198,7 @@ describe('MembersCSVImporter', function () {
                 name: 'user import label'
             }]);
 
-            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.create.args[1][0].id, undefined, 'id field should not be taken from the user input');
             assert.equal(membersRepositoryStub.create.args[1][0].email, 'member_stripe_test@example.com');
             assert.equal(membersRepositoryStub.create.args[1][0].name, 'stirpey beaver');
@@ -333,105 +334,105 @@ describe('MembersCSVImporter', function () {
 
             // CASE 1: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is true
             // Member's newsletter subscriptions should not change
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels', 'newsletters']);
             assert.equal(membersRepositoryStub.update.args[0][0].email, 'member_subscribed_true@example.com');
             assert.equal(membersRepositoryStub.update.args[0][0].subscribed, true);
             assert.deepEqual(membersRepositoryStub.update.args[0][0].newsletters, defaultNewsletters);
 
             // CASE 2: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is false
             // Member's newsletter subscriptions should be removed
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.update.args[1][0].email, 'member_subscribed_false@example.com');
             assert.equal(membersRepositoryStub.update.args[1][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[1][0].newsletters, undefined);
 
             // CASE 3: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is NULL
             // Member's newsletter subscriptions should not change
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels', 'newsletters']);
             assert.equal(membersRepositoryStub.update.args[2][0].email, 'member_subscribed_null@example.com');
             assert.equal(membersRepositoryStub.update.args[2][0].subscribed, true);
             assert.deepEqual(membersRepositoryStub.update.args[2][0].newsletters, defaultNewsletters);
 
             // CASE 4: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is empty
             // Member's newsletter subscriptions should not change
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels', 'newsletters']);
             assert.equal(membersRepositoryStub.update.args[3][0].email, 'member_subscribed_empty@example.com');
             assert.equal(membersRepositoryStub.update.args[3][0].subscribed, true);
             assert.deepEqual(membersRepositoryStub.update.args[3][0].newsletters, defaultNewsletters);
 
             // CASE 5: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is invalid
             // Member's newsletter subscriptions should not change
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels', 'newsletters']);
             assert.equal(membersRepositoryStub.update.args[4][0].email, 'member_subscribed_invalid@example.com');
             assert.equal(membersRepositoryStub.update.args[4][0].subscribed, true);
             assert.deepEqual(membersRepositoryStub.update.args[4][0].newsletters, defaultNewsletters);
 
             // CASE 6: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is true
             // Member should remain unsubscribed and not added to any newsletters
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[5][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[5][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.update.args[5][0].email, 'member_not_subscribed_true@example.com');
             assert.equal(membersRepositoryStub.update.args[5][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[5][0].newsletters, undefined);
 
             // CASE 7: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is false
             // Member should remain unsubscribed and not added to any newsletters
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[6][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[6][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.update.args[6][0].email, 'member_not_subscribed_false@example.com');
             assert.equal(membersRepositoryStub.update.args[6][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[6][0].newsletters, undefined);
 
             // CASE 8: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is NULL
             // Member should remain unsubscribed and not added to any newsletters
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[7][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[7][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.update.args[7][0].email, 'member_not_subscribed_null@example.com');
             assert.equal(membersRepositoryStub.update.args[7][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[7][0].newsletters, undefined);
 
             // CASE 9: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is empty
             // Member should remain unsubscribed and not added to any newsletters
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[8][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[8][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.update.args[8][0].email, 'member_not_subscribed_empty@example.com');
             assert.equal(membersRepositoryStub.update.args[8][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[8][0].newsletters, undefined);
 
             // CASE 10: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is invalid
             // Member should remain unsubscribed and not added to any newsletters
-            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[9][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[9][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.update.args[9][0].email, 'member_not_subscribed_invalid@example.com');
             assert.equal(membersRepositoryStub.update.args[9][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[9][0].newsletters, undefined);
 
             // CASE 11: New member, `subscribed_to_emails` column is true
             // Member should be created and subscribed
-            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.create.args[0][0].email, 'new_member_true@example.com');
             assert.equal(membersRepositoryStub.create.args[0][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[0][0].newsletters, undefined);
 
             // CASE 12: New member, `subscribed_to_emails` column is false
             // Member should be created but not subscribed
-            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.create.args[1][0].email, 'new_member_false@example.com');
             assert.equal(membersRepositoryStub.create.args[1][0].subscribed, false);
             assert.equal(membersRepositoryStub.create.args[1][0].newsletters, undefined);
 
             // CASE 13: New member, `subscribed_to_emails` column is NULL
             // Member should be created but not subscribed
-            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.create.args[2][0].email, 'new_member_null@example.com');
             assert.equal(membersRepositoryStub.create.args[2][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[2][0].newsletters, undefined);
 
             // CASE 14: New member, `subscribed_to_emails` column is empty
             // Member should be created but not subscribed
-            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.create.args[3][0].email, 'new_member_empty@example.com');
             assert.equal(membersRepositoryStub.create.args[3][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[3][0].newsletters, undefined);
 
             // CASE 15: New member, `subscribed_to_emails` column is invalid
             // Member should be created but not subscribed
-            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'email_disabled', 'labels']);
             assert.equal(membersRepositoryStub.create.args[4][0].email, 'new_member_invalid@example.com');
             assert.equal(membersRepositoryStub.create.args[4][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[4][0].newsletters, undefined);


### PR DESCRIPTION
When migrating the member lists from one Ghost instance to another this field is used to prevent sending emails to addresses that no previous email could be delivered. Not exporting and importing this field causes a lot of bounced emails on the first newsletter.

fixes https://github.com/TryGhost/Ghost/issues/25732

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single boolean field to member CSV import/export and updates tests/fixtures accordingly, with minimal impact outside the members data pipeline.
> 
> **Overview**
> Members CSV export now includes an `email_disabled` column, sourced from the `members.email_disabled` DB field and serialized as `'true'/'false'` alongside `subscribed_to_emails`.
> 
> Members CSV import accepts the same `email_disabled` column and persists it on member create/update, with e2e/unit tests and importer/exporter fixtures updated to assert the new header and values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573298d44a45f5865af87733e5132718462f64c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->