### PR TITLE
Unified glob on 10.5.0 and moved into the pnpm catalog

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -47,7 +47,7 @@
         "eslint-plugin-react-hooks": "4.6.2",
         "eslint-plugin-react-refresh": "catalog:",
         "eslint-plugin-tailwindcss": "4.0.0-beta.0",
-        "glob": "10.5.0",
+        "glob": "catalog:",
         "jsdom": "catalog:",
         "lodash-es": "4.18.1",
         "postcss": "catalog:",

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -86,7 +86,7 @@
         "eslint-plugin-react-hooks": "4.6.2",
         "eslint-plugin-react-refresh": "catalog:",
         "eslint-plugin-tailwindcss": "4.0.0-beta.0",
-        "glob": "10.5.0",
+        "glob": "catalog:",
         "jsdom": "catalog:",
         "msw": "catalog:",
         "typescript": "catalog:",

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -97,7 +97,7 @@
         "eslint-plugin-react-refresh": "catalog:",
         "eslint-plugin-storybook": "10.3.5",
         "eslint-plugin-tailwindcss": "4.0.0-beta.0",
-        "glob": "10.5.0",
+        "glob": "catalog:",
         "jsdom": "catalog:",
         "postcss": "catalog:",
         "remark-gfm": "4.0.1",

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -124,7 +124,6 @@
     "flexsearch": "0.7.43",
     "fs-extra": "catalog:",
     "ghost": "workspace:*",
-    "glob": "8.1.0",
     "google-caja-bower": "https://github.com/acburdine/google-caja-bower#ghost",
     "keymaster": "https://github.com/madrobby/keymaster.git",
     "liquid-fire": "0.34.0",

--- a/ghost/core/core/frontend/services/helpers/registry.js
+++ b/ghost/core/core/frontend/services/helpers/registry.js
@@ -1,4 +1,4 @@
-const glob = require('glob');
+const {globSync} = require('glob');
 const path = require('path');
 
 const handlebars = require('./handlebars');
@@ -21,7 +21,7 @@ const registerHelper = (name, helperFn) => {
 };
 
 const registerDir = (helperPath) => {
-    let helperFiles = glob.sync('!(index).js', {cwd: helperPath});
+    let helperFiles = globSync('!(index).js', {cwd: helperPath});
     helperFiles.forEach((helper) => {
         const name = helper.replace(/.js$/, '');
         const fn = require(path.join(helperPath, helper));

--- a/ghost/core/core/server/data/importer/import-manager.js
+++ b/ghost/core/core/server/data/importer/import-manager.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const fs = require('fs-extra');
 const path = require('path');
 const os = require('os');
-const glob = require('glob');
+const {globSync} = require('glob');
 const crypto = require('crypto');
 const config = require('../../../shared/config');
 const {extract} = require('@tryghost/zip');
@@ -190,13 +190,13 @@ class ImportManager {
      */
     isValidZip(directory) {
         // Globs match content in the root or inside a single directory
-        const extMatchesBase = glob.sync(this.getExtensionGlob(this.getExtensions(), ROOT_OR_SINGLE_DIR), {cwd: directory, nocase: true});
+        const extMatchesBase = globSync(this.getExtensionGlob(this.getExtensions(), ROOT_OR_SINGLE_DIR), {cwd: directory, nocase: true});
 
-        const extMatchesAll = glob.sync(
+        const extMatchesAll = globSync(
             this.getExtensionGlob(this.getExtensions(), ALL_DIRS), {cwd: directory, nocase: true}
         );
 
-        const dirMatches = glob.sync(
+        const dirMatches = globSync(
             this.getDirectoryGlob(this.getDirectories(), ROOT_OR_SINGLE_DIR), {cwd: directory}
         );
 
@@ -225,7 +225,7 @@ class ImportManager {
             await extract(filePath, tmpDir);
 
             // Set permissions for all extracted files
-            const files = glob.sync('**/*', {cwd: tmpDir, nodir: true});
+            const files = globSync('**/*', {cwd: tmpDir, nodir: true});
             await Promise.all(files.map(file => fs.chmod(path.join(tmpDir, file), 0o644)));
         } catch (err) {
             if (err.message.startsWith('ENAMETOOLONG:')) {
@@ -260,7 +260,7 @@ class ImportManager {
      */
     getFilesFromZip(handler, directory) {
         const globPattern = this.getExtensionGlob(handler.extensions, ALL_DIRS);
-        return _.map(glob.sync(globPattern, {cwd: directory, nocase: true}), function (file) {
+        return _.map(globSync(globPattern, {cwd: directory, nocase: true}), function (file) {
             return {name: file, path: path.join(directory, file)};
         });
     }
@@ -272,9 +272,9 @@ class ImportManager {
      */
     getBaseDirectory(directory) {
         // Globs match root level only
-        const extMatches = glob.sync(this.getExtensionGlob(this.getExtensions(), ROOT_ONLY), {cwd: directory, nocase: true});
+        const extMatches = globSync(this.getExtensionGlob(this.getExtensions(), ROOT_ONLY), {cwd: directory, nocase: true});
 
-        const dirMatches = glob.sync(this.getDirectoryGlob(this.getDirectories(), ROOT_ONLY), {cwd: directory, nocase: true});
+        const dirMatches = globSync(this.getDirectoryGlob(this.getDirectories(), ROOT_ONLY), {cwd: directory, nocase: true});
         let extMatchesAll;
 
         // There is no base directory
@@ -282,7 +282,7 @@ class ImportManager {
             return;
         }
         // There is a base directory, grab it from any ext match
-        extMatchesAll = glob.sync(
+        extMatchesAll = globSync(
             this.getExtensionGlob(this.getExtensions(), ALL_DIRS), {cwd: directory, nocase: true}
         );
         if (extMatchesAll.length < 1 || extMatchesAll[0].split('/').length < 1) {

--- a/ghost/core/core/server/services/staff/staff-service-emails.js
+++ b/ghost/core/core/server/services/staff/staff-service-emails.js
@@ -1,7 +1,7 @@
 const {promises: fs, readFileSync} = require('fs');
 const path = require('path');
 const moment = require('moment');
-const glob = require('glob');
+const {globSync} = require('glob');
 const EmailAddressParser = require('../email-address/email-address-parser');
 
 class StaffServiceEmails {
@@ -545,7 +545,7 @@ class StaffServiceEmails {
 
     registerPartials() {
         const rootDirname = './email-templates/partials/';
-        const files = glob.sync('*.hbs', {cwd: path.join(__dirname, rootDirname)});
+        const files = globSync('*.hbs', {cwd: path.join(__dirname, rootDirname)});
         files.forEach((fileName) => {
             const name = fileName.replace(/.hbs$/, '');
             const filePath = path.join(__dirname, rootDirname, `${name}.hbs`);

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -176,7 +176,7 @@
     "form-data": "4.0.5",
     "fs-extra": "catalog:",
     "ghost-storage-base": "1.1.2",
-    "glob": "8.1.0",
+    "glob": "catalog:",
     "got": "13.0.0",
     "gscan": "6.0.2",
     "handlebars": "4.7.9",

--- a/ghost/core/test/unit/api/cache-invalidation.test.js
+++ b/ghost/core/test/unit/api/cache-invalidation.test.js
@@ -1,19 +1,19 @@
 const assert = require('node:assert/strict');
 const path = require('path');
 
-const glob = require('glob');
+const {globSync} = require('glob');
 
 describe('API', function () {
     describe('Cache Invalidation', function () {
         it('Controller actions explicitly declare cacheInvalidate header', async function () {
             const controllersRootPath = path.join(__dirname, '../../../core/server/api/endpoints');
-            const controllerPaths = glob.sync('*.js', {
+            const controllerPaths = globSync('*.js', {
                 cwd: controllersRootPath,
                 ignore: [
                     'index.js',
                     'identities.js' // The identities controller can not be required directly due to requiring other parts of Ghost to have been initialised first
                 ],
-                realpath: true
+                absolute: true
             });
 
             assert.ok(controllerPaths.length > 0, `No controllers found in ${controllersRootPath}`);

--- a/ghost/core/test/unit/server/data/importer/import-manager.test.js
+++ b/ghost/core/test/unit/server/data/importer/import-manager.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const fs = require('fs-extra');
 const path = require('path');
-const glob = require('glob');
+const {globSync} = require('glob');
 const importManager = require('../../../../../core/server/data/importer/import-manager');
 
 describe('Import Manager', function () {
@@ -10,7 +10,7 @@ describe('Import Manager', function () {
             const zipPath = path.join(__dirname, '/test.zip');
             const extractedPath = await importManager.extractZip(zipPath);
             try {
-                const files = glob.sync('**/*', {cwd: extractedPath, nodir: true});
+                const files = globSync('**/*', {cwd: extractedPath, nodir: true});
                 files.forEach((file) => {
                     const filePath = path.join(extractedPath, file);
                     const stats = fs.statSync(filePath);

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -34,7 +34,7 @@
     "c8": "catalog:",
     "eslint": "catalog:",
     "fs-extra": "catalog:",
-    "glob": "13.0.6",
+    "glob": "catalog:",
     "i18next-parser": "9.3.0",
     "mocha": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ catalogs:
     fs-extra:
       specifier: 11.3.4
       version: 11.3.4
+    glob:
+      specifier: 10.5.0
+      version: 10.5.0
     jsdom:
       specifier: 28.1.0
       version: 28.1.0
@@ -603,7 +606,7 @@ importers:
         specifier: 4.0.0-beta.0
         version: 4.0.0-beta.0(tailwindcss@4.2.1)
       glob:
-        specifier: 10.5.0
+        specifier: 'catalog:'
         version: 10.5.0
       jsdom:
         specifier: 'catalog:'
@@ -721,7 +724,7 @@ importers:
         specifier: 4.0.0-beta.0
         version: 4.0.0-beta.0(tailwindcss@4.2.2)
       glob:
-        specifier: 10.5.0
+        specifier: 'catalog:'
         version: 10.5.0
       jsdom:
         specifier: 'catalog:'
@@ -1366,7 +1369,7 @@ importers:
         specifier: 4.0.0-beta.0
         version: 4.0.0-beta.0(tailwindcss@4.2.1)
       glob:
-        specifier: 10.5.0
+        specifier: 'catalog:'
         version: 10.5.0
       jsdom:
         specifier: 'catalog:'
@@ -1981,9 +1984,6 @@ importers:
       ghost:
         specifier: workspace:*
         version: link:../core
-      glob:
-        specifier: 8.1.0
-        version: 8.1.0
       google-caja-bower:
         specifier: https://github.com/acburdine/google-caja-bower#ghost
         version: https://codeload.github.com/acburdine/google-caja-bower/tar.gz/275cb75249f038492094a499756a73719ae071fd
@@ -2345,8 +2345,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       glob:
-        specifier: 8.1.0
-        version: 8.1.0
+        specifier: 'catalog:'
+        version: 10.5.0
       got:
         specifier: 13.0.0
         version: 13.0.0
@@ -2720,8 +2720,8 @@ importers:
         specifier: 'catalog:'
         version: 11.3.4
       glob:
-        specifier: 13.0.6
-        version: 13.0.6
+        specifier: 'catalog:'
+        version: 10.5.0
       i18next-parser:
         specifier: 9.3.0
         version: 9.3.0
@@ -14720,11 +14720,6 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
@@ -38766,14 +38761,6 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
-
-  glob@8.1.0:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.9
-      once: 1.4.0
 
   glob@9.3.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalog:
   eslint: 8.57.1
   eslint-plugin-react-refresh: 0.4.24
   fs-extra: 11.3.4
+  glob: 10.5.0
   jsdom: 28.1.0
   jsonc-parser: 3.3.1
   mocha: 11.7.5


### PR DESCRIPTION
## Summary

Six workspaces declared \`glob\` across three majors:

| Version | Workspaces |
|---|---|
| \`8.1.0\` | \`ghost/core\` (prod dep), \`ghost/admin\` (devDep, **unused**) |
| \`10.5.0\` | \`admin-x-design-system\`, \`admin-x-framework\`, \`shade\` |
| \`13.0.6\` | \`ghost/i18n\` |

Unified all consumers on **10.5.0** (largest cohort) and moved into the catalog.

## Changes

1. **Removed dead dep**: \`ghost/admin\`'s \`glob\` declaration had no corresponding source import — deleted entirely.
2. **Refactored \`ghost/core\` to v9+ API**: glob v9 dropped the v7-style \`const glob = require('glob'); glob.sync(...)\` pattern in favour of named exports. Updated 5 call sites (3 production, 2 test) to \`const {globSync} = require('glob'); globSync(...)\`:
   - \`core/frontend/services/helpers/registry.js\`
   - \`core/server/data/importer/import-manager.js\`
   - \`core/server/services/staff/staff-service-emails.js\`
   - \`test/unit/api/cache-invalidation.test.js\`
   - \`test/unit/server/data/importer/import-manager.test.js\`
3. **Replaced \`realpath: true\` with \`absolute: true\`** in cache-invalidation.test.js. The \`realpath\` option behaves differently in v10 (returned relative paths against my expectation); \`absolute: true\` is the documented v9+ way to get absolute paths.
4. **Downgraded \`ghost/i18n\`** from 13.0.6 to 10.5.0. Its single call (\`const {glob} = require('glob')\`) uses the named-export API that exists identically in both versions.
5. **Catalogized** at 10.5.0.

## Verification

- \`pnpm install\` clean; all 5 remaining consumers resolve to glob 10.5.0.
- \`ghost/core\` unit tests:
  - cache-invalidation: 1 passing
  - import-manager: 1 passing
  - 969 frontend helper tests passing (exercises the modified \`registry.js\`)
  - 47 staff-service tests passing (exercises the modified \`staff-service-emails.js\`)
- \`ghost/i18n\` test suite: 100% coverage maintained.
- \`pnpm nx build @tryghost/shade\` succeeds (uses \`globSync\` in vite.config).
- \`ghost/core\` lint + tsc clean.