### PR TITLE
Set up local and CI MinIO for the diskless-redirects GCSStore tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,6 +487,25 @@ jobs:
       - name: E2E tests
         run: pnpm nx run ghost:test:ci:e2e
 
+      - name: Start MinIO for integration tests
+        run: |
+          docker run -d --rm --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minio-user \
+            -e MINIO_ROOT_PASSWORD=minio-pass \
+            minio/minio:RELEASE.2024-12-13T22-19-12Z@sha256:149fdd73108553247ceee85fc65466f51034bd6e145d6e0c0e415167f5f1274f \
+            server /data
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:9000/minio/health/ready; then
+              echo "MinIO ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "MinIO did not become ready in time" >&2
+          docker logs minio
+          exit 1
+
       - name: Integration tests
         run: pnpm nx run ghost:test:ci:integration
 

--- a/compose.dev.storage.yaml
+++ b/compose.dev.storage.yaml
@@ -30,6 +30,7 @@ services:
       - MINIO_ROOT_USER=minio-user
       - MINIO_ROOT_PASSWORD=minio-pass
       - MINIO_BUCKET=ghost-dev
+      - MINIO_REDIRECTS_BUCKET=ghost-dev-redirects
     volumes:
       - ./docker/minio/setup.sh:/setup.sh:ro
     depends_on:

--- a/docker/minio/setup.sh
+++ b/docker/minio/setup.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 BUCKET=${MINIO_BUCKET:-ghost-dev}
+REDIRECTS_BUCKET=${MINIO_REDIRECTS_BUCKET:-ghost-dev-redirects}
 
 echo "Configuring MinIO alias..."
 mc alias set local http://minio:9000 "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
@@ -12,4 +13,7 @@ mc mb --ignore-existing "local/${BUCKET}"
 echo "Setting anonymous download policy on '${BUCKET}'..."
 mc anonymous set download "local/${BUCKET}"
 
-echo "MinIO bucket '${BUCKET}' ready."
+echo "Ensuring redirects bucket '${REDIRECTS_BUCKET}' exists..."
+mc mb --ignore-existing "local/${REDIRECTS_BUCKET}"
+
+echo "MinIO setup complete."

--- a/ghost/core/test/integration/utils/minio.test.js
+++ b/ghost/core/test/integration/utils/minio.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const {
+    createTestS3Client,
+    createTestBucket,
+    emptyTestBucket,
+    deleteTestBucket,
+    putObject,
+    getObject,
+    deleteObject
+} = require('../../utils/minio');
+
+describe('Integration: MinIO test helper', function () {
+    let client;
+    let bucket;
+
+    before(async function () {
+        client = createTestS3Client();
+        bucket = await createTestBucket(client);
+    });
+
+    afterEach(async function () {
+        await emptyTestBucket(client, bucket);
+    });
+
+    after(async function () {
+        await deleteTestBucket(client, bucket);
+    });
+
+    it('putObject + getObject round-trip preserves the body', async function () {
+        const body = '{"hello":"world"}';
+        await putObject(client, bucket, 'config.json', body);
+
+        const fetched = await getObject(client, bucket, 'config.json');
+        assert.equal(fetched?.toString('utf8'), body);
+    });
+
+    it('getObject returns null for a missing key', async function () {
+        assert.equal(await getObject(client, bucket, 'does-not-exist'), null);
+    });
+
+    it('deleteObject removes the object', async function () {
+        await putObject(client, bucket, 'k', 'v');
+        await deleteObject(client, bucket, 'k');
+
+        assert.equal(await getObject(client, bucket, 'k'), null);
+    });
+
+    it('emptyTestBucket removes every object', async function () {
+        await putObject(client, bucket, 'a', 'a-body');
+        await putObject(client, bucket, 'b', 'b-body');
+
+        await emptyTestBucket(client, bucket);
+
+        assert.equal(await getObject(client, bucket, 'a'), null);
+        assert.equal(await getObject(client, bucket, 'b'), null);
+    });
+});

--- a/ghost/core/test/utils/minio.ts
+++ b/ghost/core/test/utils/minio.ts
@@ -1,0 +1,98 @@
+import {randomBytes} from 'node:crypto';
+import {
+    CreateBucketCommand,
+    DeleteBucketCommand,
+    DeleteObjectCommand,
+    GetObjectCommand,
+    ListObjectsV2Command,
+    NoSuchKey,
+    PutObjectCommand,
+    S3Client
+} from '@aws-sdk/client-s3';
+
+const DEFAULT_TEST_BUCKET_PREFIX = 'test-redirects';
+
+export function createTestS3Client(): S3Client {
+    return new S3Client({
+        endpoint: process.env.MINIO_TEST_ENDPOINT || 'http://127.0.0.1:9000',
+        region: process.env.MINIO_TEST_REGION || 'us-east-1',
+        // MinIO serves buckets via URL path (http://host/bucket/key) rather than
+        // AWS's virtual-host style (https://bucket.s3.amazonaws.com/key).
+        forcePathStyle: true,
+        credentials: {
+            accessKeyId: process.env.MINIO_TEST_ACCESS_KEY || 'minio-user',
+            secretAccessKey: process.env.MINIO_TEST_SECRET_KEY || 'minio-pass'
+        }
+    });
+}
+
+export async function createTestBucket(
+    client: S3Client,
+    prefix: string = DEFAULT_TEST_BUCKET_PREFIX
+): Promise<string> {
+    const bucket = `${prefix}-${randomBytes(4).toString('hex')}`;
+    await client.send(new CreateBucketCommand({Bucket: bucket}));
+    return bucket;
+}
+
+export async function emptyTestBucket(client: S3Client, bucket: string): Promise<void> {
+    let continuationToken: string | undefined;
+    do {
+        const response = await client.send(new ListObjectsV2Command({
+            Bucket: bucket,
+            ContinuationToken: continuationToken
+        }));
+        for (const object of response.Contents ?? []) {
+            if (object.Key) {
+                await client.send(new DeleteObjectCommand({Bucket: bucket, Key: object.Key}));
+            }
+        }
+        continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+    } while (continuationToken);
+}
+
+export async function deleteTestBucket(client: S3Client, bucket: string): Promise<void> {
+    await client.send(new DeleteBucketCommand({Bucket: bucket}));
+}
+
+export async function putObject(
+    client: S3Client,
+    bucket: string,
+    key: string,
+    body: string | Buffer
+): Promise<void> {
+    await client.send(new PutObjectCommand({Bucket: bucket, Key: key, Body: body}));
+}
+
+/**
+ * Returns null when the key is missing instead of throwing. Matches the
+ * planned GCSStore.getAll() behaviour from HKG-1700 ("Returns [] on 404")
+ * so tests asserting absence don't need try/catch wrappers.
+ */
+export async function getObject(
+    client: S3Client,
+    bucket: string,
+    key: string
+): Promise<Buffer | null> {
+    try {
+        const response = await client.send(new GetObjectCommand({Bucket: bucket, Key: key}));
+        if (!response.Body) {
+            return null;
+        }
+        const bytes = await response.Body.transformToByteArray();
+        return Buffer.from(bytes);
+    } catch (err) {
+        if (err instanceof NoSuchKey) {
+            return null;
+        }
+        throw err;
+    }
+}
+
+export async function deleteObject(
+    client: S3Client,
+    bucket: string,
+    key: string
+): Promise<void> {
+    await client.send(new DeleteObjectCommand({Bucket: bucket, Key: key}));
+}


### PR DESCRIPTION
ref [HKG-1699](https://linear.app/ghost/issue/HKG-1699/set-up-local-minio-for-gcs-store-testing)

Sets up the local-dev and CI infrastructure that the upcoming GCSStore for redirects ([HKG-1700](https://linear.app/ghost/issue/HKG-1700/implement-gcsstore-with-timestamped-backups)) will need to run its tests against a real S3-compatible endpoint. Pure test scaffolding — no production code, no runtime behaviour changes, no new dependencies.

## What's in the PR

Best reviewed commit-by-commit:

1. **Added MinIO bucket for redirects in local dev** — extends the existing MinIO setup script to provision a private `ghost-dev-redirects` bucket alongside the public `ghost-dev` media bucket. The new bucket deliberately does **not** get `mc anonymous set download`: redirects.json is config fetched via signed S3 requests, not a public asset.
2. **Added MinIO test helper for upcoming GCSStore tests** — small TypeScript helper at `ghost/core/test/utils/minio.ts` exposing the bucket lifecycle + PUT/GET/DELETE primitives. Functional API matching the existing `email-verification-utils.ts` precedent. Connection conventions mirror `S3Storage.ts` (forcePathStyle, region, credential shape) so engineers reading both files don't context-switch.
3. **Added integration test for the MinIO test helper** — proves the helper actually drives a real S3 endpoint correctly (4 cases: round-trip, missing-key returns null, delete, empty-bucket). Mocking the SDK would defeat the helper's purpose.
4. **Added MinIO to CI for the redirects store integration test** — provisions MinIO in the `job_acceptance-tests` job via a `docker run` step. Same image digest as `compose.dev.storage.yaml` for dev/CI parity. `services:` block was unsuitable because `minio/minio` requires a `server` command that the services schema doesn't let you override.

## Linked issues

Closes [HKG-1699](https://linear.app/ghost/issue/HKG-1699/set-up-local-minio-for-gcs-store-testing).

Unblocks [HKG-1700](https://linear.app/ghost/issue/HKG-1700/implement-gcsstore-with-timestamped-backups)

## Test plan

- [x] `pnpm test:single test/integration/utils/minio.test.js` — 4 passing locally against MinIO at 127.0.0.1:9000 (~670ms)
- [x] `pnpm dev:storage` provisions both `ghost-dev` and `ghost-dev-redirects`; only the media bucket has `anonymous set download` applied
- [x] `tsc --noEmit -p ghost/core/tsconfig.json` clean
- [x] `pnpm lint` clean
- [ ] CI green on this PR (the new MinIO service step runs before integration tests)