### PR TITLE
Validated `successUrl` / `cancelUrl` / `returnUrl` origin in Stripe checkout

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -65,6 +65,45 @@ function extractGiftToken(input) {
     return input.trim();
 }
 
+/**
+ * Validate that a candidate return URL (e.g. Stripe Checkout success/cancel URL) points back
+ * to the configured Ghost site. Returns `undefined` when the candidate is missing, malformed,
+ * on a different origin, or outside of the site's subpath (for subpath installs) — leaving
+ * the downstream Stripe service to fall back to its configured default URL.
+ *
+ * This prevents the public checkout endpoints being abused as open-redirect surfaces.
+ *
+ * @param {string | undefined} candidate - URL provided in the request body
+ * @param {string} siteUrl - The site URL returned by urlUtils.getSiteUrl()
+ * @returns {string | undefined} The candidate URL if same-origin, otherwise undefined
+ */
+function sanitizeReturnUrl(candidate, siteUrl) {
+    if (typeof candidate !== 'string' || candidate.length === 0) {
+        return undefined;
+    }
+
+    let site;
+    let url;
+
+    try {
+        site = new URL(siteUrl);
+        url = new URL(candidate);
+    } catch {
+        return undefined;
+    }
+
+    if (url.origin !== site.origin) {
+        return undefined;
+    }
+
+    // Normalize site/candidate paths to trailing-slash form so that /blog and /blog/
+    // are treated equivalently when the site is configured at a subpath.
+    const sitePath = site.pathname.endsWith('/') ? site.pathname : `${site.pathname}/`;
+    const urlPath = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`;
+
+    return urlPath.startsWith(sitePath) ? url.href : undefined;
+}
+
 module.exports = class RouterController {
     #inboxLinksDnsResolver = new dns.Resolver({maxTimeout: 1000});
 
@@ -202,9 +241,10 @@ module.exports = class RouterController {
             customer = await this._stripeAPIService.getCustomer(subscription.get('customer_id'));
         }
 
+        const siteUrl = this._urlUtils.getSiteUrl();
         const session = await this._stripeAPIService.createCheckoutSetupSession(customer, {
-            successUrl: req.body.successUrl,
-            cancelUrl: req.body.cancelUrl,
+            successUrl: sanitizeReturnUrl(req.body.successUrl, siteUrl),
+            cancelUrl: sanitizeReturnUrl(req.body.cancelUrl, siteUrl),
             subscription_id: req.body.subscription_id,
             currency
         });
@@ -267,8 +307,9 @@ module.exports = class RouterController {
 
         const configurationId = this._settingsCache.get('stripe_billing_portal_configuration_id');
 
+        const siteUrl = this._urlUtils.getSiteUrl();
         const session = await this._stripeAPIService.createBillingPortalSession(customer, {
-            returnUrl: req.body.returnUrl,
+            returnUrl: sanitizeReturnUrl(req.body.returnUrl, siteUrl),
             ...(configurationId && {configurationId})
         });
         const sessionInfo = {
@@ -694,10 +735,14 @@ module.exports = class RouterController {
             metadata.newsletters = JSON.stringify(await this._validateNewsletters(JSON.parse(metadata.newsletters)));
         }
 
+        const siteUrl = this._urlUtils.getSiteUrl();
+        const successUrl = sanitizeReturnUrl(req.body.successUrl, siteUrl);
+        const cancelUrl = sanitizeReturnUrl(req.body.cancelUrl, siteUrl);
+
         // Build options
         const options = {
-            successUrl: req.body.successUrl,
-            cancelUrl: req.body.cancelUrl,
+            successUrl,
+            cancelUrl,
             email: req.body.customerEmail,
             member,
             metadata,
@@ -788,8 +833,8 @@ module.exports = class RouterController {
                 ...options,
                 ...data,
                 duration: 1, // gifts are currently 1 month or 1 year only
-                successUrl: this._urlUtils.getSiteUrl(),
-                cancelUrl: options.cancelUrl || this._urlUtils.getSiteUrl()
+                successUrl: siteUrl,
+                cancelUrl: options.cancelUrl || siteUrl
             });
         }
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -16,11 +16,17 @@ describe('RouterController', function () {
     let settingsCache;
     let settingsHelpers;
     let emailAddressService;
+    let urlUtils;
 
     beforeEach(async function () {
         // Mock emailAddressService for inbox links sender address transformation
         emailAddressService = {
             getMembersSupportAddress: sinon.stub().returns('noreply@example.com')
+        };
+
+        // Default urlUtils used by createCheckoutSession to validate return URLs
+        urlUtils = {
+            getSiteUrl: sinon.stub().returns('https://example.com/')
         };
 
         getPaymentLinkSpy = sinon.spy();
@@ -96,6 +102,7 @@ describe('RouterController', function () {
                 labsService,
                 settingsCache,
                 settingsHelpers,
+                urlUtils,
                 emailAddressService
             });
 
@@ -132,6 +139,7 @@ describe('RouterController', function () {
                 labsService,
                 settingsCache,
                 settingsHelpers,
+                urlUtils,
                 newslettersService: newslettersServiceStub,
                 emailAddressService
             });
@@ -181,6 +189,7 @@ describe('RouterController', function () {
                 labsService,
                 settingsCache,
                 settingsHelpers,
+                urlUtils,
                 magicLinkService,
                 memberRepository
             });
@@ -226,6 +235,7 @@ describe('RouterController', function () {
                 labsService,
                 settingsCache,
                 settingsHelpers,
+                urlUtils,
                 tokenService,
                 memberRepository
             });
@@ -259,7 +269,8 @@ describe('RouterController', function () {
                 stripeAPIService,
                 labsService,
                 settingsCache,
-                settingsHelpers
+                settingsHelpers,
+                urlUtils
             });
 
             await routerController.createCheckoutSession({
@@ -452,6 +463,7 @@ describe('RouterController', function () {
                     labsService,
                     settingsCache,
                     settingsHelpers,
+                    urlUtils,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -500,6 +512,7 @@ describe('RouterController', function () {
                     labsService,
                     settingsCache,
                     settingsHelpers,
+                    urlUtils,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -547,6 +560,7 @@ describe('RouterController', function () {
                     labsService,
                     settingsCache,
                     settingsHelpers,
+                    urlUtils,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -594,6 +608,7 @@ describe('RouterController', function () {
                     labsService,
                     settingsCache,
                     settingsHelpers,
+                    urlUtils,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -641,6 +656,7 @@ describe('RouterController', function () {
                     labsService,
                     settingsCache,
                     settingsHelpers,
+                    urlUtils,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -808,6 +824,304 @@ describe('RouterController', function () {
             });
         });
 
+        describe('return URL validation', function () {
+            // Any successUrl/cancelUrl posted to the public checkout endpoint that
+            // doesn't point back to the configured site is discarded before being
+            // forwarded to Stripe, so the downstream Stripe service falls back to its
+            // built-in same-origin defaults.
+
+            const mockRes = {writeHead: () => {}, end: () => {}};
+
+            function createSubscriptionController(overrides = {}) {
+                return new RouterController({
+                    tiersService,
+                    paymentsService,
+                    offersAPI,
+                    stripeAPIService,
+                    labsService,
+                    settingsCache,
+                    settingsHelpers,
+                    urlUtils,
+                    memberAttributionService: {getAttribution: sinon.stub().resolves({})},
+                    ...overrides
+                });
+            }
+
+            function createGiftReturnController(overrides = {}) {
+                return new RouterController({
+                    tiersService: {
+                        api: {
+                            read: sinon.stub().resolves({
+                                id: {toHexString: () => 'tier_123'},
+                                status: 'active',
+                                getPrice: sinon.stub().returns(5000)
+                            })
+                        }
+                    },
+                    paymentsService,
+                    offersAPI,
+                    stripeAPIService,
+                    labsService,
+                    settingsCache,
+                    settingsHelpers,
+                    memberRepository: {get: sinon.stub().resolves(null)},
+                    memberAttributionService: {getAttribution: sinon.stub().resolves({})},
+                    urlUtils,
+                    ...overrides
+                });
+            }
+
+            describe('subscription checkout', function () {
+                it('passes through same-origin successUrl and cancelUrl unchanged', async function () {
+                    const controller = createSubscriptionController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            successUrl: 'https://example.com/welcome?foo=bar',
+                            cancelUrl: 'https://example.com/checkout-cancelled',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
+                        successUrl: 'https://example.com/welcome?foo=bar',
+                        cancelUrl: 'https://example.com/checkout-cancelled'
+                    }));
+                });
+
+                it('drops cross-origin cancelUrl', async function () {
+                    const controller = createSubscriptionController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            successUrl: 'https://example.com/welcome',
+                            cancelUrl: 'https://external.example/steal',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
+                        successUrl: 'https://example.com/welcome',
+                        cancelUrl: undefined
+                    }));
+                });
+
+                it('drops cross-origin successUrl', async function () {
+                    const controller = createSubscriptionController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            successUrl: 'https://external.example/welcome',
+                            cancelUrl: 'https://example.com/cancel',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
+                        successUrl: undefined,
+                        cancelUrl: 'https://example.com/cancel'
+                    }));
+                });
+
+                it('drops URLs that share a hostname suffix but a different origin', async function () {
+                    const controller = createSubscriptionController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            // example.com.external.example would pass a naive .includes/startsWith check
+                            successUrl: 'https://example.com.external.example/welcome',
+                            cancelUrl: 'https://examplecom.example/cancel',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
+                        successUrl: undefined,
+                        cancelUrl: undefined
+                    }));
+                });
+
+                it('drops malformed return URLs', async function () {
+                    const controller = createSubscriptionController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            successUrl: 'not a url',
+                            cancelUrl: '//external.example/cancel',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
+                        successUrl: undefined,
+                        cancelUrl: undefined
+                    }));
+                });
+
+                it('passes undefined when successUrl/cancelUrl are missing', async function () {
+                    const controller = createSubscriptionController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
+                        successUrl: undefined,
+                        cancelUrl: undefined
+                    }));
+                });
+
+                it('respects the site subpath when validating return URLs', async function () {
+                    const subpathUrlUtils = {
+                        getSiteUrl: sinon.stub().returns('https://example.com/blog/')
+                    };
+                    const controller = createSubscriptionController({urlUtils: subpathUrlUtils});
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            // Same origin but outside the /blog/ subpath
+                            successUrl: 'https://example.com/welcome',
+                            // Inside the subpath
+                            cancelUrl: 'https://example.com/blog/cancelled',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
+                        successUrl: undefined,
+                        cancelUrl: 'https://example.com/blog/cancelled'
+                    }));
+                });
+
+                it('accepts subpath URLs without a trailing slash as equivalent to the subpath', async function () {
+                    const subpathUrlUtils = {
+                        getSiteUrl: sinon.stub().returns('https://example.com/blog/')
+                    };
+                    const controller = createSubscriptionController({urlUtils: subpathUrlUtils});
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            // No trailing slash — should be treated as equivalent to /blog/
+                            successUrl: 'https://example.com/blog',
+                            // /blogger is *not* the same as /blog/ — must be rejected
+                            cancelUrl: 'https://example.com/blogger/oops',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
+                        successUrl: 'https://example.com/blog',
+                        cancelUrl: undefined
+                    }));
+                });
+            });
+
+            describe('donation checkout', function () {
+                it('drops cross-origin successUrl and cancelUrl', async function () {
+                    const controller = createSubscriptionController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            type: 'donation',
+                            successUrl: 'https://external.example/win',
+                            cancelUrl: 'https://external.example/oops',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
+                        successUrl: undefined,
+                        cancelUrl: undefined
+                    }));
+                });
+
+                it('passes through same-origin URLs unchanged', async function () {
+                    const controller = createSubscriptionController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            type: 'donation',
+                            successUrl: 'https://example.com/donate/thanks',
+                            cancelUrl: 'https://example.com/donate/cancel',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
+                        successUrl: 'https://example.com/donate/thanks',
+                        cancelUrl: 'https://example.com/donate/cancel'
+                    }));
+                });
+            });
+
+            describe('gift checkout', function () {
+                let giftLinkSpy;
+
+                beforeEach(function () {
+                    giftLinkSpy = sinon.stub().resolves('https://checkout.stripe.com/gift');
+                    paymentsService.getGiftPaymentLink = giftLinkSpy;
+                });
+
+                it('falls back to the site URL when cancelUrl is cross-origin (Stripe requires cancel_url for gifts)', async function () {
+                    const controller = createGiftReturnController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            type: 'gift',
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            cancelUrl: 'https://external.example/cancel',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledOnce(giftLinkSpy);
+                    sinon.assert.calledWith(giftLinkSpy, sinon.match({
+                        successUrl: 'https://example.com/',
+                        cancelUrl: 'https://example.com/'
+                    }));
+                });
+
+                it('passes same-origin cancelUrl through unchanged', async function () {
+                    const controller = createGiftReturnController();
+
+                    await controller.createCheckoutSession({
+                        body: {
+                            type: 'gift',
+                            tierId: 'tier_123',
+                            cadence: 'month',
+                            cancelUrl: 'https://example.com/post/#/portal/gift',
+                            metadata: {}
+                        }
+                    }, mockRes);
+
+                    sinon.assert.calledOnce(giftLinkSpy);
+                    sinon.assert.calledWith(giftLinkSpy, sinon.match({
+                        successUrl: 'https://example.com/',
+                        cancelUrl: 'https://example.com/post/#/portal/gift'
+                    }));
+                });
+            });
+        });
+
         it('adds welcomePageUrl to response for authenticated members when tier has welcomePageURL', async function () {
             const routerController = new RouterController({
                 tiersService: {
@@ -927,6 +1241,145 @@ describe('RouterController', function () {
 
         afterEach(function () {
             sinon.restore();
+        });
+    });
+
+    describe('createCheckoutSetupSession return URL validation', function () {
+        // The setup session endpoint requires an authenticated identity token, but the
+        // successUrl/cancelUrl values still come from the request body. We validate
+        // their origin server-side and drop any URL that doesn't point back to the site.
+
+        let createSetupSessionStub;
+        let mockReq;
+        let mockRes;
+
+        function createController() {
+            createSetupSessionStub = sinon.stub().resolves({id: 'cs_test_setup'});
+            const memberStub = {
+                related: sinon.stub().returns({
+                    fetch: sinon.stub().resolves({models: []})
+                })
+            };
+            return new RouterController({
+                stripeAPIService: {
+                    createCheckoutSetupSession: createSetupSessionStub,
+                    getCustomerForMemberCheckoutSession: sinon.stub().resolves({id: 'cus_test'}),
+                    getPublicKey: sinon.stub().returns('pk_test')
+                },
+                tokenService: {decodeToken: sinon.stub().resolves({sub: 'member@example.com'})},
+                memberRepository: {get: sinon.stub().resolves(memberStub)},
+                urlUtils
+            });
+        }
+
+        beforeEach(function () {
+            mockReq = body => ({body: {identity: 'valid-token', ...body}});
+            mockRes = {writeHead: sinon.stub(), end: sinon.stub()};
+        });
+
+        it('passes same-origin successUrl and cancelUrl through unchanged', async function () {
+            const controller = createController();
+
+            await controller.createCheckoutSetupSession(mockReq({
+                successUrl: 'https://example.com/account/billing?ok=1',
+                cancelUrl: 'https://example.com/account'
+            }), mockRes);
+
+            sinon.assert.calledWith(createSetupSessionStub, sinon.match.any, sinon.match({
+                successUrl: 'https://example.com/account/billing?ok=1',
+                cancelUrl: 'https://example.com/account'
+            }));
+        });
+
+        it('drops cross-origin successUrl and cancelUrl', async function () {
+            const controller = createController();
+
+            await controller.createCheckoutSetupSession(mockReq({
+                successUrl: 'https://external.example/success',
+                cancelUrl: 'https://external.example/cancel'
+            }), mockRes);
+
+            sinon.assert.calledWith(createSetupSessionStub, sinon.match.any, sinon.match({
+                successUrl: undefined,
+                cancelUrl: undefined
+            }));
+        });
+
+        it('passes undefined when URLs are missing', async function () {
+            const controller = createController();
+
+            await controller.createCheckoutSetupSession(mockReq({}), mockRes);
+
+            sinon.assert.calledWith(createSetupSessionStub, sinon.match.any, sinon.match({
+                successUrl: undefined,
+                cancelUrl: undefined
+            }));
+        });
+    });
+
+    describe('createBillingPortalSession return URL validation', function () {
+        let createPortalSessionStub;
+        let mockReq;
+        let mockRes;
+
+        function createController() {
+            createPortalSessionStub = sinon.stub().resolves({url: 'https://billing.stripe.com/'});
+            const memberStub = {
+                related: sinon.stub().returns({
+                    fetch: sinon.stub().resolves({models: []})
+                })
+            };
+            return new RouterController({
+                stripeAPIService: {
+                    createBillingPortalSession: createPortalSessionStub,
+                    getCustomerForMemberCheckoutSession: sinon.stub().resolves({id: 'cus_test'})
+                },
+                tokenService: {decodeToken: sinon.stub().resolves({sub: 'member@example.com'})},
+                memberRepository: {get: sinon.stub().resolves(memberStub)},
+                settingsCache: {
+                    get: sinon.stub().withArgs('stripe_billing_portal_configuration_id').returns(null)
+                },
+                urlUtils
+            });
+        }
+
+        beforeEach(function () {
+            mockReq = body => ({body: {identity: 'valid-token', ...body}});
+            mockRes = {writeHead: sinon.stub(), end: sinon.stub()};
+        });
+
+        it('passes same-origin returnUrl through unchanged', async function () {
+            const controller = createController();
+
+            await controller.createBillingPortalSession(mockReq({
+                returnUrl: 'https://example.com/account'
+            }), mockRes);
+
+            sinon.assert.calledWith(createPortalSessionStub, sinon.match.any, sinon.match({
+                returnUrl: 'https://example.com/account'
+            }));
+        });
+
+        it('drops cross-origin returnUrl', async function () {
+            const controller = createController();
+
+            await controller.createBillingPortalSession(mockReq({
+                returnUrl: 'https://external.example/return'
+            }), mockRes);
+
+            sinon.assert.calledWith(createPortalSessionStub, sinon.match.any, sinon.match({
+                returnUrl: undefined
+            }));
+        });
+
+        it('passes undefined when returnUrl is missing', async function () {
+            const controller = createController();
+
+            await controller.createBillingPortalSession(mockReq({}), mockRes);
+
+            sinon.assert.calledWith(createPortalSessionStub, sinon.match.any, sinon.match({
+                returnUrl: undefined
+            }));
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3647

- the public `create-stripe-checkout-session` endpoint forwarded caller-supplied `successUrl` / `cancelUrl` verbatim to Stripe, which would redirect users to any external URL after checkout - turning the Ghost site into an open-redirect launch pad
- the same applied to `create-stripe-checkout-setup-session` and `create-stripe-billing-portal-session` (both behind an identity token, but still worth tightening)
- now reject any return URL whose origin or subpath doesn't match `urlUtils.getSiteUrl()`, letting the downstream stripe-api fall back to its existing same-origin defaults; the gift flow keeps its site-root cancelUrl fallback since Stripe gift checkout has no config-level default for `cancel_url`
- subpath comparison normalizes both sides to trailing-slash form, so `/blog` and `/blog/` are treated equivalently while `/blogger` is rejected