### PR TITLE
Fixed lazyRouting URLs 404'ing across the codebase

### DIFF
--- a/ghost/core/core/server/api/endpoints/email-post.js
+++ b/ghost/core/core/server/api/endpoints/email-post.js
@@ -35,7 +35,12 @@ const controller = {
             }
         },
         async query(frame) {
-            const model = await models.Post.findOne(Object.assign(frame.data, {status: 'sent'}), frame.options);
+            const callerIncludes = Array.isArray(frame.options.withRelated) ? frame.options.withRelated : [];
+            const options = {
+                ...frame.options,
+                withRelated: [...new Set([...callerIncludes, 'tags', 'authors'])]
+            };
+            const model = await models.Post.findOne(Object.assign(frame.data, {status: 'sent'}), options);
 
             if (!model) {
                 throw new errors.NotFoundError({

--- a/ghost/core/core/server/api/endpoints/search-index-public.js
+++ b/ghost/core/core/server/api/endpoints/search-index-public.js
@@ -15,7 +15,8 @@ const controller = {
                 filter: 'type:post',
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'slug', 'title', 'excerpt', 'url', 'updated_at', 'visibility']
+                columns: ['id', 'slug', 'title', 'excerpt', 'url', 'updated_at', 'visibility'],
+                withRelated: ['tags', 'authors']
             };
 
             return postsService.browsePosts(options);

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -18,7 +18,8 @@ const controller = {
                 filter: 'type:post+status:[draft,published,scheduled,sent]',
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility']
+                columns: ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility'],
+                withRelated: ['tags', 'authors']
             };
 
             return postsService.browsePosts(options);
@@ -37,7 +38,8 @@ const controller = {
                 filter: 'type:page+status:[draft,published,scheduled]',
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility']
+                columns: ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility'],
+                withRelated: ['tags', 'authors']
             };
 
             return postsService.browsePosts(options);

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/comments.js
@@ -14,6 +14,19 @@ module.exports = {
             }
             return relation;
         });
+
+        // If the caller asked for `post`, also load post.tags / post.authors
+        // — the comments output mapper calls url.forPost on the embedded
+        // post, which needs the relations to resolve tag/author-filtered
+        // routes under lazyRouting.
+        if (frame.options.withRelated.includes('post')) {
+            if (!frame.options.withRelated.includes('post.tags')) {
+                frame.options.withRelated.push('post.tags');
+            }
+            if (!frame.options.withRelated.includes('post.authors')) {
+                frame.options.withRelated.push('post.authors');
+            }
+        }
     },
 
     browse(apiConfig, frame) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const config = require('../../../../../../shared/config');
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:pages');
 const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
@@ -51,12 +52,23 @@ function selectAllAllowedColumns(frame) {
     }
 }
 
+// Mirror of input/posts.js. See the comment there.
+function forceUrlRelationsWhenLazy(frame) {
+    if (config.get('lazyRouting')
+        && Array.isArray(frame.options.columns)
+        && frame.options.columns.includes('url')) {
+        frame.options.withRelated = _.union(frame.options.withRelated || [], ['tags', 'authors']);
+    }
+}
+
 function defaultRelations(frame) {
+    forceUrlRelationsWhenLazy(frame);
+
     if (frame.options.withRelated) {
         return;
     }
 
-    if (frame.options.columns && !frame.options.withRelated) {
+    if (frame.options.columns) {
         return false;
     }
 
@@ -126,10 +138,11 @@ module.exports = {
         if (localUtils.isContentAPI(frame)) {
             // CASE: the content api endpoint for posts should not return mobiledoc or lexical
             removeSourceFormats(frame); // remove from the format field
-            selectAllAllowedColumns(frame); // remove from any specified column or selectRaw options            
+            selectAllAllowedColumns(frame); // remove from any specified column or selectRaw options
 
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
+            forceUrlRelationsWhenLazy(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -148,6 +161,7 @@ module.exports = {
             removeSourceFormats(frame);
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
+            forceUrlRelationsWhenLazy(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -75,17 +75,21 @@ function mapWithRelated(frame) {
     }
 }
 
-function defaultRelations(frame) {
-    // Apply same mapping as content API
-    mapWithRelated(frame);
-
-    // Under lazyRouting, urlService.facade.getUrlForResource evaluates
-    // router filters against tags/authors, so ?fields=url needs them loaded.
+// Under lazyRouting, urlService.facade.getUrlForResource evaluates
+// router filters against tags/authors, so ?fields=url needs them loaded.
+function forceUrlRelationsWhenLazy(frame) {
     if (config.get('lazyRouting')
         && Array.isArray(frame.options.columns)
         && frame.options.columns.includes('url')) {
         frame.options.withRelated = _.union(frame.options.withRelated || [], ['tags', 'authors']);
     }
+}
+
+function defaultRelations(frame) {
+    // Apply same mapping as content API
+    mapWithRelated(frame);
+
+    forceUrlRelationsWhenLazy(frame);
 
     // Additional defaults for admin API
     if (frame.options.withRelated) {
@@ -175,6 +179,7 @@ module.exports = {
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
             mapWithRelated(frame);
+            forceUrlRelationsWhenLazy(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -201,6 +206,7 @@ module.exports = {
 
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
+            forceUrlRelationsWhenLazy(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const config = require('../../../../../../shared/config');
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:posts');
 const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
@@ -78,12 +79,20 @@ function defaultRelations(frame) {
     // Apply same mapping as content API
     mapWithRelated(frame);
 
+    // Under lazyRouting, urlService.facade.getUrlForResource evaluates
+    // router filters against tags/authors, so ?fields=url needs them loaded.
+    if (config.get('lazyRouting')
+        && Array.isArray(frame.options.columns)
+        && frame.options.columns.includes('url')) {
+        frame.options.withRelated = _.union(frame.options.withRelated || [], ['tags', 'authors']);
+    }
+
     // Additional defaults for admin API
     if (frame.options.withRelated) {
         return;
     }
 
-    if (frame.options.columns && !frame.options.withRelated) {
+    if (frame.options.columns) {
         return false;
     }
 

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -201,7 +201,7 @@ class CommentsService {
      */
     async getAdminAllComments({includeNested, filter, mongoTransformer, reportCount, order, page, limit}) {
         return await this.models.Comment.findPage({
-            withRelated: ['member', 'post', 'count.replies', 'count.direct_replies', 'count.likes', 'count.reports', 'in_reply_to', 'parent'],
+            withRelated: ['member', 'post', 'post.tags', 'post.authors', 'count.replies', 'count.direct_replies', 'count.likes', 'count.reports', 'in_reply_to', 'parent'],
             filter,
             mongoTransformer,
             reportCount,

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -203,7 +203,7 @@ class BatchSendingService {
         }, {...this.#getBeforeRetryConfig(email), description: `getLazyRelation newsletter for email ${email.id}`});
 
         const post = await this.retryDb(async () => {
-            return await email.getLazyRelation('post', {require: true, withRelated: ['posts_meta', 'authors']});
+            return await email.getLazyRelation('post', {require: true, withRelated: ['posts_meta', 'authors', 'tags']});
         }, {...this.#getBeforeRetryConfig(email), description: `getLazyRelation post for email ${email.id}`});
 
         let batches = await this.retryDb(async () => {

--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -27,9 +27,9 @@ class EmailController {
         // So we need to handle both cases.
         let post;
         if (frame.options.id) {
-            post = await this.models.Post.findOne({...frame.options, status: 'all'}, {withRelated: ['posts_meta', 'authors']});
+            post = await this.models.Post.findOne({...frame.options, status: 'all'}, {withRelated: ['posts_meta', 'authors', 'tags']});
         } else {
-            post = await this.models.Post.findOne({...frame.data, status: 'all'}, {...frame.options, withRelated: ['posts_meta', 'authors']});
+            post = await this.models.Post.findOne({...frame.data, status: 'all'}, {...frame.options, withRelated: ['posts_meta', 'authors', 'tags']});
         }
 
         if (!post) {

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1086,7 +1086,8 @@ class EmailRenderer {
             const {data} = await this.#models.Post.findPage({
                 filter: `status:published+id:-'${post.id}'`,
                 order: 'published_at DESC',
-                limit: 3
+                limit: 3,
+                withRelated: ['tags', 'authors']
             });
 
             for (const latestPost of data) {

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -589,7 +589,7 @@ module.exports = class EventRepository {
     async getCommentEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'post', 'parent'],
+            withRelated: ['member', 'post', 'post.tags', 'post.authors', 'parent'],
             filter: 'member_id:-null+custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(
@@ -623,7 +623,7 @@ module.exports = class EventRepository {
     async getClickEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'link', 'link.post'],
+            withRelated: ['member', 'link', 'link.post', 'link.post.tags', 'link.post.authors'],
             filter: 'custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(
@@ -777,7 +777,7 @@ module.exports = class EventRepository {
     async getFeedbackEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'post'],
+            withRelated: ['member', 'post', 'post.tags', 'post.authors'],
             filter: 'custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -17,7 +17,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const jobsService = require('../mentions-jobs');
 
 function getPostUrl(post) {
-    const jsonModel = {};
+    const jsonModel = post.toJSON();
     outputSerializerUrlUtil.forPost(post.id, jsonModel, {options: {}});
     return jsonModel.url;
 }

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const nql = require('@tryghost/nql');
 const debug = require('@tryghost/debug')('services:url:lazy');
+const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
 const localUtils = require('../../../shared/url-utils');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
@@ -127,6 +129,12 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         }
         const candidates = this.routerConfigs.filter(c => c.resourceType === routerType);
         for (const config of candidates) {
+            // Warn loudly when a caller passes a resource that's missing
+            // the relations a tag- or author-filtered router needs. The
+            // URL silently falls through to /404/ on those routes; the
+            // log lets operators alert on any caller that hasn't been
+            // inflated with withRelated: ['tags', 'authors'].
+            this._warnIfThin(config, resource, routerType);
             // NQL filters are evaluated against the original resource (with
             // its singular DB `type` field intact) because the page:true/false
             // transformer rewrites to type:'post'/'page'.
@@ -136,6 +144,41 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             }
         }
         return this._formatPath('/404/', options);
+    }
+
+    /**
+     * Warn when a caller passes a thin resource (missing tags/authors)
+     * against a router whose filter references those relations. The
+     * filter eval will fail silently and the URL will resolve to /404/.
+     * Detection is conservative: only fires when the router filter
+     * actually references the relation, so a tag-less router (`filter:
+     * featured:true`) doesn't log for a tag-less resource.
+     */
+    private _warnIfThin(config: RouterConfig, resource: Resource, routerType: string): void {
+        if (!config.filter) {
+            return;
+        }
+        const needsTags = /\btags?\b|\bprimary_tag\b/.test(config.filter);
+        const needsAuthors = /\bauthors?\b|\bprimary_author\b/.test(config.filter);
+        const r = resource as Record<string, unknown>;
+        const missingTags = needsTags && !Array.isArray(r.tags);
+        const missingAuthors = needsAuthors && !Array.isArray(r.authors);
+        if (!missingTags && !missingAuthors) {
+            return;
+        }
+        const missing = [missingTags && 'tags', missingAuthors && 'authors']
+            .filter(Boolean) as string[];
+        logging.error(new errors.InternalServerError({
+            message: 'Thin resource passed to LazyUrlService.getUrlForResource',
+            code: 'LAZY_URL_THIN_RESOURCE',
+            errorDetails: {
+                resourceType: routerType,
+                resourceId: resource.id,
+                routerIdentifier: config.identifier,
+                filter: config.filter,
+                missing
+            }
+        }));
     }
 
     ownsResource(routerIdentifier: string, resource: Resource | null): boolean {

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -157,6 +157,29 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             }
         });
 
+        it('lazyRouting: forces tags+authors on the Content API path', async function () {
+            // Content API uses mapWithRelated rather than defaultRelations;
+            // both branches must invoke the helper.
+            configUtils.set('lazyRouting', true);
+            try {
+                const frame = {
+                    apiType: 'content',
+                    options: {
+                        context: {api_key: {id: 1, type: 'content'}},
+                        columns: ['id', 'url']
+                    }
+                };
+
+                serializers.input.posts.browse({}, frame);
+
+                assert.ok(frame.options.withRelated);
+                assert.ok(frame.options.withRelated.includes('tags'));
+                assert.ok(frame.options.withRelated.includes('authors'));
+            } finally {
+                await configUtils.restore();
+            }
+        });
+
         describe('Content API', function () {
             it('selects all columns from the posts schema but mobiledoc and lexical when no columns are specified', function () {
                 const apiConfig = {};

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
+const configUtils = require('../../../../../../utils/config-utils');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 const postsSchema = require('../../../../../../../core/server/data/schema').tables.posts;
 
@@ -127,6 +128,33 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
 
             serializers.input.posts.browse(apiConfig, frame);
             assert.equal(frame.options.order, 'updated_at desc');
+        });
+
+        // Regression for the bypass CodeRabbit caught in #27908: when the
+        // caller passes both ?fields=url and ?include=relation, the
+        // defaultRelations early-return on a non-empty withRelated must
+        // not skip the lazyRouting force-load — otherwise the URL still
+        // 404s for tag/author-filtered routes.
+        it('lazyRouting: merges tags+authors into withRelated when caller passes both ?fields=url and ?include=email', async function () {
+            configUtils.set('lazyRouting', true);
+            try {
+                const frame = {
+                    apiType: 'admin',
+                    options: {
+                        context: {user: 1},
+                        columns: ['id', 'url', 'title'],
+                        withRelated: ['email']
+                    }
+                };
+
+                serializers.input.posts.browse({}, frame);
+
+                assert.ok(frame.options.withRelated.includes('email'), 'caller-requested email must be preserved');
+                assert.ok(frame.options.withRelated.includes('tags'), 'tags must be force-loaded for URL');
+                assert.ok(frame.options.withRelated.includes('authors'), 'authors must be force-loaded for URL');
+            } finally {
+                await configUtils.restore();
+            }
         });
 
         describe('Content API', function () {

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -756,4 +756,5 @@ describe('EventRepository', function () {
             assert.equal(event.data.member_id, 'member-xyz');
         });
     });
+
 });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -756,5 +756,4 @@ describe('EventRepository', function () {
             assert.equal(event.data.member_id, 'member-xyz');
         });
     });
-
 });


### PR DESCRIPTION
## Summary

Re-opens #27908 (auto-closed when its branch was momentarily deleted during a stack rewrite).

Comprehensive fix for the `/404/` regression on tag- and author-filtered routes under `config.lazyRouting`. The lazy URL service evaluates each registered router's NQL filter against the resource passed to `getUrlForResource(resource)`; resources arriving without `tags` / `authors` arrays cause every filter to evaluate false and the URL falls through to `/404/`.

This PR fixes every caller identified by audit, adds a warn log to catch any future regression, and ships the supporting tests.

## Commits (11)

1. **Fixed search-index URLs 404-ing under lazyRouting** — `search-index.js` and `search-index-public.js` always load `tags+authors`; needed by bookmark card and similar editor search flows.
2. **Fixed posts.browse URLs 404'ing under lazyRouting** — `defaultRelations` in input/posts.js force-loads `tags+authors` when `?fields=url` is requested (Admin API).
3. **Fixed newsletter URLs 404'ing under lazyRouting** — batch-sending-service loads the post with `tags` so the email-renderer's URL serialization works.
4. **Fixed email preview URLs 404'ing under lazyRouting** — email-controller does the same for previews and test sends.
5. **Fixed /email/<uuid>/ URLs 404'ing under lazyRouting** — the email-post endpoint force-loads `tags+authors`, merging with caller-supplied `?include=`.
6. **Fixed activity-feed URLs 404'ing under lazyRouting** — `event-repository.getCommentEvents` / `getClickEvents` / `getFeedbackEvents` load `post.tags` / `post.authors` (and `link.post.tags` / `link.post.authors` for clicks).
7. **Fixed comment row post URLs 404 under lazyRouting** — `comments-service.getAdminAllComments` loads `post.tags` / `post.authors`.
8. **Fixed pages.browse URLs 404'ing under lazyRouting** — input/pages.js mirrors the posts.js fix for both admin and Content API paths.
9. **Fixed Content API posts URLs 404 under lazyRouting** — extracted `forceUrlRelationsWhenLazy` helper, called from both admin and Content API branches of input/posts.js.
10. **Added warn log when LazyUrlService receives thin resource** — fires when a router filter references a relation the resource lacks; operators can alert on this to catch future regressions.

## Known limitation

Under `?fields=url` + `lazyRouting: true`, the response includes the force-loaded `tags` and `authors` arrays (and computed `primary_tag`/`primary_author`) even when the caller didn't request them. We considered building a marker-based output strip to drop the unrequested relations but the implementation overhead and added bug surface wasn't worth it for an experimental flag. Adding fields to an API response is not a breaking change (standard REST principle); a future PR can add `withRelatedFields` to trim the response payload size if needed.

Flag-off consumers see no change.

## Test plan

- [x] `pnpm test:single test/unit/api/canary/utils/serializers/input/posts.test.js` — 29/31 (2 pre-existing html-to-mobiledoc env failures unrelated to these changes)
- [x] `pnpm test:single test/unit/api/canary/utils/serializers/input/pages.test.js` — 22/22
- [x] `pnpm test:single test/unit/api/canary/utils/serializers/output/utils/url.test.js` — 8/8
- [x] `pnpm test:single test/unit/api/endpoints/search-index.test.js` — 4/4
- [x] `pnpm test:single test/unit/api/endpoints/search-index-public.test.js` — 3/3
- [x] `pnpm test:single test/unit/api/endpoints/email-post.test.js` — 1/1
- [x] `pnpm test:single test/unit/server/services/email-service/batch-sending-service.test.js` — 55/55
- [x] `pnpm test:single test/unit/server/services/email-service/email-controller.test.js` — 14/14
- [x] `pnpm test:single test/unit/server/services/members/members-api/repositories/event-repository.test.js` — 35/35
- [x] `pnpm test:single test/unit/server/services/comments/comments-service.test.js` — 1/1
- [x] `pnpm test:single test/unit/server/services/url/lazy-url-service.test.js` — 33/33
- [ ] Smoke test against a site running `config.lazyRouting: true` with a tag-filtered collection in routes.yaml — every link (newsletter, email preview, admin activity feed, comment moderation, posts.browse, pages.browse, search-index, /email/<uuid>/) should resolve to the real URL