### PR TITLE
Updated gift subscription copy across emails, portal, and editor

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
@@ -68,7 +68,7 @@ const PortalLinks: React.FC = () => {
                 <PortalLink name='Default' value={isDataAttributes ? 'data-portal' : `${homePageURL}#/portal`} />
                 <PortalLink name='Sign in' value={isDataAttributes ? 'data-portal="signin"' : `${homePageURL}#/portal/signin`} />
                 <PortalLink name='Sign up' value={isDataAttributes ? 'data-portal="signup"' : `${homePageURL}#/portal/signup`} />
-                {hasGiftSubscriptions && <PortalLink name='Gift subscription' value={isDataAttributes ? 'data-portal="gift"' : `${homePageURL}#/portal/gift`} />}
+                {hasGiftSubscriptions && <PortalLink name='Gift subscriptions' value={isDataAttributes ? 'data-portal="gift"' : `${homePageURL}#/portal/gift`} />}
             </List>
 
             <List className='mt-14' title='Tiers' titleSize='lg'>

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.38",
+  "version": "2.68.39",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -835,7 +835,7 @@ const GiftPage = () => {
                             <div className='gh-portal-gift-checkout-cta-wrapper'>
                                 <ActionButton
                                     dataTestId='purchase-gift'
-                                    label='Continue to checkout'
+                                    label='Continue'
                                     onClick={handlePurchase}
                                     disabled={isDisabled}
                                     isRunning={isPurchasing}

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -303,7 +303,7 @@ export default class KoenigLexicalEditor extends Component {
             const giftLink = () => {
                 if (this.feature.giftSubscriptions) {
                     return [{
-                        label: 'Gift subscription',
+                        label: 'Gift subscriptions',
                         value: '#/portal/gift'
                     }];
                 }

--- a/ghost/core/core/server/services/staff/email-templates/gift.hbs
+++ b/ghost/core/core/server/services/staff/email-templates/gift.hbs
@@ -28,7 +28,7 @@
                     {{/if}}
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
-                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">Someone purchased a gift&nbsp;subscription</h1>
+                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">A gift subscription was&nbsp;purchased</h1>
                         <table width="100" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background: #F4F5F6; border-radius: 8px;">
                           <tbody>
                             <tr>

--- a/ghost/core/core/server/services/staff/email-templates/gift.txt.js
+++ b/ghost/core/core/server/services/staff/email-templates/gift.txt.js
@@ -1,7 +1,7 @@
 module.exports = function giftText(data) {
     // Be careful when you indent the email, because whitespaces are visible in emails!
     return `
-Someone purchased a gift subscription
+A gift subscription was purchased
 
 From: ${data.gift.name}
 Tier: ${data.gift.tierName} • ${data.gift.cadenceLabel}

--- a/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.hbs
+++ b/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.hbs
@@ -33,7 +33,7 @@
                     {{/if}}
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
-                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">Someone redeemed a gift&nbsp;subscription</h1>
+                        <h1 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 26px; color: #15212A; font-weight: bold; line-height: 28px; margin: 0; padding-bottom: 24px;">A gift subscription was&nbsp;redeemed</h1>
                         <table width="100" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background: #F4F5F6; border-radius: 8px;">
                           <tbody>
                             <tr>

--- a/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.txt.js
+++ b/ghost/core/core/server/services/staff/email-templates/new-gift-subscription.txt.js
@@ -1,7 +1,7 @@
 module.exports = function (data) {
     // Be careful when you indent the email, because whitespaces are visible in emails!
     return `
-Someone redeemed a gift subscription
+A gift subscription was redeemed
 
 Member: ${data.memberData.name}
 Tier: ${data.tierData.name}${data.tierData.details ? ` • ${data.tierData.details}` : ''}


### PR DESCRIPTION
no issues

- reworded staff notification email headlines from "Someone purchased/redeemed a gift subscription" to "A gift subscription was purchased/redeemed" to match the event-style voice used in the other staff emails
- pluralised "Gift subscription" to "Gift subscriptions" in the editor card link and portal links to keep them consistent with other parts of the admin
- shortened "Continue to checkout" to "Continue" on the gift selection screen

