### PR TITLE
Switched pack.js component tarballs to pnpm pack

### DIFF
--- a/ghost/core/scripts/pack.js
+++ b/ghost/core/scripts/pack.js
@@ -85,7 +85,7 @@ for (const [key, val] of Object.entries(pkg.dependencies || {})) {
 
     console.log(`  Packing ${key} → components/${tgzName}`);
     execFileSync(
-        'npm',
+        'pnpm',
         ['pack', '--pack-destination', componentsDir],
         {cwd: depDir, stdio: 'pipe'}
     );


### PR DESCRIPTION
## Summary

Swapped \`npm pack\` for \`pnpm pack\` in \`ghost/core/scripts/pack.js\` so the inner component tarballs (\`@tryghost/i18n\`, \`@tryghost/parse-email-address\`) packed inside the main \`ghost-*.tgz\` get their pnpm-specific protocol references (\`catalog:\`, \`workspace:\`, \`link:\`) rewritten to resolved versions before they hit the consuming Docker build.

## Why

Same root cause and same fix as #27870, but at the component-packing layer. \`npm pack\` does not understand pnpm's protocols and ships them verbatim. When the Docker build later runs \`pnpm install --prod\` against the deployed package, pnpm rejects external (non-workspace) packages that contain \`catalog:\` refs with \`ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER\` and the image fails to build.

Today no component tarball carries a \`catalog:\` ref in production deps, so this is preemptive — but the moment any catalog migration lands that touches a packed workspace package, the Docker build breaks. This closes that door at the source.

## Verification

Local \`pnpm --filter ghost archive\` produces an identical tarball except:
- Component manifests are pnpm-pack-formatted (LICENSE included, dependencies before scripts in JSON).
- Functional content identical.

End-to-end \`pnpm install --ignore-scripts --prod --prefer-offline\` (the exact Dockerfile.production:35 line) against the deployed \`package/\` directory completes cleanly.