### PR TITLE
Made RSS renderer synchronous

### DIFF
--- a/ghost/core/core/frontend/services/rss/cache.js
+++ b/ghost/core/core/frontend/services/rss/cache.js
@@ -3,6 +3,9 @@ const generateFeed = require('./generate-feed');
 const logging = require('@tryghost/logging');
 const feedCache = {};
 
+/**
+ * @returns {string}
+ */
 module.exports.getXML = function getFeedXml(baseUrl, data) {
     const dataHash = crypto.createHash('md5').update(JSON.stringify(data)).digest('hex');
     if (!feedCache[baseUrl] || feedCache[baseUrl].hash !== dataHash) {

--- a/ghost/core/core/frontend/services/rss/generate-feed.js
+++ b/ghost/core/core/frontend/services/rss/generate-feed.js
@@ -70,6 +70,7 @@ const generateItem = function generateItem(post) {
  *
  * @param {string} baseUrl
  * @param {{title, description, safeVersion, posts}} data
+ * @returns {string}
  */
 const generateFeed = function generateFeed(baseUrl, data) {
     const feed = new RSS({
@@ -86,14 +87,12 @@ const generateFeed = function generateFeed(baseUrl, data) {
         }
     });
 
-    return data.posts.reduce((feedPromise, post) => {
-        return feedPromise.then(() => {
-            const item = generateItem(post);
-            return feed.item(item);
-        });
-    }, Promise.resolve()).then(() => {
-        return feed.xml();
-    });
+    for (const post of data.posts) {
+        const item = generateItem(post);
+        feed.item(item);
+    }
+
+    return feed.xml();
 };
 
 module.exports = generateFeed;

--- a/ghost/core/core/frontend/services/rss/renderer.js
+++ b/ghost/core/core/frontend/services/rss/renderer.js
@@ -6,10 +6,7 @@ module.exports.render = function render(res, baseUrl, data) {
     const rssData = _.merge({}, res.locals, data);
 
     // Fetch RSS from the cache
-    return rssCache
-        .getXML(baseUrl, rssData)
-        .then(function then(feedXml) {
-            res.set('Content-Type', 'application/rss+xml; charset=UTF-8');
-            res.send(feedXml);
-        });
+    const feedXml = rssCache.getXML(baseUrl, rssData);
+    res.set('Content-Type', 'application/rss+xml; charset=UTF-8');
+    res.send(feedXml);
 };

--- a/ghost/core/test/unit/frontend/services/rss/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/renderer.test.js
@@ -24,10 +24,10 @@ describe('RSS: Renderer', function () {
         sinon.restore();
     });
 
-    it('calls the cache and attempts to render, even without data', async function () {
-        rssCacheStub.returns(Promise.resolve('dummyxml'));
+    it('calls the cache and attempts to render, even without data', function () {
+        rssCacheStub.returns('dummyxml');
 
-        await renderer.render(res, baseUrl);
+        renderer.render(res, baseUrl);
         sinon.assert.calledOnce(rssCacheStub);
         assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
 
@@ -38,12 +38,12 @@ describe('RSS: Renderer', function () {
         sinon.assert.calledWith(res.send, 'dummyxml');
     });
 
-    it('correctly merges locals into empty data before rendering', async function () {
-        rssCacheStub.returns(Promise.resolve('dummyxml'));
+    it('correctly merges locals into empty data before rendering', function () {
+        rssCacheStub.returns('dummyxml');
 
         res.locals = {foo: 'bar'};
 
-        await renderer.render(res, baseUrl);
+        renderer.render(res, baseUrl);
         sinon.assert.calledOnce(rssCacheStub);
         assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'bar'}]);
 
@@ -54,13 +54,13 @@ describe('RSS: Renderer', function () {
         sinon.assert.calledWith(res.send, 'dummyxml');
     });
 
-    it('correctly merges locals into non-empty data before rendering', async function () {
-        rssCacheStub.returns(Promise.resolve('dummyxml'));
+    it('correctly merges locals into non-empty data before rendering', function () {
+        rssCacheStub.returns('dummyxml');
 
         res.locals = {foo: 'bar'};
         const data = {foo: 'baz', fizz: 'buzz'};
 
-        await renderer.render(res, baseUrl, data);
+        renderer.render(res, baseUrl, data);
         sinon.assert.calledOnce(rssCacheStub);
         assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'baz', fizz: 'buzz'}]);
 
@@ -71,10 +71,10 @@ describe('RSS: Renderer', function () {
         sinon.assert.calledWith(res.send, 'dummyxml');
     });
 
-    it('does nothing if it gets an error', async function () {
-        rssCacheStub.returns(Promise.reject(new Error('Fake Error')));
+    it('does nothing if it gets an error', function () {
+        rssCacheStub.throws(new Error('Fake Error'));
 
-        await assert.rejects(() => renderer.render(res, baseUrl), {
+        assert.throws(() => renderer.render(res, baseUrl), {
             message: 'Fake Error'
         });
 


### PR DESCRIPTION
no ref

*I recommend [reviewing this with whitespace changes disabled](https://github.com/TryGhost/Ghost/pull/27841/changes?w=1).*

It was already synchronous, but we made it async for no reason I could see. This change should have no user impact.
