### PR TITLE
Fixed `/gift` returning HTTP 404

### DIFF
--- a/ghost/core/core/server/web/gift-preview/app.js
+++ b/ghost/core/core/server/web/gift-preview/app.js
@@ -1,6 +1,4 @@
 const express = require('../../../shared/express');
-const errorHandler = require('@tryghost/mw-error-handler');
-const sentry = require('../../../shared/sentry');
 const controller = require('./controller');
 
 module.exports = function giftPreviewApp() {
@@ -8,9 +6,6 @@ module.exports = function giftPreviewApp() {
 
     app.get('/:token/image', controller.giftPreviewImage);
     app.get('/:token', controller.giftPreview);
-
-    app.use(errorHandler.pageNotFound);
-    app.use(errorHandler.handleHTMLResponse(sentry));
 
     return app;
 };

--- a/ghost/core/test/e2e-frontend/default-routes.test.js
+++ b/ghost/core/test/e2e-frontend/default-routes.test.js
@@ -116,6 +116,37 @@ describe('Default Frontend routing', function () {
         });
     });
 
+    describe('Gift preview routes', function () {
+        before(async function () {
+            await testUtils.createPost({
+                post: {
+                    title: 'Gift a subscription',
+                    slug: 'gift',
+                    status: 'published',
+                    type: 'page'
+                }
+            });
+        });
+
+        it('does not intercept /gift/ when no token is provided — a custom page at that slug renders', async function () {
+            await request.get('/gift/')
+                .expect('Content-Type', /html/)
+                .expect(200)
+                .expect(assertCorrectFrontendHeaders)
+                .expect((res) => {
+                    const $ = cheerio.load(res.text);
+
+                    assert.match($('title').text(), /Gift a subscription/);
+                });
+        });
+
+        it('still handles /gift/<token> via the gift-preview controller (invalid token redirects to homepage)', async function () {
+            await request.get('/gift/this-token-does-not-exist')
+                .expect(302)
+                .expect('Location', /\/$/);
+        });
+    });
+
     describe('Single post', function () {
         it('/welcome/ should respond with valid HTML', async function () {
             await request.get('/welcome/')


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3662

## Summary

Gift subscription redemption links live at `/gift/<token>`. The sub-app at `ghost/core/core/server/web/gift-preview/` is mounted via `frontendApp.lazyUse('/gift', ...)` and currently captures **every** `/gift*` request — including the bare `/gift` and `/gift/`, which fall through to `errorHandler.pageNotFound` and produce a 404. That makes it impossible for a site owner to use `/gift` as a navigation link backed by a custom Ghost page or `routes.yaml` entry.

This PR removes the two terminating error-handler middlewares (and their now-unused imports) from the gift-preview sub-app. Tokenless requests now fall through into Ghost's normal frontend routing, where:

- a Ghost page with slug `gift` renders if one exists,
- a `routes.yaml` entry for `/gift/` is honored if one exists,
- otherwise Ghost's standard themed 404 is served (same as any other unconfigured path).

The token-bearing redemption flow (`/gift/<token>`, `/gift/<token>/image`) is untouched.

### Why this is safe

- Both controllers (`giftPreview`, `giftPreviewImage`) handle their own errors via `try/catch` and never propagate, so the sub-app's HTML error-handling stack was a dead path for any real request.
- `shared/express.js` already auto-registers `sentry.errorHandler` as the first error middleware on every sub-app, so removing the explicit `handleHTMLResponse(sentry)` does not drop Sentry coverage.
- Route patterns `/:token` and `/:token/image` still match tokened requests first, so the existing redemption and OG-image flows are byte-identical.

## Test plan

- [x] Existing unit tests in `test/unit/server/web/gift-preview/controller.test.js` still pass (controller is unchanged).
- [x] New e2e-frontend smoke test in `test/e2e-frontend/default-routes.test.js`:
  - Creates a page with slug `gift` and asserts `GET /gift/` returns 200 with that page's title — proves the sub-app no longer intercepts tokenless requests.
  - Asserts `GET /gift/<unknown-token>` still returns a 302 redirect to the homepage (existing controller fallback for invalid tokens — regression guard).
- [x] `pnpm lint:server` and `pnpm lint:test` clean.

## Manual verification

With `pnpm dev` running and the `giftSubscriptions` lab flag enabled:

- `GET /gift/<valid-token>` → 200 HTML with meta-refresh to `/#/portal/gift/redeem/<token>` (unchanged)
- `GET /gift/<invalid-token>` → 302 to homepage (unchanged)
- `GET /gift/<valid-token>/image` → 200 PNG (unchanged)
- `GET /gift` with no `/gift` page configured → themed Ghost 404 (was: bare sub-app 404)
- `GET /gift/` with a custom page at slug `gift` → that page renders (was: 404)
