### PR TITLE
Resolved GHCR image digest for PR preview deploys

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -100,6 +100,34 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve image digest from GHCR
+        id: digest
+        if: steps.recheck.outputs.skip != 'true'
+        env:
+          IMAGE_REPO: tryghost/ghost
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Pin the deploy to an immutable digest so Artifact Registry's pull-through
+          # cache cannot serve a stale manifest for the mutable pr-N tag.
+          TOKEN=$(curl -sf "https://ghcr.io/token?service=ghcr.io&scope=repository:${IMAGE_REPO}:pull" | jq -r '.token')
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "::error::Failed to acquire anonymous GHCR token for ${IMAGE_REPO}"
+            exit 1
+          fi
+          DIGEST=$(curl -sfI \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+            -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            "https://ghcr.io/v2/${IMAGE_REPO}/manifests/pr-${PR_NUMBER}" \
+            | awk 'tolower($1) == "docker-content-digest:" {print $2}' | tr -d '\r\n')
+          if [[ ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "::error::Could not resolve digest for ghcr.io/${IMAGE_REPO}:pr-${PR_NUMBER} (got: '$DIGEST')"
+            exit 1
+          fi
+          echo "Resolved digest: $DIGEST"
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch deploy to Ghost-Moya
         if: steps.recheck.outputs.skip != 'true'
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
@@ -110,6 +138,7 @@ jobs:
           client-payload: >-
             {
               "pr_number": "${{ github.event.pull_request.number }}",
+              "image_digest": "${{ steps.digest.outputs.digest }}",
               "action": "deploy",
               "seed": "true"
             }


### PR DESCRIPTION
PR preview deploys to Cloud Run have been occasionally serving stale images. The build job pushes a fresh image to GHCR as `ghcr.io/tryghost/ghost:pr-N`, but the consumer side in Ghost-Moya pulls through GCP Artifact Registry, whose pull-through cache can lag behind GHCR for the mutable `pr-N` tag. The result is a deploy that succeeds against an older manifest than the one we just built, and reviewers see a preview that does not reflect the latest commit.

This change resolves the canonical sha256 digest from GHCR after the build job succeeds and forwards it to Ghost-Moya as `image_digest` in the `repository_dispatch` payload. The resolver fetches an anonymous pull token for the public `tryghost/ghost` repo, issues a HEAD request against the `pr-N` manifest with the OCI index and Docker v2 manifest media types in the Accept header, and parses the `Docker-Content-Digest` response header. The digest is validated as `sha256:` + 64 hex chars before being written to the step output so a malformed or missing digest fails the job rather than dispatching garbage. The Ghost-Moya half of this change consumes `image_digest` and pins the Cloud Run deploy to the immutable ref, sidestepping the Artifact Registry cache entirely.

The token is acquired anonymously because the image is public, so no secrets are needed for the lookup. The skip guard from the recheck step is preserved so the digest resolve and dispatch are still gated together.