### PR TITLE
Cleaned up gift subscription screens

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.37",
+  "version": "2.68.38",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/common/gift-card.js
+++ b/apps/portal/src/components/common/gift-card.js
@@ -1,0 +1,45 @@
+// TODO: wrap strings with t() once copy is finalised
+/* eslint-disable i18next/no-literal-string */
+
+const GiftCard = ({cardRef, duration, tierName, name, giftValue, siteIcon, siteTitle}) => {
+    const hasMeta = duration && tierName;
+    const hasDetails = name || giftValue;
+
+    return (
+        <div className='gh-portal-gift-checkout-card-frame'>
+            <div ref={cardRef} className='gh-portal-gift-checkout-card'>
+                <div className='gh-portal-gift-checkout-card-notch' aria-hidden='true' />
+                {hasMeta && (
+                    <div className='gh-portal-gift-checkout-card-meta'>
+                        <div className='gh-portal-gift-checkout-card-duration'>{duration}</div>
+                        <div className='gh-portal-gift-checkout-card-tier'>{`${tierName} membership`}</div>
+                    </div>
+                )}
+                {hasDetails && (
+                    <div className='gh-portal-gift-checkout-card-details'>
+                        {name && (
+                            <div className='gh-portal-gift-checkout-card-detail'>
+                                <div className='gh-portal-gift-checkout-card-detail-label'>Name</div>
+                                <div className='gh-portal-gift-checkout-card-detail-value'>{name}</div>
+                            </div>
+                        )}
+                        {giftValue && (
+                            <div className='gh-portal-gift-checkout-card-detail'>
+                                <div className='gh-portal-gift-checkout-card-detail-label'>Gift value</div>
+                                <div className='gh-portal-gift-checkout-card-detail-value'>{giftValue}</div>
+                            </div>
+                        )}
+                    </div>
+                )}
+                <div className='gh-portal-gift-checkout-card-site'>
+                    {siteIcon && (
+                        <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
+                    )}
+                    <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default GiftCard;

--- a/apps/portal/src/components/common/gift-details-toggle.js
+++ b/apps/portal/src/components/common/gift-details-toggle.js
@@ -21,7 +21,7 @@ const GiftDetailsToggle = ({description, benefits, showDetails, onToggle}) => {
 
             return (
                 <div className='gh-portal-gift-checkout-benefit' key={benefitKey}>
-                    <CheckmarkIcon alt='' />
+                    <CheckmarkIcon aria-hidden='true' focusable='false' />
                     <span>{benefitName}</span>
                 </div>
             );

--- a/apps/portal/src/components/common/gift-details-toggle.js
+++ b/apps/portal/src/components/common/gift-details-toggle.js
@@ -1,0 +1,66 @@
+import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
+
+// TODO: wrap strings with t() once copy is finalised
+/* eslint-disable i18next/no-literal-string */
+
+const ChevronIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <polyline points="6 9 12 15 18 9"/>
+    </svg>
+);
+
+const GiftDetailsToggle = ({description, benefits, showDetails, onToggle}) => {
+    const visibleBenefits = (benefits || [])
+        .map((benefit, index) => {
+            const benefitName = typeof benefit === 'string' ? benefit : benefit?.name;
+            const benefitKey = typeof benefit === 'string' ? benefit : benefit?.id || `gift-benefit-${index}`;
+
+            if (!benefitName) {
+                return null;
+            }
+
+            return (
+                <div className='gh-portal-gift-checkout-benefit' key={benefitKey}>
+                    <CheckmarkIcon alt='' />
+                    <span>{benefitName}</span>
+                </div>
+            );
+        })
+        .filter(Boolean);
+
+    if (!description && visibleBenefits.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <div
+                className='gh-portal-gift-checkout-details'
+                data-open={showDetails}
+                aria-hidden={!showDetails}
+            >
+                <div className='gh-portal-gift-checkout-details-inner'>
+                    {description && (
+                        <p className='gh-portal-gift-checkout-details-description'>{description}</p>
+                    )}
+                    {visibleBenefits.length > 0 && (
+                        <div className='gh-portal-gift-checkout-benefits'>
+                            {visibleBenefits}
+                        </div>
+                    )}
+                </div>
+            </div>
+            <button
+                type='button'
+                className={'gh-portal-gift-checkout-details-toggle' + (showDetails ? ' is-open' : '')}
+                onClick={onToggle}
+                aria-expanded={showDetails}
+            >
+                {showDetails ? 'Hide details' : 'Gift details'}
+                <ChevronIcon />
+            </button>
+        </>
+    );
+};
+
+export default GiftDetailsToggle;

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -7,6 +7,7 @@ import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg'
 import giftCardNoiseUrl from '../../images/gift-card-noise.webp';
 import giftCardOrbUrl from '../../images/gift-card-orb.webp';
 import {getAvailableProducts, getCurrencySymbol, formatNumber, getStripeAmount, isCookiesDisabled, getActiveInterval} from '../../utils/helpers';
+import {getGiftDurationLabel} from '../../utils/gift-redemption-notification';
 import useCardTilt from '../../utils/use-card-tilt';
 
 // TODO: wrap strings with t() once copy is finalised
@@ -651,10 +652,6 @@ function getTierPriceLabel(product, selectedInterval) {
     return formatGiftValue(activePrice);
 }
 
-function getDurationLabel(selectedInterval) {
-    return selectedInterval === 'month' ? '1 month' : '1 year';
-}
-
 const GiftPage = () => {
     const {site, brandColor, action, doAction} = useContext(AppContext);
     const [selectedInterval, setSelectedInterval] = useState(null);
@@ -855,7 +852,7 @@ const GiftPage = () => {
                                 <div ref={cardRef} className='gh-portal-gift-checkout-card'>
                                     <div className='gh-portal-gift-checkout-card-notch' aria-hidden='true' />
                                     <div className='gh-portal-gift-checkout-card-meta'>
-                                        <div className='gh-portal-gift-checkout-card-duration'>{getDurationLabel(activeInterval)}</div>
+                                        <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel({cadence: activeInterval, duration: 1})}</div>
                                         <div className='gh-portal-gift-checkout-card-tier'>{`${activeProduct.name} membership`}</div>
                                     </div>
                                     <div className='gh-portal-gift-checkout-card-details'>

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -2,6 +2,7 @@ import {useContext, useLayoutEffect, useRef, useState} from 'react';
 import AppContext from '../../app-context';
 import CloseButton from '../common/close-button';
 import ActionButton from '../common/action-button';
+import GiftCard from '../common/gift-card';
 import LoadingPage from './loading-page';
 import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
 import giftCardNoiseUrl from '../../images/gift-card-noise.webp';
@@ -849,26 +850,14 @@ const GiftPage = () => {
                     <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
                         <div className='gh-portal-gift-checkout-right-panel'>
                             <div className='gh-portal-gift-checkout-card-stack'>
-                                <div ref={cardRef} className='gh-portal-gift-checkout-card'>
-                                    <div className='gh-portal-gift-checkout-card-notch' aria-hidden='true' />
-                                    <div className='gh-portal-gift-checkout-card-meta'>
-                                        <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel({cadence: activeInterval, duration: 1})}</div>
-                                        <div className='gh-portal-gift-checkout-card-tier'>{`${activeProduct.name} membership`}</div>
-                                    </div>
-                                    <div className='gh-portal-gift-checkout-card-details'>
-                                        <div className='gh-portal-gift-checkout-card-detail'>
-                                            <div className='gh-portal-gift-checkout-card-detail-label'>Gift value</div>
-                                            <div className='gh-portal-gift-checkout-card-detail-value'>{getTierPriceLabel(activeProduct, activeInterval)}</div>
-                                        </div>
-                                    </div>
-                                    <div className='gh-portal-gift-checkout-card-site'>
-                                        {siteIcon && (
-                                            <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
-                                        )}
-                                        <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
-                                    </div>
-                                </div>
-
+                                <GiftCard
+                                    cardRef={cardRef}
+                                    duration={getGiftDurationLabel({cadence: activeInterval, duration: 1})}
+                                    tierName={activeProduct.name}
+                                    giftValue={getTierPriceLabel(activeProduct, activeInterval)}
+                                    siteIcon={siteIcon}
+                                    siteTitle={siteTitle}
+                                />
                             </div>
                         </div>
                     </div>

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -817,7 +817,7 @@ const GiftPage = () => {
                                                                     const key = benefit?.id || `benefit-${idx}`;
                                                                     return (
                                                                         <div className='gh-portal-gift-checkout-benefit' key={key}>
-                                                                            <CheckmarkIcon alt='' />
+                                                                            <CheckmarkIcon aria-hidden='true' focusable='false' />
                                                                             <span>{benefit.name}</span>
                                                                         </div>
                                                                     );

--- a/apps/portal/src/components/pages/gift-redemption-page.js
+++ b/apps/portal/src/components/pages/gift-redemption-page.js
@@ -2,9 +2,10 @@ import {useContext, useEffect, useState} from 'react';
 import AppContext from '../../app-context';
 import ActionButton from '../common/action-button';
 import CloseButton from '../common/close-button';
+import GiftCard from '../common/gift-card';
+import GiftDetailsToggle from '../common/gift-details-toggle';
 import InputForm from '../common/input-form';
 import {ValidateInputForm} from '../../utils/form';
-import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
 import {getGiftDurationLabel, getGiftRedemptionErrorMessage} from '../../utils/gift-redemption-notification';
 import {t} from '../../utils/i18n';
 import {hasGiftSubscriptions, removePortalLinkFromUrl} from '../../utils/helpers';
@@ -20,12 +21,6 @@ export const GiftRedemptionStyles = `
     margin-top: 16px;
 }
 `;
-
-const ChevronIcon = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-        <polyline points="6 9 12 15 18 9"/>
-    </svg>
-);
 
 // TODO: Add translation strings once copy has been finalised
 const GiftRedemptionPage = () => {
@@ -200,81 +195,22 @@ const GiftRedemptionPage = () => {
                     <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
                         <div className='gh-portal-gift-checkout-right-panel'>
                             <div className='gh-portal-gift-checkout-card-stack' data-revealing={showDetails}>
-                                <div className='gh-portal-gift-checkout-card-frame'>
-                                    <div ref={cardRef} className='gh-portal-gift-checkout-card'>
-                                        <div className='gh-portal-gift-checkout-card-notch' aria-hidden='true' />
-                                        <div className='gh-portal-gift-checkout-card-meta'>
-                                            <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel(gift)}</div>
-                                            {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
-                                            <div className='gh-portal-gift-checkout-card-tier'>{`${gift.tier.name} membership`}</div>
-                                        </div>
-                                        <div className='gh-portal-gift-checkout-card-details'>
-                                            {name.trim() && (
-                                                <div className='gh-portal-gift-checkout-card-detail'>
-                                                    {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
-                                                    <div className='gh-portal-gift-checkout-card-detail-label'>Name</div>
-                                                    <div className='gh-portal-gift-checkout-card-detail-value'>{name.trim()}</div>
-                                                </div>
-                                            )}
-                                            <div className='gh-portal-gift-checkout-card-detail'>
-                                                {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
-                                                <div className='gh-portal-gift-checkout-card-detail-label'>Gift value</div>
-                                                <div className='gh-portal-gift-checkout-card-detail-value'>{formatGiftValue(gift)}</div>
-                                            </div>
-                                        </div>
-                                        <div className='gh-portal-gift-checkout-card-site'>
-                                            {siteIcon && (
-                                                <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
-                                            )}
-                                            <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
-                                        </div>
-                                    </div>
-                                </div>
+                                <GiftCard
+                                    cardRef={cardRef}
+                                    duration={getGiftDurationLabel(gift)}
+                                    tierName={gift.tier.name}
+                                    name={name.trim() || null}
+                                    giftValue={formatGiftValue(gift)}
+                                    siteIcon={siteIcon}
+                                    siteTitle={siteTitle}
+                                />
 
-                                {(tierDescription || benefits.length > 0) && (
-                                    <>
-                                        <div
-                                            className='gh-portal-gift-checkout-details'
-                                            data-open={showDetails}
-                                            aria-hidden={!showDetails}
-                                        >
-                                            <div className='gh-portal-gift-checkout-details-inner'>
-                                                {tierDescription && (
-                                                    <p className='gh-portal-gift-checkout-details-description'>{tierDescription}</p>
-                                                )}
-                                                {benefits.length > 0 && (
-                                                    <div className='gh-portal-gift-checkout-benefits'>
-                                                        {benefits.map((benefit, index) => {
-                                                            const benefitName = typeof benefit === 'string' ? benefit : benefit?.name;
-                                                            const benefitKey = typeof benefit === 'string' ? benefit : benefit?.id || `gift-benefit-${index}`;
-
-                                                            if (!benefitName) {
-                                                                return null;
-                                                            }
-
-                                                            return (
-                                                                <div className='gh-portal-gift-checkout-benefit' key={benefitKey}>
-                                                                    <CheckmarkIcon alt='' />
-                                                                    <span>{benefitName}</span>
-                                                                </div>
-                                                            );
-                                                        })}
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
-                                        <button
-                                            type='button'
-                                            className={'gh-portal-gift-checkout-details-toggle' + (showDetails ? ' is-open' : '')}
-                                            onClick={() => setShowDetails(s => !s)}
-                                            aria-expanded={showDetails}
-                                        >
-                                            {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
-                                            {showDetails ? 'Hide details' : 'Gift details'}
-                                            <ChevronIcon />
-                                        </button>
-                                    </>
-                                )}
+                                <GiftDetailsToggle
+                                    description={tierDescription}
+                                    benefits={benefits}
+                                    showDetails={showDetails}
+                                    onToggle={() => setShowDetails(s => !s)}
+                                />
                             </div>
                         </div>
                     </div>

--- a/apps/portal/src/components/pages/gift-success-page.js
+++ b/apps/portal/src/components/pages/gift-success-page.js
@@ -3,6 +3,7 @@ import AppContext from '../../app-context';
 import CloseButton from '../common/close-button';
 import copyTextToClipboard from '../../utils/copy-to-clipboard';
 import {getAvailableProducts} from '../../utils/helpers';
+import {getGiftDurationLabel} from '../../utils/gift-redemption-notification';
 import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
 import useCardTilt from '../../utils/use-card-tilt';
 import {formatGiftValue} from './gift-page';
@@ -87,10 +88,6 @@ const ChevronIcon = () => (
     </svg>
 );
 
-function getDurationLabel(cadence) {
-    return cadence === 'month' ? '1 month' : '1 year';
-}
-
 const GiftSuccessPage = () => {
     const {site, pageData} = useContext(AppContext);
     const [copied, setCopied] = useState(false);
@@ -153,7 +150,7 @@ const GiftSuccessPage = () => {
                                         <div className='gh-portal-gift-checkout-card-notch' aria-hidden='true' />
                                         {tier && cadence && (
                                             <div className='gh-portal-gift-checkout-card-meta'>
-                                                <div className='gh-portal-gift-checkout-card-duration'>{getDurationLabel(cadence)}</div>
+                                                <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel({cadence, duration: 1})}</div>
                                                 <div className='gh-portal-gift-checkout-card-tier'>{`${tier.name} membership`}</div>
                                             </div>
                                         )}

--- a/apps/portal/src/components/pages/gift-success-page.js
+++ b/apps/portal/src/components/pages/gift-success-page.js
@@ -1,10 +1,11 @@
 import {useContext, useState} from 'react';
 import AppContext from '../../app-context';
 import CloseButton from '../common/close-button';
+import GiftCard from '../common/gift-card';
+import GiftDetailsToggle from '../common/gift-details-toggle';
 import copyTextToClipboard from '../../utils/copy-to-clipboard';
 import {getAvailableProducts} from '../../utils/helpers';
 import {getGiftDurationLabel} from '../../utils/gift-redemption-notification';
-import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
 import useCardTilt from '../../utils/use-card-tilt';
 import {formatGiftValue} from './gift-page';
 
@@ -82,12 +83,6 @@ const CheckIcon = () => (
     </svg>
 );
 
-const ChevronIcon = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-        <polyline points="6 9 12 15 18 9"/>
-    </svg>
-);
-
 const GiftSuccessPage = () => {
     const {site, pageData} = useContext(AppContext);
     const [copied, setCopied] = useState(false);
@@ -145,68 +140,22 @@ const GiftSuccessPage = () => {
                     <div className='gh-portal-gift-checkout-right' {...cardTiltProps}>
                         <div className='gh-portal-gift-checkout-right-panel'>
                             <div className='gh-portal-gift-checkout-card-stack' data-revealing={showDetails}>
-                                <div className='gh-portal-gift-checkout-card-frame'>
-                                    <div ref={cardRef} className='gh-portal-gift-checkout-card'>
-                                        <div className='gh-portal-gift-checkout-card-notch' aria-hidden='true' />
-                                        {tier && cadence && (
-                                            <div className='gh-portal-gift-checkout-card-meta'>
-                                                <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel({cadence, duration: 1})}</div>
-                                                <div className='gh-portal-gift-checkout-card-tier'>{`${tier.name} membership`}</div>
-                                            </div>
-                                        )}
-                                        {tier && cadence && (
-                                            <div className='gh-portal-gift-checkout-card-details'>
-                                                <div className='gh-portal-gift-checkout-card-detail'>
-                                                    <div className='gh-portal-gift-checkout-card-detail-label'>Gift value</div>
-                                                    <div className='gh-portal-gift-checkout-card-detail-value'>{formatGiftValue(cadence === 'month' ? tier.monthlyPrice : tier.yearlyPrice)}</div>
-                                                </div>
-                                            </div>
-                                        )}
-                                        <div className='gh-portal-gift-checkout-card-site'>
-                                            {siteIcon && (
-                                                <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
-                                            )}
-                                            <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
-                                        </div>
-                                    </div>
-                                </div>
+                                <GiftCard
+                                    cardRef={cardRef}
+                                    duration={tier && cadence ? getGiftDurationLabel({cadence, duration: 1}) : null}
+                                    tierName={tier && cadence ? tier.name : null}
+                                    giftValue={tier && cadence ? formatGiftValue(cadence === 'month' ? tier.monthlyPrice : tier.yearlyPrice) : null}
+                                    siteIcon={siteIcon}
+                                    siteTitle={siteTitle}
+                                />
 
-                                {tier && (tier.description || (tier.benefits && tier.benefits.length > 0)) && (
-                                    <>
-                                        <div
-                                            className='gh-portal-gift-checkout-details'
-                                            data-open={showDetails}
-                                            aria-hidden={!showDetails}
-                                        >
-                                            <div className='gh-portal-gift-checkout-details-inner'>
-                                                {tier.description && (
-                                                    <p className='gh-portal-gift-checkout-details-description'>{tier.description}</p>
-                                                )}
-                                                {tier.benefits && tier.benefits.length > 0 && (
-                                                    <div className='gh-portal-gift-checkout-benefits'>
-                                                        {tier.benefits.map((benefit, idx) => {
-                                                            const key = benefit?.id || `benefit-${idx}`;
-                                                            return (
-                                                                <div className='gh-portal-gift-checkout-benefit' key={key}>
-                                                                    <CheckmarkIcon alt='' />
-                                                                    <span>{benefit.name}</span>
-                                                                </div>
-                                                            );
-                                                        })}
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
-                                        <button
-                                            type='button'
-                                            className={'gh-portal-gift-checkout-details-toggle' + (showDetails ? ' is-open' : '')}
-                                            onClick={() => setShowDetails(s => !s)}
-                                            aria-expanded={showDetails}
-                                        >
-                                            {showDetails ? 'Hide details' : 'Gift details'}
-                                            <ChevronIcon />
-                                        </button>
-                                    </>
+                                {tier && (
+                                    <GiftDetailsToggle
+                                        description={tier.description}
+                                        benefits={tier.benefits}
+                                        showDetails={showDetails}
+                                        onToggle={() => setShowDetails(s => !s)}
+                                    />
                                 )}
                             </div>
                         </div>

--- a/apps/portal/src/components/pages/magic-link-page.js
+++ b/apps/portal/src/components/pages/magic-link-page.js
@@ -1,20 +1,15 @@
 import React from 'react';
 import ActionButton from '../common/action-button';
 import CloseButton from '../common/close-button';
+import GiftCard from '../common/gift-card';
+import GiftDetailsToggle from '../common/gift-details-toggle';
 import InboxLinkButton from '../common/inbox-link-button';
 import AppContext from '../../app-context';
 import {ReactComponent as EnvelopeIcon} from '../../images/icons/envelope.svg';
-import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
 import {isIos} from '../../utils/is-ios';
 import {t} from '../../utils/i18n';
 import {getGiftDurationLabel} from '../../utils/gift-redemption-notification';
 import {formatGiftValue} from './gift-page';
-
-const ChevronIcon = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-        <polyline points="6 9 12 15 18 9"/>
-    </svg>
-);
 
 export const MagicLinkStyles = `
     .gh-portal-icon-envelope {
@@ -347,80 +342,21 @@ export default class MagicLinkPage extends React.Component {
                         <div className='gh-portal-gift-checkout-right'>
                             <div className='gh-portal-gift-checkout-right-panel'>
                                 <div className='gh-portal-gift-checkout-card-stack' data-revealing={this.state.showDetails}>
-                                    <div className='gh-portal-gift-checkout-card-frame'>
-                                        <div className='gh-portal-gift-checkout-card'>
-                                            <div className='gh-portal-gift-checkout-card-meta'>
-                                                <div className='gh-portal-gift-checkout-card-duration'>{getGiftDurationLabel(gift)}</div>
-                                                {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
-                                                <div className='gh-portal-gift-checkout-card-tier'>{`${gift.tier?.name} membership`}</div>
-                                            </div>
-                                            <div className='gh-portal-gift-checkout-card-details'>
-                                                {submittedName && (
-                                                    <div className='gh-portal-gift-checkout-card-detail'>
-                                                        {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
-                                                        <div className='gh-portal-gift-checkout-card-detail-label'>Name</div>
-                                                        <div className='gh-portal-gift-checkout-card-detail-value'>{submittedName}</div>
-                                                    </div>
-                                                )}
-                                                <div className='gh-portal-gift-checkout-card-detail'>
-                                                    {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
-                                                    <div className='gh-portal-gift-checkout-card-detail-label'>Gift value</div>
-                                                    <div className='gh-portal-gift-checkout-card-detail-value'>{formatGiftValue(gift)}</div>
-                                                </div>
-                                            </div>
-                                            <div className='gh-portal-gift-checkout-card-site'>
-                                                {siteIcon && (
-                                                    <img className='gh-portal-gift-checkout-card-site-icon' src={siteIcon} alt='' />
-                                                )}
-                                                <span className='gh-portal-gift-checkout-card-site-name'>{siteTitle}</span>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    <GiftCard
+                                        duration={getGiftDurationLabel(gift)}
+                                        tierName={gift.tier?.name}
+                                        name={submittedName || null}
+                                        giftValue={formatGiftValue(gift)}
+                                        siteIcon={siteIcon}
+                                        siteTitle={siteTitle}
+                                    />
 
-                                    {(tierDescription || benefits.length > 0) && (
-                                        <>
-                                            <div
-                                                className='gh-portal-gift-checkout-details'
-                                                data-open={this.state.showDetails}
-                                                aria-hidden={!this.state.showDetails}
-                                            >
-                                                <div className='gh-portal-gift-checkout-details-inner'>
-                                                    {tierDescription && (
-                                                        <p className='gh-portal-gift-checkout-details-description'>{tierDescription}</p>
-                                                    )}
-                                                    {benefits.length > 0 && (
-                                                        <div className='gh-portal-gift-checkout-benefits'>
-                                                            {benefits.map((benefit, index) => {
-                                                                const benefitName = typeof benefit === 'string' ? benefit : benefit?.name;
-                                                                const benefitKey = typeof benefit === 'string' ? benefit : benefit?.id || `gift-benefit-${index}`;
-
-                                                                if (!benefitName) {
-                                                                    return null;
-                                                                }
-
-                                                                return (
-                                                                    <div className='gh-portal-gift-checkout-benefit' key={benefitKey}>
-                                                                        <CheckmarkIcon />
-                                                                        <span>{benefitName}</span>
-                                                                    </div>
-                                                                );
-                                                            })}
-                                                        </div>
-                                                    )}
-                                                </div>
-                                            </div>
-                                            <button
-                                                type='button'
-                                                className={'gh-portal-gift-checkout-details-toggle' + (this.state.showDetails ? ' is-open' : '')}
-                                                onClick={() => this.setState(s => ({showDetails: !s.showDetails}))}
-                                                aria-expanded={this.state.showDetails}
-                                            >
-                                                {/* eslint-disable-next-line i18next/no-literal-string -- copy not yet finalised */}
-                                                {this.state.showDetails ? 'Hide details' : 'Gift details'}
-                                                <ChevronIcon />
-                                            </button>
-                                        </>
-                                    )}
+                                    <GiftDetailsToggle
+                                        description={tierDescription}
+                                        benefits={benefits}
+                                        showDetails={this.state.showDetails}
+                                        onToggle={() => this.setState(s => ({showDetails: !s.showDetails}))}
+                                    />
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3605/design-cleanup

Follow-up cleanup from the gift subscription redesign (#27668).
- **BER-3607** — gift selection and success screens now use the shared `getGiftDurationLabel` util instead of local copies.
- **BER-3606** — extracted `<GiftCard>` and `<GiftDetailsToggle>` shared components, used across all four gift screens (selection, success, redemption, magic-link in gift mode).