### PR TITLE
Used proper capitalization in automation status badge

### DIFF
--- a/apps/posts/src/views/Automations/components/automation-status-badge.tsx
+++ b/apps/posts/src/views/Automations/components/automation-status-badge.tsx
@@ -5,15 +5,15 @@ const AutomationStatusBadge: React.FC<{status: Automation['status']}> = ({status
     switch (status) {
     case 'active':
         return (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-green/20 px-2 py-0.5 text-xs font-medium text-green">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-green/20 px-2 py-0.5 text-xs font-medium text-green uppercase">
                 <span className="size-1.5 rounded-full bg-green" />
-                LIVE
+                Live
             </span>
         );
     case 'inactive':
         return (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                OFF
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground uppercase">
+                Off
             </span>
         );
     default: {

--- a/apps/posts/test/unit/views/automations/automations-list.test.tsx
+++ b/apps/posts/test/unit/views/automations/automations-list.test.tsx
@@ -28,8 +28,8 @@ describe('AutomationsList', () => {
         expect(screen.getByText('Onboard new free members with a short welcome email.')).toBeInTheDocument();
         expect(screen.getByText('Welcome Email (Paid)')).toBeInTheDocument();
         expect(screen.getByText('Greet new paid members and point them at member-only content.')).toBeInTheDocument();
-        expect(screen.getByText('LIVE')).toBeInTheDocument();
-        expect(screen.getByText('OFF')).toBeInTheDocument();
+        expect(screen.getByText('Live')).toBeInTheDocument();
+        expect(screen.getByText('Off')).toBeInTheDocument();
     });
 
     it('links each row to the automation sequence by id', () => {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/27854

Before (pseudocode):

```html
<span>LIVE</span>
```

After (pseudocode):

```html
<span class="uppercase">Live</span>
```

This has a few advantages:

- More accessible. Screen readers will be able to read this more easily. This is the big reason.
- "Live" will be copy-pasted, not "LIVE", which is probably (slightly) more desirable.
- If we want it to look lowercase in the future, it's easier to change.
