### PR TITLE
Changed Renovate grouping to bump @tryghost/limit-service on its own

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -160,9 +160,19 @@
             "matchPackageNames": [
                 "@tryghost/color-utils",
                 "@tryghost/custom-fonts",
-                "@tryghost/limit-service",
                 "@tryghost/members-csv",
                 "@tryghost/timezone-data"
+            ]
+        },
+
+        // Bump @tryghost/limit-service on its own. Limit changes are feature-tied
+        // (each new flag is consumed by specific BREAD/limit-helper code) and we
+        // want the version bump landing as an isolated, reviewable PR rather than
+        // riding in with unrelated admin-support package updates.
+        {
+            "groupName": "@tryghost/limit-service",
+            "matchPackageNames": [
+                "@tryghost/limit-service"
             ]
         },
         {


### PR DESCRIPTION
## Summary

Splits `@tryghost/limit-service` out of the "TryGhost admin support packages" Renovate group so its version bumps come out as their own PR.

## Why

Unlike the other packages in that group (`color-utils`, `custom-fonts`, `members-csv`, `timezone-data`), limit-service bumps are **feature-tied**: each new entry in its `lib/config.js` allowlist is paired with consuming BREAD-service / limit-helper code here in Ghost. We need the version bump to land as a reviewable, single-package PR so it can be coordinated with the consuming change (and so a flaky CI run on an unrelated admin-support bump doesn't block it).

No other behaviour changes — limit-service still respects the rest of the existing config (schedule, automerge windows, dashboard approval for majors, etc.).

## Test plan

- [x] Renovate config-only change; no runtime impact.
- [ ] Verify next Renovate run opens an isolated `Update dependency @tryghost/limit-service` PR rather than bundling it into the admin-support group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
