### PR TITLE
Capped number of automation actions to 20

### DIFF
--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -13,6 +13,8 @@ const domainEvents = require('@tryghost/domain-events');
 const StartAutomationsPollEvent = require('./events/start-automations-poll-event');
 const temporaryFakeAutomationsDatabase = require('./temporary-fake-database');
 
+const MAX_AUTOMATION_ACTIONS = 20;
+
 const messages = {
     automationNotFound: 'Automation not found.',
     invalidAutomationPayload: 'Automation edit payload must include status, actions, and edges.',
@@ -64,7 +66,7 @@ const editAutomationDataSchema = z.object({
     actions: z.array(z.discriminatedUnion('type', [
         waitActionSchema,
         sendEmailActionSchema
-    ])).min(1),
+    ])).min(1).max(MAX_AUTOMATION_ACTIONS),
     edges: z.array(edgeSchema)
 }).strict();
 

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -49,6 +49,19 @@ const matchPagination = () => ({
     next: null
 });
 
+const buildWaitAction = () => ({
+    id: ObjectId().toHexString(),
+    type: 'wait',
+    data: {
+        wait_hours: 24
+    }
+});
+
+const buildLinearEdges = actions => actions.slice(1).map((action, index) => ({
+    source_action_id: actions[index].id,
+    target_action_id: action.id
+}));
+
 describe('Automations API', function () {
     let agent;
     let schedulerIntegration;
@@ -236,6 +249,67 @@ describe('Automations API', function () {
                 .expectStatus(200);
 
             assert.deepEqual(readBody.automations[0], automation);
+        });
+
+        it('allows an automation with 20 actions', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            const automationId = browseBody.automations[0].id;
+            const actions = Array.from({length: 20}, buildWaitAction);
+            const edges = buildLinearEdges(actions);
+
+            const {body: editBody} = await agent
+                .put(`automations/${automationId}`)
+                .body({
+                    automations: [{
+                        status: 'inactive',
+                        actions,
+                        edges
+                    }]
+                })
+                .expectStatus(200)
+                .expect(cacheInvalidateHeaderNotSet());
+
+            const automation = editBody.automations[0];
+            assert.equal(automation.status, 'inactive');
+            assert.equal(automation.actions.length, 20);
+            assert.equal(automation.edges.length, 19);
+            assert.deepEqual(automation.actions, actions);
+            assert.deepEqual(automation.edges, edges);
+        });
+
+        it('rejects an automation with more than 20 actions', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            const automationId = browseBody.automations[0].id;
+
+            const {body: beforeBody} = await agent
+                .get(`automations/${automationId}`)
+                .expectStatus(200);
+
+            const actions = Array.from({length: 21}, buildWaitAction);
+
+            await agent
+                .put(`automations/${automationId}`)
+                .body({
+                    automations: [{
+                        status: 'inactive',
+                        actions,
+                        edges: buildLinearEdges(actions)
+                    }]
+                })
+                .expectStatus(422)
+                .expect(cacheInvalidateHeaderNotSet());
+
+            const {body: afterBody} = await agent
+                .get(`automations/${automationId}`)
+                .expectStatus(200);
+
+            assert.deepEqual(afterBody, beforeBody);
         });
 
         it('rejects an invalid automation status', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1285

This was written entirely by GPT-5.5 with the following prompt:

> Commit `63f353779c408ca781bd66ef9295f1f211c47cc2` added graph editing for automations. But you can pass an unlimited number of actions and edges.
>
> Define a constant (called something like `MAX_ACTIONS` or `MAX_AUTOMATION_ACTIONS`), set to 20, that ensures that 20 is the maximum number of automation actions allowed in an edit request. In other words, you shouldn't be able to have more than 20 actions. You may also need to check the number of edges, or you may not—I'm not sure.
>
> Use red/green TDD to verify this. You'll probably need to add one or two tests to `ghost/core/test/e2e-api/admin/automations.test.js`.
>
> When you're done, create a branch and make the following commit:
>
> ```
> Capped number of automation actions to 20
>
> ref https://linear.app/ghost/issue/NY-1285
> ```
>
> And then make a PR with the same title and description.