### PR TITLE
Refactored update-check notifications and added opt-out config

### DIFF
--- a/ghost/core/core/server/services/update-check/index.js
+++ b/ghost/core/core/server/services/update-check/index.js
@@ -35,6 +35,15 @@ module.exports = async ({
         }
     }
 
+    const notificationsEnabled = config.get('updateCheck:enabled') !== false;
+    const telemetryEnabled = !config.isPrivacyDisabled('useUpdateCheck');
+
+    // Skip polling entirely only when neither purpose remains: the operator
+    // wants no notifications AND no telemetry leaves the instance.
+    if (!notificationsEnabled && !telemetryEnabled) {
+        return;
+    }
+
     const updateChecker = new UpdateCheckService({
         api: {
             settings: {
@@ -54,7 +63,8 @@ module.exports = async ({
             env: config.get('env'),
             databaseType: databaseInfo.getEngine(),
             checkEndpoint: updateCheckUrl,
-            isPrivacyDisabled: config.isPrivacyDisabled('useUpdateCheck'),
+            isPrivacyDisabled: !telemetryEnabled,
+            notificationsEnabled,
             notificationGroups: config.get('notificationGroups'),
             siteUrl: urlUtils.urlFor('home', true),
             forceUpdate,

--- a/ghost/core/core/server/services/update-check/update-check-service.js
+++ b/ghost/core/core/server/services/update-check/update-check-service.js
@@ -45,6 +45,7 @@ class UpdateCheckService {
      * @param {string} options.config.databaseType
      * @param {string} options.config.checkEndpoint - update check service URL
      * @param {boolean} [options.config.isPrivacyDisabled]
+     * @param {boolean} [options.config.notificationsEnabled] - when false, telemetry still flows but no notifications are created from the response
      * @param {string[]} [options.config.notificationGroups] - example values ["migration", "something"]
      * @param {boolean} [options.config.rethrowErrors] - allows to force throwing errors (useful in worker threads)
      * @param {string} options.config.siteUrl - Ghost instance URL
@@ -255,6 +256,10 @@ class UpdateCheckService {
                 value: response.next_check
             }]
         }, internal);
+
+        if (this.config.notificationsEnabled === false) {
+            return;
+        }
 
         let notifications;
         if (_.isArray(response)) {

--- a/ghost/core/test/integration/jobs/update-check.test.js
+++ b/ghost/core/test/integration/jobs/update-check.test.js
@@ -2,7 +2,9 @@ const assert = require('node:assert/strict');
 const http = require('http');
 const path = require('path');
 const testUtils = require('../../utils');
+const configUtils = require('../../utils/config-utils');
 const jobService = require('../../../core/server/services/jobs/job-service');
+const runUpdateCheck = require('../../../core/server/services/update-check');
 
 const JOB_NAME = 'update-check';
 const JOB_PATH = path.resolve(__dirname, '../../../core/server/services/update-check/run-update-check.js');
@@ -12,10 +14,11 @@ describe('Run Update Check', function () {
 
     before(testUtils.setup('default'));
 
-    afterEach(function () {
+    afterEach(async function () {
         if (mockUpdateServer) {
             mockUpdateServer.close();
         }
+        await configUtils.restore();
     });
 
     it('successfully executes the update checker', async function () {
@@ -50,5 +53,26 @@ describe('Run Update Check', function () {
 
         // Assert that the mock update server received a request (which means the update-check job ran successfully)
         assert.equal(mockUpdateServerRequestCount, 1, 'Expected mock server to receive 1 request');
+    });
+
+    it('does not poll at all when both updateCheck.enabled and privacy.useUpdateCheck are disabled', async function () {
+        let mockUpdateServerRequestCount = 0;
+        mockUpdateServer = http.createServer((req, res) => {
+            mockUpdateServerRequestCount += 1;
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            res.end(JSON.stringify({hello: 'world'}));
+        });
+        mockUpdateServer.listen(0);
+        const mockUpdateServerPort = mockUpdateServer.address().port;
+
+        configUtils.set('updateCheck:enabled', false);
+        configUtils.set('privacy', {useUpdateCheck: false});
+
+        await runUpdateCheck({
+            forceUpdate: true,
+            updateCheckUrl: `http://127.0.0.1:${mockUpdateServerPort}`
+        });
+
+        assert.equal(mockUpdateServerRequestCount, 0, 'No purpose remains, so no poll should happen');
     });
 });

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -220,6 +220,58 @@ describe('Update Check', function () {
         });
     });
 
+    describe('Notifications gate', function () {
+        it('writes next_update_check but skips notification creation when notificationsEnabled is false', async function () {
+            const notificationsAddSpy = sinon.spy();
+            const updateCheckService = new UpdateCheckService({
+                api: {
+                    settings: {edit: settingsStub},
+                    users: {browse: sinon.stub().resolves({users: []})},
+                    posts: {browse: sinon.stub().resolves()}
+                },
+                notifications: {add: notificationsAddSpy},
+                config: {
+                    notificationsEnabled: false
+                },
+                request
+            });
+
+            await updateCheckService.updateCheckResponse({
+                next_check: moment().add(1, 'day').unix(),
+                messages: [{id: 'x', content: '<p>hi</p>', type: 'info'}]
+            });
+
+            sinon.assert.calledOnce(settingsStub);
+            sinon.assert.notCalled(notificationsAddSpy);
+        });
+
+        it('processes notifications normally when notificationsEnabled is true', async function () {
+            const notificationsAddSpy = sinon.stub().resolves();
+            const updateCheckService = new UpdateCheckService({
+                api: {
+                    settings: {edit: settingsStub},
+                    users: {browse: sinon.stub().resolves({users: []})},
+                    posts: {browse: sinon.stub().resolves()}
+                },
+                notifications: {add: notificationsAddSpy},
+                config: {
+                    notificationsEnabled: true,
+                    notificationGroups: ['all']
+                },
+                request
+            });
+
+            await updateCheckService.updateCheckResponse({
+                custom: true,
+                version: 'all',
+                next_check: moment().add(1, 'day').unix(),
+                messages: [{id: 'x', content: '<p>hi</p>', type: 'info'}]
+            });
+
+            sinon.assert.called(notificationsAddSpy);
+        });
+    });
+
     describe('Error handling', function () {
         it('logs an error when error', function () {
             const updateCheckService = new UpdateCheckService({


### PR DESCRIPTION
## Problem

Operators have no way to disable update notifications today. `privacy.useUpdateCheck: false` looks like an off switch but only changes POST → GET — the poll still happens and the response still produces banners and admin emails. For managed hosts running Ghost on behalf of customers, that means customers receive banner notifications and emails about updates they have no power to action.

## Solution

A single new operator-facing config that gates notifications without sacrificing Ghost's telemetry data. The two concerns — "should Ghost phone home with usage stats?" and "should my admins/customers be informed about updates?" — are now independently controllable. Self-hoster defaults stay the same; managed hosts get the off switch they need.

The composition is two-knob, four-quadrant: default everything, telemetry only, notifications only, or neither (the last case short-circuits the poll entirely since there's no purpose left).

The same config will also gate the GHSA security advisory feed once that lands — operators get one decision to make, not two. If finer granularity is needed later (separate auto-update behaviour, per-feed control), the namespace accommodates it.

## Stacking

Built on top of the notifications domain refactor in #27868. The base branch is set accordingly so the diff shows only this PR's changes.