### PR TITLE
Added Sentry monitoring for Billing app load failures

### DIFF
--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -27,6 +27,7 @@ export default class GhBillingIframe extends Component {
     @action
     setup() {
         this.billing.getBillingIframe().src = this.billing.getIframeURL();
+        this.billing.startBillingAppLoadMonitor();
         window.addEventListener('message', this.handleIframeMessage);
     }
 
@@ -38,6 +39,8 @@ export default class GhBillingIframe extends Component {
 
         // only process messages coming from the billing iframe
         if (event?.data && this.billing.getIframeURL().includes(event?.origin)) {
+            this.billing.markBillingAppLoaded();
+
             if (event.data?.request === 'token') {
                 this._handleTokenRequest();
             }

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -4,6 +4,7 @@ import {inject} from 'ghost-admin/decorators/inject';
 import {tracked} from '@glimmer/tracking';
 
 const BILLING_APP_LOAD_TIMEOUT_MS = 10_000;
+const BILLING_APP_LOAD_RETRY_DELAYS_MS = [1_000];
 const BILLING_APP_LOAD_FAILURE_MESSAGE = 'Billing app failed to become ready';
 
 export default class BillingService extends Service {
@@ -23,7 +24,11 @@ export default class BillingService extends Service {
 
     billingAppLoaded = false;
     billingAppLoadTimeout = null;
+    billingAppRetryTimeout = null;
+    billingAppLoadAttempts = 0;
+    billingAppLoadFailureReported = false;
     billingAppLoadTimeoutMs = BILLING_APP_LOAD_TIMEOUT_MS;
+    billingAppLoadRetryDelaysMs = BILLING_APP_LOAD_RETRY_DELAYS_MS;
 
     constructor() {
         super(...arguments);
@@ -61,14 +66,40 @@ export default class BillingService extends Service {
     }
 
     startBillingAppLoadMonitor() {
-        if (this.billingAppLoaded || this.billingAppLoadTimeout) {
+        if (this.billingAppLoaded || this.billingAppLoadTimeout || this.billingAppLoadFailureReported) {
             return;
         }
 
+        this.billingAppLoadAttempts += 1;
         this.billingAppLoadTimeout = setTimeout(() => {
             this.billingAppLoadTimeout = null;
-            this.reportBillingAppLoadFailure();
+            this.handleBillingAppLoadTimeout();
         }, this.billingAppLoadTimeoutMs);
+    }
+
+    handleBillingAppLoadTimeout() {
+        const retryDelay = this.billingAppLoadRetryDelaysMs[this.billingAppLoadAttempts - 1];
+
+        if (retryDelay !== undefined) {
+            this.billingAppRetryTimeout = setTimeout(() => {
+                this.billingAppRetryTimeout = null;
+                this.reloadBillingIframe();
+                this.startBillingAppLoadMonitor();
+            }, retryDelay);
+            return;
+        }
+
+        this.reportBillingAppLoadFailure();
+    }
+
+    reloadBillingIframe() {
+        const iframe = this.getBillingIframe();
+
+        if (!iframe || this.billingAppLoaded) {
+            return;
+        }
+
+        iframe.src = this.getIframeURL();
     }
 
     markBillingAppLoaded() {
@@ -77,15 +108,24 @@ export default class BillingService extends Service {
     }
 
     clearBillingAppLoadMonitor() {
-        if (!this.billingAppLoadTimeout) {
-            return;
+        if (this.billingAppLoadTimeout) {
+            clearTimeout(this.billingAppLoadTimeout);
+            this.billingAppLoadTimeout = null;
         }
 
-        clearTimeout(this.billingAppLoadTimeout);
-        this.billingAppLoadTimeout = null;
+        if (this.billingAppRetryTimeout) {
+            clearTimeout(this.billingAppRetryTimeout);
+            this.billingAppRetryTimeout = null;
+        }
     }
 
     reportBillingAppLoadFailure() {
+        if (this.billingAppLoadFailureReported) {
+            return;
+        }
+
+        this.billingAppLoadFailureReported = true;
+
         if (!this.config.sentry_dsn) {
             return;
         }
@@ -94,9 +134,11 @@ export default class BillingService extends Service {
             contexts: {
                 ghost: {
                     full_error: {
+                        attempts: this.billingAppLoadAttempts,
                         has_billing_url: !!this.config.hostSettings?.billing?.url,
                         is_force_upgrade: !!this.config.hostSettings?.forceUpgrade,
-                        location_hash: window.location.hash
+                        location_hash: window.location.hash,
+                        retry_delays_ms: this.billingAppLoadRetryDelaysMs
                     }
                 }
             },

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -136,10 +136,10 @@ export default class BillingService extends Service {
             return;
         }
 
-        Sentry.captureMessage(BILLING_APP_LOAD_FAILURE_MESSAGE, {
+        Sentry.captureException(BILLING_APP_LOAD_FAILURE_MESSAGE, {
             contexts: {
                 ghost: {
-                    full_error: {
+                    billing_monitor: {
                         attempts: this.billingAppLoadAttempts,
                         has_billing_url: !!this.config.hostSettings?.billing?.url,
                         is_force_upgrade: !!this.config.hostSettings?.forceUpgrade,

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -66,13 +66,14 @@ export default class BillingService extends Service {
     }
 
     startBillingAppLoadMonitor() {
-        if (this.billingAppLoadTimeout || this.billingAppLoadFailureReported) {
+        if (this.billingAppLoadTimeout || this.billingAppRetryTimeout) {
             return;
         }
 
-        if (this.billingAppLoaded) {
+        if (this.billingAppLoaded || this.billingAppLoadFailureReported) {
             this.billingAppLoaded = false;
             this.billingAppLoadAttempts = 0;
+            this.billingAppLoadFailureReported = false;
         }
 
         this.billingAppLoadAttempts += 1;

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -1,6 +1,10 @@
+import * as Sentry from '@sentry/ember';
 import Service, {inject as service} from '@ember/service';
 import {inject} from 'ghost-admin/decorators/inject';
 import {tracked} from '@glimmer/tracking';
+
+const BILLING_APP_LOAD_TIMEOUT_MS = 10_000;
+const BILLING_APP_LOAD_FAILURE_MESSAGE = 'Billing app failed to become ready';
 
 export default class BillingService extends Service {
     @service ghostPaths;
@@ -17,6 +21,10 @@ export default class BillingService extends Service {
     @tracked action = null;
     @tracked ownerUser = null;
 
+    billingAppLoaded = false;
+    billingAppLoadTimeout = null;
+    billingAppLoadTimeoutMs = BILLING_APP_LOAD_TIMEOUT_MS;
+
     constructor() {
         super(...arguments);
 
@@ -27,6 +35,11 @@ export default class BillingService extends Service {
                 }
             });
         }
+    }
+
+    willDestroy() {
+        super.willDestroy(...arguments);
+        this.clearBillingAppLoadMonitor();
     }
 
     handleRouteChangeInIframe(destinationRoute) {
@@ -45,6 +58,54 @@ export default class BillingService extends Service {
 
     _isBillingIframeLoaded() {
         return this.getBillingIframe() !== null && this.getBillingIframe().contentWindow;
+    }
+
+    startBillingAppLoadMonitor() {
+        if (this.billingAppLoaded || this.billingAppLoadTimeout) {
+            return;
+        }
+
+        this.billingAppLoadTimeout = setTimeout(() => {
+            this.billingAppLoadTimeout = null;
+            this.reportBillingAppLoadFailure();
+        }, this.billingAppLoadTimeoutMs);
+    }
+
+    markBillingAppLoaded() {
+        this.billingAppLoaded = true;
+        this.clearBillingAppLoadMonitor();
+    }
+
+    clearBillingAppLoadMonitor() {
+        if (!this.billingAppLoadTimeout) {
+            return;
+        }
+
+        clearTimeout(this.billingAppLoadTimeout);
+        this.billingAppLoadTimeout = null;
+    }
+
+    reportBillingAppLoadFailure() {
+        if (!this.config.sentry_dsn) {
+            return;
+        }
+
+        Sentry.captureMessage(BILLING_APP_LOAD_FAILURE_MESSAGE, {
+            contexts: {
+                ghost: {
+                    full_error: {
+                        has_billing_url: !!this.config.hostSettings?.billing?.url,
+                        is_force_upgrade: !!this.config.hostSettings?.forceUpgrade,
+                        location_hash: window.location.hash
+                    }
+                }
+            },
+            tags: {
+                source: 'billing-app-load-monitor',
+                route: this.router.currentRouteName,
+                path: window.location.hash
+            }
+        });
     }
 
     getIframeURL() {

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -66,8 +66,13 @@ export default class BillingService extends Service {
     }
 
     startBillingAppLoadMonitor() {
-        if (this.billingAppLoaded || this.billingAppLoadTimeout || this.billingAppLoadFailureReported) {
+        if (this.billingAppLoadTimeout || this.billingAppLoadFailureReported) {
             return;
+        }
+
+        if (this.billingAppLoaded) {
+            this.billingAppLoaded = false;
+            this.billingAppLoadAttempts = 0;
         }
 
         this.billingAppLoadAttempts += 1;

--- a/ghost/admin/tests/unit/services/billing-test.js
+++ b/ghost/admin/tests/unit/services/billing-test.js
@@ -46,12 +46,27 @@ describe('Unit: Service: billing', function () {
 
         service.startBillingAppLoadMonitor();
 
-        await waitUntil(() => reloadBillingIframe.called);
-        expect(reportBillingAppLoadFailure.called).to.be.false;
-
         await waitUntil(() => reportBillingAppLoadFailure.called);
 
         expect(reloadBillingIframe.calledOnce).to.be.true;
+        expect(reportBillingAppLoadFailure.calledOnce).to.be.true;
+        expect(reloadBillingIframe.calledBefore(reportBillingAppLoadFailure)).to.be.true;
+    });
+
+    it('re-arms the monitor after the billing app became ready', async function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        service.billingAppLoadTimeoutMs = 1;
+        service.billingAppLoadRetryDelaysMs = [];
+        const reportBillingAppLoadFailure = sinon.stub(service, 'reportBillingAppLoadFailure');
+
+        service.startBillingAppLoadMonitor();
+        service.markBillingAppLoaded();
+        service.startBillingAppLoadMonitor();
+
+        await waitUntil(() => reportBillingAppLoadFailure.called);
+
+        expect(service.billingAppLoadAttempts).to.equal(1);
         expect(reportBillingAppLoadFailure.calledOnce).to.be.true;
     });
 

--- a/ghost/admin/tests/unit/services/billing-test.js
+++ b/ghost/admin/tests/unit/services/billing-test.js
@@ -70,6 +70,25 @@ describe('Unit: Service: billing', function () {
         expect(reportBillingAppLoadFailure.calledOnce).to.be.true;
     });
 
+    it('re-arms the monitor after a reported billing app load failure', async function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        service.billingAppLoadTimeoutMs = 1;
+        service.billingAppLoadRetryDelaysMs = [];
+        service.billingAppLoadAttempts = 2;
+        service.billingAppLoadFailureReported = true;
+        const reportBillingAppLoadFailure = sinon.stub(service, 'reportBillingAppLoadFailure');
+
+        service.startBillingAppLoadMonitor();
+
+        expect(service.billingAppLoadAttempts).to.equal(1);
+        expect(service.billingAppLoadFailureReported).to.be.false;
+
+        await waitUntil(() => reportBillingAppLoadFailure.called);
+
+        expect(reportBillingAppLoadFailure.calledOnce).to.be.true;
+    });
+
     it('reloads the billing iframe during a retry', function () {
         const service = this.owner.lookup('service:billing');
         billingService = service;

--- a/ghost/admin/tests/unit/services/billing-test.js
+++ b/ghost/admin/tests/unit/services/billing-test.js
@@ -1,0 +1,86 @@
+import * as Sentry from '@sentry/ember';
+import sentryTestKit from 'sentry-testkit/browser';
+import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {getSentryTestConfig} from 'ghost-admin/utils/sentry';
+import {setupTest} from 'ember-mocha';
+import {waitUntil} from '@ember/test-helpers';
+
+const {sentryTransport, testkit} = sentryTestKit();
+
+describe('Unit: Service: billing', function () {
+    setupTest();
+
+    before(function () {
+        Sentry.init(getSentryTestConfig(sentryTransport));
+    });
+
+    beforeEach(function () {
+        testkit.reset();
+
+        const config = this.owner.lookup('config:main');
+        config.sentry_dsn = 'https://example.com/sentry';
+        config.hostSettings = {
+            billing: {
+                url: 'https://billing.example.test'
+            }
+        };
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('starts a load monitor for the billing app', async function () {
+        const service = this.owner.lookup('service:billing');
+        service.billingAppLoadTimeoutMs = 1;
+        const reportBillingAppLoadFailure = sinon.stub(service, 'reportBillingAppLoadFailure');
+
+        service.startBillingAppLoadMonitor();
+
+        await waitUntil(() => reportBillingAppLoadFailure.called);
+
+        expect(reportBillingAppLoadFailure.calledOnce).to.be.true;
+    });
+
+    it('reports to Sentry when the billing app does not become ready', async function () {
+        const service = this.owner.lookup('service:billing');
+
+        service.reportBillingAppLoadFailure();
+
+        await waitUntil(() => testkit.reports().length > 0);
+
+        expect(testkit.reports()).to.have.lengthOf(1);
+        const report = testkit.reports()[0];
+        expect(report.message).to.equal('Billing app failed to become ready');
+        expect(report.tags).to.deep.include({
+            source: 'billing-app-load-monitor'
+        });
+        expect(report.originalReport.contexts.ghost.full_error).to.deep.include({
+            has_billing_url: true,
+            is_force_upgrade: false
+        });
+    });
+
+    it('does not report when the billing app becomes ready before the timeout', function () {
+        const service = this.owner.lookup('service:billing');
+
+        service.startBillingAppLoadMonitor();
+        service.markBillingAppLoaded();
+
+        expect(service.billingAppLoadTimeout).to.be.null;
+        expect(testkit.reports()).to.have.lengthOf(0);
+    });
+
+    it('does not report when Sentry is not configured', function () {
+        const config = this.owner.lookup('config:main');
+        config.sentry_dsn = null;
+
+        const service = this.owner.lookup('service:billing');
+
+        service.reportBillingAppLoadFailure();
+
+        expect(testkit.reports()).to.have.lengthOf(0);
+    });
+});

--- a/ghost/admin/tests/unit/services/billing-test.js
+++ b/ghost/admin/tests/unit/services/billing-test.js
@@ -116,7 +116,7 @@ describe('Unit: Service: billing', function () {
         expect(report.tags).to.deep.include({
             source: 'billing-app-load-monitor'
         });
-        expect(report.originalReport.contexts.ghost.full_error).to.deep.include({
+        expect(report.originalReport.contexts.ghost.billing_monitor).to.deep.include({
             attempts: 2,
             has_billing_url: true,
             is_force_upgrade: false

--- a/ghost/admin/tests/unit/services/billing-test.js
+++ b/ghost/admin/tests/unit/services/billing-test.js
@@ -12,6 +12,8 @@ const {sentryTransport, testkit} = sentryTestKit();
 describe('Unit: Service: billing', function () {
     setupTest();
 
+    let billingService;
+
     before(function () {
         Sentry.init(getSentryTestConfig(sentryTransport));
     });
@@ -29,23 +31,46 @@ describe('Unit: Service: billing', function () {
     });
 
     afterEach(function () {
+        billingService?.clearBillingAppLoadMonitor();
+        billingService = null;
         sinon.restore();
     });
 
-    it('starts a load monitor for the billing app', async function () {
+    it('retries loading the billing app before reporting', async function () {
         const service = this.owner.lookup('service:billing');
+        billingService = service;
         service.billingAppLoadTimeoutMs = 1;
+        service.billingAppLoadRetryDelaysMs = [1];
+        const reloadBillingIframe = sinon.stub(service, 'reloadBillingIframe');
         const reportBillingAppLoadFailure = sinon.stub(service, 'reportBillingAppLoadFailure');
 
         service.startBillingAppLoadMonitor();
 
+        await waitUntil(() => reloadBillingIframe.called);
+        expect(reportBillingAppLoadFailure.called).to.be.false;
+
         await waitUntil(() => reportBillingAppLoadFailure.called);
 
+        expect(reloadBillingIframe.calledOnce).to.be.true;
         expect(reportBillingAppLoadFailure.calledOnce).to.be.true;
+    });
+
+    it('reloads the billing iframe during a retry', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const iframe = {src: ''};
+        sinon.stub(service, 'getBillingIframe').returns(iframe);
+        sinon.stub(service, 'getIframeURL').returns('https://billing.example.test/pro');
+
+        service.reloadBillingIframe();
+
+        expect(iframe.src).to.equal('https://billing.example.test/pro');
     });
 
     it('reports to Sentry when the billing app does not become ready', async function () {
         const service = this.owner.lookup('service:billing');
+        billingService = service;
+        service.billingAppLoadAttempts = 2;
 
         service.reportBillingAppLoadFailure();
 
@@ -58,6 +83,7 @@ describe('Unit: Service: billing', function () {
             source: 'billing-app-load-monitor'
         });
         expect(report.originalReport.contexts.ghost.full_error).to.deep.include({
+            attempts: 2,
             has_billing_url: true,
             is_force_upgrade: false
         });
@@ -65,11 +91,13 @@ describe('Unit: Service: billing', function () {
 
     it('does not report when the billing app becomes ready before the timeout', function () {
         const service = this.owner.lookup('service:billing');
+        billingService = service;
 
         service.startBillingAppLoadMonitor();
         service.markBillingAppLoaded();
 
         expect(service.billingAppLoadTimeout).to.be.null;
+        expect(service.billingAppRetryTimeout).to.be.null;
         expect(testkit.reports()).to.have.lengthOf(0);
     });
 
@@ -78,6 +106,7 @@ describe('Unit: Service: billing', function () {
         config.sentry_dsn = null;
 
         const service = this.owner.lookup('service:billing');
+        billingService = service;
 
         service.reportBillingAppLoadFailure();
 


### PR DESCRIPTION
## Summary
- Added a Billing iframe readiness monitor that reports to Sentry if the Billing app does not send a valid message within 10 seconds
- Starts monitoring when the Billing iframe src is assigned, matching the preload path before Ghost(Pro) is clicked
- Clears the monitor when the Billing iframe sends its first accepted message

ref [INC-284](https://app.incident.io/ghost/incidents/284)

## Testing
- `corepack pnpm exec eslint app/services/billing.js app/components/gh-billing-iframe.js tests/unit/services/billing-test.js --cache`
- `corepack pnpm exec ember exam --file-path tests/unit/services/billing-test.js --split 1 --parallel 1`