### PR TITLE
🎨 Added "Revert all" button to theme editor review modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -707,6 +707,35 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
         setFilesAndSelection(nextFiles);
     };
 
+    const handleRevertAll = async () => {
+        if (changes.length === 0) {
+            return;
+        }
+
+        const confirmed = await requestConfirmation({
+            title: 'Revert all changes?',
+            prompt: `Discard all ${changes.length} pending change${changes.length === 1 ? '' : 's'} and restore the theme to its last saved state? This cannot be undone.`,
+            okLabel: 'Revert all',
+            okColor: 'red'
+        });
+
+        if (!confirmed) {
+            return;
+        }
+
+        const nextFiles: Record<string, ThemeEditorFile> = {};
+
+        for (const [path, file] of Object.entries(baseFiles)) {
+            nextFiles[path] = {
+                ...file,
+                binary: file.binary ? new Uint8Array(file.binary) : null
+            };
+        }
+
+        setFilesAndSelection(nextFiles);
+        setIsReviewOpen(false);
+    };
+
     const requestSaveAsThemeName = async () => {
         const requestedName = await requestInput({
             title: 'Save as new theme',
@@ -1017,6 +1046,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                             setIsReviewOpen(false);
                         }}
                         onRevert={handleRevertPath}
+                        onRevertAll={() => void handleRevertAll()}
                     />
                 )}
             </div>

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-review-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-review-modal.tsx
@@ -51,13 +51,15 @@ type ThemeReviewModalProps = {
     onClose: () => void;
     onOpenInEditor: (path: string) => void;
     onRevert: (path: string) => void;
+    onRevertAll: () => void;
 };
 
 const ThemeReviewModal: React.FC<ThemeReviewModalProps> = ({
     reviewItems,
     onClose,
     onOpenInEditor,
-    onRevert
+    onRevert,
+    onRevertAll
 }) => {
     const [selectedReviewPath, setSelectedReviewPath] = useState<string | null>(null);
     const selectedReviewItem = reviewItems.find(item => item.path === selectedReviewPath) || reviewItems[0] || null;
@@ -86,9 +88,17 @@ const ThemeReviewModal: React.FC<ThemeReviewModalProps> = ({
                         <h3 className='text-[16px] font-semibold text-[#f4f5f7]'>All changes</h3>
                         <p className='mt-1 text-[12px] text-[#9aa0aa]'>{reviewSummary}</p>
                     </div>
-                    <button aria-label='Close review' className={iconButtonClass} type='button' onClick={onClose}>
-                        <X size={14} />
-                    </button>
+                    <div className='flex items-center gap-2'>
+                        {reviewItems.length > 0 && (
+                            <button className={ghostButtonClass} type='button' onClick={onRevertAll}>
+                                <Undo2 size={14} />
+                                Revert all
+                            </button>
+                        )}
+                        <button aria-label='Close review' className={iconButtonClass} type='button' onClick={onClose}>
+                            <X size={14} />
+                        </button>
+                    </div>
                 </div>
 
                 <div className='grid min-h-0 flex-1 grid-cols-[320px_1fr] gap-3'>

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -399,6 +399,61 @@ test.describe('Theme settings', async () => {
         await expect(editorModal).toContainText(/1 file modified/);
     });
 
+    test('Reverts all pending changes from the review modal', async ({page}) => {
+        // Build a minimal clean theme archive — the shared theme.zip fixture
+        // contains __MACOSX junk that pollutes the file tree and prevents
+        // detectCommonRoot() from collapsing the leading folder, making it
+        // brittle to drive multi-file edits against.
+        const themeZip = await createArchiveBuffer((zip) => {
+            zip.file('package.json', '{"name":"edition","version":"1.0.0"}\n');
+            zip.file('styles.css', 'body { color: black; }\n');
+        });
+
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: {
+                method: 'GET',
+                path: '/themes/edition/download/',
+                response: '',
+                rawResponse: themeZip,
+                responseHeaders: {'content-type': 'application/zip'}
+            }
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+
+        // Modify the first editable file (the alphabetically-first editable
+        // file — package.json — is auto-selected when the editor opens).
+        const codeEditor = editorModal.locator('.cm-content');
+        await expect(codeEditor).toBeVisible();
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('{"name":"edition","version":"99.0.0"}\n');
+        await expect(editorModal).toContainText(/1 file modified/);
+
+        // Switch to a second editable file and modify it too — we want to
+        // prove revert-all clears every change, not just the active one.
+        await editorModal.getByRole('button', {name: 'styles.css', exact: true}).click();
+        await codeEditor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.insertText('body { color: red; }\n');
+        await expect(editorModal).toContainText(/2 files modified/);
+
+        // Open the review modal via the "files modified" badge and revert all.
+        await editorModal.getByRole('button', {name: /files modified/}).click();
+        await expect(page.getByRole('heading', {name: 'All changes'})).toBeVisible();
+        await page.getByRole('button', {name: 'Revert all'}).click();
+
+        // Destructive prompt should require confirmation before discarding.
+        await page.getByTestId('theme-editor-confirm-modal').getByRole('button', {name: 'Revert all'}).click();
+
+        // Review modal closes and the toolbar's "files modified" badge is gone,
+        // proving every pending change was discarded.
+        await expect(page.getByRole('heading', {name: 'All changes'})).not.toBeVisible();
+        await expect(editorModal).not.toContainText(/files? modified/);
+    });
+
     test('Saves built-in themes as a new theme name', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,


### PR DESCRIPTION
- the review modal already supports per-file revert, but discarding a batch of pending edits previously required one click per file
- adds a destructive-confirmation prompt before reverting, mirroring the existing "Discard changes?" flow used on editor close
- closes the review modal after reverting since the underlying file list is empty

<img width="1440" height="900" alt="27919-revert-all" src="https://github.com/user-attachments/assets/206cc43a-6263-48d2-8c90-df3e0e9f31ed" />

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
