### PR TITLE
🎨 Added keyboard navigation and shortcuts cheat sheet to theme editor

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -1012,25 +1012,16 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                             {selectedFile?.editable && (
                                 <CodeMirror
                                     key={`${selectedFile.path}:${editorExtensions.length}`}
+                                    autoFocus={editorAutoFocus}
                                     basicSetup={{
                                         highlightActiveLine: false,
                                         highlightActiveLineGutter: false
                                     }}
                                     className='h-full [&_.cm-button]:h-8 [&_.cm-button]:rounded-md [&_.cm-button]:border [&_.cm-button]:border-[#2f333b] [&_.cm-button]:bg-[#1f2228] [&_.cm-button]:bg-none [&_.cm-button]:px-3 [&_.cm-button]:text-[13px] [&_.cm-button]:text-[#c8ccd3] [&_.cm-button:hover]:bg-[#2a2d33] [&_.cm-content]:min-h-full [&_.cm-content]:py-3 [&_.cm-content_*::selection]:bg-[#355070] [&_.cm-cursor]:border-l-[#e6e7ea] [&_.cm-editor]:h-full [&_.cm-editor]:rounded-none [&_.cm-editor]:border-0 [&_.cm-editor]:bg-[#16181c] [&_.cm-gutters]:border-r-[#23262c] [&_.cm-gutters]:bg-[#17191d] [&_.cm-line::selection]:bg-[#355070] [&_.cm-panel]:bg-[#17191d] [&_.cm-panel]:shadow-none [&_.cm-panel.cm-search]:gap-2 [&_.cm-panel.cm-search]:px-3 [&_.cm-panel.cm-search]:py-2 [&_.cm-panel.cm-search]:text-[13px] [&_.cm-panels]:border-b [&_.cm-panels]:border-[#23262c] [&_.cm-panels]:bg-[#17191d] [&_.cm-panels]:text-[#c8ccd3] [&_.cm-scroller]:min-h-full [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:bg-[#16181c] [&_.cm-search]:flex [&_.cm-search]:flex-wrap [&_.cm-search]:items-center [&_.cm-search]:gap-2 [&_.cm-search_label]:inline-flex [&_.cm-search_label]:items-center [&_.cm-search_label]:gap-1.5 [&_.cm-search_label]:text-[#a5abb4] [&_.cm-search_label_input]:h-4 [&_.cm-search_label_input]:w-4 [&_.cm-search_label_input]:accent-[#14b886] [&_.cm-searchMatch]:bg-[#243043] [&_.cm-searchMatch-selected]:bg-[#3b2a16] [&_.cm-searchMatch-selected]:outline-none [&_.cm-selectionBackground]:!bg-[#355070] [&_.cm-selectionLayer_.cm-selectionBackground]:!bg-[#355070] [&_.cm-textfield]:h-8 [&_.cm-textfield]:min-w-[220px] [&_.cm-textfield]:rounded-md [&_.cm-textfield]:border [&_.cm-textfield]:border-[#2f333b] [&_.cm-textfield]:bg-[#16181c] [&_.cm-textfield]:px-2.5 [&_.cm-textfield]:text-[#e6e7ea] [&_.cm-textfield]:outline-none [&_.cm-textfield]:placeholder:text-[#6a6f78]'
-                                    autoFocus={editorAutoFocus}
                                     extensions={editorExtensions}
                                     height='full'
                                     theme={oneDark}
                                     value={selectedFile.content || ''}
-                                    onCreateEditor={() => {
-                                        // Consume the one-shot flag once
-                                        // CodeMirror has mounted and focused.
-                                        // Next remount (e.g. arrow-key
-                                        // navigation) will see autoFocus=false.
-                                        if (editorAutoFocus) {
-                                            setEditorAutoFocus(false);
-                                        }
-                                    }}
                                     onChange={(value) => {
                                         setCurrentFiles(files => ({
                                             ...files,
@@ -1039,6 +1030,17 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                                                 content: value
                                             }
                                         }));
+                                    }}
+                                    onCreateEditor={() => {
+                                        // Consume the one-shot autoFocus flag
+                                        // once CodeMirror has mounted. Next
+                                        // remount (e.g. arrow-key navigation
+                                        // through the tree) will see
+                                        // autoFocus=false and won't steal
+                                        // focus from the tree.
+                                        if (editorAutoFocus) {
+                                            setEditorAutoFocus(false);
+                                        }
                                     }}
                                 />
                             )}

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -4,6 +4,7 @@ import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import ThemeEditorConfirmModal from './theme-editor-confirm-modal';
 import ThemeEditorInputModal from './theme-editor-input-modal';
+import ThemeEditorShortcutsModal from './theme-editor-shortcuts-modal';
 import ThemeEditorToolbar from './theme-editor-toolbar';
 import ThemeFileTree from './theme-file-tree';
 import ThemeInstalledModal from './theme-installed-modal';
@@ -250,6 +251,13 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const [isSaving, setIsSaving] = useState(false);
     const [loadError, setLoadError] = useState<string | null>(null);
     const [isReviewOpen, setIsReviewOpen] = useState(false);
+    const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
+    // CodeMirror is keyed by file path, so it re-mounts every time the user
+    // switches files. The default `autoFocus` then steals focus from the tree
+    // each time arrow keys move selection onto a file — making keyboard nav
+    // unusable. Gate autoFocus on a one-shot flag: true on first mount and
+    // when a tree click explicitly opens a file, false otherwise.
+    const [editorAutoFocus, setEditorAutoFocus] = useState(true);
     const [isTextWrapEnabled, setIsTextWrapEnabled] = useState(false);
     const [editorExtensions, setEditorExtensions] = useState<Array<ReturnType<typeof search> | typeof oneDark | typeof editorSelectionTheme | typeof EditorView.lineWrapping | Awaited<ReturnType<typeof getLanguageExtension>>>>([]);
 
@@ -435,6 +443,16 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const handleSaveRef = useRef<() => void>(() => {});
 
     useEffect(() => {
+        const isTypingTarget = (target: EventTarget | null) => {
+            if (!(target instanceof HTMLElement)) {
+                return false;
+            }
+            if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+                return true;
+            }
+            return target.isContentEditable;
+        };
+
         const handleKeydown = (event: KeyboardEvent) => {
             if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
                 event.preventDefault();
@@ -442,13 +460,18 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                 return;
             }
 
-            if (event.key !== 'Escape') {
+            if (event.key === '?' && !event.metaKey && !event.ctrlKey && !event.altKey && !isTypingTarget(event.target)) {
+                event.preventDefault();
+                setIsShortcutsOpen(true);
                 return;
             }
 
-            event.preventDefault();
-            event.stopPropagation();
-            event.stopImmediatePropagation();
+            // Intentionally do not consume Escape here. Sub-dialogs (the
+            // shortcuts cheat sheet, the review modal, and NiceModal-rendered
+            // confirm/input modals) each manage their own Esc dismissal, and
+            // swallowing Esc here would either block them outright or force
+            // users to press Esc twice. Leaving Esc alone lets each layer
+            // close itself before the next press can reach the editor frame.
         };
 
         window.addEventListener('keydown', handleKeydown, true);
@@ -876,6 +899,11 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const openFile = (path: string) => {
         setSelectedNode({type: 'file', path});
         ensurePathExpanded(path);
+        // Explicit open via click (or review-modal "Open in editor") — focus
+        // the editor so the user can start typing. Keyboard arrow-key
+        // navigation in the tree goes through setSelectedNode directly and
+        // skips this, so focus stays in the tree.
+        setEditorAutoFocus(true);
     };
 
     const selectedFileStatus = selectedFile ? changesMap.get(selectedFile.path) : null;
@@ -900,6 +928,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                     isSaving={isSaving}
                     onClose={closeEditor}
                     onOpenReview={() => setIsReviewOpen(true)}
+                    onOpenShortcuts={() => setIsShortcutsOpen(true)}
                     onSave={() => void handleSave()}
                 />
 
@@ -988,11 +1017,20 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                                         highlightActiveLineGutter: false
                                     }}
                                     className='h-full [&_.cm-button]:h-8 [&_.cm-button]:rounded-md [&_.cm-button]:border [&_.cm-button]:border-[#2f333b] [&_.cm-button]:bg-[#1f2228] [&_.cm-button]:bg-none [&_.cm-button]:px-3 [&_.cm-button]:text-[13px] [&_.cm-button]:text-[#c8ccd3] [&_.cm-button:hover]:bg-[#2a2d33] [&_.cm-content]:min-h-full [&_.cm-content]:py-3 [&_.cm-content_*::selection]:bg-[#355070] [&_.cm-cursor]:border-l-[#e6e7ea] [&_.cm-editor]:h-full [&_.cm-editor]:rounded-none [&_.cm-editor]:border-0 [&_.cm-editor]:bg-[#16181c] [&_.cm-gutters]:border-r-[#23262c] [&_.cm-gutters]:bg-[#17191d] [&_.cm-line::selection]:bg-[#355070] [&_.cm-panel]:bg-[#17191d] [&_.cm-panel]:shadow-none [&_.cm-panel.cm-search]:gap-2 [&_.cm-panel.cm-search]:px-3 [&_.cm-panel.cm-search]:py-2 [&_.cm-panel.cm-search]:text-[13px] [&_.cm-panels]:border-b [&_.cm-panels]:border-[#23262c] [&_.cm-panels]:bg-[#17191d] [&_.cm-panels]:text-[#c8ccd3] [&_.cm-scroller]:min-h-full [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:bg-[#16181c] [&_.cm-search]:flex [&_.cm-search]:flex-wrap [&_.cm-search]:items-center [&_.cm-search]:gap-2 [&_.cm-search_label]:inline-flex [&_.cm-search_label]:items-center [&_.cm-search_label]:gap-1.5 [&_.cm-search_label]:text-[#a5abb4] [&_.cm-search_label_input]:h-4 [&_.cm-search_label_input]:w-4 [&_.cm-search_label_input]:accent-[#14b886] [&_.cm-searchMatch]:bg-[#243043] [&_.cm-searchMatch-selected]:bg-[#3b2a16] [&_.cm-searchMatch-selected]:outline-none [&_.cm-selectionBackground]:!bg-[#355070] [&_.cm-selectionLayer_.cm-selectionBackground]:!bg-[#355070] [&_.cm-textfield]:h-8 [&_.cm-textfield]:min-w-[220px] [&_.cm-textfield]:rounded-md [&_.cm-textfield]:border [&_.cm-textfield]:border-[#2f333b] [&_.cm-textfield]:bg-[#16181c] [&_.cm-textfield]:px-2.5 [&_.cm-textfield]:text-[#e6e7ea] [&_.cm-textfield]:outline-none [&_.cm-textfield]:placeholder:text-[#6a6f78]'
+                                    autoFocus={editorAutoFocus}
                                     extensions={editorExtensions}
                                     height='full'
                                     theme={oneDark}
                                     value={selectedFile.content || ''}
-                                    autoFocus
+                                    onCreateEditor={() => {
+                                        // Consume the one-shot flag once
+                                        // CodeMirror has mounted and focused.
+                                        // Next remount (e.g. arrow-key
+                                        // navigation) will see autoFocus=false.
+                                        if (editorAutoFocus) {
+                                            setEditorAutoFocus(false);
+                                        }
+                                    }}
                                     onChange={(value) => {
                                         setCurrentFiles(files => ({
                                             ...files,
@@ -1018,6 +1056,10 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                         }}
                         onRevert={handleRevertPath}
                     />
+                )}
+
+                {isShortcutsOpen && (
+                    <ThemeEditorShortcutsModal onClose={() => setIsShortcutsOpen(false)} />
                 )}
             </div>
         </div>

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-shortcuts-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-shortcuts-modal.tsx
@@ -1,0 +1,110 @@
+import React, {useEffect, useRef} from 'react';
+import {X} from 'lucide-react';
+import {iconButtonClass} from './theme-editor-styles';
+
+type Shortcut = {
+    keys: string[];
+    description: string;
+};
+
+type ShortcutSection = {
+    title: string;
+    shortcuts: Shortcut[];
+};
+
+const SHORTCUT_SECTIONS: ShortcutSection[] = [
+    {
+        title: 'Global',
+        shortcuts: [
+            {keys: ['⌘/Ctrl', 'S'], description: 'Save and upload theme'},
+            {keys: ['Esc'], description: 'Close editor (prompts if unsaved)'},
+            {keys: ['?'], description: 'Show keyboard shortcuts'}
+        ]
+    },
+    {
+        title: 'File tree',
+        shortcuts: [
+            {keys: ['↑', '↓'], description: 'Move selection'},
+            {keys: ['→'], description: 'Expand folder or move to first child'},
+            {keys: ['←'], description: 'Collapse folder or move to parent'},
+            {keys: ['Enter'], description: 'Open file or toggle folder'},
+            {keys: ['Space'], description: 'Open file or toggle folder'},
+            {keys: ['F2'], description: 'Rename selected file or folder'},
+            {keys: ['Del'], description: 'Delete selected file or folder'}
+        ]
+    }
+];
+
+const kbdClass = 'inline-flex min-w-[26px] items-center justify-center rounded border border-[#2f333b] bg-[#1a1d21] px-1.5 py-0.5 text-[11px] font-medium text-[#e6e7ea]';
+
+type Props = {
+    onClose: () => void;
+};
+
+const ThemeEditorShortcutsModal: React.FC<Props> = ({onClose}) => {
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        closeButtonRef.current?.focus();
+    }, []);
+
+    const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        // Element-level handler so the editor's own window-capture Esc
+        // listener doesn't swallow this. Stop propagation to keep the
+        // dialog dismissable without also triggering the editor's
+        // close-with-discard flow.
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            event.stopPropagation();
+            onClose();
+        }
+    };
+
+    return (
+        <div
+            aria-label='Keyboard shortcuts'
+            aria-modal='true'
+            className='absolute inset-0 z-20 flex items-center justify-center bg-[rgba(8,10,14,0.64)]'
+            role='dialog'
+            onClick={onClose}
+            onKeyDown={onKeyDown}
+        >
+            <div
+                className='flex max-h-[min(80vh,640px)] w-[min(560px,calc(100%-24px))] flex-col overflow-hidden rounded-[10px] border border-[#2b3038] bg-[#171a20] p-5 shadow-[0_24px_64px_rgba(0,0,0,0.45)]'
+                data-testid='theme-editor-shortcuts-modal'
+                onClick={event => event.stopPropagation()}
+            >
+                <div className='mb-3 flex items-center justify-between gap-3'>
+                    <h3 className='text-[16px] font-semibold text-[#f4f5f7]'>Keyboard shortcuts</h3>
+                    <button ref={closeButtonRef} aria-label='Close keyboard shortcuts' className={iconButtonClass} type='button' onClick={onClose}>
+                        <X size={14} />
+                    </button>
+                </div>
+                <div className='min-h-0 flex-1 space-y-4 overflow-y-auto pr-1'>
+                    {SHORTCUT_SECTIONS.map(section => (
+                        <section key={section.title}>
+                            <h4 className='mb-2 text-[11px] font-semibold tracking-[0.08em] text-[#8a8f98] uppercase'>{section.title}</h4>
+                            <ul className='space-y-1.5'>
+                                {section.shortcuts.map(shortcut => (
+                                    <li key={shortcut.description} className='flex items-center justify-between gap-4 rounded-md border border-transparent px-2 py-1 text-[13px] text-[#d4d8de]'>
+                                        <span>{shortcut.description}</span>
+                                        <span className='flex shrink-0 items-center gap-1'>
+                                            {shortcut.keys.map((key, index) => (
+                                                <React.Fragment key={key}>
+                                                    {index > 0 && <span className='text-[11px] text-[#6a6f78]'>+</span>}
+                                                    <kbd className={kbdClass}>{key}</kbd>
+                                                </React.Fragment>
+                                            ))}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ThemeEditorShortcutsModal;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-toolbar.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-editor-toolbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {Save, X} from 'lucide-react';
-import {ghostButtonClass, primaryButtonClass} from './theme-editor-styles';
+import {Keyboard, Save, X} from 'lucide-react';
+import {ghostButtonClass, iconButtonClass, primaryButtonClass} from './theme-editor-styles';
 import type {ThemeChange} from './theme-editor-utils';
 
 type ThemeEditorToolbarProps = {
@@ -8,6 +8,7 @@ type ThemeEditorToolbarProps = {
     changes: ThemeChange[];
     isSaving: boolean;
     onOpenReview: () => void;
+    onOpenShortcuts: () => void;
     onClose: () => void;
     onSave: () => void;
 };
@@ -17,6 +18,7 @@ const ThemeEditorToolbar: React.FC<ThemeEditorToolbarProps> = ({
     changes,
     isSaving,
     onOpenReview,
+    onOpenShortcuts,
     onClose,
     onSave
 }) => {
@@ -36,6 +38,9 @@ const ThemeEditorToolbar: React.FC<ThemeEditorToolbarProps> = ({
                 </button>
             )}
             <div className='grow' />
+            <button aria-label='Show keyboard shortcuts' className={iconButtonClass} title='Keyboard shortcuts (?)' type='button' onClick={onOpenShortcuts}>
+                <Keyboard size={14} />
+            </button>
             <button className={ghostButtonClass} type='button' onClick={onClose}>
                 <X size={14} />
                 Close

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-file-tree.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-file-tree.tsx
@@ -27,6 +27,11 @@ type TreeNode = {
 type VisibleNode = {
     node: TreeNode;
     depth: number;
+    // 1-based position among visible siblings at the same depth + the total
+    // count of siblings, surfaced as aria-posinset / aria-setsize so screen
+    // readers can announce "item N of M" inside the flattened tree.
+    posInSet: number;
+    setSize: number;
 };
 
 const buildTree = (files: Record<string, ThemeEditorFile>) => {
@@ -91,17 +96,17 @@ const sortTreeNodes = (nodes: TreeNode[]) => {
 const collectVisibleNodes = (root: TreeNode, expanded: Set<string>): VisibleNode[] => {
     const result: VisibleNode[] = [];
 
-    const visit = (node: TreeNode, depth: number) => {
-        result.push({node, depth});
+    const visit = (node: TreeNode, depth: number, posInSet: number, setSize: number) => {
+        result.push({node, depth, posInSet, setSize});
 
         if (node.type === 'dir' && expanded.has(node.path) && node.children) {
             const sorted = sortTreeNodes(Array.from(node.children.values()));
-            sorted.forEach(child => visit(child, depth + 1));
+            sorted.forEach((child, index) => visit(child, depth + 1, index + 1, sorted.length));
         }
     };
 
     const topLevel = sortTreeNodes(Array.from(root.children?.values() || []));
-    topLevel.forEach(node => visit(node, 0));
+    topLevel.forEach((node, index) => visit(node, 0, index + 1, topLevel.length));
 
     return result;
 };
@@ -224,7 +229,12 @@ const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
             return;
         }
 
-        if (event.metaKey || event.ctrlKey || event.altKey) {
+        // Plain modifier combos belong to the surrounding admin (Cmd+S, Cmd+R
+        // and friends) — bail out unless this is the Cmd/Ctrl+Backspace
+        // delete shortcut, which we want to land in the Backspace case below.
+        const isDeleteShortcut = event.key === 'Backspace' && (event.metaKey || event.ctrlKey);
+
+        if ((event.metaKey || event.ctrlKey || event.altKey) && !isDeleteShortcut) {
             return;
         }
 
@@ -284,12 +294,12 @@ const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
             return;
         case 'Delete':
         case 'Backspace':
-            if (event.key === 'Backspace' && !event.metaKey) {
+            if (event.key === 'Backspace' && !(event.metaKey || event.ctrlKey)) {
                 // Plain Backspace inside a content-editable would normally
-                // delete text; we only treat it as "delete node" when meta
-                // isn't held (the editor itself listens for Cmd/Ctrl+S etc).
-                // We still skip it to avoid surprising users typing in modals
-                // that render on top of the tree.
+                // delete text. We only treat it as "delete node" when Cmd
+                // or Ctrl is held (matching the macOS Finder / VS Code
+                // delete shortcut), which is the only way Backspace gets
+                // past the modifier bailout above.
                 return;
             }
             event.preventDefault();
@@ -310,7 +320,7 @@ const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
     }, []);
 
     const renderTreeItem = (entry: VisibleNode, index: number) => {
-        const {node, depth} = entry;
+        const {node, depth, posInSet, setSize} = entry;
         const isSelected = index === selectedIndex;
         const isTabbable = index === tabbableIndex;
         const key = refKeyFor(node.type, node.path);
@@ -323,7 +333,9 @@ const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
                     key={node.path}
                     ref={registerButtonRef(key)}
                     aria-level={depth + 1}
+                    aria-posinset={posInSet}
                     aria-selected={isSelected}
+                    aria-setsize={setSize}
                     className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#243043] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'} ${!node.editable ? 'opacity-70' : ''}`}
                     data-tree-item='true'
                     role='treeitem'
@@ -350,7 +362,9 @@ const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
                 ref={registerButtonRef(key)}
                 aria-expanded={isExpanded}
                 aria-level={depth + 1}
+                aria-posinset={posInSet}
                 aria-selected={isSelected}
+                aria-setsize={setSize}
                 className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#202630] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'}`}
                 data-tree-item='true'
                 role='treeitem'

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-file-tree.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-file-tree.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
     ChevronDown,
     ChevronRight,
@@ -22,6 +22,11 @@ type TreeNode = {
     path: string;
     editable?: boolean;
     children?: Map<string, TreeNode>;
+};
+
+type VisibleNode = {
+    node: TreeNode;
+    depth: number;
 };
 
 const buildTree = (files: Record<string, ThemeEditorFile>) => {
@@ -83,6 +88,48 @@ const sortTreeNodes = (nodes: TreeNode[]) => {
     });
 };
 
+const collectVisibleNodes = (root: TreeNode, expanded: Set<string>): VisibleNode[] => {
+    const result: VisibleNode[] = [];
+
+    const visit = (node: TreeNode, depth: number) => {
+        result.push({node, depth});
+
+        if (node.type === 'dir' && expanded.has(node.path) && node.children) {
+            const sorted = sortTreeNodes(Array.from(node.children.values()));
+            sorted.forEach(child => visit(child, depth + 1));
+        }
+    };
+
+    const topLevel = sortTreeNodes(Array.from(root.children?.values() || []));
+    topLevel.forEach(node => visit(node, 0));
+
+    return result;
+};
+
+// "Parent" within the visible-node list — the nearest preceding entry whose
+// depth is strictly less. Used for Arrow Left collapsed-or-leaf behavior so we
+// don't have to derive the parent path from string-splitting (which would miss
+// cases where a directory only became "visible" because a sibling was expanded).
+const findParentVisibleNode = (visibleNodes: VisibleNode[], index: number): VisibleNode | null => {
+    const currentDepth = visibleNodes[index]?.depth ?? 0;
+
+    for (let i = index - 1; i >= 0; i -= 1) {
+        if (visibleNodes[i].depth < currentDepth) {
+            return visibleNodes[i];
+        }
+    }
+
+    return null;
+};
+
+const findNodeIndex = (visibleNodes: VisibleNode[], selected: SelectedNode): number => {
+    if (!selected) {
+        return -1;
+    }
+
+    return visibleNodes.findIndex(({node}) => node.type === selected.type && node.path === selected.path);
+};
+
 const fileActionButtonClass = 'inline-flex h-5 w-5 items-center justify-center rounded-sm text-[#c8ccd3] transition-opacity hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a9eff] disabled:cursor-not-allowed disabled:opacity-30';
 
 type ThemeFileTreeProps = {
@@ -112,66 +159,213 @@ const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
     onDeleteSelected,
     onOpenFile
 }) => {
-    const renderTreeNode = (node: TreeNode, depth = 0): React.ReactNode => {
+    const tree = useMemo(() => buildTree(currentFiles), [currentFiles]);
+    const visibleNodes = useMemo(() => collectVisibleNodes(tree, expandedDirectories), [tree, expandedDirectories]);
+
+    const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+    const [pendingFocusKey, setPendingFocusKey] = useState<string | null>(null);
+
+    // Buttons are keyed by `${type}:${path}` so a file and a dir at the same
+    // path (a synthetic case, but possible in renames) don't collide.
+    const refKeyFor = useCallback((type: 'file' | 'dir', path: string) => `${type}:${path}`, []);
+
+    useEffect(() => {
+        if (!pendingFocusKey) {
+            return;
+        }
+
+        const button = buttonRefs.current.get(pendingFocusKey);
+
+        if (button) {
+            button.focus();
+        }
+
+        setPendingFocusKey(null);
+    }, [pendingFocusKey, visibleNodes]);
+
+    const selectedIndex = findNodeIndex(visibleNodes, selectedNode);
+    // Roving tabindex: the selected node owns tabIndex=0 so Tab lands on it.
+    // If nothing is selected, the first visible node becomes tabbable so the
+    // tree is still keyboard-reachable from the toolbar.
+    const tabbableIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+    const moveSelectionToVisible = useCallback((index: number) => {
+        const entry = visibleNodes[index];
+
+        if (!entry) {
+            return;
+        }
+
+        setSelectedNode({type: entry.node.type, path: entry.node.path});
+        setPendingFocusKey(refKeyFor(entry.node.type, entry.node.path));
+    }, [visibleNodes, setSelectedNode, refKeyFor]);
+
+    const toggleDirectory = useCallback((path: string) => {
+        setExpandedDirectories((current) => {
+            const next = new Set(current);
+
+            if (next.has(path)) {
+                next.delete(path);
+            } else {
+                next.add(path);
+            }
+
+            return next;
+        });
+    }, [setExpandedDirectories]);
+
+    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+        // Avoid hijacking keys that bubble up from the toolbar's icon
+        // buttons or other interactive children — only treeitem buttons
+        // carry data-tree-item.
+        const target = event.target as HTMLElement;
+
+        if (!target.closest('[data-tree-item="true"]')) {
+            return;
+        }
+
+        if (event.metaKey || event.ctrlKey || event.altKey) {
+            return;
+        }
+
+        const currentIndex = selectedIndex >= 0 ? selectedIndex : 0;
+        const current = visibleNodes[currentIndex];
+
+        switch (event.key) {
+        case 'ArrowDown':
+            event.preventDefault();
+            if (currentIndex < visibleNodes.length - 1) {
+                moveSelectionToVisible(currentIndex + 1);
+            }
+            return;
+        case 'ArrowUp':
+            event.preventDefault();
+            if (currentIndex > 0) {
+                moveSelectionToVisible(currentIndex - 1);
+            }
+            return;
+        case 'ArrowRight':
+            event.preventDefault();
+            if (!current) {
+                return;
+            }
+            if (current.node.type === 'dir') {
+                if (!expandedDirectories.has(current.node.path)) {
+                    toggleDirectory(current.node.path);
+                    return;
+                }
+                if (currentIndex < visibleNodes.length - 1 && visibleNodes[currentIndex + 1].depth > current.depth) {
+                    moveSelectionToVisible(currentIndex + 1);
+                }
+            }
+            return;
+        case 'ArrowLeft':
+            event.preventDefault();
+            if (!current) {
+                return;
+            }
+            if (current.node.type === 'dir' && expandedDirectories.has(current.node.path)) {
+                toggleDirectory(current.node.path);
+                return;
+            }
+            {
+                const parent = findParentVisibleNode(visibleNodes, currentIndex);
+                if (parent) {
+                    const parentIndex = visibleNodes.indexOf(parent);
+                    moveSelectionToVisible(parentIndex);
+                }
+            }
+            return;
+        case 'F2':
+            event.preventDefault();
+            if (selectedNode) {
+                onRenameSelected();
+            }
+            return;
+        case 'Delete':
+        case 'Backspace':
+            if (event.key === 'Backspace' && !event.metaKey) {
+                // Plain Backspace inside a content-editable would normally
+                // delete text; we only treat it as "delete node" when meta
+                // isn't held (the editor itself listens for Cmd/Ctrl+S etc).
+                // We still skip it to avoid surprising users typing in modals
+                // that render on top of the tree.
+                return;
+            }
+            event.preventDefault();
+            if (selectedNode) {
+                onDeleteSelected();
+            }
+            return;
+        default:
+        }
+    }, [visibleNodes, selectedIndex, selectedNode, expandedDirectories, moveSelectionToVisible, toggleDirectory, onRenameSelected, onDeleteSelected]);
+
+    const registerButtonRef = useCallback((key: string) => (element: HTMLButtonElement | null) => {
+        if (element) {
+            buttonRefs.current.set(key, element);
+        } else {
+            buttonRefs.current.delete(key);
+        }
+    }, []);
+
+    const renderTreeItem = (entry: VisibleNode, index: number) => {
+        const {node, depth} = entry;
+        const isSelected = index === selectedIndex;
+        const isTabbable = index === tabbableIndex;
+        const key = refKeyFor(node.type, node.path);
+
         if (node.type === 'file') {
-            const isSelected = selectedNode?.type === 'file' && selectedNode.path === node.path;
             const changeStatus = changesMap.get(node.path);
 
             return (
                 <button
                     key={node.path}
+                    ref={registerButtonRef(key)}
+                    aria-level={depth + 1}
+                    aria-selected={isSelected}
                     className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#243043] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'} ${!node.editable ? 'opacity-70' : ''}`}
+                    data-tree-item='true'
+                    role='treeitem'
                     style={{paddingLeft: `${depth * 14 + 8}px`}}
+                    tabIndex={isTabbable ? 0 : -1}
                     type='button'
                     onClick={() => onOpenFile(node.path)}
                 >
-                    <span className='w-3 shrink-0' />
-                    <FileCode2 size={14} />
+                    <span aria-hidden='true' className='w-3 shrink-0' />
+                    <FileCode2 aria-hidden='true' size={14} />
                     <span className='min-w-0 grow truncate'>{node.name}</span>
                     {changeStatus && (
-                        <span className={`mr-1 h-1.5 w-1.5 shrink-0 rounded-full ${changeStatus === 'deleted' ? 'bg-[#ff6b6b]' : changeStatus === 'added' ? 'bg-[#14b886]' : 'bg-[#f5a623]'}`} />
+                        <span aria-hidden='true' className={`mr-1 h-1.5 w-1.5 shrink-0 rounded-full ${changeStatus === 'deleted' ? 'bg-[#ff6b6b]' : changeStatus === 'added' ? 'bg-[#14b886]' : 'bg-[#f5a623]'}`} />
                     )}
                 </button>
             );
         }
 
         const isExpanded = expandedDirectories.has(node.path);
-        const isSelected = selectedNode?.type === 'dir' && selectedNode.path === node.path;
-        const children = sortTreeNodes(Array.from(node.children?.values() || []));
 
         return (
-            <div key={node.path || 'root'}>
-                {node.path && (
-                    <button
-                        className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#202630] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'}`}
-                        style={{paddingLeft: `${depth * 14 + 8}px`}}
-                        type='button'
-                        onClick={() => {
-                            setSelectedNode({type: 'dir', path: node.path});
-                            setExpandedDirectories((current) => {
-                                const next = new Set(current);
-
-                                if (next.has(node.path)) {
-                                    next.delete(node.path);
-                                } else {
-                                    next.add(node.path);
-                                }
-
-                                return next;
-                            });
-                        }}
-                    >
-                        {isExpanded ? <ChevronDown className='shrink-0 text-[#6a6f78]' size={12} /> : <ChevronRight className='shrink-0 text-[#6a6f78]' size={12} />}
-                        {isExpanded ? <FolderOpen className='shrink-0 text-[#8a8f98]' size={14} /> : <Folder className='shrink-0 text-[#8a8f98]' size={14} />}
-                        <span className='truncate'>{node.name}</span>
-                    </button>
-                )}
-                {(node.path === '' || isExpanded) && (
-                    <div>
-                        {children.map(child => renderTreeNode(child, node.path ? depth + 1 : depth))}
-                    </div>
-                )}
-            </div>
+            <button
+                key={node.path}
+                ref={registerButtonRef(key)}
+                aria-expanded={isExpanded}
+                aria-level={depth + 1}
+                aria-selected={isSelected}
+                className={`flex min-h-6 w-full items-center gap-1.5 rounded px-2 py-1 text-left text-[13px] leading-5 ${isSelected ? 'bg-[#202630] text-white' : 'text-[#c8ccd3] hover:bg-[#1f2228]'}`}
+                data-tree-item='true'
+                role='treeitem'
+                style={{paddingLeft: `${depth * 14 + 8}px`}}
+                tabIndex={isTabbable ? 0 : -1}
+                type='button'
+                onClick={() => {
+                    setSelectedNode({type: 'dir', path: node.path});
+                    toggleDirectory(node.path);
+                }}
+            >
+                {isExpanded ? <ChevronDown aria-hidden='true' className='shrink-0 text-[#6a6f78]' size={12} /> : <ChevronRight aria-hidden='true' className='shrink-0 text-[#6a6f78]' size={12} />}
+                {isExpanded ? <FolderOpen aria-hidden='true' className='shrink-0 text-[#8a8f98]' size={14} /> : <Folder aria-hidden='true' className='shrink-0 text-[#8a8f98]' size={14} />}
+                <span className='truncate'>{node.name}</span>
+            </button>
         );
     };
 
@@ -191,7 +385,7 @@ const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
                     </button>
                 </div>
             </div>
-            <div className='min-h-0 flex-1 overflow-y-auto px-2 py-2'>
+            <div className='min-h-0 flex-1 overflow-y-auto px-2 py-2' onKeyDown={handleKeyDown}>
                 {isLoading ? (
                     <div className='flex h-full flex-col items-center justify-center gap-3 text-center text-[13px] text-[#8a8f98]'>
                         <div className='h-5 w-5 animate-spin rounded-full border-2 border-[#2f333b] border-t-[#14b886]' />
@@ -200,7 +394,9 @@ const ThemeFileTree: React.FC<ThemeFileTreeProps> = ({
                 ) : Object.keys(currentFiles).length === 0 ? (
                     <div className='px-3 py-4 text-[12px] text-[#8a8f98]'>This theme archive does not contain any files.</div>
                 ) : (
-                    renderTreeNode(buildTree(currentFiles))
+                    <div aria-label='Theme files' role='tree'>
+                        {visibleNodes.map((entry, index) => renderTreeItem(entry, index))}
+                    </div>
                 )}
             </div>
         </aside>

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -399,6 +399,121 @@ test.describe('Theme settings', async () => {
         await expect(editorModal).toContainText(/1 file modified/);
     });
 
+    test('Tree keyboard navigation moves selection and arrows expand folders', async ({page}) => {
+        // Clean fixture so detectCommonRoot collapses the leading folder and
+        // the tree shows a stable flat list of editable files / folders.
+        const themeZip = await createArchiveBuffer((zip) => {
+            zip.file('package.json', '{"name":"edition","version":"1.0.0"}\n');
+            zip.file('styles.css', 'body { color: black; }\n');
+            zip.file('partials/header.hbs', '<header></header>\n');
+        });
+
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: {
+                method: 'GET',
+                path: '/themes/edition/download/',
+                response: '',
+                rawResponse: themeZip,
+                responseHeaders: {'content-type': 'application/zip'}
+            }
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+
+        // package.json is the default selection — confirm it carries
+        // aria-selected so the roving-tabindex pattern landed correctly.
+        const packageItem = editorModal.getByRole('treeitem', {name: 'package.json'});
+        await expect(packageItem).toHaveAttribute('aria-selected', 'true');
+
+        // Visible order: dirs first, then files alphabetically — so
+        // [partials/, package.json, styles.css]. Default selection is
+        // package.json (index 1). Walk down to styles.css with ArrowDown.
+        await packageItem.focus();
+        await page.keyboard.press('ArrowDown');
+        await expect(editorModal.getByRole('treeitem', {name: 'styles.css'})).toHaveAttribute('aria-selected', 'true');
+        // Editor breadcrumb should reflect the new selection — proves the
+        // arrow-key flow drives the same state that opens files on click.
+        await expect(editorModal).toContainText('styles.css');
+
+        // ArrowUp twice walks back to the partials folder (above package.json).
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+        const partialsItem = editorModal.getByRole('treeitem', {name: /partials/});
+        await expect(partialsItem).toHaveAttribute('aria-selected', 'true');
+        await expect(partialsItem).toHaveAttribute('aria-expanded', 'false');
+
+        // ArrowRight expands the folder; ArrowLeft collapses it again.
+        await page.keyboard.press('ArrowRight');
+        await expect(partialsItem).toHaveAttribute('aria-expanded', 'true');
+        await expect(editorModal.getByRole('treeitem', {name: 'header.hbs'})).toBeVisible();
+        await page.keyboard.press('ArrowLeft');
+        await expect(partialsItem).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('F2 opens rename and Delete opens delete confirmation', async ({page}) => {
+        const themeZip = await createArchiveBuffer((zip) => {
+            zip.file('package.json', '{"name":"edition","version":"1.0.0"}\n');
+            zip.file('styles.css', 'body { color: black; }\n');
+        });
+
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: {
+                method: 'GET',
+                path: '/themes/edition/download/',
+                response: '',
+                rawResponse: themeZip,
+                responseHeaders: {'content-type': 'application/zip'}
+            }
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+
+        const packageItem = editorModal.getByRole('treeitem', {name: 'package.json'});
+        await packageItem.focus();
+        await page.keyboard.press('F2');
+
+        const renameModal = page.getByTestId('theme-editor-input-modal');
+        await expect(renameModal).toBeVisible();
+        await renameModal.getByRole('button', {name: 'Cancel'}).click();
+        await expect(renameModal).not.toBeVisible();
+
+        await packageItem.focus();
+        await page.keyboard.press('Delete');
+
+        const confirmModal = page.getByTestId('theme-editor-confirm-modal');
+        await expect(confirmModal).toBeVisible();
+        await expect(confirmModal).toContainText(/delete/i);
+    });
+
+    test('Toolbar button opens the keyboard shortcuts cheat sheet', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            downloadTheme: themeDownloadRequest('edition')
+        }});
+
+        const editorModal = await openInstalledThemeEditor(page, 'edition');
+        await expect(editorModal).toBeVisible();
+
+        await editorModal.getByRole('button', {name: 'Show keyboard shortcuts'}).click();
+        const shortcutsModal = page.getByTestId('theme-editor-shortcuts-modal');
+        await expect(shortcutsModal).toBeVisible();
+        await expect(shortcutsModal).toContainText('Keyboard shortcuts');
+        // Surface at least one shortcut from each section so a future copy
+        // change can't silently empty the cheat sheet.
+        await expect(shortcutsModal).toContainText('Save and upload theme');
+        await expect(shortcutsModal).toContainText('Move selection');
+
+        // Closing returns focus to the editor frame without closing it.
+        await shortcutsModal.getByRole('button', {name: 'Close keyboard shortcuts'}).click();
+        await expect(shortcutsModal).not.toBeVisible();
+        await expect(editorModal).toBeVisible();
+    });
+
     test('Saves built-in themes as a new theme name', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -487,6 +487,16 @@ test.describe('Theme settings', async () => {
         const confirmModal = page.getByTestId('theme-editor-confirm-modal');
         await expect(confirmModal).toBeVisible();
         await expect(confirmModal).toContainText(/delete/i);
+        await confirmModal.getByRole('button', {name: 'Cancel'}).click();
+        await expect(confirmModal).not.toBeVisible();
+
+        // Cmd/Ctrl+Backspace is the macOS-style delete shortcut — should
+        // open the same confirmation as Delete. Plain Backspace stays a
+        // no-op so the tree doesn't surprise users who hit it by reflex.
+        await packageItem.focus();
+        await page.keyboard.press('ControlOrMeta+Backspace');
+        await expect(confirmModal).toBeVisible();
+        await expect(confirmModal).toContainText(/delete/i);
     });
 
     test('Toolbar button opens the keyboard shortcuts cheat sheet', async ({page}) => {

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -958,7 +958,7 @@ test.describe('Theme settings', async () => {
 
         const editorModal = await openInstalledThemeEditor(page, 'edition');
 
-        await editorModal.getByRole('button', {name: '.DS_Store'}).click();
+        await editorModal.getByRole('treeitem', {name: '.DS_Store'}).click();
 
         await expect(editorModal).toContainText('This file cannot be edited in the browser.');
         await expect(editorModal.locator('.cm-editor')).toHaveCount(0);


### PR DESCRIPTION
- the file tree was mouse-only; users could not move between files, open folders, rename, or delete without a pointing device
- adds a roving-tabindex tree with role=tree/treeitem, aria-expanded on folders, aria-selected on the current node, and arrow / Enter / Space / F2 / Delete bindings
- adds a "?" toolbar button and global "?" shortcut that opens a cheat-sheet listing every keyboard shortcut the editor supports
- gates CodeMirror's autoFocus to a one-shot flag so arrow-key navigation onto a file no longer drags focus into the editor mid-traversal
- editor no longer swallows Esc, letting sub-dialogs (rename, delete confirm, review, shortcuts) dismiss themselves

<img width="1440" height="900" alt="27922-a11y-shortcuts" src="https://github.com/user-attachments/assets/7b15a3b6-9e4a-421c-9ea2-7768f31bb50c" />

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
