### PR TITLE
Add theme upload size limits

### DIFF
--- a/ghost/core/core/server/services/themes/storage.js
+++ b/ghost/core/core/server/services/themes/storage.js
@@ -12,6 +12,10 @@ const ThemeStorage = require('./theme-storage');
 const themeLoader = require('./loader');
 const activator = require('./activation-bridge');
 const toJSON = require('./to-json');
+const {
+    isThemeUploadSizeLimitError,
+    reportThemeUploadSizeLimitError
+} = require('./upload-size-limit-reporter');
 
 const settingsCache = require('../../../shared/settings-cache');
 
@@ -94,6 +98,10 @@ module.exports = {
                 theme: toJSON(themeName, themeErrors)
             };
         } catch (error) {
+            if (isThemeUploadSizeLimitError(error)) {
+                reportThemeUploadSizeLimitError(error, {themeName, zip});
+            }
+
             // restore backup if we renamed an existing theme but saving failed
             if (renamedExisting) {
                 return getStorage().exists(themeName).then((themeExists) => {

--- a/ghost/core/core/server/services/themes/storage.js
+++ b/ghost/core/core/server/services/themes/storage.js
@@ -99,7 +99,11 @@ module.exports = {
             };
         } catch (error) {
             if (isThemeUploadSizeLimitError(error)) {
-                reportThemeUploadSizeLimitError(error, {themeName, zip});
+                try {
+                    reportThemeUploadSizeLimitError(error, {themeName, zip});
+                } catch (reportingError) {
+                    logging.error(reportingError);
+                }
             }
 
             // restore backup if we renamed an existing theme but saving failed

--- a/ghost/core/core/server/services/themes/upload-size-limit-reporter.js
+++ b/ghost/core/core/server/services/themes/upload-size-limit-reporter.js
@@ -1,0 +1,44 @@
+const logging = require('@tryghost/logging');
+const sentry = require('../../../shared/sentry');
+
+const THEME_UPLOAD_LOG_KEY = '[theme-upload]';
+const SIZE_LIMIT_EVENTS_BY_CODE = {
+    COMPRESSED_TOO_LARGE: 'compressed_too_large',
+    ENTRY_TOO_LARGE: 'entry_too_large',
+    TOTAL_TOO_LARGE: 'total_too_large'
+};
+
+const isThemeUploadSizeLimitError = (err) => {
+    return err.errorType === 'UnsupportedMediaTypeError' && !!SIZE_LIMIT_EVENTS_BY_CODE[err.code];
+};
+
+const reportThemeUploadSizeLimitError = (err, {themeName = null, zip = null} = {}) => {
+    if (!isThemeUploadSizeLimitError(err)) {
+        return;
+    }
+
+    const eventName = `theme_upload.${SIZE_LIMIT_EVENTS_BY_CODE[err.code]}`;
+    const errorDetails = err.errorDetails || {};
+    const eventDetails = {
+        theme_name: themeName,
+        entry_name: errorDetails.entryName ?? null,
+        observed_bytes: errorDetails.observedBytes,
+        limit_bytes: errorDetails.limitBytes,
+        compressed_size_bytes: zip?.size ?? null
+    };
+
+    logging.error({
+        system: {event: eventName, ...eventDetails},
+        err
+    }, `${THEME_UPLOAD_LOG_KEY} ${err.message}`);
+
+    sentry.captureException(err, {
+        tags: {source: eventName},
+        extra: eventDetails
+    });
+};
+
+module.exports = {
+    isThemeUploadSizeLimitError,
+    reportThemeUploadSizeLimitError
+};

--- a/ghost/core/core/server/services/themes/validate.js
+++ b/ghost/core/core/server/services/themes/validate.js
@@ -58,7 +58,11 @@ const check = async function check(themeName, theme, options = {}) {
             keepExtractedDir: true,
             checkVersion: checkedVersion,
             labs: labs.getAll(),
-            skipChecks: options.skipChecks || false
+            skipChecks: options.skipChecks || false,
+            limits: {
+                perEntryUncompressedBytes: config.get('theme:uploadLimits:entryUncompressedBytes'),
+                totalUncompressedBytes: config.get('theme:uploadLimits:totalUncompressedBytes')
+            }
         });
     } else {
         debug('non-zip mode');

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -225,7 +225,7 @@ module.exports = function apiRoutes() {
 
     router.post('/themes/upload',
         mw.authAdminApi,
-        apiMw.upload.single('file'),
+        apiMw.upload.themeZip('file'),
         apiMw.upload.validation({type: 'themes'}),
         http(api.themes.upload)
     );

--- a/ghost/core/core/server/web/api/middleware/upload.js
+++ b/ghost/core/core/server/web/api/middleware/upload.js
@@ -8,6 +8,7 @@ const errors = require('@tryghost/errors');
 const config = require('../../../../shared/config');
 const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
+const {reportThemeUploadSizeLimitError} = require('../../../services/themes/upload-size-limit-reporter');
 
 const gunzip = util.promisify(zlib.gunzip);
 const gzip = util.promisify(zlib.gzip);
@@ -61,6 +62,39 @@ const messages = {
 
 const enabledClear = config.get('uploadClear') || true;
 const upload = multer({dest: os.tmpdir()});
+const themeUpload = multer({
+    dest: os.tmpdir(),
+    limits: {
+        fileSize: config.get('theme:uploadLimits:compressedBytes')
+    }
+});
+
+const getContentLength = (req) => {
+    const contentLengthHeader = req.get?.('content-length') ?? req.headers?.['content-length'];
+    const contentLength = Number(contentLengthHeader);
+
+    if (Number.isFinite(contentLength)) {
+        return contentLength;
+    }
+
+    return undefined;
+};
+
+const getCompressedSizeLimitError = (err, req) => {
+    const observedBytes = getContentLength(req);
+    const limitBytes = config.get('theme:uploadLimits:compressedBytes');
+
+    return new errors.UnsupportedMediaTypeError({
+        message: 'Theme upload exceeds maximum compressed size.',
+        context: 'Theme upload exceeds the maximum compressed size.',
+        code: 'COMPRESSED_TOO_LARGE',
+        errorDetails: {
+            observedBytes,
+            limitBytes,
+            fieldName: err.field
+        }
+    });
+};
 
 const deleteSingleFile = (file) => {
     if (!file.path) {
@@ -70,11 +104,21 @@ const deleteSingleFile = (file) => {
     fs.unlink(file.path).catch(err => logging.error(err));
 };
 
-const single = name => function singleUploadFunction(req, res, next) {
-    const singleUpload = upload.single(name);
+const single = (name, uploader = upload, options = {}) => function singleUploadFunction(req, res, next) {
+    const singleUpload = uploader.single(name);
 
     singleUpload(req, res, (err) => {
         if (err) {
+            if (options.isThemeUpload && err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+                const sizeLimitError = getCompressedSizeLimitError(err, req);
+
+                reportThemeUploadSizeLimitError(sizeLimitError, {
+                    zip: {size: sizeLimitError.errorDetails.observedBytes}
+                });
+
+                return next(sizeLimitError);
+            }
+
             // Busboy, Multer or Dicer errors are usually caused by invalid file uploads
             if (err instanceof multer.MulterError || err.stack?.includes('dicer') || err.stack?.includes('busboy')) {
                 return next(new errors.BadRequestError({
@@ -106,6 +150,8 @@ const single = name => function singleUploadFunction(req, res, next) {
         next();
     });
 };
+
+const themeZip = name => single(name, themeUpload, {isThemeUpload: true});
 
 const media = (fileName, thumbName) => function mediaUploadFunction(req, res, next) {
     const mediaUpload = upload.fields([{
@@ -398,6 +444,7 @@ const fileValidation = function ({type}) {
 
 module.exports = {
     single,
+    themeZip,
     media,
     validation,
     mediaValidation,
@@ -408,5 +455,6 @@ module.exports = {
 module.exports._test = {
     checkFileExists,
     checkFileIsValid,
+    getCompressedSizeLimitError,
     sanitizeSvgContent
 };

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -213,6 +213,13 @@
             "skipBootChecks": false
         }
     },
+    "theme": {
+        "uploadLimits": {
+            "compressedBytes": 1073741824,
+            "entryUncompressedBytes": 536870912,
+            "totalUncompressedBytes": 4294967296
+        }
+    },
     "imageOptimization": {
         "resize": true,
         "srcsets": true

--- a/ghost/core/test/unit/server/services/themes/upload-size-limit-reporter.test.js
+++ b/ghost/core/test/unit/server/services/themes/upload-size-limit-reporter.test.js
@@ -1,0 +1,71 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const sentry = require('../../../../../core/shared/sentry');
+const {
+    isThemeUploadSizeLimitError,
+    reportThemeUploadSizeLimitError
+} = require('../../../../../core/server/services/themes/upload-size-limit-reporter');
+
+describe('Theme upload size limit reporter', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('identifies supported theme upload size limit errors', function () {
+        const err = new errors.UnsupportedMediaTypeError({
+            code: 'ENTRY_TOO_LARGE'
+        });
+
+        assert.equal(isThemeUploadSizeLimitError(err), true);
+        assert.equal(isThemeUploadSizeLimitError(new errors.UnsupportedMediaTypeError({
+            code: 'SYMLINK_NOT_ALLOWED'
+        })), false);
+        assert.equal(isThemeUploadSizeLimitError(new Error('nope')), false);
+    });
+
+    it('logs and reports size limit errors to Sentry', function () {
+        const loggingStub = sinon.stub(logging, 'error');
+        const sentryStub = sinon.stub(sentry, 'captureException');
+        const err = new errors.UnsupportedMediaTypeError({
+            message: 'Zip entry exceeds maximum uncompressed size.',
+            context: 'The zip contains an entry that exceeds the maximum uncompressed size.',
+            code: 'ENTRY_TOO_LARGE',
+            errorDetails: {
+                entryName: 'assets/big.jpg',
+                observedBytes: 101,
+                limitBytes: 100
+            }
+        });
+
+        reportThemeUploadSizeLimitError(err, {
+            themeName: 'large-theme',
+            zip: {size: 42}
+        });
+
+        sinon.assert.calledOnce(loggingStub);
+        sinon.assert.calledWith(loggingStub, {
+            system: {
+                event: 'theme_upload.entry_too_large',
+                theme_name: 'large-theme',
+                entry_name: 'assets/big.jpg',
+                observed_bytes: 101,
+                limit_bytes: 100,
+                compressed_size_bytes: 42
+            },
+            err
+        }, '[theme-upload] Zip entry exceeds maximum uncompressed size.');
+
+        sinon.assert.calledOnceWithExactly(sentryStub, err, {
+            tags: {source: 'theme_upload.entry_too_large'},
+            extra: {
+                theme_name: 'large-theme',
+                entry_name: 'assets/big.jpg',
+                observed_bytes: 101,
+                limit_bytes: 100,
+                compressed_size_bytes: 42
+            }
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -7,6 +7,7 @@ const adapterManager = require('../../../../../core/server/services/adapter-mana
 const InMemoryCache = require('../../../../../core/server/adapters/cache/MemoryCache');
 const logging = require('@tryghost/logging');
 const _ = require('lodash');
+const config = require('../../../../../core/shared/config');
 
 describe('Themes', function () {
     let checkZipStub;
@@ -51,8 +52,8 @@ describe('Themes', function () {
                     sinon.assert.calledWith(checkZipStub, testTheme);
                     sinon.assert.calledWith(checkZipStub, testTheme, sinon.match({
                         limits: {
-                            perEntryUncompressedBytes: 536870912,
-                            totalUncompressedBytes: 4294967296
+                            perEntryUncompressedBytes: config.get('theme:uploadLimits:entryUncompressedBytes'),
+                            totalUncompressedBytes: config.get('theme:uploadLimits:totalUncompressedBytes')
                         }
                     }));
                     sinon.assert.notCalled(checkStub);

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -49,6 +49,12 @@ describe('Themes', function () {
                 .then((checkedTheme) => {
                     sinon.assert.calledOnce(checkZipStub);
                     sinon.assert.calledWith(checkZipStub, testTheme);
+                    sinon.assert.calledWith(checkZipStub, testTheme, sinon.match({
+                        limits: {
+                            perEntryUncompressedBytes: 536870912,
+                            totalUncompressedBytes: 4294967296
+                        }
+                    }));
                     sinon.assert.notCalled(checkStub);
                     sinon.assert.calledOnce(formatStub);
                     assert(_.isPlainObject(checkedTheme));

--- a/ghost/core/test/unit/server/web/api/middleware/upload.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/upload.test.js
@@ -3,6 +3,7 @@ const imageFixturePath = ('../../../../../utils/fixtures/images/');
 const fs = require('fs');
 const path = require('path');
 const assert = require('node:assert/strict');
+const config = require('../../../../../../core/shared/config');
 
 describe('web utils', function () {
     describe('checkFileExists', function () {
@@ -46,8 +47,10 @@ describe('web utils', function () {
 
     describe('getCompressedSizeLimitError', function () {
         it('returns a structured theme upload size limit error', function () {
+            const expectedLimit = config.get('theme:uploadLimits:compressedBytes');
+            const expectedObserved = expectedLimit + 1;
             const err = validation.getCompressedSizeLimitError({field: 'file'}, {
-                get: () => '1073741825'
+                get: () => `${expectedObserved}`
             });
 
             assert.equal(err.errorType, 'UnsupportedMediaTypeError');
@@ -55,8 +58,8 @@ describe('web utils', function () {
             assert.equal(err.context, 'Theme upload exceeds the maximum compressed size.');
             assert.equal(err.code, 'COMPRESSED_TOO_LARGE');
             assert.deepEqual(err.errorDetails, {
-                observedBytes: 1073741825,
-                limitBytes: 1073741824,
+                observedBytes: expectedObserved,
+                limitBytes: expectedLimit,
                 fieldName: 'file'
             });
         });

--- a/ghost/core/test/unit/server/web/api/middleware/upload.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/upload.test.js
@@ -44,6 +44,24 @@ describe('web utils', function () {
         });
     });
 
+    describe('getCompressedSizeLimitError', function () {
+        it('returns a structured theme upload size limit error', function () {
+            const err = validation.getCompressedSizeLimitError({field: 'file'}, {
+                get: () => '1073741825'
+            });
+
+            assert.equal(err.errorType, 'UnsupportedMediaTypeError');
+            assert.equal(err.message, 'Theme upload exceeds maximum compressed size.');
+            assert.equal(err.context, 'Theme upload exceeds the maximum compressed size.');
+            assert.equal(err.code, 'COMPRESSED_TOO_LARGE');
+            assert.deepEqual(err.errorDetails, {
+                observedBytes: 1073741825,
+                limitBytes: 1073741824,
+                fieldName: 'file'
+            });
+        });
+    });
+
     describe('sanitizeSvgContent', function () {
         it('it removes <script> tags from SVGs', async function () {
             const filepath = path.join(__dirname, imageFixturePath, 'svg-with-unsafe-script.svg');


### PR DESCRIPTION
## Summary
- Add configurable theme upload limits for compressed, per-entry uncompressed, and total uncompressed sizes.
- Use a theme-specific Multer uploader for the compressed zip cap without affecting other upload routes.
- Pass uncompressed limits through to gscan and explicitly report theme upload size-limit failures to logs and Sentry.

## Testing
- `pnpm test:single test/unit/server/web/api/middleware/upload.test.js`
- `pnpm test:single test/unit/server/services/themes/validate.test.js`
- `pnpm test:single test/unit/server/services/themes/upload-size-limit-reporter.test.js`
- `pnpm lint:server` (passes with existing warnings)
- `pnpm lint:test`