### PR TITLE
Added is all of operator to member label filters

### DIFF
--- a/apps/posts/src/views/filters/filter-codecs.test.ts
+++ b/apps/posts/src/views/filters/filter-codecs.test.ts
@@ -272,6 +272,17 @@ describe('setCodec', () => {
         expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[alpha,vip]']);
     });
 
+    it('serializes all-of set membership as AND clauses', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'label',
+            operator: 'is-all',
+            values: ['vip', 'alpha']
+        };
+
+        expect(setCodec().serialize(predicate, labelContext)).toEqual(['(label:alpha+label:vip)']);
+    });
+
     it('can serialize singleton string values as quoted scalars', () => {
         const predicate: FilterPredicate = {
             id: '1',

--- a/apps/posts/src/views/filters/filter-codecs.ts
+++ b/apps/posts/src/views/filters/filter-codecs.ts
@@ -269,13 +269,19 @@ export function setCodec(config?: CodecConfig): FilterCodec {
                 return null;
             }
 
+            const values = normalizeMultiValue(predicate.values);
+
+            if (predicate.operator === 'is-all') {
+                const clauses = values.map(value => `${field}:${serializeScalarValue(value, config)}`);
+
+                return [`(${clauses.join('+')})`];
+            }
+
             const operator = SET_OPERATOR_SYMBOLS[predicate.operator];
 
             if (operator === undefined) {
                 return null;
             }
-
-            const values = normalizeMultiValue(predicate.values);
 
             if (config?.serializeSingletonAsScalar && values.length === 1) {
                 return [`${field}:${operator}${serializeScalarValue(values[0], config)}`];

--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -46,7 +46,7 @@ describe('memberFields', () => {
     });
 
     it('keeps the expected operators for key member fields', () => {
-        expect(memberFields.label.operators).toEqual(['is-any', 'is-not-any']);
+        expect(memberFields.label.operators).toEqual(['is-any', 'is-all', 'is-not-any']);
         expect(memberFields.tier_id.operators).toEqual(['is-any', 'is-not-any']);
         expect(memberFields['newsletters.:slug'].operators).toEqual(['is']);
         expect(memberFields.newsletter_feedback.operators).toEqual(['1', '0']);

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -8,6 +8,7 @@ const TEXT_OPERATORS = ['is', 'contains', 'does-not-contain', 'starts-with', 'en
 const NUMBER_OPERATORS = ['is', 'is-greater', 'is-less'] as const;
 const SCALAR_OPERATORS = ['is', 'is-not'] as const;
 const SET_OPERATORS = ['is-any', 'is-not-any'] as const;
+const LABEL_SET_OPERATORS = ['is-any', 'is-all', 'is-not-any'] as const;
 const SUBSCRIPTION_STATUS_OPTIONS: Array<{value: string; label: string}> = [
     {value: 'active', label: 'Active'},
     {value: 'trialing', label: 'Trialing'},
@@ -114,7 +115,7 @@ export const memberFields = defineFields({
         codec: textCodec()
     },
     label: {
-        operators: SET_OPERATORS,
+        operators: LABEL_SET_OPERATORS,
         ui: {
             label: 'Label',
             type: 'multiselect',

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -51,6 +51,26 @@ describe('member-filter-query', () => {
         ]);
     });
 
+    it('parses grouped positive label filters into an all-of predicate', () => {
+        expect(stripIds(parseMemberFilter('(label:alpha+label:vip)', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']}
+        ]);
+    });
+
+    it('parses grouped label all-of filters alongside other predicates', () => {
+        expect(stripIds(parseMemberFilter('(label:alpha+label:vip)+status:paid', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+    });
+
+    it('keeps ungrouped repeated positive label filters as separate predicates', () => {
+        expect(stripIds(parseMemberFilter('label:alpha+label:vip', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-any', values: ['alpha']},
+            {field: 'label', operator: 'is-any', values: ['vip']}
+        ]);
+    });
+
     it('best-effort parses compat subscribed booleans into subscribed filters', () => {
         expect(stripIds(parseMemberFilter('subscribed:true', 'UTC'))).toEqual([
             {field: 'subscribed', operator: 'is', values: ['subscribed']}
@@ -136,6 +156,15 @@ describe('member-filter-query', () => {
         ];
 
         expect(serializeMemberFilters(predicates, 'UTC')).toBe('label:[alpha,vip]+status:paid');
+    });
+
+    it('serializes label all-of filters as repeated AND clauses', () => {
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['vip', 'alpha']},
+            {id: '2', field: 'status', operator: 'is', values: ['paid']}
+        ];
+
+        expect(serializeMemberFilters(predicates, 'UTC')).toBe('(label:alpha+label:vip)+status:paid');
     });
 
     it('round-trips canonical member examples', () => {

--- a/apps/posts/src/views/members/member-filter-query.ts
+++ b/apps/posts/src/views/members/member-filter-query.ts
@@ -168,13 +168,85 @@ function matchFeedbackGroupedNode(node: AstNode): ParsedPredicate | null {
     };
 }
 
+function extractLabelAllOfPredicate(children: AstNode[]): {predicate: ParsedPredicate; remaining: AstNode[]} | null {
+    const labelValues: string[] = [];
+    const remaining: AstNode[] = [];
+
+    for (const child of children) {
+        const keys = Object.keys(child);
+        const key = keys[0];
+        const value = child[key];
+
+        if (
+            keys.length === 1 &&
+            (key === 'label' || key === 'labels') &&
+            typeof value === 'string'
+        ) {
+            labelValues.push(value);
+            continue;
+        }
+
+        remaining.push(child);
+    }
+
+    if (labelValues.length < 2) {
+        return null;
+    }
+
+    return {
+        predicate: {
+            field: 'label',
+            operator: 'is-all',
+            values: labelValues
+        },
+        remaining
+    };
+}
+
 const MEMBER_COMPOUND_MATCHERS: CompoundMatcher[] = [
     matchSubscribedNode,
     matchNewsletterGroupedNode,
     matchFeedbackGroupedNode
 ];
 
-function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
+function hasOuterGrouping(filter: string): boolean {
+    const trimmed = filter.trim();
+
+    if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) {
+        return false;
+    }
+
+    let depth = 0;
+    let quote: string | null = null;
+
+    for (let index = 0; index < trimmed.length; index += 1) {
+        const char = trimmed[index];
+        const previousChar = trimmed[index - 1];
+
+        if ((char === '\'' || char === '"') && previousChar !== '\\') {
+            quote = quote === char ? null : quote ?? char;
+            continue;
+        }
+
+        if (quote) {
+            continue;
+        }
+
+        if (char === '(') {
+            depth += 1;
+        } else if (char === ')') {
+            depth -= 1;
+
+            if (depth === 0 && index < trimmed.length - 1) {
+                return false;
+            }
+        }
+    }
+
+    return depth === 0;
+}
+
+function parseMemberNode(node: AstNode, timezone: string, isGroupedContext = false): ParsedPredicate[] {
     for (const matcher of MEMBER_COMPOUND_MATCHERS) {
         const parsed = matcher(node);
 
@@ -186,7 +258,16 @@ function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
     const compound = getCompoundChildren(node);
 
     if (compound?.operator === '$and') {
-        return compound.children.flatMap(child => parseMemberNode(child, timezone));
+        const labelAllOf = isGroupedContext ? extractLabelAllOfPredicate(compound.children) : null;
+
+        if (labelAllOf) {
+            return [
+                labelAllOf.predicate,
+                ...labelAllOf.remaining.flatMap(child => parseMemberNode(child, timezone, true))
+            ];
+        }
+
+        return compound.children.flatMap(child => parseMemberNode(child, timezone, true));
     }
 
     return dispatchSimpleNodes([node], memberFields, timezone);
@@ -199,7 +280,7 @@ export function parseMemberFilter(filter: string | undefined, timezone: string):
         return [];
     }
 
-    return stampPredicates(parseMemberNode(ast, timezone));
+    return stampPredicates(parseMemberNode(ast, timezone, hasOuterGrouping(filter ?? '')));
 }
 
 export function hasTimezoneSensitiveMemberFilter(filter: string | undefined): boolean {

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -52,6 +52,11 @@ describe('useMemberFilterFields', () => {
         const emailPostField = emailFields.find(field => field.key === 'emails.post_id');
 
         expect(labelField?.operators?.map(operator => operator.value)).toEqual(memberFields.label.operators);
+        expect(labelField?.operators?.map(operator => operator.label)).toEqual([
+            'is any of',
+            'is all of',
+            'is none of'
+        ]);
         expect(labelField).toMatchObject({
             options: [],
             valueSource: labelValueSource

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -31,6 +31,7 @@ type SearchableFieldOverrides = Pick<FilterFieldConfig, 'options' | 'valueSource
 
 const MEMBER_OPERATOR_LABELS: Record<string, string> = {
     'is-any': 'is any of',
+    'is-all': 'is all of',
     'is-not-any': 'is none of',
     'does-not-contain': 'does not contain',
     ...DATE_OPERATOR_LABELS,


### PR DESCRIPTION
## Summary
- Added an `is all of` operator to member Label filters
- Serialized all-of label filters as grouped NQL, e.g. `(label:alpha+label:vip)`
- Preserved ungrouped repeated label filters as separate filter rows when parsing back to UI state

## Issue
ref https://linear.app/ghost/issue/BER-3664/add-is-all-of-operator-to-member-label-filters

## Validation
- `pnpm --filter @tryghost/posts exec vitest run src/views/members/member-filter-query.test.ts src/views/filters/filter-codecs.test.ts src/views/members/member-fields.test.ts src/views/members/use-member-filter-fields.test.ts`
- `pnpm --filter @tryghost/posts build`