### PR TITLE
✨ Added gift subscriptions

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -64,10 +64,6 @@ const features: Feature[] = [{
     description: 'Use optimized COUNT queries for API pagination when safe',
     flag: 'smarterCounts'
 }, {
-    title: 'Gift Subscriptions',
-    description: 'Allow site visitors to purchase gift subscriptions for others',
-    flag: 'giftSubscriptions'
-}, {
     title: 'Comments Threads',
     description: 'Enable deeper threading view in Comments-UI',
     flag: 'commentsThreads'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -24,7 +24,8 @@ const GA_FEATURES = [
     'customFonts',
     'explore',
     'commentModeration',
-    'featurebaseFeedback'
+    'featurebaseFeedback',
+    'giftSubscriptions'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -50,7 +51,6 @@ const PRIVATE_FEATURES = [
     'indexnow',
     'pictureImageFormats',
     'smarterCounts',
-    'giftSubscriptions',
     'commentsThreads',
     'commentsPinning'
 ];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1803,7 +1803,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5379",
+  "content-length": "5406",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3597

Gift subscriptions let anyone purchase a paid subscription on behalf of someone else — a friend, family member, or colleague — giving them full access to a site’s paid content for up to a year.