### PR TITLE
Added types for Papaparse

### DIFF
--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -43,6 +43,7 @@
         "@testing-library/jest-dom": "^6",
         "@testing-library/react": "14.3.1",
         "@types/jest": "29.5.14",
+        "@types/papaparse": "5.5.2",
         "@types/react": "18.3.28",
         "@vitest/coverage-v8": "^4.1.2",
         "eslint": "catalog:",

--- a/apps/posts/src/typings.d.ts
+++ b/apps/posts/src/typings.d.ts
@@ -1,1 +1,0 @@
-declare module 'papaparse';

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -265,6 +265,7 @@
     "@types/node-jose": "1.1.13",
     "@types/nodemailer": "6.4.23",
     "@types/on-headers": "1.0.4",
+    "@types/papaparse": "5.5.2",
     "@types/sinon": "17.0.4",
     "@types/supertest": "6.0.3",
     "@typescript-eslint/parser": "8.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,6 +1005,9 @@ importers:
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
+      '@types/papaparse':
+        specifier: 5.5.2
+        version: 5.5.2
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
@@ -2427,6 +2430,9 @@ importers:
       '@types/on-headers':
         specifier: 1.0.4
         version: 1.0.4
+      '@types/papaparse':
+        specifier: 5.5.2
+        version: 5.5.2
       '@types/sinon':
         specifier: 17.0.4
         version: 17.0.4
@@ -8769,9 +8775,6 @@ packages:
   '@tryghost/logging@4.1.0':
     resolution: {integrity: sha512-M8tNHRDSGLtAydgNbGRsN4zgUZpprOgXalEcK1112TODmEQMdIUxCjf1Eys3AhOyZZAeQyvonyuqJqDgJDrmww==}
 
-  '@tryghost/members-csv@2.0.5':
-    resolution: {integrity: sha512-5BMzhWSoJg+pOQuXdO8ygHDxLFcwZLob903NX7lprWQtooLPD8FAWwdFql/ZA7gPG5Bq9lV7TyUFK3hWVtvIlw==}
-
   '@tryghost/members-csv@2.0.7':
     resolution: {integrity: sha512-RnpaY2jKXC2waJTH4tI34vW541YBoDu7rX3NPZeHIdzoRP1102NCrzhPrFB/edmcyJ9fMMj5XpcvoQWw7FR/5A==}
 
@@ -9159,6 +9162,9 @@ packages:
 
   '@types/on-headers@1.0.4':
     resolution: {integrity: sha512-D8Dy7oiM4fFQPA1TtHVTGPFNgCCYY132dTFLezhvlPiiiyKkuW6tVipPXpUOiuTUu8Kzd+ASKjULvZld197Dhw==}
+
+  '@types/papaparse@5.5.2':
+    resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -25181,8 +25187,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -29973,13 +29978,6 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
-  '@tryghost/members-csv@2.0.5':
-    dependencies:
-      fs-extra: 11.3.0
-      lodash: 4.18.1
-      papaparse: 5.3.2
-      pump: 3.0.2
-
   '@tryghost/members-csv@2.0.7':
     dependencies:
       fs-extra: 11.3.0
@@ -30601,6 +30599,10 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/on-headers@1.0.4':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/papaparse@5.5.2':
     dependencies:
       '@types/node': 25.6.0
 
@@ -45239,7 +45241,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@1.2.0:
     dependencies:


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/27752

_This change should have no user impact._

We use `papaparse` in a few places. Let's install types for it. Luckily, there were no type errors!
