### PR TITLE
Added commentsPinning private labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -71,6 +71,10 @@ const features: Feature[] = [{
     title: 'Comments Threads',
     description: 'Enable deeper threading view in Comments-UI',
     flag: 'commentsThreads'
+}, {
+    title: 'Comments Pinning',
+    description: 'Allow staff to pin top-level comments in Comments-UI and Admin',
+    flag: 'commentsPinning'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -51,7 +51,8 @@ const PRIVATE_FEATURES = [
     'pictureImageFormats',
     'smarterCounts',
     'giftSubscriptions',
-    'commentsThreads'
+    'commentsThreads',
+    'commentsPinning'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -13,6 +13,7 @@ Object {
       "adminUIRefresh": true,
       "automations": true,
       "commentModeration": true,
+      "commentsPinning": true,
       "commentsThreads": true,
       "customFonts": true,
       "editorExcerpt": true,


### PR DESCRIPTION
## Summary
- Register the `commentsPinning` flag in `PRIVATE_FEATURES`.
- Surface it as an Alpha feature toggle in Admin → Settings → Labs (same pattern as `commentsThreads`).
- Update the Config API snapshot.

No behaviour is wired up to the flag yet — landing it first so the upcoming pinning work (#27653) can gate on it from the start.

## Test plan
- [ ] Config API snapshot test passes
- [ ] Flag appears in Admin → Labs → Alpha as "Comments Pinning"
- [ ] Toggling it persists and round-trips via the Settings API

🤖 Generated with [Claude Code](https://claude.com/claude-code)