### PR TITLE
Fixed gift checkout cancel returning to site root instead of gift page

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.39",
+  "version": "2.68.40",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -608,6 +608,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
         },
 
         async checkoutGift({tierId, cadence} = {}) {
+            const siteUrlObj = new URL(siteUrl);
             const url = endpointFor({type: 'members', resource: 'create-stripe-checkout-session'});
 
             let identity = null;
@@ -617,6 +618,9 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 // Not authenticated - that's fine for gift purchases
             }
 
+            const cancelUrlObj = window.location.href.startsWith(siteUrlObj.href) ? new URL(window.location.href) : new URL(siteUrl);
+            cancelUrlObj.hash = '#/portal/gift';
+
             const body = {
                 identity,
                 metadata: {
@@ -624,7 +628,8 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 },
                 type: 'gift',
                 tierId,
-                cadence
+                cadence,
+                cancelUrl: cancelUrlObj.href
             };
 
             const response = await makeRequest({

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -789,7 +789,7 @@ module.exports = class RouterController {
                 ...data,
                 duration: 1, // gifts are currently 1 month or 1 year only
                 successUrl: this._urlUtils.getSiteUrl(),
-                cancelUrl: this._urlUtils.getSiteUrl()
+                cancelUrl: options.cancelUrl || this._urlUtils.getSiteUrl()
             });
         }
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -734,6 +734,26 @@ describe('RouterController', function () {
                 }));
             });
 
+            it('uses cancelUrl from the request body when provided', async function () {
+                const controller = createGiftController({tiersService: paidTierService()});
+
+                await controller.createCheckoutSession({
+                    body: {
+                        type: 'gift',
+                        tierId: 'tier_123',
+                        cadence: 'month',
+                        metadata: {},
+                        cancelUrl: 'https://example.com/post/#/portal/gift'
+                    }
+                }, mockRes);
+
+                sinon.assert.calledOnce(getGiftLinkSpy);
+                sinon.assert.calledWith(getGiftLinkSpy, sinon.match({
+                    successUrl: 'https://example.com/',
+                    cancelUrl: 'https://example.com/post/#/portal/gift'
+                }));
+            });
+
             it('rejects when giftSubscriptions labs flag is disabled', async function () {
                 labsService.isSet = sinon.stub().returns(false);
                 const controller = createGiftController();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3641

- portal wasn't sending a `cancelUrl` when creating a gift Stripe Checkout session, and the server was hardcoding `cancelUrl` to the site root, so cancelling mid-checkout dropped the user on the homepage
- portal now builds a `cancelUrl` that reopens `#/portal/gift` on the originating page, and the server honours `req.body.cancelUrl` for gift checkouts (falling back to the site root)
- `successUrl` stays server-controlled so the payments service can still augment it with the gift token, tier, and cadence query params the gift-success flow relies on
