### PR TITLE
🐛 Fixed Unsplash picker not opening on Settings pages

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -16,6 +16,7 @@
     "@tryghost/activitypub": "workspace:*",
     "@tryghost/admin-x-framework": "workspace:*",
     "@tryghost/admin-x-settings": "workspace:*",
+    "@tryghost/kg-unsplash-selector": "0.4.1",
     "@tryghost/koenig-lexical": "catalog:",
     "@tryghost/posts": "workspace:*",
     "@tryghost/shade": "workspace:*",

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -4,7 +4,7 @@
 @source "../../activitypub/src/**/*.{ts,tsx}";
 @source "../../admin-x-settings/src/**/*.{ts,tsx}";
 @source "../../admin-x-design-system/src/**/*.{ts,tsx}";
-@source "../../../node_modules/@tryghost/kg-unsplash-selector/dist/**/*.js";
+@source "../node_modules/@tryghost/kg-unsplash-selector/dist/**/*.js";
 
 @import "@tryghost/shade/styles.css";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       '@tryghost/admin-x-settings':
         specifier: workspace:*
         version: link:../admin-x-settings
+      '@tryghost/kg-unsplash-selector':
+        specifier: 0.4.1
+        version: 0.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tryghost/koenig-lexical':
         specifier: 'catalog:'
         version: 1.8.1


### PR DESCRIPTION
## Describe the problem you are solving

This PR fixes the Unsplash image picker not opening on Settings pages of admin-x-settings. Clicking the trigger surfaced no usable modal — it rendered with no layout or positioning because Tailwind v4 wasn't generating the utility classes the modal depends on.

Root cause: the TWCSS4 migration (a90817a0f0, #26648) replaced the package's explicit CSS import with an `@source` scan in `apps/admin/src/index.css`, but the scan path resolved to `<repo-root>/node_modules/@tryghost/kg-unsplash-selector` — a directory that doesn't exist under pnpm. The package is only installed under `apps/admin-x-settings/node_modules/` because that workspace is the only declaring consumer. Tailwind silently produced zero utilities for the modal's classes (`fixed`, `inset-0`, `size-*`, etc.).

The fix declares `@tryghost/kg-unsplash-selector` as a direct dep of `apps/admin` (which owns the central Tailwind v4 pipeline) and points the `@source` at admin's own `node_modules`, so the path now resolves to a real directory.

## Changelog for devs

* Added `@tryghost/kg-unsplash-selector@0.4.1` as a direct dependency of `apps/admin`
* Changed the `@source` path in `apps/admin/src/index.css` from `../../../node_modules/...` to `../node_modules/...` so it resolves under pnpm's per-workspace `node_modules` layout
* Fixed bug where Tailwind v4 silently generated no utilities for the Unsplash modal because the `@source` scan path pointed at a non-existent directory

## Changelog for customers

* Fixed Unsplash image picker not opening from Settings pages

## Notes

* Completes a piece of the TWCSS4 migration (#26648) that didn't account for pnpm's per-workspace `node_modules` layout. The migration removed the explicit CSS import in favor of an `@source` scan, but the scan path assumed a hoisted root `node_modules` that pnpm doesn't produce for this package.
* Considered the simpler alternative of re-importing the package's prebuilt CSS but rejected it: that CSS is a Tailwind v3 standalone build (universal preflight `*,:before,:after,::backdrop` setting all `--tw-*` vars, plus unlayered utilities) that would re-introduce the same class of v3/v4 cascade conflict cleaned up in 94f9b7341d. It also violates the rule in `CLAUDE.md`: *"Embedded apps consumed via `@source` must NOT import Shade/Tailwind CSS independently."*
* Verification: built `apps/admin` and confirmed every class the modal uses (`fixed`, `inset-0`, `absolute`, `size-4`, `size-8`, `size-[50px]`, `px-20`, `text-2xl`, `z-50`, `before:size-[7px]`, `cursor-zoom-in`, `from-black/5`, …) is now emitted in `dist/assets/index-*.css`. Confirmed visually in dev — modal opens correctly on Settings pages.

## Technical debt

* No new technical debt introduced.
* Follow-up worth considering: a CI sanity check that flags `@source` paths in admin's Tailwind config which resolve to empty or non-existent directories. Today a broken `@source` fails silently — Tailwind generates no utilities for that source and there is no error to surface the misconfiguration.

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [ ] Enhances the readability of our code
- [ ] Simplifies the maintenance of our software
- [x] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [ ] It includes documentation
- [ ] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.