### PR TITLE
✨ Added {{#social_accounts}} block helper for theme social rendering

### DIFF
--- a/ghost/core/core/frontend/helpers/social_accounts.js
+++ b/ghost/core/core/frontend/helpers/social_accounts.js
@@ -1,13 +1,13 @@
 // # Social Accounts Helper
 // Usage:
 //   {{#social_accounts @site}}
-//       <a href="{{url}}" target="_blank" rel="noopener" aria-label="{{name}}">
+//       <a href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
 //           {{> (concat "icons/" type)}}
 //       </a>
 //   {{/social_accounts}}
 //
 // Iterates over the social accounts on the given source object in canonical
-// order, yielding `{type, url, username, name}` for each platform with a
+// order, yielding `{type, href, username, name}` for each platform with a
 // username set.
 //
 // A source must be passed explicitly:
@@ -65,7 +65,7 @@ module.exports = function social_accounts(source, options) { // eslint-disable-l
     const accounts = SOCIAL_PLATFORMS.reduce((acc, {type, name}) => {
         const username = source && source[type];
         if (username && typeof socialUrls[type] === 'function') {
-            acc.push({type, name, username, url: socialUrls[type](username)});
+            acc.push({type, name, username, href: socialUrls[type](username)});
         }
         return acc;
     }, []);

--- a/ghost/core/core/frontend/helpers/social_accounts.js
+++ b/ghost/core/core/frontend/helpers/social_accounts.js
@@ -1,0 +1,91 @@
+// # Social Accounts Helper
+// Usage:
+//   {{#social_accounts @site}}
+//       <a href="{{url}}" target="_blank" rel="noopener" aria-label="{{name}}">
+//           {{> (concat "icons/" type)}}
+//       </a>
+//   {{/social_accounts}}
+//
+// Iterates over the social accounts on the given source object in canonical
+// order, yielding `{type, url, username, name}` for each platform with a
+// username set.
+//
+// A source must be passed explicitly:
+//   {{#social_accounts @site}}    - site-level accounts
+//   {{#social_accounts author}}   - a specific author
+//   {{#social_accounts this}}     - the current context (e.g. inside {{#foreach authors}})
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+const {socialUrls} = require('../services/proxy');
+const {hbs} = require('../services/handlebars');
+
+const createFrame = hbs.handlebars.createFrame;
+
+const messages = {
+    sourceRequired: 'The {{#social_accounts}} helper requires a source argument, e.g. {{#social_accounts @site}}...{{/social_accounts}}.',
+    blockRequired: 'The {{#social_accounts}} helper must be used as a block helper, e.g. {{#social_accounts @site}}...{{/social_accounts}}.'
+};
+
+// Canonical order mirrors the admin settings UI (SOCIAL_PLATFORM_KEYS).
+const SOCIAL_PLATFORMS = [
+    {type: 'twitter', name: 'X'},
+    {type: 'facebook', name: 'Facebook'},
+    {type: 'linkedin', name: 'LinkedIn'},
+    {type: 'bluesky', name: 'Bluesky'},
+    {type: 'threads', name: 'Threads'},
+    {type: 'mastodon', name: 'Mastodon'},
+    {type: 'tiktok', name: 'TikTok'},
+    {type: 'youtube', name: 'YouTube'},
+    {type: 'instagram', name: 'Instagram'}
+];
+
+module.exports = function social_accounts(source, options) { // eslint-disable-line camelcase
+    // {{#social_accounts}} with no positional arg: handlebars passes only options.
+    if (arguments.length < 2) {
+        throw new errors.IncorrectUsageError({
+            level: 'normal',
+            message: tpl(messages.sourceRequired),
+            help: 'https://ghost.org/docs/themes/helpers/social-accounts/'
+        });
+    }
+
+    options = options || {};
+    options.data = options.data || {};
+
+    const {fn, inverse, data} = options;
+
+    if (typeof fn !== 'function') {
+        throw new errors.IncorrectUsageError({
+            level: 'normal',
+            message: tpl(messages.blockRequired),
+            help: 'https://ghost.org/docs/themes/helpers/social-accounts/'
+        });
+    }
+
+    const accounts = SOCIAL_PLATFORMS.reduce((acc, {type, name}) => {
+        const username = source && source[type];
+        if (username && typeof socialUrls[type] === 'function') {
+            acc.push({type, name, username, url: socialUrls[type](username)});
+        }
+        return acc;
+    }, []);
+
+    if (!accounts.length) {
+        return inverse ? inverse(this) : '';
+    }
+
+    const frame = createFrame(data);
+    let output = '';
+
+    accounts.forEach((account, index) => {
+        frame.index = index;
+        frame.number = index + 1;
+        frame.first = index === 0;
+        frame.last = index === accounts.length - 1;
+        frame.even = index % 2 === 1;
+        frame.odd = !frame.even;
+        output += fn(account, {data: frame});
+    });
+
+    return output;
+};

--- a/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
@@ -51,10 +51,21 @@ describe('{{#social_accounts}} helper', function () {
     it('uses `href` (not `url`) for the link to avoid collision with the {{url}} helper', function () {
         // Register a stub `url` helper to ensure that {{href}} inside the block
         // resolves to the per-iteration property and not the global helper.
-        helpers.registerHelper('url', () => 'WRONG');
-        const out = compile(`{{#social_accounts @site}}{{href}};{{/social_accounts}}`)
-            .with({}, {data: {site: {twitter: 'me'}}});
-        assert.equal(out, 'https://x.com/me;');
+        // Use handlebars directly (not Ghost's idempotent registerHelper) so we
+        // can override and then restore the previous registration.
+        const originalUrlHelper = handlebars.helpers.url;
+        handlebars.registerHelper('url', () => 'WRONG');
+        try {
+            const out = compile(`{{#social_accounts @site}}{{href}};{{/social_accounts}}`)
+                .with({}, {data: {site: {twitter: 'me'}}});
+            assert.equal(out, 'https://x.com/me;');
+        } finally {
+            if (originalUrlHelper) {
+                handlebars.registerHelper('url', originalUrlHelper);
+            } else {
+                delete handlebars.helpers.url;
+            }
+        }
     });
 
     it('skips platforms without a username', function () {

--- a/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
@@ -42,10 +42,19 @@ describe('{{#social_accounts}} helper', function () {
         assert.equal(out, 'twitter|facebook|linkedin|bluesky|threads|mastodon|tiktok|youtube|instagram|');
     });
 
-    it('exposes type, url, username, and name per iteration', function () {
-        const out = compile(`{{#social_accounts @site}}{{type}}={{url}}|{{name}}|{{username}};{{/social_accounts}}`)
+    it('exposes type, href, username, and name per iteration', function () {
+        const out = compile(`{{#social_accounts @site}}{{type}}={{href}}|{{name}}|{{username}};{{/social_accounts}}`)
             .with({}, {data: {site: {twitter: 'testuser-tw', linkedin: 'testuser-li'}}});
         assert.equal(out, 'twitter=https://x.com/testuser-tw|X|testuser-tw;linkedin=https://www.linkedin.com/in/testuser-li|LinkedIn|testuser-li;');
+    });
+
+    it('uses `href` (not `url`) for the link to avoid collision with the {{url}} helper', function () {
+        // Register a stub `url` helper to ensure that {{href}} inside the block
+        // resolves to the per-iteration property and not the global helper.
+        helpers.registerHelper('url', () => 'WRONG');
+        const out = compile(`{{#social_accounts @site}}{{href}};{{/social_accounts}}`)
+            .with({}, {data: {site: {twitter: 'me'}}});
+        assert.equal(out, 'https://x.com/me;');
     });
 
     it('skips platforms without a username', function () {

--- a/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const errors = require('@tryghost/errors');
 const handlebars = require('../../../../core/frontend/services/theme-engine/engine').handlebars;
 const helpers = require('../../../../core/frontend/services/helpers');
 const social_accounts = require('../../../../core/frontend/helpers/social_accounts');
@@ -107,14 +108,14 @@ describe('{{#social_accounts}} helper', function () {
     it('throws an IncorrectUsageError when called with no source', function () {
         assert.throws(
             () => compile(`{{#social_accounts}}x{{/social_accounts}}`).with({}),
-            /requires a source argument/
+            err => err instanceof errors.IncorrectUsageError && /requires a source argument/.test(err.message)
         );
     });
 
     it('throws an IncorrectUsageError when used as an inline helper', function () {
         assert.throws(
             () => compile(`{{social_accounts @site}}`).with({}),
-            /must be used as a block helper/
+            err => err instanceof errors.IncorrectUsageError && /must be used as a block helper/.test(err.message)
         );
     });
 

--- a/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
@@ -1,0 +1,106 @@
+const assert = require('node:assert/strict');
+const handlebars = require('../../../../core/frontend/services/theme-engine/engine').handlebars;
+const helpers = require('../../../../core/frontend/services/helpers');
+const social_accounts = require('../../../../core/frontend/helpers/social_accounts');
+
+const socialData = {
+    facebook: 'testuser-fb',
+    twitter: 'testuser-tw',
+    linkedin: 'testuser-li',
+    threads: 'testuser-th',
+    bluesky: 'testuser.bsky.social',
+    mastodon: 'mastodon.social/@testuser',
+    tiktok: 'testuser-tt',
+    youtube: 'testuser-yt',
+    instagram: 'testuser-ig'
+};
+
+let defaultGlobals;
+
+function compile(templateString) {
+    const template = handlebars.compile(templateString);
+    template.with = (locals = {}, globals) => {
+        globals = globals || defaultGlobals;
+        return template(locals, globals);
+    };
+    return template;
+}
+
+describe('{{#social_accounts}} helper', function () {
+    before(function () {
+        helpers.registerHelper('social_accounts', social_accounts);
+
+        defaultGlobals = {
+            data: {
+                site: {...socialData}
+            }
+        };
+    });
+
+    it('iterates over @site accounts in canonical order', function () {
+        const out = compile(`{{#social_accounts @site}}{{type}}|{{/social_accounts}}`).with({});
+        assert.equal(out, 'twitter|facebook|linkedin|bluesky|threads|mastodon|tiktok|youtube|instagram|');
+    });
+
+    it('exposes type, url, username, and name per iteration', function () {
+        const out = compile(`{{#social_accounts @site}}{{type}}={{url}}|{{name}}|{{username}};{{/social_accounts}}`)
+            .with({}, {data: {site: {twitter: 'testuser-tw', linkedin: 'testuser-li'}}});
+        assert.equal(out, 'twitter=https://x.com/testuser-tw|X|testuser-tw;linkedin=https://www.linkedin.com/in/testuser-li|LinkedIn|testuser-li;');
+    });
+
+    it('skips platforms without a username', function () {
+        const out = compile(`{{#social_accounts @site}}{{type}},{{/social_accounts}}`)
+            .with({}, {data: {site: {twitter: 'me', instagram: 'me-ig'}}});
+        assert.equal(out, 'twitter,instagram,');
+    });
+
+    it('renders the {{else}} block when nothing is set', function () {
+        const out = compile(`{{#social_accounts @site}}link{{else}}none{{/social_accounts}}`)
+            .with({}, {data: {site: {}}});
+        assert.equal(out, 'none');
+    });
+
+    it('returns an empty string when nothing is set and no else block is provided', function () {
+        const out = compile(`{{#social_accounts @site}}link{{/social_accounts}}`)
+            .with({}, {data: {site: {}}});
+        assert.equal(out, '');
+    });
+
+    it('iterates over a passed author object', function () {
+        const out = compile(`{{#social_accounts author}}{{type}}={{username}};{{/social_accounts}}`)
+            .with({author: {twitter: 'author-tw', bluesky: 'author.bsky.social'}});
+        assert.equal(out, 'twitter=author-tw;bluesky=author.bsky.social;');
+    });
+
+    it('iterates over the current context with `this`', function () {
+        const out = compile(`{{#social_accounts this}}{{type}}={{username}};{{/social_accounts}}`)
+            .with({twitter: 'ctx-tw', mastodon: 'mastodon.social/@me'});
+        assert.equal(out, 'twitter=ctx-tw;mastodon=mastodon.social/@me;');
+    });
+
+    it('exposes @first, @last, @index iteration vars', function () {
+        const out = compile(`{{#social_accounts @site}}{{@index}}:{{type}}{{#if @first}}!{{/if}}{{#if @last}}*{{/if}} {{/social_accounts}}`)
+            .with({}, {data: {site: {twitter: 'tw', facebook: 'fb', instagram: 'ig'}}});
+        assert.equal(out, '0:twitter! 1:facebook 2:instagram* ');
+    });
+
+    it('throws an IncorrectUsageError when called with no source', function () {
+        assert.throws(
+            () => compile(`{{#social_accounts}}x{{/social_accounts}}`).with({}),
+            /requires a source argument/
+        );
+    });
+
+    it('throws an IncorrectUsageError when used as an inline helper', function () {
+        assert.throws(
+            () => compile(`{{social_accounts @site}}`).with({}),
+            /must be used as a block helper/
+        );
+    });
+
+    it('renders nothing when source is undefined (variable not in scope)', function () {
+        const out = compile(`{{#social_accounts missingVar}}x{{else}}none{{/social_accounts}}`)
+            .with({});
+        assert.equal(out, 'none');
+    });
+});

--- a/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
@@ -13,7 +13,7 @@ describe('Helpers', function () {
         'asset', 'authors', 'body_class', 'cancel_link', 'color_to_rgba', 'concat', 'content', 'content_api_key', 'content_api_url', 'contrast_text_color', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
         'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'json', 'link', 'link_class', 'meta_description', 'meta_title', 'navigation',
         'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'price', 'raw', 'reading_time', 'split', 't', 'tags', 'title','total_members', 'total_paid_members', 'twitter_url',
-        'url', 'comment_count', 'collection', 'recommendations', 'readable_url', 'social_url'
+        'url', 'comment_count', 'collection', 'recommendations', 'readable_url', 'social_url', 'social_accounts'
     ];
     const experimentalHelpers = ['match', 'tiers', 'comments', 'search'];
 


### PR DESCRIPTION
## Summary

Adds a `{{#social_accounts}}` block helper that iterates over the connected social platforms on a given source object, replacing the ~27 lines of repetitive `{{#if twitter}}…{{#if facebook}}…` blocks that themes currently need for a row of social icons.

```hbs
{{#social_accounts @site}}
    <a class="gh-social-link" href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
        {{> (concat "icons/" type)}}
    </a>
{{/social_accounts}}
```

Per-iteration the helper exposes `{type, href, username, name}` plus standard `@first` / `@last` / `@index` frame vars. The link uses `href` rather than `url` to avoid colliding with the existing `{{url}}` helper, which would otherwise win over the per-iteration property in the handlebars resolution order. Themes keep full control of their markup (wrapper classes, icon partials, link attributes); the helper just iterates platforms with a username set and builds the URL via `@tryghost/social-urls`. Platform order matches the admin "Social accounts" settings UI.

## Design — one obvious way, no magic

The source object **must** be passed explicitly as a positional argument:

```hbs
{{#social_accounts @site}}…{{/social_accounts}}     {{!-- site-level accounts --}}
{{#social_accounts author}}…{{/social_accounts}}    {{!-- a specific author --}}
{{#foreach authors}}
    {{#social_accounts this}}…{{/social_accounts}}  {{!-- inside an author loop --}}
{{/foreach}}
```

Calling it bare (`{{#social_accounts}}`) or as an inline helper (no `#`) throws an `IncorrectUsageError` with a help link.

We deliberately chose **not** to follow the implicit-context-fallback pattern used by `{{social_url type=…}}` (which walks `this` then falls back to `@site` via `localUtils.findKey`). Reasons:

- **Self-documenting call sites.** Reading any usage tells you exactly which object is being rendered, with no need to know the surrounding template scope.
- **No surprises in nested contexts.** Inside `{{#foreach authors}}`, magic context-walking would silently switch source — convenient when intended, confusing when not.
- **Symmetric.** Neither site nor author is privileged.
- **One-way door.** Strict-now is easy to loosen later if it proves painful; adding magic now is hard to remove without a breaking change.
- **Fail loud.** Silent empty output is a theme-developer debugging nightmare across thousands of sites; an `IncorrectUsageError` at theme-dev time is the kindness.

## Naming

Considered two options:

1. **`{{#social_accounts}}`** (chosen) — formal, matches the admin "Social accounts" settings section verbatim, consistent with Ghost's snake_case helper convention (`social_url`, `meta_description`, `reading_time`, etc.).
2. **`{{#socials}}`** — colloquial, shorter, reads more naturally at the call site (`{{#socials @site}}…{{/socials}}`). Matches how people actually talk about these and Ghost's friendly product tone, but breaks the formal-name convention every other helper follows and loses the direct lexical link to the admin UI section.

Landed on `social_accounts` for consistency with the existing helper family and the admin UI. **Swap to `socials` is trivial if we decide that way** — rename the file, the test file, three identifier mentions in each, and one string in the error message; one-minute change.

## Test plan

- [x] `pnpm test:single test/unit/frontend/helpers/social-accounts.test.js` — 11 passing
- [x] `pnpm test:single test/unit/frontend/helpers/social-url.test.js` — 21 passing (no regression in the related helper)
- [x] `npx eslint` clean on both new files
- [x] CodeRabbit pre-check addressed (added block-only guard; skipped string-typeof guard as schema-typed fields make it noise)

Tests cover: canonical order, per-iteration fields, skipping unset platforms, `{{else}}` block, all three source patterns (`@site` / named var / `this`), iteration vars, throw-on-bare, throw-on-inline, silent-render when source variable is undefined.
