### PR TITLE
Added Billing app loading and error states

### DIFF
--- a/ghost/admin/app/components/gh-billing-modal.hbs
+++ b/ghost/admin/app/components/gh-billing-modal.hbs
@@ -10,7 +10,15 @@
 
         {{#if this.showErrorState}}
             <div class="gh-billing-status gh-billing-status-error" role="alert" data-test-billing-load-error>
-                <p>We couldn't load your Ghost(Pro) settings. Refresh the page and try again. If the issue continues, contact <a href="mailto:support@ghost.org">support@ghost.org</a>.</p>
+                <div class="gh-billing-empty-indicator">
+                    <div class="gh-billing-empty-badge" aria-hidden="true">
+                        {{svg-jar "cloud-off"}}
+                    </div>
+                    <div class="gh-billing-empty-copy">
+                        <h3>We couldn't load your Ghost(Pro) settings</h3>
+                        <p>Refresh the page and try again. If the issue continues, contact <a href="mailto:support@ghost.org">support@ghost.org</a>.</p>
+                    </div>
+                </div>
             </div>
         {{/if}}
     </div>

--- a/ghost/admin/app/components/gh-billing-modal.hbs
+++ b/ghost/admin/app/components/gh-billing-modal.hbs
@@ -10,7 +10,7 @@
 
         {{#if this.showErrorState}}
             <div class="gh-billing-status gh-billing-status-error" role="alert" data-test-billing-load-error>
-                <p>We weren't able to load the Ghost(Pro) app. Please refresh the page and check that no extensions are blocking the app. If the issue continues, contact <a href="mailto:support@ghost.org">support@ghost.org</a>.</p>
+                <p>We couldn't load your Ghost(Pro) settings. Refresh the page and try again. If the issue continues, contact <a href="mailto:support@ghost.org">support@ghost.org</a>.</p>
             </div>
         {{/if}}
     </div>

--- a/ghost/admin/app/components/gh-billing-modal.hbs
+++ b/ghost/admin/app/components/gh-billing-modal.hbs
@@ -15,8 +15,8 @@
                         {{svg-jar "cloud-off"}}
                     </div>
                     <div class="gh-billing-empty-copy">
-                        <h3>We couldn't load your Ghost(Pro) settings</h3>
-                        <p>Refresh the page and try again. If the issue continues, contact <a href="mailto:support@ghost.org">support@ghost.org</a>.</p>
+                        <h3 data-test-billing-load-error-title>We couldn't load your Ghost(Pro) settings</h3>
+                        <p data-test-billing-load-error-description>Refresh the page and try again. If the issue continues, contact <a href="mailto:support@ghost.org">support@ghost.org</a>.</p>
                     </div>
                 </div>
             </div>

--- a/ghost/admin/app/components/gh-billing-modal.hbs
+++ b/ghost/admin/app/components/gh-billing-modal.hbs
@@ -1,5 +1,17 @@
 <div class="{{this.visibilityClass}}">
     <div class="gh-billing-container">
         <GhBillingIframe></GhBillingIframe>
+
+        {{#if this.showLoadingState}}
+            <div class="gh-billing-status gh-billing-status-loading" data-test-billing-loading>
+                <div class="gh-loading-spinner"></div>
+            </div>
+        {{/if}}
+
+        {{#if this.showErrorState}}
+            <div class="gh-billing-status gh-billing-status-error" role="alert" data-test-billing-load-error>
+                <p>We weren't able to load the Ghost(Pro) app. Please refresh the page and check that no extensions are blocking the app. If the issue continues, contact <a href="mailto:support@ghost.org">support@ghost.org</a>.</p>
+            </div>
+        {{/if}}
     </div>
 </div>

--- a/ghost/admin/app/components/gh-billing-modal.js
+++ b/ghost/admin/app/components/gh-billing-modal.js
@@ -1,14 +1,20 @@
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
-import {computed} from '@ember/object';
+import Component from '@glimmer/component';
 import {inject as service} from '@ember/service';
 
-@classic
 export default class GhBillingModal extends Component {
     @service billing;
 
-    @computed('billingWindowOpen')
     get visibilityClass() {
-        return this.billingWindowOpen ? 'gh-billing' : 'gh-billing closed';
+        return this.args.billingWindowOpen ? 'gh-billing' : 'gh-billing closed';
+    }
+
+    get showLoadingState() {
+        return this.args.billingWindowOpen
+            && !this.billing.billingAppLoaded
+            && !this.billing.billingAppLoadFailureReported;
+    }
+
+    get showErrorState() {
+        return this.args.billingWindowOpen && this.billing.billingAppLoadFailureReported;
     }
 }

--- a/ghost/admin/app/components/gh-billing-modal.js
+++ b/ghost/admin/app/components/gh-billing-modal.js
@@ -15,6 +15,8 @@ export default class GhBillingModal extends Component {
     }
 
     get showErrorState() {
-        return this.args.billingWindowOpen && this.billing.billingAppLoadFailureReported;
+        return this.args.billingWindowOpen
+            && this.billing.billingAppLoadFailureReported
+            && !this.billing.billingAppLoaded;
     }
 }

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -22,11 +22,12 @@ export default class BillingService extends Service {
     @tracked action = null;
     @tracked ownerUser = null;
 
-    billingAppLoaded = false;
+    @tracked billingAppLoaded = false;
+    @tracked billingAppLoadFailureReported = false;
+
     billingAppLoadTimeout = null;
     billingAppRetryTimeout = null;
     billingAppLoadAttempts = 0;
-    billingAppLoadFailureReported = false;
     billingAppLoadTimeoutMs = BILLING_APP_LOAD_TIMEOUT_MS;
     billingAppLoadRetryDelaysMs = BILLING_APP_LOAD_RETRY_DELAYS_MS;
 

--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -111,6 +111,7 @@
     color: var(--midgrey);
     font-size: 1.6rem;
     line-height: 1.35;
+    text-wrap: pretty;
 }
 
 .gh-billing-status-error a {

--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -59,13 +59,58 @@
     padding: 32px;
 }
 
-.gh-billing-status-error p {
-    max-width: 520px;
+.gh-billing-empty-indicator {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    max-width: 320px;
+    color: var(--black);
+    text-align: center;
+}
+
+.gh-billing-empty-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    max-width: 48px;
+    max-height: 48px;
+    color: var(--midgrey);
+    background: var(--whitegrey-l1);
+    border-radius: 50%;
+}
+
+.gh-billing-empty-badge svg {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+}
+
+.gh-billing-empty-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.gh-billing-empty-copy h3,
+.gh-billing-empty-copy p {
     margin: 0;
+}
+
+.gh-billing-empty-copy h3 {
+    color: var(--black);
+    font-size: 1.8rem;
+    line-height: 1.3;
+    font-weight: 500;
+    letter-spacing: 0;
+}
+
+.gh-billing-empty-copy p {
     color: var(--midgrey);
     font-size: 1.6rem;
-    line-height: 1.5;
-    text-align: center;
+    line-height: 1.35;
 }
 
 .gh-billing-status-error a {

--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -64,7 +64,7 @@
     flex-direction: column;
     align-items: center;
     gap: 12px;
-    max-width: 560px;
+    max-width: 760px;
     color: var(--black);
     text-align: center;
 }

--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -64,7 +64,7 @@
     flex-direction: column;
     align-items: center;
     gap: 12px;
-    max-width: 320px;
+    max-width: 560px;
     color: var(--black);
     text-align: center;
 }
@@ -115,7 +115,9 @@
 
 .gh-billing-status-error a {
     color: inherit;
-    text-decoration: underline;
+    padding-bottom: 1px;
+    border-bottom: 1px solid currentColor;
+    text-decoration: none;
 }
 
 .gh-billing-close {

--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -117,7 +117,7 @@
 .gh-billing-status-error a {
     color: inherit;
     padding-bottom: 1px;
-    border-bottom: 1px solid currentColor;
+    border-bottom: 1px solid currentcolor;
     text-decoration: none;
 }
 

--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -42,6 +42,37 @@
     transform: translate3d(0, 0, 0);
 }
 
+.gh-billing-status {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--main-bg-color);
+}
+
+.gh-billing-status-error {
+    padding: 32px;
+}
+
+.gh-billing-status-error p {
+    max-width: 520px;
+    margin: 0;
+    color: var(--midgrey);
+    font-size: 1.6rem;
+    line-height: 1.5;
+    text-align: center;
+}
+
+.gh-billing-status-error a {
+    color: inherit;
+    text-decoration: underline;
+}
+
 .gh-billing-close {
     width: calc(50vw - 200px)
 }

--- a/ghost/admin/public/assets/icons/cloud-off.svg
+++ b/ghost/admin/public/assets/icons/cloud-off.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <title>cloud-off</title>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m2 2 20 20M5.8 5.8A5.5 5.5 0 0 0 5 16h11.2M17.3 17.3A4.5 4.5 0 0 0 18.5 9h-1.26A8 8 0 0 0 4.82 4.82"/>
+</svg>

--- a/ghost/admin/tests/integration/components/gh-billing-modal-test.js
+++ b/ghost/admin/tests/integration/components/gh-billing-modal-test.js
@@ -1,0 +1,57 @@
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {find, render, settled} from '@ember/test-helpers';
+import {setupRenderingTest} from 'ember-mocha';
+
+describe('Integration: Component: gh-billing-modal', function () {
+    setupRenderingTest();
+
+    let billing;
+
+    beforeEach(function () {
+        billing = this.owner.lookup('service:billing');
+        billing.billingAppLoaded = false;
+        billing.billingAppLoadFailureReported = false;
+
+        sinon.stub(billing, 'getIframeURL').returns('https://billing.example.test');
+        sinon.stub(billing, 'startBillingAppLoadMonitor');
+    });
+
+    afterEach(function () {
+        billing.clearBillingAppLoadMonitor();
+        sinon.restore();
+    });
+
+    it('shows a loading state until the billing app sends its first message', async function () {
+        await render(hbs`<GhBillingModal @billingWindowOpen={{true}} />`);
+
+        expect(find('[data-test-billing-loading]')).to.exist;
+        expect(find('[data-test-billing-load-error]')).to.not.exist;
+
+        billing.markBillingAppLoaded();
+        await settled();
+
+        expect(find('[data-test-billing-loading]')).to.not.exist;
+        expect(find('[data-test-billing-load-error]')).to.not.exist;
+    });
+
+    it('shows a customer-facing error when the billing app does not become ready', async function () {
+        billing.billingAppLoadFailureReported = true;
+
+        await render(hbs`<GhBillingModal @billingWindowOpen={{true}} />`);
+
+        expect(find('[data-test-billing-loading]')).to.not.exist;
+        expect(find('[data-test-billing-load-error]')).to.contain.text('We weren\'t able to load the Ghost(Pro) app.');
+        expect(find('[data-test-billing-load-error]')).to.contain.text('support@ghost.org');
+        expect(find('[data-test-billing-load-error] a')).to.have.attribute('href', 'mailto:support@ghost.org');
+    });
+
+    it('does not show loading or error states when the billing window is closed', async function () {
+        await render(hbs`<GhBillingModal @billingWindowOpen={{false}} />`);
+
+        expect(find('[data-test-billing-loading]')).to.not.exist;
+        expect(find('[data-test-billing-load-error]')).to.not.exist;
+    });
+});

--- a/ghost/admin/tests/integration/components/gh-billing-modal-test.js
+++ b/ghost/admin/tests/integration/components/gh-billing-modal-test.js
@@ -43,9 +43,10 @@ describe('Integration: Component: gh-billing-modal', function () {
         await render(hbs`<GhBillingModal @billingWindowOpen={{true}} />`);
 
         expect(find('[data-test-billing-loading]')).to.not.exist;
-        expect(find('[data-test-billing-load-error]')).to.contain.text('We couldn\'t load your Ghost(Pro) settings.');
-        expect(find('[data-test-billing-load-error]')).to.contain.text('support@ghost.org');
-        expect(find('[data-test-billing-load-error] a')).to.have.attribute('href', 'mailto:support@ghost.org');
+        expect(find('[data-test-billing-load-error]')).to.exist;
+        expect(find('[data-test-billing-load-error-title]').textContent.trim()).to.equal('We couldn\'t load your Ghost(Pro) settings');
+        expect(find('[data-test-billing-load-error-description]').textContent.trim()).to.equal('Refresh the page and try again. If the issue continues, contact support@ghost.org.');
+        expect(find('[data-test-billing-load-error-description] a')).to.have.attribute('href', 'mailto:support@ghost.org');
     });
 
     it('clears a reported error when the billing app sends a late message', async function () {

--- a/ghost/admin/tests/integration/components/gh-billing-modal-test.js
+++ b/ghost/admin/tests/integration/components/gh-billing-modal-test.js
@@ -43,7 +43,7 @@ describe('Integration: Component: gh-billing-modal', function () {
         await render(hbs`<GhBillingModal @billingWindowOpen={{true}} />`);
 
         expect(find('[data-test-billing-loading]')).to.not.exist;
-        expect(find('[data-test-billing-load-error]')).to.contain.text('We weren\'t able to load the Ghost(Pro) app.');
+        expect(find('[data-test-billing-load-error]')).to.contain.text('We couldn\'t load your Ghost(Pro) settings.');
         expect(find('[data-test-billing-load-error]')).to.contain.text('support@ghost.org');
         expect(find('[data-test-billing-load-error] a')).to.have.attribute('href', 'mailto:support@ghost.org');
     });

--- a/ghost/admin/tests/integration/components/gh-billing-modal-test.js
+++ b/ghost/admin/tests/integration/components/gh-billing-modal-test.js
@@ -48,6 +48,19 @@ describe('Integration: Component: gh-billing-modal', function () {
         expect(find('[data-test-billing-load-error] a')).to.have.attribute('href', 'mailto:support@ghost.org');
     });
 
+    it('clears a reported error when the billing app sends a late message', async function () {
+        billing.billingAppLoadFailureReported = true;
+
+        await render(hbs`<GhBillingModal @billingWindowOpen={{true}} />`);
+
+        expect(find('[data-test-billing-load-error]')).to.exist;
+
+        billing.markBillingAppLoaded();
+        await settled();
+
+        expect(find('[data-test-billing-load-error]')).to.not.exist;
+    });
+
     it('does not show loading or error states when the billing window is closed', async function () {
         await render(hbs`<GhBillingModal @billingWindowOpen={{false}} />`);
 


### PR DESCRIPTION
## Summary

Adds visible loading and error states around the Ghost(Pro) Billing iframe in Ghost Admin. The loading state remains active until the embedded Billing app proves it is alive by sending the first trusted `postMessage`, and the existing load monitor now drives a customer-facing error message when the iframe never becomes ready.

ref [INC-284](https://app.incident.io/ghost/incidents/284)

## Impact

Customers no longer see a blank Billing surface when the app is blocked by an extension or fails before it can phone home. The error state asks them to refresh, check extensions, and contact `support@ghost.org` if the issue continues.

## Validation

- `ember-template-lint` ran through the pre-commit hook for `ghost/admin/app/components/gh-billing-modal.hbs`
- `eslint` ran through the pre-commit hook for the staged JS files
- pre-commit secret scanning passed
- `git diff --check` passed
- Targeted Ember browser tests were attempted locally, but Testem could not connect to Chrome or Firefox in this shell within 120s