### PR TITLE
Small design tweaks for gift subscriptions

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.35",
+  "version": "2.68.36",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -100,6 +100,7 @@ export const GiftPageStyles = `
     font-size: 1.6rem;
     line-height: 1.45em;
     color: var(--grey3);
+    text-wrap: pretty;
 }
 
 .gh-portal-gift-checkout-section {

--- a/apps/portal/src/components/pages/gift-success-page.js
+++ b/apps/portal/src/components/pages/gift-success-page.js
@@ -130,7 +130,6 @@ const GiftSuccessPage = () => {
                             </header>
 
                             <div className='gh-portal-gift-checkout-section'>
-                                <div className='gh-portal-gift-checkout-label'>Shareable link</div>
                                 <div className='gh-portal-gift-success-link'>
                                     <span className='gh-portal-gift-success-link-url'>{redeemUrl}</span>
                                     <button className='gh-portal-gift-success-copy' onClick={handleCopy} type='button'>

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -149,7 +149,7 @@ export default class ParseMemberEventHelper extends Helper {
         }
 
         if (event.type === 'gift_ended_event') {
-            icon = 'expired-gift';
+            icon = 'gift';
         }
 
         if (event.type === 'email_change_event') {

--- a/ghost/admin/public/assets/icons/event-expired-gift.svg
+++ b/ghost/admin/public/assets/icons/event-expired-gift.svg
@@ -1,4 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M5.8375 10.575v6.8a.6375.6375 0 0 0 .6375.6375h11.05a.6375.6375 0 0 0 .6375-.6375v-6.8M4.5625 7.3875h14.875v3.1875H4.5625zM12 7.3875v10.625M12 7.3875c-.6375-1.9125-1.9125-3.4-3.4-3.4a1.7 1.7 0 0 0 0 3.4h3.4zM12 7.3875c.6375-1.9125 1.9125-3.4 3.4-3.4a1.7 1.7 0 0 1 0 3.4h-3.4z" stroke="#6C747D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M16.5 6.5 7.5 17" stroke="#F50B23" stroke-width="1.7" stroke-linecap="round"/>
-</svg>

--- a/ghost/admin/tests/unit/helpers/parse-member-event-test.js
+++ b/ghost/admin/tests/unit/helpers/parse-member-event-test.js
@@ -108,10 +108,10 @@ describe('Unit: Helper: parse-member-event', function () {
             expect(result.action).to.equal('gift subscription expired');
         });
 
-        it('returns "event-expired-gift" icon', function () {
+        it('returns "event-gift" icon', function () {
             const event = buildEvent({type: 'gift_ended_event'});
             const result = helper.compute([event]);
-            expect(result.icon).to.equal('event-expired-gift');
+            expect(result.icon).to.equal('event-gift');
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3600/design-iteration

- Member activity uses one plain gift box icon for both started and expired events (was a slashed icon for expired)
- Gift checkout subtitle wraps cleanly with `text-wrap: pretty`
- Removed redundant "Shareable link" label on the gift success page