### PR TITLE
Fixed label create/edit mutation error handling

### DIFF
--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -1,5 +1,6 @@
 import {InfiniteData} from '@tanstack/react-query';
 import {Meta, createInfiniteQuery, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
+import {AlreadyExistsError, ValidationError} from '../utils/errors';
 
 export type Label = {
     id: string;
@@ -15,6 +16,16 @@ export interface LabelsResponseType {
 }
 
 const dataType = 'LabelsResponseType';
+const DUPLICATE_LABEL_API_CODE = 'LABEL_ALREADY_EXISTS';
+const DUPLICATE_LABEL_INLINE_MESSAGE = 'A label with this name already exists';
+
+const mapDuplicateLabelError = (error: unknown) => {
+    if (error instanceof ValidationError && error.data?.errors[0]?.code === DUPLICATE_LABEL_API_CODE) {
+        return new AlreadyExistsError(DUPLICATE_LABEL_INLINE_MESSAGE);
+    }
+
+    return error;
+};
 
 export const useBrowseLabels = createQuery<LabelsResponseType>({
     dataType,
@@ -56,6 +67,7 @@ export const useCreateLabel = createMutation<LabelsResponseType, Pick<Label, 'na
     method: 'POST',
     path: () => '/labels/',
     body: label => ({labels: [label]}),
+    mapError: mapDuplicateLabelError,
     invalidateQueries: {
         dataType
     }
@@ -65,6 +77,7 @@ export const useEditLabel = createMutation<LabelsResponseType, Pick<Label, 'id' 
     method: 'PUT',
     path: label => `/labels/${label.id}/`,
     body: label => ({labels: [label]}),
+    mapError: mapDuplicateLabelError,
     invalidateQueries: {
         dataType
     }

--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -3,7 +3,7 @@ import {showToast} from '@tryghost/admin-x-design-system';
 import {useCallback} from 'react';
 import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
-import {APIError, ValidationError} from '../utils/errors';
+import {APIError, AlreadyExistsError, ValidationError} from '../utils/errors';
 
 /**
  * Generic error handling for API calls. This is enabled by default for queries (can be disabled by
@@ -43,6 +43,11 @@ const useHandleError = () => {
         if (error instanceof APIError && error.response?.status === 418) {
             // We use this status in tests to indicate the API request was not mocked -
             // don't show a toast because it may block clicking things in the test
+        } else if (error instanceof AlreadyExistsError) {
+            showToast({
+                message: error.message,
+                type: 'error'
+            });
         } else if (error instanceof ValidationError && error.data?.errors[0]) {
             showToast({
                 message: error.data.errors[0].context || error.data.errors[0].message,

--- a/apps/admin-x-framework/src/test/setup.ts
+++ b/apps/admin-x-framework/src/test/setup.ts
@@ -37,6 +37,9 @@ export function setupShadeMocks() {
         value: ResizeObserverMock
     });
 
+    // Mock scrollIntoView - required for cmdk-based components
+    Element.prototype.scrollIntoView = () => {};
+
     // Mock getBoundingClientRect - required for positioning calculations
     Element.prototype.getBoundingClientRect = () => ({
         width: 0,

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -156,6 +156,7 @@ interface MutationOptions<ResponseData, Payload> extends Omit<QueryOptions<Respo
     headers?: Record<string, string>;
     body?: (payload: Payload) => FormData | object;
     searchParams?: (payload: Payload) => { [key: string]: string; };
+    mapError?: (error: unknown, payload: Payload) => unknown;
     invalidateQueries?: { dataType: string; } | {
         filters?: InvalidateQueryFilters<unknown>,
         options?: InvalidateOptions,
@@ -187,7 +188,7 @@ const mutate = <ResponseData, Payload>({fetchApi, path, payload, searchParams, o
     });
 };
 
-export const createMutation = <ResponseData, Payload>({path, searchParams, defaultSearchParams, updateQueries, invalidateQueries, ...mutateOptions}: MutationOptions<ResponseData, Payload>) => () => {
+export const createMutation = <ResponseData, Payload>({path, searchParams, defaultSearchParams, updateQueries, invalidateQueries, mapError, ...mutateOptions}: MutationOptions<ResponseData, Payload>) => () => {
     const fetchApi = useFetchApi();
     const queryClient = useQueryClient();
     const {onUpdate, onInvalidate, onDelete} = useFramework();
@@ -215,7 +216,13 @@ export const createMutation = <ResponseData, Payload>({path, searchParams, defau
     }, [onInvalidate, onUpdate, onDelete, queryClient]);
 
     return useMutation<ResponseData, unknown, Payload>({
-        mutationFn: payload => mutate({fetchApi, path: path(payload), payload, searchParams: searchParams?.(payload) || defaultSearchParams, options: mutateOptions}),
+        mutationFn: async (payload) => {
+            try {
+                return await mutate({fetchApi, path: path(payload), payload, searchParams: searchParams?.(payload) || defaultSearchParams, options: mutateOptions});
+            } catch (error) {
+                throw (mapError?.(error, payload) ?? error);
+            }
+        },
         onSuccess: afterMutate
     });
 };

--- a/apps/admin-x-framework/test/unit/api/labels.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/labels.test.tsx
@@ -1,0 +1,85 @@
+import {act} from '@testing-library/react';
+import {AlreadyExistsError, ValidationError} from '../../../src/utils/errors';
+import {describe, expect, it} from 'vitest';
+import {renderHookWithProviders} from '../../../src/test/test-utils';
+import {useCreateLabel, useEditLabel} from '../../../src/api/labels';
+import {withMockFetch} from '../../utils/mock-fetch';
+
+const createValidationErrorResponse = ({
+    code,
+    context,
+    property = null
+}: {
+    code: string;
+    context: string;
+    property?: string | null;
+}) => ({
+    errors: [{
+        code,
+        context,
+        details: null,
+        ghostErrorCode: null,
+        help: null,
+        id: 'label-error-id',
+        message: 'Validation error, cannot save label.',
+        property,
+        type: 'ValidationError'
+    }]
+});
+
+describe('labels api', () => {
+    it('maps duplicate create errors to AlreadyExistsError', async () => {
+        await withMockFetch({
+            json: createValidationErrorResponse({
+                code: 'LABEL_ALREADY_EXISTS',
+                context: 'Label already exists'
+            }),
+            headers: {'content-type': 'application/json'},
+            ok: false,
+            status: 422
+        }, async () => {
+            const {result} = renderHookWithProviders(() => useCreateLabel());
+
+            await act(async () => {
+                await expect(result.current.mutateAsync({name: 'Existing label'})).rejects.toBeInstanceOf(AlreadyExistsError);
+            });
+        });
+    });
+
+    it('maps duplicate edit errors to AlreadyExistsError', async () => {
+        await withMockFetch({
+            json: createValidationErrorResponse({
+                code: 'LABEL_ALREADY_EXISTS',
+                context: 'Label already exists'
+            }),
+            headers: {'content-type': 'application/json'},
+            ok: false,
+            status: 422
+        }, async () => {
+            const {result} = renderHookWithProviders(() => useEditLabel());
+
+            await act(async () => {
+                await expect(result.current.mutateAsync({id: 'label-1', name: 'Existing label'})).rejects.toBeInstanceOf(AlreadyExistsError);
+            });
+        });
+    });
+
+    it('leaves non-duplicate validation errors unchanged', async () => {
+        await withMockFetch({
+            json: createValidationErrorResponse({
+                code: 'VALIDATION',
+                context: 'Name is required',
+                property: 'name'
+            }),
+            headers: {'content-type': 'application/json'},
+            ok: false,
+            status: 422
+        }, async () => {
+            const {result} = renderHookWithProviders(() => useCreateLabel());
+
+            await act(async () => {
+                await expect(result.current.mutateAsync({name: ''})).rejects.toBeInstanceOf(ValidationError);
+            });
+        });
+    });
+});

--- a/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
@@ -2,7 +2,7 @@ import {renderHook} from '@testing-library/react';
 import React, {ReactNode} from 'react';
 import useHandleError from '../../../src/hooks/use-handle-error';
 import {FrameworkProvider} from '../../../src/providers/framework-provider';
-import {APIError, ValidationError} from '../../../src/utils/errors';
+import {APIError, AlreadyExistsError, ValidationError} from '../../../src/utils/errors';
 
 // Mock external dependencies
 vi.mock('@sentry/react', () => ({
@@ -230,6 +230,18 @@ describe('useHandleError', () => {
 
         expect(showToast).toHaveBeenCalledWith({
             message: 'Field is required',
+            type: 'error'
+        });
+    });
+
+    it('shows AlreadyExistsError message', () => {
+        const wrapper = createWrapper();
+        const {result} = renderHook(() => useHandleError(), {wrapper});
+
+        result.current(new AlreadyExistsError('A label with this name already exists'));
+
+        expect(showToast).toHaveBeenCalledWith({
+            message: 'A label with this name already exists',
             type: 'error'
         });
     });

--- a/apps/posts/src/components/label-picker/edit-row.tsx
+++ b/apps/posts/src/components/label-picker/edit-row.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useRef, useState} from 'react';
+import {AlreadyExistsError} from '@tryghost/admin-x-framework/errors';
 import {Button} from '@tryghost/shade/components';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
 
@@ -45,7 +46,10 @@ export const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDele
         try {
             await onSave(label.id, name.trim());
             onCancel();
-        } catch {
+        } catch (saveError) {
+            if (saveError instanceof AlreadyExistsError) {
+                setError(saveError.message);
+            }
             setIsSaving(false);
         }
     };

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -181,7 +181,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                         onChange={onChange}
                         onSearchChange={(value) => {
                             setCreateError('');
-                            picker.onSearchChange(value);
+                            picker.optionSource.onSearchChange?.(value);
                         }}
                     />
                 )}

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useRef, useState} from 'react';
+import {AlreadyExistsError} from '@tryghost/admin-x-framework/errors';
 import {
     Button,
     CommandItem,
@@ -24,6 +25,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
 
     const triggerRef = useRef<HTMLButtonElement>(null);
     const [alignOffset, setAlignOffset] = useState(0);
+    const [createError, setCreateError] = useState('');
 
     const updateAlignOffset = useCallback(() => {
         const trigger = triggerRef.current;
@@ -113,19 +115,32 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                     disabled={picker.isCreating}
                     variant="ghost"
                     onClick={async () => {
-                        const newLabel = await picker.createLabel(searchInput.trim());
-                        if (newLabel) {
-                            picker.toggleLabel(newLabel.slug);
+                        try {
+                            const newLabel = await picker.createLabel(searchInput.trim());
+                            if (newLabel) {
+                                picker.toggleLabel(newLabel.slug);
+                            }
+                            setCreateError('');
+                            clearSearch();
+                        } catch (error) {
+                            if (error instanceof AlreadyExistsError) {
+                                setCreateError(error.message);
+                            }
+                            return;
                         }
-                        clearSearch();
                     }}
                 >
                     <LucideIcon.Plus className="size-4" />
                     {picker.isCreating ? 'Creating...' : `Create "${searchInput.trim()}"`}
                 </Button>
+                {createError && (
+                    <div className="px-2 pt-1 text-xs text-destructive">
+                        {createError}
+                    </div>
+                )}
             </div>
         );
-    }, [picker]);
+    }, [createError, picker]);
 
     return (
         <Popover
@@ -164,6 +179,10 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                         renderItem={renderItem}
                         values={values}
                         onChange={onChange}
+                        onSearchChange={(value) => {
+                            setCreateError('');
+                            picker.onSearchChange(value);
+                        }}
                     />
                 )}
             </PopoverContent>

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {AlreadyExistsError} from '@tryghost/admin-x-framework/errors';
 import {
     Badge,
     type ComboboxOptionSource,
@@ -97,19 +98,31 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
     onSearchClear
 }) => {
     const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
+    const [createError, setCreateError] = useState('');
     const normalizedSearch = search.trim().toLowerCase();
     const visibleLabels = normalizedSearch
         ? labels.filter(label => label.name.toLowerCase().includes(normalizedSearch))
         : labels;
     const showCreate = !!onCreate && search.trim() && canCreateFromSearch?.(search);
     const showEdit = !!onEdit;
+
+    useEffect(() => {
+        setCreateError('');
+    }, [search]);
     const handleCreate = async () => {
         if (onCreate) {
-            const newLabel = await onCreate(search.trim());
-            if (newLabel) {
-                onToggle(newLabel.slug);
+            try {
+                const newLabel = await onCreate(search.trim());
+                if (newLabel) {
+                    onToggle(newLabel.slug);
+                }
+                onSearchClear?.();
+            } catch (error) {
+                if (error instanceof AlreadyExistsError) {
+                    setCreateError(error.message);
+                }
+                return;
             }
-            onSearchClear?.();
         }
     };
 
@@ -157,15 +170,22 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
                 </CommandGroup>
             )}
             {showCreate && (
-                <CommandGroup className="[&_[cmdk-group-heading]]:hidden">
-                    <CommandItem
-                        disabled={isCreating}
-                        onSelect={handleCreate}
-                    >
-                        <LucideIcon.Plus className="size-4" />
-                        {isCreating ? 'Creating...' : `Create "${search.trim()}"`}
-                    </CommandItem>
-                </CommandGroup>
+                <>
+                    <CommandGroup className="[&_[cmdk-group-heading]]:hidden">
+                        <CommandItem
+                            disabled={isCreating}
+                            onSelect={handleCreate}
+                        >
+                            <LucideIcon.Plus className="size-4" />
+                            {isCreating ? 'Creating...' : `Create "${search.trim()}"`}
+                        </CommandItem>
+                    </CommandGroup>
+                    {createError && (
+                        <div className="px-2 pb-2 text-xs text-destructive">
+                            {createError}
+                        </div>
+                    )}
+                </>
             )}
         </>
     );

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,6 +1,8 @@
+import {AlreadyExistsError} from '@tryghost/admin-x-framework/errors';
 import {Label, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
 import {ValueSource} from '@tryghost/shade/patterns';
 import {useCallback, useMemo, useRef, useState} from 'react';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useLabelValueSource} from './filter-sources/use-label-value-source';
 import type {ComboboxOptionSource} from '@tryghost/shade/components';
 
@@ -32,6 +34,7 @@ export function useLabelPicker({
 }: UseLabelPickerOptions): UseLabelPickerResult {
     const defaultLabelValueSource = useLabelValueSource();
     const labelValueSource = valueSource ?? defaultLabelValueSource;
+    const handleError = useHandleError();
     const [searchValue, setSearchValue] = useState('');
     const labelSourceState = labelValueSource.useOptions({
         query: searchValue,
@@ -61,6 +64,15 @@ export function useLabelPicker({
     const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
     const {mutateAsync: editLabelMutation} = useEditLabel();
     const {mutateAsync: deleteLabelMutation} = useDeleteLabel();
+
+    const handleMutationError = useCallback((error: unknown) => {
+        if (error instanceof AlreadyExistsError) {
+            throw error;
+        }
+
+        handleError(error);
+        throw error;
+    }, [handleError]);
 
     // Ref to always read the latest selectedSlugs in callbacks,
     // avoiding stale closures and keeping callbacks stable
@@ -94,10 +106,14 @@ export function useLabelPicker({
         if (!trimmed || isDuplicateName(trimmed)) {
             return undefined;
         }
-        const result = await createLabelMutation({name: trimmed});
-        const newLabel = result?.labels?.[0];
-        return newLabel;
-    }, [createLabelMutation, isDuplicateName]);
+        try {
+            const result = await createLabelMutation({name: trimmed});
+            const newLabel = result?.labels?.[0];
+            return newLabel;
+        } catch (error) {
+            handleMutationError(error);
+        }
+    }, [createLabelMutation, handleMutationError, isDuplicateName]);
 
     const editLabel = useCallback(async (id: string, name: string) => {
         const trimmed = name.trim();
@@ -105,27 +121,35 @@ export function useLabelPicker({
             return;
         }
         const oldLabel = labels.find(l => l.id === id);
-        const result = await editLabelMutation({id, name: trimmed});
-        const updatedLabel = result?.labels?.[0];
-        // If the slug changed and the old slug was selected, swap it
-        if (oldLabel && updatedLabel && oldLabel.slug !== updatedLabel.slug) {
-            const current = selectedSlugsRef.current;
-            if (current.includes(oldLabel.slug)) {
-                onSelectionChange(current.map(s => (s === oldLabel.slug ? updatedLabel.slug : s)));
+        try {
+            const result = await editLabelMutation({id, name: trimmed});
+            const updatedLabel = result?.labels?.[0];
+            // If the slug changed and the old slug was selected, swap it
+            if (oldLabel && updatedLabel && oldLabel.slug !== updatedLabel.slug) {
+                const current = selectedSlugsRef.current;
+                if (current.includes(oldLabel.slug)) {
+                    onSelectionChange(current.map(s => (s === oldLabel.slug ? updatedLabel.slug : s)));
+                }
             }
+        } catch (error) {
+            handleMutationError(error);
         }
-    }, [editLabelMutation, isDuplicateName, labels, onSelectionChange]);
+    }, [editLabelMutation, handleMutationError, isDuplicateName, labels, onSelectionChange]);
 
     const deleteLabel = useCallback(async (id: string) => {
         const label = labels.find(l => l.id === id);
-        await deleteLabelMutation(id);
-        if (label) {
-            const current = selectedSlugsRef.current;
-            if (current.includes(label.slug)) {
-                onSelectionChange(current.filter(s => s !== label.slug));
+        try {
+            await deleteLabelMutation(id);
+            if (label) {
+                const current = selectedSlugsRef.current;
+                if (current.includes(label.slug)) {
+                    onSelectionChange(current.filter(s => s !== label.slug));
+                }
             }
+        } catch (error) {
+            handleMutationError(error);
         }
-    }, [deleteLabelMutation, labels, onSelectionChange]);
+    }, [deleteLabelMutation, handleMutationError, labels, onSelectionChange]);
 
     return {
         labels,

--- a/apps/posts/test/setup.ts
+++ b/apps/posts/test/setup.ts
@@ -2,4 +2,4 @@ import '@testing-library/jest-dom/vitest';
 import {setupShadeMocks} from '@tryghost/admin-x-framework/test/setup';
 
 // Set up common mocks for shade components
-setupShadeMocks(); 
+setupShadeMocks();

--- a/apps/posts/test/unit/components/label-picker.test.tsx
+++ b/apps/posts/test/unit/components/label-picker.test.tsx
@@ -1,0 +1,68 @@
+import {AlreadyExistsError} from '@tryghost/admin-x-framework/errors';
+import {EditRow, LabelPicker} from '@src/components/label-picker';
+import {describe, expect, it, vi} from 'vitest';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+
+describe('label-picker components', () => {
+    it('shows duplicate create errors inline', async () => {
+        const onCreate = vi.fn().mockRejectedValue(new AlreadyExistsError('A label with this name already exists'));
+        const optionSource = {
+            options: [],
+            isInitialLoad: false,
+            isSearching: false,
+            isLoadingMore: false,
+            hasMore: false,
+            loadMore: vi.fn(),
+            shouldClientFilter: true,
+            onSearchChange: vi.fn()
+        };
+
+        render(
+            <LabelPicker
+                canCreateFromSearch={() => true}
+                labels={[]}
+                optionSource={optionSource}
+                selectedSlugs={[]}
+                onCreate={onCreate}
+                onToggle={vi.fn()}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('combobox'));
+        fireEvent.change(screen.getByPlaceholderText('Search labels...'), {target: {value: 'New Label'}});
+        fireEvent.click(screen.getByText('Create "New Label"'));
+
+        await waitFor(() => {
+            expect(onCreate).toHaveBeenCalledWith('New Label');
+        });
+
+        expect(screen.getByText('A label with this name already exists')).toBeInTheDocument();
+    });
+
+    it('shows duplicate save errors inline', async () => {
+        const onSave = vi.fn().mockRejectedValue(new AlreadyExistsError('A label with this name already exists'));
+
+        render(
+            <EditRow
+                label={{
+                    id: 'label-1',
+                    name: 'Existing Label',
+                    slug: 'existing-label',
+                    created_at: '',
+                    updated_at: ''
+                }}
+                onCancel={vi.fn()}
+                onDelete={vi.fn()}
+                onSave={onSave}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledWith('label-1', 'Existing Label');
+        });
+
+        expect(screen.getByText('A label with this name already exists')).toBeInTheDocument();
+    });
+});

--- a/ghost/core/core/server/api/endpoints/labels.js
+++ b/ghost/core/core/server/api/endpoints/labels.js
@@ -7,6 +7,21 @@ const messages = {
     labelAlreadyExists: 'Label already exists'
 };
 
+const errorCodes = {
+    labelAlreadyExists: 'LABEL_ALREADY_EXISTS'
+};
+
+const normalizeDuplicateLabelError = (error) => {
+    if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
+        throw new errors.ValidationError({
+            message: tpl(messages.labelAlreadyExists),
+            code: errorCodes.labelAlreadyExists
+        });
+    }
+
+    throw error;
+};
+
 const ALLOWED_INCLUDES = ['count.members'];
 
 /** @type {import('@tryghost/api-framework').Controller} */
@@ -89,13 +104,7 @@ const controller = {
         permissions: true,
         query(frame) {
             return models.Label.add(frame.data.labels[0], frame.options)
-                .catch((error) => {
-                    if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
-                        throw new errors.ValidationError({message: tpl(messages.labelAlreadyExists)});
-                    }
-
-                    throw error;
-                });
+                .catch(normalizeDuplicateLabelError);
         }
     },
 
@@ -119,7 +128,8 @@ const controller = {
         },
         permissions: true,
         async query(frame) {
-            const model = await models.Label.edit(frame.data.labels[0], frame.options);
+            const model = await models.Label.edit(frame.data.labels[0], frame.options)
+                .catch(normalizeDuplicateLabelError);
             if (!model) {
                 throw new errors.NotFoundError({
                     message: tpl(messages.labelNotFound)

--- a/ghost/core/test/e2e-api/admin/__snapshots__/labels.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/labels.test.js.snap
@@ -256,7 +256,7 @@ exports[`Labels API Errors when adding label with the same name 1: [body] 1`] = 
 Object {
   "errors": Array [
     Object {
-      "code": null,
+      "code": "LABEL_ALREADY_EXISTS",
       "context": "Label already exists",
       "details": null,
       "ghostErrorCode": null,
@@ -274,7 +274,38 @@ exports[`Labels API Errors when adding label with the same name 2: [headers] 1`]
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "242",
+  "content-length": "260",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Labels API Errors when editing label with the same name 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": "LABEL_ALREADY_EXISTS",
+      "context": "Label already exists",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit label.",
+      "property": null,
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Labels API Errors when editing label with the same name 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "260",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/labels.test.js
+++ b/ghost/core/test/e2e-api/admin/labels.test.js
@@ -149,4 +149,42 @@ describe('Labels API', function () {
                 etag: anyEtag
             });
     });
+
+    it('Errors when editing label with the same name', async function () {
+        const loggingStub = sinon.stub(logging, 'error');
+
+        await agent
+            .post('labels')
+            .body({labels: [{
+                name: 'edit-source-label'
+            }]})
+            .expectStatus(201);
+
+        const {body} = await agent
+            .post('labels')
+            .body({labels: [{
+                name: 'edit-target-label'
+            }]})
+            .expectStatus(201);
+
+        const id = body.labels[0].id;
+
+        await agent
+            .put(`labels/${id}`)
+            .body({labels: [{
+                name: 'edit-source-label'
+            }]})
+            .expectStatus(422)
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            });
+
+        sinon.assert.calledOnce(loggingStub);
+    });
 });


### PR DESCRIPTION
## Issue
fixes https://linear.app/ghost/issue/BER-3493/label-createedit-mutation-errors-are-silently-swallowed

## Summary
- normalize duplicate label API failures for both create and edit with a stable LABEL_ALREADY_EXISTS error code
- map duplicate label mutation errors to AlreadyExistsError in admin-x-framework and show them inline in the posts label picker
- keep non-duplicate API and network failures on the existing toast path, and add backend/frontend coverage for the new behavior

## Testing
- pnpm --filter @tryghost/admin-x-framework exec vitest run test/unit/api/labels.test.tsx test/unit/hooks/use-handle-error.test.tsx
- pnpm --filter @tryghost/posts exec vitest run test/unit/components/label-picker.test.tsx
- pnpm --dir ghost/core test:single test/e2e-api/admin/labels.test.js