### PR TITLE
Added publicSiteAccess limit enforcement to the Settings API

### DIFF
--- a/ghost/core/core/server/services/settings/settings-bread-service.js
+++ b/ghost/core/core/server/services/settings/settings-bread-service.js
@@ -13,7 +13,7 @@ const messages = {
     problemFindingSetting: 'Problem finding setting: {key}',
     accessCoreSettingFromExtReq: 'Attempted to access core setting from external request',
     invalidEmail: 'Invalid email address',
-    publicSiteAccessLocked: 'Site visibility and access code are managed by Ghost while this site is on a trial.'
+    publicSiteAccessLocked: 'Site visibility and access code cannot be changed.'
 };
 
 class SettingsBREADService {

--- a/ghost/core/core/server/services/settings/settings-bread-service.js
+++ b/ghost/core/core/server/services/settings/settings-bread-service.js
@@ -8,10 +8,12 @@ const MagicLink = require('../lib/magic-link/magic-link');
 const sentry = require('../../../shared/sentry');
 
 const EMAIL_KEYS = ['members_support_address'];
+const PUBLIC_SITE_ACCESS_LOCKED_KEYS = ['is_private', 'password'];
 const messages = {
     problemFindingSetting: 'Problem finding setting: {key}',
     accessCoreSettingFromExtReq: 'Attempted to access core setting from external request',
-    invalidEmail: 'Invalid email address'
+    invalidEmail: 'Invalid email address',
+    publicSiteAccessLocked: 'Site visibility and access code are managed by Ghost while this site is on a trial.'
 };
 
 class SettingsBREADService {
@@ -193,6 +195,21 @@ class SettingsBREADService {
                     message: tpl(messages.accessCoreSettingFromExtReq)
                 });
             }
+
+            if (this._isPublicSiteAccessLimited()) {
+                const lockedEdit = filteredSettings.find((setting) => {
+                    if (setting.key === 'password') {
+                        return true;
+                    }
+                    return setting.key === 'is_private' && setting.value !== true;
+                });
+
+                if (lockedEdit) {
+                    throw new NoPermissionError({
+                        message: tpl(messages.publicSiteAccessLocked)
+                    });
+                }
+            }
         }
 
         if (stripeConnectData) {
@@ -300,7 +317,20 @@ class SettingsBREADService {
             labsSetting.value = JSON.stringify(this.labs.getAll());
         }
 
+        if (this._isPublicSiteAccessLimited()) {
+            settings = settings.map((setting) => {
+                if (PUBLIC_SITE_ACCESS_LOCKED_KEYS.includes(setting.key)) {
+                    return {...setting, is_read_only: true};
+                }
+                return setting;
+            });
+        }
+
         return settings;
+    }
+
+    _isPublicSiteAccessLimited() {
+        return Boolean(this.limitsService && this.limitsService.isDisabled('publicSiteAccess'));
     }
 
     /**

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -8079,6 +8079,42 @@ Object {
 }
 `;
 
+exports[`Settings API publicSiteAccess limit rejects external attempts to change the access code 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Site visibility and access code are managed by Ghost while this site is on a trial.",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot edit setting.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Settings API publicSiteAccess limit rejects external attempts to set is_private = false 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Site visibility and access code are managed by Ghost while this site is on a trial.",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot edit setting.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
 exports[`Settings API stripe connect Can attempt to connect to stripe 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -8084,7 +8084,7 @@ Object {
   "errors": Array [
     Object {
       "code": null,
-      "context": "Site visibility and access code are managed by Ghost while this site is on a trial.",
+      "context": "Site visibility and access code cannot be changed.",
       "details": null,
       "ghostErrorCode": null,
       "help": null,
@@ -8102,7 +8102,7 @@ Object {
   "errors": Array [
     Object {
       "code": null,
-      "context": "Site visibility and access code are managed by Ghost while this site is on a trial.",
+      "context": "Site visibility and access code cannot be changed.",
       "details": null,
       "ghostErrorCode": null,
       "help": null,

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -8,6 +8,7 @@ const {agentProvider, fixtureManager, mockManager, matchers, configUtils} = requ
 const {stringMatching, anyEtag, anyUuid, anyContentLength, anyContentVersion} = matchers;
 const models = require('../../../core/server/models');
 const membersService = require('../../../core/server/services/members');
+const limits = require('../../../core/server/services/limits');
 const {anyErrorId} = matchers;
 
 // Updated to reflect current total based on test output
@@ -735,6 +736,68 @@ describe('Settings API', function () {
                 });
 
             emailMockReceiver.assertSentEmailCount(0);
+        });
+    });
+
+    describe('publicSiteAccess limit', function () {
+        function stubPublicSiteAccessDisabled(disabled) {
+            // Stub the singleton directly rather than driving the limit through configUtils +
+            // limits.init(). The hostSettings.limits config is registered once at boot from the
+            // `@tryghost/limit-service` allowlist; bumps of that package are owned by Renovate
+            // so this PR cannot rely on `publicSiteAccess` being a recognised name yet.
+            sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(disabled);
+        }
+
+        it('marks is_private and password as is_read_only when the limit is disabled', async function () {
+            stubPublicSiteAccessDisabled(true);
+
+            const response = await agent.get('settings/').expectStatus(200);
+            const byKey = Object.fromEntries(response.body.settings.map(s => [s.key, s]));
+
+            assert.equal(byKey.is_private.is_read_only, true);
+            assert.equal(byKey.password.is_read_only, true);
+        });
+
+        it('rejects external attempts to set is_private = false', async function () {
+            stubPublicSiteAccessDisabled(true);
+            sinon.stub(logging, 'error');
+
+            await agent.put('settings/')
+                .body({
+                    settings: [{key: 'is_private', value: false}]
+                })
+                .expectStatus(403)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                });
+        });
+
+        it('rejects external attempts to change the access code', async function () {
+            stubPublicSiteAccessDisabled(true);
+            sinon.stub(logging, 'error');
+
+            await agent.put('settings/')
+                .body({
+                    settings: [{key: 'password', value: 'attacker-chosen-code'}]
+                })
+                .expectStatus(403)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                });
+        });
+
+        it('does not mark is_private or password as is_read_only when the limit is not disabled', async function () {
+            stubPublicSiteAccessDisabled(false);
+
+            const response = await agent.get('settings/').expectStatus(200);
+            const byKey = Object.fromEntries(response.body.settings.map(s => [s.key, s]));
+
+            assert.notEqual(byKey.is_private.is_read_only, true);
+            assert.notEqual(byKey.password.is_read_only, true);
         });
     });
 

--- a/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
@@ -272,7 +272,7 @@ describe('UNIT > Settings BREAD Service:', function () {
 
                 await assert.rejects(
                     service.edit([{key: 'is_private', value: false}], {context: {user: 'test'}}, null),
-                    /Site visibility and access code are managed by Ghost/
+                    /Site visibility and access code cannot be changed/
                 );
             });
 
@@ -281,7 +281,7 @@ describe('UNIT > Settings BREAD Service:', function () {
 
                 await assert.rejects(
                     service.edit([{key: 'password', value: 'attacker-chosen-code'}], {context: {user: 'test'}}, null),
-                    /Site visibility and access code are managed by Ghost/
+                    /Site visibility and access code cannot be changed/
                 );
             });
 

--- a/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
@@ -217,6 +217,108 @@ describe('UNIT > Settings BREAD Service:', function () {
         });
     });
 
+    describe('publicSiteAccess limit', function () {
+        const siteSettings = {
+            is_private: {key: 'is_private', value: true, group: 'site'},
+            password: {key: 'password', value: 'silver042', group: 'site'}
+        };
+
+        function createService({isDisabled = false} = {}) {
+            return new SettingsBreadService({
+                SettingsModel: {
+                    async edit(changes) {
+                        return changes.map(change => ({toJSON: () => ({...siteSettings[change.key], ...change})}));
+                    }
+                },
+                settingsCache: {
+                    get: key => siteSettings[key],
+                    getAll: () => ({...siteSettings})
+                },
+                mail,
+                urlUtils,
+                singleUseTokenProvider: {},
+                labsService: {getAll: () => ({})},
+                limitsService: {
+                    isDisabled: sinon.stub().withArgs('publicSiteAccess').returns(isDisabled)
+                }
+            });
+        }
+
+        describe('browse', function () {
+            it('marks is_private and password as is_read_only when the limit is disabled', async function () {
+                const service = createService({isDisabled: true});
+
+                const settings = await service.browse({user: 'test'});
+                const byKey = Object.fromEntries(settings.map(s => [s.key, s]));
+
+                assert.equal(byKey.is_private.is_read_only, true);
+                assert.equal(byKey.password.is_read_only, true);
+            });
+
+            it('does not mark is_private or password as is_read_only when the limit is not disabled', async function () {
+                const service = createService({isDisabled: false});
+
+                const settings = await service.browse({user: 'test'});
+                const byKey = Object.fromEntries(settings.map(s => [s.key, s]));
+
+                assert.equal(byKey.is_private.is_read_only, undefined);
+                assert.equal(byKey.password.is_read_only, undefined);
+            });
+        });
+
+        describe('edit', function () {
+            it('rejects external attempts to set is_private = false when the limit is disabled', async function () {
+                const service = createService({isDisabled: true});
+
+                await assert.rejects(
+                    service.edit([{key: 'is_private', value: false}], {context: {user: 'test'}}, null),
+                    /Site visibility and access code are managed by Ghost/
+                );
+            });
+
+            it('rejects external attempts to change password when the limit is disabled', async function () {
+                const service = createService({isDisabled: true});
+
+                await assert.rejects(
+                    service.edit([{key: 'password', value: 'attacker-chosen-code'}], {context: {user: 'test'}}, null),
+                    /Site visibility and access code are managed by Ghost/
+                );
+            });
+
+            it('allows is_private = true (no-op) when the limit is disabled', async function () {
+                const service = createService({isDisabled: true});
+
+                const settings = await service.edit([{key: 'is_private', value: true}], {context: {user: 'test'}}, null);
+
+                assert.equal(settings.find(s => s.key === 'is_private').value, true);
+            });
+
+            it('allows internal context to edit is_private and password when the limit is disabled', async function () {
+                const service = createService({isDisabled: true});
+
+                const settings = await service.edit([
+                    {key: 'is_private', value: false},
+                    {key: 'password', value: 'regenerated-by-ghost'}
+                ], {context: {internal: true}}, null);
+
+                assert.equal(settings.find(s => s.key === 'is_private').value, false);
+                assert.equal(settings.find(s => s.key === 'password').value, 'regenerated-by-ghost');
+            });
+
+            it('does not block edits when the limit is not disabled', async function () {
+                const service = createService({isDisabled: false});
+
+                const settings = await service.edit([
+                    {key: 'is_private', value: false},
+                    {key: 'password', value: 'user-chosen'}
+                ], {context: {user: 'test'}}, null);
+
+                assert.equal(settings.find(s => s.key === 'is_private').value, false);
+                assert.equal(settings.find(s => s.key === 'password').value, 'user-chosen');
+            });
+        });
+    });
+
     describe('verifyKeyUpdate', function () {
         it('can set members_support_address', async function () {
             const defaultSettingsManager = new SettingsBreadService({


### PR DESCRIPTION
## Summary

Adds API-layer enforcement for the new `publicSiteAccess` flag limit on `@tryghost/limit-service`. When Ghost(Pro) applies that limit to a trial site, the Settings BREAD service now:

- marks `is_private` and `password` with `is_read_only: true` on browse — the field already flows through `ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/settings.js:6` and Admin-X's `isSettingReadOnly()` helper, so this is just populating it server-side;
- rejects external `PUT /settings/` attempts to flip `is_private = false` or change the access code, returning `NoPermissionError` (403);
- keeps internal-context edits open so boot-time enforcement and a future regenerate endpoint can still manage the values.

## Why now, why dormant

The limit-service package was updated to recognise `publicSiteAccess` in [TryGhost/SDK#918](https://github.com/TryGhost/SDK/pull/918). The catalogued dependency in this repo is intentionally **not** bumped here — Renovate handles that as its own PR (see #27916, which isolates `@tryghost/limit-service` from the admin-support group so the bump lands standalone).

Until both the Renovate bump AND a Ghost(Pro) Daisy.js applied-limit land, `limitsService.isDisabled('publicSiteAccess')` returns `undefined`, the new code paths are no-ops, and nothing changes for any existing site.

The remaining trial-private-site backend work — boot-time persistence of `is_private = true` and the generated access-code helper — is deliberately scoped out and will follow in a separate PR.

## Test plan

- [x] `pnpm test:single test/unit/server/services/settings/settings-bread-service.test.js` — 15 passing, including a new `publicSiteAccess limit` suite covering browse marking, edit rejection on `is_private` and `password`, no-op `is_private = true` edits, internal-context bypass, and the limit-off path.
- [x] `pnpm test:single test/e2e-api/admin/settings.test.js` — 28 passing. New cases sinon-stub `limits.isDisabled('publicSiteAccess')` on the singleton (with an inline comment explaining why) rather than driving the limit through `configUtils.set` + `limits.init()`, because this PR doesn't bump the SDK catalog version that recognises the limit name.
- [x] `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
