### PR TITLE
Enabled FK in fake automations database

### DIFF
--- a/ghost/core/core/server/services/automations/temporary-fake-database.js
+++ b/ghost/core/core/server/services/automations/temporary-fake-database.js
@@ -20,6 +20,7 @@ function createTemporaryFakeAutomationsDatabase() {
     const {DatabaseSync} = require('node:sqlite');
 
     const database = new DatabaseSync(':memory:');
+    database.exec('PRAGMA foreign_keys = ON;');
 
     const id = () => ObjectId().toHexString();
     const now = () => new Date().toISOString();


### PR DESCRIPTION
no ref

SQLite doesn't enable foreign keys by default. Let's enable them.
