### PR TITLE
Fixed remaining lazyRouting URL 404s in service-layer + serializer call sites

### DIFF
--- a/ghost/core/core/server/api/endpoints/email-post.js
+++ b/ghost/core/core/server/api/endpoints/email-post.js
@@ -35,7 +35,16 @@ const controller = {
             }
         },
         async query(frame) {
-            const model = await models.Post.findOne(Object.assign(frame.data, {status: 'sent'}), frame.options);
+            // tags+authors are needed by url.forPost (called from the
+            // email-posts output mapper) so urlService.facade.getUrlForResource
+            // can resolve tag- and author-filtered routes under lazyRouting.
+            // Merge with any caller-supplied withRelated so we don't clobber.
+            const callerIncludes = Array.isArray(frame.options.withRelated) ? frame.options.withRelated : [];
+            const options = {
+                ...frame.options,
+                withRelated: [...new Set([...callerIncludes, 'tags', 'authors'])]
+            };
+            const model = await models.Post.findOne(Object.assign(frame.data, {status: 'sent'}), options);
 
             if (!model) {
                 throw new errors.NotFoundError({

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const config = require('../../../../../../shared/config');
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:pages');
 const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
@@ -51,12 +52,27 @@ function selectAllAllowedColumns(frame) {
     }
 }
 
+// Mirrors the same helper in input/posts.js. Under lazyRouting the URL
+// is computed at serialization time from tags/authors, so a `?fields=url`
+// request without those relations resolves every URL to /404/ for tag-
+// or author-filtered routes in routes.yaml. Force-load (merging with any
+// caller-supplied withRelated) so the URL serializer can do its work.
+function forceUrlRelationsWhenLazy(frame) {
+    if (config.get('lazyRouting')
+        && Array.isArray(frame.options.columns)
+        && frame.options.columns.includes('url')) {
+        frame.options.withRelated = _.union(frame.options.withRelated || [], ['tags', 'authors']);
+    }
+}
+
 function defaultRelations(frame) {
+    forceUrlRelationsWhenLazy(frame);
+
     if (frame.options.withRelated) {
         return;
     }
 
-    if (frame.options.columns && !frame.options.withRelated) {
+    if (frame.options.columns) {
         return false;
     }
 
@@ -126,10 +142,11 @@ module.exports = {
         if (localUtils.isContentAPI(frame)) {
             // CASE: the content api endpoint for posts should not return mobiledoc or lexical
             removeSourceFormats(frame); // remove from the format field
-            selectAllAllowedColumns(frame); // remove from any specified column or selectRaw options            
+            selectAllAllowedColumns(frame); // remove from any specified column or selectRaw options
 
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
+            forceUrlRelationsWhenLazy(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -148,6 +165,7 @@ module.exports = {
             removeSourceFormats(frame);
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
+            forceUrlRelationsWhenLazy(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -75,24 +75,28 @@ function mapWithRelated(frame) {
     }
 }
 
-function defaultRelations(frame) {
-    // Apply same mapping as content API
-    mapWithRelated(frame);
-
-    // Under lazyRouting the URL is computed at serialization time from the
-    // resource's tags/authors (LazyUrlService re-evaluates each router's
-    // NQL filter against the loaded record). A thin column request like
-    // ?fields=id,url would otherwise produce /404/ for every tag- or
-    // author-filtered route in routes.yaml. Force-load the relations
-    // whenever `url` is in the response shape — even if the caller already
-    // set withRelated via ?include=, since their list may not include
-    // tags/authors. The output mapper strips force-loaded relations from
-    // the JSON response when the caller didn't ask for them.
+// Under lazyRouting the URL is computed at serialization time from the
+// resource's tags/authors (LazyUrlService re-evaluates each router's NQL
+// filter against the loaded record). A thin column request like
+// ?fields=id,url would otherwise produce /404/ for every tag- or
+// author-filtered route in routes.yaml. Force-load the relations whenever
+// `url` is in the response shape — even if the caller already set
+// withRelated via ?include=, since their list may not include
+// tags/authors. The output mapper strips force-loaded relations from the
+// JSON response when the caller didn't ask for them.
+function forceUrlRelationsWhenLazy(frame) {
     if (config.get('lazyRouting')
         && Array.isArray(frame.options.columns)
         && frame.options.columns.includes('url')) {
         frame.options.withRelated = _.union(frame.options.withRelated || [], ['tags', 'authors']);
     }
+}
+
+function defaultRelations(frame) {
+    // Apply same mapping as content API
+    mapWithRelated(frame);
+
+    forceUrlRelationsWhenLazy(frame);
 
     // Additional defaults for admin API
     if (frame.options.withRelated) {
@@ -182,6 +186,7 @@ module.exports = {
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
             mapWithRelated(frame);
+            forceUrlRelationsWhenLazy(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -208,6 +213,7 @@ module.exports = {
 
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
+            forceUrlRelationsWhenLazy(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -201,7 +201,11 @@ class CommentsService {
      */
     async getAdminAllComments({includeNested, filter, mongoTransformer, reportCount, order, page, limit}) {
         return await this.models.Comment.findPage({
-            withRelated: ['member', 'post', 'count.replies', 'count.direct_replies', 'count.likes', 'count.reports', 'in_reply_to', 'parent'],
+            // post.tags / post.authors needed so url.forPost (in
+            // mappers/comments.js) can resolve tag- / author-filtered
+            // routes under lazyRouting; otherwise the post URL on every
+            // comment row is /404/ for sites using collection routing.
+            withRelated: ['member', 'post', 'post.tags', 'post.authors', 'count.replies', 'count.direct_replies', 'count.likes', 'count.reports', 'in_reply_to', 'parent'],
             filter,
             mongoTransformer,
             reportCount,

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -203,7 +203,12 @@ class BatchSendingService {
         }, {...this.#getBeforeRetryConfig(email), description: `getLazyRelation newsletter for email ${email.id}`});
 
         const post = await this.retryDb(async () => {
-            return await email.getLazyRelation('post', {require: true, withRelated: ['posts_meta', 'authors']});
+            // tags+authors needed so urlService.facade.getUrlForResource()
+            // (called from email-renderer when building post URLs) can
+            // resolve tag- and author-filtered routes under lazyRouting.
+            // Without these the post URL embedded in the newsletter would
+            // fall through to /404/.
+            return await email.getLazyRelation('post', {require: true, withRelated: ['posts_meta', 'authors', 'tags']});
         }, {...this.#getBeforeRetryConfig(email), description: `getLazyRelation post for email ${email.id}`});
 
         let batches = await this.retryDb(async () => {

--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -27,9 +27,9 @@ class EmailController {
         // So we need to handle both cases.
         let post;
         if (frame.options.id) {
-            post = await this.models.Post.findOne({...frame.options, status: 'all'}, {withRelated: ['posts_meta', 'authors']});
+            post = await this.models.Post.findOne({...frame.options, status: 'all'}, {withRelated: ['posts_meta', 'authors', 'tags']});
         } else {
-            post = await this.models.Post.findOne({...frame.data, status: 'all'}, {...frame.options, withRelated: ['posts_meta', 'authors']});
+            post = await this.models.Post.findOne({...frame.data, status: 'all'}, {...frame.options, withRelated: ['posts_meta', 'authors', 'tags']});
         }
 
         if (!post) {

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -589,7 +589,12 @@ module.exports = class EventRepository {
     async getCommentEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'post', 'parent'],
+            // post.tags / post.authors needed by url.forPost (in
+            // mappers/comments.js → mappers/activity-feed-events.js) so
+            // urlService.facade.getUrlForResource can resolve tag- /
+            // author-filtered routes under lazyRouting; otherwise the
+            // post URL on every comment row is /404/.
+            withRelated: ['member', 'post', 'post.tags', 'post.authors', 'parent'],
             filter: 'member_id:-null+custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(
@@ -623,7 +628,10 @@ module.exports = class EventRepository {
     async getClickEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'link', 'link.post'],
+            // link.post.tags / link.post.authors needed for the post URL
+            // embedded in click-event rows under lazyRouting (same as
+            // getCommentEvents above).
+            withRelated: ['member', 'link', 'link.post', 'link.post.tags', 'link.post.authors'],
             filter: 'custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(
@@ -777,7 +785,10 @@ module.exports = class EventRepository {
     async getFeedbackEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'post'],
+            // post.tags / post.authors needed for URL serialization
+            // under lazyRouting (same as the other post-embedding events
+            // above).
+            withRelated: ['member', 'post', 'post.tags', 'post.authors'],
             filter: 'custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
+const configUtils = require('../../../../../../utils/config-utils');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 const postsSchema = require('../../../../../../../core/server/data/schema').tables.posts;
 
@@ -67,6 +68,65 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             assert(!frame.options.formats.includes('lexical'));
             assert(frame.options.formats.includes('html'));
             assert(frame.options.formats.includes('plaintext'));
+        });
+
+        // Same gap as the posts.* serializer: under lazyRouting the URL is
+        // computed at serialization time from tags/authors. A `?fields=url`
+        // request without those relations resolves every URL to /404/ for
+        // tag- or author-filtered routes in routes.yaml.
+        describe('lazyRouting + thin columns', function () {
+            afterEach(async function () {
+                await configUtils.restore();
+            });
+
+            it('forces tags+authors into withRelated when columns include url under lazyRouting (admin)', function () {
+                configUtils.set('lazyRouting', true);
+                const frame = {
+                    apiType: 'admin',
+                    options: {
+                        context: {user: 1},
+                        columns: ['id', 'url', 'title']
+                    }
+                };
+
+                serializers.input.pages.browse({}, frame);
+
+                assert.ok(frame.options.withRelated);
+                assert.ok(frame.options.withRelated.includes('tags'));
+                assert.ok(frame.options.withRelated.includes('authors'));
+            });
+
+            it('forces tags+authors on the Content API path too', function () {
+                configUtils.set('lazyRouting', true);
+                const frame = {
+                    apiType: 'content',
+                    options: {
+                        context: {api_key: {id: 1, type: 'content'}},
+                        columns: ['id', 'url']
+                    }
+                };
+
+                serializers.input.pages.browse({}, frame);
+
+                assert.ok(frame.options.withRelated);
+                assert.ok(frame.options.withRelated.includes('tags'));
+                assert.ok(frame.options.withRelated.includes('authors'));
+            });
+
+            it('does not force withRelated when lazyRouting is off', function () {
+                configUtils.set('lazyRouting', false);
+                const frame = {
+                    apiType: 'admin',
+                    options: {
+                        context: {user: 1},
+                        columns: ['id', 'url', 'title']
+                    }
+                };
+
+                serializers.input.pages.browse({}, frame);
+
+                assert.equal(frame.options.withRelated, undefined);
+            });
         });
 
         describe('Content API', function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -230,6 +230,31 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 assert.ok(frame.options.withRelated.includes('tags'), 'tags must be force-loaded for URL');
                 assert.ok(frame.options.withRelated.includes('authors'), 'authors must be force-loaded for URL');
             });
+
+            it('forces tags+authors on the Content API path too', async function () {
+                // The Content API uses mapWithRelated rather than
+                // defaultRelations, so the admin-side patch doesn't cover
+                // it. A `?fields=url` request on the Content API would
+                // otherwise resolve every URL to /404/ for tag/author
+                // filtered routes under lazyRouting.
+                configUtils.set('lazyRouting', true);
+                const apiConfig = {};
+                const frame = {
+                    apiType: 'content',
+                    options: {
+                        context: {
+                            api_key: {id: 1, type: 'content'}
+                        },
+                        columns: ['id', 'url']
+                    }
+                };
+
+                serializers.input.posts.browse(apiConfig, frame);
+
+                assert.ok(frame.options.withRelated, 'withRelated should be set');
+                assert.ok(frame.options.withRelated.includes('tags'));
+                assert.ok(frame.options.withRelated.includes('authors'));
+            });
         });
 
         describe('Content API', function () {

--- a/ghost/core/test/unit/api/endpoints/email-post.test.js
+++ b/ghost/core/test/unit/api/endpoints/email-post.test.js
@@ -1,0 +1,40 @@
+const sinon = require('sinon');
+const models = require('../../../../core/server/models');
+
+// The /email/<uuid>/ landing page handler returns a post that gets rendered
+// via mappers.posts → url.forPost → urlService.facade.getUrlForResource.
+// Under lazyRouting that call evaluates each router's NQL filter against
+// the loaded record; without tags/authors a tag- or author-filtered route
+// resolves to /404/ for the post URL embedded in the rendered page.
+
+describe('email-post endpoint', function () {
+    let findOneStub;
+    let controller;
+
+    beforeEach(function () {
+        findOneStub = sinon.stub(models.Post, 'findOne').resolves({});
+        delete require.cache[require.resolve('../../../../core/server/api/endpoints/email-post')];
+        controller = require('../../../../core/server/api/endpoints/email-post');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('read', function () {
+        it('loads tags and authors so URL serialization can resolve filtered routes under lazyRouting', async function () {
+            const frame = {
+                data: {uuid: 'some-uuid'},
+                options: {}
+            };
+            await controller.read.query(frame);
+            sinon.assert.calledOnce(findOneStub);
+            const callOptions = findOneStub.firstCall.args[1];
+            const withRelated = callOptions?.withRelated || [];
+            const includes = callOptions?.include || [];
+            const loaded = [...withRelated, ...(typeof includes === 'string' ? includes.split(',') : includes)];
+            sinon.assert.match(loaded, sinon.match.array.contains(['tags']));
+            sinon.assert.match(loaded, sinon.match.array.contains(['authors']));
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/comments/comments-service.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service.test.js
@@ -1,0 +1,49 @@
+const sinon = require('sinon');
+const CommentsService = require('../../../../../core/server/services/comments/comments-service');
+
+// The admin moderation listing emits a `post` field per comment which is
+// rendered through mappers/comments.js → url.forPost → urlService.facade.
+// Under lazyRouting that needs the post's tags+authors loaded or every
+// comment row's post URL is /404/ for tag-/author-filtered routes.
+
+describe('CommentsService.getAdminAllComments lazyRouting URL relations', function () {
+    let findPage;
+    let service;
+
+    beforeEach(function () {
+        findPage = sinon.fake.resolves({data: [], meta: {}});
+        service = new CommentsService({
+            models: {Comment: {findPage}},
+            // Other deps default to null/undefined; they're not exercised
+            // by getAdminAllComments.
+            config: null,
+            logging: null,
+            mailer: null,
+            settingsCache: null,
+            settingsHelpers: null,
+            urlService: null,
+            urlUtils: null,
+            contentGating: null,
+            labs: null
+        });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('loads post.tags and post.authors so URL serialization can resolve filtered routes', async function () {
+        await service.getAdminAllComments({
+            includeNested: false,
+            order: 'created_at desc',
+            page: 1,
+            limit: 10
+        });
+
+        sinon.assert.calledOnce(findPage);
+        const opts = findPage.firstCall.args[0];
+        const wr = opts.withRelated || [];
+        sinon.assert.match(wr, sinon.match.array.contains(['post.tags']));
+        sinon.assert.match(wr, sinon.match.array.contains(['post.authors']));
+    });
+});

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -302,6 +302,36 @@ describe('Batch Sending Service', function () {
             const argument = sendBatches.firstCall.args[0];
             assert.equal(argument.batches, createdBatches);
         });
+
+        it('loads the post with tags and authors so URL serialization can resolve filtered routes under lazyRouting', async function () {
+            // The post is loaded here and threaded through to the email
+            // renderer, which calls urlService.facade.getUrlForResource() to
+            // build the post URL embedded in the newsletter. Under
+            // lazyRouting that call evaluates each router's NQL filter
+            // against the loaded record; a route filtered by `tag:` or
+            // `author:` needs the relations populated or the URL falls
+            // through to /404/ and the newsletter ships with broken links.
+            const EmailBatch = createModelClass({findAll: []});
+            const service = new BatchSendingService({
+                models: {EmailBatch}
+            });
+            const getLazyRelation = sinon.stub();
+            getLazyRelation.withArgs('newsletter', sinon.match.any).resolves(createModel({}));
+            getLazyRelation.withArgs('post', sinon.match.any).resolves(createModel({}));
+            const email = {
+                id: 'email1',
+                get: () => null,
+                getLazyRelation
+            };
+            sinon.stub(service, 'sendBatches').resolves();
+            sinon.stub(service, 'createBatches').resolves([createModel({})]);
+
+            await service.sendEmail(email);
+
+            sinon.assert.calledWith(getLazyRelation, 'post', sinon.match({
+                withRelated: sinon.match.array.contains(['tags', 'authors'])
+            }));
+        });
     });
 
     describe('createBatches', function () {

--- a/ghost/core/test/unit/server/services/email-service/email-controller.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-controller.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const EmailController = require('../../../../../core/server/services/email-service/email-controller');
 const {createModel, createModelClass} = require('./utils');
 
@@ -142,6 +143,34 @@ describe('Email Controller', function () {
                 }
             });
             assert.equal(segment, 'free');
+        });
+
+        it('loads the post with tags and authors so URL serialization can resolve filtered routes under lazyRouting', async function () {
+            // Email previews and test sends both render the post through
+            // email-renderer, which calls urlService.facade.getUrlForResource
+            // to embed the post URL. Under lazyRouting that call evaluates
+            // each router's NQL filter against the loaded record; without
+            // tags/authors, tag- or author-filtered routes fall through to
+            // /404/ and the preview / test email shows broken links.
+            const Post = createModelClass({
+                findOne: {newsletter: createModel({slug: 'n'})}
+            });
+            const findOneSpy = sinon.spy(Post, 'findOne');
+            const controller = new EmailController({}, {
+                models: {Post}
+            });
+
+            // Both branches: id-via-options and id-via-data
+            await controller._getFrameData({options: {id: 'opt-id'}, data: {}});
+            await controller._getFrameData({options: {}, data: {id: 'data-id'}});
+
+            sinon.assert.calledTwice(findOneSpy);
+            const [, firstOpts] = findOneSpy.firstCall.args;
+            const [, secondOpts] = findOneSpy.secondCall.args;
+            assert.ok(firstOpts.withRelated.includes('tags'), `expected 'tags' in first call withRelated, got ${JSON.stringify(firstOpts.withRelated)}`);
+            assert.ok(firstOpts.withRelated.includes('authors'), `expected 'authors' in first call`);
+            assert.ok(secondOpts.withRelated.includes('tags'), `expected 'tags' in second call withRelated, got ${JSON.stringify(secondOpts.withRelated)}`);
+            assert.ok(secondOpts.withRelated.includes('authors'), `expected 'authors' in second call`);
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -756,4 +756,74 @@ describe('EventRepository', function () {
             assert.equal(event.data.member_id, 'member-xyz');
         });
     });
+
+    // The activity-feed mappers (mappers/activity-feed-events.js,
+    // mappers/comments.js) call url.forPost on the embedded post, which
+    // routes to urlService.facade.getUrlForResource. Under lazyRouting
+    // that needs the post's tags+authors loaded or it returns /404/ for
+    // any tag- or author-filtered route in routes.yaml.
+    describe('lazyRouting URL relations on post-embedding events', function () {
+        it('getCommentEvents loads post.tags and post.authors so URL serialization can resolve filtered routes', async function () {
+            const fake = sinon.fake.returns({data: []});
+            const repo = new EventRepository({
+                EmailRecipient: null,
+                MemberSubscribeEvent: null,
+                MemberPaymentEvent: null,
+                MemberStatusEvent: null,
+                MemberLoginEvent: null,
+                MemberPaidSubscriptionEvent: null,
+                Comment: {findPage: fake},
+                labsService: null
+            });
+
+            await repo.getCommentEvents({}, {});
+
+            sinon.assert.calledOnce(fake);
+            const opts = fake.firstCall.args[0];
+            assert.ok(opts.withRelated.includes('post.tags'), `expected post.tags in ${JSON.stringify(opts.withRelated)}`);
+            assert.ok(opts.withRelated.includes('post.authors'), `expected post.authors in ${JSON.stringify(opts.withRelated)}`);
+        });
+
+        it('getClickEvents loads link.post.tags and link.post.authors', async function () {
+            const fake = sinon.fake.returns({data: []});
+            const repo = new EventRepository({
+                EmailRecipient: null,
+                MemberSubscribeEvent: null,
+                MemberPaymentEvent: null,
+                MemberStatusEvent: null,
+                MemberLoginEvent: null,
+                MemberPaidSubscriptionEvent: null,
+                MemberLinkClickEvent: {findPage: fake},
+                labsService: null
+            });
+
+            await repo.getClickEvents({}, {});
+
+            sinon.assert.calledOnce(fake);
+            const opts = fake.firstCall.args[0];
+            assert.ok(opts.withRelated.includes('link.post.tags'), `expected link.post.tags in ${JSON.stringify(opts.withRelated)}`);
+            assert.ok(opts.withRelated.includes('link.post.authors'), `expected link.post.authors in ${JSON.stringify(opts.withRelated)}`);
+        });
+
+        it('getFeedbackEvents loads post.tags and post.authors', async function () {
+            const fake = sinon.fake.returns({data: []});
+            const repo = new EventRepository({
+                EmailRecipient: null,
+                MemberSubscribeEvent: null,
+                MemberPaymentEvent: null,
+                MemberStatusEvent: null,
+                MemberLoginEvent: null,
+                MemberPaidSubscriptionEvent: null,
+                MemberFeedback: {findPage: fake},
+                labsService: null
+            });
+
+            await repo.getFeedbackEvents({}, {});
+
+            sinon.assert.calledOnce(fake);
+            const opts = fake.firstCall.args[0];
+            assert.ok(opts.withRelated.includes('post.tags'), `expected post.tags in ${JSON.stringify(opts.withRelated)}`);
+            assert.ok(opts.withRelated.includes('post.authors'), `expected post.authors in ${JSON.stringify(opts.withRelated)}`);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Stacks on #27908. After the audit triggered by that PR's review, seven additional call sites of `urlService.facade.getUrlForResource(...)` were identified that load posts without `tags`/`authors` relations and produce `/404/` URLs under `config.lazyRouting` for any tag- or author-filtered route in `routes.yaml`.

Each commit is a single-site fix with a TDD-style test that demonstrates the bug before the fix and pins the contract afterward.

## Commits (7)

| # | Site | Impact |
|---|---|---|
| 1 | `services/email-service/batch-sending-service.js` | Newsletters ship with `/404/` post URLs and broken share links |
| 2 | `services/email-service/email-controller.js` | Email previews and test sends have broken post URLs |
| 3 | `api/endpoints/email-post.js` | `/email/<uuid>/` landing pages render with broken canonical URL |
| 4 | `services/members/members-api/repositories/event-repository.js` | Admin activity feed (comment / click / feedback events) shows `/404/` post URL on every row |
| 5 | `services/comments/comments-service.js` | Comment moderation listing + public widget show `/404/` post URL on every row |
| 6 | `api/endpoints/utils/serializers/input/pages.js` | `pages.browse?fields=url` resolves to `/404/` (Admin and Content API) |
| 7 | `api/endpoints/utils/serializers/input/posts.js` Content API branch | `posts.browse?fields=url` resolves to `/404/` on the Content API |

## Pattern

Most fixes are one-line `withRelated` extensions: add `'tags'` (or `'post.tags'` / `'link.post.tags'` as appropriate) to the existing relation list. The two serializer fixes (commits 6 and 7) extract a small `forceUrlRelationsWhenLazy(frame)` helper that mirrors what #27908 added for `input/posts.js`'s admin branch.

All fixes are gated on the same condition class as #27908: `config.lazyRouting` is on AND the call site is one where the URL serializer needs the relations to evaluate router filters. Eager-mode behaviour is unchanged.

## Test plan

- [x] `pnpm test:single test/unit/server/services/email-service/batch-sending-service.test.js` (55/55)
- [x] `pnpm test:single test/unit/server/services/email-service/email-controller.test.js` (14/14)
- [x] `pnpm test:single test/unit/api/endpoints/email-post.test.js` (1/1, new file)
- [x] `pnpm test:single test/unit/server/services/members/members-api/repositories/event-repository.test.js` (35/35)
- [x] `pnpm test:single test/unit/server/services/comments/comments-service.test.js` (1/1, new file)
- [x] `pnpm test:single test/unit/api/canary/utils/serializers/input/pages.test.js` (22/22)
- [x] `pnpm test:single test/unit/api/canary/utils/serializers/input/posts.test.js` (29/29 of mine; 2 pre-existing html-to-mobiledoc env failures unrelated)
- [ ] Smoke test against a site running `config.lazyRouting: true` with a tag-filtered collection in routes.yaml: send a newsletter / open a comment moderation page / open the admin activity feed → all post URLs should be the real post URL, not `/404/`