### PR TITLE
Cleaned up defensive fallback that is no longer necessary

### DIFF
--- a/ghost/admin/app/services/members-stats.js
+++ b/ghost/admin/app/services/members-stats.js
@@ -23,8 +23,7 @@ export default class MembersStatsService extends Service {
         if (!stats) {
             return 0;
         }
-        // TODO: remove gift default once API includes `gift`
-        const {free, paid, comped, gift = 0} = stats.meta.totals;
+        const {free, paid, comped, gift} = stats.meta.totals;
         const total = free + paid + comped + gift || 0;
         return total;
     }

--- a/ghost/admin/tests/unit/services/member-stats-test.js
+++ b/ghost/admin/tests/unit/services/member-stats-test.js
@@ -95,12 +95,5 @@ describe('Unit: Service: membersStats', function () {
             };
             expect(memberStatsService.memberCount).to.equal(117);
         });
-
-        it('defaults gift to 0 when missing from API response', function () {
-            memberStatsService.totalMemberCount = {
-                meta: {totals: {paid: 10, free: 100, comped: 5}}
-            };
-            expect(memberStatsService.memberCount).to.equal(115);
-        });
     });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/27503
ref https://linear.app/ghost/issue/BER-3554

The defensive fallback `gift = 0` was added in [#27503](https://github.com/TryGhost/Ghost/pull/27503) as a temporary safety net as Admin is deployed ahead of the server on Ghost (Pro). Now that the corresponding server change (that includes `gift` in the member count) has been rolled out fully, we can remove the defensive fallback.
