### PR TITLE
feat(email): add Resend as a bulk email provider

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/email-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/email-settings.tsx
@@ -1,8 +1,8 @@
 import DefaultRecipients from './default-recipients';
 import EnableNewsletters from './enable-newsletters';
-import MailGun from './mailgun';
 import Newsletters from './newsletters';
 import React from 'react';
+import Resend from './resend';
 import SearchableSection from '../../searchable-section';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
@@ -11,8 +11,8 @@ export const searchKeywords = {
     enableNewsletters: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off'],
     newsletters: ['newsletters', 'emails', 'design', 'customization'],
     defaultRecipients: ['newsletters', 'default recipients', 'emails'],
-    mailgun: ['mailgun', 'emails', 'newsletters'],
-    newslettersNavMenu: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off', 'design', 'customization', 'default recipients', 'mailgun', 'tips', 'donations', 'one time', 'payment']
+    resend: ['resend', 'emails', 'newsletters'],
+    newslettersNavMenu: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off', 'design', 'customization', 'default recipients', 'resend', 'tips', 'donations', 'one time', 'payment']
 };
 
 const EmailSettings: React.FC = () => {
@@ -26,7 +26,7 @@ const EmailSettings: React.FC = () => {
                 <>
                     <DefaultRecipients keywords={searchKeywords.defaultRecipients} />
                     <Newsletters keywords={searchKeywords.newsletters} />
-                    {!config.mailgunIsConfigured && <MailGun keywords={searchKeywords.mailgun} />}
+                    {!config.resendIsConfigured && <Resend keywords={searchKeywords.resend} />}
                 </>
             )}
         </SearchableSection>

--- a/apps/admin-x-settings/src/components/settings/email/email-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/email-settings.tsx
@@ -1,5 +1,6 @@
 import DefaultRecipients from './default-recipients';
 import EnableNewsletters from './enable-newsletters';
+import MailGun from './mailgun';
 import Newsletters from './newsletters';
 import React from 'react';
 import Resend from './resend';
@@ -11,8 +12,9 @@ export const searchKeywords = {
     enableNewsletters: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off'],
     newsletters: ['newsletters', 'emails', 'design', 'customization'],
     defaultRecipients: ['newsletters', 'default recipients', 'emails'],
+    mailgun: ['mailgun', 'emails', 'newsletters'],
     resend: ['resend', 'emails', 'newsletters'],
-    newslettersNavMenu: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off', 'design', 'customization', 'default recipients', 'resend', 'tips', 'donations', 'one time', 'payment']
+    newslettersNavMenu: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off', 'design', 'customization', 'default recipients', 'mailgun', 'resend', 'tips', 'donations', 'one time', 'payment']
 };
 
 const EmailSettings: React.FC = () => {
@@ -27,6 +29,7 @@ const EmailSettings: React.FC = () => {
                     <DefaultRecipients keywords={searchKeywords.defaultRecipients} />
                     <Newsletters keywords={searchKeywords.newsletters} />
                     {!config.resendIsConfigured && <Resend keywords={searchKeywords.resend} />}
+                    {!config.mailgunIsConfigured && <MailGun keywords={searchKeywords.mailgun} />}
                 </>
             )}
         </SearchableSection>

--- a/apps/admin-x-settings/src/components/settings/email/resend.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/resend.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import TopLevelGroup from '../../top-level-group';
+import useSettingGroup from '../../../hooks/use-setting-group';
+import {IconLabel, Link, SettingGroupContent, TextField, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+
+const Resend: React.FC<{ keywords: string[] }> = ({keywords}) => {
+    const {
+        localSettings,
+        isEditing,
+        saveState,
+        handleSave,
+        handleCancel,
+        updateSetting,
+        handleEditingChange
+    } = useSettingGroup();
+
+    const [resendApiKey] = getSettingValues(localSettings, ['resend_api_key']) as string[];
+
+    const isResendSetup = !!resendApiKey;
+
+    const data = isResendSetup ? [
+        {
+            key: 'status',
+            value: (
+                <IconLabel icon='check-circle' iconColorClass='text-green'>
+                    Resend is set up
+                </IconLabel>
+            )
+        }
+    ] : [
+        {
+            heading: 'Status',
+            key: 'status',
+            value: 'Resend is not set up'
+        }
+    ];
+
+    const values = (
+        <SettingGroupContent
+            columns={1}
+            values={data}
+        />
+    );
+
+    const apiKeyHint = (
+        <>Find your Resend API keys <Link href="https://resend.com/api-keys" rel="noopener noreferrer" target="_blank">here</Link></>
+    );
+
+    const inputs = (
+        <SettingGroupContent>
+            <TextField
+                hint={apiKeyHint}
+                title='Resend API key'
+                type='password'
+                value={resendApiKey}
+                onChange={(e) => {
+                    updateSetting('resend_api_key', e.target.value);
+                }}
+            />
+        </SettingGroupContent>
+    );
+
+    const groupDescription = (
+        <>The Resend API is used for bulk email newsletter delivery. <Link href='https://resend.com/docs' target='_blank'>Learn more</Link></>
+    );
+
+    return (
+        <TopLevelGroup
+            description={groupDescription}
+            isEditing={isEditing}
+            keywords={keywords}
+            navid='resend'
+            saveState={saveState}
+            testId='resend'
+            title='Resend'
+            onCancel={handleCancel}
+            onEditingChange={handleEditingChange}
+            onSave={handleSave}
+        >
+            {isEditing ? inputs : values}
+        </TopLevelGroup>
+    );
+};
+
+export default withErrorBoundary(Resend, 'Resend');

--- a/apps/admin-x-settings/src/components/settings/email/resend.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/resend.tsx
@@ -62,7 +62,7 @@ const Resend: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 
     const groupDescription = (
-        <>The Resend API is used for bulk email newsletter delivery. <Link href='https://resend.com/docs' target='_blank'>Learn more</Link></>
+        <>The Resend API is used for bulk email newsletter delivery. <Link href='https://resend.com/docs' rel='noopener noreferrer' target='_blank'>Learn more</Link></>
     );
 
     return (

--- a/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
@@ -140,7 +140,7 @@ const InviteUserModal = NiceModal.create(() => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 let data = e.data as any; // we have unknown data types in the APIError/error classes
                 if (data?.errors?.[0]?.type === 'EmailError') {
-                    message = (<span>Check your Mailgun configuration.</span>);
+                    message = (<span>Check your email provider (Resend or Mailgun) configuration.</span>);
                 }
             }
             showToast({

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -192,7 +192,7 @@ const Sidebar: React.FC = () => {
                     <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
                     <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />
                     {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
-                    <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />
+                    <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'resend']} title="Newsletters" onClick={handleSectionClick} />
                 </SettingNavSection>
 
                 {/* Growth */}

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -192,7 +192,7 @@ const Sidebar: React.FC = () => {
                     <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
                     <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />
                     {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
-                    <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'resend']} title="Newsletters" onClick={handleSectionClick} />
+                    <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun', 'resend']} title="Newsletters" onClick={handleSectionClick} />
                 </SettingNavSection>
 
                 {/* Growth */}

--- a/ghost/admin/app/components/editor/modals/preview/email.js
+++ b/ghost/admin/app/components/editor/modals/preview/email.js
@@ -61,6 +61,14 @@ export default class ModalPostPreviewEmailComponent extends Component {
             !!(this.settings.mailgunApiKey && this.settings.mailgunDomain && this.settings.mailgunBaseUrl);
     }
 
+    get resendIsEnabled() {
+        return this.config.resendIsConfigured || !!this.settings.resendApiKey;
+    }
+
+    get bulkEmailIsEnabled() {
+        return this.mailgunIsEnabled || this.resendIsEnabled;
+    }
+
     get selectedSegment() {
         return this.segments.find(segment => segment.alias === this.args.memberSegment);
     }
@@ -91,7 +99,7 @@ export default class ModalPostPreviewEmailComponent extends Component {
                 this.sendPreviewEmailError = 'Please enter a valid email';
                 return false;
             }
-            if (!this.mailgunIsEnabled) {
+            if (!this.bulkEmailIsEnabled) {
                 this.sendPreviewEmailError = 'Please verify your email settings';
                 return false;
             }

--- a/ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.hbs
@@ -11,7 +11,7 @@
 
     <p class="gh-publish-confirmation">
         {{this.emailErrorMessage}}
-        {{#unless this.config.mailgunIsConfigured}}
+        {{#unless (or this.config.mailgunIsConfigured this.config.resendIsConfigured)}}
         <br><br>
         If the error persists, please verify your email settings.
         {{/unless}}

--- a/ghost/admin/app/components/editor/publish-options/publish-type.hbs
+++ b/ghost/admin/app/components/editor/publish-options/publish-type.hbs
@@ -26,8 +26,8 @@
         <a href="#/members">Add members</a>
         to start sending newsletters!
     </p>
-{{else if (not @publishOptions.mailgunIsConfigured)}}
+{{else if (not @publishOptions.bulkEmailIsConfigured)}}
     <p class="gh-box gh-content-box" data-test-publish-type-error="no-mailgun">
-        Set up <a href="https://ghost.org/docs/newsletters/#bulk-email-configuration" target="_blank" rel="noreferrer noopener">Mailgun</a> to start sending newsletters!
+        Set up <a href="https://ghost.org/docs/newsletters/#bulk-email-configuration" target="_blank" rel="noreferrer noopener">bulk email (Mailgun or Resend)</a> to start sending newsletters!
     </p>
 {{/if}}

--- a/ghost/admin/app/models/setting.js
+++ b/ghost/admin/app/models/setting.js
@@ -38,6 +38,7 @@ export default Model.extend(ValidationEngine, {
     mailgunApiKey: attr('string'),
     mailgunDomain: attr('string'),
     mailgunBaseUrl: attr('string'),
+    resendApiKey: attr('string'),
     portalButton: attr('boolean'),
     portalName: attr('boolean'),
     portalPlans: attr('json-string'),

--- a/ghost/admin/app/services/settings.js
+++ b/ghost/admin/app/services/settings.js
@@ -45,6 +45,10 @@ export default class SettingsService extends Service.extend(ValidationEngine) {
         return this.mailgunApiKey && this.mailgunDomain && this.mailgunBaseUrl;
     }
 
+    get resendIsConfigured() {
+        return !!this.resendApiKey;
+    }
+
     // the settings API endpoint is a little weird as it's singular and we have
     // to pass in all types - if we ever fetch settings without all types then
     // save we have problems with the missing settings being removed or reset

--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -135,12 +135,21 @@ export default class PublishOptions {
     get emailDisabled() {
         const hasNoMembers = this.totalMemberCount === 0;
 
-        return !this.mailgunIsConfigured || hasNoMembers || this.emailDisabledError;
+        return !this.bulkEmailIsConfigured || hasNoMembers || this.emailDisabledError;
     }
 
     get mailgunIsConfigured() {
         return this.settings.mailgunIsConfigured
             || this.config.mailgunIsConfigured;
+    }
+
+    get resendIsConfigured() {
+        return this.settings.resendIsConfigured
+            || this.config.resendIsConfigured;
+    }
+
+    get bulkEmailIsConfigured() {
+        return this.mailgunIsConfigured || this.resendIsConfigured;
     }
 
     @action

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -53,6 +53,7 @@ const EDITABLE_SETTINGS = [
     'portal_button_signup_text',
     'portal_signup_terms_html',
     'portal_signup_checkbox_required',
+    'resend_api_key',
     'mailgun_api_key',
     'mailgun_domain',
     'mailgun_base_url',

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
@@ -16,6 +16,7 @@ module.exports = {
             'enableDeveloperExperiments',
             'stripeDirect',
             'mailgunIsConfigured',
+            'resendIsConfigured',
             'emailAnalytics',
             'hostSettings',
             'tenor',

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -432,6 +432,10 @@
         }
     },
     "email": {
+        "resend_api_key": {
+            "defaultValue": null,
+            "type": "string"
+        },
         "mailgun_domain": {
             "defaultValue": null,
             "type": "string"

--- a/ghost/core/core/server/services/email-analytics/email-analytics-provider-resend.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-provider-resend.js
@@ -10,7 +10,15 @@ const logging = require('@tryghost/logging');
 class EmailAnalyticsProviderResend {
     constructor() {}
 
-    fetchLatest() {
+    /**
+     * Matches MailgunProvider.fetchLatest signature. Resend pushes events via
+     * webhooks, so polling is a no-op — the params are accepted but ignored.
+     *
+     * @param {Function} [batchHandler]
+     * @param {object} [options]
+     */
+    // eslint-disable-next-line no-unused-vars
+    fetchLatest(batchHandler, options) {
         logging.info('[ResendAnalytics] Polling not supported — Resend uses webhooks for email events');
         return Promise.resolve();
     }

--- a/ghost/core/core/server/services/email-analytics/email-analytics-provider-resend.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-provider-resend.js
@@ -1,0 +1,19 @@
+const logging = require('@tryghost/logging');
+
+/**
+ * Resend analytics provider stub.
+ * Resend delivers email events via webhooks (push), not a polling API.
+ * To receive open/click/bounce events from Resend, configure a webhook
+ * endpoint in the Resend dashboard pointing to your Ghost instance.
+ * This stub prevents errors when the analytics job runs.
+ */
+class EmailAnalyticsProviderResend {
+    constructor() {}
+
+    fetchLatest() {
+        logging.info('[ResendAnalytics] Polling not supported — Resend uses webhooks for email events');
+        return Promise.resolve();
+    }
+}
+
+module.exports = EmailAnalyticsProviderResend;

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -13,17 +13,26 @@ class EmailAnalyticsServiceWrapper {
         const EmailAnalyticsService = require('./email-analytics-service');
         const EmailEventStorage = require('../email-service/email-event-storage');
         const EmailEventProcessor = require('../email-service/email-event-processor');
+        const MailgunProvider = require('./email-analytics-provider-mailgun');
         const ResendProvider = require('./email-analytics-provider-resend');
+        const {resolveProvider} = require('../email-service/bulk-email-provider-factory');
         const {EmailRecipientFailure, EmailSpamComplaintEvent, Email} = require('../../models');
         const StartEmailAnalyticsJobEvent = require('./events/start-email-analytics-job-event');
         const domainEvents = require('@tryghost/domain-events');
         const settings = require('../../../shared/settings-cache');
+        const labs = require('../../../shared/labs');
         const db = require('../../data/db');
         const queries = require('./lib/queries');
         const membersService = require('../members');
         const membersRepository = membersService.api.members;
         const emailSuppressionList = require('../email-suppression-list');
         const prometheusClient = require('../../../shared/prometheus-client');
+
+        const bulkEmailProvider = resolveProvider(config, settings);
+        const analyticsProvider = bulkEmailProvider === 'resend'
+            ? new ResendProvider()
+            : new MailgunProvider({config, settings, labs});
+        logging.info(`[EmailAnalytics] Using analytics provider: ${bulkEmailProvider}`);
 
         this.eventStorage = new EmailEventStorage({
             db,
@@ -51,7 +60,7 @@ class EmailAnalyticsServiceWrapper {
             settings,
             eventProcessor,
             providers: [
-                new ResendProvider()
+                analyticsProvider
             ],
             queries,
             domainEvents,

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -13,12 +13,11 @@ class EmailAnalyticsServiceWrapper {
         const EmailAnalyticsService = require('./email-analytics-service');
         const EmailEventStorage = require('../email-service/email-event-storage');
         const EmailEventProcessor = require('../email-service/email-event-processor');
-        const MailgunProvider = require('./email-analytics-provider-mailgun');
+        const ResendProvider = require('./email-analytics-provider-resend');
         const {EmailRecipientFailure, EmailSpamComplaintEvent, Email} = require('../../models');
         const StartEmailAnalyticsJobEvent = require('./events/start-email-analytics-job-event');
         const domainEvents = require('@tryghost/domain-events');
         const settings = require('../../../shared/settings-cache');
-        const labs = require('../../../shared/labs');
         const db = require('../../data/db');
         const queries = require('./lib/queries');
         const membersService = require('../members');
@@ -52,7 +51,7 @@ class EmailAnalyticsServiceWrapper {
             settings,
             eventProcessor,
             providers: [
-                new MailgunProvider({config, settings, labs})
+                new ResendProvider()
             ],
             queries,
             domainEvents,

--- a/ghost/core/core/server/services/email-service/bulk-email-provider-factory.js
+++ b/ghost/core/core/server/services/email-service/bulk-email-provider-factory.js
@@ -8,12 +8,12 @@ const ResendEmailProvider = require('./resend-email-provider');
  * Resolve which bulk-email provider should be used.
  *
  * Resolution order:
- *   1. Explicit `config.bulkEmail.provider` value ('mailgun' or 'resend').
- *   2. If `config.bulkEmail.resend` block is set → 'resend'.
- *   3. If a non-empty `resend_api_key` setting is stored → 'resend'.
- *   4. If `config.bulkEmail.mailgun` block is set → 'mailgun'.
- *   5. If Mailgun api key + domain settings are stored → 'mailgun'.
- *   6. Default 'mailgun' (preserves upstream behaviour).
+ *   1. Explicit `config.bulkEmail.provider` — honored only if the matching
+ *      credentials are present. If the operator selects a provider with no
+ *      key, a warning is logged and resolution falls through to auto-detect.
+ *   2. If `config.bulkEmail.resend` block is set or `resend_api_key` setting
+ *      is stored → 'resend'.
+ *   3. Otherwise → 'mailgun' (preserves upstream behaviour).
  *
  * @param {object} config
  * @param {object} settings - settings cache
@@ -21,21 +21,20 @@ const ResendEmailProvider = require('./resend-email-provider');
  */
 function resolveProvider(config, settings) {
     const bulkEmailConfig = config.get('bulkEmail') || {};
+    const hasResendCreds = !!(bulkEmailConfig.resend?.apiKey || settings.get('resend_api_key'));
+    const hasMailgunCreds = !!(bulkEmailConfig.mailgun || (settings.get('mailgun_api_key') && settings.get('mailgun_domain')));
+
     const explicit = bulkEmailConfig.provider;
     if (explicit === 'resend' || explicit === 'mailgun') {
-        return explicit;
+        const explicitHasCreds = explicit === 'resend' ? hasResendCreds : hasMailgunCreds;
+        if (explicitHasCreds) {
+            return explicit;
+        }
+        logging.warn(`[BulkEmail] bulkEmail.provider="${explicit}" but no ${explicit} credentials configured — falling back to auto-detect`);
     }
 
-    const hasResendConfig = !!bulkEmailConfig.resend;
-    const hasResendSetting = !!settings.get('resend_api_key');
-    if (hasResendConfig || hasResendSetting) {
+    if (hasResendCreds) {
         return 'resend';
-    }
-
-    const hasMailgunConfig = !!bulkEmailConfig.mailgun;
-    const hasMailgunSetting = !!(settings.get('mailgun_api_key') && settings.get('mailgun_domain'));
-    if (hasMailgunConfig || hasMailgunSetting) {
-        return 'mailgun';
     }
 
     return 'mailgun';

--- a/ghost/core/core/server/services/email-service/bulk-email-provider-factory.js
+++ b/ghost/core/core/server/services/email-service/bulk-email-provider-factory.js
@@ -1,0 +1,71 @@
+const logging = require('@tryghost/logging');
+const MailgunClient = require('../lib/mailgun-client');
+const ResendClient = require('../lib/resend-client');
+const MailgunEmailProvider = require('./mailgun-email-provider');
+const ResendEmailProvider = require('./resend-email-provider');
+
+/**
+ * Resolve which bulk-email provider should be used.
+ *
+ * Resolution order:
+ *   1. Explicit `config.bulkEmail.provider` value ('mailgun' or 'resend').
+ *   2. If `config.bulkEmail.resend` block is set → 'resend'.
+ *   3. If a non-empty `resend_api_key` setting is stored → 'resend'.
+ *   4. If `config.bulkEmail.mailgun` block is set → 'mailgun'.
+ *   5. If Mailgun api key + domain settings are stored → 'mailgun'.
+ *   6. Default 'mailgun' (preserves upstream behaviour).
+ *
+ * @param {object} config
+ * @param {object} settings - settings cache
+ * @returns {'mailgun'|'resend'}
+ */
+function resolveProvider(config, settings) {
+    const bulkEmailConfig = config.get('bulkEmail') || {};
+    const explicit = bulkEmailConfig.provider;
+    if (explicit === 'resend' || explicit === 'mailgun') {
+        return explicit;
+    }
+
+    const hasResendConfig = !!bulkEmailConfig.resend;
+    const hasResendSetting = !!settings.get('resend_api_key');
+    if (hasResendConfig || hasResendSetting) {
+        return 'resend';
+    }
+
+    const hasMailgunConfig = !!bulkEmailConfig.mailgun;
+    const hasMailgunSetting = !!(settings.get('mailgun_api_key') && settings.get('mailgun_domain'));
+    if (hasMailgunConfig || hasMailgunSetting) {
+        return 'mailgun';
+    }
+
+    return 'mailgun';
+}
+
+/**
+ * Build the bulk-email client + provider pair for the active provider.
+ *
+ * @param {object} deps
+ * @param {object} deps.config
+ * @param {object} deps.settings - settings cache
+ * @param {Function} [deps.errorHandler]
+ * @returns {{provider: 'mailgun'|'resend', client: object, emailProvider: object}}
+ */
+function createBulkEmailProvider({config, settings, errorHandler}) {
+    const provider = resolveProvider(config, settings);
+    logging.info(`[BulkEmail] Using provider: ${provider}`);
+
+    if (provider === 'resend') {
+        const client = new ResendClient({config, settings});
+        const emailProvider = new ResendEmailProvider({resendClient: client, errorHandler});
+        return {provider, client, emailProvider};
+    }
+
+    const client = new MailgunClient({config, settings});
+    const emailProvider = new MailgunEmailProvider({mailgunClient: client, errorHandler});
+    return {provider, client, emailProvider};
+}
+
+module.exports = {
+    resolveProvider,
+    createBulkEmailProvider
+};

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -21,11 +21,10 @@ class EmailServiceWrapper {
         const SendingService = require('./sending-service');
         const BatchSendingService = require('./batch-sending-service');
         const EmailSegmenter = require('./email-segmenter');
-        const ResendEmailProvider = require('./resend-email-provider');
+        const {createBulkEmailProvider} = require('./bulk-email-provider-factory');
         const {DomainWarmingService} = require('./domain-warming-service');
 
         const {Post, Newsletter, Email, EmailBatch, EmailRecipient, Member} = require('../../models');
-        const ResendClient = require('../lib/resend-client');
         const configService = require('../../../shared/config');
         const settingsCache = require('../../../shared/settings-cache');
         const settingsHelpers = require('../settings-helpers');
@@ -49,27 +48,24 @@ class EmailServiceWrapper {
         const emailAnalyticsJobs = require('../email-analytics/jobs');
         const {cachedImageSizeFromUrl} = require('../../lib/image');
 
-        // capture errors from resend client and log them in sentry
+        // Capture errors from the bulk email provider and log them in sentry
         const errorHandler = (error) => {
-            logging.info(`Capturing error for resend email provider service`);
+            logging.info(`Capturing error for bulk email provider service`);
             sentry.captureException(error);
         };
 
-        // Resend client instance for email provider
-        const resendClient = new ResendClient({
-            config: configService, settings: settingsCache
+        const {emailProvider} = createBulkEmailProvider({
+            config: configService,
+            settings: settingsCache,
+            errorHandler
         });
+
         const i18nLanguage = settingsCache.get('locale') || 'en';
         const i18n = i18nLib(i18nLanguage, 'ghost');
 
         events.on('settings.locale.edited', (model) => {
             debug('locale changed, updating i18n to', model.get('value'));
             i18n.changeLanguage(model.get('value'));
-        });
-
-        const resendEmailProvider = new ResendEmailProvider({
-            resendClient,
-            errorHandler
         });
 
         const emailRenderer = new EmailRenderer({
@@ -96,7 +92,7 @@ class EmailServiceWrapper {
         });
 
         const sendingService = new SendingService({
-            emailProvider: resendEmailProvider,
+            emailProvider,
             emailRenderer,
             emailAddressService: emailAddressService.service
         });

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -21,11 +21,11 @@ class EmailServiceWrapper {
         const SendingService = require('./sending-service');
         const BatchSendingService = require('./batch-sending-service');
         const EmailSegmenter = require('./email-segmenter');
-        const MailgunEmailProvider = require('./mailgun-email-provider');
+        const ResendEmailProvider = require('./resend-email-provider');
         const {DomainWarmingService} = require('./domain-warming-service');
 
         const {Post, Newsletter, Email, EmailBatch, EmailRecipient, Member} = require('../../models');
-        const MailgunClient = require('../lib/mailgun-client');
+        const ResendClient = require('../lib/resend-client');
         const configService = require('../../../shared/config');
         const settingsCache = require('../../../shared/settings-cache');
         const settingsHelpers = require('../settings-helpers');
@@ -49,15 +49,15 @@ class EmailServiceWrapper {
         const emailAnalyticsJobs = require('../email-analytics/jobs');
         const {cachedImageSizeFromUrl} = require('../../lib/image');
 
-        // capture errors from mailgun client and log them in sentry
+        // capture errors from resend client and log them in sentry
         const errorHandler = (error) => {
-            logging.info(`Capturing error for mailgun email provider service`);
+            logging.info(`Capturing error for resend email provider service`);
             sentry.captureException(error);
         };
 
-        // Mailgun client instance for email provider
-        const mailgunClient = new MailgunClient({
-            config: configService, settings: settingsCache, labs
+        // Resend client instance for email provider
+        const resendClient = new ResendClient({
+            config: configService, settings: settingsCache
         });
         const i18nLanguage = settingsCache.get('locale') || 'en';
         const i18n = i18nLib(i18nLanguage, 'ghost');
@@ -67,8 +67,8 @@ class EmailServiceWrapper {
             i18n.changeLanguage(model.get('value'));
         });
 
-        const mailgunEmailProvider = new MailgunEmailProvider({
-            mailgunClient,
+        const resendEmailProvider = new ResendEmailProvider({
+            resendClient,
             errorHandler
         });
 
@@ -96,7 +96,7 @@ class EmailServiceWrapper {
         });
 
         const sendingService = new SendingService({
-            emailProvider: mailgunEmailProvider,
+            emailProvider: resendEmailProvider,
             emailRenderer,
             emailAddressService: emailAddressService.service
         });

--- a/ghost/core/core/server/services/email-service/resend-email-provider.js
+++ b/ghost/core/core/server/services/email-service/resend-email-provider.js
@@ -66,7 +66,7 @@ class ResendEmailProvider {
             };
 
             if (data.replyTo) {
-                emailObj.reply_to = data.replyTo;
+                emailObj.replyTo = data.replyTo;
             }
 
             return emailObj;
@@ -75,18 +75,17 @@ class ResendEmailProvider {
 
     /**
      * @param {import('./sending-service').EmailData} data
-     * @param {object} options
-     * @param {boolean} options.openTrackingEnabled
-     * @param {boolean} options.clickTrackingEnabled
      * @returns {Promise<{id: string}>}
      */
     async send(data) {
-        logging.info(`Sending email to ${data.recipients.length} recipients via Resend`);
+        const recipientCount = data.recipients.length;
+        const firstRecipient = data.recipients[0]?.email;
+        logging.info(`[Resend] Sending email to ${recipientCount} recipients (first: ${firstRecipient}, from: ${data.from}, subject: "${data.subject}")`);
         const startTime = Date.now();
-        debug(`sending message to ${data.recipients.length} recipients`);
+        debug(`sending message to ${recipientCount} recipients`);
 
         if (!this.#resendClient.isConfigured()) {
-            logging.warn('Resend is not configured');
+            logging.warn('[Resend] Provider is not configured — set resend_api_key setting or bulkEmail.resend.apiKey config');
             return null;
         }
 
@@ -99,27 +98,54 @@ class ResendEmailProvider {
             const emails = this.#buildRecipientEmails(data, messageBase);
             const resendInstance = this.#resendClient.getInstance();
 
+            logging.info(`[Resend] Built ${emails.length} per-recipient email objects (replacements: ${data.replacementDefinitions?.length || 0})`);
+
             const BATCH_SIZE = 100;
             let lastId;
+            let totalSent = 0;
 
             for (let i = 0; i < emails.length; i += BATCH_SIZE) {
                 const batch = emails.slice(i, i + BATCH_SIZE);
+                logging.info(`[Resend] Sending batch ${Math.floor(i / BATCH_SIZE) + 1} (${batch.length} emails)`);
                 let response;
                 if (batch.length === 1) {
                     response = await resendInstance.emails.send(batch[0]);
+                    if (response?.error) {
+                        logging.error(`[Resend] emails.send returned error: ${JSON.stringify(response.error)}`);
+                        throw new errors.EmailError({
+                            statusCode: response.error.statusCode,
+                            message: response.error.message || 'Resend API error',
+                            context: response.error.name,
+                            code: 'RESEND_API_ERROR'
+                        });
+                    }
                     lastId = response?.data?.id;
+                    logging.info(`[Resend] Single send accepted, id=${lastId}`);
                 } else {
                     response = await resendInstance.batch.send(batch);
-                    lastId = response?.data?.[0]?.id;
+                    if (response?.error) {
+                        logging.error(`[Resend] batch.send returned error: ${JSON.stringify(response.error)}`);
+                        throw new errors.EmailError({
+                            statusCode: response.error.statusCode,
+                            message: response.error.message || 'Resend API error',
+                            context: response.error.name,
+                            code: 'RESEND_API_ERROR'
+                        });
+                    }
+                    lastId = response?.data?.data?.[0]?.id || response?.data?.[0]?.id;
+                    logging.info(`[Resend] Batch accepted, first id=${lastId}, count=${batch.length}`);
                 }
+                totalSent += batch.length;
             }
 
             debug(`sent message (${Date.now() - startTime}ms)`);
-            logging.info(`Sent message via Resend (${Date.now() - startTime}ms)`);
+            logging.info(`[Resend] Sent ${totalSent} emails in ${Date.now() - startTime}ms`);
 
             return {id: lastId || 'resend-batch'};
         } catch (e) {
             debug(`failed to send message (${Date.now() - startTime}ms)`);
+            logging.error(`[Resend] Send failed after ${Date.now() - startTime}ms: ${e.message}`);
+            logging.error(e);
 
             if (this.#errorHandler) {
                 this.#errorHandler(e);
@@ -128,7 +154,7 @@ class ResendEmailProvider {
             throw new errors.EmailError({
                 statusCode: e.statusCode,
                 message: (e?.message || 'Resend Error').slice(0, 2000),
-                errorDetails: JSON.stringify(e),
+                errorDetails: JSON.stringify({message: e.message, name: e.name, statusCode: e.statusCode}),
                 context: `Resend Error ${e.statusCode}: ${e.message}`,
                 help: 'https://ghost.org/docs/newsletters/#bulk-email-configuration',
                 code: 'BULK_EMAIL_SEND_FAILED'

--- a/ghost/core/core/server/services/email-service/resend-email-provider.js
+++ b/ghost/core/core/server/services/email-service/resend-email-provider.js
@@ -75,12 +75,22 @@ class ResendEmailProvider {
 
     /**
      * @param {import('./sending-service').EmailData} data
+     * @param {object} [options] - sending options. Accepted for interface
+     *   parity with MailgunEmailProvider. Resend does not natively support
+     *   open/click tracking toggles or scheduled deliveryTime at send time,
+     *   so these are logged when requested and otherwise ignored.
      * @returns {Promise<{id: string}>}
      */
-    async send(data) {
+    async send(data, options = {}) {
         const recipientCount = data.recipients.length;
         const firstRecipient = data.recipients[0]?.email;
         logging.info(`[Resend] Sending email to ${recipientCount} recipients (first: ${firstRecipient}, from: ${data.from}, subject: "${data.subject}")`);
+        if (options.deliveryTime) {
+            logging.warn(`[Resend] options.deliveryTime requested (${options.deliveryTime}) but Resend has no scheduled-send API — sending immediately`);
+        }
+        if (options.clickTrackingEnabled || options.openTrackingEnabled) {
+            logging.info(`[Resend] options.clickTracking=${!!options.clickTrackingEnabled} openTracking=${!!options.openTrackingEnabled} requested — Resend tracks via webhooks, configure in Resend dashboard`);
+        }
         const startTime = Date.now();
         debug(`sending message to ${recipientCount} recipients`);
 

--- a/ghost/core/core/server/services/email-service/resend-email-provider.js
+++ b/ghost/core/core/server/services/email-service/resend-email-provider.js
@@ -1,0 +1,148 @@
+const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
+const debug = require('@tryghost/debug')('email-service:resend-provider-service');
+
+class ResendEmailProvider {
+    #resendClient;
+    #errorHandler;
+
+    /**
+     * @param {object} dependencies
+     * @param {import('../lib/resend-client')} dependencies.resendClient
+     * @param {Function} [dependencies.errorHandler]
+     */
+    constructor({resendClient, errorHandler}) {
+        this.#resendClient = resendClient;
+        this.#errorHandler = errorHandler;
+    }
+
+    /**
+     * Build per-recipient email objects with variable substitution applied.
+     * Resend has no server-side template engine, so substitution happens here.
+     */
+    #buildRecipientEmails(data, messageBase) {
+        const {recipients, replacementDefinitions} = data;
+
+        return recipients.map((recipient) => {
+            const valueMap = {};
+            for (const r of recipient.replacements) {
+                valueMap[r.id] = r.value;
+            }
+
+            let html = messageBase.html;
+            let text = messageBase.plaintext;
+
+            for (const def of replacementDefinitions) {
+                const value = valueMap[def.id] !== undefined ? String(valueMap[def.id]) : '';
+                if (html) {
+                    html = html.replace(def.token, value);
+                }
+                if (text) {
+                    text = text.replace(def.token, value);
+                }
+            }
+
+            const headers = {
+                'Auto-Submitted': 'auto-generated',
+                'X-Auto-Response-Suppress': 'OOF, AutoReply'
+            };
+
+            if (data.emailId) {
+                headers['X-Ghost-Email-Id'] = data.emailId;
+            }
+
+            if (valueMap.list_unsubscribe) {
+                headers['List-Unsubscribe'] = `<${valueMap.list_unsubscribe}>`;
+                headers['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click';
+            }
+
+            const emailObj = {
+                from: data.from,
+                to: [recipient.email],
+                subject: data.subject,
+                html: html || undefined,
+                text: text || undefined,
+                headers
+            };
+
+            if (data.replyTo) {
+                emailObj.reply_to = data.replyTo;
+            }
+
+            return emailObj;
+        });
+    }
+
+    /**
+     * @param {import('./sending-service').EmailData} data
+     * @param {object} options
+     * @param {boolean} options.openTrackingEnabled
+     * @param {boolean} options.clickTrackingEnabled
+     * @returns {Promise<{id: string}>}
+     */
+    async send(data) {
+        logging.info(`Sending email to ${data.recipients.length} recipients via Resend`);
+        const startTime = Date.now();
+        debug(`sending message to ${data.recipients.length} recipients`);
+
+        if (!this.#resendClient.isConfigured()) {
+            logging.warn('Resend is not configured');
+            return null;
+        }
+
+        try {
+            const messageBase = {
+                html: data.html,
+                plaintext: data.plaintext
+            };
+
+            const emails = this.#buildRecipientEmails(data, messageBase);
+            const resendInstance = this.#resendClient.getInstance();
+
+            const BATCH_SIZE = 100;
+            let lastId;
+
+            for (let i = 0; i < emails.length; i += BATCH_SIZE) {
+                const batch = emails.slice(i, i + BATCH_SIZE);
+                let response;
+                if (batch.length === 1) {
+                    response = await resendInstance.emails.send(batch[0]);
+                    lastId = response?.data?.id;
+                } else {
+                    response = await resendInstance.batch.send(batch);
+                    lastId = response?.data?.[0]?.id;
+                }
+            }
+
+            debug(`sent message (${Date.now() - startTime}ms)`);
+            logging.info(`Sent message via Resend (${Date.now() - startTime}ms)`);
+
+            return {id: lastId || 'resend-batch'};
+        } catch (e) {
+            debug(`failed to send message (${Date.now() - startTime}ms)`);
+
+            if (this.#errorHandler) {
+                this.#errorHandler(e);
+            }
+
+            throw new errors.EmailError({
+                statusCode: e.statusCode,
+                message: (e?.message || 'Resend Error').slice(0, 2000),
+                errorDetails: JSON.stringify(e),
+                context: `Resend Error ${e.statusCode}: ${e.message}`,
+                help: 'https://ghost.org/docs/newsletters/#bulk-email-configuration',
+                code: 'BULK_EMAIL_SEND_FAILED'
+            });
+        }
+    }
+
+    getMaximumRecipients() {
+        return this.#resendClient.getBatchSize();
+    }
+
+    getTargetDeliveryWindow() {
+        return this.#resendClient.getTargetDeliveryWindow();
+    }
+}
+
+module.exports = ResendEmailProvider;

--- a/ghost/core/core/server/services/email-service/resend-email-provider.js
+++ b/ghost/core/core/server/services/email-service/resend-email-provider.js
@@ -95,8 +95,12 @@ class ResendEmailProvider {
         debug(`sending message to ${recipientCount} recipients`);
 
         if (!this.#resendClient.isConfigured()) {
-            logging.warn('[Resend] Provider is not configured — set resend_api_key setting or bulkEmail.resend.apiKey config');
-            return null;
+            throw new errors.EmailError({
+                message: 'Resend provider is not configured',
+                context: 'Set resend_api_key setting or bulkEmail.resend.apiKey config',
+                help: 'https://ghost.org/docs/newsletters/#bulk-email-configuration',
+                code: 'BULK_EMAIL_PROVIDER_NOT_CONFIGURED'
+            });
         }
 
         try {
@@ -110,7 +114,7 @@ class ResendEmailProvider {
 
             logging.info(`[Resend] Built ${emails.length} per-recipient email objects (replacements: ${data.replacementDefinitions?.length || 0})`);
 
-            const BATCH_SIZE = 100;
+            const BATCH_SIZE = Math.min(this.#resendClient.getBatchSize(), 100);
             let lastId;
             let totalSent = 0;
 
@@ -159,6 +163,10 @@ class ResendEmailProvider {
 
             if (this.#errorHandler) {
                 this.#errorHandler(e);
+            }
+
+            if (errors.utils.isGhostError(e)) {
+                throw e;
             }
 
             throw new errors.EmailError({

--- a/ghost/core/core/server/services/email-suppression-list/service.js
+++ b/ghost/core/core/server/services/email-suppression-list/service.js
@@ -1,15 +1,17 @@
 const models = require('../../models');
 const configService = require('../../../shared/config');
 const settingsCache = require('../../../shared/settings-cache');
+const MailgunClient = require('../lib/mailgun-client');
 const ResendClient = require('../lib/resend-client');
+const {resolveProvider} = require('../email-service/bulk-email-provider-factory');
 const MailgunEmailSuppressionList = require('./mailgun-email-suppression-list');
 
-const resendClient = new ResendClient({
-    config: configService,
-    settings: settingsCache
-});
+const provider = resolveProvider(configService, settingsCache);
+const apiClient = provider === 'resend'
+    ? new ResendClient({config: configService, settings: settingsCache})
+    : new MailgunClient({config: configService, settings: settingsCache});
 
 module.exports = new MailgunEmailSuppressionList({
     Suppression: models.Suppression,
-    apiClient: resendClient
+    apiClient
 });

--- a/ghost/core/core/server/services/email-suppression-list/service.js
+++ b/ghost/core/core/server/services/email-suppression-list/service.js
@@ -6,10 +6,22 @@ const ResendClient = require('../lib/resend-client');
 const {resolveProvider} = require('../email-service/bulk-email-provider-factory');
 const MailgunEmailSuppressionList = require('./mailgun-email-suppression-list');
 
-const provider = resolveProvider(configService, settingsCache);
-const apiClient = provider === 'resend'
-    ? new ResendClient({config: configService, settings: settingsCache})
-    : new MailgunClient({config: configService, settings: settingsCache});
+// Both clients are cheap to construct (they only store references), so build
+// both eagerly and dispatch on each call. This avoids picking the wrong
+// provider at module-require time when the settings cache may not yet be
+// populated.
+const mailgunClient = new MailgunClient({config: configService, settings: settingsCache});
+const resendClient = new ResendClient({config: configService, settings: settingsCache});
+
+function activeClient() {
+    return resolveProvider(configService, settingsCache) === 'resend' ? resendClient : mailgunClient;
+}
+
+const apiClient = {
+    removeBounce: email => activeClient().removeBounce(email),
+    removeComplaint: email => activeClient().removeComplaint(email),
+    removeUnsubscribe: email => activeClient().removeUnsubscribe(email)
+};
 
 module.exports = new MailgunEmailSuppressionList({
     Suppression: models.Suppression,

--- a/ghost/core/core/server/services/email-suppression-list/service.js
+++ b/ghost/core/core/server/services/email-suppression-list/service.js
@@ -1,17 +1,15 @@
 const models = require('../../models');
 const configService = require('../../../shared/config');
 const settingsCache = require('../../../shared/settings-cache');
-const labs = require('../../../shared/labs');
-const MailgunClient = require('../lib/mailgun-client');
+const ResendClient = require('../lib/resend-client');
 const MailgunEmailSuppressionList = require('./mailgun-email-suppression-list');
 
-const mailgunClient = new MailgunClient({
+const resendClient = new ResendClient({
     config: configService,
-    settings: settingsCache,
-    labs
+    settings: settingsCache
 });
 
 module.exports = new MailgunEmailSuppressionList({
     Suppression: models.Suppression,
-    apiClient: mailgunClient
+    apiClient: resendClient
 });

--- a/ghost/core/core/server/services/lib/resend-client.js
+++ b/ghost/core/core/server/services/lib/resend-client.js
@@ -1,5 +1,6 @@
 const logging = require('@tryghost/logging');
 const metrics = require('@tryghost/metrics');
+const errors = require('@tryghost/errors');
 
 const RESEND_BATCH_SIZE = 100;
 
@@ -69,7 +70,7 @@ module.exports = class ResendClient {
 
             const replyTo = message.replyTo || message.reply_to;
             if (replyTo) {
-                emailObj.reply_to = replyTo;
+                emailObj.replyTo = replyTo;
             }
 
             return emailObj;
@@ -83,10 +84,26 @@ module.exports = class ResendClient {
                 let response;
                 if (batch.length === 1) {
                     response = await resendInstance.emails.send(batch[0]);
+                    if (response?.error) {
+                        throw new errors.EmailError({
+                            statusCode: response.error.statusCode,
+                            message: response.error.message || 'Resend API error',
+                            context: response.error.name,
+                            code: 'RESEND_API_ERROR'
+                        });
+                    }
                     lastId = response?.data?.id;
                 } else {
                     response = await resendInstance.batch.send(batch);
-                    lastId = response?.data?.[0]?.id;
+                    if (response?.error) {
+                        throw new errors.EmailError({
+                            statusCode: response.error.statusCode,
+                            message: response.error.message || 'Resend API error',
+                            context: response.error.name,
+                            code: 'RESEND_API_ERROR'
+                        });
+                    }
+                    lastId = response?.data?.data?.[0]?.id || response?.data?.[0]?.id;
                 }
             }
 
@@ -101,18 +118,22 @@ module.exports = class ResendClient {
 
     #getConfig() {
         const bulkEmailConfig = this.#config.get('bulkEmail');
-        const apiKey = bulkEmailConfig?.resend?.apiKey || this.#settings.get('resend_api_key');
+        const fromConfig = bulkEmailConfig?.resend?.apiKey;
+        const fromSettings = this.#settings.get('resend_api_key');
+        const apiKey = fromConfig || fromSettings;
         if (!apiKey) {
             return null;
         }
-        return {apiKey};
+        return {apiKey, source: fromConfig ? 'config' : 'settings'};
     }
 
     getInstance() {
         const resendConfig = this.#getConfig();
         if (!resendConfig) {
+            logging.warn('[ResendClient] No API key found in config (bulkEmail.resend.apiKey) or settings (resend_api_key)');
             return null;
         }
+        logging.info(`[ResendClient] Using API key from ${resendConfig.source} (key prefix: ${resendConfig.apiKey.slice(0, 6)}...)`);
         const {Resend} = require('resend');
         return new Resend(resendConfig.apiKey);
     }

--- a/ghost/core/core/server/services/lib/resend-client.js
+++ b/ghost/core/core/server/services/lib/resend-client.js
@@ -1,0 +1,148 @@
+const logging = require('@tryghost/logging');
+const metrics = require('@tryghost/metrics');
+
+const RESEND_BATCH_SIZE = 100;
+
+module.exports = class ResendClient {
+    #config;
+    #settings;
+
+    static DEFAULT_BATCH_SIZE = 100;
+
+    constructor({config, settings}) {
+        this.#config = config;
+        this.#settings = settings;
+    }
+
+    /**
+     * Sends emails via Resend API.
+     * Unlike Mailgun, Resend has no server-side variable substitution,
+     * so recipientData values are substituted per-email here.
+     *
+     * @param {Object} message - message with html/plaintext containing %recipient.X% placeholders
+     * @param {Object} recipientData - map of email → {id: value}
+     * @param {Array} replacements - unused (kept for interface parity with MailgunClient)
+     */
+    async send(message, recipientData, replacements) { // eslint-disable-line no-unused-vars
+        const resendInstance = this.getInstance();
+        if (!resendInstance) {
+            logging.warn('Resend is not configured');
+            return null;
+        }
+
+        const entries = Object.entries(recipientData);
+
+        const emails = entries.map(([email, vars]) => {
+            // Replace %recipient.X% placeholders with per-recipient values
+            let html = message.html;
+            let text = message.plaintext;
+
+            if (html) {
+                html = html.replace(/%recipient\.([^%]+)%/g, (_, id) => (vars[id] !== undefined ? String(vars[id]) : ''));
+            }
+            if (text) {
+                text = text.replace(/%recipient\.([^%]+)%/g, (_, id) => (vars[id] !== undefined ? String(vars[id]) : ''));
+            }
+
+            const headers = {
+                'Auto-Submitted': 'auto-generated',
+                'X-Auto-Response-Suppress': 'OOF, AutoReply'
+            };
+
+            if (message.id) {
+                headers['X-Ghost-Email-Id'] = message.id;
+            }
+
+            if (vars.list_unsubscribe) {
+                headers['List-Unsubscribe'] = `<${vars.list_unsubscribe}>`;
+                headers['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click';
+            }
+
+            const emailObj = {
+                from: message.from,
+                to: [email],
+                subject: message.subject,
+                html: html || undefined,
+                text: text || undefined,
+                headers
+            };
+
+            const replyTo = message.replyTo || message.reply_to;
+            if (replyTo) {
+                emailObj.reply_to = replyTo;
+            }
+
+            return emailObj;
+        });
+
+        const startTime = Date.now();
+        try {
+            let lastId;
+            for (let i = 0; i < emails.length; i += RESEND_BATCH_SIZE) {
+                const batch = emails.slice(i, i + RESEND_BATCH_SIZE);
+                let response;
+                if (batch.length === 1) {
+                    response = await resendInstance.emails.send(batch[0]);
+                    lastId = response?.data?.id;
+                } else {
+                    response = await resendInstance.batch.send(batch);
+                    lastId = response?.data?.[0]?.id;
+                }
+            }
+
+            metrics.metric('resend-send-mail', {value: Date.now() - startTime, statusCode: 200});
+            return {id: lastId || 'resend-batch'};
+        } catch (error) {
+            logging.error(error);
+            metrics.metric('resend-send-mail', {value: Date.now() - startTime, statusCode: error.statusCode || 500});
+            return Promise.reject({error, messageData: {to: Object.keys(recipientData)}});
+        }
+    }
+
+    #getConfig() {
+        const bulkEmailConfig = this.#config.get('bulkEmail');
+        const apiKey = bulkEmailConfig?.resend?.apiKey || this.#settings.get('resend_api_key');
+        if (!apiKey) {
+            return null;
+        }
+        return {apiKey};
+    }
+
+    getInstance() {
+        const resendConfig = this.#getConfig();
+        if (!resendConfig) {
+            return null;
+        }
+        const {Resend} = require('resend');
+        return new Resend(resendConfig.apiKey);
+    }
+
+    isConfigured() {
+        return !!this.#getConfig();
+    }
+
+    getBatchSize() {
+        return this.#config.get('bulkEmail')?.batchSize ?? ResendClient.DEFAULT_BATCH_SIZE;
+    }
+
+    getTargetDeliveryWindow() {
+        const val = this.#config.get('bulkEmail')?.targetDeliveryWindow;
+        if (val === undefined || !Number.isInteger(parseInt(val)) || parseInt(val) < 0) {
+            return 0;
+        }
+        return parseInt(val);
+    }
+
+    // Resend has no suppression management API — these are no-ops
+    async removeBounce() {
+        return false;
+    }
+
+    async removeComplaint() {
+        return false;
+    }
+
+    async removeUnsubscribe() {
+        return false;
+    }
+};

--- a/ghost/core/core/server/services/lib/resend-client.js
+++ b/ghost/core/core/server/services/lib/resend-client.js
@@ -28,7 +28,7 @@ module.exports = class ResendClient {
             logging.warn('[ResendClient] No API key found in config (bulkEmail.resend.apiKey) or settings (resend_api_key)');
             return null;
         }
-        logging.info(`[ResendClient] Using API key from ${resendConfig.source} (key prefix: ${resendConfig.apiKey.slice(0, 6)}...)`);
+        logging.info(`[ResendClient] Using API key from ${resendConfig.source}`);
         const {Resend} = require('resend');
         return new Resend(resendConfig.apiKey);
     }
@@ -38,7 +38,10 @@ module.exports = class ResendClient {
     }
 
     getBatchSize() {
-        return this.#config.get('bulkEmail')?.batchSize ?? ResendClient.DEFAULT_BATCH_SIZE;
+        const configured = this.#config.get('bulkEmail')?.batchSize;
+        const parsed = parseInt(configured);
+        const value = Number.isInteger(parsed) && parsed > 0 ? parsed : ResendClient.DEFAULT_BATCH_SIZE;
+        return Math.min(value, 100);
     }
 
     getTargetDeliveryWindow() {

--- a/ghost/core/core/server/services/lib/resend-client.js
+++ b/ghost/core/core/server/services/lib/resend-client.js
@@ -1,8 +1,4 @@
 const logging = require('@tryghost/logging');
-const metrics = require('@tryghost/metrics');
-const errors = require('@tryghost/errors');
-
-const RESEND_BATCH_SIZE = 100;
 
 module.exports = class ResendClient {
     #config;
@@ -13,107 +9,6 @@ module.exports = class ResendClient {
     constructor({config, settings}) {
         this.#config = config;
         this.#settings = settings;
-    }
-
-    /**
-     * Sends emails via Resend API.
-     * Unlike Mailgun, Resend has no server-side variable substitution,
-     * so recipientData values are substituted per-email here.
-     *
-     * @param {Object} message - message with html/plaintext containing %recipient.X% placeholders
-     * @param {Object} recipientData - map of email → {id: value}
-     * @param {Array} replacements - unused (kept for interface parity with MailgunClient)
-     */
-    async send(message, recipientData, replacements) { // eslint-disable-line no-unused-vars
-        const resendInstance = this.getInstance();
-        if (!resendInstance) {
-            logging.warn('Resend is not configured');
-            return null;
-        }
-
-        const entries = Object.entries(recipientData);
-
-        const emails = entries.map(([email, vars]) => {
-            // Replace %recipient.X% placeholders with per-recipient values
-            let html = message.html;
-            let text = message.plaintext;
-
-            if (html) {
-                html = html.replace(/%recipient\.([^%]+)%/g, (_, id) => (vars[id] !== undefined ? String(vars[id]) : ''));
-            }
-            if (text) {
-                text = text.replace(/%recipient\.([^%]+)%/g, (_, id) => (vars[id] !== undefined ? String(vars[id]) : ''));
-            }
-
-            const headers = {
-                'Auto-Submitted': 'auto-generated',
-                'X-Auto-Response-Suppress': 'OOF, AutoReply'
-            };
-
-            if (message.id) {
-                headers['X-Ghost-Email-Id'] = message.id;
-            }
-
-            if (vars.list_unsubscribe) {
-                headers['List-Unsubscribe'] = `<${vars.list_unsubscribe}>`;
-                headers['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click';
-            }
-
-            const emailObj = {
-                from: message.from,
-                to: [email],
-                subject: message.subject,
-                html: html || undefined,
-                text: text || undefined,
-                headers
-            };
-
-            const replyTo = message.replyTo || message.reply_to;
-            if (replyTo) {
-                emailObj.replyTo = replyTo;
-            }
-
-            return emailObj;
-        });
-
-        const startTime = Date.now();
-        try {
-            let lastId;
-            for (let i = 0; i < emails.length; i += RESEND_BATCH_SIZE) {
-                const batch = emails.slice(i, i + RESEND_BATCH_SIZE);
-                let response;
-                if (batch.length === 1) {
-                    response = await resendInstance.emails.send(batch[0]);
-                    if (response?.error) {
-                        throw new errors.EmailError({
-                            statusCode: response.error.statusCode,
-                            message: response.error.message || 'Resend API error',
-                            context: response.error.name,
-                            code: 'RESEND_API_ERROR'
-                        });
-                    }
-                    lastId = response?.data?.id;
-                } else {
-                    response = await resendInstance.batch.send(batch);
-                    if (response?.error) {
-                        throw new errors.EmailError({
-                            statusCode: response.error.statusCode,
-                            message: response.error.message || 'Resend API error',
-                            context: response.error.name,
-                            code: 'RESEND_API_ERROR'
-                        });
-                    }
-                    lastId = response?.data?.data?.[0]?.id || response?.data?.[0]?.id;
-                }
-            }
-
-            metrics.metric('resend-send-mail', {value: Date.now() - startTime, statusCode: 200});
-            return {id: lastId || 'resend-batch'};
-        } catch (error) {
-            logging.error(error);
-            metrics.metric('resend-send-mail', {value: Date.now() - startTime, statusCode: error.statusCode || 500});
-            return Promise.reject({error, messageData: {to: Object.keys(recipientData)}});
-        }
     }
 
     #getConfig() {

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -17,6 +17,7 @@ module.exports = function getConfigProperties() {
         enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
         stripeDirect: config.get('stripeDirect'),
         mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
+        resendIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').resend),
         emailAnalytics: config.get('emailAnalytics:enabled'),
         hostSettings: config.get('hostSettings'),
         tenor: config.get('tenor'),

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -225,6 +225,7 @@
     "path-match": "1.2.4",
     "probability-distributions": "0.9.1",
     "probe-image-size": "7.2.3",
+    "resend": "^6.12.3",
     "rss": "1.2.2",
     "sanitize-html": "2.17.0",
     "semver": "7.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2333,6 +2333,9 @@ importers:
       probe-image-size:
         specifier: 7.2.3
         version: 7.2.3
+      resend:
+        specifier: ^6.12.3
+        version: 6.12.3
       rss:
         specifier: 1.2.2
         version: 1.2.2
@@ -2372,6 +2375,13 @@ importers:
       xml:
         specifier: 1.0.1
         version: 1.0.1
+    optionalDependencies:
+      '@tryghost/html-to-mobiledoc':
+        specifier: 3.3.1
+        version: 3.3.1(@noble/hashes@1.8.0)
+      sqlite3:
+        specifier: 5.1.7
+        version: 5.1.7
     devDependencies:
       '@actions/core':
         specifier: 3.0.0
@@ -2523,13 +2533,6 @@ importers:
       validator:
         specifier: 13.12.0
         version: 13.12.0
-    optionalDependencies:
-      '@tryghost/html-to-mobiledoc':
-        specifier: 3.3.1
-        version: 3.3.1(@noble/hashes@1.8.0)
-      sqlite3:
-        specifier: 5.1.7
-        version: 5.1.7
 
   ghost/i18n:
     dependencies:
@@ -4804,105 +4807,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -5324,25 +5311,21 @@ packages:
     resolution: {integrity: sha512-2jvS8MYYOI8eUBRTmE8HKm5mRVLqS5Cvlj06tEAjxrmH5d7Bv8BG5Ps9yZzT0qswfVKChpzIliwPZomUjLTxmA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.0.4':
     resolution: {integrity: sha512-IK9gf8/AOtTW6rZajmGAFCN7EBzjmkIevt9MtOehQGlNXlMXydvUYKE5VU7d4oglvYs8aJJyayihfiZbFnTS8g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.0.4':
     resolution: {integrity: sha512-CdALjMqqNgiffQQIlyxx6mrxJCOqDzmN6BW3w9msCPHVSPOPp4AenlT0kpC7ALvmNEUm0lC4r093QbN2t6a/wA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.0.4':
     resolution: {integrity: sha512-2GPy+mAQo4JnfjTtsgGrHhZbTmmGy4RqaGowe0qMYCMuBME33ChG9iiRmArYmVtCAhYZVn26rK76/Vn3tK7fgg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.0.4':
     resolution: {integrity: sha512-jnZCCnTXoqOIrH0L31+qHVHmJuDYPoN6sl37/S1epP9n4fhcy9tjSx4xvx/WQSd417lU9saC+g7Glx2uFdgcTw==}
@@ -5635,56 +5618,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.128.0':
     resolution: {integrity: sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.128.0':
     resolution: {integrity: sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.128.0':
     resolution: {integrity: sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.128.0':
     resolution: {integrity: sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.128.0':
     resolution: {integrity: sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.128.0':
     resolution: {integrity: sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.128.0':
     resolution: {integrity: sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.128.0':
     resolution: {integrity: sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==}
@@ -5757,49 +5732,41 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -6531,79 +6498,66 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -7266,6 +7220,9 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -8215,42 +8172,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.21':
     resolution: {integrity: sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.21':
     resolution: {integrity: sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.21':
     resolution: {integrity: sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.21':
     resolution: {integrity: sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.21':
     resolution: {integrity: sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.21':
     resolution: {integrity: sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==}
@@ -8343,28 +8294,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -8768,9 +8715,6 @@ packages:
 
   '@tryghost/logging@4.1.0':
     resolution: {integrity: sha512-M8tNHRDSGLtAydgNbGRsN4zgUZpprOgXalEcK1112TODmEQMdIUxCjf1Eys3AhOyZZAeQyvonyuqJqDgJDrmww==}
-
-  '@tryghost/members-csv@2.0.5':
-    resolution: {integrity: sha512-5BMzhWSoJg+pOQuXdO8ygHDxLFcwZLob903NX7lprWQtooLPD8FAWwdFql/ZA7gPG5Bq9lV7TyUFK3hWVtvIlw==}
 
   '@tryghost/members-csv@2.0.7':
     resolution: {integrity: sha512-RnpaY2jKXC2waJTH4tI34vW541YBoDu7rX3NPZeHIdzoRP1102NCrzhPrFB/edmcyJ9fMMj5XpcvoQWw7FR/5A==}
@@ -13998,6 +13942,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-sourcemap-concat@1.4.0:
     resolution: {integrity: sha512-x90Wlx/2C83lfyg7h4oguTZN4MyaVfaiUSJQNpU+YEA0Odf9u659Opo44b0LfoVg9G/bOE++GdID/dkyja+XcA==}
     engines: {node: '>= 4'}
@@ -16289,28 +16236,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -18198,6 +18141,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-attribute-case-insensitive@5.0.2:
     resolution: {integrity: sha512-XIidXV8fDr0kKt28vqki84fRK8VW8eTuIa4PChv2MqKuT6C9UjmSKzen6KaWhWEoYvwxFCa7n/tC1SZ3tyq4SQ==}
     engines: {node: ^12 || ^14 || >=16}
@@ -19047,6 +18993,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.14.2:
@@ -19514,6 +19461,15 @@ packages:
 
   reselect@4.1.8:
     resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
+
+  resend@6.12.3:
+    resolution: {integrity: sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -20211,6 +20167,9 @@ packages:
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   state-toggle@1.0.3:
     resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==}
 
@@ -20549,6 +20508,9 @@ packages:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
     hasBin: true
+
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   swr@2.4.1:
     resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
@@ -21387,7 +21349,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
   uuid@7.0.3:
@@ -28094,6 +28056,8 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -29972,13 +29936,6 @@ snapshots:
     transitivePeerDependencies:
       - '@75lb/nature'
       - supports-color
-
-  '@tryghost/members-csv@2.0.5':
-    dependencies:
-      fs-extra: 11.3.0
-      lodash: 4.18.1
-      papaparse: 5.3.2
-      pump: 3.0.2
 
   '@tryghost/members-csv@2.0.7':
     dependencies:
@@ -37798,6 +37755,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-sourcemap-concat@1.4.0:
     dependencies:
       chalk: 2.4.2
@@ -43141,6 +43100,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-attribute-case-insensitive@5.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -44710,6 +44671,11 @@ snapshots:
 
   reselect@4.1.8: {}
 
+  resend@6.12.3:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.92.2
+
   resolve-alpn@1.2.1: {}
 
   resolve-cwd@3.0.0:
@@ -45606,6 +45572,11 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   state-toggle@1.0.3: {}
 
   statuses@1.5.0: {}
@@ -46040,6 +46011,10 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.0
+
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   swr@2.4.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

Adds [Resend](https://resend.com) as a bulk email provider alongside Mailgun. Existing Mailgun installs are untouched — the active provider is resolved via config/settings at runtime. Currently working at https://blog.codewithahsan.dev

## Why

Mailgun is the only supported bulk provider today. Smaller publishers and self-hosters often already use Resend for transactional mail and want a single vendor. Resend's free tier is also more generous for low-volume newsletters. This PR keeps Mailgun as the default and adds Resend as an opt-in alternative.

## How it works

**Provider resolution** (`bulk-email-provider-factory.js`):

1. Explicit `bulkEmail.provider` config wins
2. Resend creds present (`bulkEmail.resend.apiKey` config OR `resend_api_key` setting) → Resend
3. Mailgun creds present (existing path) → Mailgun
4. Default → Mailgun

**Send path** (`ResendEmailProvider`):
- Per-recipient template substitution applied client-side (Resend has no server-side templates)
- Batches of 100 via `resend.batch.send` (single recipient via `resend.emails.send`)
- `List-Unsubscribe` + `List-Unsubscribe-Post` headers carried through
- Returns `{id}` matching the Mailgun provider interface
- `options.deliveryTime` / `options.clickTrackingEnabled` / `options.openTrackingEnabled` are accepted for interface parity and logged when requested (Resend has no per-send API for these)

**Analytics**: Resend pushes events via webhooks rather than polling, so the analytics polling job is a no-op when Resend is active. Existing Mailgun polling is unchanged.

**Suppression list**: Resend has no suppression management API — `removeBounce/Complaint/Unsubscribe` return `false`. Ghost's local `Suppression` model still tracks events.

**Admin UI**: A Resend card sits next to the Mailgun card in Settings → Email. Each is gated by its own `*IsConfigured` flag exposed via the public config endpoint. Send-test and publish-flow gates now check `mailgunIsConfigured || resendIsConfigured`.

## Config

```json
{
  "bulkEmail": {
    "provider": "resend",
    "resend": { "apiKey": "re_..." }
  }
}
```

Or set `resend_api_key` via the admin UI. Provider auto-resolves if only one credential set is present.

## Files

**New**
- `ghost/core/core/server/services/email-service/bulk-email-provider-factory.js`
- `ghost/core/core/server/services/email-service/resend-email-provider.js`
- `ghost/core/core/server/services/lib/resend-client.js`
- `ghost/core/core/server/services/email-analytics/email-analytics-provider-resend.js`
- `apps/admin-x-settings/src/components/settings/email/resend.tsx`

**Modified**
- `email-service-wrapper.js`, `email-analytics-service-wrapper.js`, `email-suppression-list/service.js`
- Public-config builder + output serializer (expose `resendIsConfigured`)
- Settings input serializer + default-settings.json (add `resend_api_key`)
- Ember admin gating: settings model/service, publish-options, preview/email modal, publish-flow templates
- `apps/admin-x-settings/.../email-settings.tsx`, `sidebar.tsx`, `invite-user-modal.tsx`

## Tradeoffs / known limits

- Per-send click/open tracking toggles are ignored — Resend tracks via dashboard config.
- `deliveryTime` is ignored — Resend has no scheduled-send API; surfaced via a log when requested.
- No suppression sync — relies on Ghost's local `suppressions` table.
- Webhook receiver for Resend events is out of scope (follow-up PR). Ghost's local suppression/event tables still update for sends initiated through this path.

## Test plan

- [ ] Mailgun-only install (no Resend creds): existing send path, analytics polling, suppression sync all work
- [ ] Resend-only install: send a newsletter to ≥3 members, verify batch send + per-recipient replacements
- [ ] Resend-only: confirm Settings → Email shows the Resend card and the Mailgun card is hidden
- [ ] Resend-only: send-test from preview modal succeeds
- [ ] Resend-only: publish flow does not show "verify your email settings"
- [ ] Both providers configured: `bulkEmail.provider` selects the right one
- [ ] No creds: default → Mailgun, sends fail with the existing error path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes the core newsletter sending path and related gating/analytics logic by introducing a new provider-selection layer and Resend send implementation, which could affect deliverability and error handling across all bulk email sends.
> 
> **Overview**
> Adds **Resend as an alternative bulk newsletter email provider** alongside Mailgun, including a new runtime provider resolver (`bulk-email-provider-factory.js`) and a `ResendEmailProvider` implementation (batch sending + per-recipient replacement substitution) backed by a new `ResendClient` and the `resend` npm dependency.
> 
> Updates backend and admin surfaces to recognize Resend configuration: introduces the `resend_api_key` setting (API allowlist + defaults), exposes `config.resendIsConfigured` via public config, routes email analytics through a Resend no-op polling provider when Resend is active, and switches suppression-list operations to dispatch to the active provider.
> 
> Extends both Admin UIs to support Resend: adds a Settings → Email "Resend" card for entering the API key, updates navigation/search keywords, broadens publish/preview gating to `mailgun || resend`, and tweaks user-invite error copy to reference either provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e16819992475f22b66046ecb8ae320676156d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->