### PR TITLE
Added docker:rebase script for post-rebase dev env refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
     "docker:clean": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} --profile all down -v --remove-orphans --rmi local",
     "docker:down": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down",
+    "docker:rebase": "git fetch ${GHOST_UPSTREAM:-origin} main && git rebase ${GHOST_UPSTREAM:-origin}/main && pnpm install && pnpm nx run-many -t build --projects=@tryghost/shade,@tryghost/admin-x-design-system,@tryghost/admin-x-framework && docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --build --force-recreate ghost-dev",
     "knip": "knip",
     "knip:fix": "knip --fix --allow-remove-files=false",
     "lint": "pnpm nx run-many -t lint",


### PR DESCRIPTION
## Summary

Adds a single `pnpm docker:rebase` script that bundles the chain of steps needed to bring a feature branch back to a working dev env after rebasing on `main`.

After a rebase that touches `pnpm-lock.yaml` or any workspace `package.json`, the dev env can break in three independent ways:

1. **Host `node_modules` out of sync** — Vite resolves the wrong versions, admin fails to load.
2. **Foundation libraries (`shade`, `admin-x-design-system`, `admin-x-framework`) have new entry points** that the running Vite dev server cannot find — typical symptom is `Pre-transform error: Failed to resolve import @tryghost/shade/...`.
3. **`ghost-dev` container has stale baked `node_modules`** from an older lockfile — typical symptom is `Cannot find module 'X'` in the container logs and a 502 at the gateway.

Doing the dance manually means remembering all three remedies and running them in the right order. The new script bundles them:

```bash
git fetch origin main
git rebase origin/main
pnpm install
pnpm nx run-many -t build --projects=@tryghost/shade,@tryghost/admin-x-design-system,@tryghost/admin-x-framework
docker compose ... up -d --build --force-recreate ghost-dev
```

Each step is idempotent and cheap when nothing changed (pnpm install is fast on a clean lockfile, nx caches foundation builds, docker uses layer caches). The `&&` chain aborts cleanly if the rebase fails on conflicts, so there is no wasted rebuild on a half-applied state.

`GHOST_UPSTREAM` is honored to match the existing `main:monorepo` and `main:submodules` script conventions.

## Test plan
- [ ] On a branch with no diff against `origin/main`: `pnpm docker:rebase` completes as a no-op (~30s, mostly caching)
- [ ] After main moves with a lockfile change: `pnpm docker:rebase` rebases, syncs deps, rebuilds container, and `http://localhost:2368/ghost/` returns 200
- [ ] With uncommitted local changes: `pnpm docker:rebase` aborts at the rebase step without running any of the rebuild steps
- [ ] With a merge conflict on rebase: the chain aborts at `git rebase`, no rebuilds triggered, branch left in conflict state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
