### PR TITLE
Fixed redirect in image resizing middleware

### DIFF
--- a/ghost/core/core/frontend/web/middleware/handle-image-sizes.js
+++ b/ghost/core/core/frontend/web/middleware/handle-image-sizes.js
@@ -48,6 +48,10 @@ module.exports = function handleImageSizes(req, res, next) {
         if (format) {
             url = url.replace(`/format/${format}`, '');
         }
+
+        // Strip multiple leading slashes to prevent protocol-relative redirects
+        url = url.replace(/^\/+/, '/');
+
         return res.redirect(url);
     };
 

--- a/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
@@ -179,6 +179,30 @@ describe('handleImageSizes middleware', function () {
             });
         });
 
+        it('strips multiple leading slashes when redirecting to the original URL', function (done) {
+            const fakeReq = {
+                url: '/size/w123/image.jpg',
+                originalUrl: '////example.com/content/images/size/w123/image.jpg'
+            };
+            const fakeRes = {
+                redirect(url) {
+                    try {
+                        assert.equal(url, '/example.com/content/images/image.jpg');
+                    } catch (e) {
+                        return done(e);
+                    }
+                    done();
+                },
+                setHeader() {}
+            };
+            handleImageSizes(fakeReq, fakeRes, function next(err) {
+                if (err) {
+                    return done(err);
+                }
+                done(new Error('Should not have called next'));
+            });
+        });
+
         it('redirects for invalid configured size', function (done) {
             const fakeReq = {
                 url: '/size/missing/image.jpg',


### PR DESCRIPTION
no ref

The image resizing middleware has a redirect that could, theoretically, create an open redirect if it were ever mounted somewhere else. This isn't a problem today, but let's harden it in case the mount changes.
