### PR TITLE
Skipped app version bump check for dependency-only changes

### DIFF
--- a/.github/scripts/check-app-version-bump.js
+++ b/.github/scripts/check-app-version-bump.js
@@ -173,14 +173,21 @@ function getChangedFiles(baseSha, compareSha) {
         .filter(Boolean);
 }
 
+function getChangedAppFiles(app, changedFiles) {
+    return changedFiles.filter((file) => {
+        return file === app.path || file.startsWith(`${app.path}/`);
+    });
+}
+
 function getChangedApps(changedFiles) {
     return MONITORED_APP_ENTRIES
-        .filter(([, app]) => {
-            return changedFiles.some((file) => {
-                return file === app.path || file.startsWith(`${app.path}/`);
-            });
-        })
+        .filter(([, app]) => getChangedAppFiles(app, changedFiles).length > 0)
         .map(([key, app]) => ({key, ...app}));
+}
+
+function isDependencyOnlyChange(app, changedFiles) {
+    const filesInApp = getChangedAppFiles(app, changedFiles);
+    return filesInApp.length > 0 && filesInApp.every(file => file === `${app.path}/package.json`);
 }
 
 function getPrVersion(app) {
@@ -228,6 +235,11 @@ function main() {
     const failedApps = [];
 
     for (const app of changedApps) {
+        if (isDependencyOnlyChange(app, changedFiles)) {
+            console.log(`${app.key} only has dependency changes in package.json; skipping version bump check.`);
+            continue;
+        }
+
         const prVersion = getPrVersion(app);
         const mainVersion = getMainVersion(app);
 


### PR DESCRIPTION
## Summary

`Check app version bump` fails any PR that changes a file under `apps/{portal,sodo-search,comments-ui,announcement-bar,signup-form}` without bumping that app's `version` field. Renovate never bumps app versions when it updates dependencies, so every dep bump that touches one of those apps' `package.json` files dies on this check — including current security PRs (postcss, vite, others).

This change exempts diffs whose only change inside a monitored app is `package.json`. A human PR that edits both source and `package.json` in the same app still trips the check, so the cache-busting guarantee for actual code changes is preserved.

## Test plan

- [ ] Trigger the workflow on this PR — script touches no monitored app files, so the check should report no app changes detected.
- [ ] Rebase one of the stuck Renovate security PRs (e.g. #27595, #27354) onto this branch and confirm `Check app version bump` passes.
- [ ] Open a synthetic test PR that edits a source file under `apps/portal/src` without bumping `apps/portal/package.json` and confirm the check still fails.