### PR TITLE
Added GCSStore for redirects with timestamped backups

### DIFF
--- a/ghost/core/core/server/services/custom-redirects/gcs-store.ts
+++ b/ghost/core/core/server/services/custom-redirects/gcs-store.ts
@@ -92,10 +92,7 @@ export class GCSStore implements RedirectsStore {
                 Bucket: this.bucket,
                 Key: this.key
             }));
-            if (!response.Body) {
-                return [];
-            }
-            body = await response.Body.transformToString('utf-8');
+            body = await response.Body!.transformToString('utf-8');
         } catch (err) {
             if (this._isNotFound(err)) {
                 return [];

--- a/ghost/core/core/server/services/custom-redirects/gcs-store.ts
+++ b/ghost/core/core/server/services/custom-redirects/gcs-store.ts
@@ -5,8 +5,7 @@ import {
     NoSuchKey,
     NotFound,
     PutObjectCommand,
-    S3Client,
-    S3ClientConfig
+    S3Client
 } from '@aws-sdk/client-s3';
 import tpl from '@tryghost/tpl';
 import * as errors from '@tryghost/errors';
@@ -19,19 +18,13 @@ const DEFAULT_KEY = 'redirects.json';
 
 const messages = {
     missingBucket: 'GCSStore requires a bucket name',
-    partialCredentials: 'GCSStore requires both accessKeyId and secretAccessKey, or neither'
+    missingClient: 'GCSStore requires an S3 client',
+    missingResponseBody: 'S3 GetObject returned no body'
 };
 
 export interface GCSStoreOptions {
     bucket: string;
-    key?: string;
-    region?: string;
-    endpoint?: string;
-    forcePathStyle?: boolean;
-    accessKeyId?: string;
-    secretAccessKey?: string;
-    sessionToken?: string;
-    s3Client?: S3Client;
+    s3Client: S3Client;
     getBackupKey?: (key: string) => string;
 }
 
@@ -44,7 +37,6 @@ export interface GCSStoreOptions {
 export class GCSStore implements RedirectsStore {
     private readonly client: S3Client;
     private readonly bucket: string;
-    private readonly key: string;
     private readonly getBackupKey: (key: string) => string;
 
     constructor(options: GCSStoreOptions) {
@@ -53,36 +45,15 @@ export class GCSStore implements RedirectsStore {
                 message: tpl(messages.missingBucket)
             });
         }
+        if (!options.s3Client) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.missingClient)
+            });
+        }
 
         this.bucket = options.bucket;
-        this.key = options.key || DEFAULT_KEY;
+        this.client = options.s3Client;
         this.getBackupKey = options.getBackupKey || getBackupRedirectsFilePath;
-
-        if (options.s3Client) {
-            this.client = options.s3Client;
-        } else {
-            if (Boolean(options.accessKeyId) !== Boolean(options.secretAccessKey)) {
-                throw new errors.IncorrectUsageError({
-                    message: tpl(messages.partialCredentials)
-                });
-            }
-
-            const clientConfig: S3ClientConfig = {
-                region: options.region,
-                endpoint: options.endpoint,
-                forcePathStyle: options.forcePathStyle
-            };
-
-            if (options.accessKeyId && options.secretAccessKey) {
-                clientConfig.credentials = {
-                    accessKeyId: options.accessKeyId,
-                    secretAccessKey: options.secretAccessKey,
-                    sessionToken: options.sessionToken
-                };
-            }
-
-            this.client = new S3Client(clientConfig);
-        }
     }
 
     async getAll(): Promise<RedirectConfig[]> {
@@ -90,9 +61,14 @@ export class GCSStore implements RedirectsStore {
         try {
             const response = await this.client.send(new GetObjectCommand({
                 Bucket: this.bucket,
-                Key: this.key
+                Key: DEFAULT_KEY
             }));
-            body = await response.Body!.transformToString('utf-8');
+            if (!response.Body) {
+                throw new errors.InternalServerError({
+                    message: tpl(messages.missingResponseBody)
+                });
+            }
+            body = await response.Body.transformToString('utf-8');
         } catch (err) {
             if (this._isNotFound(err)) {
                 return [];
@@ -107,14 +83,14 @@ export class GCSStore implements RedirectsStore {
         if (await this._canonicalExists()) {
             await this.client.send(new CopyObjectCommand({
                 Bucket: this.bucket,
-                Key: this.getBackupKey(this.key),
-                CopySource: `${this.bucket}/${this.key}`
+                Key: this.getBackupKey(DEFAULT_KEY),
+                CopySource: `${this.bucket}/${DEFAULT_KEY}`
             }));
         }
 
         await this.client.send(new PutObjectCommand({
             Bucket: this.bucket,
-            Key: this.key,
+            Key: DEFAULT_KEY,
             Body: JSON.stringify(redirects),
             ContentType: 'application/json'
         }));
@@ -124,7 +100,7 @@ export class GCSStore implements RedirectsStore {
         try {
             await this.client.send(new HeadObjectCommand({
                 Bucket: this.bucket,
-                Key: this.key
+                Key: DEFAULT_KEY
             }));
             return true;
         } catch (err) {

--- a/ghost/core/core/server/services/custom-redirects/gcs-store.ts
+++ b/ghost/core/core/server/services/custom-redirects/gcs-store.ts
@@ -1,6 +1,9 @@
 import {
+    CopyObjectCommand,
     GetObjectCommand,
+    HeadObjectCommand,
     NoSuchKey,
+    NotFound,
     PutObjectCommand,
     S3Client,
     S3ClientConfig
@@ -9,6 +12,7 @@ import tpl from '@tryghost/tpl';
 import * as errors from '@tryghost/errors';
 
 import {parseJson} from './redirect-config-parser';
+import {getBackupRedirectsFilePath} from './utils';
 import type {RedirectConfig, RedirectsStore} from './types';
 
 const DEFAULT_KEY = 'redirects.json';
@@ -28,16 +32,20 @@ export interface GCSStoreOptions {
     secretAccessKey?: string;
     sessionToken?: string;
     s3Client?: S3Client;
+    getBackupKey?: (key: string) => string;
 }
 
 /**
  * Implements RedirectsStore against an S3-compatible bucket. Reads and
- * writes a single JSON object at the configured key.
+ * writes a single JSON object at the configured key, keeping a
+ * timestamped server-side copy of the previous contents on each
+ * overwrite.
  */
 export class GCSStore implements RedirectsStore {
     private readonly client: S3Client;
     private readonly bucket: string;
     private readonly key: string;
+    private readonly getBackupKey: (key: string) => string;
 
     constructor(options: GCSStoreOptions) {
         if (!options.bucket) {
@@ -48,6 +56,7 @@ export class GCSStore implements RedirectsStore {
 
         this.bucket = options.bucket;
         this.key = options.key || DEFAULT_KEY;
+        this.getBackupKey = options.getBackupKey || getBackupRedirectsFilePath;
 
         if (options.s3Client) {
             this.client = options.s3Client;
@@ -88,7 +97,7 @@ export class GCSStore implements RedirectsStore {
             }
             body = await response.Body.transformToString('utf-8');
         } catch (err) {
-            if (err instanceof NoSuchKey) {
+            if (this._isNotFound(err)) {
                 return [];
             }
             throw err;
@@ -98,11 +107,38 @@ export class GCSStore implements RedirectsStore {
     }
 
     async replaceAll(redirects: RedirectConfig[]): Promise<void> {
+        if (await this._canonicalExists()) {
+            await this.client.send(new CopyObjectCommand({
+                Bucket: this.bucket,
+                Key: this.getBackupKey(this.key),
+                CopySource: `${this.bucket}/${this.key}`
+            }));
+        }
+
         await this.client.send(new PutObjectCommand({
             Bucket: this.bucket,
             Key: this.key,
             Body: JSON.stringify(redirects),
             ContentType: 'application/json'
         }));
+    }
+
+    private async _canonicalExists(): Promise<boolean> {
+        try {
+            await this.client.send(new HeadObjectCommand({
+                Bucket: this.bucket,
+                Key: this.key
+            }));
+            return true;
+        } catch (err) {
+            if (this._isNotFound(err)) {
+                return false;
+            }
+            throw err;
+        }
+    }
+
+    private _isNotFound(err: unknown): boolean {
+        return err instanceof NotFound || err instanceof NoSuchKey;
     }
 }

--- a/ghost/core/core/server/services/custom-redirects/gcs-store.ts
+++ b/ghost/core/core/server/services/custom-redirects/gcs-store.ts
@@ -1,0 +1,108 @@
+import {
+    GetObjectCommand,
+    NoSuchKey,
+    PutObjectCommand,
+    S3Client,
+    S3ClientConfig
+} from '@aws-sdk/client-s3';
+import tpl from '@tryghost/tpl';
+import * as errors from '@tryghost/errors';
+
+import {parseJson} from './redirect-config-parser';
+import type {RedirectConfig, RedirectsStore} from './types';
+
+const DEFAULT_KEY = 'redirects.json';
+
+const messages = {
+    missingBucket: 'GCSStore requires a bucket name',
+    partialCredentials: 'GCSStore requires both accessKeyId and secretAccessKey, or neither'
+};
+
+export interface GCSStoreOptions {
+    bucket: string;
+    key?: string;
+    region?: string;
+    endpoint?: string;
+    forcePathStyle?: boolean;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    s3Client?: S3Client;
+}
+
+/**
+ * Implements RedirectsStore against an S3-compatible bucket. Reads and
+ * writes a single JSON object at the configured key.
+ */
+export class GCSStore implements RedirectsStore {
+    private readonly client: S3Client;
+    private readonly bucket: string;
+    private readonly key: string;
+
+    constructor(options: GCSStoreOptions) {
+        if (!options.bucket) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.missingBucket)
+            });
+        }
+
+        this.bucket = options.bucket;
+        this.key = options.key || DEFAULT_KEY;
+
+        if (options.s3Client) {
+            this.client = options.s3Client;
+        } else {
+            if (Boolean(options.accessKeyId) !== Boolean(options.secretAccessKey)) {
+                throw new errors.IncorrectUsageError({
+                    message: tpl(messages.partialCredentials)
+                });
+            }
+
+            const clientConfig: S3ClientConfig = {
+                region: options.region,
+                endpoint: options.endpoint,
+                forcePathStyle: options.forcePathStyle
+            };
+
+            if (options.accessKeyId && options.secretAccessKey) {
+                clientConfig.credentials = {
+                    accessKeyId: options.accessKeyId,
+                    secretAccessKey: options.secretAccessKey,
+                    sessionToken: options.sessionToken
+                };
+            }
+
+            this.client = new S3Client(clientConfig);
+        }
+    }
+
+    async getAll(): Promise<RedirectConfig[]> {
+        let body: string;
+        try {
+            const response = await this.client.send(new GetObjectCommand({
+                Bucket: this.bucket,
+                Key: this.key
+            }));
+            if (!response.Body) {
+                return [];
+            }
+            body = await response.Body.transformToString('utf-8');
+        } catch (err) {
+            if (err instanceof NoSuchKey) {
+                return [];
+            }
+            throw err;
+        }
+
+        return parseJson(body);
+    }
+
+    async replaceAll(redirects: RedirectConfig[]): Promise<void> {
+        await this.client.send(new PutObjectCommand({
+            Bucket: this.bucket,
+            Key: this.key,
+            Body: JSON.stringify(redirects),
+            ContentType: 'application/json'
+        }));
+    }
+}

--- a/ghost/core/test/integration/services/custom-redirects/gcs-store.test.ts
+++ b/ghost/core/test/integration/services/custom-redirects/gcs-store.test.ts
@@ -1,16 +1,23 @@
 /* eslint-disable ghost/mocha/no-setup-in-describe -- runStoreContract is the parameterised-test seam; calling it inside describe is the intended use. */
-import {S3Client} from '@aws-sdk/client-s3';
+import assert from 'node:assert/strict';
+import {ListObjectsV2Command, S3Client} from '@aws-sdk/client-s3';
 
 import {GCSStore} from '../../../../core/server/services/custom-redirects/gcs-store';
 import {
     createTestS3Client,
     createTestBucket,
     emptyTestBucket,
-    deleteTestBucket
+    deleteTestBucket,
+    getObject
 } from '../../../utils/minio';
 import {runStoreContract} from '../../../unit/server/services/custom-redirects/helpers/store-contract';
 
-describe('Integration: GCSStore (validates the contract)', function () {
+const listObjectKeys = async (s3Client: S3Client, bucketName: string): Promise<string[]> => {
+    const response = await s3Client.send(new ListObjectsV2Command({Bucket: bucketName}));
+    return (response.Contents ?? []).map(o => o.Key ?? '').filter(Boolean);
+};
+
+describe('Integration: GCSStore', function () {
     let client: S3Client;
     let bucket: string;
 
@@ -29,5 +36,60 @@ describe('Integration: GCSStore (validates the contract)', function () {
 
     runStoreContract({
         createStore: () => new GCSStore({s3Client: client, bucket})
+    });
+
+    describe('replaceAll: timestamped backups', function () {
+        it('writes the canonical key without a backup when the bucket is empty', async function () {
+            const store = new GCSStore({s3Client: client, bucket});
+
+            await store.replaceAll([{from: '/a', to: '/b', permanent: true}]);
+
+            assert.deepEqual(await listObjectKeys(client, bucket), ['redirects.json']);
+        });
+
+        it('backs up the prior contents before overwriting', async function () {
+            // Inject a stable backup key — the default per-second
+            // timestamp would otherwise make this test depend on
+            // wall-clock granularity.
+            const backupKey = 'redirects-backup.json';
+            const store = new GCSStore({
+                s3Client: client,
+                bucket,
+                getBackupKey: () => backupKey
+            });
+            const initial = [{from: '/old', to: '/old-target', permanent: true}];
+
+            await store.replaceAll(initial);
+            await store.replaceAll([{from: '/new', to: '/new-target', permanent: false}]);
+
+            const backupBody = await getObject(client, bucket, backupKey);
+            assert.equal(backupBody?.toString('utf-8'), JSON.stringify(initial));
+        });
+
+        it('creates a new backup on every overwrite', async function () {
+            // Counter-based generator gives each overwrite a distinct
+            // backup key, so the test can assert accumulation without
+            // depending on wall-clock granularity.
+            let backupCounter = 0;
+            const store = new GCSStore({
+                s3Client: client,
+                bucket,
+                getBackupKey: () => {
+                    backupCounter += 1;
+                    return `redirects-backup-${backupCounter}.json`;
+                }
+            });
+
+            await store.replaceAll([{from: '/a', to: '/a', permanent: true}]);
+            await store.replaceAll([{from: '/b', to: '/b', permanent: true}]);
+            await store.replaceAll([{from: '/c', to: '/c', permanent: true}]);
+
+            const keys = (await listObjectKeys(client, bucket)).sort();
+            assert.deepEqual(keys, [
+                'redirects-backup-1.json',
+                'redirects-backup-2.json',
+                'redirects.json'
+            ]);
+        });
     });
 });

--- a/ghost/core/test/integration/services/custom-redirects/gcs-store.test.ts
+++ b/ghost/core/test/integration/services/custom-redirects/gcs-store.test.ts
@@ -8,7 +8,8 @@ import {
     createTestBucket,
     emptyTestBucket,
     deleteTestBucket,
-    getObject
+    getObject,
+    putObject
 } from '../../../utils/minio';
 import {runStoreContract} from '../../../unit/server/services/custom-redirects/helpers/store-contract';
 
@@ -36,6 +37,19 @@ describe('Integration: GCSStore', function () {
 
     runStoreContract({
         createStore: () => new GCSStore({s3Client: client, bucket})
+    });
+
+    describe('getAll: error handling', function () {
+        it('throws when redirects.json is corrupt', async function () {
+            await putObject(client, bucket, 'redirects.json', '{not valid');
+
+            const store = new GCSStore({s3Client: client, bucket});
+
+            await assert.rejects(
+                () => store.getAll(),
+                {errorType: 'BadRequestError'}
+            );
+        });
     });
 
     describe('replaceAll: timestamped backups', function () {

--- a/ghost/core/test/integration/services/custom-redirects/gcs-store.test.ts
+++ b/ghost/core/test/integration/services/custom-redirects/gcs-store.test.ts
@@ -1,0 +1,33 @@
+/* eslint-disable ghost/mocha/no-setup-in-describe -- runStoreContract is the parameterised-test seam; calling it inside describe is the intended use. */
+import {S3Client} from '@aws-sdk/client-s3';
+
+import {GCSStore} from '../../../../core/server/services/custom-redirects/gcs-store';
+import {
+    createTestS3Client,
+    createTestBucket,
+    emptyTestBucket,
+    deleteTestBucket
+} from '../../../utils/minio';
+import {runStoreContract} from '../../../unit/server/services/custom-redirects/helpers/store-contract';
+
+describe('Integration: GCSStore (validates the contract)', function () {
+    let client: S3Client;
+    let bucket: string;
+
+    before(async function () {
+        client = createTestS3Client();
+        bucket = await createTestBucket(client);
+    });
+
+    afterEach(async function () {
+        await emptyTestBucket(client, bucket);
+    });
+
+    after(async function () {
+        await deleteTestBucket(client, bucket);
+    });
+
+    runStoreContract({
+        createStore: () => new GCSStore({s3Client: client, bucket})
+    });
+});

--- a/ghost/core/test/unit/server/services/custom-redirects/gcs-store.test.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/gcs-store.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+
+import {GCSStore} from '../../../../../core/server/services/custom-redirects/gcs-store';
+
+describe('UNIT: GCSStore', function () {
+    describe('constructor validation', function () {
+        it('throws when no bucket is provided', function () {
+            assert.throws(
+                () => new GCSStore({} as never),
+                {errorType: 'IncorrectUsageError', message: /bucket/}
+            );
+        });
+
+        it('throws when only accessKeyId is provided', function () {
+            assert.throws(
+                () => new GCSStore({bucket: 'x', accessKeyId: 'a'}),
+                {errorType: 'IncorrectUsageError', message: /accessKeyId and secretAccessKey/}
+            );
+        });
+
+        it('throws when only secretAccessKey is provided', function () {
+            assert.throws(
+                () => new GCSStore({bucket: 'x', secretAccessKey: 's'}),
+                {errorType: 'IncorrectUsageError', message: /accessKeyId and secretAccessKey/}
+            );
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/custom-redirects/gcs-store.test.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/gcs-store.test.ts
@@ -11,17 +11,10 @@ describe('UNIT: GCSStore', function () {
             );
         });
 
-        it('throws when only accessKeyId is provided', function () {
+        it('throws when no S3 client is provided', function () {
             assert.throws(
-                () => new GCSStore({bucket: 'x', accessKeyId: 'a'}),
-                {errorType: 'IncorrectUsageError', message: /accessKeyId and secretAccessKey/}
-            );
-        });
-
-        it('throws when only secretAccessKey is provided', function () {
-            assert.throws(
-                () => new GCSStore({bucket: 'x', secretAccessKey: 's'}),
-                {errorType: 'IncorrectUsageError', message: /accessKeyId and secretAccessKey/}
+                () => new GCSStore({bucket: 'x'} as never),
+                {errorType: 'IncorrectUsageError', message: /S3 client/}
             );
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1700

Adds `GCSStore`, an S3-compatible `RedirectsStore` implementation built on `@aws-sdk/client-s3`. Pairs with the in-memory and file-system stores introduced in #27697 .

This PR is **the store** — `RedirectsService` is not yet wired to use it. That switch lands in HKG-1701 so reviewers here only have to reason about S3 semantics, not the boot/upload paths.

### Why

Ghost Pro can't scale redirects horizontally while they live on local disk: every replica has its own copy, uploads only land on one box, and a redeploy wipes whatever was uploaded. Moving this to an S3-compatible store is a step towards making Ghost more horizontally scalable. 

### What's in this PR

**`RedirectsStore` implementation**
- `getAll()` reads `redirects.json` from the bucket and parses it through the shared `parseJson` validator. Returns `[]` on `NoSuchKey` — a fresh bucket and a freshly-mounted disk should be indistinguishable to `RedirectsService` at boot.
- `replaceAll(...)` `HEAD`s the canonical key, `CopyObject`s it to a timestamped backup if it exists, then `PutObject`s the new contents.
- Hybrid constructor: accepts either connection primitives (`bucket`, `region`, `endpoint`, credentials) or a pre-built `s3Client`. The override path keeps tests against MinIO trivial; the primitives path is what production will use.

**Design decisions worth flagging for review**
- **Server-side `CopyObject` for backups** — bytes never leave the S3 endpoint. Mirrors `S3Storage.copy()` in `ghost-storage-adapter-s3`. Linear-cost in redirect-file size, not quadratic.
- **`HeadObject` (not `GetObject`) for the existence probe** — the hot path is "config already exists", and downloading the JSON just to discard it would waste bandwidth on every save. Same trick `S3Storage.exists()` uses.
- **Backup key reuses `getBackupRedirectsFilePath`** — `FileStore` and `GCSStore` produce identical `name-YYYY-MM-DD-HH-mm-ss.ext` shapes. Operators don't learn two conventions when migrating.
- **Partial credentials throw** — passing only one of `accessKeyId`/`secretAccessKey` falls through the SDK's default credential chain (env vars, IMDS). A typo'd config would otherwise deploy under whatever identity the runtime resolves. Loud failure is much easier to debug.
- **Copy before `Put`, not after** — a failed put leaves the canonical untouched and the backup as a harmless idempotent dupe. Reverse order would clobber the canonical first and a copy failure would leave nothing to back up from.

### Test plan

Integration tests run against MinIO (introduced in #27858 for HKG-1699)
