### PR TITLE
Added pnpmDedupe to Renovate postUpdateOptions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,14 @@
     "toolSettings": {
         "nodeMaxMemory": 1024
     },
+    // Run `pnpm dedupe` after every lockfile update. The shared preset still
+    // passes `yarnDedupeHighest`, which is a no-op for pnpm — Renovate's array
+    // merge concats both, so this entry is what actually consolidates duplicate
+    // transitive versions in `pnpm-lock.yaml`. Local override pending an upstream
+    // swap in tryghost/renovate-config.
+    "postUpdateOptions": [
+        "pnpmDedupe"
+    ],
     // We have to disable platform based automerge (forcing renovate to do it manually)
     // as otherwise renovate wont follow our schedule
     "platformAutomerge": false,


### PR DESCRIPTION
## Summary
- Renovate has been running zero lockfile dedupe since the repo moved off yarn. The shared `tryghost/renovate-config` preset passes `yarnDedupeHighest`, which `yarn-deduplicate` can't apply to `pnpm-lock.yaml` — so it's a silent no-op.
- Adding `"postUpdateOptions": ["pnpmDedupe"]` here makes Renovate run `pnpm dedupe` after every lockfile update. Renovate's array merge concats with the preset's value, so `yarnDedupeHighest` keeps being a harmless no-op until it's swapped upstream in `tryghost/renovate-config`.
- Expected to slightly reduce duplicated transitive versions in `pnpm-lock.yaml` over time, shrink the on-disk store, and reduce transitive-vuln exposure from stale versions.

## Test plan
- [ ] First Renovate PR that touches `pnpm-lock.yaml` after merge runs `pnpm dedupe` as part of the update. Lockfile diff on that PR will likely be noisier than usual as accumulated duplicates collapse — that's expected, one-time.
- [ ] No change to `package.json` files. `pnpm dedupe` only consolidates within existing semver constraints.

## Follow-up
- Upstream the swap in `tryghost/renovate-config:quiet.json5` so other repos extending the preset benefit and the local override here can be removed.