### PR TITLE
Updated automations editor to add steps

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -103,7 +103,7 @@
         "@tinybirdco/charts": "0.2.4",
         "@tryghost/admin-x-design-system": "workspace:*",
         "@tryghost/shade": "workspace:*",
-        "bson-objectid": "2.0.4",
+        "bson-objectid": "catalog:",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-hot-toast": "2.6.0",

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -89,6 +89,7 @@
         "glob": "catalog:",
         "jsdom": "catalog:",
         "msw": "catalog:",
+        "type-fest": "catalog:",
         "typescript": "catalog:",
         "vite": "catalog:",
         "vite-plugin-css-injected-by-js": "3.5.2",

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -102,6 +102,7 @@
         "@tinybirdco/charts": "0.2.4",
         "@tryghost/admin-x-design-system": "workspace:*",
         "@tryghost/shade": "workspace:*",
+        "bson-objectid": "2.0.4",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-hot-toast": "2.6.0",

--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -1,6 +1,8 @@
+import ObjectId from 'bson-objectid';
 import {Meta, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 
 export type AutomationStatus = 'active' | 'inactive';
+export const MAX_AUTOMATION_ACTIONS = 20;
 
 export type Automation = {
     id: string;
@@ -86,3 +88,94 @@ export const useEditAutomation = createMutation<AutomationDetailResponseType, Ed
         dataType
     }
 });
+
+const generateActionId = (): string => ObjectId().toHexString();
+
+// TODO NY-1253: replace this placeholder when email content can be edited.
+const PLACEHOLDER_EMAIL_LEXICAL = JSON.stringify({
+    root: {
+        children: [{
+            type: 'paragraph',
+            children: [{
+                type: 'text',
+                text: 'Untitled email body.'
+            }]
+        }],
+        direction: null,
+        format: '',
+        indent: 0,
+        type: 'root',
+        version: 1
+    }
+});
+
+const buildWaitAction = (): AutomationWaitAction => ({
+    id: generateActionId(),
+    type: 'wait',
+    data: {wait_hours: 24}
+});
+
+const buildSendEmailAction = (): AutomationSendEmailAction => ({
+    id: generateActionId(),
+    type: 'send_email',
+    data: {
+        email_subject: 'Untitled email',
+        email_lexical: PLACEHOLDER_EMAIL_LEXICAL,
+        email_sender_name: null,
+        email_sender_email: null,
+        email_sender_reply_to: null,
+        // TODO NY-1252: replace this placeholder when email design settings are available.
+        email_design_setting_id: 'placeholder'
+    }
+});
+
+// Anchor for where to splice a new action into the chain. `undefined` on either side means "no
+// real action there" — i.e. inserting at the head (no previousActionId) or the tail (no
+// nextActionId). When both are defined, we're inserting between two existing actions and the
+// direct edge between them is replaced.
+export type InsertActionAnchor = {
+    previousActionId?: string;
+    nextActionId?: string;
+};
+
+type SpliceActionArgs = {
+    detail: AutomationDetail;
+    action: AutomationAction;
+    anchor: InsertActionAnchor;
+};
+
+type InsertActionArgs = {
+    detail: AutomationDetail;
+    anchor: InsertActionAnchor;
+};
+
+const isActionId = (detail: AutomationDetail, id: string | undefined): id is string => (
+    !!id && detail.actions.some(action => action.id === id)
+);
+
+const spliceAction = ({detail, action, anchor}: SpliceActionArgs): AutomationDetail => {
+    const {previousActionId, nextActionId} = anchor;
+    const actions = [...detail.actions, action];
+    const removed = (previousActionId && nextActionId)
+        ? detail.edges.find(edge => edge.source_action_id === previousActionId && edge.target_action_id === nextActionId)
+        : undefined;
+    const remaining = removed ? detail.edges.filter(edge => edge !== removed) : detail.edges;
+    const newEdges = [...remaining];
+    // Anchor IDs that don't correspond to a real action are silently skipped — keeps the resulting
+    // edge graph well-formed even if the caller passes a stale ID.
+    if (isActionId(detail, previousActionId)) {
+        newEdges.push({source_action_id: previousActionId, target_action_id: action.id});
+    }
+    if (isActionId(detail, nextActionId)) {
+        newEdges.push({source_action_id: action.id, target_action_id: nextActionId});
+    }
+    return {...detail, actions, edges: newEdges};
+};
+
+export const insertWaitAction = ({detail, anchor}: InsertActionArgs): AutomationDetail => (
+    spliceAction({detail, action: buildWaitAction(), anchor})
+);
+
+export const insertSendEmailAction = ({detail, anchor}: InsertActionArgs): AutomationDetail => (
+    spliceAction({detail, action: buildSendEmailAction(), anchor})
+);

--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -139,16 +139,16 @@ export type InsertActionAnchor = {
     nextActionId?: string;
 };
 
-type SpliceActionArgs = {
-    detail: ReadonlyDeep<AutomationDetail>;
+type SpliceActionArgs = ReadonlyDeep<{
+    detail: AutomationDetail;
     action: AutomationAction;
-    anchor: ReadonlyDeep<InsertActionAnchor>;
-};
+    anchor: InsertActionAnchor;
+}>;
 
-type InsertActionArgs = {
-    detail: ReadonlyDeep<AutomationDetail>;
-    anchor: ReadonlyDeep<InsertActionAnchor>;
-};
+type InsertActionArgs = ReadonlyDeep<{
+    detail: AutomationDetail;
+    anchor: InsertActionAnchor;
+}>;
 
 const assertActionExists = (detail: ReadonlyDeep<AutomationDetail>, id: string): void => {
     if (!detail.actions.some(action => action.id === id)) {

--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -1,5 +1,6 @@
 import ObjectId from 'bson-objectid';
 import {Meta, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
+import type {ReadonlyDeep} from 'type-fest';
 
 export type AutomationStatus = 'active' | 'inactive';
 export const MAX_AUTOMATION_ACTIONS = 20;
@@ -139,17 +140,17 @@ export type InsertActionAnchor = {
 };
 
 type SpliceActionArgs = {
-    detail: AutomationDetail;
+    detail: ReadonlyDeep<AutomationDetail>;
     action: AutomationAction;
-    anchor: InsertActionAnchor;
+    anchor: ReadonlyDeep<InsertActionAnchor>;
 };
 
 type InsertActionArgs = {
-    detail: AutomationDetail;
-    anchor: InsertActionAnchor;
+    detail: ReadonlyDeep<AutomationDetail>;
+    anchor: ReadonlyDeep<InsertActionAnchor>;
 };
 
-const assertActionExists = (detail: AutomationDetail, id: string): void => {
+const assertActionExists = (detail: ReadonlyDeep<AutomationDetail>, id: string): void => {
     if (!detail.actions.some(action => action.id === id)) {
         throw new Error(`spliceAction: anchor references unknown action id "${id}"`);
     }

--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -149,24 +149,30 @@ type InsertActionArgs = {
     anchor: InsertActionAnchor;
 };
 
-const isActionId = (detail: AutomationDetail, id: string | undefined): id is string => (
-    !!id && detail.actions.some(action => action.id === id)
-);
+const assertActionExists = (detail: AutomationDetail, id: string): void => {
+    if (!detail.actions.some(action => action.id === id)) {
+        throw new Error(`spliceAction: anchor references unknown action id "${id}"`);
+    }
+};
 
 const spliceAction = ({detail, action, anchor}: SpliceActionArgs): AutomationDetail => {
     const {previousActionId, nextActionId} = anchor;
+    if (previousActionId !== undefined) {
+        assertActionExists(detail, previousActionId);
+    }
+    if (nextActionId !== undefined) {
+        assertActionExists(detail, nextActionId);
+    }
     const actions = [...detail.actions, action];
     const removed = (previousActionId && nextActionId)
         ? detail.edges.find(edge => edge.source_action_id === previousActionId && edge.target_action_id === nextActionId)
         : undefined;
     const remaining = removed ? detail.edges.filter(edge => edge !== removed) : detail.edges;
     const newEdges = [...remaining];
-    // Anchor IDs that don't correspond to a real action are silently skipped — keeps the resulting
-    // edge graph well-formed even if the caller passes a stale ID.
-    if (isActionId(detail, previousActionId)) {
+    if (previousActionId !== undefined) {
         newEdges.push({source_action_id: previousActionId, target_action_id: action.id});
     }
-    if (isActionId(detail, nextActionId)) {
+    if (nextActionId !== undefined) {
         newEdges.push({source_action_id: action.id, target_action_id: nextActionId});
     }
     return {...detail, actions, edges: newEdges};

--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -156,6 +156,10 @@ const assertActionExists = (detail: ReadonlyDeep<AutomationDetail>, id: string):
     }
 };
 
+const hasEdge = (detail: ReadonlyDeep<AutomationDetail>, sourceActionId: string, targetActionId: string): boolean => (
+    detail.edges.some(edge => edge.source_action_id === sourceActionId && edge.target_action_id === targetActionId)
+);
+
 const spliceAction = ({detail, action, anchor}: SpliceActionArgs): AutomationDetail => {
     const {previousActionId, nextActionId} = anchor;
     if (previousActionId !== undefined) {
@@ -163,6 +167,18 @@ const spliceAction = ({detail, action, anchor}: SpliceActionArgs): AutomationDet
     }
     if (nextActionId !== undefined) {
         assertActionExists(detail, nextActionId);
+    }
+    if (previousActionId === undefined && nextActionId === undefined && detail.actions.length > 0) {
+        throw new Error('spliceAction: anchor is required when inserting into a non-empty automation');
+    }
+    if (previousActionId !== undefined && nextActionId !== undefined && !hasEdge(detail, previousActionId, nextActionId)) {
+        throw new Error(`spliceAction: anchor edge "${previousActionId}" -> "${nextActionId}" does not exist`);
+    }
+    if (previousActionId !== undefined && nextActionId === undefined && detail.edges.some(edge => edge.source_action_id === previousActionId)) {
+        throw new Error(`spliceAction: anchor previousActionId "${previousActionId}" is not the tail action`);
+    }
+    if (previousActionId === undefined && nextActionId !== undefined && detail.edges.some(edge => edge.target_action_id === nextActionId)) {
+        throw new Error(`spliceAction: anchor nextActionId "${nextActionId}" is not the head action`);
     }
     const actions = [...detail.actions, action];
     const newEdges = detail.edges.filter(edge => !(edge.source_action_id === previousActionId && edge.target_action_id === nextActionId));

--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -165,11 +165,7 @@ const spliceAction = ({detail, action, anchor}: SpliceActionArgs): AutomationDet
         assertActionExists(detail, nextActionId);
     }
     const actions = [...detail.actions, action];
-    const removed = (previousActionId && nextActionId)
-        ? detail.edges.find(edge => edge.source_action_id === previousActionId && edge.target_action_id === nextActionId)
-        : undefined;
-    const remaining = removed ? detail.edges.filter(edge => edge !== removed) : detail.edges;
-    const newEdges = [...remaining];
+    const newEdges = detail.edges.filter(edge => !(edge.source_action_id === previousActionId && edge.target_action_id === nextActionId));
     if (previousActionId !== undefined) {
         newEdges.push({source_action_id: previousActionId, target_action_id: action.id});
     }

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -73,18 +73,6 @@ describe('automations api helpers', () => {
             expect(next.edges).toHaveLength(2);
         });
 
-        it('does not mutate the input detail', () => {
-            const detail = baseDetail(
-                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
-                []
-            );
-
-            insertWaitAction({detail, anchor: {previousActionId: 'a'}});
-
-            expect(detail.actions).toHaveLength(1);
-            expect(detail.edges).toEqual([]);
-        });
-
         it('uses ObjectId-compatible action ids', () => {
             const next = insertWaitAction({detail: baseDetail([], []), anchor: {}});
 

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -91,28 +91,22 @@ describe('automations api helpers', () => {
             expect(ObjectId.isValid(next.actions[0].id)).toBe(true);
         });
 
-        it('skips wiring an edge when previousActionId references a non-existent action', () => {
+        it('throws when previousActionId references a non-existent action', () => {
             const detail = baseDetail(
                 [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
                 []
             );
 
-            const next = insertWaitAction({detail, anchor: {previousActionId: 'does-not-exist'}});
-
-            expect(next.actions).toHaveLength(2);
-            expect(next.edges).toEqual([]);
+            expect(() => insertWaitAction({detail, anchor: {previousActionId: 'does-not-exist'}})).toThrow(/unknown action id "does-not-exist"/);
         });
 
-        it('skips wiring an edge when nextActionId references a non-existent action', () => {
+        it('throws when nextActionId references a non-existent action', () => {
             const detail = baseDetail(
                 [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
                 []
             );
 
-            const next = insertWaitAction({detail, anchor: {nextActionId: 'does-not-exist'}});
-
-            expect(next.actions).toHaveLength(2);
-            expect(next.edges).toEqual([]);
+            expect(() => insertWaitAction({detail, anchor: {nextActionId: 'does-not-exist'}})).toThrow(/unknown action id "does-not-exist"/);
         });
     });
 

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -1,6 +1,8 @@
 import ObjectId from 'bson-objectid';
 import {
+    AutomationAction,
     AutomationDetail,
+    AutomationSendEmailAction,
     insertSendEmailAction,
     insertWaitAction
 } from '../../../src/api/automations';
@@ -15,6 +17,10 @@ const baseDetail = (actions: AutomationDetail['actions'], edges: AutomationDetai
     actions,
     edges
 });
+
+function expectSendEmailAction(action: AutomationAction): asserts action is AutomationSendEmailAction {
+    expect(action.type).toBe('send_email');
+}
 
 describe('automations api helpers', () => {
     describe('insertWaitAction', () => {
@@ -106,13 +112,11 @@ describe('automations api helpers', () => {
 
             expect(next.actions).toHaveLength(1);
             const newAction = next.actions[0];
-            expect(newAction.type).toBe('send_email');
-            if (newAction.type === 'send_email') {
-                expect(newAction.data.email_subject).toBe('Untitled email');
-                expect(() => JSON.parse(newAction.data.email_lexical)).not.toThrow();
-                expect(JSON.parse(newAction.data.email_lexical).root.children.length).toBeGreaterThan(0);
-                expect(newAction.data.email_design_setting_id).toBe('placeholder');
-            }
+            expectSendEmailAction(newAction);
+            expect(newAction.data.email_subject).toBe('Untitled email');
+            expect(() => JSON.parse(newAction.data.email_lexical)).not.toThrow();
+            expect(JSON.parse(newAction.data.email_lexical).root.children.length).toBeGreaterThan(0);
+            expect(newAction.data.email_design_setting_id).toBe('placeholder');
         });
 
         it('returns an action id that the backend schema treats as a valid ObjectId', () => {

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -1,0 +1,190 @@
+import ObjectId from 'bson-objectid';
+import {
+    AutomationDetail,
+    insertSendEmailAction,
+    insertWaitAction
+} from '../../../src/api/automations';
+
+const baseDetail = (actions: AutomationDetail['actions'], edges: AutomationDetail['edges']): AutomationDetail => ({
+    id: 'a1',
+    slug: 'welcome',
+    name: 'Welcome',
+    status: 'active',
+    created_at: '2026-05-05T00:00:00.000Z',
+    updated_at: '2026-05-05T00:00:00.000Z',
+    actions,
+    edges
+});
+
+describe('automations api helpers', () => {
+    describe('insertWaitAction', () => {
+        it('appends to an empty chain (no previous, no next)', () => {
+            const detail = baseDetail([], []);
+
+            const next = insertWaitAction({detail, anchor: {}});
+
+            expect(next.actions).toHaveLength(1);
+            expect(next.actions[0]).toMatchObject({type: 'wait', data: {wait_hours: 24}});
+            expect(next.edges).toEqual([]);
+        });
+
+        it('appends at the tail of a non-empty chain by wiring the previous tail to the new action', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            const next = insertWaitAction({detail, anchor: {previousActionId: 'a'}});
+
+            expect(next.actions).toHaveLength(2);
+            const newAction = next.actions[1];
+            expect(next.edges).toEqual([{source_action_id: 'a', target_action_id: newAction.id}]);
+        });
+
+        it('inserts at the head by leaving the new action as the new head', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            const next = insertWaitAction({detail, anchor: {nextActionId: 'a'}});
+
+            expect(next.actions).toHaveLength(2);
+            const newAction = next.actions[1];
+            expect(next.edges).toEqual([{source_action_id: newAction.id, target_action_id: 'a'}]);
+        });
+
+        it('inserts between two existing actions by replacing one edge with two', () => {
+            const detail = baseDetail(
+                [
+                    {id: 'a', type: 'wait', data: {wait_hours: 24}},
+                    {id: 'b', type: 'wait', data: {wait_hours: 48}}
+                ],
+                [{source_action_id: 'a', target_action_id: 'b'}]
+            );
+
+            const next = insertWaitAction({detail, anchor: {previousActionId: 'a', nextActionId: 'b'}});
+
+            expect(next.actions).toHaveLength(3);
+            const newAction = next.actions[2];
+            expect(next.edges).toContainEqual({source_action_id: 'a', target_action_id: newAction.id});
+            expect(next.edges).toContainEqual({source_action_id: newAction.id, target_action_id: 'b'});
+            expect(next.edges).not.toContainEqual({source_action_id: 'a', target_action_id: 'b'});
+            expect(next.edges).toHaveLength(2);
+        });
+
+        it('does not mutate the input detail', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            insertWaitAction({detail, anchor: {previousActionId: 'a'}});
+
+            expect(detail.actions).toHaveLength(1);
+            expect(detail.edges).toEqual([]);
+        });
+
+        it('uses ObjectId-compatible action ids', () => {
+            const next = insertWaitAction({detail: baseDetail([], []), anchor: {}});
+
+            expect(ObjectId.isValid(next.actions[0].id)).toBe(true);
+        });
+
+        it('skips wiring an edge when previousActionId references a non-existent action', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            const next = insertWaitAction({detail, anchor: {previousActionId: 'does-not-exist'}});
+
+            expect(next.actions).toHaveLength(2);
+            expect(next.edges).toEqual([]);
+        });
+
+        it('skips wiring an edge when nextActionId references a non-existent action', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            const next = insertWaitAction({detail, anchor: {nextActionId: 'does-not-exist'}});
+
+            expect(next.actions).toHaveLength(2);
+            expect(next.edges).toEqual([]);
+        });
+    });
+
+    describe('insertSendEmailAction', () => {
+        it('creates a send_email action with placeholder defaults', () => {
+            const detail = baseDetail([], []);
+
+            const next = insertSendEmailAction({detail, anchor: {}});
+
+            expect(next.actions).toHaveLength(1);
+            const newAction = next.actions[0];
+            expect(newAction.type).toBe('send_email');
+            if (newAction.type === 'send_email') {
+                expect(newAction.data.email_subject).toBe('Untitled email');
+                expect(() => JSON.parse(newAction.data.email_lexical)).not.toThrow();
+                expect(JSON.parse(newAction.data.email_lexical).root.children.length).toBeGreaterThan(0);
+                expect(newAction.data.email_design_setting_id).toBe('placeholder');
+            }
+        });
+
+        it('returns an action id that the backend schema treats as a valid ObjectId', () => {
+            const next = insertSendEmailAction({detail: baseDetail([], []), anchor: {}});
+
+            expect(ObjectId.isValid(next.actions[0].id)).toBe(true);
+        });
+
+        it('inserts at the head of a non-empty chain', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            const next = insertSendEmailAction({detail, anchor: {nextActionId: 'a'}});
+
+            expect(next.actions).toHaveLength(2);
+            const newAction = next.actions[1];
+            expect(newAction.type).toBe('send_email');
+            expect(next.edges).toEqual([{source_action_id: newAction.id, target_action_id: 'a'}]);
+        });
+
+        it('inserts at the tail of a non-empty chain', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            const next = insertSendEmailAction({detail, anchor: {previousActionId: 'a'}});
+
+            expect(next.actions).toHaveLength(2);
+            const newAction = next.actions[1];
+            expect(newAction.type).toBe('send_email');
+            expect(next.edges).toEqual([{source_action_id: 'a', target_action_id: newAction.id}]);
+        });
+
+        it('inserts between two existing actions by replacing one edge with two', () => {
+            const detail = baseDetail(
+                [
+                    {id: 'a', type: 'wait', data: {wait_hours: 24}},
+                    {id: 'b', type: 'wait', data: {wait_hours: 48}}
+                ],
+                [{source_action_id: 'a', target_action_id: 'b'}]
+            );
+
+            const next = insertSendEmailAction({detail, anchor: {previousActionId: 'a', nextActionId: 'b'}});
+
+            expect(next.actions).toHaveLength(3);
+            const newAction = next.actions[2];
+            expect(newAction.type).toBe('send_email');
+            expect(next.edges).toContainEqual({source_action_id: 'a', target_action_id: newAction.id});
+            expect(next.edges).toContainEqual({source_action_id: newAction.id, target_action_id: 'b'});
+            expect(next.edges).not.toContainEqual({source_action_id: 'a', target_action_id: 'b'});
+            expect(next.edges).toHaveLength(2);
+        });
+    });
+});

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -3,6 +3,7 @@ import {
     AutomationAction,
     AutomationDetail,
     AutomationSendEmailAction,
+    InsertActionAnchor,
     insertSendEmailAction,
     insertWaitAction
 } from '../../../src/api/automations';
@@ -22,29 +23,31 @@ function expectSendEmailAction(action: AutomationAction): asserts action is Auto
     expect(action.type).toBe('send_email');
 }
 
+const insertionCases: Array<{
+    name: string;
+    insert: (args: {detail: AutomationDetail; anchor: InsertActionAnchor}) => AutomationDetail;
+    expectedType: AutomationAction['type'];
+}> = [
+    {name: 'insertWaitAction', insert: insertWaitAction, expectedType: 'wait'},
+    {name: 'insertSendEmailAction', insert: insertSendEmailAction, expectedType: 'send_email'}
+];
+
 describe('automations api helpers', () => {
-    describe('insertWaitAction', () => {
-        it('appends to an empty chain (no previous, no next)', () => {
-            const detail = baseDetail([], []);
-
-            const next = insertWaitAction({detail, anchor: {}});
-
-            expect(next.actions).toHaveLength(1);
-            expect(next.actions[0]).toMatchObject({type: 'wait', data: {wait_hours: 24}});
-            expect(next.edges).toEqual([]);
-        });
-
+    describe('shared insertion behavior', () => {
         it('appends at the tail of a non-empty chain by wiring the previous tail to the new action', () => {
             const detail = baseDetail(
                 [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
                 []
             );
 
-            const next = insertWaitAction({detail, anchor: {previousActionId: 'a'}});
+            for (const {insert, expectedType} of insertionCases) {
+                const next = insert({detail, anchor: {previousActionId: 'a'}});
 
-            expect(next.actions).toHaveLength(2);
-            const newAction = next.actions[1];
-            expect(next.edges).toEqual([{source_action_id: 'a', target_action_id: newAction.id}]);
+                expect(next.actions).toHaveLength(2);
+                const newAction = next.actions[1];
+                expect(newAction.type).toBe(expectedType);
+                expect(next.edges).toEqual([{source_action_id: 'a', target_action_id: newAction.id}]);
+            }
         });
 
         it('inserts at the head by leaving the new action as the new head', () => {
@@ -53,11 +56,14 @@ describe('automations api helpers', () => {
                 []
             );
 
-            const next = insertWaitAction({detail, anchor: {nextActionId: 'a'}});
+            for (const {insert, expectedType} of insertionCases) {
+                const next = insert({detail, anchor: {nextActionId: 'a'}});
 
-            expect(next.actions).toHaveLength(2);
-            const newAction = next.actions[1];
-            expect(next.edges).toEqual([{source_action_id: newAction.id, target_action_id: 'a'}]);
+                expect(next.actions).toHaveLength(2);
+                const newAction = next.actions[1];
+                expect(newAction.type).toBe(expectedType);
+                expect(next.edges).toEqual([{source_action_id: newAction.id, target_action_id: 'a'}]);
+            }
         });
 
         it('inserts between two existing actions by replacing one edge with two', () => {
@@ -69,14 +75,29 @@ describe('automations api helpers', () => {
                 [{source_action_id: 'a', target_action_id: 'b'}]
             );
 
-            const next = insertWaitAction({detail, anchor: {previousActionId: 'a', nextActionId: 'b'}});
+            for (const {insert, expectedType} of insertionCases) {
+                const next = insert({detail, anchor: {previousActionId: 'a', nextActionId: 'b'}});
 
-            expect(next.actions).toHaveLength(3);
-            const newAction = next.actions[2];
-            expect(next.edges).toContainEqual({source_action_id: 'a', target_action_id: newAction.id});
-            expect(next.edges).toContainEqual({source_action_id: newAction.id, target_action_id: 'b'});
-            expect(next.edges).not.toContainEqual({source_action_id: 'a', target_action_id: 'b'});
-            expect(next.edges).toHaveLength(2);
+                expect(next.actions).toHaveLength(3);
+                const newAction = next.actions[2];
+                expect(newAction.type).toBe(expectedType);
+                expect(next.edges).toContainEqual({source_action_id: 'a', target_action_id: newAction.id});
+                expect(next.edges).toContainEqual({source_action_id: newAction.id, target_action_id: 'b'});
+                expect(next.edges).not.toContainEqual({source_action_id: 'a', target_action_id: 'b'});
+                expect(next.edges).toHaveLength(2);
+            }
+        });
+    });
+
+    describe('insertWaitAction', () => {
+        it('creates a wait action with placeholder defaults', () => {
+            const detail = baseDetail([], []);
+
+            const next = insertWaitAction({detail, anchor: {}});
+
+            expect(next.actions).toHaveLength(1);
+            expect(next.actions[0]).toMatchObject({type: 'wait', data: {wait_hours: 24}});
+            expect(next.edges).toEqual([]);
         });
 
         it('uses ObjectId-compatible action ids', () => {
@@ -102,6 +123,51 @@ describe('automations api helpers', () => {
 
             expect(() => insertWaitAction({detail, anchor: {nextActionId: 'does-not-exist'}})).toThrow(/unknown action id "does-not-exist"/);
         });
+
+        it('throws when inserting without an anchor into a non-empty automation', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            expect(() => insertWaitAction({detail, anchor: {}})).toThrow(/anchor is required/);
+        });
+
+        it('throws when inserting between actions that are not directly connected', () => {
+            const detail = baseDetail(
+                [
+                    {id: 'a', type: 'wait', data: {wait_hours: 24}},
+                    {id: 'b', type: 'wait', data: {wait_hours: 48}}
+                ],
+                []
+            );
+
+            expect(() => insertWaitAction({detail, anchor: {previousActionId: 'a', nextActionId: 'b'}})).toThrow(/anchor edge "a" -> "b" does not exist/);
+        });
+
+        it('throws when appending after an action that already has an outgoing edge', () => {
+            const detail = baseDetail(
+                [
+                    {id: 'a', type: 'wait', data: {wait_hours: 24}},
+                    {id: 'b', type: 'wait', data: {wait_hours: 48}}
+                ],
+                [{source_action_id: 'a', target_action_id: 'b'}]
+            );
+
+            expect(() => insertWaitAction({detail, anchor: {previousActionId: 'a'}})).toThrow(/previousActionId "a" is not the tail action/);
+        });
+
+        it('throws when prepending before an action that already has an incoming edge', () => {
+            const detail = baseDetail(
+                [
+                    {id: 'a', type: 'wait', data: {wait_hours: 24}},
+                    {id: 'b', type: 'wait', data: {wait_hours: 48}}
+                ],
+                [{source_action_id: 'a', target_action_id: 'b'}]
+            );
+
+            expect(() => insertWaitAction({detail, anchor: {nextActionId: 'b'}})).toThrow(/nextActionId "b" is not the head action/);
+        });
     });
 
     describe('insertSendEmailAction', () => {
@@ -123,54 +189,6 @@ describe('automations api helpers', () => {
             const next = insertSendEmailAction({detail: baseDetail([], []), anchor: {}});
 
             expect(ObjectId.isValid(next.actions[0].id)).toBe(true);
-        });
-
-        it('inserts at the head of a non-empty chain', () => {
-            const detail = baseDetail(
-                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
-                []
-            );
-
-            const next = insertSendEmailAction({detail, anchor: {nextActionId: 'a'}});
-
-            expect(next.actions).toHaveLength(2);
-            const newAction = next.actions[1];
-            expect(newAction.type).toBe('send_email');
-            expect(next.edges).toEqual([{source_action_id: newAction.id, target_action_id: 'a'}]);
-        });
-
-        it('inserts at the tail of a non-empty chain', () => {
-            const detail = baseDetail(
-                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
-                []
-            );
-
-            const next = insertSendEmailAction({detail, anchor: {previousActionId: 'a'}});
-
-            expect(next.actions).toHaveLength(2);
-            const newAction = next.actions[1];
-            expect(newAction.type).toBe('send_email');
-            expect(next.edges).toEqual([{source_action_id: 'a', target_action_id: newAction.id}]);
-        });
-
-        it('inserts between two existing actions by replacing one edge with two', () => {
-            const detail = baseDetail(
-                [
-                    {id: 'a', type: 'wait', data: {wait_hours: 24}},
-                    {id: 'b', type: 'wait', data: {wait_hours: 48}}
-                ],
-                [{source_action_id: 'a', target_action_id: 'b'}]
-            );
-
-            const next = insertSendEmailAction({detail, anchor: {previousActionId: 'a', nextActionId: 'b'}});
-
-            expect(next.actions).toHaveLength(3);
-            const newAction = next.actions[2];
-            expect(newAction.type).toBe('send_email');
-            expect(next.edges).toContainEqual({source_action_id: 'a', target_action_id: newAction.id});
-            expect(next.edges).toContainEqual({source_action_id: newAction.id, target_action_id: 'b'});
-            expect(next.edges).not.toContainEqual({source_action_id: 'a', target_action_id: 'b'});
-            expect(next.edges).toHaveLength(2);
         });
     });
 });

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -61,6 +61,7 @@
         "@tryghost/nql-lang": "catalog:",
         "@tryghost/shade": "workspace:*",
         "@xyflow/react": "12.8.6",
+        "dequal": "catalog:",
         "i18n-iso-countries": "7.14.0",
         "moment-timezone": "0.5.45",
         "papaparse": "5.5.3",

--- a/apps/posts/src/views/Automations/components/add-step-edge.tsx
+++ b/apps/posts/src/views/Automations/components/add-step-edge.tsx
@@ -60,7 +60,7 @@ const AddStepEdge: React.FC<EdgeProps> = ({
                 'flex size-7 items-center justify-center rounded-full border transition-opacity focus-visible:opacity-100 focus-visible:outline-none',
                 INSERT_BUTTON_CLASSES,
                 visible ? 'opacity-100' : 'opacity-0',
-                edgeData.disabled && 'cursor-not-allowed'
+                edgeData.disabled && 'cursor-not-allowed!'
             )}
             data-testid={`add-step-button-${edgeData.sourceId}-${edgeData.targetId}`}
             disabled={edgeData.disabled}

--- a/apps/posts/src/views/Automations/components/add-step-edge.tsx
+++ b/apps/posts/src/views/Automations/components/add-step-edge.tsx
@@ -1,0 +1,121 @@
+import React, {useState} from 'react';
+import StepPicker, {type StepPickerType} from './step-picker';
+import {BaseEdge, EdgeLabelRenderer, EdgeProps, getSmoothStepPath} from '@xyflow/react';
+import {LucideIcon, cn} from '@tryghost/shade/utils';
+import {Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+
+export type AddStepEdgeData = {
+    sourceId: string;
+    targetId: string;
+    disabled: boolean;
+    disabledReason?: string;
+    onPick: (type: StepPickerType, anchor: {sourceId: string; targetId: string}) => void;
+};
+
+const INSERT_BUTTON_CLASSES = 'border-transparent bg-blue-500 text-white shadow-sm hover:bg-blue-600';
+const DEFAULT_EDGE_STROKE = 'var(--color-grey-500)';
+const HOVERED_EDGE_STROKE = 'var(--color-blue-500)';
+
+const AddStepEdge: React.FC<EdgeProps> = ({
+    id,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    data
+}) => {
+    const [open, setOpen] = useState(false);
+    const [hovered, setHovered] = useState(false);
+    const edgeData = data as AddStepEdgeData | undefined;
+
+    const [path, labelX, labelY] = getSmoothStepPath({
+        sourceX,
+        sourceY,
+        sourcePosition,
+        targetX,
+        targetY,
+        targetPosition
+    });
+
+    const edgeStyle: React.CSSProperties = {
+        stroke: hovered || open ? HOVERED_EDGE_STROKE : DEFAULT_EDGE_STROKE
+    };
+
+    if (!edgeData) {
+        return <BaseEdge id={id} path={path} style={{stroke: DEFAULT_EDGE_STROKE}} />;
+    }
+
+    const handlePick = (type: StepPickerType) => {
+        setOpen(false);
+        edgeData.onPick(type, {sourceId: edgeData.sourceId, targetId: edgeData.targetId});
+    };
+
+    const visible = open || hovered;
+    const button = (
+        <button
+            aria-label='Insert step here'
+            className={cn(
+                'flex size-7 items-center justify-center rounded-full border transition-opacity focus-visible:opacity-100 focus-visible:outline-none',
+                INSERT_BUTTON_CLASSES,
+                visible ? 'opacity-100' : 'opacity-0',
+                edgeData.disabled && 'cursor-not-allowed'
+            )}
+            data-testid={`add-step-button-${edgeData.sourceId}-${edgeData.targetId}`}
+            disabled={edgeData.disabled}
+            type='button'
+        >
+            <LucideIcon.Plus className='size-4' strokeWidth={1.5} />
+        </button>
+    );
+
+    let control: React.ReactNode;
+    if (edgeData.disabled) {
+        control = edgeData.disabledReason ? (
+            <TooltipProvider delayDuration={150}>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <span tabIndex={0}>{button}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>{edgeData.disabledReason}</TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
+        ) : button;
+    } else {
+        control = (
+            <Popover open={open} onOpenChange={setOpen}>
+                <PopoverTrigger asChild>{button}</PopoverTrigger>
+                <PopoverContent align='center' className='p-0' side='right'>
+                    <StepPicker onPick={handlePick} />
+                </PopoverContent>
+            </Popover>
+        );
+    }
+
+    return (
+        <g
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+        >
+            <BaseEdge id={id} interactionWidth={30} path={path} style={edgeStyle} />
+            <EdgeLabelRenderer>
+                <div
+                    className='pointer-events-auto absolute'
+                    style={{
+                        transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`
+                    }}
+                    onMouseEnter={() => setHovered(true)}
+                    onMouseLeave={() => setHovered(false)}
+                >
+                    {/* Wider hit zone so the + becomes visible when the cursor is near the edge midpoint. */}
+                    <div className='flex h-10 w-16 items-center justify-center'>
+                        {control}
+                    </div>
+                </div>
+            </EdgeLabelRenderer>
+        </g>
+    );
+};
+
+export default AddStepEdge;

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -18,7 +18,7 @@ export const TAIL_CANVAS_ID = '__tail__';
 
 // Canvas-local anchor: React Flow node IDs of the two nodes between which a step is being inserted.
 // Translated to the API's `InsertActionAnchor` by `toApiAnchor` before reaching the data helpers.
-export type CanvasAnchor = {sourceId: string; targetId: string};
+type CanvasAnchor = {sourceId: string; targetId: string};
 
 const toApiAnchor = ({sourceId, targetId}: CanvasAnchor): InsertActionAnchor => ({
     previousActionId: sourceId === TRIGGER_CANVAS_ID ? undefined : sourceId,
@@ -221,7 +221,7 @@ const getInitialActionOrder = (automation: AutomationDetail): AutomationAction[]
     return ordered;
 };
 
-interface BuildGraphArgs {
+type BuildGraphArgs = {
     automation: AutomationDetail;
     disabled: boolean;
     onPick: (type: StepPickerType, anchor: CanvasAnchor) => void;
@@ -268,8 +268,6 @@ const buildGraph = ({automation, disabled, onPick}: BuildGraphArgs): {nodes: Aut
         type: 'tail',
         position: {x: NODE_X, y: NODE_GAP_Y * (ordered.length + 1)},
         data: {disabled, disabledReason, onPick, anchor: tailAnchor},
-        // Match the prototype's tail config: only `draggable` and `connectable` overrides.
-        // Leaving `selectable` / `focusable` at their defaults keeps clicks flowing through.
         draggable: false,
         connectable: false
     });
@@ -292,7 +290,7 @@ const buildGraph = ({automation, disabled, onPick}: BuildGraphArgs): {nodes: Aut
             target: action.id,
             type: 'add-step-edge',
             focusable: false,
-            data: edgeData as unknown as Record<string, unknown>
+            data: edgeData
         });
         previousCanvasId = action.id;
     });
@@ -309,7 +307,7 @@ const buildGraph = ({automation, disabled, onPick}: BuildGraphArgs): {nodes: Aut
     return {nodes, edges};
 };
 
-interface AutomationCanvasProps {
+type AutomationCanvasProps = {
     automation?: AutomationDetail;
     isLoading: boolean;
     isError: boolean;

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -1,13 +1,30 @@
 import '@xyflow/react/dist/style.css';
-import React from 'react';
-import {AutomationAction, AutomationDetail} from '@tryghost/admin-x-framework/api/automations';
+import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
+import React, {useCallback, useState} from 'react';
+import StepPicker, {type StepPickerType} from './step-picker';
+import {AutomationAction, AutomationDetail, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
-import {Banner, LoadingIndicator} from '@tryghost/shade/components';
-import {LucideIcon} from '@tryghost/shade/utils';
+import {Banner, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {LucideIcon, cn} from '@tryghost/shade/utils';
 
-const TAIL_NODE_ID = '__tail__';
 const NODE_X = 0;
 const NODE_GAP_Y = 180;
+const DISABLED_REASON = `Limit of ${MAX_AUTOMATION_ACTIONS} steps reached`;
+
+// React Flow node IDs for the trigger and tail nodes. The canvas builds the visual graph using
+// these; they are not action IDs and never reach the API. Exported so add-step-edge can recognize
+// them when building its anchor data.
+export const TRIGGER_CANVAS_ID = 'trigger';
+export const TAIL_CANVAS_ID = '__tail__';
+
+// Canvas-local anchor: React Flow node IDs of the two nodes between which a step is being inserted.
+// Translated to the API's `InsertActionAnchor` by `toApiAnchor` before reaching the data helpers.
+export type CanvasAnchor = {sourceId: string; targetId: string};
+
+const toApiAnchor = ({sourceId, targetId}: CanvasAnchor): InsertActionAnchor => ({
+    previousActionId: sourceId === TRIGGER_CANVAS_ID ? undefined : sourceId,
+    nextActionId: targetId === TAIL_CANVAS_ID ? undefined : targetId
+});
 
 type StepNodeData = {
     icon: React.ElementType;
@@ -15,8 +32,15 @@ type StepNodeData = {
     value?: string;
 };
 
+type TailNodeData = {
+    disabled: boolean;
+    disabledReason?: string;
+    onPick: (type: StepPickerType, anchor: CanvasAnchor) => void;
+    anchor: CanvasAnchor;
+};
+
 type StepFlowNode = Node<StepNodeData, 'trigger' | 'step'>;
-type TailFlowNode = Node<Record<string, never>, 'tail'>;
+type TailFlowNode = Node<TailNodeData, 'tail'>;
 type AutomationFlowNode = StepFlowNode | TailFlowNode;
 
 const HIDDEN_HANDLE_STYLE: React.CSSProperties = {
@@ -26,15 +50,13 @@ const HIDDEN_HANDLE_STYLE: React.CSSProperties = {
     border: 'none'
 };
 
-const EDGE_STYLE: React.CSSProperties = {stroke: 'var(--color-grey-500)'};
-
 const HiddenHandle: React.FC<{type: 'source' | 'target'; position: Position}> = ({type, position}) => (
     <Handle isConnectable={false} position={position} style={HIDDEN_HANDLE_STYLE} type={type} />
 );
 
 const NodeShell: React.FC<React.PropsWithChildren<{className?: string}>> = ({children, className}) => (
     <div
-        className={`flex w-64 items-center gap-3 rounded-lg bg-white px-4 py-3 text-left text-sm shadow-sm ${className ?? ''}`}
+        className={cn('flex w-64 items-center gap-3 rounded-lg bg-white px-4 py-3 text-left text-sm shadow-sm', className)}
     >
         {children}
     </div>
@@ -72,19 +94,67 @@ const StepNode = React.memo<NodeProps<StepFlowNode>>(({data}) => (
 ));
 StepNode.displayName = 'StepNode';
 
-// TODO: convert to a <button> once "add step" is wired up. Currently decorative.
-const TailNode = React.memo<NodeProps<TailFlowNode>>(() => (
-    <div aria-hidden='true' className='flex h-12 w-64 items-center justify-center rounded-lg border border-dashed border-grey-300 bg-white'>
-        <HiddenHandle position={Position.Top} type='target' />
-        <LucideIcon.Plus className='size-5 text-grey-500' strokeWidth={1.5} />
-    </div>
-));
-TailNode.displayName = 'TailNode';
+const TailNode: React.FC<NodeProps<TailFlowNode>> = ({data}) => {
+    const [open, setOpen] = useState(false);
+
+    const handlePick = (type: StepPickerType) => {
+        setOpen(false);
+        data.onPick(type, data.anchor);
+    };
+
+    const triggerClassName = 'flex h-12 w-64 items-center justify-center rounded-lg border border-dashed border-grey-300 bg-white transition-colors hover:border-grey-400 focus-visible:border-grey-500 focus-visible:outline-none dark:border-grey-800 dark:bg-grey-950 dark:hover:border-grey-700';
+
+    if (data.disabled) {
+        const content = (
+            <div
+                aria-disabled='true'
+                className={cn(triggerClassName, 'cursor-not-allowed opacity-60')}
+                data-testid='add-step-tail-button'
+            >
+                <HiddenHandle position={Position.Top} type='target' />
+                <LucideIcon.Plus className='size-5 text-grey-500' strokeWidth={1.5} />
+            </div>
+        );
+        if (!data.disabledReason) {
+            return content;
+        }
+        return (
+            <TooltipProvider delayDuration={150}>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <span tabIndex={0}>{content}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>{data.disabledReason}</TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
+        );
+    }
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger
+                aria-label='Add step'
+                className={cn(triggerClassName, 'cursor-pointer')}
+                data-testid='add-step-tail-button'
+            >
+                <HiddenHandle position={Position.Top} type='target' />
+                <LucideIcon.Plus className='size-5 text-grey-500' strokeWidth={1.5} />
+            </PopoverTrigger>
+            <PopoverContent align='center' className='p-0' side='top'>
+                <StepPicker onPick={handlePick} />
+            </PopoverContent>
+        </Popover>
+    );
+};
 
 const nodeTypes = {
     trigger: TriggerNode,
     step: StepNode,
     tail: TailNode
+};
+
+const edgeTypes = {
+    'add-step-edge': AddStepEdge
 };
 
 export const formatWait = (hours: number): string => {
@@ -111,6 +181,9 @@ const buildActionData = (action: AutomationAction): StepNodeData => {
     }
 };
 
+// Returns the actions of `automation` ordered along the chain from the head. Throws on malformed
+// data (cycle, branch, or disconnected nodes). The canvas wraps its render tree in an Error
+// Boundary that catches these and renders the same "Couldn't load automation" banner.
 const getInitialActionOrder = (automation: AutomationDetail): AutomationAction[] => {
     if (automation.actions.length === 0) {
         return [];
@@ -149,7 +222,13 @@ const getInitialActionOrder = (automation: AutomationDetail): AutomationAction[]
     return ordered;
 };
 
-const buildGraph = (automation: AutomationDetail): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
+interface BuildGraphArgs {
+    automation: AutomationDetail;
+    disabled: boolean;
+    onPick: (type: StepPickerType, anchor: CanvasAnchor) => void;
+}
+
+const buildGraph = ({automation, disabled, onPick}: BuildGraphArgs): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
     const ordered = getInitialActionOrder(automation);
     const baseNodeProps = {
         draggable: false,
@@ -157,10 +236,17 @@ const buildGraph = (automation: AutomationDetail): {nodes: AutomationFlowNode[];
         connectable: false,
         focusable: false
     };
+    const disabledReason = disabled ? DISABLED_REASON : undefined;
+
+    const lastActionId = ordered[ordered.length - 1]?.id;
+    const tailAnchor: CanvasAnchor = {
+        sourceId: lastActionId ?? TRIGGER_CANVAS_ID,
+        targetId: TAIL_CANVAS_ID
+    };
 
     const nodes: AutomationFlowNode[] = [
         {
-            id: 'trigger',
+            id: TRIGGER_CANVAS_ID,
             type: 'trigger',
             position: {x: NODE_X, y: 0},
             data: {icon: LucideIcon.Zap, label: 'Trigger', value: 'Member signs up'},
@@ -179,30 +265,47 @@ const buildGraph = (automation: AutomationDetail): {nodes: AutomationFlowNode[];
     });
 
     nodes.push({
-        id: TAIL_NODE_ID,
+        id: TAIL_CANVAS_ID,
         type: 'tail',
         position: {x: NODE_X, y: NODE_GAP_Y * (ordered.length + 1)},
-        data: {},
-        ...baseNodeProps
+        data: {disabled, disabledReason, onPick, anchor: tailAnchor},
+        // Match the prototype's tail config: only `draggable` and `connectable` overrides.
+        // Leaving `selectable` / `focusable` at their defaults keeps clicks flowing through.
+        draggable: false,
+        connectable: false
     });
 
+    // Every connecting line between existing nodes gets a circular + on hover. The trailing edge into the
+    // tail node intentionally has none — the rectangular tail button already covers that slot.
     const edges: Edge[] = [];
-    let previousId = 'trigger';
-    const pushEdge = (source: string, target: string) => {
-        edges.push({
-            id: `e-${source}-${target}`,
-            source,
-            target,
-            type: 'smoothstep',
-            focusable: false,
-            style: EDGE_STYLE
-        });
-    };
+    let previousCanvasId: string = TRIGGER_CANVAS_ID;
     ordered.forEach((action) => {
-        pushEdge(previousId, action.id);
-        previousId = action.id;
+        const edgeData: AddStepEdgeData = {
+            sourceId: previousCanvasId,
+            targetId: action.id,
+            disabled,
+            disabledReason,
+            onPick
+        };
+        edges.push({
+            id: `e-${previousCanvasId}-${action.id}`,
+            source: previousCanvasId,
+            target: action.id,
+            type: 'add-step-edge',
+            focusable: false,
+            data: edgeData as unknown as Record<string, unknown>
+        });
+        previousCanvasId = action.id;
     });
-    pushEdge(previousId, TAIL_NODE_ID);
+
+    edges.push({
+        id: `e-${previousCanvasId}-${TAIL_CANVAS_ID}`,
+        source: previousCanvasId,
+        target: TAIL_CANVAS_ID,
+        type: 'smoothstep',
+        focusable: false,
+        style: {stroke: 'var(--color-grey-500)'}
+    });
 
     return {nodes, edges};
 };
@@ -211,13 +314,40 @@ interface AutomationCanvasProps {
     automation?: AutomationDetail;
     isLoading: boolean;
     isError: boolean;
+    onChange: (next: AutomationDetail) => void;
 }
 
-const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError}) => {
-    const graph = React.useMemo(
-        () => (automation ? buildGraph(automation) : null),
-        [automation]
-    );
+const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError, onChange}) => {
+    const handlePick = useCallback((type: StepPickerType, anchor: CanvasAnchor) => {
+        if (!automation) {
+            return;
+        }
+        if (automation.actions.length >= MAX_AUTOMATION_ACTIONS) {
+            return;
+        }
+        const apiAnchor = toApiAnchor(anchor);
+        const next = type === 'wait'
+            ? insertWaitAction({detail: automation, anchor: apiAnchor})
+            : insertSendEmailAction({detail: automation, anchor: apiAnchor});
+        onChange(next);
+    }, [automation, onChange]);
+
+    const graph = React.useMemo(() => {
+        if (!automation) {
+            return null;
+        }
+        return buildGraph({
+            automation,
+            disabled: automation.actions.length >= MAX_AUTOMATION_ACTIONS,
+            onPick: handlePick
+        });
+    }, [automation, handlePick]);
+
+    // Fit only the trigger + first two action nodes on initial render so a deep chain doesn't zoom
+    // out to a postage stamp. Below that, the user pans/scrolls to see the rest.
+    const initialFitNodes = React.useMemo(() => (
+        graph?.nodes.slice(0, 3).map(node => ({id: node.id})) ?? []
+    ), [graph]);
 
     if (isLoading) {
         return (
@@ -248,7 +378,8 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             <ReactFlow
                 edges={graph.edges}
                 edgesFocusable={false}
-                fitViewOptions={{maxZoom: 1, padding: 0.4}}
+                edgeTypes={edgeTypes}
+                fitViewOptions={{maxZoom: 1, minZoom: 1, padding: 0.2, nodes: initialFitNodes}}
                 nodes={graph.nodes}
                 nodesConnectable={false}
                 nodesDraggable={false}

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -314,6 +314,11 @@ type AutomationCanvasProps = {
     onChange: (next: AutomationDetail) => void;
 }
 
+const insertActionByType = {
+    wait: insertWaitAction,
+    send_email: insertSendEmailAction
+};
+
 const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError, onChange}) => {
     const handlePick = useCallback((type: StepPickerType, anchor: CanvasAnchor) => {
         if (!automation) {
@@ -323,9 +328,8 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             return;
         }
         const apiAnchor = toApiAnchor(anchor);
-        const next = type === 'wait'
-            ? insertWaitAction({detail: automation, anchor: apiAnchor})
-            : insertSendEmailAction({detail: automation, anchor: apiAnchor});
+        const insertAction = insertActionByType[type];
+        const next = insertAction({detail: automation, anchor: apiAnchor});
         onChange(next);
     }, [automation, onChange]);
 

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -12,9 +12,8 @@ const NODE_GAP_Y = 180;
 const DISABLED_REASON = `Limit of ${MAX_AUTOMATION_ACTIONS} steps reached`;
 
 // React Flow node IDs for the trigger and tail nodes. The canvas builds the visual graph using
-// these; they are not action IDs and never reach the API. Exported so add-step-edge can recognize
-// them when building its anchor data.
-export const TRIGGER_CANVAS_ID = 'trigger';
+// these; they are not action IDs and never reach the API.
+export const TRIGGER_CANVAS_ID = '__trigger__';
 export const TAIL_CANVAS_ID = '__tail__';
 
 // Canvas-local anchor: React Flow node IDs of the two nodes between which a step is being inserted.

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -221,13 +221,13 @@ const getInitialActionOrder = (automation: AutomationDetail): AutomationAction[]
     return ordered;
 };
 
-type BuildGraphArgs = {
+type BuildGraphParams = {
     automation: AutomationDetail;
     disabled: boolean;
     onPick: (type: StepPickerType, anchor: CanvasAnchor) => void;
 }
 
-const buildGraph = ({automation, disabled, onPick}: BuildGraphArgs): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
+const buildGraph = ({automation, disabled, onPick}: BuildGraphParams): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
     const ordered = getInitialActionOrder(automation);
     const baseNodeProps = {
         draggable: false,

--- a/apps/posts/src/views/Automations/components/step-picker.tsx
+++ b/apps/posts/src/views/Automations/components/step-picker.tsx
@@ -39,7 +39,7 @@ const StepPicker: React.FC<StepPickerProps> = ({onPick}) => (
             onClick={() => onPick('send_email')}
         />
         <PickerOption
-            description='Wait for a time or a date'
+            description='Wait a set amount of time'
             icon={LucideIcon.Clock}
             label='Wait'
             onClick={() => onPick('wait')}

--- a/apps/posts/src/views/Automations/components/step-picker.tsx
+++ b/apps/posts/src/views/Automations/components/step-picker.tsx
@@ -33,16 +33,16 @@ const PickerOption: React.FC<PickerOptionProps> = ({icon: Icon, label, descripti
 const StepPicker: React.FC<StepPickerProps> = ({onPick}) => (
     <div className='flex w-64 flex-col gap-1 p-1' data-testid='step-picker'>
         <PickerOption
-            description='Pause the sequence for a set time'
+            description='Send an email'
+            icon={LucideIcon.Mail}
+            label='Email'
+            onClick={() => onPick('send_email')}
+        />
+        <PickerOption
+            description='Wait for a time or a date'
             icon={LucideIcon.Clock}
             label='Wait'
             onClick={() => onPick('wait')}
-        />
-        <PickerOption
-            description='Send an email to the member'
-            icon={LucideIcon.Mail}
-            label='Send email'
-            onClick={() => onPick('send_email')}
         />
     </div>
 );

--- a/apps/posts/src/views/Automations/components/step-picker.tsx
+++ b/apps/posts/src/views/Automations/components/step-picker.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {LucideIcon} from '@tryghost/shade/utils';
+
+export type StepPickerType = 'wait' | 'send_email';
+
+interface StepPickerProps {
+    onPick: (type: StepPickerType) => void;
+}
+
+interface PickerOptionProps {
+    icon: React.ElementType;
+    label: string;
+    description: string;
+    onClick: () => void;
+}
+
+const PickerOption: React.FC<PickerOptionProps> = ({icon: Icon, label, description, onClick}) => (
+    <button
+        className='flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm hover:bg-grey-100 focus-visible:bg-grey-100 focus-visible:outline-none dark:hover:bg-grey-925 dark:focus-visible:bg-grey-925'
+        type='button'
+        onClick={onClick}
+    >
+        <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-grey-100 text-grey-700 dark:bg-grey-900 dark:text-grey-300'>
+            <Icon className='size-4' />
+        </div>
+        <div className='flex min-w-0 flex-col'>
+            <span className='font-medium'>{label}</span>
+            <span className='text-xs text-grey-600 dark:text-grey-500'>{description}</span>
+        </div>
+    </button>
+);
+
+const StepPicker: React.FC<StepPickerProps> = ({onPick}) => (
+    <div className='flex w-64 flex-col gap-1 p-1' data-testid='step-picker'>
+        <PickerOption
+            description='Pause the sequence for a set time'
+            icon={LucideIcon.Clock}
+            label='Wait'
+            onClick={() => onPick('wait')}
+        />
+        <PickerOption
+            description='Send an email to the member'
+            icon={LucideIcon.Mail}
+            label='Send email'
+            onClick={() => onPick('send_email')}
+        />
+    </div>
+);
+
+export default StepPicker;

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -3,37 +3,9 @@ import AutomationHeader from './components/automation-header';
 import React from 'react';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, type ButtonProps, LoadingIndicator} from '@tryghost/shade/components';
 import {AutomationDetail, AutomationStatus, useEditAutomation, useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
+import {dequal} from 'dequal/lite';
 import {useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
-
-// Recursive structural equality. Used by the dirty check to compare the user-editable slice of an
-// automation (status, actions, edges) without depending on the key order of server-parsed JSON.
-const deepEqual = (a: unknown, b: unknown): boolean => {
-    if (a === b) {
-        return true;
-    }
-    if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
-        return false;
-    }
-    if (Array.isArray(a)) {
-        if (!Array.isArray(b) || a.length !== b.length) {
-            return false;
-        }
-        return a.every((item, index) => deepEqual(item, b[index]));
-    }
-    if (Array.isArray(b)) {
-        return false;
-    }
-    const aKeys = Object.keys(a as Record<string, unknown>);
-    const bKeys = Object.keys(b as Record<string, unknown>);
-    if (aKeys.length !== bKeys.length) {
-        return false;
-    }
-    return aKeys.every(key => deepEqual(
-        (a as Record<string, unknown>)[key],
-        (b as Record<string, unknown>)[key]
-    ));
-};
 
 const editableSlice = (automation: AutomationDetail) => ({
     status: automation.status,
@@ -95,16 +67,16 @@ const AutomationEditor: React.FC = () => {
     // automation first loads, and reset to the response after every successful edit.
     const [draft, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
     React.useEffect(() => {
-        if (automation && !draft) {
-            setDraft(automation);
+        if (automation) {
+            setDraft(oldDraft => oldDraft || automation);
         }
-    }, [automation, draft]);
+    }, [automation]);
 
     // Only compare the fields the user can edit; server-stamped fields like `updated_at` would
     // otherwise flip the dirty flag immediately after every successful publish.
     const hasUnsavedChanges = !!draft
         && !!automation
-        && !deepEqual(editableSlice(draft), editableSlice(automation));
+        && !dequal(editableSlice(draft), editableSlice(automation));
 
     // A local edit clears the previous failure state — the user is moving forward, so the
     // destructive Retry affordance shouldn't linger.
@@ -146,10 +118,7 @@ const AutomationEditor: React.FC = () => {
             },
             {
                 onSuccess: (response) => {
-                    const updated = response.automations[0];
-                    if (updated) {
-                        setDraft(updated);
-                    }
+                    setDraft(response.automations[0]);
                     setEditState('idle');
                 },
                 onError: () => setEditState(errorState)

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -13,44 +13,6 @@ const editableSlice = (automation: AutomationDetail) => ({
     edges: automation.edges
 });
 
-type DerivePublishButtonChildrenArgs = {
-    editState: AutomationEditState;
-    draftStatus: AutomationStatus | undefined;
-    hasUnsavedChanges: boolean;
-};
-
-const derivePublishButtonChildren = ({
-    editState,
-    draftStatus,
-    hasUnsavedChanges
-}: DerivePublishButtonChildrenArgs): React.ReactNode => {
-    switch (editState) {
-    case 'publishing':
-        return (
-            <>
-                <LoadingIndicator color='light' size='sm' />
-                <span className='sr-only'>Publishing...</span>
-            </>
-        );
-    case 'failed to publish':
-        return 'Retry';
-    case 'idle':
-    case 'unpublishing':
-    case 'confirming unpublish':
-    case 'failed to unpublish':
-        if (draftStatus === 'active') {
-            return hasUnsavedChanges ? 'Publish changes' : 'Published';
-        }
-        // Inactive (or not yet loaded): "Publish" reads better than "Publish changes" because the
-        // automation has never been published in its current state.
-        return 'Publish';
-    default: {
-        const _exhaustive: never = editState;
-        throw new Error(`Unhandled edit state: ${_exhaustive}`);
-    }
-    }
-};
-
 const AutomationEditor: React.FC = () => {
     const {id = ''} = useParams<{id: string}>();
 
@@ -130,6 +92,11 @@ const AutomationEditor: React.FC = () => {
     let isEditRequestActive = false;
     let isPublishButtonEnabled = draft?.status === 'inactive' || hasUnsavedChanges;
     let publishButtonVariant: ButtonProps['variant'] = 'default';
+    // Inactive (or not yet loaded): "Publish" reads better than "Publish changes" because the
+    // automation has never been published in its current state.
+    let publishButtonChildren: React.ReactNode = draft?.status === 'active'
+        ? (hasUnsavedChanges ? 'Publish changes' : 'Published')
+        : 'Publish';
     let isTurnOffButtonEnabled = true;
     let turnOffButtonChildren: React.ReactNode = 'Turn off';
     switch (editState) {
@@ -137,6 +104,12 @@ const AutomationEditor: React.FC = () => {
         isEditRequestActive = true;
         isPublishButtonEnabled = false;
         isTurnOffButtonEnabled = false;
+        publishButtonChildren = (
+            <>
+                <LoadingIndicator color='light' size='sm' />
+                <span className='sr-only'>Publishing...</span>
+            </>
+        );
         break;
     case 'unpublishing':
         isEditRequestActive = true;
@@ -157,6 +130,7 @@ const AutomationEditor: React.FC = () => {
         break;
     case 'failed to publish':
         publishButtonVariant = 'destructive';
+        publishButtonChildren = 'Retry';
         break;
     case 'failed to unpublish':
         isConfirmUnpublishAlertOpen = true;
@@ -164,11 +138,6 @@ const AutomationEditor: React.FC = () => {
         turnOffButtonChildren = 'Retry';
         break;
     }
-    const publishButtonChildren = derivePublishButtonChildren({
-        editState,
-        draftStatus: draft?.status,
-        hasUnsavedChanges
-    });
 
     const onConfirmUnpublishOpenChange = (open: boolean): void => {
         setEditState((oldEditState) => {

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -30,7 +30,9 @@ const AutomationEditor: React.FC = () => {
     const [draft, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
     React.useEffect(() => {
         if (automation) {
-            setDraft(oldDraft => oldDraft || automation);
+            setDraft((oldDraft) => {
+                return oldDraft?.id === automation.id ? oldDraft : automation;
+            });
         }
     }, [automation]);
 
@@ -88,7 +90,7 @@ const AutomationEditor: React.FC = () => {
 
     let isConfirmUnpublishAlertOpen = false;
     let isEditRequestActive = false;
-    let isPublishButtonEnabled = draft?.status === 'inactive' || hasUnsavedChanges;
+    let isPublishButtonEnabled = !!draft && draft.actions.length > 0 && (draft.status === 'inactive' || hasUnsavedChanges);
     let publishButtonVariant: ButtonProps['variant'] = 'default';
     let publishButtonChildren: React.ReactNode = draft?.status === 'active'
         ? (hasUnsavedChanges ? 'Publish changes' : 'Published')

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -3,7 +3,7 @@ import AutomationHeader from './components/automation-header';
 import React from 'react';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, type ButtonProps, LoadingIndicator} from '@tryghost/shade/components';
 import {AutomationDetail, AutomationStatus, useEditAutomation, useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
-import {dequal} from 'dequal/lite';
+import {dequal} from 'dequal';
 import {useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
 
@@ -40,8 +40,6 @@ const AutomationEditor: React.FC = () => {
         && !!automation
         && !dequal(editableSlice(draft), editableSlice(automation));
 
-    // A local edit clears the previous failure state — the user is moving forward, so the
-    // destructive Retry affordance shouldn't linger.
     const onDraftChange = (next: AutomationDetail) => {
         setDraft(next);
         setEditState((prev) => {
@@ -92,8 +90,6 @@ const AutomationEditor: React.FC = () => {
     let isEditRequestActive = false;
     let isPublishButtonEnabled = draft?.status === 'inactive' || hasUnsavedChanges;
     let publishButtonVariant: ButtonProps['variant'] = 'default';
-    // Inactive (or not yet loaded): "Publish" reads better than "Publish changes" because the
-    // automation has never been published in its current state.
     let publishButtonChildren: React.ReactNode = draft?.status === 'active'
         ? (hasUnsavedChanges ? 'Publish changes' : 'Published')
         : 'Publish';

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -2,9 +2,82 @@ import AutomationCanvas from './components/automation-canvas';
 import AutomationHeader from './components/automation-header';
 import React from 'react';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, type ButtonProps, LoadingIndicator} from '@tryghost/shade/components';
-import {AutomationStatus, useEditAutomation, useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
+import {AutomationDetail, AutomationStatus, useEditAutomation, useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
 import {useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
+
+// Recursive structural equality. Used by the dirty check to compare the user-editable slice of an
+// automation (status, actions, edges) without depending on the key order of server-parsed JSON.
+const deepEqual = (a: unknown, b: unknown): boolean => {
+    if (a === b) {
+        return true;
+    }
+    if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
+        return false;
+    }
+    if (Array.isArray(a)) {
+        if (!Array.isArray(b) || a.length !== b.length) {
+            return false;
+        }
+        return a.every((item, index) => deepEqual(item, b[index]));
+    }
+    if (Array.isArray(b)) {
+        return false;
+    }
+    const aKeys = Object.keys(a as Record<string, unknown>);
+    const bKeys = Object.keys(b as Record<string, unknown>);
+    if (aKeys.length !== bKeys.length) {
+        return false;
+    }
+    return aKeys.every(key => deepEqual(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key]
+    ));
+};
+
+const editableSlice = (automation: AutomationDetail) => ({
+    status: automation.status,
+    actions: automation.actions,
+    edges: automation.edges
+});
+
+type DerivePublishButtonChildrenArgs = {
+    editState: AutomationEditState;
+    draftStatus: AutomationStatus | undefined;
+    hasUnsavedChanges: boolean;
+};
+
+const derivePublishButtonChildren = ({
+    editState,
+    draftStatus,
+    hasUnsavedChanges
+}: DerivePublishButtonChildrenArgs): React.ReactNode => {
+    switch (editState) {
+    case 'publishing':
+        return (
+            <>
+                <LoadingIndicator color='light' size='sm' />
+                <span className='sr-only'>Publishing...</span>
+            </>
+        );
+    case 'failed to publish':
+        return 'Retry';
+    case 'idle':
+    case 'unpublishing':
+    case 'confirming unpublish':
+    case 'failed to unpublish':
+        if (draftStatus === 'active') {
+            return hasUnsavedChanges ? 'Publish changes' : 'Published';
+        }
+        // Inactive (or not yet loaded): "Publish" reads better than "Publish changes" because the
+        // automation has never been published in its current state.
+        return 'Publish';
+    default: {
+        const _exhaustive: never = editState;
+        throw new Error(`Unhandled edit state: ${_exhaustive}`);
+    }
+    }
+};
 
 const AutomationEditor: React.FC = () => {
     const {id = ''} = useParams<{id: string}>();
@@ -16,8 +89,37 @@ const AutomationEditor: React.FC = () => {
 
     const editMutation = useEditAutomation();
     const [editState, setEditState] = React.useState<AutomationEditState>('idle');
+
+    // Draft is the user-facing, locally mutable copy. The React Query cache stays as server truth;
+    // staged edits (adding steps, etc.) live here until the user publishes. Seeded once when the
+    // automation first loads, and reset to the response after every successful edit.
+    const [draft, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
+    React.useEffect(() => {
+        if (automation && !draft) {
+            setDraft(automation);
+        }
+    }, [automation, draft]);
+
+    // Only compare the fields the user can edit; server-stamped fields like `updated_at` would
+    // otherwise flip the dirty flag immediately after every successful publish.
+    const hasUnsavedChanges = !!draft
+        && !!automation
+        && !deepEqual(editableSlice(draft), editableSlice(automation));
+
+    // A local edit clears the previous failure state — the user is moving forward, so the
+    // destructive Retry affordance shouldn't linger.
+    const onDraftChange = (next: AutomationDetail) => {
+        setDraft(next);
+        setEditState((prev) => {
+            if (prev === 'failed to publish' || prev === 'failed to unpublish') {
+                return 'idle';
+            }
+            return prev;
+        });
+    };
+
     const editStatus = (status: AutomationStatus): void => {
-        if (!automation) {
+        if (!draft) {
             throw new Error('Cannot edit an automation that has not loaded.');
         }
         let errorState: AutomationEditState;
@@ -37,13 +139,19 @@ const AutomationEditor: React.FC = () => {
         }
         editMutation.mutate(
             {
-                id: automation.id,
+                id: draft.id,
                 status,
-                actions: automation.actions,
-                edges: automation.edges
+                actions: draft.actions,
+                edges: draft.edges
             },
             {
-                onSuccess: () => setEditState('idle'),
+                onSuccess: (response) => {
+                    const updated = response.automations[0];
+                    if (updated) {
+                        setDraft(updated);
+                    }
+                    setEditState('idle');
+                },
                 onError: () => setEditState(errorState)
             }
         );
@@ -51,22 +159,15 @@ const AutomationEditor: React.FC = () => {
 
     let isConfirmUnpublishAlertOpen = false;
     let isEditRequestActive = false;
-    let isPublishButtonEnabled = automation?.status === 'inactive';
+    let isPublishButtonEnabled = draft?.status === 'inactive' || hasUnsavedChanges;
     let publishButtonVariant: ButtonProps['variant'] = 'default';
     let isTurnOffButtonEnabled = true;
-    let publishButtonChildren: React.ReactNode = automation?.status === 'active' ? 'Published' : 'Publish changes';
     let turnOffButtonChildren: React.ReactNode = 'Turn off';
     switch (editState) {
     case 'publishing':
         isEditRequestActive = true;
         isPublishButtonEnabled = false;
         isTurnOffButtonEnabled = false;
-        publishButtonChildren = (
-            <>
-                <LoadingIndicator color='light' size='sm' />
-                <span className='sr-only'>Publishing...</span>
-            </>
-        );
         break;
     case 'unpublishing':
         isEditRequestActive = true;
@@ -87,7 +188,6 @@ const AutomationEditor: React.FC = () => {
         break;
     case 'failed to publish':
         publishButtonVariant = 'destructive';
-        publishButtonChildren = 'Retry';
         break;
     case 'failed to unpublish':
         isConfirmUnpublishAlertOpen = true;
@@ -95,6 +195,11 @@ const AutomationEditor: React.FC = () => {
         turnOffButtonChildren = 'Retry';
         break;
     }
+    const publishButtonChildren = derivePublishButtonChildren({
+        editState,
+        draftStatus: draft?.status,
+        hasUnsavedChanges
+    });
 
     const onConfirmUnpublishOpenChange = (open: boolean): void => {
         setEditState((oldEditState) => {
@@ -121,7 +226,7 @@ const AutomationEditor: React.FC = () => {
     return (
         <div className='flex h-full w-full flex-col' data-testid='automation-editor'>
             <AutomationHeader
-                automation={automation}
+                automation={draft}
                 isLoadingAutomation={isLoadingAutomation}
                 isPublishButtonEnabled={isPublishButtonEnabled}
                 isTurnOffButtonEnabled={isTurnOffButtonEnabled}
@@ -131,7 +236,12 @@ const AutomationEditor: React.FC = () => {
                 onTurnOff={() => setEditState('confirming unpublish')}
             />
 
-            <AutomationCanvas automation={automation} isError={isError} isLoading={isLoadingAutomation} />
+            <AutomationCanvas
+                automation={draft}
+                isError={isError}
+                isLoading={isLoadingAutomation}
+                onChange={onDraftChange}
+            />
 
             <AlertDialog
                 open={isConfirmUnpublishAlertOpen}

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1,8 +1,9 @@
 import AutomationEditor from '@src/views/Automations/editor';
 import React from 'react';
+import {AutomationDetail, MAX_AUTOMATION_ACTIONS} from '@tryghost/admin-x-framework/api/automations';
 import {MemoryRouter, Route, Routes} from 'react-router';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 
 const mockUseReadAutomation = vi.fn();
 const mockEditMutation = {
@@ -11,26 +12,34 @@ const mockEditMutation = {
     variables: undefined as {id: string; status: 'active' | 'inactive'} | undefined
 };
 
-vi.mock('@tryghost/admin-x-framework/api/automations', () => ({
-    useReadAutomation: (...args: unknown[]) => mockUseReadAutomation(...args),
-    useEditAutomation: () => mockEditMutation
-}));
+vi.mock('@tryghost/admin-x-framework/api/automations', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/automations')>(
+        '@tryghost/admin-x-framework/api/automations'
+    );
+    return {
+        ...actual,
+        useReadAutomation: (...args: unknown[]) => mockUseReadAutomation(...args),
+        useEditAutomation: () => mockEditMutation
+    };
+});
 
 // xyflow's ReactFlow needs a sized container; stub it out for unit tests.
 type StubNode = {id: string; data?: Record<string, unknown>; type?: string};
-type StubEdge = {id: string; source: string; target: string};
+type StubEdge = {id: string; source: string; target: string; type?: string; data?: Record<string, unknown>};
 type StubReactFlowProps = {
     nodes: StubNode[];
     edges?: StubEdge[];
     nodeTypes?: Record<string, React.ComponentType<NodeRenderProps>>;
+    edgeTypes?: Record<string, React.ComponentType<EdgeRenderProps>>;
 };
 type NodeRenderProps = {id: string; data: Record<string, unknown>; type: string};
+type EdgeRenderProps = {id: string; data: Record<string, unknown>; sourceX: number; sourceY: number; targetX: number; targetY: number; sourcePosition: string; targetPosition: string};
 
 vi.mock('@xyflow/react', async () => {
     const actual = await vi.importActual<typeof import('@xyflow/react')>('@xyflow/react');
     return {
         ...actual,
-        ReactFlow: ({nodes, edges, nodeTypes}: StubReactFlowProps) => (
+        ReactFlow: ({nodes, edges, nodeTypes, edgeTypes}: StubReactFlowProps) => (
             <div data-testid='react-flow-mock'>
                 {nodes.map((node) => {
                     const nodeType = node.type ?? 'default';
@@ -42,33 +51,48 @@ vi.mock('@xyflow/react', async () => {
                     );
                 })}
                 <ul data-testid='react-flow-mock-edges'>
-                    {(edges ?? []).map(edge => (
-                        <li key={edge.id} data-edge-id={edge.id} data-source={edge.source} data-target={edge.target} />
-                    ))}
+                    {(edges ?? []).map((edge) => {
+                        const Custom = edge.type ? edgeTypes?.[edge.type] : undefined;
+                        return (
+                            <li key={edge.id} data-edge-id={edge.id} data-edge-type={edge.type ?? 'smoothstep'} data-source={edge.source} data-target={edge.target}>
+                                {Custom ? (
+                                    <Custom
+                                        data={edge.data ?? {}}
+                                        id={edge.id}
+                                        sourcePosition='bottom'
+                                        sourceX={0}
+                                        sourceY={0}
+                                        targetPosition='top'
+                                        targetX={0}
+                                        targetY={0}
+                                    />
+                                ) : null}
+                            </li>
+                        );
+                    })}
                 </ul>
             </div>
         ),
         Background: () => null,
-        Handle: () => null
+        Handle: () => null,
+        BaseEdge: () => null,
+        EdgeLabelRenderer: ({children}: {children: React.ReactNode}) => <>{children}</>,
+        getSmoothStepPath: () => ['M 0 0', 0, 0]
     };
 });
 
-const automationDetail = {
+const automationDetail: AutomationDetail = {
     id: 'automation-id-1',
     slug: 'member-welcome-email-free',
     name: 'Welcome Email (Free)',
-    status: 'active' as const,
+    status: 'active',
     created_at: '2026-05-05T00:00:00.000Z',
     updated_at: '2026-05-05T00:00:00.000Z',
     actions: [
-        {
-            id: 'action-wait',
-            type: 'wait' as const,
-            data: {wait_hours: 24}
-        },
+        {id: 'action-wait', type: 'wait', data: {wait_hours: 24}},
         {
             id: 'action-email',
-            type: 'send_email' as const,
+            type: 'send_email',
             data: {
                 email_subject: 'Welcome to The Blueprint',
                 email_lexical: '{"root":{"children":[]}}',
@@ -79,9 +103,7 @@ const automationDetail = {
             }
         }
     ],
-    edges: [
-        {source_action_id: 'action-wait', target_action_id: 'action-email'}
-    ]
+    edges: [{source_action_id: 'action-wait', target_action_id: 'action-email'}]
 };
 
 const renderEditor = () => render(
@@ -110,7 +132,7 @@ describe('AutomationEditor', () => {
         renderEditor();
 
         expect(screen.getByTestId('automation-canvas-loading')).toBeInTheDocument();
-        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Publish'})).toBeDisabled();
     });
 
     it('renders the error banner when the read query fails', () => {
@@ -165,10 +187,10 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Publish'})).toBeDisabled();
     });
 
-    it('publishes an inactive automation when clicking Publish changes', () => {
+    it('publishes an inactive automation when clicking Publish', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},
             isLoading: false,
@@ -177,7 +199,7 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        const button = screen.getByRole('button', {name: 'Publish changes'});
+        const button = screen.getByRole('button', {name: 'Publish'});
         expect(button).not.toBeDisabled();
         fireEvent.click(button);
 
@@ -226,7 +248,7 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
 
         const button = screen.getByRole('button', {name: 'Publishing...'});
         expect(button).toBeDisabled();
@@ -266,7 +288,7 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
 
         const button = await screen.findByRole('button', {name: 'Retry'});
         expect(button).not.toBeDisabled();
@@ -354,8 +376,8 @@ describe('AutomationEditor', () => {
             isLoading: false,
             isError: false
         });
-        mockEditMutation.mutate.mockImplementation((_payload, options) => {
-            options.onSuccess();
+        mockEditMutation.mutate.mockImplementation((payload, options) => {
+            options.onSuccess({automations: [{...automationDetail, status: payload.status}]});
         });
 
         renderEditor();
@@ -381,5 +403,369 @@ describe('AutomationEditor', () => {
         renderEditor();
 
         expect(screen.getByRole('link', {name: 'Back to automations'})).toHaveAttribute('href', '/automations');
+    });
+
+    it('inserts a wait step at the tail when the tail + is clicked and a type is picked', async () => {
+        // Use a 12-hour wait in the fixture so the appended 24h step's "1 day" label is distinguishable.
+        const fixture: AutomationDetail = {
+            ...automationDetail,
+            actions: [
+                {id: 'action-wait', type: 'wait', data: {wait_hours: 12}},
+                automationDetail.actions[1]
+            ]
+        };
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [fixture]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        // The picker renders into a portal; query the document body.
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Wait'));
+
+        // The new step renders with the default 24h wait ("1 day") at the end of the chain.
+        expect(screen.getByText('1 day')).toBeInTheDocument();
+        // Adding a step flips the editor into a dirty state.
+        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+    });
+
+    it('inserts a send_email step with placeholder defaults when picked from the tail', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Send email'));
+
+        // The new send_email step renders with the placeholder subject.
+        expect(screen.getByText('Untitled email')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+    });
+
+    it('inserts a step between two existing actions via the in-edge + button', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByTestId('add-step-button-action-wait-action-email'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Wait'));
+
+        // The canvas now shows three step nodes (the trigger + tail are extra), with two "Wait" labels.
+        expect(screen.getAllByText('Wait')).toHaveLength(2);
+        // The original wait→send_email edge has been split: the new edge order goes
+        // action-wait → <new> → action-email.
+        const edgeList = screen.getByTestId('react-flow-mock-edges');
+        const edgePairs = Array.from(edgeList.querySelectorAll('li')).map(li => [
+            li.getAttribute('data-source'),
+            li.getAttribute('data-target')
+        ]);
+        expect(edgePairs.some(([source, target]) => source === 'action-wait' && target === 'action-email')).toBe(false);
+        const insertedId = edgePairs.find(([source]) => source === 'action-wait')?.[1];
+        expect(insertedId).toBeTruthy();
+        expect(edgePairs).toContainEqual([insertedId, 'action-email']);
+    });
+
+    it('enables Publish changes when the user adds a step locally', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
+
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Wait'));
+
+        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+    });
+
+    it('publishes structural changes and clears dirty state when Publish succeeds', async () => {
+        const inactive: AutomationDetail = {...automationDetail, status: 'inactive'};
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [inactive]},
+            isLoading: false,
+            isError: false
+        });
+
+        // After mutate, echo the submitted payload back so the editor's draft snaps to the
+        // post-publish state. Also bump the read mock so the next render sees the server in sync
+        // (with a fresh updated_at, which the dirty check is intentionally insensitive to).
+        mockEditMutation.mutate.mockImplementation((payload, options) => {
+            const published: AutomationDetail = {
+                ...inactive,
+                status: payload.status,
+                actions: payload.actions,
+                edges: payload.edges,
+                updated_at: '2026-05-06T00:00:00.000Z'
+            };
+            mockUseReadAutomation.mockReturnValue({
+                data: {automations: [published]},
+                isLoading: false,
+                isError: false
+            });
+            options.onSuccess({automations: [published]});
+        });
+
+        renderEditor();
+
+        // Stage a structural change locally via the canvas — this is the only way drafts diverge now.
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Wait'));
+
+        // The fixture is inactive, so the button reads "Publish" regardless of dirty state.
+        const publishButton = screen.getByRole('button', {name: 'Publish'});
+        expect(publishButton).toBeEnabled();
+        fireEvent.click(publishButton);
+
+        const mutateCall = mockEditMutation.mutate.mock.calls.at(-1)![0];
+        expect(mutateCall.id).toBe('automation-id-1');
+        expect(mutateCall.status).toBe('active');
+        // Three actions now: the original wait + send_email + the locally-added wait.
+        expect(mutateCall.actions).toHaveLength(3);
+
+        // After publish the draft matches the response, so the button settles on Published + disabled.
+        expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
+    });
+
+    it('disables both + affordances when the action limit is reached', () => {
+        const filled: AutomationDetail = {
+            ...automationDetail,
+            actions: Array.from({length: MAX_AUTOMATION_ACTIONS}, (_, index) => ({
+                id: `wait-${index}`,
+                type: 'wait' as const,
+                data: {wait_hours: 24}
+            })),
+            edges: Array.from({length: MAX_AUTOMATION_ACTIONS - 1}, (_, index) => ({
+                source_action_id: `wait-${index}`,
+                target_action_id: `wait-${index + 1}`
+            }))
+        };
+
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [filled]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        // The tail is a div with role=button; check aria-disabled instead of the disabled attribute.
+        expect(screen.getByTestId('add-step-tail-button')).toHaveAttribute('aria-disabled', 'true');
+        // The edge + uses a real <button> element.
+        expect(screen.getByTestId('add-step-button-wait-0-wait-1')).toBeDisabled();
+    });
+
+    it('keeps both + affordances enabled at one below the action limit', () => {
+        const justUnder: AutomationDetail = {
+            ...automationDetail,
+            actions: Array.from({length: MAX_AUTOMATION_ACTIONS - 1}, (_, index) => ({
+                id: `wait-${index}`,
+                type: 'wait' as const,
+                data: {wait_hours: 24}
+            })),
+            edges: Array.from({length: MAX_AUTOMATION_ACTIONS - 2}, (_, index) => ({
+                source_action_id: `wait-${index}`,
+                target_action_id: `wait-${index + 1}`
+            }))
+        };
+
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [justUnder]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        expect(screen.getByTestId('add-step-tail-button')).not.toHaveAttribute('aria-disabled', 'true');
+        expect(screen.getByTestId('add-step-button-wait-0-wait-1')).not.toBeDisabled();
+    });
+
+    it('does not flip the dirty flag when the server refetches with only a new updated_at', () => {
+        const initial = {...automationDetail, updated_at: '2026-05-05T00:00:00.000Z'};
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [initial]},
+            isLoading: false,
+            isError: false
+        });
+
+        const {rerender} = renderEditor();
+
+        // Baseline: clean active automation → Published, disabled.
+        expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
+
+        // Simulate a focus-refetch that updates only `updated_at` (server-stamped, not user-editable).
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...initial, updated_at: '2026-05-06T12:34:56.000Z'}]},
+            isLoading: false,
+            isError: false
+        });
+        rerender(
+            <MemoryRouter initialEntries={['/automations/automation-id-1']}>
+                <Routes>
+                    <Route element={<AutomationEditor />} path='/automations/:id' />
+                </Routes>
+            </MemoryRouter>
+        );
+
+        expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
+    });
+
+    it('adds three steps locally and publishes them all in the mutate payload', async () => {
+        // Start from a clean active automation; we'll stage three local inserts before publishing.
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+        mockEditMutation.mutate.mockImplementation((payload, options) => {
+            options.onSuccess({automations: [{
+                ...automationDetail,
+                actions: payload.actions,
+                edges: payload.edges
+            }]});
+        });
+
+        renderEditor();
+
+        // Insert at the tail three times in a row.
+        const pickWaitAtTail = async () => {
+            fireEvent.click(screen.getByTestId('add-step-tail-button'));
+            const picker = await screen.findByTestId('step-picker');
+            fireEvent.click(within(picker).getByText('Wait'));
+        };
+        await pickWaitAtTail();
+        await pickWaitAtTail();
+        await pickWaitAtTail();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
+
+        const mutateCall = mockEditMutation.mutate.mock.calls.at(-1)![0];
+        // Original 2 actions + 3 locally inserted = 5.
+        expect(mutateCall.actions).toHaveLength(5);
+        // The edge graph should form one continuous chain (n-1 edges connecting all actions).
+        expect(mutateCall.edges).toHaveLength(4);
+        const sources = new Set(mutateCall.edges.map((e: {source_action_id: string}) => e.source_action_id));
+        const targets = new Set(mutateCall.edges.map((e: {target_action_id: string}) => e.target_action_id));
+        // Every source/target references a real action in the payload.
+        const actionIds = new Set(mutateCall.actions.map((a: {id: string}) => a.id));
+        sources.forEach(id => expect(actionIds.has(id as string)).toBe(true));
+        targets.forEach(id => expect(actionIds.has(id as string)).toBe(true));
+    });
+
+    // Publish-button label matrix. Captures the contract that the label switches across the four
+    // combinations of (status, dirty). One assertion per cell so a regression in any cell flags
+    // a specific test, not a parameterized table.
+    const stageLocalEdit = async () => {
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Wait'));
+    };
+
+    it('publish-button label: inactive + clean reads "Publish" and is enabled', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+        renderEditor();
+        expect(screen.getByRole('button', {name: 'Publish'})).toBeEnabled();
+    });
+
+    it('publish-button label: inactive + dirty still reads "Publish" (not "Publish changes")', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+        renderEditor();
+        await stageLocalEdit();
+        expect(screen.getByRole('button', {name: 'Publish'})).toBeEnabled();
+    });
+
+    it('publish-button label: active + clean reads "Published" and is disabled', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+        renderEditor();
+        expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
+    });
+
+    it('publish-button label: active + dirty reads "Publish changes" and is enabled', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+        renderEditor();
+        await stageLocalEdit();
+        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+    });
+
+    it('clears the Retry state when the user stages another local edit after a failed publish', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+        mockEditMutation.mutate.mockImplementation((_payload, options) => {
+            options.onError();
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
+        // After the failure, the button is the destructive Retry.
+        expect(await screen.findByRole('button', {name: 'Retry'})).toHaveClass('bg-destructive');
+
+        // Staging another local edit clears the failure state; the button returns to plain Publish.
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Wait'));
+
+        const recoveredButton = screen.getByRole('button', {name: 'Publish'});
+        expect(recoveredButton).toBeEnabled();
+        expect(recoveredButton).not.toHaveClass('bg-destructive');
+    });
+
+    it('survives onSuccess returning an empty automations array', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+        mockEditMutation.mutate.mockImplementation((_payload, options) => {
+            options.onSuccess({automations: []});
+        });
+
+        renderEditor();
+
+        // Should not throw; editor returns to idle (button enabled and labeled "Publish" since the
+        // draft is still inactive after the no-op response).
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
+
+        const button = screen.getByRole('button', {name: 'Publish'});
+        expect(button).toBeEnabled();
     });
 });

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -418,11 +418,11 @@ describe('AutomationEditor', () => {
     });
 
     it('inserts a wait step at the tail when the tail + is clicked and a type is picked', async () => {
-        // Use a 12-hour wait in the fixture so the appended 24h step's "1 day" label is distinguishable.
+        // Use a 48-hour wait in the fixture so the appended 24h step's "1 day" label is distinguishable.
         const fixture: AutomationDetail = {
             ...automationDetail,
             actions: [
-                {id: 'action-wait', type: 'wait', data: {wait_hours: 12}},
+                {id: 'action-wait', type: 'wait', data: {wait_hours: 48}},
                 automationDetail.actions[1]
             ]
         };

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -423,7 +423,6 @@ describe('AutomationEditor', () => {
         renderEditor();
 
         fireEvent.click(screen.getByTestId('add-step-tail-button'));
-        // The picker renders into a portal; query the document body.
         const picker = await screen.findByTestId('step-picker');
         fireEvent.click(within(picker).getByText('Wait'));
 
@@ -444,7 +443,7 @@ describe('AutomationEditor', () => {
 
         fireEvent.click(screen.getByTestId('add-step-tail-button'));
         const picker = await screen.findByTestId('step-picker');
-        fireEvent.click(within(picker).getByText('Send email'));
+        fireEvent.click(within(picker).getByText('Email'));
 
         // The new send_email step renders with the placeholder subject.
         expect(screen.getByText('Untitled email')).toBeInTheDocument();
@@ -747,25 +746,5 @@ describe('AutomationEditor', () => {
         const recoveredButton = screen.getByRole('button', {name: 'Publish'});
         expect(recoveredButton).toBeEnabled();
         expect(recoveredButton).not.toHaveClass('bg-destructive');
-    });
-
-    it('survives onSuccess returning an empty automations array', () => {
-        mockUseReadAutomation.mockReturnValue({
-            data: {automations: [{...automationDetail, status: 'inactive'}]},
-            isLoading: false,
-            isError: false
-        });
-        mockEditMutation.mutate.mockImplementation((_payload, options) => {
-            options.onSuccess({automations: []});
-        });
-
-        renderEditor();
-
-        // Should not throw; editor returns to idle (button enabled and labeled "Publish" since the
-        // draft is still inactive after the no-op response).
-        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
-
-        const button = screen.getByRole('button', {name: 'Publish'});
-        expect(button).toBeEnabled();
     });
 });

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -172,7 +172,7 @@ describe('AutomationEditor', () => {
             li.getAttribute('data-target')
         ]);
         expect(edgePairs).toEqual([
-            ['trigger', 'action-wait'],
+            ['__trigger__', 'action-wait'],
             ['action-wait', 'action-email'],
             ['action-email', '__tail__']
         ]);

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -190,6 +190,18 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Publish'})).toBeDisabled();
     });
 
+    it('disables the publish button when the automation has no actions', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive', actions: [], edges: []}]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        expect(screen.getByRole('button', {name: 'Publish'})).toBeDisabled();
+    });
+
     it('publishes an inactive automation when clicking Publish', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ catalogs:
     storybook:
       specifier: 10.3.5
       version: 10.3.5
+    type-fest:
+      specifier: 4.41.0
+      version: 4.41.0
     typescript:
       specifier: 5.9.3
       version: 5.9.3
@@ -753,6 +756,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.12.14(@types/node@25.6.0)(typescript@5.9.3)
+      type-fest:
+        specifier: 'catalog:'
+        version: 4.41.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,7 +693,7 @@ importers:
         specifier: workspace:*
         version: link:../shade
       bson-objectid:
-        specifier: 2.0.4
+        specifier: 'catalog:'
         version: 2.0.4
       react:
         specifier: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ catalogs:
     cross-fetch:
       specifier: 4.1.0
       version: 4.1.0
+    dequal:
+      specifier: 2.0.3
+      version: 2.0.3
     dompurify:
       specifier: 3.4.1
       version: 3.4.1
@@ -1159,6 +1162,9 @@ importers:
       '@xyflow/react':
         specifier: 12.8.6
         version: 12.8.6(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      dequal:
+        specifier: 'catalog:'
+        version: 2.0.3
       i18n-iso-countries:
         specifier: 7.14.0
         version: 7.14.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,9 @@ importers:
       '@tryghost/shade':
         specifier: workspace:*
         version: link:../shade
+      bson-objectid:
+        specifier: 2.0.4
+        version: 2.0.4
       react:
         specifier: 18.3.1
         version: 18.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,7 @@ catalog:
   sinon: 21.1.1
   sonner: 2.0.7
   storybook: 10.3.5
+  type-fest: 4.41.0
   typescript: 5.9.3
   validator: 13.12.0
   vite: 7.3.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,7 @@ catalog:
   clsx: 2.1.1
   concurrently: 8.2.2
   cross-fetch: 4.1.0
+  dequal: 2.0.3
   dompurify: 3.4.1
   dotenv: 17.3.1
   eslint: 8.57.1


### PR DESCRIPTION
closes [NY-1255](https://linear.app/ghost/issue/NY-1255/add-ability-to-add-additional-delayssteps)

## Summary

- Adds step insertion to the automations editor so publishers can add wait or email steps from the tail `+` button.
- Adds hover insertion between existing steps via a circular `+` control on connecting lines.
- Stages inserted steps locally, tracks dirty state against the server automation, and publishes the updated action/edge graph in the edit payload.
- Adds automation helper coverage for inserting actions at the head, tail, and between existing actions, including immutable updates and invalid anchor handling.

## Notes

- New wait steps default to a 24-hour delay, displayed as `1 day`.
- New email steps use placeholder email content and subject until the email editing work lands.
- The action limit is enforced at `MAX_AUTOMATION_ACTIONS`; both tail and in-edge add controls are disabled at the limit.
- Active automations show `Publish changes` only when staged edits differ from the server copy; inactive automations continue to show `Publish`.

<img width="1323" height="615" alt="Screenshot 2026-05-18 at 2 55 26 PM" src="https://github.com/user-attachments/assets/bc704e47-8082-4543-b5e6-94b0c3e72b29" />

when limit of 20 is reached, just shows a tool tip and a not-allowed cursor (not shown here bc screenshot)
<img width="446" height="289" alt="Screenshot 2026-05-18 at 2 58 23 PM" src="https://github.com/user-attachments/assets/07f4f268-0fe0-4219-88f9-a2d3e0d97e07" />
