### PR TITLE
Fixed broken gift page when Stripe is disconnected

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.40",
+  "version": "2.68.41",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -15,7 +15,7 @@ import {getActivePage, isAccountPage, isOfferPage} from './pages';
 import ActionHandler from './actions';
 import {getGiftRedemptionErrorMessage} from './utils/gift-redemption-notification';
 import './app.css';
-import {hasRecommendations, hasGiftSubscriptions, createNotification, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isRetentionOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
+import {hasRecommendations, hasGiftSubscriptions, canPurchaseGift, createNotification, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isRetentionOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {validateHexColor} from './utils/sanitize-html';
 import {handleDataAttributes} from './data-attributes';
 
@@ -189,7 +189,7 @@ export default class App extends React.Component {
             }
             const {page, pageQuery, pageData} = linkData;
             if (this.state.initStatus === 'success') {
-                if (page === 'gift' && !hasGiftSubscriptions({site: this.state.site})) {
+                if (page === 'gift' && !canPurchaseGift({site: this.state.site})) {
                     this.invalidateGiftRedemptionRequest();
                     removePortalLinkFromUrl();
 
@@ -733,7 +733,7 @@ export default class App extends React.Component {
                 };
             }
 
-            if (page === 'gift' && !hasGiftSubscriptions({site})) {
+            if (page === 'gift' && !canPurchaseGift({site})) {
                 removePortalLinkFromUrl();
 
                 return {};

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -274,6 +274,14 @@ export function hasGiftSubscriptions({site}) {
     return site?.labs?.giftSubscriptions === true;
 }
 
+export function isStripeConfigured({site}) {
+    return site?.is_stripe_configured === true;
+}
+
+export function canPurchaseGift({site}) {
+    return hasGiftSubscriptions({site}) && isStripeConfigured({site});
+}
+
 export function isSigninAllowed({site}) {
     return site?.members_signup_access !== 'none';
 }
@@ -604,11 +612,10 @@ export function getProductCadenceFromPrice({site, priceId}) {
 
 export function getAvailablePrices({site, products = null}) {
     const {
-        portal_plans: portalPlans = [],
-        is_stripe_configured: isStripeConfigured
+        portal_plans: portalPlans = []
     } = site || {};
 
-    if (!isStripeConfigured) {
+    if (!isStripeConfigured({site})) {
         return [];
     }
 

--- a/apps/portal/test/portal-links.test.js
+++ b/apps/portal/test/portal-links.test.js
@@ -435,6 +435,20 @@ describe('Portal Data links:', () => {
             expect(triggerButtonFrame).toBeInTheDocument();
             expect(popupFrame).not.toBeInTheDocument();
         });
+
+        test('does not open when Stripe is disconnected', async () => {
+            window.location.hash = '#/portal/gift';
+
+            let {
+                popupFrame, triggerButtonFrame
+            } = await setup({
+                site: {...FixtureSite.singleTier.withoutStripe, labs: {giftSubscriptions: true}},
+                showPopup: false
+            });
+
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(popupFrame).not.toBeInTheDocument();
+        });
     });
 
     describe('#/portal/gift/redeem/<token>', () => {

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -1,6 +1,8 @@
 import {
     getActiveInterval,
     hasGiftSubscriptions,
+    isStripeConfigured,
+    canPurchaseGift,
     hasAvailablePrices,
     getAllProductsForSite,
     getAvailableProducts,
@@ -933,6 +935,42 @@ describe('Helpers - ', () => {
 
         test('returns false when labs is undefined', () => {
             expect(hasGiftSubscriptions({site: {}})).toBe(false);
+        });
+    });
+
+    describe('isStripeConfigured', () => {
+        test('returns true when is_stripe_configured is true', () => {
+            expect(isStripeConfigured({site: {is_stripe_configured: true}})).toBe(true);
+        });
+
+        test('returns false when is_stripe_configured is false', () => {
+            expect(isStripeConfigured({site: {is_stripe_configured: false}})).toBe(false);
+        });
+
+        test('returns false when is_stripe_configured is missing', () => {
+            expect(isStripeConfigured({site: {}})).toBe(false);
+        });
+
+        test('returns false when site is undefined', () => {
+            expect(isStripeConfigured({})).toBe(false);
+        });
+    });
+
+    describe('canPurchaseGift', () => {
+        test('returns true when gift subscriptions enabled and Stripe configured', () => {
+            expect(canPurchaseGift({site: {labs: {giftSubscriptions: true}, is_stripe_configured: true}})).toBe(true);
+        });
+
+        test('returns false when gift subscriptions disabled', () => {
+            expect(canPurchaseGift({site: {labs: {giftSubscriptions: false}, is_stripe_configured: true}})).toBe(false);
+        });
+
+        test('returns false when Stripe is not configured', () => {
+            expect(canPurchaseGift({site: {labs: {giftSubscriptions: true}, is_stripe_configured: false}})).toBe(false);
+        });
+
+        test('returns false when both are missing', () => {
+            expect(canPurchaseGift({site: {}})).toBe(false);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3643

- visiting `/#/portal/gift` with the gift subscriptions labs flag on but Stripe disconnected rendered a half-empty "Gift subscriptions are not available right now" screen
- now mirrors the existing labs-flag-off behaviour: strip the portal link from the URL and never open the popup
- extracted `isStripeConfigured` and `canPurchaseGift` helpers so the two gift-purchase guard sites can't drift