### PR TITLE
Hid gift "Continue subscription" button when Stripe is disconnected

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.41",
+  "version": "2.68.42",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/continue-gift-subscription-banner.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/continue-gift-subscription-banner.js
@@ -1,12 +1,13 @@
 import AppContext from '../../../../app-context';
 import ActionButton from '../../../common/action-button';
-import {getSubscriptionExpiry, isArchivedTier, isGiftMember} from '../../../../utils/helpers';
+import {getSubscriptionExpiry, isArchivedTier, isGiftMember, isStripeConfigured} from '../../../../utils/helpers';
 import {useContext} from 'react';
 
 const ContinueGiftSubscriptionBanner = () => {
     const {member, site, doAction, action, brandColor} = useContext(AppContext);
 
-    if (!isGiftMember({member}) || isArchivedTier({member, site})) {
+    const canContinueGiftSubscription = isGiftMember({member}) && !isArchivedTier({member, site}) && isStripeConfigured({site});
+    if (!canContinueGiftSubscription) {
         return null;
     }
 

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isArchivedTier, isComplimentaryMember, isGiftMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isArchivedTier, isComplimentaryMember, isGiftMember, isPaidMember, isStripeConfigured, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as GiftIcon} from '../../../../images/icons/gift.svg';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
@@ -16,8 +16,7 @@ const PaidAccountActions = () => {
     };
 
     const openUpdatePlan = () => {
-        const {is_stripe_configured: isStripeConfigured} = site;
-        if (isStripeConfigured) {
+        if (isStripeConfigured({site})) {
             doAction('switchPage', {
                 page: 'accountPlan',
                 lastPage: 'accountHome'
@@ -100,6 +99,11 @@ const PaidAccountActions = () => {
 
     const PlanUpdateButton = ({isPaid}) => {
         const hasGiftSubscription = isGiftMember({member});
+
+        if (hasGiftSubscription && !isStripeConfigured({site})) {
+            return null;
+        }
+
         const canContinueGiftSubscription = hasGiftSubscription && !isArchivedTier({member, site});
 
         // If no paid tiers are available, hide the plan update button for:

--- a/apps/portal/test/unit/components/pages/AccountHomePage/continue-gift-subscription-banner.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/continue-gift-subscription-banner.test.js
@@ -1,0 +1,85 @@
+import {render} from '../../../../utils/test-utils';
+import ContinueGiftSubscriptionBanner from '../../../../../src/components/pages/AccountHomePage/components/continue-gift-subscription-banner';
+import {getMemberData, getProductsData, getSiteData, getSubscriptionData} from '../../../../../src/utils/fixtures-generator';
+
+const setup = (overrides) => {
+    return render(
+        <ContinueGiftSubscriptionBanner />,
+        {
+            overrideContext: {
+                ...overrides
+            }
+        }
+    );
+};
+
+const buildGiftMember = ({tierId}) => getMemberData({
+    paid: true,
+    status: 'gift',
+    subscriptions: [
+        getSubscriptionData({
+            status: 'active',
+            amount: 0,
+            currency: 'USD',
+            interval: 'month',
+            tier: {id: tierId, expiry_at: new Date('2099-01-01T12:00:00.000Z')}
+        })
+    ]
+});
+
+describe('ContinueGiftSubscriptionBanner', () => {
+    test('renders the "Continue subscription" button for a gift member on an active tier', () => {
+        const products = getProductsData({numOfProducts: 1});
+        const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+        const member = buildGiftMember({tierId: products[0].id});
+
+        const {queryByText} = setup({site, member});
+
+        expect(queryByText('Continue subscription')).toBeInTheDocument();
+    });
+
+    test('renders nothing when Stripe is disconnected', () => {
+        const products = getProductsData({numOfProducts: 1});
+        const site = getSiteData({
+            products,
+            portalProducts: products.map(p => p.id),
+            isStripeConfigured: false
+        });
+        const member = buildGiftMember({tierId: products[0].id});
+
+        const {queryByText} = setup({site, member});
+
+        expect(queryByText('Continue subscription')).not.toBeInTheDocument();
+    });
+
+    test('renders nothing for a non-gift member', () => {
+        const products = getProductsData({numOfProducts: 1});
+        const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+        const member = getMemberData({
+            paid: true,
+            subscriptions: [
+                getSubscriptionData({
+                    status: 'active',
+                    amount: 500,
+                    currency: 'USD',
+                    interval: 'month'
+                })
+            ]
+        });
+
+        const {queryByText} = setup({site, member});
+
+        expect(queryByText('Continue subscription')).not.toBeInTheDocument();
+    });
+
+    test('renders nothing when the gift tier has been archived', () => {
+        const products = getProductsData({numOfProducts: 1});
+        const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+        // Member's tier id is not in site.products → archived tier
+        const member = buildGiftMember({tierId: 'product_archived'});
+
+        const {queryByText} = setup({site, member});
+
+        expect(queryByText('Continue subscription')).not.toBeInTheDocument();
+    });
+});

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -549,6 +549,21 @@ describe('PaidAccountActions', () => {
             expect(container.querySelector('[data-test-button="change-plan"]')).not.toBeInTheDocument();
         });
 
+        test('renders nothing for a gift member when Stripe is disconnected', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({
+                products,
+                portalProducts: products.map(p => p.id),
+                isStripeConfigured: false
+            });
+            const member = buildGiftMember({tierId: products[0].id});
+
+            const {container} = setup({site, member});
+
+            expect(container.querySelector('[data-test-button="continue-gift-subscription"]')).not.toBeInTheDocument();
+            expect(container.querySelector('[data-test-button="change-plan"]')).not.toBeInTheDocument();
+        });
+
         test('renders "Change" for a gift member when the tier has been archived', () => {
             // Archived tier = tier id absent from site.products
             const {site} = buildPaidSite();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3644/

- gift members on a site with Stripe disconnected were shown a "Continue subscription" button that always failed at checkout with a generic "Failed to process checkout" error
- the banner and the inline plan-update button both now return `null` for gift members when `site.is_stripe_configured` is false, matching the existing canPurchaseGift gate used elsewhere in Portal
- also updated `openUpdatePlan` to use the `isStripeConfigured` helper so the whole file uses a single consistent Stripe check
