### PR TITLE
Switched @tryghost npm publish to pnpm to rewrite catalog: refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1694,7 +1694,7 @@ jobs:
         if: steps.version_check.outputs.version_changed == 'true'
         working-directory: ${{ matrix.package_path }}
         run: |
-          npm publish --access public
+          pnpm publish --access public --no-git-checks
 
       - name: Replace version placeholders in cdn-paths
         id: cdn_paths


### PR DESCRIPTION
## Summary

Swapped `npm publish` for `pnpm publish --no-git-checks` in the `publish_packages` job so pnpm's tarball rewrites strip the `catalog:` protocol before the manifest hits the npm registry.

## Why

`npm publish` doesn't understand pnpm's `catalog:` protocol, so the literal string `"catalog:"` was being shipped to npm in published manifests. Verified live on the registry today — every `@tryghost/*` frontend package we publish carries `devDependencies.eslint = "catalog:"`:

| Package | Latest |
|---|---|
| `@tryghost/portal` | 2.68.45 |
| `@tryghost/signup-form` | 0.3.22 |
| `@tryghost/comments-ui` | 1.4.14 |
| `@tryghost/sodo-search` | 1.8.18 |
| `@tryghost/announcement-bar` | 1.1.20 |
| `@tryghost/activitypub` | 3.1.19 |

The leak is harmless to real consumers today because every offending ref is in `devDependencies` (skipped by `npm install`). But a future `catalog:` reference in `dependencies` or `peerDependencies` would silently break npm consumers. `pnpm publish` rewrites `catalog:`, `workspace:`, and `link:` protocols across all dependency sections during tarball assembly, so switching the publisher closes that door without needing per-package precautions.

`--no-git-checks` disables pnpm's branch / clean-tree / up-to-date guards. The branch and up-to-date checks are redundant with the workflow's existing `is_main` gating, and the clean-tree check would surface as a confusing publish failure if a future build target ever wrote untracked output — none of these are guarding against a real CI threat model.

OIDC trusted publishing is unaffected: pnpm shells out to the bundled `npm` for the registry handshake after preparing the tarball, so the `npm@11` shim stays in place.

## Verification

Local `pnpm pack` on `apps/portal` rewrote `"eslint": "catalog:"` to `"eslint": "8.57.1"` with zero `catalog:` strings remaining in the packed `package.json`. End-to-end OIDC publish can only be verified by an actual release; the next legitimate version bump of any of the six packages will act as the live test.

## Test plan

- [ ] After the next release of any `@tryghost/*` frontend package, run `npm view @tryghost/<pkg>@latest devDependencies.eslint` and confirm it returns the resolved version (e.g. `8.57.1`) rather than `catalog:`
- [ ] CI passes for this PR (no publish actually triggers on a feature branch — only verifies the workflow still parses)