### PR TITLE
Fixed shade test ESLint config to apply TypeScript-aware rules

### DIFF
--- a/apps/shade/.eslintrc.cjs
+++ b/apps/shade/.eslintrc.cjs
@@ -1,6 +1,7 @@
 const tailwindCssConfig = `${__dirname}/../admin/src/index.css`;
 
 module.exports = {
+    root: true,
     extends: [
         'plugin:ghost/ts',
         'plugin:react/recommended',

--- a/apps/shade/test/.eslintrc.cjs
+++ b/apps/shade/test/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
         browser: true
     },
     extends: [
-        'plugin:ghost/test'
+        'plugin:ghost/ts-test'
     ],
     rules: {
         // Enforce a kebab-case (lowercase with hyphens) for all filenames

--- a/apps/shade/test/unit/components/layout/error-page.test.tsx
+++ b/apps/shade/test/unit/components/layout/error-page.test.tsx
@@ -34,8 +34,8 @@ describe('ErrorPage Component', () => {
         const handleBackToDashboard = vi.fn();
         render(
             <ErrorPage 
-                onBackToDashboard={handleBackToDashboard} 
                 data-testid="error-page" 
+                onBackToDashboard={handleBackToDashboard} 
             />
         );
         
@@ -46,7 +46,7 @@ describe('ErrorPage Component', () => {
     });
 
     it('passes additional props to the outer div', () => {
-        render(<ErrorPage id="custom-id" aria-label="Error message" data-testid="error-page" />);
+        render(<ErrorPage aria-label="Error message" data-testid="error-page" id="custom-id" />);
         const errorPage = screen.getByTestId('error-page');
         
         assert.equal(errorPage.id, 'custom-id', 'Should have custom id attribute');

--- a/apps/shade/test/unit/components/layout/list-header.test.tsx
+++ b/apps/shade/test/unit/components/layout/list-header.test.tsx
@@ -22,8 +22,8 @@ describe('ListHeader ActionGroup', () => {
     it('renders all actions directly when no mobile menu is provided', () => {
         render(
             <ListHeader.ActionGroup>
-                <button>Search</button>
-                <button>Filter</button>
+                <button type="button">Search</button>
+                <button type="button">Filter</button>
             </ListHeader.ActionGroup>
         );
 
@@ -38,11 +38,11 @@ describe('ListHeader ActionGroup', () => {
     it('renders only the mobile menu trigger in mobile row when no primary action is provided', () => {
         render(
             <ListHeader.ActionGroup mobileMenuBreakpoint={1200}>
-                <button>Search</button>
-                <button>Filter</button>
+                <button type="button">Search</button>
+                <button type="button">Filter</button>
                 <ListHeader.ActionGroup.MobileMenu>
                     <ListHeader.ActionGroup.MobileMenuTrigger>
-                        <button aria-label="Open menu">Menu</button>
+                        <button aria-label="Open menu" type="button">Menu</button>
                     </ListHeader.ActionGroup.MobileMenuTrigger>
                     <ListHeader.ActionGroup.MobileMenuContent>
                         <DropdownMenuItem>Filter</DropdownMenuItem>
@@ -66,14 +66,14 @@ describe('ListHeader ActionGroup', () => {
     it('renders both primary action and mobile menu trigger in mobile row when primary action is provided', () => {
         render(
             <ListHeader.ActionGroup mobileMenuBreakpoint={1200}>
-                <button>Search</button>
-                <button>Filter</button>
+                <button type="button">Search</button>
+                <button type="button">Filter</button>
                 <ListHeader.ActionGroup.Primary>
-                    <button>Add member</button>
+                    <button type="button">Add member</button>
                 </ListHeader.ActionGroup.Primary>
                 <ListHeader.ActionGroup.MobileMenu>
                     <ListHeader.ActionGroup.MobileMenuTrigger>
-                        <button aria-label="Open menu">Menu</button>
+                        <button aria-label="Open menu" type="button">Menu</button>
                     </ListHeader.ActionGroup.MobileMenuTrigger>
                     <ListHeader.ActionGroup.MobileMenuContent>
                         <DropdownMenuItem>Filter</DropdownMenuItem>
@@ -101,14 +101,14 @@ describe('ListHeader ActionGroup', () => {
     it('shows full desktop actions when viewport is above the provided mobile breakpoint', () => {
         render(
             <ListHeader.ActionGroup mobileMenuBreakpoint={900}>
-                <button>Search</button>
-                <button>Filter</button>
+                <button type="button">Search</button>
+                <button type="button">Filter</button>
                 <ListHeader.ActionGroup.Primary>
-                    <button>Add member</button>
+                    <button type="button">Add member</button>
                 </ListHeader.ActionGroup.Primary>
                 <ListHeader.ActionGroup.MobileMenu>
                     <ListHeader.ActionGroup.MobileMenuTrigger>
-                        <button aria-label="Open menu">Menu</button>
+                        <button aria-label="Open menu" type="button">Menu</button>
                     </ListHeader.ActionGroup.MobileMenuTrigger>
                     <ListHeader.ActionGroup.MobileMenuContent>
                         <DropdownMenuItem>Filter</DropdownMenuItem>

--- a/apps/shade/test/unit/components/layout/page.test.tsx
+++ b/apps/shade/test/unit/components/layout/page.test.tsx
@@ -31,7 +31,7 @@ describe('Page Component', () => {
             <Page data-testid="page">
                 <h1>Page Title</h1>
                 <p>Page paragraph</p>
-                <button>Page button</button>
+                <button type="button">Page button</button>
             </Page>
         );
         
@@ -48,9 +48,9 @@ describe('Page Component', () => {
     it('passes additional props to the div element', () => {
         render(
             <Page 
-                data-testid="page" 
+                aria-label="Test page" 
+                data-testid="page"
                 id="test-page-id"
-                aria-label="Test page"
             >
                 Page Content
             </Page>

--- a/apps/shade/test/unit/components/layout/view-header.test.tsx
+++ b/apps/shade/test/unit/components/layout/view-header.test.tsx
@@ -10,8 +10,8 @@ describe('ViewHeader Components', () => {
             <ViewHeader>
                 <div>Header Content</div>
                 <ViewHeaderActions>
-                    <button>Action 1</button>
-                    <button>Action 2</button>
+                    <button type="button">Action 1</button>
+                    <button type="button">Action 2</button>
                 </ViewHeaderActions>
             </ViewHeader>
         );
@@ -47,7 +47,7 @@ describe('ViewHeader Components', () => {
     it('renders ViewHeaderActions with correct styling', () => {
         render(
             <ViewHeaderActions>
-                <button>Action</button>
+                <button type="button">Action</button>
             </ViewHeaderActions>
         );
         
@@ -79,9 +79,9 @@ describe('ViewHeader Components', () => {
             <ViewHeader>
                 <div>Header Content</div>
                 <ViewHeaderActions>
-                    <button>Action 1</button>
+                    <button type="button">Action 1</button>
                     <span>Separator</span>
-                    <button>Action 2</button>
+                    <button type="button">Action 2</button>
                 </ViewHeaderActions>
             </ViewHeader>
         );

--- a/apps/shade/test/unit/components/patterns/filters.test.tsx
+++ b/apps/shade/test/unit/components/patterns/filters.test.tsx
@@ -129,310 +129,312 @@ function openCalendar() {
     fireEvent.click(screen.getByRole('button', {name: 'Open calendar'}));
 }
 
-describe('Filters ValueSource', () => {
-    beforeAll(() => {
-        global.ResizeObserver = class {
-            observe() {
-                return undefined;
-            }
+describe('Filters', () => {
+    describe('ValueSource', () => {
+        beforeAll(() => {
+            global.ResizeObserver = class {
+                observe() {
+                    return undefined;
+                }
 
-            unobserve() {
-                return undefined;
-            }
+                unobserve() {
+                    return undefined;
+                }
 
-            disconnect() {
-                return undefined;
-            }
-        } as unknown as typeof ResizeObserver;
-        HTMLElement.prototype.scrollIntoView = vi.fn();
-    });
-
-    afterEach(() => {
-        vi.useRealTimers();
-    });
-
-    it('calls the value source with local query state and selected values', async () => {
-        const valueSource = createMatchingValueSource();
-        const {useOptions} = valueSource;
-
-        render(<TestFilters valueSource={valueSource} />);
-
-        expect(useOptions).toHaveBeenCalledWith({
-            query: '',
-            selectedValues: ['published']
+                disconnect() {
+                    return undefined;
+                }
+            } as unknown as typeof ResizeObserver;
+            HTMLElement.prototype.scrollIntoView = vi.fn();
         });
 
-        openSelectedValuePopover();
+        afterEach(() => {
+            vi.useRealTimers();
+        });
 
-        const input = await screen.findByPlaceholderText('Search status...');
-        fireEvent.change(input, {target: {value: 'dra'}});
+        it('calls the value source with local query state and selected values', async () => {
+            const valueSource = createMatchingValueSource();
+            const {useOptions} = valueSource;
 
-        await waitFor(() => {
-            expect(useOptions).toHaveBeenLastCalledWith({
-                query: 'dra',
+            render(<TestFilters valueSource={valueSource} />);
+
+            expect(useOptions).toHaveBeenCalledWith({
+                query: '',
                 selectedValues: ['published']
             });
+
+            openSelectedValuePopover();
+
+            const input = await screen.findByPlaceholderText('Search status...');
+            fireEvent.change(input, {target: {value: 'dra'}});
+
+            await waitFor(() => {
+                expect(useOptions).toHaveBeenLastCalledWith({
+                    query: 'dra',
+                    selectedValues: ['published']
+                });
+            });
         });
-    });
 
-    it('keeps the selected option out of the options list when the current query excludes it', async () => {
-        const useOptions = vi.fn(({query}: {query: string; selectedValues: string[]}) => ({
-            options: query
-                ? ALL_OPTIONS.filter(option => option.value === 'draft')
-                : ALL_OPTIONS,
-            isInitialLoad: false,
-            isSearching: false,
-            isLoadingMore: false,
-            hasMore: false,
-            loadMore: () => {}
-        }));
+        it('keeps the selected option out of the options list when the current query excludes it', async () => {
+            const useOptions = vi.fn(({query}: {query: string; selectedValues: string[]}) => ({
+                options: query
+                    ? ALL_OPTIONS.filter(option => option.value === 'draft')
+                    : ALL_OPTIONS,
+                isInitialLoad: false,
+                isSearching: false,
+                isLoadingMore: false,
+                hasMore: false,
+                loadMore: () => {}
+            }));
 
-        render(<TestFilters valueSource={{id: 'status', useOptions}} />);
+            render(<TestFilters valueSource={{id: 'status', useOptions}} />);
 
-        openSelectedValuePopover();
+            openSelectedValuePopover();
 
-        const input = await screen.findByPlaceholderText('Search status...');
-        fireEvent.change(input, {target: {value: 'dra'}});
+            const input = await screen.findByPlaceholderText('Search status...');
+            fireEvent.change(input, {target: {value: 'dra'}});
 
-        await waitFor(() => {
-            expect(screen.getAllByText('Published')).toHaveLength(1);
+            await waitFor(() => {
+                expect(screen.getAllByText('Published')).toHaveLength(1);
+                expect(screen.getByText('Draft')).toBeDefined();
+            });
+        });
+
+        it('resets the local query and visible options when the popover closes', async () => {
+            const valueSource = createMatchingValueSource();
+            const {useOptions} = valueSource;
+
+            render(<TestFilters valueSource={valueSource} />);
+
+            openSelectedValuePopover();
+
+            const input = await screen.findByPlaceholderText('Search status...');
+            fireEvent.change(input, {target: {value: 'dra'}});
+
+            await waitFor(() => {
+                expect(useOptions).toHaveBeenLastCalledWith({
+                    query: 'dra',
+                    selectedValues: ['published']
+                });
+            });
+
+            const trigger = getSelectedValueTrigger();
+
+            fireEvent.click(trigger);
+
+            await act(async () => {
+                await new Promise<void>((resolve) => {
+                    setTimeout(() => {
+                        resolve();
+                    }, 250);
+                });
+            });
+
+            fireEvent.click(trigger);
+
+            const reopenedInput = await screen.findByPlaceholderText('Search status...');
+            expect((reopenedInput as HTMLInputElement).value).toBe('');
             expect(screen.getByText('Draft')).toBeDefined();
-        });
-    });
-
-    it('resets the local query and visible options when the popover closes', async () => {
-        const valueSource = createMatchingValueSource();
-        const {useOptions} = valueSource;
-
-        render(<TestFilters valueSource={valueSource} />);
-
-        openSelectedValuePopover();
-
-        const input = await screen.findByPlaceholderText('Search status...');
-        fireEvent.change(input, {target: {value: 'dra'}});
-
-        await waitFor(() => {
             expect(useOptions).toHaveBeenLastCalledWith({
-                query: 'dra',
+                query: '',
                 selectedValues: ['published']
             });
         });
 
-        const trigger = getSelectedValueTrigger();
+        it('renders and triggers load more when the value source supports pagination', async () => {
+            const loadMore = vi.fn();
+            const useOptions = vi.fn(() => ({
+                options: ALL_OPTIONS,
+                isInitialLoad: false,
+                isSearching: false,
+                isLoadingMore: false,
+                hasMore: true,
+                loadMore
+            }));
 
-        fireEvent.click(trigger);
+            render(<TestFilters valueSource={{id: 'status', useOptions}} />);
 
-        await act(async () => {
-            await new Promise<void>((resolve) => {
-                setTimeout(() => {
-                    resolve();
-                }, 250);
+            openSelectedValuePopover();
+
+            const loadMoreButton = await screen.findByRole('button', {name: 'Load more'});
+            fireEvent.click(loadMoreButton);
+
+            expect(loadMore).toHaveBeenCalledTimes(1);
+        });
+
+        it('shows loading states for static select fields', async () => {
+            const {rerender} = render(<StaticLoadingFilters isLoading={true} options={[]} />);
+
+            fireEvent.click(screen.getByRole('button', {name: 'Select...'}));
+            expect(await screen.findByText('Loading...')).toBeDefined();
+
+            rerender(<StaticLoadingFilters isLoading={true} options={ALL_OPTIONS} />);
+            expect(await screen.findByPlaceholderText('Search status...')).toBeDefined();
+            expect(document.querySelector('.animate-spin')).toBeTruthy();
+        });
+
+        it('calls date field onInputChange when a typed date is committed', () => {
+            const handleFiltersChange = vi.fn();
+            const handleInputChange = vi.fn();
+
+            render(<DateFilters onFiltersChange={handleFiltersChange} onInputChange={handleInputChange} />);
+
+            const input = screen.getByDisplayValue('2026-05-07');
+            fireEvent.change(input, {target: {value: '2026-05-08'}});
+            fireEvent.blur(input);
+
+            expect(handleFiltersChange).toHaveBeenCalledWith('2026-05-08');
+            expect(handleInputChange).toHaveBeenCalledWith('2026-05-08');
+        });
+
+        it('resets manually entered invalid date values to today', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date(2026, 4, 9));
+            const handleFiltersChange = vi.fn();
+            const handleInputChange = vi.fn();
+
+            render(<DateFilters onFiltersChange={handleFiltersChange} onInputChange={handleInputChange} />);
+
+            const input = screen.getByDisplayValue('2026-05-07');
+            fireEvent.change(input, {target: {value: '2026-02-30'}});
+            fireEvent.blur(input);
+
+            expect(screen.getByDisplayValue('2026-05-09')).toBeDefined();
+            expect(handleFiltersChange).toHaveBeenCalledWith('2026-05-09');
+            expect(handleInputChange).toHaveBeenCalledWith('2026-05-09');
+        });
+
+        it('passes valid date values to the calendar selection', async () => {
+            render(<DateFilters onFiltersChange={vi.fn()} onInputChange={vi.fn()} />);
+
+            openCalendar();
+
+            expect((await screen.findByTestId('calendar-selected')).getAttribute('data-selected')).toBe('2026-05-07');
+        });
+
+        it('updates the date input when a calendar date is selected', async () => {
+            const handleFiltersChange = vi.fn();
+            const handleInputChange = vi.fn();
+
+            render(<DateFilters onFiltersChange={handleFiltersChange} onInputChange={handleInputChange} />);
+
+            openCalendar();
+            fireEvent.click(await screen.findByRole('button', {name: 'Select May 8'}));
+
+            expect(screen.getByDisplayValue('2026-05-08')).toBeDefined();
+            expect(handleFiltersChange).toHaveBeenCalledWith('2026-05-08');
+            expect(handleInputChange).toHaveBeenCalledWith('2026-05-08');
+        });
+
+        it('uses an editable text input for date values', () => {
+            render(<DateFilters onFiltersChange={vi.fn()} onInputChange={vi.fn()} />);
+
+            const input = screen.getByDisplayValue('2026-05-07') as HTMLInputElement;
+
+            expect(input.type).toBe('text');
+            expect(input.pattern).toBe('\\d{4}-\\d{2}-\\d{2}');
+        });
+
+        it('does not normalize overflow date values for the calendar selection', async () => {
+            render(<DateFilters initialValue="2026-02-30" onFiltersChange={vi.fn()} onInputChange={vi.fn()} />);
+
+            openCalendar();
+
+            expect((await screen.findByTestId('calendar-selected')).getAttribute('data-selected')).toBe('');
+        });
+
+        it('requires date values to use the HTML date input format', async () => {
+            render(<DateFilters initialValue="2026-5-7" onFiltersChange={vi.fn()} onInputChange={vi.fn()} />);
+
+            openCalendar();
+
+            expect((await screen.findByTestId('calendar-selected')).getAttribute('data-selected')).toBe('');
+        });
+    });
+
+    describe('allowMultiple multiselect', () => {
+        beforeAll(() => {
+            global.ResizeObserver = class {
+                observe() {
+                    return undefined;
+                }
+
+                unobserve() {
+                    return undefined;
+                }
+
+                disconnect() {
+                    return undefined;
+                }
+            } as unknown as typeof ResizeObserver;
+            HTMLElement.prototype.scrollIntoView = vi.fn();
+        });
+
+        function MultiselectTestFilters({initialFilters, onChangeSpy}: Readonly<{
+            initialFilters: Filter<string>[];
+            // eslint-disable-next-line no-unused-vars
+            onChangeSpy: (filters: Filter<string>[]) => void;
+        }>) {
+            const [filters, setFilters] = useState<Filter<string>[]>(initialFilters);
+            const fields = useMemo<FilterFieldConfig<string>[]>(() => ([
+                {
+                    key: 'label',
+                    label: 'Label',
+                    type: 'multiselect',
+                    searchable: false,
+                    operators: [{value: 'is-any', label: 'is any of'}],
+                    defaultOperator: 'is-any',
+                    options: [
+                        {value: 'vip', label: 'VIP'},
+                        {value: 'premium', label: 'Premium'},
+                        {value: 'gold', label: 'Gold'}
+                    ]
+                }
+            ]), []);
+
+            return (
+                <Filters
+                    addButtonText="Add filter"
+                    allowMultiple={true}
+                    fields={fields}
+                    filters={filters}
+                    showSearchInput={false}
+                    onChange={(next) => {
+                        onChangeSpy(next);
+                        setFilters(next);
+                    }}
+                />
+            );
+        }
+
+        it('commits a new single-value label filter and closes the picker after one selection', async () => {
+            const onChangeSpy = vi.fn();
+            const initial = [createFilter<string>('label', 'is-any', ['vip'])];
+
+            render(<MultiselectTestFilters initialFilters={initial} onChangeSpy={onChangeSpy} />);
+
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            const labelMenuItem = await screen.findByRole('option', {name: 'Label'});
+            fireEvent.click(labelMenuItem);
+
+            const premiumOption = await screen.findByRole('option', {name: 'Premium'});
+            fireEvent.click(premiumOption);
+
+            await waitFor(() => {
+                const lastCall = onChangeSpy.mock.calls.at(-1);
+                expect(lastCall).toBeDefined();
+                const finalFilters = lastCall![0] as Filter<string>[];
+                expect(finalFilters).toHaveLength(2);
+                expect(finalFilters[0].field).toBe('label');
+                expect(finalFilters[0].values).toEqual(['vip']);
+                expect(finalFilters[1].field).toBe('label');
+                expect(finalFilters[1].values).toEqual(['premium']);
             });
+
+            // Picker should have closed — no more option role elements visible.
+            expect(screen.queryByRole('option', {name: 'Gold'})).toBeNull();
         });
-
-        fireEvent.click(trigger);
-
-        const reopenedInput = await screen.findByPlaceholderText('Search status...');
-        expect((reopenedInput as HTMLInputElement).value).toBe('');
-        expect(screen.getByText('Draft')).toBeDefined();
-        expect(useOptions).toHaveBeenLastCalledWith({
-            query: '',
-            selectedValues: ['published']
-        });
-    });
-
-    it('renders and triggers load more when the value source supports pagination', async () => {
-        const loadMore = vi.fn();
-        const useOptions = vi.fn(() => ({
-            options: ALL_OPTIONS,
-            isInitialLoad: false,
-            isSearching: false,
-            isLoadingMore: false,
-            hasMore: true,
-            loadMore
-        }));
-
-        render(<TestFilters valueSource={{id: 'status', useOptions}} />);
-
-        openSelectedValuePopover();
-
-        const loadMoreButton = await screen.findByRole('button', {name: 'Load more'});
-        fireEvent.click(loadMoreButton);
-
-        expect(loadMore).toHaveBeenCalledTimes(1);
-    });
-
-    it('shows loading states for static select fields', async () => {
-        const {rerender} = render(<StaticLoadingFilters isLoading={true} options={[]} />);
-
-        fireEvent.click(screen.getByRole('button', {name: 'Select...'}));
-        expect(await screen.findByText('Loading...')).toBeDefined();
-
-        rerender(<StaticLoadingFilters isLoading={true} options={ALL_OPTIONS} />);
-        expect(await screen.findByPlaceholderText('Search status...')).toBeDefined();
-        expect(document.querySelector('.animate-spin')).toBeTruthy();
-    });
-
-    it('calls date field onInputChange when a typed date is committed', () => {
-        const handleFiltersChange = vi.fn();
-        const handleInputChange = vi.fn();
-
-        render(<DateFilters onFiltersChange={handleFiltersChange} onInputChange={handleInputChange} />);
-
-        const input = screen.getByDisplayValue('2026-05-07');
-        fireEvent.change(input, {target: {value: '2026-05-08'}});
-        fireEvent.blur(input);
-
-        expect(handleFiltersChange).toHaveBeenCalledWith('2026-05-08');
-        expect(handleInputChange).toHaveBeenCalledWith('2026-05-08');
-    });
-
-    it('resets manually entered invalid date values to today', () => {
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date(2026, 4, 9));
-        const handleFiltersChange = vi.fn();
-        const handleInputChange = vi.fn();
-
-        render(<DateFilters onFiltersChange={handleFiltersChange} onInputChange={handleInputChange} />);
-
-        const input = screen.getByDisplayValue('2026-05-07');
-        fireEvent.change(input, {target: {value: '2026-02-30'}});
-        fireEvent.blur(input);
-
-        expect(screen.getByDisplayValue('2026-05-09')).toBeDefined();
-        expect(handleFiltersChange).toHaveBeenCalledWith('2026-05-09');
-        expect(handleInputChange).toHaveBeenCalledWith('2026-05-09');
-    });
-
-    it('passes valid date values to the calendar selection', async () => {
-        render(<DateFilters onFiltersChange={vi.fn()} onInputChange={vi.fn()} />);
-
-        openCalendar();
-
-        expect((await screen.findByTestId('calendar-selected')).getAttribute('data-selected')).toBe('2026-05-07');
-    });
-
-    it('updates the date input when a calendar date is selected', async () => {
-        const handleFiltersChange = vi.fn();
-        const handleInputChange = vi.fn();
-
-        render(<DateFilters onFiltersChange={handleFiltersChange} onInputChange={handleInputChange} />);
-
-        openCalendar();
-        fireEvent.click(await screen.findByRole('button', {name: 'Select May 8'}));
-
-        expect(screen.getByDisplayValue('2026-05-08')).toBeDefined();
-        expect(handleFiltersChange).toHaveBeenCalledWith('2026-05-08');
-        expect(handleInputChange).toHaveBeenCalledWith('2026-05-08');
-    });
-
-    it('uses an editable text input for date values', () => {
-        render(<DateFilters onFiltersChange={vi.fn()} onInputChange={vi.fn()} />);
-
-        const input = screen.getByDisplayValue('2026-05-07') as HTMLInputElement;
-
-        expect(input.type).toBe('text');
-        expect(input.pattern).toBe('\\d{4}-\\d{2}-\\d{2}');
-    });
-
-    it('does not normalize overflow date values for the calendar selection', async () => {
-        render(<DateFilters initialValue="2026-02-30" onFiltersChange={vi.fn()} onInputChange={vi.fn()} />);
-
-        openCalendar();
-
-        expect((await screen.findByTestId('calendar-selected')).getAttribute('data-selected')).toBe('');
-    });
-
-    it('requires date values to use the HTML date input format', async () => {
-        render(<DateFilters initialValue="2026-5-7" onFiltersChange={vi.fn()} onInputChange={vi.fn()} />);
-
-        openCalendar();
-
-        expect((await screen.findByTestId('calendar-selected')).getAttribute('data-selected')).toBe('');
-    });
-});
-
-describe('Filters allowMultiple multiselect', () => {
-    beforeAll(() => {
-        global.ResizeObserver = class {
-            observe() {
-                return undefined;
-            }
-
-            unobserve() {
-                return undefined;
-            }
-
-            disconnect() {
-                return undefined;
-            }
-        } as unknown as typeof ResizeObserver;
-        HTMLElement.prototype.scrollIntoView = vi.fn();
-    });
-
-    function MultiselectTestFilters({initialFilters, onChangeSpy}: Readonly<{
-        initialFilters: Filter<string>[];
-        // eslint-disable-next-line no-unused-vars
-        onChangeSpy: (filters: Filter<string>[]) => void;
-    }>) {
-        const [filters, setFilters] = useState<Filter<string>[]>(initialFilters);
-        const fields = useMemo<FilterFieldConfig<string>[]>(() => ([
-            {
-                key: 'label',
-                label: 'Label',
-                type: 'multiselect',
-                searchable: false,
-                operators: [{value: 'is-any', label: 'is any of'}],
-                defaultOperator: 'is-any',
-                options: [
-                    {value: 'vip', label: 'VIP'},
-                    {value: 'premium', label: 'Premium'},
-                    {value: 'gold', label: 'Gold'}
-                ]
-            }
-        ]), []);
-
-        return (
-            <Filters
-                addButtonText="Add filter"
-                allowMultiple={true}
-                fields={fields}
-                filters={filters}
-                showSearchInput={false}
-                onChange={(next) => {
-                    onChangeSpy(next);
-                    setFilters(next);
-                }}
-            />
-        );
-    }
-
-    it('commits a new single-value label filter and closes the picker after one selection', async () => {
-        const onChangeSpy = vi.fn();
-        const initial = [createFilter<string>('label', 'is-any', ['vip'])];
-
-        render(<MultiselectTestFilters initialFilters={initial} onChangeSpy={onChangeSpy} />);
-
-        fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
-
-        const labelMenuItem = await screen.findByRole('option', {name: 'Label'});
-        fireEvent.click(labelMenuItem);
-
-        const premiumOption = await screen.findByRole('option', {name: 'Premium'});
-        fireEvent.click(premiumOption);
-
-        await waitFor(() => {
-            const lastCall = onChangeSpy.mock.calls.at(-1);
-            expect(lastCall).toBeDefined();
-            const finalFilters = lastCall![0] as Filter<string>[];
-            expect(finalFilters).toHaveLength(2);
-            expect(finalFilters[0].field).toBe('label');
-            expect(finalFilters[0].values).toEqual(['vip']);
-            expect(finalFilters[1].field).toBe('label');
-            expect(finalFilters[1].values).toEqual(['premium']);
-        });
-
-        // Picker should have closed — no more option role elements visible.
-        expect(screen.queryByRole('option', {name: 'Gold'})).toBeNull();
     });
 });

--- a/apps/shade/test/unit/components/primitives/primitives.test.tsx
+++ b/apps/shade/test/unit/components/primitives/primitives.test.tsx
@@ -25,7 +25,7 @@ describe('Primitives', () => {
     });
 
     it('maps Stack custom gap/align/justify props to classes', () => {
-        render(<Stack data-testid="stack" gap="xl" align="center" justify="between">A</Stack>);
+        render(<Stack align="center" data-testid="stack" gap="xl" justify="between">A</Stack>);
         const stack = screen.getByTestId('stack');
 
         assert.ok(stack.className.includes('gap-6'));
@@ -47,7 +47,7 @@ describe('Primitives', () => {
     });
 
     it('renders Inline polymorphically with as and maps wrap', () => {
-        render(<Inline data-testid="inline" as="nav" wrap gap="sm">A</Inline>);
+        render(<Inline as="nav" data-testid="inline" gap="sm" wrap>A</Inline>);
         const inline = screen.getByTestId('inline');
 
         assert.equal(inline.tagName.toLowerCase(), 'nav');
@@ -84,7 +84,7 @@ describe('Primitives', () => {
         assert.ok(container.className.includes('mx-auto'));
 
         render(
-            <Container data-testid="container-custom" size="prose" centered={false} paddingX="md">
+            <Container centered={false} data-testid="container-custom" paddingX="md" size="prose">
                 B
             </Container>
         );
@@ -106,7 +106,7 @@ describe('Primitives', () => {
         assert.ok(grid.className.includes('justify-start'));
 
         render(
-            <Grid data-testid="grid-custom" columns={3} gap="2xl" align="end" justify="evenly">
+            <Grid align="end" columns={3} data-testid="grid-custom" gap="2xl" justify="evenly">
                 B
             </Grid>
         );
@@ -130,12 +130,12 @@ describe('Primitives', () => {
 
         render(
             <Text
-                data-testid="text-custom"
                 as="h2"
-                size="2xl"
-                weight="bold"
-                tone="secondary"
+                data-testid="text-custom"
                 leading="heading"
+                size="2xl"
+                tone="secondary"
+                weight="bold"
                 truncate
             >
                 Heading

--- a/apps/shade/test/unit/components/ui/avatar.test.tsx
+++ b/apps/shade/test/unit/components/ui/avatar.test.tsx
@@ -67,10 +67,10 @@ describe('Avatar Components', () => {
     it('passes props to Avatar component', () => {
         render(
             <Avatar 
+                aria-label="User avatar" 
                 data-testid="avatar" 
                 id="custom-id" 
-                role="img" 
-                aria-label="User avatar"
+                role="img"
             />
         );
         
@@ -85,7 +85,7 @@ describe('Avatar Components', () => {
         // We're not testing detailed functionality since it's not fully working in the test environment
         const {container} = render(
             <Avatar>
-                <AvatarImage src="test.jpg" alt="Test" />
+                <AvatarImage alt="Test" src="test.jpg" />
             </Avatar>
         );
         

--- a/apps/shade/test/unit/components/ui/banner.test.tsx
+++ b/apps/shade/test/unit/components/ui/banner.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable ghost/mocha/no-setup-in-describe */
+import React from 'react';
 import assert from 'assert/strict';
 import {describe, it, vi} from 'vitest';
 import {fireEvent, screen} from '@testing-library/react';
@@ -74,9 +75,9 @@ describe('Banner Component', () => {
     it('allows overriding ARIA attributes via standard props', () => {
         render(
             <Banner
-                role="region"
-                aria-live="assertive"
                 aria-label="Test banner"
+                aria-live="assertive"
+                role="region"
             >
                 Content
             </Banner>
@@ -167,14 +168,14 @@ describe('Banner Component', () => {
     });
 
     it('forwards ref correctly', () => {
-        const ref = {current: null};
-        render(<Banner ref={ref as any}>Content</Banner>);
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Banner ref={ref}>Content</Banner>);
 
         assert.ok(ref.current, 'Ref should be forwarded');
     });
 
     it('renders with region role when specified', () => {
-        render(<Banner role="region" aria-label="Important region">Content</Banner>);
+        render(<Banner aria-label="Important region" role="region">Content</Banner>);
         const banner = screen.getByRole('region');
 
         assert.ok(banner, 'Banner should render with region role');

--- a/apps/shade/test/unit/components/ui/card.test.tsx
+++ b/apps/shade/test/unit/components/ui/card.test.tsx
@@ -22,7 +22,7 @@ describe('Card Components', () => {
     });
 
     it('renders Card with plain variant', () => {
-        render(<Card variant="plain" data-testid="card">Card Content</Card>);
+        render(<Card data-testid="card" variant="plain">Card Content</Card>);
         const card = screen.getByTestId('card');
 
         assert.ok(card, 'Card should be rendered');
@@ -51,7 +51,7 @@ describe('Card Components', () => {
 
     it('renders CardHeader with plain variant styling', () => {
         render(
-            <Card variant="plain" data-testid="card">
+            <Card data-testid="card" variant="plain">
                 <CardHeader data-testid="card-header">Header Content</CardHeader>
             </Card>
         );
@@ -93,7 +93,7 @@ describe('Card Components', () => {
 
     it('renders CardContent with plain variant styling', () => {
         render(
-            <Card variant="plain" data-testid="card">
+            <Card data-testid="card" variant="plain">
                 <CardContent data-testid="card-content">Content</CardContent>
             </Card>
         );
@@ -117,7 +117,7 @@ describe('Card Components', () => {
 
     it('renders CardFooter with plain variant styling', () => {
         render(
-            <Card variant="plain" data-testid="card">
+            <Card data-testid="card" variant="plain">
                 <CardFooter data-testid="card-footer">Footer Content</CardFooter>
             </Card>
         );

--- a/apps/shade/test/unit/components/ui/dialog.test.tsx
+++ b/apps/shade/test/unit/components/ui/dialog.test.tsx
@@ -24,8 +24,8 @@ describe('Dialog Components', () => {
                     </DialogHeader>
                     <p>Dialog Content</p>
                     <DialogFooter>
-                        <button>Cancel</button>
-                        <button>Submit</button>
+                        <button type="button">Cancel</button>
+                        <button type="button">Submit</button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
@@ -61,7 +61,7 @@ describe('Dialog Components', () => {
                     <DialogTitle>Required Title</DialogTitle>
                     <DialogDescription>Required Description</DialogDescription>
                     <DialogFooter className="custom-footer-class" data-testid="dialog-footer">
-                        <button>Button</button>
+                        <button type="button">Button</button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
@@ -149,8 +149,8 @@ describe('Dialog Components', () => {
                     </DialogHeader>
                     <div>Dialog body content</div>
                     <DialogFooter data-testid="dialog-footer">
-                        <button>Cancel</button>
-                        <button>Confirm</button>
+                        <button type="button">Cancel</button>
+                        <button type="button">Confirm</button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
@@ -314,7 +314,7 @@ describe('Dialog Components', () => {
                     </DialogHeader>
                     <div>Main Content</div>
                     <DialogFooter data-testid="dialog-footer">
-                        <button>Footer Button</button>
+                        <button type="button">Footer Button</button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>

--- a/apps/shade/test/unit/components/ui/indicator.test.tsx
+++ b/apps/shade/test/unit/components/ui/indicator.test.tsx
@@ -43,7 +43,7 @@ describe('Indicator Component', () => {
     });
 
     it('applies error variant correctly', () => {
-        render(<Indicator variant="error" data-testid="indicator" />);
+        render(<Indicator data-testid="indicator" variant="error" />);
         const container = screen.getByTestId('indicator');
         const indicator = container.querySelector('[aria-hidden="true"]');
 
@@ -51,7 +51,7 @@ describe('Indicator Component', () => {
     });
 
     it('applies warning variant correctly', () => {
-        render(<Indicator variant="warning" data-testid="indicator" />);
+        render(<Indicator data-testid="indicator" variant="warning" />);
         const container = screen.getByTestId('indicator');
         const indicator = container.querySelector('[aria-hidden="true"]');
 
@@ -59,7 +59,7 @@ describe('Indicator Component', () => {
     });
 
     it('applies idle state correctly', () => {
-        render(<Indicator variant="success" state="idle" data-testid="indicator" />);
+        render(<Indicator data-testid="indicator" state="idle" variant="success" />);
         const container = screen.getByTestId('indicator');
         const indicator = container.querySelector('[aria-hidden="true"]');
 
@@ -69,7 +69,7 @@ describe('Indicator Component', () => {
     });
 
     it('applies active state correctly', () => {
-        render(<Indicator variant="success" state="active" data-testid="indicator" />);
+        render(<Indicator data-testid="indicator" state="active" variant="success" />);
         const container = screen.getByTestId('indicator');
         const indicator = container.querySelector('[aria-hidden="true"]');
 
@@ -108,7 +108,7 @@ describe('Indicator Component', () => {
     });
 
     it('applies inactive state with error variant correctly', () => {
-        render(<Indicator variant="error" state="inactive" data-testid="indicator" />);
+        render(<Indicator data-testid="indicator" state="inactive" variant="error" />);
         const container = screen.getByTestId('indicator');
         const indicator = container.querySelector('[aria-hidden="true"]');
 
@@ -118,7 +118,7 @@ describe('Indicator Component', () => {
     });
 
     it('applies inactive state with warning variant correctly', () => {
-        render(<Indicator variant="warning" state="inactive" data-testid="indicator" />);
+        render(<Indicator data-testid="indicator" state="inactive" variant="warning" />);
         const container = screen.getByTestId('indicator');
         const indicator = container.querySelector('[aria-hidden="true"]');
 
@@ -128,24 +128,24 @@ describe('Indicator Component', () => {
     });
 
     it('applies different sizes correctly', () => {
-        const {rerender} = render(<Indicator size="sm" data-testid="indicator" />);
+        const {rerender} = render(<Indicator data-testid="indicator" size="sm" />);
         let container = screen.getByTestId('indicator');
         let indicator = container.querySelector('[aria-hidden="true"]');
         assert.ok(indicator?.className.includes('size-2'), 'Should have small size class');
 
-        rerender(<Indicator size="md" data-testid="indicator" />);
+        rerender(<Indicator data-testid="indicator" size="md" />);
         container = screen.getByTestId('indicator');
         indicator = container.querySelector('[aria-hidden="true"]');
         assert.ok(indicator?.className.includes('size-3'), 'Should have medium size class');
 
-        rerender(<Indicator size="lg" data-testid="indicator" />);
+        rerender(<Indicator data-testid="indicator" size="lg" />);
         container = screen.getByTestId('indicator');
         indicator = container.querySelector('[aria-hidden="true"]');
         assert.ok(indicator?.className.includes('size-4'), 'Should have large size class');
     });
 
     it('combines variant and state correctly', () => {
-        render(<Indicator variant="error" state="active" data-testid="indicator" />);
+        render(<Indicator data-testid="indicator" state="active" variant="error" />);
         const container = screen.getByTestId('indicator');
         const indicator = container.querySelector('[aria-hidden="true"]');
 
@@ -186,7 +186,7 @@ describe('Indicator Component', () => {
     });
 
     it('passes additional props to the container span element', () => {
-        render(<Indicator data-testid="indicator-test" data-custom="value" />);
+        render(<Indicator data-custom="value" data-testid="indicator-test" />);
         const container = screen.getByTestId('indicator-test');
 
         assert.equal(container.getAttribute('data-custom'), 'value', 'Should pass additional props to container');

--- a/apps/shade/test/unit/components/ui/input.test.tsx
+++ b/apps/shade/test/unit/components/ui/input.test.tsx
@@ -7,7 +7,7 @@ import {render} from '../../utils/test-utils';
 
 describe('Input Component', () => {
     it('renders correctly with default props', () => {
-        render(<Input placeholder="Enter text" data-testid="input" />);
+        render(<Input data-testid="input" placeholder="Enter text" />);
         const input = screen.getByTestId('input');
         
         assert.ok(input, 'Input should be rendered');
@@ -23,7 +23,7 @@ describe('Input Component', () => {
 
     it('handles input changes', () => {
         const handleChange = vi.fn();
-        render(<Input onChange={handleChange} data-testid="input" />);
+        render(<Input data-testid="input" onChange={handleChange} />);
         
         const input = screen.getByTestId('input');
         fireEvent.change(input, {target: {value: 'test value'}});
@@ -32,7 +32,7 @@ describe('Input Component', () => {
     });
 
     it('renders disabled state correctly', () => {
-        render(<Input disabled data-testid="input" />);
+        render(<Input data-testid="input" disabled />);
         const input = screen.getByTestId('input');
         
         assert.ok(input.hasAttribute('disabled'), 'Input should be disabled');
@@ -40,7 +40,7 @@ describe('Input Component', () => {
     });
 
     it('passes type attribute correctly', () => {
-        render(<Input type="password" data-testid="input" />);
+        render(<Input data-testid="input" type="password" />);
         const input = screen.getByTestId('input');
         
         assert.equal(input.getAttribute('type'), 'password', 'Should have correct type attribute');

--- a/apps/shade/test/unit/components/ui/sheet.test.tsx
+++ b/apps/shade/test/unit/components/ui/sheet.test.tsx
@@ -24,8 +24,8 @@ describe('Sheet Components', () => {
                     </SheetHeader>
                     <p>Sheet Content</p>
                     <SheetFooter>
-                        <button>Cancel</button>
-                        <button>Submit</button>
+                        <button type="button">Cancel</button>
+                        <button type="button">Submit</button>
                     </SheetFooter>
                 </SheetContent>
             </Sheet>
@@ -61,7 +61,7 @@ describe('Sheet Components', () => {
                     <SheetTitle>Required Title</SheetTitle>
                     <SheetDescription>Required Description</SheetDescription>
                     <SheetFooter className="custom-footer-class" data-testid="sheet-footer">
-                        <button>Button</button>
+                        <button type="button">Button</button>
                     </SheetFooter>
                 </SheetContent>
             </Sheet>
@@ -115,7 +115,7 @@ describe('Sheet Components', () => {
                     </SheetHeader>
                     <div>Main Content</div>
                     <SheetFooter data-testid="sheet-footer">
-                        <button>Footer Button</button>
+                        <button type="button">Footer Button</button>
                     </SheetFooter>
                 </SheetContent>
             </Sheet>


### PR DESCRIPTION
## Summary

`apps/shade/test/.eslintrc.cjs` extended `plugin:ghost/test` (non-TS-aware) while the test files are `.tsx`, and `apps/shade/.eslintrc.cjs` was missing `root: true`. ESLint's computed ruleset for shade test files therefore only had the `ghost` plugin loaded — no `react`, `react-hooks`, or `@typescript-eslint` rules ran on them. Confirmed with `eslint --print-config`.

The misconfig hid **74 pre-existing rule violations**. This PR is pure lint hygiene — no production code or dependency changes.

## Config changes

- Added `root: true` to `apps/shade/.eslintrc.cjs`
- Switched `apps/shade/test/.eslintrc.cjs` from `plugin:ghost/test` to `plugin:ghost/ts-test` (the same setup already used by `apps/stats`, `apps/admin-x-framework`, etc.)

## Violations resolved

- `react/jsx-sort-props` × 43 — autofixed (prop reorderings across 9 files)
- `react/button-has-type` × 29 — added `type="button"` to bare `<button>` elements in layout/dialog/sheet test fixtures
- `@typescript-eslint/no-explicit-any` × 1 — replaced `ref as any` in `banner.test.tsx` with a properly typed `React.createRef<HTMLDivElement>()`
- `ghost/mocha/max-top-level-suites` × 1 — wrapped the two top-level `describe` blocks in `filters.test.tsx` under one `Filters` parent (this is the source of the large reflow in that file's diff)

## Why now

Prep work for an upcoming vite + vitest bump in shade. With the corrected lint config in place, that PR can land without any new `eslint-disable` comments for issues the lint config should have surfaced years ago.

## Test plan

- [x] `pnpm --filter @tryghost/shade lint` — exit 0 (only the pre-existing `react-hooks/exhaustive-deps` warning in `src/components/patterns/filters.tsx` remains, unchanged by this PR)
- [x] `pnpm --filter @tryghost/shade test` — 220/220 across 22 files
- [x] `pnpm --filter @tryghost/shade build` — exit 0
- [ ] CI confirms the same against the canonical environment