### PR TITLE
Added publicSiteAccess boot-time enforcement to settings service

### DIFF
--- a/ghost/core/core/server/services/settings/private-site-access-code.js
+++ b/ghost/core/core/server/services/settings/private-site-access-code.js
@@ -1,0 +1,14 @@
+const crypto = require('crypto');
+
+/**
+ * Placeholder access-code generator — returns `fake-###`.
+ * The real format will be implemented in a follow-up PR.
+ *
+ * @returns {string}
+ */
+function generatePrivateSiteAccessCode() {
+    const number = crypto.randomInt(1000).toString().padStart(3, '0');
+    return `fake-${number}`;
+}
+
+module.exports = {generatePrivateSiteAccessCode};

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -10,6 +10,7 @@ const config = require('../../../shared/config');
 const adapterManager = require('../adapter-manager');
 const SettingsCache = require('../../../shared/settings-cache');
 const SettingsBREADService = require('./settings-bread-service');
+const {generatePrivateSiteAccessCode} = require('./private-site-access-code');
 const {obfuscatedSetting, isSecretSetting, hideValueIfSecret} = require('./settings-utils');
 const mail = require('../mail');
 const SingleUseTokenProvider = require('../members/single-use-token-provider');
@@ -85,12 +86,48 @@ module.exports = {
      */
     async init() {
         const cacheStore = adapterManager.getAdapter('cache:settings');
-        const settingsCollection = await models.Settings.populateDefaults();
+        await models.Settings.populateDefaults();
+        await this.enforcePublicSiteAccessLimit();
+        const settingsCollection = await models.Settings.findAll({context: {internal: true}});
         const settingsOverrides = getSettingsOverrides();
         SettingsCache.init(events, settingsCollection, this.getCalculatedFields(), cacheStore, settingsOverrides);
 
         // Validate site_uuid matches config
         this.validateSiteUuid();
+    },
+
+    /**
+     * When the `publicSiteAccess` flag limit is disabled, ensure the site
+     * is private and has an access code before the cache is built.
+     *
+     * @private
+     */
+    async enforcePublicSiteAccessLimit() {
+        if (!limits.isDisabled('publicSiteAccess')) {
+            return;
+        }
+
+        const isPrivateSetting = await models.Settings.findOne({key: 'is_private'}, {context: {internal: true}});
+        // Note: the `password` setting is the storage key for what we call the
+        // access code; the underlying setting is staying named for compatibility
+        // and will be renamed in a separate follow-up.
+        const accessCodeSetting = await models.Settings.findOne({key: 'password'}, {context: {internal: true}});
+        const writes = [];
+
+        if (!isPrivateSetting || isPrivateSetting.get('value') !== true) {
+            writes.push({key: 'is_private', value: true});
+        }
+
+        const currentAccessCode = accessCodeSetting && accessCodeSetting.get('value');
+        if (typeof currentAccessCode !== 'string' || currentAccessCode.trim() === '') {
+            writes.push({key: 'password', value: generatePrivateSiteAccessCode()});
+        }
+
+        if (writes.length === 0) {
+            return;
+        }
+
+        await models.Settings.edit(writes, {context: {internal: true}});
     },
 
     /**

--- a/ghost/core/test/unit/server/services/settings/private-site-access-code.test.js
+++ b/ghost/core/test/unit/server/services/settings/private-site-access-code.test.js
@@ -1,0 +1,22 @@
+const assert = require('node:assert/strict');
+const {generatePrivateSiteAccessCode} = require('../../../../../core/server/services/settings/private-site-access-code');
+
+describe('UNIT > private-site-access-code', function () {
+    it('returns a placeholder string matching the fake-### format', function () {
+        for (let i = 0; i < 50; i++) {
+            const code = generatePrivateSiteAccessCode();
+            assert.match(code, /^fake-\d{3}$/);
+        }
+    });
+
+    it('produces varied codes across consecutive calls', function () {
+        const codes = new Set();
+        for (let i = 0; i < 50; i++) {
+            codes.add(generatePrivateSiteAccessCode());
+        }
+        // Just ensure the output isn't constant — 50 draws from a 1,000-value
+        // space has a non-trivial birthday-collision rate, so any tighter
+        // threshold would be flaky.
+        assert.ok(codes.size > 1, `expected varied codes, got ${codes.size} distinct value(s)`);
+    });
+});

--- a/ghost/core/test/unit/server/services/settings/settings-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-service.test.js
@@ -5,6 +5,7 @@ const settingsCache = require('../../../../../core/shared/settings-cache');
 const logging = require('@tryghost/logging');
 const models = require('../../../../../core/server/models');
 const adapterManager = require('../../../../../core/server/services/adapter-manager');
+const limits = require('../../../../../core/server/services/limits');
 
 describe('UNIT: Settings Service', function () {
     let settingsService;
@@ -102,7 +103,8 @@ describe('UNIT: Settings Service', function () {
             configUtils.set('hostSettings:limits:customIntegrations:disabled', true);
 
             sinon.stub(adapterManager, 'getAdapter').withArgs('cache:settings').returns(cacheStore);
-            sinon.stub(models.Settings, 'populateDefaults').resolves(settingsCollection);
+            sinon.stub(models.Settings, 'populateDefaults').resolves();
+            sinon.stub(models.Settings, 'findAll').resolves(settingsCollection);
             const initStub = sinon.stub(settingsCache, 'init');
 
             await settingsService.init();
@@ -124,7 +126,8 @@ describe('UNIT: Settings Service', function () {
             });
 
             sinon.stub(adapterManager, 'getAdapter').withArgs('cache:settings').returns(cacheStore);
-            sinon.stub(models.Settings, 'populateDefaults').resolves(settingsCollection);
+            sinon.stub(models.Settings, 'populateDefaults').resolves();
+            sinon.stub(models.Settings, 'findAll').resolves(settingsCollection);
             const initStub = sinon.stub(settingsCache, 'init');
 
             await settingsService.init();
@@ -134,6 +137,85 @@ describe('UNIT: Settings Service', function () {
                 title: 'Custom title',
                 transistor: true
             });
+        });
+    });
+
+    describe('publicSiteAccess enforcement', function () {
+        function fakeSettingRow(value) {
+            return {get: () => value};
+        }
+
+        beforeEach(function () {
+            sinon.stub(adapterManager, 'getAdapter').withArgs('cache:settings').returns({});
+            sinon.stub(settingsCache, 'init');
+            sinon.stub(models.Settings, 'populateDefaults').resolves();
+            sinon.stub(models.Settings, 'findAll').resolves({});
+        });
+
+        it('is a no-op when the limit is not disabled', async function () {
+            sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(false);
+            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+
+            await settingsService.init();
+
+            sinon.assert.notCalled(editStub);
+        });
+
+        it('persists is_private = true and a generated access code when both are missing', async function () {
+            sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
+            const findOneStub = sinon.stub(models.Settings, 'findOne');
+            findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(false));
+            findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow(''));
+            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+
+            await settingsService.init();
+
+            sinon.assert.calledOnce(editStub);
+            const writes = editStub.firstCall.args[0];
+            const writesByKey = Object.fromEntries(writes.map(w => [w.key, w.value]));
+            assert.equal(writesByKey.is_private, true);
+            assert.match(writesByKey.password, /^fake-\d{3}$/);
+            assert.deepEqual(editStub.firstCall.args[1], {context: {internal: true}});
+        });
+
+        it('only writes the missing values when one is already enforced', async function () {
+            sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
+            const findOneStub = sinon.stub(models.Settings, 'findOne');
+            findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(true));
+            findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow(''));
+            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+
+            await settingsService.init();
+
+            const writes = editStub.firstCall.args[0];
+            assert.equal(writes.length, 1);
+            assert.equal(writes[0].key, 'password');
+        });
+
+        it('does not write when both values are already enforced', async function () {
+            sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
+            const findOneStub = sinon.stub(models.Settings, 'findOne');
+            findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(true));
+            findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow('fake-042'));
+            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+
+            await settingsService.init();
+
+            sinon.assert.notCalled(editStub);
+        });
+
+        it('treats a whitespace-only access code as missing', async function () {
+            sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
+            const findOneStub = sinon.stub(models.Settings, 'findOne');
+            findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(true));
+            findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow('   '));
+            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+
+            await settingsService.init();
+
+            const writes = editStub.firstCall.args[0];
+            assert.equal(writes.length, 1);
+            assert.equal(writes[0].key, 'password');
         });
     });
 });


### PR DESCRIPTION
## Summary

- When the `publicSiteAccess` flag limit is disabled, `settings-service.init()` now ensures the site is private and has an access code before the settings cache is built.
- Uses `models.Settings.findOne` / `edit` to read and write directly — same patterns used elsewhere in the codebase. The cache is initialized once afterward with the final state.
- After first boot the values already match, so steady state is zero writes.
- Access-code generator is a `fake-###` placeholder — the real format will land in a follow-up PR.

## Test plan

- [x] `pnpm test:single test/unit/server/services/settings/private-site-access-code.test.js` — format validation and variability
- [x] `pnpm test:single test/unit/server/services/settings/settings-service.test.js` — 13 passing: limit-off no-op, both values missing, one already enforced, both enforced (zero writes), whitespace-only access code treated as missing
- [x] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)