### PR TITLE
Added threaded comments display behind labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -67,6 +67,10 @@ const features: Feature[] = [{
     title: 'Gift Subscriptions',
     description: 'Allow site visitors to purchase gift subscriptions for others',
     flag: 'giftSubscriptions'
+}, {
+    title: 'Comments Threads',
+    description: 'Enable deeper threading view in Comments-UI',
+    flag: 'commentsThreads'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -24,6 +24,7 @@ export type Comment = {
     liked: boolean,
     count: {
         replies: number,
+        total_replies?: number,
         likes: number,
     },
     member: Member | null,

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -6,6 +6,7 @@ import React, {useCallback} from 'react';
 import Replies, {RepliesProps} from './replies';
 import ReplyButton from './buttons/reply-button';
 import ReplyForm from './forms/reply-form';
+import ThreadedReplies from './threaded-replies';
 import {Avatar, BlankAvatar} from './avatar';
 import {Comment, OpenCommentForm, useAppContext} from '../../app-context';
 import {Transition} from '@headlessui/react';
@@ -15,9 +16,10 @@ import {useRelativeTime} from '../../utils/hooks';
 type AnimatedCommentProps = {
     comment: Comment;
     parent?: Comment;
+    useThreading?: boolean;
 };
 
-const AnimatedComment: React.FC<AnimatedCommentProps> = ({comment, parent}) => {
+const AnimatedComment: React.FC<React.PropsWithChildren<AnimatedCommentProps>> = ({children, comment, parent, useThreading}) => {
     const {commentsIsLoading} = useAppContext();
 
     return (
@@ -34,14 +36,17 @@ const AnimatedComment: React.FC<AnimatedCommentProps> = ({comment, parent}) => {
             show={true}
             appear
         >
-            <CommentComponent comment={comment} parent={parent} />
+            <CommentComponent comment={comment} parent={parent} useThreading={useThreading}>
+                {children}
+            </CommentComponent>
         </Transition>
     );
 };
 
-export const CommentComponent: React.FC<CommentProps> = ({comment, parent}) => {
+export const CommentComponent: React.FC<CommentProps> = ({children, comment, parent, useThreading = false}) => {
     const {dispatchAction, isAdmin} = useAppContext();
-    const {showDeletedMessage, showHiddenMessage, showCommentContent} = useCommentVisibility(comment, isAdmin);
+    const hasNestedReplies = React.Children.count(children) > 0;
+    const {showDeletedMessage, showHiddenMessage, showCommentContent} = useCommentVisibility(comment, isAdmin, hasNestedReplies);
 
     const openEditMode = useCallback(() => {
         const newForm: OpenCommentForm = {
@@ -55,17 +60,35 @@ export const CommentComponent: React.FC<CommentProps> = ({comment, parent}) => {
     }, [comment.id, dispatchAction]);
 
     if (showDeletedMessage || showHiddenMessage) {
-        return <UnpublishedComment comment={comment} openEditMode={openEditMode} />;
+        return <UnpublishedComment comment={comment} openEditMode={openEditMode} parent={parent} useThreading={useThreading}>{children}</UnpublishedComment>;
     } else if (showCommentContent && !showHiddenMessage) {
-        return <PublishedComment comment={comment} openEditMode={openEditMode} parent={parent} />;
+        return <PublishedComment comment={comment} openEditMode={openEditMode} parent={parent} useThreading={useThreading}>{children}</PublishedComment>;
     }
 
     return null;
 };
 
-type CommentProps = AnimatedCommentProps;
-const useCommentVisibility = (comment: Comment, admin: boolean) => {
-    const hasReplies = comment.replies && comment.replies.length > 0;
+type CommentProps = React.PropsWithChildren<AnimatedCommentProps>;
+
+const getReplyFormDisplayState = (comment: Comment, openCommentForms: OpenCommentForm[], useThreading: boolean) => {
+    // Non-threaded replies to replies are displayed inside the top-level comment,
+    // so match either the comment id or parent id. Threaded replies render their
+    // own reply form inline, so only match the current comment.
+    const openForm = useThreading
+        ? openCommentForms.find(f => f.id === comment.id && f.type === 'reply')
+        : openCommentForms.find(f => (f.id === comment.id || f.parent_id === comment.id) && f.type === 'reply');
+
+    return {
+        openForm,
+        // Avoid showing nested reply forms in non-threaded RepliesContainer output.
+        displayReplyForm: useThreading
+            ? !!openForm
+            : !!openForm && (!openForm.parent_id || openForm.parent_id === comment.id)
+    };
+};
+
+const useCommentVisibility = (comment: Comment, admin: boolean, hasNestedReplies?: boolean) => {
+    const hasReplies = hasNestedReplies || (comment.replies && comment.replies.length > 0);
     const isDeleted = comment.status === 'deleted';
     const isHidden = comment.status === 'hidden';
 
@@ -81,9 +104,11 @@ const useCommentVisibility = (comment: Comment, admin: boolean) => {
 
 type PublishedCommentProps = CommentProps & {
     openEditMode: () => void;
+    useThreading: boolean;
 }
-const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, openEditMode}) => {
+const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, parent, openEditMode, useThreading}) => {
     const {dispatchAction, openCommentForms, isAdmin, commentIdToHighlight} = useAppContext();
+    const hasNestedReplies = React.Children.count(children) > 0;
 
     // Determine if the comment should be displayed with reduced opacity
     const isHidden = isAdmin && comment.status === 'hidden';
@@ -93,11 +118,7 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, ope
     const editForm = openCommentForms.find(openForm => openForm.id === comment.id && openForm.type === 'edit');
     const isInEditMode = !!editForm;
 
-    // currently a reply-to-reply form is displayed inside the top-level PublishedComment component
-    // so we need to check for a match of either the comment id or the parent id
-    const openForm = openCommentForms.find(f => (f.id === comment.id || f.parent_id === comment.id) && f.type === 'reply');
-    // avoid displaying the reply form inside RepliesContainer
-    const displayReplyForm = openForm && (!openForm.parent_id || openForm.parent_id === comment.id);
+    const {openForm, displayReplyForm} = getReplyFormDisplayState(comment, openCommentForms, useThreading);
     // only highlight the reply button for the comment that is being replied to
     const highlightReplyButton = !!(openForm && openForm.id === comment.id);
 
@@ -124,33 +145,33 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, ope
         }
     }, [comment, parent, openForm, dispatchAction]);
 
-    const hasReplies = displayReplyForm || (comment.replies && comment.replies.length > 0);
+    const hasReplies = displayReplyForm || hasNestedReplies || (comment.replies && comment.replies.length > 0);
     const avatar = (<Avatar member={comment.member} />);
+    const replyFormParent = parent || comment;
 
     return (
         <CommentLayout avatar={avatar} className={hiddenClass} hasReplies={hasReplies} memberUuid={comment.member?.uuid}>
             <div>
                 {isInEditMode ? (
                     <>
-                        <CommentHeader className={hiddenClass} comment={comment} />
+                        <CommentHeader className={hiddenClass} comment={comment} useThreading={useThreading} />
                         <EditForm comment={comment} openForm={editForm} parent={parent} />
                     </>
                 ) : (
                     <>
-                        <CommentHeader className={hiddenClass} comment={comment} />
+                        <CommentHeader className={hiddenClass} comment={comment} useThreading={useThreading} />
                         <CommentBody className={hiddenClass} html={comment.html} isHighlighted={comment.id === commentIdToHighlight} />
                         <CommentMenu
                             comment={comment}
                             highlightReplyButton={highlightReplyButton}
                             openEditMode={openEditMode}
                             openReplyForm={openReplyForm}
-                            parent={parent}
                         />
                     </>
                 )}
             </div>
-            <RepliesContainer comment={comment} />
-            {displayReplyForm && <ReplyFormBox comment={comment} openForm={openForm} />}
+            <RepliesContainer comment={comment} parent={parent} useThreading={useThreading}>{children}</RepliesContainer>
+            {displayReplyForm && <ReplyFormBox openForm={openForm} parent={replyFormParent} />}
         </CommentLayout>
     );
 };
@@ -158,29 +179,29 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, ope
 type UnpublishedCommentProps = {
     comment: Comment;
     openEditMode: () => void;
+    parent?: Comment;
+    useThreading: boolean;
 }
-const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, openEditMode}) => {
+const UnpublishedComment: React.FC<React.PropsWithChildren<UnpublishedCommentProps>> = ({children, comment, openEditMode, parent, useThreading}) => {
     const {isAdmin, openCommentForms, t} = useAppContext();
+    const hasNestedReplies = React.Children.count(children) > 0;
 
     const avatar = (isAdmin && comment.status !== 'deleted')
         ? <Avatar member={comment.member} />
         : <BlankAvatar />;
-    const hasReplies = comment.replies && comment.replies.length > 0;
-
     const notPublishedMessage = comment.status === 'hidden' ?
         t('This comment has been hidden.') :
         comment.status === 'deleted' ?
             t('This comment has been removed.') :
             '';
 
-    // currently a reply-to-reply form is displayed inside the top-level PublishedComment component
-    // so we need to check for a match of either the comment id or the parent id
-    const openForm = openCommentForms.find(f => (f.id === comment.id || f.parent_id === comment.id) && f.type === 'reply');
-    // avoid displaying the reply form inside RepliesContainer
-    const displayReplyForm = openForm && (!openForm.parent_id || openForm.parent_id === comment.id);
+    const {openForm, displayReplyForm} = getReplyFormDisplayState(comment, openCommentForms, useThreading);
+    const hasReplies = displayReplyForm || hasNestedReplies || (comment.replies && comment.replies.length > 0);
 
     // Only show MoreButton for hidden (not deleted) comments when admin
     const showMoreButton = isAdmin && comment.status === 'hidden';
+
+    const replyFormParent = parent || comment;
 
     return (
         <CommentLayout avatar={avatar} hasReplies={hasReplies}>
@@ -196,8 +217,8 @@ const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, openEdi
                     )}
                 </div>
             </div>
-            <RepliesContainer comment={comment} />
-            {displayReplyForm && <ReplyFormBox comment={comment} openForm={openForm} />}
+            <RepliesContainer comment={comment} parent={parent} useThreading={useThreading}>{children}</RepliesContainer>
+            {displayReplyForm && <ReplyFormBox openForm={openForm} parent={replyFormParent} />}
         </CommentLayout>
     );
 };
@@ -228,8 +249,10 @@ const EditedInfo: React.FC<{comment: Comment}> = ({comment}) => {
         </span>
     );
 };
-const RepliesContainer: React.FC<RepliesProps & {className?: string}> = ({comment, className = ''}) => {
-    const hasReplies = comment.replies && comment.replies.length > 0;
+const RepliesContainer: React.FC<React.PropsWithChildren<RepliesProps & {className?: string; parent?: Comment; useThreading?: boolean}>> = ({children, comment, className = '', parent, useThreading = false}) => {
+    const hasNestedReplies = React.Children.count(children) > 0;
+    const hasReplies = hasNestedReplies || (comment.replies && comment.replies.length > 0);
+    const shouldRenderThreadedReplies = useThreading && !parent;
 
     if (!hasReplies) {
         return null;
@@ -237,19 +260,19 @@ const RepliesContainer: React.FC<RepliesProps & {className?: string}> = ({commen
 
     return (
         <div className={`-ml-2 mb-4 mt-7 sm:mb-0 sm:mt-8 ${className}`}>
-            <Replies comment={comment} />
+            {hasNestedReplies ? children : shouldRenderThreadedReplies ? <ThreadedReplies comment={comment} useThreading={useThreading} /> : <Replies comment={comment} />}
         </div>
     );
 };
 
 type ReplyFormBoxProps = {
-    comment: Comment;
     openForm: OpenCommentForm;
+    parent: Comment;
 };
-const ReplyFormBox: React.FC<ReplyFormBoxProps> = ({comment, openForm}) => {
+const ReplyFormBox: React.FC<ReplyFormBoxProps> = ({openForm, parent}) => {
     return (
         <div className="my-8 sm:my-10">
-            <ReplyForm openForm={openForm} parent={comment} />
+            <ReplyForm openForm={openForm} parent={parent} />
         </div>
     );
 };
@@ -295,13 +318,14 @@ export const RepliedToSnippet: React.FC<{comment: Comment}> = ({comment}) => {
 type CommentHeaderProps = {
     comment: Comment;
     className?: string;
+    useThreading: boolean;
 }
 
-const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = ''}) => {
+const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = '', useThreading}) => {
     const {member, t, pageUrl} = useAppContext();
     const createdAtRelative = useRelativeTime(comment.created_at);
     const memberExpertise = member && comment.member && comment.member.uuid === member.uuid ? member.expertise : comment?.member?.expertise;
-    const isReplyToReply = comment.in_reply_to_id && comment.in_reply_to_snippet;
+    const showReplyContext = !useThreading && comment.in_reply_to_id && comment.in_reply_to_snippet;
 
     const timestampElement = (
         <a
@@ -316,7 +340,7 @@ const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = ''}) 
 
     return (
         <>
-            <div className={`mt-0.5 flex flex-wrap items-start sm:flex-row ${memberExpertise ? 'flex-col' : 'flex-row'} ${isReplyToReply ? 'mb-0.5' : 'mb-2'} ${className}`}>
+            <div className={`mt-0.5 flex flex-wrap items-start sm:flex-row ${memberExpertise ? 'flex-col' : 'flex-row'} ${showReplyContext ? 'mb-0.5' : 'mb-2'} ${className}`}>
                 <AuthorName comment={comment} />
                 <div className="flex items-baseline pr-4 font-sans text-base leading-snug text-neutral-900/50 sm:text-sm dark:text-white/60">
                     <span>
@@ -326,7 +350,7 @@ const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = ''}) 
                     </span>
                 </div>
             </div>
-            {(isReplyToReply &&
+            {(showReplyContext &&
                 <div className="mb-2 line-clamp-1 font-sans text-base leading-snug text-neutral-900/50 sm:text-sm dark:text-white/60">
                     <span>{t('Replied to')}</span>:&nbsp;<RepliedToSnippet comment={comment} />
                 </div>

--- a/apps/comments-ui/src/components/content/content.tsx
+++ b/apps/comments-ui/src/components/content/content.tsx
@@ -173,8 +173,9 @@ const Content = () => {
     const showMainForm = canComment;
     const showDisabledBox = !canComment && isCommentingDisabled;
     const showCtaBox = !canComment && !isCommentingDisabled;
+    const useThreading = !!labs.commentsThreads;
 
-    const commentsComponents = comments.map(comment => <Comment key={comment.id} comment={comment} />);
+    const commentsComponents = comments.map(comment => <Comment key={comment.id} comment={comment} useThreading={useThreading} />);
 
     return (
         <>

--- a/apps/comments-ui/src/components/content/threaded-replies.tsx
+++ b/apps/comments-ui/src/components/content/threaded-replies.tsx
@@ -1,0 +1,80 @@
+import CommentComponent from './comment';
+import React, {useEffect, useMemo, useRef} from 'react';
+import {Comment, useAppContext} from '../../app-context';
+import {ThreadedReply, buildThreadedReplies} from '../../utils/helpers';
+
+const NestedReply: React.FC<{
+    reply: ThreadedReply;
+    threadParentComment: Comment;
+    useThreading: boolean;
+}> = ({reply, threadParentComment, useThreading}) => {
+    const nestedReplies = reply.nestedReplies.map(childReply => (
+        <NestedReply
+            key={childReply.id}
+            reply={childReply}
+            threadParentComment={threadParentComment}
+            useThreading={useThreading}
+        />
+    ));
+
+    return (
+        <CommentComponent
+            comment={reply}
+            parent={threadParentComment}
+            useThreading={useThreading}
+        >
+            {nestedReplies}
+        </CommentComponent>
+    );
+};
+
+export type ThreadedRepliesProps = {
+    comment: Comment;
+    useThreading: boolean;
+};
+
+const ThreadedReplies: React.FC<ThreadedRepliesProps> = ({comment, useThreading}) => {
+    const {dispatchAction} = useAppContext();
+    const requestedAllRepliesKey = useRef<string | null>(null);
+    const previousComment = useRef<Comment | null>(null);
+    const loadedReplies = comment.replies ?? [];
+    const totalReplies = comment.count.total_replies ?? comment.count.replies;
+    const serverHasMore = totalReplies > loadedReplies.length;
+    const loadRequestKey = `${comment.id}:${loadedReplies.map(reply => reply.id).join(',')}`;
+
+    useEffect(() => {
+        if (previousComment.current !== comment) {
+            requestedAllRepliesKey.current = null;
+            previousComment.current = comment;
+        }
+
+        if (!serverHasMore) {
+            requestedAllRepliesKey.current = null;
+            return;
+        }
+
+        if (requestedAllRepliesKey.current === loadRequestKey) {
+            return;
+        }
+
+        requestedAllRepliesKey.current = loadRequestKey;
+        dispatchAction('loadMoreReplies', {comment, limit: 'all'});
+    }, [comment, dispatchAction, loadRequestKey, serverHasMore]);
+
+    const threadedReplies = useMemo(() => buildThreadedReplies(comment), [comment]);
+
+    return (
+        <div>
+            {threadedReplies.map(reply => (
+                <NestedReply
+                    key={reply.id}
+                    reply={reply}
+                    threadParentComment={comment}
+                    useThreading={useThreading}
+                />
+            ))}
+        </div>
+    );
+};
+
+export default ThreadedReplies;

--- a/apps/comments-ui/src/utils/helpers.ts
+++ b/apps/comments-ui/src/utils/helpers.ts
@@ -18,6 +18,38 @@ export function flattenComments(comments: Comment[]): Comment[] {
     return comments.flatMap(comment => [comment, ...(comment.replies || [])]);
 }
 
+export type ThreadedReply = Comment & {
+    nestedReplies: ThreadedReply[];
+};
+
+export function buildThreadedReplies(threadParentComment: Comment): ThreadedReply[] {
+    const replies = threadParentComment.replies || [];
+    const byId = new Map<string, ThreadedReply>();
+
+    replies.forEach((reply) => {
+        byId.set(reply.id, {...reply, nestedReplies: []});
+    });
+
+    const topLevelReplies: ThreadedReply[] = [];
+
+    replies.forEach((reply) => {
+        const threadedReply = byId.get(reply.id);
+        const parentReply = reply.in_reply_to_id ? byId.get(reply.in_reply_to_id) : null;
+
+        if (!threadedReply) {
+            return;
+        }
+
+        if (parentReply && parentReply.id !== threadedReply.id) {
+            parentReply.nestedReplies.push(threadedReply);
+        } else {
+            topLevelReplies.push(threadedReply);
+        }
+    });
+
+    return topLevelReplies;
+}
+
 export function findCommentById(comments: Comment[], id: string): Comment | undefined {
     return comments.find(comment => comment?.id === id)
         || comments.flatMap(comment => comment.replies || []).find(reply => reply?.id === id);

--- a/apps/comments-ui/test/unit/components/content/comment.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/comment.test.jsx
@@ -62,6 +62,61 @@ describe('<CommentComponent>', function () {
         const {container} = contextualRender(<CommentComponent comment={comment} />, {appContext});
         expect(container.querySelector('[data-member-uuid="123"]')).not.toBeInTheDocument();
     });
+
+    it('renders nested reply threads when commentsThreads is enabled', function () {
+        const reply1 = buildComment({
+            html: '<p>First reply</p>'
+        });
+        const reply2 = buildComment({
+            in_reply_to_id: reply1.id,
+            html: '<p>Second reply</p>'
+        });
+        const comment = buildComment({
+            replies: [reply1, reply2],
+            count: {
+                replies: 2
+            }
+        });
+        const appContext = {
+            comments: [comment],
+            dispatchAction: () => {},
+            labs: {
+                commentsThreads: true
+            }
+        };
+
+        const {container} = contextualRender(<CommentComponent comment={comment} useThreading={true} />, {appContext});
+
+        expect(screen.getByText('First reply')).toBeInTheDocument();
+        expect(screen.getByText('Second reply')).toBeInTheDocument();
+        expect(container.ownerDocument.getElementById(reply2.id)).toHaveAttribute('data-testid', 'animated-comment');
+        expect(screen.queryByTestId('replies-pagination')).not.toBeInTheDocument();
+    });
+
+    it('hides reply-to-reply context when commentsThreads is enabled', function () {
+        const reply1 = buildComment({
+            html: '<p>First reply</p>'
+        });
+        const reply2 = buildComment({
+            in_reply_to_id: reply1.id,
+            in_reply_to_snippet: 'First reply',
+            html: '<p>Second reply</p>'
+        });
+        const parent = buildComment({
+            replies: [reply1, reply2]
+        });
+        const appContext = {
+            comments: [parent],
+            labs: {
+                commentsThreads: true
+            }
+        };
+
+        contextualRender(<CommentComponent comment={reply2} parent={parent} useThreading={true} />, {appContext});
+
+        expect(screen.queryByText('Replied to')).not.toBeInTheDocument();
+        expect(screen.queryByText('First reply')).not.toBeInTheDocument();
+    });
 });
 
 describe('<RepliedToSnippet>', function () {

--- a/apps/comments-ui/test/unit/components/content/content.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/content.test.jsx
@@ -1,6 +1,7 @@
 import Content from '../../../../src/components/content/content';
 import {AppContext} from '../../../../src/app-context';
-import {render, screen, act} from '@testing-library/react';
+import {act, render, screen} from '@testing-library/react';
+import {buildComment} from '../../../utils/fixtures';
 
 const contextualRender = (ui, {appContext, ...renderOptions}) => {
     const member = appContext?.member ?? null;
@@ -18,10 +19,12 @@ const contextualRender = (ui, {appContext, ...renderOptions}) => {
         comments: [],
         openCommentForms: [],
         member,
+        pageUrl: 'https://example.com/post',
         isMember,
         isPaidOnly,
         hasRequiredTier,
         isCommentingDisabled,
+        dispatchAction: () => {},
         t: str => str,
         ...appContext
     };
@@ -135,6 +138,46 @@ describe('<Content>', function () {
 
             window.removeEventListener('error', onError);
             expect(errors).toHaveLength(0);
+        });
+    });
+
+    describe('threaded display', function () {
+        it('passes the commentsThreads display mode through to rendered comments', function () {
+            const reply1 = buildComment({
+                html: '<p>First reply</p>'
+            });
+            const reply2 = buildComment({
+                html: '<p>Second reply</p>'
+            });
+            const reply3 = buildComment({
+                html: '<p>Third reply</p>'
+            });
+            const reply4 = buildComment({
+                html: '<p>Nested reply</p>',
+                in_reply_to_id: reply1.id,
+                in_reply_to_snippet: 'First reply'
+            });
+            const comment = buildComment({
+                html: '<p>Parent comment</p>',
+                replies: [reply1, reply2, reply3, reply4],
+                count: {
+                    replies: 4
+                }
+            });
+
+            contextualRender(<Content />, {
+                appContext: {
+                    comments: [comment],
+                    commentCount: 1,
+                    labs: {
+                        commentsThreads: true
+                    }
+                }
+            });
+
+            expect(screen.getByText('Nested reply')).toBeInTheDocument();
+            expect(screen.queryByText('Replied to')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('replies-pagination')).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/comments-ui/test/unit/utils/helpers.test.ts
+++ b/apps/comments-ui/test/unit/utils/helpers.test.ts
@@ -3,7 +3,6 @@ import moment, {DurationInputObject} from 'moment';
 import sinon from 'sinon';
 import {buildAnonymousMember, buildComment, buildDeletedMember} from '../../utils/fixtures';
 
-
 describe('COMMENT_HASH_PREFIX', function () {
     it('exports the correct prefix', function () {
         expect(helpers.COMMENT_HASH_PREFIX).toEqual('ghost-comments-');
@@ -85,6 +84,37 @@ describe('flattenComments', function () {
             {id: '2'},
             {id: '3', replies: []}
         ]);
+    });
+});
+
+describe('buildThreadedReplies', function () {
+    it('builds nested replies from a flat reply list', function () {
+        const threadParentComment = buildComment({
+            id: 'root',
+            replies: [
+                {id: 'reply-1', in_reply_to_id: null},
+                {id: 'reply-2', in_reply_to_id: 'reply-1'},
+                {id: 'reply-3', in_reply_to_id: 'reply-2'},
+                {id: 'reply-4', in_reply_to_id: null}
+            ]
+        });
+
+        const threadedReplies = helpers.buildThreadedReplies(threadParentComment);
+
+        expect(threadedReplies.map(reply => reply.id)).toEqual(['reply-1', 'reply-4']);
+        expect(threadedReplies[0].nestedReplies.map(reply => reply.id)).toEqual(['reply-2']);
+        expect(threadedReplies[0].nestedReplies[0].nestedReplies.map(reply => reply.id)).toEqual(['reply-3']);
+    });
+
+    it('keeps replies with missing parents at the root', function () {
+        const threadParentComment = buildComment({
+            id: 'root',
+            replies: [
+                {id: 'reply-1', in_reply_to_id: 'missing'}
+            ]
+        });
+
+        expect(helpers.buildThreadedReplies(threadParentComment).map(reply => reply.id)).toEqual(['reply-1']);
     });
 });
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -50,7 +50,8 @@ const PRIVATE_FEATURES = [
     'indexnow',
     'pictureImageFormats',
     'smarterCounts',
-    'giftSubscriptions'
+    'giftSubscriptions',
+    'commentsThreads'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -13,6 +13,7 @@ Object {
       "adminUIRefresh": true,
       "automations": true,
       "commentModeration": true,
+      "commentsThreads": true,
       "customFonts": true,
       "editorExcerpt": true,
       "emailCustomization": true,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3556/
ref https://linear.app/ghost/issue/BER-3584/

## Summary
- Added the commentsThreads private Labs flag and Admin private feature toggle
- Added comments-ui threaded display behind the commentsThreads flag
- Supports nested reply display without focused thread navigation or "more replies" pagination in threaded mode
- Hides the "Replied to" context line when threaded display is active