### PR TITLE
Switched lazy sitemap populate to raw-knex for parity with eager

### DIFF
--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -1,7 +1,6 @@
 const DomainEvents = require('@tryghost/domain-events');
 const config = require('../../../shared/config');
 const {URLResourceUpdatedEvent} = require('../../../shared/events');
-const toPlain = require('../../../server/lib/common/to-plain');
 const IndexMapGenerator = require('./site-map-index-generator');
 const PagesMapGenerator = require('./page-map-generator');
 const PostsMapGenerator = require('./post-map-generator');
@@ -155,61 +154,143 @@ class SiteMapManager {
         const urlService = require('../../../server/services/url');
         const facade = urlService.facade;
 
-        // Use TagPublic/Author for the shouldHavePosts gate (so tags/users
-        // with no published posts are excluded). The visibility filter is
-        // applied in TYPE_BROWSE_OPTIONS below; together these mirror what
-        // the eager URL service does in services/url/config.js.
         await Promise.all([
-            this._loadType(models.Post, 'posts', this.posts, facade),
-            this._loadType(models.Post, 'pages', this.pages, facade),
-            this._loadType(models.TagPublic, 'tags', this.tags, facade),
-            this._loadType(models.Author, 'authors', this.users, facade)
+            this._loadType('posts', this.posts, facade, models),
+            this._loadType('pages', this.pages, facade, models),
+            this._loadType('tags', this.tags, facade, models),
+            this._loadType('authors', this.users, facade, models)
         ]);
     }
 
-    async _loadType(Model, type, generator, facade) {
-        const baseOptions = browseOptionsFor(type);
-        let page = 1;
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-            const result = await Model.findPage({...baseOptions, page});
-            for (const model of result.data) {
-                const datum = toPlain(model);
-                const url = facade.getUrlForResource({...datum, type}, {absolute: true});
-                if (url && !url.match(/\/404\//)) {
-                    generator.addUrl(url, datum);
-                }
+    async _loadType(type, generator, facade, models) {
+        const fetchOptions = TYPE_FETCH_OPTIONS[type];
+        if (!fetchOptions) {
+            return;
+        }
+        // Use the same raw-knex path as the eager URL service's resource
+        // fetcher (services/url/resources.js → raw_knex.fetchAll). The
+        // previous implementation went through Bookshelf's findPage and
+        // toPlain per row, which is minutes-not-seconds for 50k posts —
+        // slow enough that edge proxies 503 on the first sitemap request.
+        const objects = await models.Base.Model.raw_knex.fetchAll(fetchOptions);
+        for (const datum of objects) {
+            const url = facade.getUrlForResource({...datum, type}, {absolute: true});
+            if (url && !url.match(/\/404\//)) {
+                generator.addUrl(url, datum);
             }
-            const totalPages = result?.meta?.pagination?.pages;
-            // Guard against unexpected response shapes (missing meta,
-            // empty page) so we don't loop forever.
-            if (!totalPages || page >= totalPages || result.data.length === 0) {
-                break;
-            }
-            page += 1;
         }
     }
 }
 
-// Per-router-type browse options for the lazy populate path. Mirrors the
-// eager URL service's resource queries (services/url/config.js): posts/pages
-// filter by published+type, tags/authors by visibility:public.
+// Mirrors the eager URL service's resource configs (services/url/config.js)
+// so the lazy sitemap renders the same URL set as the eager service would.
+// When the eager service is removed this becomes the only copy — kept
+// inline (rather than imported from services/url) so the eager removal is
+// a clean delete.
 //
-// `withRelated: ['tags', 'authors']` for posts: needed so the Bookshelf
-// model's toJSON output includes `primary_tag` and `primary_author`, which
-// custom permalink templates like `/:primary_tag/:slug/` evaluate against.
-// Without this preload the lazy sitemap would emit `/undefined/.../` for
-// any site using a primary_tag/primary_author permalink. Pages exclude
-// these in the eager config so we mirror that.
-const TYPE_BROWSE_OPTIONS = {
-    posts: {limit: 200, status: 'published', filter: 'type:post', withRelated: ['tags', 'authors']},
-    pages: {limit: 200, status: 'published', filter: 'type:page'},
-    tags: {limit: 200, filter: 'visibility:public'},
-    authors: {limit: 200, filter: 'visibility:public'}
+// The `exclude` lists trim heavy columns (mobiledoc, lexical, html,
+// plaintext, codeinjection, og/twitter card fields, …) before they ever
+// reach memory. Without them, fetchAll loads the full body of every post
+// — multiple GB on a 50k-post site.
+//
+// `withRelated: ['tags', 'authors']` for posts is what surfaces
+// `primary_tag` / `primary_author` on the result: Post.toJSON's computed
+// `primary_tag` field (models/post.js) and the authors-relation
+// serialize mixin both run as part of raw_knex.fetchAll's per-row
+// toJSON pass, gated only on the relation being loaded.
+const TYPE_FETCH_OPTIONS = {
+    posts: {
+        modelName: 'Post',
+        filter: 'status:published+type:post',
+        exclude: [
+            'title',
+            'mobiledoc',
+            'lexical',
+            'html',
+            'plaintext',
+            'status',
+            'codeinjection_head',
+            'codeinjection_foot',
+            'meta_title',
+            'meta_description',
+            'custom_excerpt',
+            'og_image',
+            'og_title',
+            'og_description',
+            'twitter_image',
+            'twitter_title',
+            'twitter_description',
+            'custom_template',
+            'locale',
+            'newsletter_id',
+            'show_title_and_feature_image',
+            'email_recipient_filter',
+            'comment_id',
+            'tiers'
+        ],
+        withRelated: ['tags', 'authors'],
+        withRelatedFields: {
+            tags: ['tags.id', 'tags.slug'],
+            authors: ['users.id', 'users.slug']
+        }
+    },
+    pages: {
+        modelName: 'Post',
+        filter: 'status:published+type:page',
+        exclude: [
+            'title',
+            'mobiledoc',
+            'lexical',
+            'html',
+            'plaintext',
+            'codeinjection_head',
+            'codeinjection_foot',
+            'meta_title',
+            'meta_description',
+            'custom_excerpt',
+            'og_image',
+            'og_title',
+            'og_description',
+            'twitter_image',
+            'twitter_title',
+            'twitter_description',
+            'custom_template',
+            'locale',
+            'tags',
+            'authors',
+            'primary_tag',
+            'primary_author',
+            'newsletter_id',
+            'show_title_and_feature_image',
+            'email_recipient_filter',
+            'comment_id',
+            'tiers'
+        ]
+    },
+    tags: {
+        modelName: 'Tag',
+        filter: 'visibility:public',
+        exclude: ['description', 'meta_title', 'meta_description', 'parent_id'],
+        shouldHavePosts: {joinTo: 'tag_id', joinTable: 'posts_tags'}
+    },
+    authors: {
+        modelName: 'User',
+        filter: 'visibility:public',
+        exclude: [
+            'bio',
+            'website',
+            'location',
+            'facebook',
+            'twitter',
+            'locale',
+            'accessibility',
+            'meta_title',
+            'meta_description',
+            'tour',
+            'last_seen'
+        ],
+        shouldHavePosts: {joinTo: 'author_id', joinTable: 'posts_authors'}
+    }
 };
-
-function browseOptionsFor(type) {
-    return TYPE_BROWSE_OPTIONS[type] || {limit: 200};
-}
 
 module.exports = SiteMapManager;

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -177,9 +177,7 @@ describe('Unit: sitemap/manager', function () {
     // for the right resources.
     describe('_populateFromDatabase', function () {
         let sandbox;
-        let postFindPage;
-        let tagFindPage;
-        let userFindPage;
+        let fetchAll;
         let getUrlForResource;
 
         const models = require('../../../../../core/server/models');
@@ -191,11 +189,13 @@ describe('Unit: sitemap/manager', function () {
         // beforeEach failure can't leak stubs across cases.
         beforeEach(function () {
             sandbox = sinon.createSandbox();
-            postFindPage = sandbox.stub(models.Post, 'findPage');
-            // Sitemap populate uses TagPublic and Author (the scoped models
-            // with shouldHavePosts gating) instead of Tag/User.
-            tagFindPage = sandbox.stub(models.TagPublic, 'findPage');
-            userFindPage = sandbox.stub(models.Author, 'findPage');
+            // The lazy sitemap populate goes through raw_knex.fetchAll —
+            // the same fast path the eager URL service uses
+            // (services/url/resources.js). All four resource types route
+            // through this single static method, discriminated by
+            // `modelName` and `filter` in the options.
+            fetchAll = sandbox.stub(models.Base.Model.raw_knex, 'fetchAll');
+            fetchAll.resolves([]);
 
             sandbox.stub(PageGenerator.prototype, 'addUrl');
             sandbox.stub(TagGenerator.prototype, 'addUrl');
@@ -212,13 +212,6 @@ describe('Unit: sitemap/manager', function () {
             sandbox.restore();
         });
 
-        function paged(rows) {
-            return {
-                data: rows.map(r => ({...r, toJSON: () => r})),
-                meta: {pagination: {pages: 1}}
-            };
-        }
-
         function makeLazyManager() {
             return new SiteMapManager({
                 posts: new PostGenerator(),
@@ -229,15 +222,16 @@ describe('Unit: sitemap/manager', function () {
             });
         }
 
+        const postsMatcher = sinon.match({modelName: 'Post', filter: 'status:published+type:post'});
+        const pagesMatcher = sinon.match({modelName: 'Post', filter: 'status:published+type:page'});
+        const tagsMatcher = sinon.match({modelName: 'Tag'});
+        const authorsMatcher = sinon.match({modelName: 'User'});
+
         it('feeds non-/404/ URLs into the per-type generators', async function () {
-            postFindPage
-                .withArgs(sinon.match({filter: 'type:post'}))
-                .resolves(paged([{id: 'p1', slug: 'hello', type: 'post'}]));
-            postFindPage
-                .withArgs(sinon.match({filter: 'type:page'}))
-                .resolves(paged([{id: 'pg1', slug: 'about', type: 'page'}]));
-            tagFindPage.resolves(paged([{id: 't1', slug: 'food'}]));
-            userFindPage.resolves(paged([{id: 'u1', slug: 'jane'}]));
+            fetchAll.withArgs(postsMatcher).resolves([{id: 'p1', slug: 'hello', type: 'post'}]);
+            fetchAll.withArgs(pagesMatcher).resolves([{id: 'pg1', slug: 'about', type: 'page'}]);
+            fetchAll.withArgs(tagsMatcher).resolves([{id: 't1', slug: 'food'}]);
+            fetchAll.withArgs(authorsMatcher).resolves([{id: 'u1', slug: 'jane'}]);
 
             getUrlForResource.callsFake((resource) => {
                 if (resource.id === 'p1') {
@@ -265,53 +259,76 @@ describe('Unit: sitemap/manager', function () {
         });
 
         it('preloads tags+authors for posts so primary_tag permalinks resolve', async function () {
-            postFindPage.resolves(paged([]));
-            tagFindPage.resolves(paged([]));
-            userFindPage.resolves(paged([]));
             getUrlForResource.returns('http://example.com/x/');
 
             await makeLazyManager().ensurePopulatedFromDatabase();
 
             // Sites using `/:primary_tag/:slug/` permalinks need
-            // `primary_tag` populated on the resource. Bookshelf only fills
-            // it in toJSON when the `tags` relation is loaded.
-            sinon.assert.calledWith(postFindPage, sinon.match({
-                filter: 'type:post',
+            // `primary_tag` populated on the resource. raw_knex.fetchAll
+            // attaches relations listed in withRelated and runs Post.toJSON
+            // per row; toJSON's computed primary_tag/primary_author fields
+            // only fire when the underlying tags/authors relation is loaded,
+            // so `withRelated: ['tags', 'authors']` is the load-bearing key
+            // here.
+            sinon.assert.calledWith(fetchAll, sinon.match({
+                modelName: 'Post',
+                filter: 'status:published+type:post',
                 withRelated: ['tags', 'authors']
             }));
         });
 
-        it('queries tags and authors with visibility:public to mirror the eager URL service', async function () {
-            postFindPage.resolves(paged([]));
-            tagFindPage.resolves(paged([]));
-            userFindPage.resolves(paged([]));
+        it('excludes heavy post body columns from the fetch so a large site does not OOM', async function () {
             getUrlForResource.returns('http://example.com/x/');
 
             await makeLazyManager().ensurePopulatedFromDatabase();
 
-            // Pin the full options shape so a future drop of `limit` or a
-            // change in the filter expression still fails this test. The
-            // tag schema permits visibility:'internal' and the user schema
-            // defaults to 'public' but doesn't enforce it; without these
-            // filters the lazy sitemap diverges from the eager URL service
-            // (services/url/config.js applies both).
-            sinon.assert.calledWith(tagFindPage, sinon.match({
-                limit: 200,
-                filter: 'visibility:public'
+            // The sitemap only needs slug + dates + the primary_tag/author
+            // computed fields. Without `exclude`, raw_knex.fetchAll falls
+            // through to `SELECT *` and loads multi-MB mobiledoc/lexical/
+            // html/plaintext columns for every post into memory at once.
+            // Mirrors the eager URL service's exclude list at
+            // services/url/config.js.
+            sinon.assert.calledWith(fetchAll, sinon.match({
+                modelName: 'Post',
+                filter: 'status:published+type:post',
+                exclude: sinon.match.array
+                    .contains(['mobiledoc', 'lexical', 'html', 'plaintext'])
             }));
-            sinon.assert.calledWith(userFindPage, sinon.match({
-                limit: 200,
-                filter: 'visibility:public'
+            sinon.assert.calledWith(fetchAll, sinon.match({
+                modelName: 'Post',
+                filter: 'status:published+type:page',
+                exclude: sinon.match.array
+                    .contains(['mobiledoc', 'lexical', 'html', 'plaintext'])
+            }));
+        });
+
+        it('queries tags and authors with visibility:public + shouldHavePosts to mirror the eager URL service', async function () {
+            getUrlForResource.returns('http://example.com/x/');
+
+            await makeLazyManager().ensurePopulatedFromDatabase();
+
+            // shouldHavePosts at the raw_knex layer is the gate that the
+            // TagPublic/Author scoped models used to apply. Without it,
+            // tags/users with no published posts would appear in the
+            // sitemap (and in particular staff User accounts could be
+            // exposed by author-slug guessing).
+            sinon.assert.calledWith(fetchAll, sinon.match({
+                modelName: 'Tag',
+                filter: 'visibility:public',
+                shouldHavePosts: {joinTo: 'tag_id', joinTable: 'posts_tags'}
+            }));
+            sinon.assert.calledWith(fetchAll, sinon.match({
+                modelName: 'User',
+                filter: 'visibility:public',
+                shouldHavePosts: {joinTo: 'author_id', joinTable: 'posts_authors'}
             }));
         });
 
         it('skips resources whose URL would be /404/', async function () {
-            postFindPage.resolves(paged([
+            fetchAll.withArgs(postsMatcher).resolves([
                 {id: 'p1', slug: 'good', type: 'post'},
                 {id: 'p2', slug: 'orphan', type: 'post'}
-            ]));
-            tagFindPage.resolves(paged([]));
-            userFindPage.resolves(paged([]));
+            ]);
 
             getUrlForResource.callsFake((resource) => {
                 return resource.id === 'p1' ? 'http://example.com/good/' : '/404/';
@@ -334,19 +351,13 @@ describe('Unit: sitemap/manager', function () {
             // Fix: only clear _populating if it still points to T1's promise.
             let unblockT1;
             let unblockT2;
-            postFindPage
-                .withArgs(sinon.match({filter: 'type:post'}))
+            fetchAll.withArgs(postsMatcher)
                 .onFirstCall().returns(new Promise((resolve) => {
-                    unblockT1 = () => resolve(paged([]));
+                    unblockT1 = () => resolve([]);
                 }))
                 .onSecondCall().returns(new Promise((resolve) => {
-                    unblockT2 = () => resolve(paged([]));
+                    unblockT2 = () => resolve([]);
                 }));
-            postFindPage
-                .withArgs(sinon.match({filter: 'type:page'}))
-                .resolves(paged([]));
-            tagFindPage.resolves(paged([]));
-            userFindPage.resolves(paged([]));
             getUrlForResource.returns('http://example.com/x/');
 
             const manager = makeLazyManager();
@@ -376,19 +387,13 @@ describe('Unit: sitemap/manager', function () {
         });
 
         it('routers.reset during a populate cancels the populate via the generation token', async function () {
-            // The "post" findPage call hangs until we explicitly resolve it,
+            // The posts fetchAll call hangs until we explicitly resolve it,
             // simulating a slow DB load that races with a routes.yaml reload.
             let unblockPopulate;
-            postFindPage
-                .withArgs(sinon.match({filter: 'type:post'}))
+            fetchAll.withArgs(postsMatcher)
                 .returns(new Promise((resolve) => {
-                    unblockPopulate = () => resolve(paged([]));
+                    unblockPopulate = () => resolve([]);
                 }));
-            postFindPage
-                .withArgs(sinon.match({filter: 'type:page'}))
-                .resolves(paged([]));
-            tagFindPage.resolves(paged([]));
-            userFindPage.resolves(paged([]));
             getUrlForResource.returns('http://example.com/x/');
 
             const manager = makeLazyManager();
@@ -409,10 +414,10 @@ describe('Unit: sitemap/manager', function () {
             // must re-issue the DB queries because the previous populate's
             // result was invalidated by the routers.reset. (Asserting on the
             // private `_populated` flag would couple to internal state.)
-            const callsBefore = postFindPage.callCount;
+            const callsBefore = fetchAll.callCount;
             await manager.ensurePopulatedFromDatabase();
             assert.ok(
-                postFindPage.callCount > callsBefore,
+                fetchAll.callCount > callsBefore,
                 'A reset mid-populate must invalidate the in-flight result so the next call re-queries'
             );
         });


### PR DESCRIPTION
## Summary

Follow-up to #27714 (HKG-1738). Switches the lazy sitemap populate from `Model.findPage(...)` to the same `raw_knex.fetchAll(...)` path the eager URL service uses, so first-request sitemap generation stops timing out behind edge proxies on large sites.

**Why:** the previous populate path used Bookshelf's `findPage(limit: 200)` per type, with `toPlain` per row. On a 50k+ post site that's minutes-long — long enough that edge proxies 503 the first `/sitemap.xml` request, even though the index handler only needs to know which child sitemaps exist. The eager URL service already builds the full routing table in ~20s by going through `raw_knex.fetchAll` with trimmed columns and batched IN-queries per relation. Same data, vastly less overhead. This PR reuses that call shape.

**Why a copy, not a shared import:** the eager URL service is on its way out once `config.lazyRouting` graduates to the default. Sharing infrastructure with code slated for deletion would just complicate the eventual removal. `TYPE_FETCH_OPTIONS` here mirrors `services/url/config.js`; when eager is dropped, this becomes the only copy and stands alone.

**Side effect:** `shouldHavePosts` applied at the raw-knex layer replaces the `TagPublic` / `Author` Bookshelf scoped models — same effective gate (tags/users with no published posts excluded, staff User accounts not exposed via author-slug guessing).

## Test plan

- [x] `pnpm test:single test/unit/frontend/services/sitemap/manager.test.js` (15/15 pass)
- [x] `pnpm test:single test/integration/url-service.test.js` (9/9 pass)
- [ ] Smoke-test against a large Ghost site under `config.lazyRouting: true` — first-request `/sitemap.xml` should complete within the edge proxy timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)