### PR TITLE
Renamed notifyGiftReceived to notifyGiftPurchased

### DIFF
--- a/ghost/core/core/server/services/gifts/gift-service.ts
+++ b/ghost/core/core/server/services/gifts/gift-service.ts
@@ -80,7 +80,7 @@ interface GiftEmailService {
 }
 
 interface StaffServiceEmails {
-    notifyGiftReceived(data: {
+    notifyGiftPurchased(data: {
         name: string | null;
         email: string;
         memberId: string | null;
@@ -208,7 +208,7 @@ export class GiftService {
         }
 
         try {
-            await this.deps.staffServiceEmails.notifyGiftReceived({
+            await this.deps.staffServiceEmails.notifyGiftPurchased({
                 name: member?.get('name') ?? null,
                 email: member?.get('email') ?? data.buyerEmail,
                 memberId: member?.id ?? null,

--- a/ghost/core/core/server/services/staff/staff-service-emails.js
+++ b/ghost/core/core/server/services/staff/staff-service-emails.js
@@ -317,7 +317,7 @@ class StaffServiceEmails {
      *
      * @returns {Promise<void>}
      */
-    async notifyGiftReceived({name, email, memberId, amount, currency, tierName, cadence, duration}) {
+    async notifyGiftPurchased({name, email, memberId, amount, currency, tierName, cadence, duration}) {
         const users = await this.models.User.getEmailAlertUsers('gift-subscriptions');
         const formattedAmount = this.getFormattedAmount({currency, amount: amount / 100});
 

--- a/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift-service.test.ts
@@ -50,7 +50,7 @@ describe('GiftService', function () {
         enqueueWelcomeEmailRun: sinon.SinonStub;
     };
     let staffServiceEmails: {
-        notifyGiftReceived: sinon.SinonStub;
+        notifyGiftPurchased: sinon.SinonStub;
         notifyGiftSubscriptionStarted: sinon.SinonStub;
     };
     let giftEmailService: {
@@ -102,7 +102,7 @@ describe('GiftService', function () {
             enqueueWelcomeEmailRun: sinon.stub().resolves(undefined)
         };
         staffServiceEmails = {
-            notifyGiftReceived: sinon.stub(),
+            notifyGiftPurchased: sinon.stub(),
             notifyGiftSubscriptionStarted: sinon.stub()
         };
         giftEmailService = {
@@ -280,9 +280,9 @@ describe('GiftService', function () {
 
             await service.recordPurchase(purchaseData);
 
-            sinon.assert.calledOnce(staffServiceEmails.notifyGiftReceived);
+            sinon.assert.calledOnce(staffServiceEmails.notifyGiftPurchased);
 
-            const emailData = staffServiceEmails.notifyGiftReceived.getCall(0).args[0];
+            const emailData = staffServiceEmails.notifyGiftPurchased.getCall(0).args[0];
 
             assert.equal(emailData.name, 'Member Name');
             assert.equal(emailData.email, 'member@example.com');
@@ -304,7 +304,7 @@ describe('GiftService', function () {
                 {message: 'Tier not found: tier_1'}
             );
 
-            sinon.assert.notCalled(staffServiceEmails.notifyGiftReceived);
+            sinon.assert.notCalled(staffServiceEmails.notifyGiftPurchased);
             sinon.assert.notCalled(giftEmailService.sendPurchaseConfirmation);
         });
 
@@ -313,9 +313,9 @@ describe('GiftService', function () {
 
             await service.recordPurchase({...purchaseData, stripeCustomerId: null});
 
-            sinon.assert.calledOnce(staffServiceEmails.notifyGiftReceived);
+            sinon.assert.calledOnce(staffServiceEmails.notifyGiftPurchased);
 
-            const emailData = staffServiceEmails.notifyGiftReceived.getCall(0).args[0];
+            const emailData = staffServiceEmails.notifyGiftPurchased.getCall(0).args[0];
 
             assert.equal(emailData.name, null);
             assert.equal(emailData.email, 'buyer@example.com');

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -1024,9 +1024,9 @@ describe('StaffService', function () {
             });
         });
 
-        describe('notifyGiftReceived', function () {
+        describe('notifyGiftPurchased', function () {
             it('sends gift email with correct subject', async function () {
-                await service.emails.notifyGiftReceived({
+                await service.emails.notifyGiftPurchased({
                     name: 'Alice',
                     email: 'alice@example.com',
                     memberId: null,
@@ -1043,7 +1043,7 @@ describe('StaffService', function () {
             });
 
             it('includes amount in HTML', async function () {
-                await service.emails.notifyGiftReceived({
+                await service.emails.notifyGiftPurchased({
                     name: 'Bob',
                     email: 'bob@example.com',
                     memberId: null,
@@ -1059,7 +1059,7 @@ describe('StaffService', function () {
             });
 
             it('includes purchaser name in HTML', async function () {
-                await service.emails.notifyGiftReceived({
+                await service.emails.notifyGiftPurchased({
                     name: 'Charlie',
                     email: 'charlie@example.com',
                     memberId: null,
@@ -1075,7 +1075,7 @@ describe('StaffService', function () {
             });
 
             it('includes amount in plain text', async function () {
-                await service.emails.notifyGiftReceived({
+                await service.emails.notifyGiftPurchased({
                     name: 'Diana',
                     email: 'diana@example.com',
                     memberId: null,
@@ -1091,7 +1091,7 @@ describe('StaffService', function () {
             });
 
             it('falls back to email when name is null', async function () {
-                await service.emails.notifyGiftReceived({
+                await service.emails.notifyGiftPurchased({
                     name: null,
                     email: 'anon@example.com',
                     memberId: null,
@@ -1107,7 +1107,7 @@ describe('StaffService', function () {
             });
 
             it('includes tier and cadence in HTML when provided', async function () {
-                await service.emails.notifyGiftReceived({
+                await service.emails.notifyGiftPurchased({
                     name: 'Erin',
                     email: 'erin@example.com',
                     memberId: null,
@@ -1124,7 +1124,7 @@ describe('StaffService', function () {
             });
 
             it('formats cadence with pluralized unit when duration is greater than 1', async function () {
-                await service.emails.notifyGiftReceived({
+                await service.emails.notifyGiftPurchased({
                     name: 'Erin',
                     email: 'erin@example.com',
                     memberId: null,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3554

- Renamed `notifyGiftReceived` to `notifyGiftPurchased` across the gift service, staff service emails, and their unit tests - as this staff notification is sent when a gift is purchased
- This change should have no user impact
