### PR TITLE
Split out "automation status" type in admin-x-framework types

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -1,10 +1,12 @@
 import {Meta, createQuery, createQueryWithId} from '../utils/api/hooks';
 
+export type AutomationStatus = 'active' | 'inactive';
+
 export type Automation = {
     id: string;
     name: string;
     slug: string;
-    status: 'active' | 'inactive';
+    status: AutomationStatus;
 }
 
 export type AutomationWaitAction = {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1267

This is a types-only change that should have no user impact. I think this is a useful change on its own but will also make [an upcoming change][0] a little easier.

[0]: https://linear.app/ghost/issue/NY-1267
