### PR TITLE
Set pnpm catalogMode to strict

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'e2e'
 
 strictDepBuilds: true
+catalogMode: strict
 
 catalog:
   '@eslint/js': 8.57.1


### PR DESCRIPTION
## Summary

Sets `catalogMode: strict` in `pnpm-workspace.yaml` so that `pnpm add` cannot silently introduce versions that conflict with the catalog.

### Behavior

- `pnpm add foo` (no version) — resolves to the catalog entry when one exists, otherwise normal install. Unchanged for the common case.
- `pnpm add foo@x.y.z` where the range falls outside the catalog entry — fails with `ERR_PNPM_CATALOG_VERSION_MISMATCH`, forcing either a deliberate catalog update or a `catalog:` reference.
- `pnpm install` on the existing tree — unaffected; verified locally, completes in <2s with no lockfile churn.

### Why

Default `catalogMode` is `manual`, which means the catalog only takes effect when a package.json explicitly says `"foo": "catalog:"`. Anything added via `pnpm add` bypasses the catalog entirely, which is how the duplication we've been unwinding crept in.

`strict` enforces the policy at the point of entry without changing anything about the existing tree.

## Test plan

- [ ] CI install passes
- [ ] CI build passes