### PR TITLE
Combined "enqueue automations poll" operations into one

### DIFF
--- a/ghost/core/core/server/services/automations/index.js
+++ b/ghost/core/core/server/services/automations/index.js
@@ -42,6 +42,12 @@ class AutomationsService {
 
         /** @param {Readonly<Date>} date */
         const enqueuePollAt = async (date) => {
+            const isRequestedDateInTheFuture = new Date() < date;
+            if (!isRequestedDateInTheFuture) {
+                this.#enqueuePollNow();
+                return;
+            }
+
             try {
                 const key = await internalKeys.get('ghost-scheduler');
                 const signedAdminToken = getSignedAdminToken({publishedAt: date.toISOString(), apiUrl, key});
@@ -55,13 +61,13 @@ class AutomationsService {
 
         domainEvents.subscribe(StartAutomationsPollEvent, oneAtATime(async () => poll({
             memberWelcomeEmailService,
-            enqueueAnotherPollNow: this.#enqueuePollNow,
             enqueueAnotherPollAt: enqueuePollAt
         })));
 
         schedulerAdapter.register(this);
 
-        this.#enqueuePollNow();
+        enqueuePollAt(new Date());
+
         this.#initialized = true;
     }
 

--- a/ghost/core/core/server/services/automations/poll.js
+++ b/ghost/core/core/server/services/automations/poll.js
@@ -264,13 +264,11 @@ async function processRun({
  *
  * @param {object} options
  * @param {MemberWelcomeEmailService} options.memberWelcomeEmailService
- * @param {() => unknown} options.enqueueAnotherPollNow
  * @param {(date: Readonly<Date>) => unknown} options.enqueueAnotherPollAt
  */
 async function poll(options) {
     const {
         memberWelcomeEmailService,
-        enqueueAnotherPollNow,
         enqueueAnotherPollAt
     } = options;
     const {runs, nextFutureReadyAt} = await fetchAndLockRuns();
@@ -290,7 +288,7 @@ async function poll(options) {
     // If the batch is full, we might have another batch to execute. (There's
     // no way to know without trying.)
     if (runs.length >= MAX_RUNS_PER_BATCH) {
-        enqueueAnotherPollNow();
+        enqueueAnotherPollAt(new Date());
     }
 }
 

--- a/ghost/core/test/integration/services/automations/poll.test.js
+++ b/ghost/core/test/integration/services/automations/poll.test.js
@@ -34,7 +34,6 @@ describe('automations poll', function () {
                     send: sinon.stub().resolves()
                 }
             },
-            enqueueAnotherPollNow: sinon.stub(),
             enqueueAnotherPollAt: sinon.stub()
         };
     });
@@ -168,7 +167,6 @@ describe('automations poll', function () {
         sinon.assert.notCalled(options.memberWelcomeEmailService.init);
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.loadMemberWelcomeEmails);
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
         sinon.assert.notCalled(options.enqueueAnotherPollAt);
         assert.deepEqual(await readTrackedRecipients(), []);
     });
@@ -213,7 +211,6 @@ describe('automations poll', function () {
         sinon.assert.notCalled(options.memberWelcomeEmailService.init);
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.loadMemberWelcomeEmails);
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
         sinon.assert.calledWith(options.enqueueAnotherPollAt, futureReadyAt);
         assert.deepEqual(await readTrackedRecipients(), []);
     });
@@ -258,7 +255,6 @@ describe('automations poll', function () {
 
         sinon.assert.calledOnce(options.memberWelcomeEmailService.init);
         sinon.assert.calledOnce(options.memberWelcomeEmailService.api.loadMemberWelcomeEmails);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
 
         sinon.assert.calledWith(options.memberWelcomeEmailService.api.send, sinon.match({
             member: {
@@ -328,7 +324,6 @@ describe('automations poll', function () {
         sinon.assert.calledOnce(options.memberWelcomeEmailService.init);
         sinon.assert.calledOnce(options.memberWelcomeEmailService.api.loadMemberWelcomeEmails);
         sinon.assert.calledOnce(options.memberWelcomeEmailService.api.send);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
 
         const enqueuedAt = options.enqueueAnotherPollAt.firstCall.args[0];
         const enqueuedDrift = Math.abs(enqueuedAt.getTime() - (pollStart + RETRY_DELAY_MS));
@@ -403,7 +398,6 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
         sinon.assert.notCalled(options.enqueueAnotherPollAt);
 
         const updatedRun = await readRun(run.id);
@@ -432,7 +426,6 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
         sinon.assert.notCalled(options.enqueueAnotherPollAt);
         assert.deepEqual(await readTrackedRecipients(), []);
 
@@ -467,7 +460,6 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
         sinon.assert.notCalled(options.enqueueAnotherPollAt);
         assert.equal(await readRun(run.id), undefined);
         assert.deepEqual(await readTrackedRecipients(), []);
@@ -498,7 +490,6 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
         sinon.assert.notCalled(options.enqueueAnotherPollAt);
         assert.deepEqual(await readTrackedRecipients(), []);
 
@@ -566,7 +557,6 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.notCalled(options.memberWelcomeEmailService.api.send);
-        sinon.assert.notCalled(options.enqueueAnotherPollNow);
 
         const updatedRun = await readRun(run.id);
         assert.equal(updatedRun.exit_reason, 'email send failed');
@@ -591,9 +581,15 @@ describe('automations poll', function () {
             });
         }
 
+        const beforePoll = new Date();
+
         await poll(options);
 
         sinon.assert.callCount(options.memberWelcomeEmailService.api.send, MAX_RUNS_PER_BATCH);
-        sinon.assert.calledOnce(options.enqueueAnotherPollNow);
+        sinon.assert.calledOnceWithExactly(options.enqueueAnotherPollAt, sinon.match(date => (
+            date instanceof Date &&
+            date <= new Date() &&
+            date >= beforePoll
+        )));
     });
 });


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1286

This change should have no user impact.

Before (pseudocode):

```javascript
const enqueuePollNow = () => {
    dispatch(StartAutomationsPollEvent.create());
};
const enqueuePollAt = (date) => {
    scheduler.at(date, 'PUT', '/automations/poll');
};
```

After (pseudocode):

```javascript
const enqueuePollAt = (date) => {
    if (new Date() < date) {
        dispatch(StartAutomationsPollEvent.create());
    } else {
        scheduler.at(date, 'PUT', '/automations/poll');
    }
};
```

I think this is a useful change on its own (makes it easier for functions that want this behavior), but it'll also make [an upcoming change][0] easier.

[0]: https://linear.app/ghost/issue/NY-1286
