### PR TITLE
Fixed plan upgrade for gift members on an archived tier

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.38",
+  "version": "2.68.39",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
+import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isArchivedTier, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isGiftMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 import {translateCadence} from '../../utils/helpers';
@@ -93,6 +93,9 @@ const Header = ({showConfirmation, confirmationType, pendingOffer}) => {
 const CancelSubscriptionButton = ({member, onCancelSubscription, action, brandColor}) => {
     const {site} = useContext(AppContext);
     if (!member.paid) {
+        return null;
+    }
+    if (isGiftMember({member})) {
         return null;
     }
     const subscription = getMemberSubscription({member});
@@ -441,8 +444,8 @@ const PlansContainer = ({
     onAcceptRetentionOffer, onDeclineRetentionOffer
 }) => {
     const {member} = useContext(AppContext);
-    // Plan upgrade flow for free member or complimentary member
-    if (!isPaidMember({member}) || isComplimentaryMember({member})) {
+    // Plan upgrade flow for free, complimentary, or gift members.
+    if (!isPaidMember({member}) || isComplimentaryMember({member}) || isGiftMember({member})) {
         return (
             <UpgradePlanSection
                 {...{plans, selectedPlan, onPlanSelect, onPlanCheckout}}
@@ -493,10 +496,19 @@ export default class AccountPlanPage extends React.Component {
     }
 
     componentDidMount() {
-        const {member} = this.context;
+        const {member, site} = this.context;
         if (!member) {
             this.context.doAction('switchPage', {
                 page: 'signin'
+            });
+            return;
+        }
+
+        // Gift members on an active tier can only continue on the same tier via AccountHomePage "Continue" button
+        // Redirect them home if they land here via deep link (#/portal/account/plans)
+        if (isGiftMember({member}) && !isArchivedTier({member, site})) {
+            this.context.doAction('switchPage', {
+                page: 'accountHome'
             });
             return;
         }
@@ -611,7 +623,7 @@ export default class AccountPlanPage extends React.Component {
             selectedPlan = priceId;
         }
 
-        if (isPaidMember({member}) && !isComplimentaryMember({member})) {
+        if (isPaidMember({member}) && !isComplimentaryMember({member}) && !isGiftMember({member})) {
             const subscription = getMemberSubscription({member});
             const subscriptionId = subscription ? subscription.id : '';
             if (subscriptionId) {
@@ -627,8 +639,8 @@ export default class AccountPlanPage extends React.Component {
 
         const {member} = this.context;
 
-        // Work as checkboxes for free member plan selection and button for paid members
-        if (!isPaidMember({member}) || isComplimentaryMember({member})) {
+        // Work as checkboxes for free, complimentary, and gift members and as button for paid Stripe members.
+        if (!isPaidMember({member}) || isComplimentaryMember({member}) || isGiftMember({member})) {
             // Hack: React checkbox gets out of sync with dom state with instant update
             this.timeoutId = setTimeout(() => {
                 this.setState(() => {

--- a/apps/portal/test/unit/components/pages/account-plan-page.test.js
+++ b/apps/portal/test/unit/components/pages/account-plan-page.test.js
@@ -727,4 +727,107 @@ describe('Account Plan Page', () => {
         expect(queryByText('20% off')).toBeInTheDocument();
         expect(queryByText('Save 20% on your next 3 billing cycles. Then $10/month.')).toBeInTheDocument();
     });
+
+    describe('gift members', () => {
+        const buildGiftMember = ({tier}) => {
+            const subscription = getSubscriptionData({
+                status: 'active',
+                interval: 'month',
+                amount: 1200,
+                currency: 'USD',
+                priceId: '',
+                tier: {
+                    id: tier.id,
+                    name: tier.name,
+                    expiry_at: '2027-01-11T00:00:00.000Z'
+                }
+            });
+            subscription.id = '';
+            subscription.price.id = '';
+            subscription.price.product.product_id = tier.id;
+
+            return getMemberData({
+                status: 'gift',
+                paid: true,
+                subscriptions: [subscription]
+            });
+        };
+
+        describe('on an archived tier', () => {
+            test('hides the Cancel subscription button and allows to upgrade to a new plan', async () => {
+                const premiumTier = getProductData({
+                    name: 'Premium',
+                    monthlyPrice: getPriceData({interval: 'month', amount: 1500, currency: 'usd'}),
+                    yearlyPrice: getPriceData({interval: 'year', amount: 15000, currency: 'usd'})
+                });
+                const ultraTier = getProductData({
+                    name: 'Ultra',
+                    monthlyPrice: getPriceData({interval: 'month', amount: 2500, currency: 'usd'}),
+                    yearlyPrice: getPriceData({interval: 'year', amount: 25000, currency: 'usd'})
+                });
+
+                const archivedTier = getProductData({
+                    name: 'Archived Tier',
+                    monthlyPrice: getPriceData({interval: 'month', amount: 1200, currency: 'usd'}),
+                    yearlyPrice: getPriceData({interval: 'year', amount: 12000, currency: 'usd'})
+                });
+
+                // Archived tiers are filtered out of site.products by the backend
+                const site = getSiteData({
+                    products: [premiumTier, ultraTier, getProductData({type: 'free'})],
+                    portalProducts: [premiumTier.id, ultraTier.id]
+                });
+
+                const member = buildGiftMember({tier: archivedTier});
+
+                const {queryByRole, queryAllByRole, mockDoActionFn} = customSetup({site, member});
+
+                expect(queryByRole('button', {name: 'Cancel subscription'})).not.toBeInTheDocument();
+                expect(queryByRole('button', {name: 'Confirm cancellation'})).not.toBeInTheDocument();
+
+                const chooseButtons = queryAllByRole('button', {name: 'Choose'});
+                expect(chooseButtons.length).toBeGreaterThan(0);
+
+                fireEvent.click(chooseButtons[0]);
+
+                expect(mockDoActionFn).toHaveBeenCalledWith('checkoutPlan', expect.objectContaining({plan: expect.any(String)}));
+                expect(mockDoActionFn).not.toHaveBeenCalledWith('updateSubscription', expect.anything());
+                expect(mockDoActionFn).not.toHaveBeenCalledWith('cancelSubscription', expect.anything());
+            });
+        });
+
+        describe('on an active tier', () => {
+            test('hides the cancellations button and allows to continue on the same tier', () => {
+                const activeTier = getProductData({
+                    name: 'Basic',
+                    monthlyPrice: getPriceData({interval: 'month', amount: 1200, currency: 'usd'}),
+                    yearlyPrice: getPriceData({interval: 'year', amount: 12000, currency: 'usd'})
+                });
+                const otherTier = getProductData({
+                    name: 'Premium',
+                    monthlyPrice: getPriceData({interval: 'month', amount: 2000, currency: 'usd'}),
+                    yearlyPrice: getPriceData({interval: 'year', amount: 20000, currency: 'usd'})
+                });
+
+                const site = getSiteData({
+                    products: [activeTier, otherTier, getProductData({type: 'free'})],
+                    portalProducts: [activeTier.id, otherTier.id]
+                });
+
+                const member = buildGiftMember({tier: activeTier});
+
+                const {mockDoActionFn, queryByRole} = customSetup({site, member});
+
+                // No "Cancel subscription" — gift subs cannot be cancelled.
+                expect(queryByRole('button', {name: 'Cancel subscription'})).not.toBeInTheDocument();
+
+                // Active-tier gift members are bounced back to AccountHomePage where their only
+                // option is to "Continue" on the same tier (via continueGiftSubscription). The
+                // change-plan UI is not available to them.
+                expect(mockDoActionFn).toHaveBeenCalledWith('switchPage', {page: 'accountHome'});
+                expect(mockDoActionFn).not.toHaveBeenCalledWith('checkoutPlan', expect.anything());
+                expect(mockDoActionFn).not.toHaveBeenCalledWith('updateSubscription', expect.anything());
+            });
+        });
+    });
 });


### PR DESCRIPTION
ref [BER-3642](https://linear.app/ghost/issue/BER-3642)

Fixed a dead-end in Portal where gift members on an archived tier couldn't switch to another tier. Clicking "Choose" on a different tier opened the cancellation form, and clicking "Confirm cancellation" did nothing.

#### Context
Gift members on an active tier can only continue on the same tier (as their remaining gift days are converted into trial time). However, gift members on an archived tier cannot continue on the same tier (as the tier is archived), and therefore should be allowed to change plans.

#### Changes
- Routed gift members on an archived tier to the same upgrade flow as comped members
- Prevented gift members on an active tier from reaching the upgrade screen via a deep link (#/portal/account/plans)
- Hid the cancellation button for all gift members