### PR TITLE
Unified @types/node on 22.19.17 and moved into the pnpm catalog

### DIFF
--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -70,7 +70,7 @@
     "@tryghost/admin-x-framework": "workspace:*",
     "@tryghost/custom-fonts": "catalog:",
     "@tryghost/shade": "workspace:*",
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/validator": "catalog:",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -31,7 +31,7 @@
     "@tanstack/react-query": "catalog:",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "14.3.1",
-    "@types/node": "25.6.0",
+    "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react-swc": "4.1.0",

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -86,7 +86,7 @@
         "@storybook/react-vite": "catalog:",
         "@tailwindcss/postcss": "4.2.1",
         "@testing-library/react": "14.3.1",
-        "@types/node": "22.19.17",
+        "@types/node": "catalog:",
         "@types/react-world-flags": "1.6.0",
         "@typescript-eslint/parser": "catalog:",
         "@vitejs/plugin-react": "catalog:",

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -45,7 +45,7 @@
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "14.3.1",
         "@types/jest": "catalog:",
-        "@types/node": "22.19.17",
+        "@types/node": "catalog:",
         "@types/react": "catalog:",
         "@types/react-svg-map": "2.1.4",
         "@vitest/coverage-v8": "catalog:",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -263,7 +263,7 @@
     "@types/lodash-es": "4.17.12",
     "@types/mime-types": "3.0.1",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@types/node-fetch": "2.6.13",
     "@types/node-jose": "1.1.13",
     "@types/nodemailer": "6.4.23",

--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/node": "25.6.0",
+    "@types/node": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "c8": "catalog:",
     "eslint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     '@types/jest':
       specifier: 29.5.14
       version: 29.5.14
+    '@types/node':
+      specifier: 22.19.17
+      version: 22.19.17
     '@types/react':
       specifier: 18.3.28
       version: 18.3.28
@@ -402,7 +405,7 @@ importers:
         version: 9.37.0
       '@tailwindcss/vite':
         specifier: 4.2.1
-        version: 4.2.1(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.1(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -413,8 +416,8 @@ importers:
         specifier: 14.3.1
         version: 14.3.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
-        specifier: 25.6.0
-        version: 25.6.0
+        specifier: 'catalog:'
+        version: 22.19.17
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.28
@@ -423,7 +426,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react-swc':
         specifier: 4.1.0
-        version: 4.1.0(@swc/helpers@0.5.21)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@swc/helpers@0.5.21)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: catalog:eslint9
         version: 9.37.0(jiti@2.6.1)
@@ -444,13 +447,13 @@ importers:
         version: 17.4.0
       jest-extended:
         specifier: 7.0.0
-        version: 7.0.0(jest@29.7.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.2(@swc/core@1.15.21(@swc/helpers@0.5.21))(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 7.0.0(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.2(@swc/core@1.15.21(@swc/helpers@0.5.21))(@types/node@22.19.17)(typescript@5.9.3)))(typescript@5.9.3)
       jsdom:
         specifier: 'catalog:'
         version: 28.1.0(@noble/hashes@1.8.0)
       msw:
         specifier: 'catalog:'
-        version: 2.12.14(@types/node@25.6.0)(typescript@5.9.3)
+        version: 2.12.14(@types/node@22.19.17)(typescript@5.9.3)
       sirv:
         specifier: 3.0.2
         version: 3.0.2
@@ -465,13 +468,13 @@ importers:
         version: 8.58.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
-        version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: 5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.6.0)(typescript@5.9.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@22.19.17)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/admin-x-design-system:
     dependencies:
@@ -830,7 +833,7 @@ importers:
         specifier: workspace:*
         version: link:../shade
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@types/react':
         specifier: 'catalog:'
@@ -1330,7 +1333,7 @@ importers:
         specifier: 14.3.1
         version: 14.3.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@types/react-world-flags':
         specifier: 1.6.0
@@ -1585,7 +1588,7 @@ importers:
         specifier: 'catalog:'
         version: 29.5.14
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@types/react':
         specifier: 'catalog:'
@@ -2577,7 +2580,7 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@types/node-fetch':
         specifier: 2.6.13
@@ -2733,8 +2736,8 @@ importers:
         version: 0.0.2
     devDependencies:
       '@types/node':
-        specifier: 25.6.0
-        version: 25.6.0
+        specifier: 'catalog:'
+        version: 22.19.17
       '@typescript-eslint/parser':
         specifier: 'catalog:'
         version: 8.49.0(eslint@8.57.1)(typescript@5.9.3)
@@ -25530,7 +25533,6 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
       '@types/node': 22.19.17
-    optional: true
 
   '@inquirer/confirm@5.1.21(@types/node@25.6.0)':
     dependencies:
@@ -25551,7 +25553,6 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 22.19.17
-    optional: true
 
   '@inquirer/core@10.3.2(@types/node@25.6.0)':
     dependencies:
@@ -25578,7 +25579,6 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@22.19.17)':
     optionalDependencies:
       '@types/node': 22.19.17
-    optional: true
 
   '@inquirer/type@3.0.10(@types/node@25.6.0)':
     optionalDependencies:
@@ -29515,12 +29515,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/query-core@4.36.1': {}
 
@@ -31270,11 +31270,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react-swc@4.1.0(@swc/helpers@0.5.21)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react-swc@4.1.0(@swc/helpers@0.5.21)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.35
       '@swc/core': 1.15.21(@swc/helpers@0.5.21)
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -40183,12 +40183,12 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-extended@7.0.0(jest@29.7.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.2(@swc/core@1.15.21(@swc/helpers@0.5.21))(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3):
+  jest-extended@7.0.0(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.2(@swc/core@1.15.21(@swc/helpers@0.5.21))(@types/node@22.19.17)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       jest-diff: 30.3.0
       typescript: 5.9.3
     optionalDependencies:
-      jest: 29.7.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.2(@swc/core@1.15.21(@swc/helpers@0.5.21))(@types/node@25.6.0)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)(ts-node@10.9.2(@swc/core@1.15.21(@swc/helpers@0.5.21))(@types/node@22.19.17)(typescript@5.9.3))
 
   jest-get-type@29.6.3: {}
 
@@ -42463,7 +42463,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   msw@2.12.14(@types/node@25.6.0)(typescript@5.9.3):
     dependencies:
@@ -47806,13 +47805,13 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ catalog:
   '@tryghost/timezone-data': 0.4.18
   '@types/express': 4.17.25
   '@types/jest': 29.5.14
+  '@types/node': 22.19.17
   '@types/react': 18.3.28
   '@types/react-dom': 18.3.7
   '@types/validator': 13.15.10


### PR DESCRIPTION
## Summary

Six workspaces declared \`@types/node\` at two different majors:

| Version | Workspaces |
|---|---|
| \`22.19.17\` | \`admin-x-settings\`, \`shade\`, \`stats\`, \`ghost/core\` |
| \`25.6.0\` | \`admin\`, \`parse-email-address\` |

Pinned all six to **22.19.17** and moved the entry into the default catalog.

## Why 22 (not 25)

Ghost CI runs Node **22.18.0** (LTS). \`@types/node\` should match the runtime — types ahead of runtime risk autocomplete suggesting APIs that throw at runtime, and tsc happily compiling code that fails at execution.

## Verification

- \`pnpm install\` clean.
- \`tsc --noEmit\` passes on both downgraded packages (\`apps/admin\` via root tsconfig, \`ghost/parse-email-address\` via its \`test:types\` script). Confirms neither was using v25-only declarations.
- \`pnpm nx build @tryghost/admin-x-settings\` succeeds.

## Why catalog

Six workspaces is well above the 3+ threshold; centralizing means future Node-version bumps update one entry instead of six, and prevents the same drift recurring.