### PR TITLE
Read installed @playwright/test version when building the e2e image tag

### DIFF
--- a/e2e/scripts/load-playwright-container-env.sh
+++ b/e2e/scripts/load-playwright-container-env.sh
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 cd "$REPO_ROOT"
 
-PLAYWRIGHT_VERSION="$(node -p 'require("./e2e/package.json").devDependencies["@playwright/test"]')"
+PLAYWRIGHT_VERSION="$(cd e2e && node -p "require('@playwright/test/package.json').version")"
 PLAYWRIGHT_IMAGE="mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble"
 WORKSPACE_PATH="${GITHUB_WORKSPACE:-$REPO_ROOT}"
 


### PR DESCRIPTION
## Summary

\`e2e/scripts/load-playwright-container-env.sh\` constructs the Playwright Docker image tag from the version declared in \`e2e/package.json\`. Switched from reading the manifest field (\`devDependencies["@playwright/test"]\`) to reading the installed package's actual version (\`require("@playwright/test/package.json").version\`).

## Why

The manifest field can be any valid version specifier — an exact pin (\`1.59.1\`), a range (\`^1.59.0\`, \`~1.59.0\`), or a pnpm-specific protocol (\`catalog:\`, \`workspace:\`, \`link:\`). Splicing any of those into \`mcr.microsoft.com/playwright:v\${VERSION}-noble\` produces a tag Docker rejects with \`invalid reference format\`.

Today the declaration happens to be an exact pin, so the failure mode is latent — but the resolver should produce a correct tag regardless of how the dep is declared. Reading the installed manifest gives the concrete resolved version that pnpm chose, which is always a single semver string.

## Ordering guarantee

\`pnpm install\` runs before this script in every flow:
- **CI**: \`.github/workflows/ci.yml\` runs \`pnpm install --frozen-lockfile\` before invoking the prepare script chain that sources this file.
- **Local dev**: \`e2e/AGENTS.md\` documents that \`pnpm dev\` must be running before \`pnpm test\`, and \`pnpm dev\` does an install.

So \`e2e/node_modules/@playwright/test/package.json\` is always present when this resolver runs.

## Verification

\`\`\`bash
$ bash -c 'source e2e/scripts/load-playwright-container-env.sh && echo "$PLAYWRIGHT_IMAGE"'
mcr.microsoft.com/playwright:v1.59.1-noble
\`\`\`