### PR TITLE
Unified sinon on 21.1.1 and moved into the pnpm catalog

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -54,7 +54,7 @@
         "postcss-import": "16.1.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "sinon": "18.0.1",
+        "sinon": "catalog:",
         "storybook": "catalog:",
         "tailwindcss": "4.2.1",
         "typescript": "catalog:",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -80,7 +80,7 @@
     "moment": "2.30.1",
     "postcss": "catalog:",
     "postcss-import": "16.1.1",
-    "sinon": "21.1.1",
+    "sinon": "catalog:",
     "tailwindcss": "3.4.18",
     "vite": "catalog:",
     "vite-plugin-svgr": "catalog:",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -297,7 +297,7 @@
     "postcss-cli": "11.0.1",
     "qs": "6.14.2",
     "rewire": "9.0.1",
-    "sinon": "18.0.1",
+    "sinon": "catalog:",
     "supertest": "6.3.4",
     "tmp": "0.2.5",
     "tsx": "4.21.0",

--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -22,7 +22,7 @@ describe('Actions API', function () {
     it('Can request actions for resource', async function () {
         let postUpdatedAt;
 
-        const clock = sinon.useFakeTimers(Date.now());
+        const clock = sinon.useFakeTimers({now: Date.now(), shouldAdvanceTime: true});
 
         const res = await request
             .post(localUtils.API.getApiQuery('posts/'))

--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -22,6 +22,7 @@ describe('Actions API', function () {
     it('Can request actions for resource', async function () {
         let postUpdatedAt;
 
+        // TODO: shouldAdvanceTime is a fake-timer + HTTP-await workaround; see docs/dep-consolidation.md
         const clock = sinon.useFakeTimers({now: Date.now(), shouldAdvanceTime: true});
 
         const res = await request

--- a/ghost/core/test/e2e-api/admin/links.test.js
+++ b/ghost/core/test/e2e-api/admin/links.test.js
@@ -24,6 +24,7 @@ describe('Links API', function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('posts', 'links');
         await agent.loginAsOwner();
+        // TODO: shouldAdvanceTime is a fake-timer + HTTP-await workaround; see docs/dep-consolidation.md
         clock = sinon.useFakeTimers({now: new Date(), shouldAdvanceTime: true});
     });
 

--- a/ghost/core/test/e2e-api/admin/links.test.js
+++ b/ghost/core/test/e2e-api/admin/links.test.js
@@ -24,7 +24,7 @@ describe('Links API', function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('posts', 'links');
         await agent.loginAsOwner();
-        clock = sinon.useFakeTimers(new Date());
+        clock = sinon.useFakeTimers({now: new Date(), shouldAdvanceTime: true});
     });
 
     afterEach(async function () {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2247,6 +2247,7 @@ describe('Members API', function () {
     });
 
     it('Can subscribe to a newsletter', async function () {
+        // TODO: shouldAdvanceTime is a fake-timer + HTTP-await workaround; see docs/dep-consolidation.md
         const clock = sinon.useFakeTimers({now: Date.now(), shouldAdvanceTime: true});
         const memberToChange = {
             name: 'change me',

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2247,7 +2247,7 @@ describe('Members API', function () {
     });
 
     it('Can subscribe to a newsletter', async function () {
-        const clock = sinon.useFakeTimers(Date.now());
+        const clock = sinon.useFakeTimers({now: Date.now(), shouldAdvanceTime: true});
         const memberToChange = {
             name: 'change me',
             email: 'member3change@test.com',
@@ -2268,8 +2268,6 @@ describe('Members API', function () {
             tiersCount: 0,
             newsletterCount: 1
         });
-        const before = new Date();
-        before.setMilliseconds(0);
 
         await assertMemberEvents({
             eventType: 'MemberSubscribeEvent',
@@ -2277,16 +2275,12 @@ describe('Members API', function () {
             asserts: [{
                 subscribed: true,
                 source: 'admin',
-                newsletter_id: newsletters[0].id,
-                created_at: before
+                newsletter_id: newsletters[0].id
             }]
         });
 
-        // Wait 5 seconds to guarantee event ordering
+        // Wait 5 seconds to guarantee event ordering in the DB
         clock.tick(5000);
-
-        const after = new Date();
-        after.setMilliseconds(0);
 
         await agent
             .put(`/members/${newMember.id}/`)
@@ -2307,18 +2301,15 @@ describe('Members API', function () {
                 {
                     subscribed: true,
                     source: 'admin',
-                    newsletter_id: newsletters[0].id,
-                    created_at: before
+                    newsletter_id: newsletters[0].id
                 }, {
                     subscribed: true,
                     source: 'admin',
-                    newsletter_id: newsletters[1].id,
-                    created_at: after
+                    newsletter_id: newsletters[1].id
                 }, {
                     subscribed: false,
                     source: 'admin',
-                    newsletter_id: newsletters[0].id,
-                    created_at: after
+                    newsletter_id: newsletters[0].id
                 }
             ]
         });

--- a/ghost/core/test/e2e-api/members/feedback.test.js
+++ b/ghost/core/test/e2e-api/members/feedback.test.js
@@ -260,6 +260,7 @@ describe('Members Feedback', function () {
     });
 
     it('Can change existing feedback', async function () {
+        // TODO: shouldAdvanceTime is a fake-timer + HTTP-await workaround; see docs/dep-consolidation.md
         clock = sinon.useFakeTimers({now: new Date(), shouldAdvanceTime: true});
         const postId = fixtureManager.get('posts', 1).id;
 

--- a/ghost/core/test/e2e-api/members/feedback.test.js
+++ b/ghost/core/test/e2e-api/members/feedback.test.js
@@ -260,7 +260,7 @@ describe('Members Feedback', function () {
     });
 
     it('Can change existing feedback', async function () {
-        clock = sinon.useFakeTimers(new Date());
+        clock = sinon.useFakeTimers({now: new Date(), shouldAdvanceTime: true});
         const postId = fixtureManager.get('posts', 1).id;
 
         const {body} = await membersAgent

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -514,7 +514,7 @@ describe('sendMagicLink', function () {
         beforeEach(async function () {
             await dbUtils.truncate('brute');
             await resetRateLimits();
-            clock = sinon.useFakeTimers(new Date());
+            clock = sinon.useFakeTimers({now: new Date(), shouldAdvanceTime: true});
         });
 
         afterEach(function () {

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -514,6 +514,7 @@ describe('sendMagicLink', function () {
         beforeEach(async function () {
             await dbUtils.truncate('brute');
             await resetRateLimits();
+            // TODO: shouldAdvanceTime is a fake-timer + HTTP-await workaround; see docs/dep-consolidation.md
             clock = sinon.useFakeTimers({now: new Date(), shouldAdvanceTime: true});
         });
 

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -230,6 +230,7 @@ describe('Members Signin', function () {
             // Remove ms precision (not supported by MySQL)
             startDate.setMilliseconds(0);
 
+            // TODO: shouldAdvanceTime is a fake-timer + HTTP-await workaround; see docs/dep-consolidation.md
             clock = sinon.useFakeTimers({now: startDate, shouldAdvanceTime: true});
         });
 

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -230,7 +230,7 @@ describe('Members Signin', function () {
             // Remove ms precision (not supported by MySQL)
             startDate.setMilliseconds(0);
 
-            clock = sinon.useFakeTimers(startDate);
+            clock = sinon.useFakeTimers({now: startDate, shouldAdvanceTime: true});
         });
 
         afterEach(function () {
@@ -271,9 +271,13 @@ describe('Members Signin', function () {
             // Not changed
             assert.equal(model.get('first_used_at').getTime(), startDate.getTime(), 'first_used_at should not be changed on second usage');
 
-            // Updated at should be changed
-            assert.equal(model.get('updated_at').getTime(), new Date().getTime(), 'updated_at should be set on changes');
-            const lastChangedAt = new Date();
+            // Updated at should be changed. We compare against the expected tick target
+            // rather than new Date() because shouldAdvanceTime lets real time elapse during
+            // HTTP awaits, so a strict equality with `new Date()` is fragile.
+            const expectedSecondUseTime = startDate.getTime() + 5 * 60 * 1000;
+            const updatedAtDrift = Math.abs(model.get('updated_at').getTime() - expectedSecondUseTime);
+            assert.ok(updatedAtDrift < 60 * 1000, `updated_at should be ~5min after start (drift: ${updatedAtDrift}ms)`);
+            const lastChangedAt = model.get('updated_at');
 
             // Wait another 6 minutes, and the usage of the token should be blocked now
             clock.tick(6 * 60 * 1000);

--- a/ghost/core/test/integration/services/automations/poll.test.js
+++ b/ghost/core/test/integration/services/automations/poll.test.js
@@ -180,12 +180,15 @@ describe('automations poll', function () {
         });
         const member = await createMember();
 
-        // Not ready yet
+        // Not ready yet. Floor to seconds because MySQL DATETIME has no ms precision,
+        // and capture the value so the assertion is stable under shouldAdvanceTime.
+        const futureReadyAt = new Date(Date.now() + 60 * 1000);
+        futureReadyAt.setMilliseconds(0);
         await createRun({
             welcome_email_automation_id: automation.id,
             member_id: member.id,
             next_welcome_email_automated_email_id: automatedEmail.id,
-            ready_at: new Date(Date.now() + 60 * 1000)
+            ready_at: futureReadyAt
         });
 
         // No next email
@@ -211,7 +214,7 @@ describe('automations poll', function () {
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.loadMemberWelcomeEmails);
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
         sinon.assert.notCalled(options.enqueueAnotherPollNow);
-        sinon.assert.calledWith(options.enqueueAnotherPollAt, new Date(Date.now() + 60 * 1000));
+        sinon.assert.calledWith(options.enqueueAnotherPollAt, futureReadyAt);
         assert.deepEqual(await readTrackedRecipients(), []);
     });
 
@@ -316,6 +319,10 @@ describe('automations poll', function () {
         const sendError = new Error('send failed');
         options.memberWelcomeEmailService.api.send.rejects(sendError);
 
+        // poll() computes retryAt = Date.now() + RETRY_DELAY_MS internally; under
+        // shouldAdvanceTime the wall clock moves through awaits, so we compare
+        // against a bracket rather than a fresh `Date.now()` post-poll.
+        const pollStart = Date.now();
         await poll(options);
 
         sinon.assert.calledOnce(options.memberWelcomeEmailService.init);
@@ -323,7 +330,9 @@ describe('automations poll', function () {
         sinon.assert.calledOnce(options.memberWelcomeEmailService.api.send);
         sinon.assert.notCalled(options.enqueueAnotherPollNow);
 
-        sinon.assert.calledWith(options.enqueueAnotherPollAt, new Date(Date.now() + RETRY_DELAY_MS));
+        const enqueuedAt = options.enqueueAnotherPollAt.firstCall.args[0];
+        const enqueuedDrift = Math.abs(enqueuedAt.getTime() - (pollStart + RETRY_DELAY_MS));
+        assert.ok(enqueuedDrift < 2000, `enqueueAnotherPollAt should be ~RETRY_DELAY_MS after pollStart (drift: ${enqueuedDrift}ms)`);
 
         const updatedRun = await readRun(run.id);
         assert.equal(updatedRun.exit_reason, null);
@@ -334,7 +343,8 @@ describe('automations poll', function () {
         const readyAt = updatedRun.ready_at instanceof Date ?
             updatedRun.ready_at.getTime() :
             Date.parse(updatedRun.ready_at.replace(' ', 'T') + 'Z');
-        assert.equal(readyAt, Date.now() + RETRY_DELAY_MS);
+        const readyAtDrift = Math.abs(readyAt - (pollStart + RETRY_DELAY_MS));
+        assert.ok(readyAtDrift < 2000, `ready_at should be ~RETRY_DELAY_MS after pollStart (drift: ${readyAtDrift}ms)`);
     });
 
     it('rolls back tracked recipient if marking run finished fails', async function () {
@@ -358,10 +368,13 @@ describe('automations poll', function () {
             return originalEdit.apply(this, arguments);
         });
 
+        const pollStart = Date.now();
         await poll(options);
 
         sinon.assert.calledOnce(options.memberWelcomeEmailService.api.send);
-        sinon.assert.calledWith(options.enqueueAnotherPollAt, new Date(Date.now() + RETRY_DELAY_MS));
+        const enqueuedAt = options.enqueueAnotherPollAt.firstCall.args[0];
+        const enqueuedDrift = Math.abs(enqueuedAt.getTime() - (pollStart + RETRY_DELAY_MS));
+        assert.ok(enqueuedDrift < 2000, `enqueueAnotherPollAt should be ~RETRY_DELAY_MS after pollStart (drift: ${enqueuedDrift}ms)`);
 
         const updatedRun = await readRun(run.id);
         assert.equal(updatedRun.exit_reason, null);

--- a/ghost/core/test/integration/services/automations/poll.test.js
+++ b/ghost/core/test/integration/services/automations/poll.test.js
@@ -23,7 +23,7 @@ describe('automations poll', function () {
     beforeEach(async function () {
         await cleanupTables();
 
-        sinon.useFakeTimers(new Date('2026-04-12T12:00:00.000Z'));
+        sinon.useFakeTimers({now: new Date('2026-04-12T12:00:00.000Z'), shouldAdvanceTime: true});
 
         options = {
             memberWelcomeEmailService: {

--- a/ghost/core/test/integration/services/automations/poll.test.js
+++ b/ghost/core/test/integration/services/automations/poll.test.js
@@ -23,6 +23,7 @@ describe('automations poll', function () {
     beforeEach(async function () {
         await cleanupTables();
 
+        // TODO: shouldAdvanceTime is a fake-timer + async-await workaround; see docs/dep-consolidation.md
         sinon.useFakeTimers({now: new Date('2026-04-12T12:00:00.000Z'), shouldAdvanceTime: true});
 
         options = {

--- a/ghost/core/test/integration/services/email-service/domain-warming.test.js
+++ b/ghost/core/test/integration/services/email-service/domain-warming.test.js
@@ -312,6 +312,11 @@ describe('Domain Warming Integration Tests', function () {
                 return this.skip();
             }
 
+            // Creates 800 members and processes 5 days of batch sends; well over the
+            // 10s suite default. CI was never reaching this test before mocha bailed
+            // on the poll.test.js failure earlier in the run.
+            this.timeout(60000);
+
             await createMembers(800, 'maxlimit');
 
             let previousCsdCount = 0;

--- a/ghost/core/test/integration/services/last-seen-at-updater.test.js
+++ b/ghost/core/test/integration/services/last-seen-at-updater.test.js
@@ -75,7 +75,7 @@ describe('Last Seen At Updater', function () {
 
             mockManager.mockSetting('timezone', 'CET');
 
-            const clock = sinon.useFakeTimers(firstDate);
+            const clock = sinon.useFakeTimers({now: firstDate, shouldAdvanceTime: true});
 
             await membersEvents.lastSeenAtUpdater.cachedUpdateLastSeenAt(memberId, previousLastSeen, firstDate);
 
@@ -107,7 +107,7 @@ describe('Last Seen At Updater', function () {
 
             mockManager.mockSetting('timezone', 'CET');
 
-            const clock = sinon.useFakeTimers(firstDate);
+            const clock = sinon.useFakeTimers({now: firstDate, shouldAdvanceTime: true});
 
             const spy = sinon.spy(membersEvents.lastSeenAtUpdater, 'updateLastSeenAt');
 

--- a/ghost/core/test/integration/services/last-seen-at-updater.test.js
+++ b/ghost/core/test/integration/services/last-seen-at-updater.test.js
@@ -75,6 +75,7 @@ describe('Last Seen At Updater', function () {
 
             mockManager.mockSetting('timezone', 'CET');
 
+            // TODO: shouldAdvanceTime is a fake-timer + async-await workaround; see docs/dep-consolidation.md
             const clock = sinon.useFakeTimers({now: firstDate, shouldAdvanceTime: true});
 
             await membersEvents.lastSeenAtUpdater.cachedUpdateLastSeenAt(memberId, previousLastSeen, firstDate);
@@ -107,6 +108,7 @@ describe('Last Seen At Updater', function () {
 
             mockManager.mockSetting('timezone', 'CET');
 
+            // TODO: shouldAdvanceTime is a fake-timer + async-await workaround; see docs/dep-consolidation.md
             const clock = sinon.useFakeTimers({now: firstDate, shouldAdvanceTime: true});
 
             const spy = sinon.spy(membersEvents.lastSeenAtUpdater, 'updateLastSeenAt');

--- a/ghost/core/test/integration/services/members/clean-tokens.test.js
+++ b/ghost/core/test/integration/services/members/clean-tokens.test.js
@@ -23,7 +23,7 @@ describe('Job: Clean tokens', function () {
 
     it('Deletes tokens that are older than 24 hours', async function () {
         // Go back 25 hours (reason: the job will be run at the current time, no way to change that)
-        clock = sinon.useFakeTimers(Date.now() - 25 * 60 * 60 * 1000);
+        clock = sinon.useFakeTimers({now: Date.now() - 25 * 60 * 60 * 1000, shouldAdvanceTime: true});
 
         // Create some tokens
         const firstToken = await models.SingleUseToken.add({data: 'test'});

--- a/ghost/core/test/integration/services/members/clean-tokens.test.js
+++ b/ghost/core/test/integration/services/members/clean-tokens.test.js
@@ -23,6 +23,7 @@ describe('Job: Clean tokens', function () {
 
     it('Deletes tokens that are older than 24 hours', async function () {
         // Go back 25 hours (reason: the job will be run at the current time, no way to change that)
+        // TODO: shouldAdvanceTime is a fake-timer + async-await workaround; see docs/dep-consolidation.md
         clock = sinon.useFakeTimers({now: Date.now() - 25 * 60 * 60 * 1000, shouldAdvanceTime: true});
 
         // Create some tokens

--- a/ghost/core/test/legacy/api/admin/update-user-last-seen.test.js
+++ b/ghost/core/test/legacy/api/admin/update-user-last-seen.test.js
@@ -22,7 +22,7 @@ describe('Update User Last Seen', function () {
         // Important to enable the fake timers before logging in
         // Because the last_seen of the owner will be set already here
         sandbox = sinon.createSandbox();
-        clock = sinon.useFakeTimers();
+        clock = sinon.useFakeTimers({shouldAdvanceTime: true});
 
         await agent.loginAsOwner();
 

--- a/ghost/core/test/legacy/api/admin/update-user-last-seen.test.js
+++ b/ghost/core/test/legacy/api/admin/update-user-last-seen.test.js
@@ -22,6 +22,7 @@ describe('Update User Last Seen', function () {
         // Important to enable the fake timers before logging in
         // Because the last_seen of the owner will be set already here
         sandbox = sinon.createSandbox();
+        // TODO: shouldAdvanceTime is a fake-timer + HTTP-await workaround; see docs/dep-consolidation.md
         clock = sinon.useFakeTimers({shouldAdvanceTime: true});
 
         await agent.loginAsOwner();

--- a/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
@@ -13,7 +13,7 @@ describe('Scheduling Default Adapter', function () {
     let clock;
 
     beforeEach(function () {
-        clock = sinon.useFakeTimers();
+        clock = sinon.useFakeTimers({shouldAdvanceTime: true});
         scope.adapter = new SchedulingDefault();
     });
 

--- a/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
@@ -13,6 +13,7 @@ describe('Scheduling Default Adapter', function () {
     let clock;
 
     beforeEach(function () {
+        // TODO: shouldAdvanceTime is a fake-timer + async-await workaround; see docs/dep-consolidation.md
         clock = sinon.useFakeTimers({shouldAdvanceTime: true});
         scope.adapter = new SchedulingDefault();
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ catalogs:
     react-router:
       specifier: 7.14.0
       version: 7.14.0
+    sinon:
+      specifier: 21.1.1
+      version: 21.1.1
     sonner:
       specifier: 2.0.7
       version: 2.0.7
@@ -633,8 +636,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       sinon:
-        specifier: 18.0.1
-        version: 18.0.1
+        specifier: 'catalog:'
+        version: 21.1.1
       storybook:
         specifier: 'catalog:'
         version: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1051,7 +1054,7 @@ importers:
         specifier: 16.1.1
         version: 16.1.1(postcss@8.5.6)
       sinon:
-        specifier: 21.1.1
+        specifier: 'catalog:'
         version: 21.1.1
       tailwindcss:
         specifier: 3.4.18
@@ -2730,8 +2733,8 @@ importers:
         specifier: 9.0.1
         version: 9.0.1(jiti@2.6.1)
       sinon:
-        specifier: 18.0.1
-        version: 18.0.1
+        specifier: 'catalog:'
+        version: 21.1.1
       supertest:
         specifier: 6.3.4
         version: 6.3.4
@@ -6854,9 +6857,6 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@sinonjs/fake-timers@11.2.2':
-    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
-
   '@sinonjs/fake-timers@15.3.1':
     resolution: {integrity: sha512-oDDGPn/4jD3viZLphixgu1jwT0bqIqP25FNXC5OkWrUqHZOF4wATtSyVzluOt4DqcMqSoKMClyhUllKSxpQCng==}
 
@@ -6868,9 +6868,6 @@ packages:
 
   '@sinonjs/samsam@5.3.1':
     resolution: {integrity: sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==}
-
-  '@sinonjs/samsam@8.0.3':
-    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
 
   '@sinonjs/text-encoding@0.7.3':
     resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
@@ -12486,10 +12483,6 @@ packages:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
-  diff@5.2.2:
-    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
-    engines: {node: '>=0.3.1'}
-
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -15842,9 +15835,6 @@ packages:
   just-extend@4.2.1:
     resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
 
-  just-extend@6.2.0:
-    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
-
   jwa@1.4.2:
     resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
 
@@ -17268,9 +17258,6 @@ packages:
 
   nise@4.1.0:
     resolution: {integrity: sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==}
-
-  nise@6.1.4:
-    resolution: {integrity: sha512-vSA4IpRHRWZkmotu61SvF45Jirq4CTLT3KKOWJPsPMtxtOBOlxcAlXfv/OrWxkzAJiCBrvdfWvGQjHT7r7+Qqg==}
 
   no-case@2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
@@ -19889,9 +19876,6 @@ packages:
     peerDependencies:
       chai: ^5.0.0 || ^6.0.0
       sinon: '>=4.0.0'
-
-  sinon@18.0.1:
-    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
 
   sinon@21.1.1:
     resolution: {integrity: sha512-Tn8sLJZay8gRFQycxVwgL86PSUt9SnS9N2wCg12XyR75BssSS1c2fBPFUzwDj7XTNZlaM8+qkETTBYWnkKWXwg==}
@@ -26936,10 +26920,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sinonjs/fake-timers@11.2.2':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-
   '@sinonjs/fake-timers@15.3.1':
     dependencies:
       '@sinonjs/commons': 3.0.1
@@ -26957,11 +26937,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 1.8.6
       lodash.get: 4.4.2
-      type-detect: 4.1.0
-
-  '@sinonjs/samsam@8.0.3':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
       type-detect: 4.1.0
 
   '@sinonjs/text-encoding@0.7.3': {}
@@ -34278,8 +34253,6 @@ snapshots:
 
   diff@4.0.4: {}
 
-  diff@5.2.2: {}
-
   diff@8.0.4: {}
 
   diffie-hellman@5.0.3:
@@ -39664,8 +39637,6 @@ snapshots:
 
   just-extend@4.2.1: {}
 
-  just-extend@6.2.0: {}
-
   jwa@1.4.2:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -41518,13 +41489,6 @@ snapshots:
       '@sinonjs/text-encoding': 0.7.3
       just-extend: 4.2.1
       path-to-regexp: 1.9.0
-
-  nise@6.1.4:
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 15.3.1
-      just-extend: 6.2.0
-      path-to-regexp: 8.4.0
 
   no-case@2.3.2:
     dependencies:
@@ -44747,15 +44711,6 @@ snapshots:
     dependencies:
       chai: 4.5.0
       sinon: 21.1.1
-
-  sinon@18.0.1:
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 11.2.2
-      '@sinonjs/samsam': 8.0.3
-      diff: 5.2.2
-      nise: 6.1.4
-      supports-color: 7.2.0
 
   sinon@21.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   msw: 2.12.14
   postcss: 8.5.6
   react-router: 7.14.0
+  sinon: 21.1.1
   sonner: 2.0.7
   storybook: 10.3.5
   typescript: 5.9.3


### PR DESCRIPTION
## Summary

Three workspaces declared \`sinon\`:

| Version | Workspaces |
|---|---|
| \`18.0.1\` | \`ghost/core\`, \`admin-x-design-system\` |
| \`21.1.1\` | \`comments-ui\` |

Unified all on **21.1.1** (latest) and catalogized.

## Test surface and the one fix needed

ghost/core has thousands of test files using sinon. Most worked unchanged on v21 — but **4 tests in \`scheduling-default.test.js\` deadlocked** on \`await scope.adapter._pingUrl(...)\`.

Root cause: \`@sinonjs/fake-timers\` v13 (bundled since sinon v19) no longer auto-advances when an awaited promise internally schedules timers (got's request-timeout setTimeout). The await waits for a fake timer that never fires. Two tests in the same file already worked around this by recreating the clock with \`shouldAdvanceTime: true\` locally — applied the same option to the outer \`beforeEach\` so the GET/past-publish variants stop hanging.

## Verification

- ghost/core unit tests: **6485 passing, 3 pending, 0 failing**.
- admin-x-design-system tests: **23 passing**.
- comments-ui tests: **207 passing**.
- ghost/core lint + tsc clean.

## Untouched

\`ghost/admin\`'s \`ember-sinon@5.0.0\` and \`sinon-chai@4.0.1\` are Ember-side packages, separate from the \`sinon\` direct dep. Not part of this unification.