### PR TITLE
Improved Sentry diagnostics for Billing app load failures

### DIFF
--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -26,7 +26,7 @@ export default class GhBillingIframe extends Component {
 
     @action
     setup() {
-        this.billing.getBillingIframe().src = this.billing.getIframeURL();
+        this.billing.setBillingIframeSrc();
         this.billing.startBillingAppLoadMonitor();
         window.addEventListener('message', this.handleIframeMessage);
     }

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -33,7 +33,7 @@ export default class BillingService extends Service {
     billingAppIframeSrcSetAt = null;
     billingAppIframeLoadFired = false;
 
-    _loadListenerAttached = false;
+    _loadListenerAttachedTo = null;
 
     constructor() {
         super(...arguments);
@@ -108,11 +108,11 @@ export default class BillingService extends Service {
         if (!iframe) {
             return;
         }
-        if (!this._loadListenerAttached && typeof iframe.addEventListener === 'function') {
+        if (this._loadListenerAttachedTo !== iframe && typeof iframe.addEventListener === 'function') {
             iframe.addEventListener('load', () => {
                 this.billingAppIframeLoadFired = true;
             });
-            this._loadListenerAttached = true;
+            this._loadListenerAttachedTo = iframe;
         }
         this.billingAppIframeLoadFired = false;
         this.billingAppIframeSrcSetAt = Date.now();

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -30,6 +30,10 @@ export default class BillingService extends Service {
     billingAppLoadAttempts = 0;
     billingAppLoadTimeoutMs = BILLING_APP_LOAD_TIMEOUT_MS;
     billingAppLoadRetryDelaysMs = BILLING_APP_LOAD_RETRY_DELAYS_MS;
+    billingAppIframeSrcSetAt = null;
+    billingAppIframeLoadFired = false;
+
+    _loadListenerAttached = false;
 
     constructor() {
         super(...arguments);
@@ -99,6 +103,22 @@ export default class BillingService extends Service {
         this.reportBillingAppLoadFailure();
     }
 
+    setBillingIframeSrc() {
+        const iframe = this.getBillingIframe();
+        if (!iframe) {
+            return;
+        }
+        if (!this._loadListenerAttached && typeof iframe.addEventListener === 'function') {
+            iframe.addEventListener('load', () => {
+                this.billingAppIframeLoadFired = true;
+            });
+            this._loadListenerAttached = true;
+        }
+        this.billingAppIframeLoadFired = false;
+        this.billingAppIframeSrcSetAt = Date.now();
+        iframe.src = this.getIframeURL();
+    }
+
     reloadBillingIframe() {
         const iframe = this.getBillingIframe();
 
@@ -106,7 +126,7 @@ export default class BillingService extends Service {
             return;
         }
 
-        iframe.src = this.getIframeURL();
+        this.setBillingIframeSrc();
     }
 
     markBillingAppLoaded() {
@@ -137,7 +157,44 @@ export default class BillingService extends Service {
             return;
         }
 
+        const iframe = this.getBillingIframe();
+        const visibilityState = document.visibilityState;
+
+        // Fields are kept flat on `billing_monitor` because Sentry's default
+        // `normalizeDepth` of 3 stringifies anything deeper to '[Object]',
+        // dropping the diagnostic data entirely.
+        let bmaBootAccessible = false;
+        let bmaBootHasMarkReady = false;
+        let bmaBootThrew = false;
+        try {
+            const bootObj = iframe?.contentWindow?.__bmaBoot;
+            bmaBootAccessible = bootObj !== undefined && bootObj !== null;
+            bmaBootHasMarkReady = typeof bootObj?.markReady === 'function';
+        } catch (e) {
+            // cross-origin access throws — capturing that is itself a signal
+            bmaBootThrew = true;
+        }
+        let computedDisplay = null;
+        let computedVisibility = null;
+        let rectWidth = null;
+        let rectHeight = null;
+        if (iframe) {
+            try {
+                const computed = window.getComputedStyle(iframe);
+                computedDisplay = computed.display;
+                computedVisibility = computed.visibility;
+                const rect = iframe.getBoundingClientRect();
+                rectWidth = rect.width;
+                rectHeight = rect.height;
+            } catch (e) {
+                // diagnostic collection must never throw
+            }
+        }
+
         Sentry.captureException(BILLING_APP_LOAD_FAILURE_MESSAGE, {
+            // not surfaced to the user (the error UI is rendered separately), so warning is correct severity
+            level: 'warning',
+            fingerprint: ['billing-app-load-failure', visibilityState, String(this.billingAppLoadAttempts)],
             contexts: {
                 ghost: {
                     billing_monitor: {
@@ -145,7 +202,21 @@ export default class BillingService extends Service {
                         has_billing_url: !!this.config.hostSettings?.billing?.url,
                         is_force_upgrade: !!this.config.hostSettings?.forceUpgrade,
                         location_hash: window.location.hash,
-                        retry_delays_ms: this.billingAppLoadRetryDelaysMs
+                        retry_delays_ms: this.billingAppLoadRetryDelaysMs,
+                        document_visibility_state: visibilityState,
+                        iframe_offset_parent_visible: iframe ? iframe.offsetParent !== null : null,
+                        iframe_computed_display: computedDisplay,
+                        iframe_computed_visibility: computedVisibility,
+                        iframe_rect_width: rectWidth,
+                        iframe_rect_height: rectHeight,
+                        iframe_load_fired: this.billingAppIframeLoadFired,
+                        ms_since_src_set: this.billingAppIframeSrcSetAt ? Date.now() - this.billingAppIframeSrcSetAt : null,
+                        navigator_online: navigator.onLine,
+                        connection_effective_type: navigator.connection?.effectiveType ?? null,
+                        bma_boot_accessible: bmaBootAccessible,
+                        bma_boot_has_mark_ready: bmaBootHasMarkReady,
+                        bma_boot_threw: bmaBootThrew,
+                        billing_window_open: this.billingWindowOpen
                     }
                 }
             },

--- a/ghost/admin/tests/unit/services/billing-test.js
+++ b/ghost/admin/tests/unit/services/billing-test.js
@@ -92,7 +92,7 @@ describe('Unit: Service: billing', function () {
     it('reloads the billing iframe during a retry', function () {
         const service = this.owner.lookup('service:billing');
         billingService = service;
-        const iframe = {src: ''};
+        const iframe = {src: '', addEventListener: sinon.stub()};
         sinon.stub(service, 'getBillingIframe').returns(iframe);
         sinon.stub(service, 'getIframeURL').returns('https://billing.example.test/pro');
 
@@ -101,26 +101,43 @@ describe('Unit: Service: billing', function () {
         expect(iframe.src).to.equal('https://billing.example.test/pro');
     });
 
-    it('reports to Sentry when the billing app does not become ready', async function () {
+    it('reports to Sentry with diagnostics when the billing app does not become ready', async function () {
         const service = this.owner.lookup('service:billing');
         billingService = service;
+        sinon.stub(service, 'getBillingIframe').returns(null);
         service.billingAppLoadAttempts = 2;
+        service.billingAppIframeSrcSetAt = Date.now() - 1234;
+        service.billingAppIframeLoadFired = true;
+        service.billingWindowOpen = true;
 
         service.reportBillingAppLoadFailure();
 
         await waitUntil(() => testkit.reports().length > 0);
 
-        expect(testkit.reports()).to.have.lengthOf(1);
         const report = testkit.reports()[0];
         expect(report.message).to.equal('Billing app failed to become ready');
-        expect(report.tags).to.deep.include({
-            source: 'billing-app-load-monitor'
-        });
-        expect(report.originalReport.contexts.ghost.billing_monitor).to.deep.include({
+        expect(report.level).to.equal('warning');
+        expect(report.originalReport.fingerprint).to.deep.equal([
+            'billing-app-load-failure',
+            document.visibilityState,
+            '2'
+        ]);
+        expect(report.tags).to.deep.include({source: 'billing-app-load-monitor'});
+
+        const billingMonitor = report.originalReport.contexts.ghost.billing_monitor;
+        expect(billingMonitor).to.deep.include({
             attempts: 2,
             has_billing_url: true,
-            is_force_upgrade: false
+            is_force_upgrade: false,
+            iframe_load_fired: true,
+            billing_window_open: true,
+            navigator_online: navigator.onLine,
+            document_visibility_state: document.visibilityState,
+            bma_boot_accessible: false,
+            bma_boot_has_mark_ready: false,
+            bma_boot_threw: false
         });
+        expect(billingMonitor.ms_since_src_set).to.be.a('number').and.to.be.at.least(1234);
     });
 
     it('does not report when the billing app becomes ready before the timeout', function () {


### PR DESCRIPTION
ref [INC-284](https://app.incident.io/ghost/incidents/284)
ref Sentry [ADMIN-1BZQ](https://ghost.sentry.io/issues/?query=ADMIN-1BZQ) — 439 events / 294 users

## Summary

`Billing app failed to become ready` (ADMIN-1BZQ) currently lands in Sentry with very little context — we can't tell whether the iframe is being blocked, the network is offline, the BMA is hanging during boot, the iframe `load` event never fired, or the load monitor is firing while the iframe is still hidden behind the closed modal.

This PR enriches the existing Sentry capture in `BillingService.reportBillingAppLoadFailure` with the data needed to actually diagnose ADMIN-1BZQ. Added fields under `contexts.ghost.billing_monitor`:

- `document_visibility_state`
- `iframe_offset_parent_visible`, `iframe_computed_display`, `iframe_computed_visibility`, `iframe_bounding_rect`
- `bma_boot_probe` — `{accessible, has_markReady, threw}` against `iframe.contentWindow.__bmaBoot`
- `iframe_load_fired` — whether the iframe's `load` event ever fired
- `ms_since_src_set` — how long the parent has been waiting since `iframe.src` was assigned
- `navigator_online`, `connection_effective_type`
- `billing_window_open`

The event is also now reported at `level: 'warning'` (the user-facing error UI is rendered separately by `gh-billing-modal`, so a hard error is the wrong severity) with a stable `fingerprint: ['billing-app-load-failure', visibilityState, attempts]` so enriched events don't merge into the legacy bucket.

`setBillingIframeSrc` is extracted from `gh-billing-iframe.js`'s `setup()` so both the initial render and the retry path consistently record `billingAppIframeSrcSetAt` and attach the `load` listener. **No behavioral change to the monitor itself** — same 10s timeout, same one retry.

Ship diagnostics, observe what the enriched events actually say, then make an informed behavioral change in a follow-up.

## Test plan

- [x] `pnpm exec eslint` clean on changed files
- [x] Updated unit test asserts the new `billing_monitor` fields, the `warning` level, and the `fingerprint`; `bma_boot_probe` is asserted by key-shape (value depends on iframe presence)
- [x] Test stubs `getBillingIframe` to `null` for deterministic diagnostics (the previous CI failure was caused by a sibling test leaving an iframe in the DOM with `id="billing-frame"`)
- [ ] Manual: trigger a failure by blocking the BMA origin and confirm enriched fields appear in Sentry with `level: warning`