### PR TITLE
Extended {{contrast_text_color}} helper to support CSS variable

### DIFF
--- a/ghost/core/core/frontend/helpers/contrast_text_color.js
+++ b/ghost/core/core/frontend/helpers/contrast_text_color.js
@@ -2,10 +2,12 @@ const {textColorForBackgroundColor} = require('@tryghost/color-utils');
 
 module.exports = function contrast_text_color(color) { // eslint-disable-line camelcase
     const backgroundColor = (typeof color === 'string' && color.trim()) ? color.trim() : '#15171A';
-
     try {
-        return textColorForBackgroundColor(backgroundColor).hex();
+        const contrastColor = textColorForBackgroundColor(backgroundColor).hex();
+        if (contrastColor === '#FFFFFF') return 'var(--ghost-contrast-color-white, #FFFFFF)';
+        if (contrastColor === '#000000') return 'var(--ghost-contrast-color-black, #000000)';
+        return contrastColor;
     } catch (err) {
-        return '#FFFFFF';
+        return 'var(--ghost-contrast-color-white, #FFFFFF)';
     }
 };


### PR DESCRIPTION
### What
`{{contrast_text_color}}` helper now returns CSS variables instead of hardcoded  hex values, with a fallback to pure white/black for backward compatibility.

### Why
Theme developers often use slightly off-white or off-black text colors for  better visual consistency. Previously there was no way to override the  hardcoded `#FFFFFF`/`#000000` returned by this helper.

By returning `var(--ghost-contrast-color-white)` and  `var(--ghost-contrast-color-black)`, theme developers can now define these  variables in their CSS to match their typography:

```css
:root {
  --ghost-contrast-color-white: #F5F5F5;
  --ghost-contrast-color-black: #1A1A1A;
}
```

### Backward compatible
If the CSS variables are not defined, the fallback values `#FFFFFF` and  `#000000` are used — so existing themes are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to a theme helper’s return values; main risk is behavior/expectation changes where callers or tests assume raw hex strings.
> 
> **Overview**
> Updates the `{{contrast_text_color}}` helper to return CSS `var()` references for pure white/black results (`--ghost-contrast-color-white`/`--ghost-contrast-color-black`) with hex fallbacks, instead of always returning hardcoded `#FFFFFF`/`#000000`.
> 
> Invalid/exception paths now also return the white CSS variable fallback, while non-white/black contrast results continue to return the computed hex value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee45b89c21a39d24ea4f84404383da53894c76ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->