### PR TITLE
Update i18n-ignores.json

### DIFF
--- a/ghost/i18n/test/i18n-ignores.json
+++ b/ghost/i18n/test/i18n-ignores.json
@@ -69,6 +69,16 @@
                 "comment": "translated text doesn't fit on the button"
             },
             {
+                "file": "eu/ghost.json",
+                "key": "{count} month_one",
+                "comment": "FIXME: This error was automatically ignored. Please update the translation, or explain why a variable is ignored"
+            },
+            {
+                "file": "eu/ghost.json",
+                "key": "{count} year_one",
+                "comment": "FIXME: This error was automatically ignored. Please update the translation, or explain why a variable is ignored"
+            },
+            {
                 "file": "is/portal.json",
                 "key": "{trialDays} days free",
                 "comment": "FIXME: This error was automatically ignored. Please update the translation, or explain why a variable is ignored"

--- a/ghost/i18n/test/i18n-ignores.json
+++ b/ghost/i18n/test/i18n-ignores.json
@@ -71,12 +71,12 @@
             {
                 "file": "eu/ghost.json",
                 "key": "{count} month_one",
-                "comment": "FIXME: This error was automatically ignored. Please update the translation, or explain why a variable is ignored"
+                "comment": "There is no need for the variable since in Basque there is this word that means one month, and it would be redundant to pair it with the number."
             },
             {
                 "file": "eu/ghost.json",
                 "key": "{count} year_one",
-                "comment": "FIXME: This error was automatically ignored. Please update the translation, or explain why a variable is ignored"
+                "comment": "There is no need for the variable since in Basque there is this word that means one year, and it would be redundant to pair it with the number."
             },
             {
                 "file": "is/portal.json",


### PR DESCRIPTION
I have added two strings for Basque, since we can specify `one month` and `one year` with a single word (each).


Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works