### PR TITLE
Added vitest unit-test step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,17 @@ jobs:
           NX_SKIP_LOG_GROUPING: true
           logging__level: fatal
 
+      - name: Run vitest unit tests
+        # ghost/core is mid-migration from mocha to vitest. The vitest
+        # target covers a scoped subset (see ghost/core/vitest.config.ts)
+        # and runs additively alongside mocha — both runners run the same
+        # files during the migration as a divergence safety net.
+        run: pnpm nx run-many -t test:vitest -p "${{ needs.job_setup.outputs.affected_projects_str }}"
+        env:
+          FORCE_COLOR: 0
+          NX_SKIP_LOG_GROUPING: true
+          logging__level: fatal
+
       - name: Check for unexpected file changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
## Summary

- Wires `pnpm test:vitest` into the existing `job_unit-tests` workflow so that ghost/core's migrated tests are actually validated by CI on every affected PR. Without this, the `vitest.config.ts` in ghost/core could rot silently between migration PRs.
- Runs additively after the existing mocha step using the same nx affected-projects filter (`pnpm nx run-many -t test:vitest -p "${{ needs.job_setup.outputs.affected_projects_str }}"`). Only fires when ghost/core is in the affected set.
- Both runners run the same files during the migration. That's intentional — dual-running is the divergence safety net while the migration is in flight. Mocha stays the primary runner until the final cleanup that removes it.

## Why this is non-interruptive

- The new step is independent of the mocha step — mocha runs first, exits normally, then vitest runs. A vitest failure can't taint a mocha pass.
- Cost is bounded: vitest's currently-scoped subset runs in ~11s locally on top of the existing multi-minute mocha unit run.
- nx target discovery already picks up `test:vitest` from `ghost/core/package.json`; verified with `pnpm nx show project ghost`. No new project.json plumbing needed.
- If vitest goes flaky in the future, the response is the same as any test flake: fix the underlying test or exclude the file in `vitest.config.ts`. We do not bypass the step.

## Test plan

- [x] `pnpm nx run-many -t test:vitest -p ghost` works locally (4 files / 18 tests pass against current `main`'s vitest include glob)
- [x] `pnpm nx show project ghost` lists `test:vitest` in the discovered NPM Scripts targets
- [ ] CI green on this PR (the new step now runs on this PR itself)