### PR TITLE
Reduced flakes in Portal upgrade-flow timeout-prone test

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.47",
+  "version": "2.68.48",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/test/upgrade-flow.test.js
+++ b/apps/portal/test/upgrade-flow.test.js
@@ -201,6 +201,12 @@ describe('Logged-in free member', () => {
             const singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
 
             fireEvent.click(viewPlansButton);
+            // Wait for the full plan picker to render (Yearly is the second
+            // option) before clicking Monthly. Mirrors the yearly-plan test
+            // and gives React time to attach event handlers — without this
+            // settle point, the first test in the file occasionally raced
+            // against initial render under JIT/module-loading warm-up.
+            await within(popupIframeDocument).findByText('Yearly');
             const monthlyPlanContainer = await within(popupIframeDocument).findByText('Monthly');
             fireEvent.click(monthlyPlanContainer);
             // added fake timeout for react state delay in setting plan

--- a/apps/portal/vite.config.mjs
+++ b/apps/portal/vite.config.mjs
@@ -88,7 +88,13 @@ export default defineConfig((config) => {
             globals: true,
             environment: 'jsdom',
             setupFiles: './test/setup-tests.js',
-            testTimeout: 10000,
+            // The first test in a heavy integration-style file (e.g. upgrade-flow,
+            // which runs the full Portal app under JSDOM) pays a module-loading
+            // and JIT warm-up cost on top of its actual work. Hardcoding 10s
+            // left flakes when CI workers were slow; 20s gives clear headroom
+            // for warm-up while still keeping the suite honest. Other Ghost
+            // apps use the same env-var override pattern for one-off CI bumps.
+            testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 20000,
             coverage: {
                 reporter: ['cobertura', 'text-summary', 'html']
             }


### PR DESCRIPTION
## Summary

Addresses the `apps/portal/test/upgrade-flow.test.js > Logged-in free member > can upgrade on single tier site > with default settings on monthly plan` flake that tripped CI on main after a recent merge ([example failing job](https://github.com/TryGhost/Ghost/actions/runs/25826369918/job/75880794632)).

The failure mode is a 10s vitest timeout, not an assertion error. Diagnosis from that CI run:

- The flaky test took **10221ms** before being killed.
- The very next test in the same describe block (`with default settings on yearly plan`) — same setup, same fixtures, near-identical body — took **5393ms** and passed.
- The flaky test is the **first test in the file**, which is exactly where vitest's per-file warm-up cost (module loading + JIT for heavy React/JSDOM rendering) hits hardest.

A 10s timeout left no headroom for that warm-up; first-test runs on slower CI workers occasionally landed just past the cliff.

## Changes

**`apps/portal/vite.config.mjs`** — Bump default `testTimeout` from 10s to 20s and adopt the env-var override pattern (`process.env.TIMEOUT ? parseInt(...) : 20000`) that admin-x-framework, comments-ui, shade and signup-form already use. 20s gives ~3x headroom over the slowest passing test in this file (~7s) without making the suite meaningfully more lenient about real bugs.

**`apps/portal/test/upgrade-flow.test.js`** — Add an extra `await findByText('Yearly')` in the monthly-plan test, mirroring the yearly-plan test's pattern. Both tests now wait for the full plan picker to render before clicking, giving React time to attach event handlers. Belt-and-braces alongside the timeout bump.

## Why these two and not, e.g., a `findByRole` for the Continue button

The failure was a hard timeout, not a "couldn't find element" error. The `queryByRole('button', {name: 'Continue'})` after the click is sync and didn't throw — the test was running, just running too long. Switching that to `findByRole` would only help if Continue was being rendered too late, which the timing data doesn't suggest.

## Test plan

- [x] `vite.config.mjs` parses; `testTimeout` honours `TIMEOUT` env var
- [x] Monthly test now matches yearly test's two-`findByText` settle pattern
- [ ] Monitor CI on this branch — should pass cleanly with extra headroom

Local validation note: tests fail on Node 24 + JSDOM 28 with an unrelated `InvalidCharacterError` on SVG data URIs. CI uses Node 22 where this isn't an issue.
