### PR TITLE
🐛 Fixed {{#social_accounts}} emitting "twitter" as the type for X

### DIFF
--- a/ghost/core/core/frontend/helpers/social_accounts.js
+++ b/ghost/core/core/frontend/helpers/social_accounts.js
@@ -27,8 +27,11 @@ const messages = {
 };
 
 // Canonical order mirrors the admin settings UI (SOCIAL_PLATFORM_KEYS).
+// `type` is the theme-facing key (used for icon partial names and CSS hooks)
+// and `sourceKey` is the schema field on the source object (defaults to `type`).
+// X is the only platform where they differ: the DB field is still `twitter`.
 const SOCIAL_PLATFORMS = [
-    {type: 'twitter', name: 'X'},
+    {type: 'x', sourceKey: 'twitter', name: 'X'},
     {type: 'facebook', name: 'Facebook'},
     {type: 'linkedin', name: 'LinkedIn'},
     {type: 'bluesky', name: 'Bluesky'},
@@ -62,10 +65,10 @@ module.exports = function social_accounts(source, options) { // eslint-disable-l
         });
     }
 
-    const accounts = SOCIAL_PLATFORMS.reduce((acc, {type, name}) => {
-        const username = source && source[type];
-        if (username && typeof socialUrls[type] === 'function') {
-            acc.push({type, name, username, href: socialUrls[type](username)});
+    const accounts = SOCIAL_PLATFORMS.reduce((acc, {type, name, sourceKey = type}) => {
+        const username = source && source[sourceKey];
+        if (username && typeof socialUrls[sourceKey] === 'function') {
+            acc.push({type, name, username, href: socialUrls[sourceKey](username)});
         }
         return acc;
     }, []);

--- a/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
@@ -133,4 +133,15 @@ describe('{{#social_accounts}} helper', function () {
             .with({}, {data: {site: {twitter: 'ghost'}}});
         assert.equal(out, 'x=X;');
     });
+
+    // User-reported reproduction shape (TryGhost/Ghost#27871): theme used
+    //   {{#author}}{{#social_accounts this}}{{> (concat "icons/social/" type)}}{{/social_accounts}}{{/author}}
+    // and got a 500 because the dynamic partial pointed at `twitter.hbs` while
+    // the theme only shipped `x.hbs`. With the fix, the emitted type matches
+    // the theme's partial filename.
+    it('emits type "x" when iterating an author inside {{#author}}', function () {
+        const out = compile(`{{#author}}{{#social_accounts this}}{{type}}{{/social_accounts}}{{/author}}`)
+            .with({author: {twitter: 'author-tw'}});
+        assert.equal(out, 'x');
+    });
 });

--- a/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
@@ -40,13 +40,13 @@ describe('{{#social_accounts}} helper', function () {
 
     it('iterates over @site accounts in canonical order', function () {
         const out = compile(`{{#social_accounts @site}}{{type}}|{{/social_accounts}}`).with({});
-        assert.equal(out, 'twitter|facebook|linkedin|bluesky|threads|mastodon|tiktok|youtube|instagram|');
+        assert.equal(out, 'x|facebook|linkedin|bluesky|threads|mastodon|tiktok|youtube|instagram|');
     });
 
     it('exposes type, href, username, and name per iteration', function () {
         const out = compile(`{{#social_accounts @site}}{{type}}={{href}}|{{name}}|{{username}};{{/social_accounts}}`)
             .with({}, {data: {site: {twitter: 'testuser-tw', linkedin: 'testuser-li'}}});
-        assert.equal(out, 'twitter=https://x.com/testuser-tw|X|testuser-tw;linkedin=https://www.linkedin.com/in/testuser-li|LinkedIn|testuser-li;');
+        assert.equal(out, 'x=https://x.com/testuser-tw|X|testuser-tw;linkedin=https://www.linkedin.com/in/testuser-li|LinkedIn|testuser-li;');
     });
 
     it('uses `href` (not `url`) for the link to avoid collision with the {{url}} helper', function () {
@@ -72,7 +72,7 @@ describe('{{#social_accounts}} helper', function () {
     it('skips platforms without a username', function () {
         const out = compile(`{{#social_accounts @site}}{{type}},{{/social_accounts}}`)
             .with({}, {data: {site: {twitter: 'me', instagram: 'me-ig'}}});
-        assert.equal(out, 'twitter,instagram,');
+        assert.equal(out, 'x,instagram,');
     });
 
     it('renders the {{else}} block when nothing is set', function () {
@@ -90,19 +90,19 @@ describe('{{#social_accounts}} helper', function () {
     it('iterates over a passed author object', function () {
         const out = compile(`{{#social_accounts author}}{{type}}={{username}};{{/social_accounts}}`)
             .with({author: {twitter: 'author-tw', bluesky: 'author.bsky.social'}});
-        assert.equal(out, 'twitter=author-tw;bluesky=author.bsky.social;');
+        assert.equal(out, 'x=author-tw;bluesky=author.bsky.social;');
     });
 
     it('iterates over the current context with `this`', function () {
         const out = compile(`{{#social_accounts this}}{{type}}={{username}};{{/social_accounts}}`)
             .with({twitter: 'ctx-tw', mastodon: 'mastodon.social/@me'});
-        assert.equal(out, 'twitter=ctx-tw;mastodon=mastodon.social/@me;');
+        assert.equal(out, 'x=ctx-tw;mastodon=mastodon.social/@me;');
     });
 
     it('exposes @first, @last, @index iteration vars', function () {
         const out = compile(`{{#social_accounts @site}}{{@index}}:{{type}}{{#if @first}}!{{/if}}{{#if @last}}*{{/if}} {{/social_accounts}}`)
             .with({}, {data: {site: {twitter: 'tw', facebook: 'fb', instagram: 'ig'}}});
-        assert.equal(out, '0:twitter! 1:facebook 2:instagram* ');
+        assert.equal(out, '0:x! 1:facebook 2:instagram* ');
     });
 
     it('throws an IncorrectUsageError when called with no source', function () {
@@ -123,5 +123,14 @@ describe('{{#social_accounts}} helper', function () {
         const out = compile(`{{#social_accounts missingVar}}x{{else}}none{{/social_accounts}}`)
             .with({});
         assert.equal(out, 'none');
+    });
+
+    // Reported bug: the helper emitted `type: "twitter"`, causing
+    // `{{> (concat "icons/" type)}}` to 500 in themes that ship an `x.hbs`
+    // partial (matching the admin "X" label and modern branding).
+    it('emits type "x" (not "twitter") for the X/Twitter platform', function () {
+        const out = compile(`{{#social_accounts @site}}{{type}}={{name}};{{/social_accounts}}`)
+            .with({}, {data: {site: {twitter: 'ghost'}}});
+        assert.equal(out, 'x=X;');
     });
 });


### PR DESCRIPTION
## Summary

Fixes a reported bug in the new `{{#social_accounts}}` block helper (added in #27834, shipped in 6.38).

The helper was exposing `type: "twitter"` for the X/Twitter platform — the legacy DB field name — even though the admin UI labels it "X" and modern theme authors naturally write `x.hbs` icon partials (matching X branding). The recommended pattern `{{> (concat "icons/" type)}}` therefore 500ed in themes that ship `x.hbs` (not `twitter.hbs`), forcing developers to either ship a legacy-named partial or fork the helper.

```hbs
{{!-- This now works again in themes that have x.hbs --}}
{{#social_accounts @site}}
    <a href="{{href}}" aria-label="{{name}}">
        {{> (concat "icons/" type)}}
    </a>
{{/social_accounts}}
```

## Change

Decoupled the theme-facing iteration `type` from the source object's schema key. The helper now emits `type: "x"` while still reading from the `twitter` field on the source — the DB schema is unchanged, no migration needed. The two are wired up via a `sourceKey` indirection on the X platform entry (every other platform has the same key on both sides, so they default).

```js
const SOCIAL_PLATFORMS = [
    {type: 'x', sourceKey: 'twitter', name: 'X'},  // emit `x`, read `twitter`
    {type: 'facebook', name: 'Facebook'},
    // …
];
```

## Test plan

- [x] New failing test that captures the bug — `emits type "x" (not "twitter") for the X/Twitter platform`
- [x] Updated assertions in all existing tests that referenced `twitter` in iteration output to expect `x`
- [x] 13/13 tests pass on the fix
- [x] `social-url.test.js` 21/21 still pass (no regression in the related helper)
- [x] `helpers.test.js` registry-shape test still passes

## Companion docs update

The `social_accounts.mdx` page in TryGhost/Docs lists `twitter` in the supported-platforms line. A one-line follow-up there will swap it to `x` (the docs PR #62 hasn't merged yet, so it can go in directly).
