### PR TITLE
Added "live" and "off" indicators to automation header

### DIFF
--- a/apps/posts/src/views/Automations/components/automation-header.tsx
+++ b/apps/posts/src/views/Automations/components/automation-header.tsx
@@ -1,3 +1,4 @@
+import AutomationStatusBadge from './automation-status-badge';
 import React from 'react';
 import {Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Skeleton} from '@tryghost/shade/components';
 import {Link} from '@tryghost/admin-x-framework';
@@ -11,7 +12,8 @@ interface AutomationHeaderProps {
 
 const AutomationHeader: React.FC<AutomationHeaderProps> = ({automation, isLoading}) => {
     const name = automation?.name;
-    const isActive = automation?.status === 'active';
+    const status = automation?.status;
+    const isActive = status === 'active';
 
     return (
         <header className='relative z-10 flex h-14 shrink-0 items-center justify-between bg-background px-4 shadow-sm'>
@@ -24,7 +26,10 @@ const AutomationHeader: React.FC<AutomationHeaderProps> = ({automation, isLoadin
                 {isLoading ? (
                     <Skeleton className='h-5 w-40' />
                 ) : (
-                    <span className='truncate font-medium'>{name}</span>
+                    <>
+                        <span className='truncate font-medium'>{name}</span>
+                        {status && <AutomationStatusBadge status={status} />}
+                    </>
                 )}
             </div>
             <div className='flex shrink-0 items-center gap-3'>

--- a/apps/posts/src/views/Automations/components/automation-status-badge.tsx
+++ b/apps/posts/src/views/Automations/components/automation-status-badge.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type {Automation} from '@tryghost/admin-x-framework/api/automations';
+
+const AutomationStatusBadge: React.FC<{status: Automation['status']}> = ({status}) => {
+    switch (status) {
+    case 'active':
+        return (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-green/20 px-2 py-0.5 text-xs font-medium text-green">
+                <span className="size-1.5 rounded-full bg-green" />
+                LIVE
+            </span>
+        );
+    case 'inactive':
+        return (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                OFF
+            </span>
+        );
+    default: {
+        const invalidStatus: never = status;
+        throw new Error(`Unhandled status: ${invalidStatus}`);
+    }
+    }
+};
+
+export default AutomationStatusBadge;

--- a/apps/posts/src/views/Automations/components/automations-list.tsx
+++ b/apps/posts/src/views/Automations/components/automations-list.tsx
@@ -1,3 +1,4 @@
+import AutomationStatusBadge from './automation-status-badge';
 import React from 'react';
 import {Automation} from '@tryghost/admin-x-framework/api/automations';
 import {Link} from '@tryghost/admin-x-framework';
@@ -6,28 +7,6 @@ import {Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow}
 const AUTOMATION_DESCRIPTIONS: Record<string, string> = {
     'member-welcome-email-free': 'Onboard new free members with a short welcome email.',
     'member-welcome-email-paid': 'Greet new paid members and point them at member-only content.'
-};
-
-const AutomationsStatusBadge: React.FC<{status: Automation['status']}> = ({status}) => {
-    switch (status) {
-    case 'active':
-        return (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-green/20 px-2 py-0.5 text-xs font-medium text-green">
-                <span className="size-1.5 rounded-full bg-green" />
-                LIVE
-            </span>
-        );
-    case 'inactive':
-        return (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                OFF
-            </span>
-        );
-    default: {
-        const invalidStatus: never = status;
-        throw new Error(`Unhandled status: ${invalidStatus}`);
-    }
-    }
 };
 
 interface AutomationsListProps {
@@ -104,7 +83,7 @@ const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLo
                                 )}
                             </TableCell>
                             <TableCell className="lg:w-32 lg:p-4">
-                                <AutomationsStatusBadge status={automation.status} />
+                                <AutomationStatusBadge status={automation.status} />
                             </TableCell>
                         </TableRow>
                     );


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1267

| Off | Live |
|---|---|
| ![Off](https://github.com/user-attachments/assets/09de32a1-93b3-4f7c-9fd2-8fec2bd47d75) | ![Live](https://github.com/user-attachments/assets/ead83ebc-5d52-45eb-8ff5-e4b4b75bb8a5) |

This adds a little "off" or "live" indicator in the automation header.