### PR TITLE
Removed useless `models.init()`

### DIFF
--- a/ghost/core/core/server/models/index.js
+++ b/ghost/core/core/server/models/index.js
@@ -189,16 +189,3 @@ exports.Webhook = Webhook;
 exports.Webhooks = Webhooks;
 exports.WelcomeEmailAutomatedEmail = WelcomeEmailAutomatedEmail;
 exports.WelcomeEmailAutomationRun = WelcomeEmailAutomationRun;
-
-function init() {
-    // `init` used to be a necessary call, but now it's unnecessary.
-    // Ghost(Pro) still calls it, though, so we define a no-op.
-    // Once Ghost(Pro) stops calling it, we can remove this function.
-    // See the relevant PR in Ghost-Moya.
-}
-
-/**
- * Expose `init`
- */
-
-exports.init = init;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1268

Now that we've removed all callers, we can remove this function.
