### PR TITLE
🐛 Fixed broken oembeds on sites with many past embeds

### DIFF
--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -8,6 +8,7 @@ const _ = require('lodash');
 const charset = require('charset');
 const iconv = require('iconv-lite');
 const path = require('path');
+const crypto = require('crypto');
 
 // Some sites block non-standard user agents so we need to mimic a typical browser
 // Note: the Ghost/5.0 string _may_ be in use by 3rd parties so use caution when updating across majors
@@ -155,22 +156,15 @@ class OEmbedService {
 
         // Extract file name from URL
         const fileName = path.basename(new URL(imageUrl).pathname);
-        let ext = path.extname(fileName);
-        let name;
+        const ext = path.extname(fileName);
+        const baseName = ext ? path.basename(fileName, ext) : fileName;
+        const name = store.getSanitizedFileName(baseName);
 
-        if (ext) {
-            name = store.getSanitizedFileName(path.basename(fileName, ext));
-        } else {
-            name = store.getSanitizedFileName(path.basename(fileName));
-        }
+        const hash = crypto.createHash('sha256').update(imageBuffer).digest('hex');
+        const hashedFileName = `${name}-${hash}${ext}`;
+        const targetPath = path.join(imageType, hashedFileName);
 
-        let targetDir = path.join(this.config.getContentPath('images'), imageType);
-        const uniqueFilePath = await store.generateUnique(targetDir, name, ext, 0);
-        const targetPath = path.join(imageType, path.basename(uniqueFilePath));
-
-        const imageStoredUrl = await store.saveRaw(imageBuffer, targetPath);
-
-        return imageStoredUrl;
+        return store.saveRaw(imageBuffer, targetPath);
     }
 
     /**

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -262,9 +262,12 @@ describe('oembed-service', function () {
     });
 
     describe('processImageFromUrl', function () {
+        const crypto = require('crypto');
+        const hashFor = buffer => crypto.createHash('sha256').update(buffer).digest('hex');
+
         it('stores downloaded bookmark assets via image storage and returns stored URL', async function () {
+            const imageBytes = Buffer.from('img-bytes');
             const saveRaw = sinon.stub().resolves('https://storage.ghost.is/c/6f/a3/site/content/images/thumbnail/sample.png');
-            const generateUnique = sinon.stub().resolves('/tmp/content/images/thumbnail/sample.png');
             const getSanitizedFileName = sinon.stub().returns('sample');
 
             const service = new OembedService({
@@ -277,14 +280,13 @@ describe('oembed-service', function () {
                     getStorage() {
                         return {
                             getSanitizedFileName,
-                            generateUnique,
                             saveRaw
                         };
                     }
                 },
                 externalRequest() {
                     return {
-                        buffer: async () => Buffer.from('img-bytes')
+                        buffer: async () => imageBytes
                     };
                 }
             });
@@ -293,14 +295,83 @@ describe('oembed-service', function () {
 
             assert.equal(storedUrl, 'https://storage.ghost.is/c/6f/a3/site/content/images/thumbnail/sample.png');
             sinon.assert.calledOnce(getSanitizedFileName);
-            sinon.assert.calledOnce(generateUnique);
             sinon.assert.calledOnce(saveRaw);
-            assert.equal(saveRaw.firstCall.args[1], 'thumbnail/sample.png');
+            assert.equal(saveRaw.firstCall.args[1], `thumbnail/sample-${hashFor(imageBytes)}.png`);
         });
 
-        it('works when saveRaw returns a relative path (local storage)', async function () {
+        it('writes the same path for identical bytes (idempotent across re-bookmarks)', async function () {
+            const imageBytes = Buffer.from('ico-bytes');
             const saveRaw = sinon.stub().resolves('/content/images/icon/favicon.ico');
-            const generateUnique = sinon.stub().resolves('/tmp/content/images/icon/favicon.ico');
+            const getSanitizedFileName = sinon.stub().returns('favicon');
+
+            const service = new OembedService({
+                config: {
+                    getContentPath() {
+                        return '/tmp/content/images';
+                    }
+                },
+                storage: {
+                    getStorage() {
+                        return {
+                            getSanitizedFileName,
+                            saveRaw
+                        };
+                    }
+                },
+                externalRequest() {
+                    return {
+                        buffer: async () => imageBytes
+                    };
+                }
+            });
+
+            await service.processImageFromUrl('https://a.example.com/favicon.ico', 'icon');
+            await service.processImageFromUrl('https://b.example.com/favicon.ico', 'icon');
+
+            const expectedPath = `icon/favicon-${hashFor(imageBytes)}.ico`;
+            assert.equal(saveRaw.firstCall.args[1], expectedPath);
+            assert.equal(saveRaw.secondCall.args[1], expectedPath);
+        });
+
+        it('writes different paths for different bytes (CAS discriminates)', async function () {
+            const aBytes = Buffer.from('icon-a');
+            const bBytes = Buffer.from('icon-b');
+            const saveRaw = sinon.stub().resolves('/stored');
+            const getSanitizedFileName = sinon.stub().returns('favicon');
+
+            const buffers = [aBytes, bBytes];
+            const service = new OembedService({
+                config: {
+                    getContentPath() {
+                        return '/tmp/content/images';
+                    }
+                },
+                storage: {
+                    getStorage() {
+                        return {
+                            getSanitizedFileName,
+                            saveRaw
+                        };
+                    }
+                },
+                externalRequest() {
+                    return {
+                        buffer: async () => buffers.shift()
+                    };
+                }
+            });
+
+            await service.processImageFromUrl('https://a.example.com/favicon.png', 'icon');
+            await service.processImageFromUrl('https://b.example.com/favicon.png', 'icon');
+
+            assert.equal(saveRaw.firstCall.args[1], `icon/favicon-${hashFor(aBytes)}.png`);
+            assert.equal(saveRaw.secondCall.args[1], `icon/favicon-${hashFor(bBytes)}.png`);
+            assert.notEqual(saveRaw.firstCall.args[1], saveRaw.secondCall.args[1]);
+        });
+
+        it('does not call generateUnique (no per-write S3 HEAD walk)', async function () {
+            const generateUnique = sinon.stub().resolves('/should/not/be/called.png');
+            const saveRaw = sinon.stub().resolves('/stored');
             const getSanitizedFileName = sinon.stub().returns('favicon');
 
             const service = new OembedService({
@@ -320,15 +391,14 @@ describe('oembed-service', function () {
                 },
                 externalRequest() {
                     return {
-                        buffer: async () => Buffer.from('ico-bytes')
+                        buffer: async () => Buffer.from('bytes')
                     };
                 }
             });
 
-            const storedUrl = await service.processImageFromUrl('https://example.com/favicon.ico', 'icon');
+            await service.processImageFromUrl('https://example.com/favicon.png', 'icon');
 
-            assert.equal(storedUrl, '/content/images/icon/favicon.ico');
-            assert.equal(saveRaw.firstCall.args[1], 'icon/favicon.ico');
+            sinon.assert.notCalled(generateUnique);
         });
 
         it('throws when storage lacks saveRaw', async function () {
@@ -341,8 +411,7 @@ describe('oembed-service', function () {
                 storage: {
                     getStorage() {
                         return {
-                            getSanitizedFileName: sinon.stub().returns('sample'),
-                            generateUnique: sinon.stub().resolves('/tmp/sample.png')
+                            getSanitizedFileName: sinon.stub().returns('sample')
                         };
                     }
                 },
@@ -370,7 +439,6 @@ describe('oembed-service', function () {
                     getStorage() {
                         return {
                             getSanitizedFileName: sinon.stub().returns('sample'),
-                            generateUnique: sinon.stub().resolves('/tmp/sample.png'),
                             saveRaw: sinon.stub().resolves('/stored')
                         };
                     }


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-1727

## Root cause

`processImageFromUrl` saves bookmark icons under `images/icon/<basename>`. On sites with many entries sharing a basename, `getUniqueFileName` walks the accumulated `<basename>-N` tail one S3 HEAD per iteration to find a free slot — linear in the accumulation, easily 60-90s per bookmark on busy publishers.

The walk was masked before [7c3ca72](https://github.com/TryGhost/Ghost/commit/7c3ca72ab1677a1f57ac998a1d2c87ef24daac45) (6.37.0) by a malformed-key bug in `S3Storage.exists()` that made every uniqueness check return false; once the key was fixed, the walk started actually running.

## Fix

Content-addressing the filename removes the need for the uniqueness check entirely: identical bytes land at the same key, different bytes land at different keys, no walk in either case. It's also the right model for what these files are — a cache of an external resource, where the basename carries no user intent.

## Scope

Only `processImageFromUrl` in the oembed service. Other image-saving paths (post uploads, media uploads, site logo, importer, etc.) pass relative `targetDir` already and aren't affected by the walk.