### PR TITLE
Fixed avatar aspect ratio in add details popup

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/components/popups/add-details-popup.tsx
+++ b/apps/comments-ui/src/components/popups/add-details-popup.tsx
@@ -80,7 +80,7 @@ const AddDetailsPopup = (props: Props) => {
                     appear
                 >
                     <div className="flex flex-row items-center justify-start gap-3 pr-4">
-                        <div className="size-10 rounded-full border-2 border-white bg-cover bg-no-repeat" style={{backgroundImage: `url(${profile.avatar})`}} />
+                        <div className="size-10 shrink-0 rounded-full border-2 border-white bg-cover bg-no-repeat" style={{backgroundImage: `url(${profile.avatar})`}} />
                         <div className="flex flex-col items-start justify-center">
                             <div className="font-sans text-base font-semibold tracking-tight text-white">
                                 {profile.name}


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1373/oss-issue-ui-avatar-aspect-ratio-on-comments-due-to-expertise and https://github.com/TryGhost/Ghost/issues/27795

Ensures that avatars retain their aspect ratio when expertise wrap over more than 1 line.

| Before | After |
|--------|--------|
| <img width="761" height="464" alt="Screenshot 2026-05-12 at 10 42 12" src="https://github.com/user-attachments/assets/518d1e42-04a0-43ff-ab26-3bee025bc9a3" /> | <img width="769" height="466" alt="Screenshot 2026-05-12 at 10 41 45" src="https://github.com/user-attachments/assets/41f30b63-331e-4a31-9371-45b8855e860e" /> | 
