### PR TITLE
Added is all of operator to member label filters

### DIFF
--- a/apps/posts/src/views/filters/filter-codecs.test.ts
+++ b/apps/posts/src/views/filters/filter-codecs.test.ts
@@ -272,6 +272,17 @@ describe('setCodec', () => {
         expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[alpha,vip]']);
     });
 
+    it('serializes all-of set membership as AND clauses', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'label',
+            operator: 'is-all',
+            values: ['vip', 'alpha']
+        };
+
+        expect(setCodec().serialize(predicate, labelContext)).toEqual(['(label:alpha+label:vip)']);
+    });
+
     it('can serialize singleton string values as quoted scalars', () => {
         const predicate: FilterPredicate = {
             id: '1',

--- a/apps/posts/src/views/filters/filter-codecs.ts
+++ b/apps/posts/src/views/filters/filter-codecs.ts
@@ -269,13 +269,19 @@ export function setCodec(config?: CodecConfig): FilterCodec {
                 return null;
             }
 
+            const values = normalizeMultiValue(predicate.values);
+
+            if (predicate.operator === 'is-all') {
+                const clauses = values.map(value => `${field}:${serializeScalarValue(value, config)}`);
+
+                return [`(${clauses.join('+')})`];
+            }
+
             const operator = SET_OPERATOR_SYMBOLS[predicate.operator];
 
             if (operator === undefined) {
                 return null;
             }
-
-            const values = normalizeMultiValue(predicate.values);
 
             if (config?.serializeSingletonAsScalar && values.length === 1) {
                 return [`${field}:${operator}${serializeScalarValue(values[0], config)}`];

--- a/apps/posts/src/views/filters/filter-codecs.ts
+++ b/apps/posts/src/views/filters/filter-codecs.ts
@@ -49,9 +49,22 @@ const DATE_OPERATOR_SYMBOLS: Record<string, string> = {
     'is-or-greater': '>='
 };
 
-const SET_OPERATOR_SYMBOLS: Record<string, string> = {
-    'is-any': '',
-    'is-not-any': '-'
+type SetOperatorSerializer = (field: string, values: string[], config?: CodecConfig) => string;
+
+function serializeSetMembership(symbol: string): SetOperatorSerializer {
+    return (field, values, config) => {
+        if (config?.serializeSingletonAsScalar && values.length === 1) {
+            return `${field}:${symbol}${serializeScalarValue(values[0], config)}`;
+        }
+
+        return `${field}:${symbol}[${values.map(value => serializeScalarValue(value, config)).join(',')}]`;
+    };
+}
+
+const SET_OPERATOR_SERIALIZERS: Record<string, SetOperatorSerializer> = {
+    'is-any': serializeSetMembership(''),
+    'is-not-any': serializeSetMembership('-'),
+    'is-all': (field, values, config) => `(${values.map(value => `${field}:${serializeScalarValue(value, config)}`).join('+')})`
 };
 
 const UNQUOTED_TOKEN_PATTERN = /^[A-Za-z0-9_.-]+$/;
@@ -269,25 +282,13 @@ export function setCodec(config?: CodecConfig): FilterCodec {
                 return null;
             }
 
-            const values = normalizeMultiValue(predicate.values);
+            const serializeOperator = SET_OPERATOR_SERIALIZERS[predicate.operator];
 
-            if (predicate.operator === 'is-all') {
-                const clauses = values.map(value => `${field}:${serializeScalarValue(value, config)}`);
-
-                return [`(${clauses.join('+')})`];
-            }
-
-            const operator = SET_OPERATOR_SYMBOLS[predicate.operator];
-
-            if (operator === undefined) {
+            if (serializeOperator === undefined) {
                 return null;
             }
 
-            if (config?.serializeSingletonAsScalar && values.length === 1) {
-                return [`${field}:${operator}${serializeScalarValue(values[0], config)}`];
-            }
-
-            return [`${field}:${operator}[${values.map(value => serializeScalarValue(value, config)).join(',')}]`];
+            return [serializeOperator(field, normalizeMultiValue(predicate.values), config)];
         }
     };
 }

--- a/apps/posts/src/views/filters/filter-query-core.test.ts
+++ b/apps/posts/src/views/filters/filter-query-core.test.ts
@@ -1,7 +1,7 @@
 import {defineFields} from './filter-types';
 import {describe, expect, it} from 'vitest';
-import {dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates} from './filter-query-core';
-import {numberCodec, scalarCodec} from './filter-codecs';
+import {dispatchSimpleNodes, extractAllOfPredicates, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates} from './filter-query-core';
+import {numberCodec, scalarCodec, setCodec} from './filter-codecs';
 import type {AstNode} from './filter-ast';
 import type {FilterPredicate} from './filter-types';
 
@@ -118,5 +118,40 @@ describe('filter-query-core', () => {
 
         expect([...fieldKeys]).toEqual(['created_at', 'created_at_utc']);
         expect(hasFieldKey(ast, fieldKeys)).toBe(true);
+    });
+});
+
+describe('extractAllOfPredicates', () => {
+    const allOfFields = defineFields({
+        label: {
+            operators: ['is-any', 'is-all', 'is-not-any'],
+            parseKeys: ['labels'],
+            ui: {
+                label: 'Label',
+                type: 'multiselect'
+            },
+            codec: setCodec()
+        },
+        tier: {
+            operators: ['is-any', 'is-not-any'],
+            ui: {
+                label: 'Tier',
+                type: 'multiselect'
+            },
+            codec: setCodec()
+        }
+    });
+
+    it('groups repeated clauses for fields declaring is-all, resolving alias keys', () => {
+        const result = extractAllOfPredicates([{label: 'alpha'}, {labels: 'vip'}, {status: 'paid'}], allOfFields, 'UTC');
+
+        expect(result).toEqual({
+            predicates: [{field: 'label', operator: 'is-all', values: ['alpha', 'vip']}],
+            remaining: [{status: 'paid'}]
+        });
+    });
+
+    it('returns null when no field accumulates at least two all-of clauses', () => {
+        expect(extractAllOfPredicates([{label: 'alpha'}, {tier: 'gold'}, {tier: 'silver'}], allOfFields, 'UTC')).toBeNull();
     });
 });

--- a/apps/posts/src/views/filters/filter-query-core.ts
+++ b/apps/posts/src/views/filters/filter-query-core.ts
@@ -76,6 +76,64 @@ export function dispatchSimpleNodes<TFields extends Record<string, FilterField>>
     });
 }
 
+/**
+ * Pulls repeated positive scalar clauses for the same field out of a grouped
+ * AND's children, e.g. `(label:a+label:b)` → one all-of predicate. A field is
+ * eligible when it declares the `is-all` operator; alias keys come from
+ * `parseKeys`. Fields need at least two clauses to form a group — lone
+ * clauses stay in `remaining`. Returns null when nothing qualifies.
+ */
+export function extractAllOfPredicates<TFields extends Record<string, FilterField>>(
+    children: AstNode[],
+    fields: TFields,
+    timezone: string
+): {predicates: ParsedPredicate[]; remaining: AstNode[]} | null {
+    const clauses = children.map((child) => {
+        const keys = Object.keys(child);
+        const value = child[keys[0]];
+
+        if (keys.length !== 1 || keys[0].startsWith('$') || typeof value !== 'string') {
+            return {child, allOf: null};
+        }
+
+        const resolved = resolveField(fields, keys[0], timezone);
+
+        if (!resolved?.definition.operators.includes('is-all')) {
+            return {child, allOf: null};
+        }
+
+        return {child, allOf: {field: resolved.context.key, value}};
+    });
+
+    const clauseCounts = new Map<string, number>();
+
+    for (const {allOf} of clauses) {
+        if (allOf) {
+            clauseCounts.set(allOf.field, (clauseCounts.get(allOf.field) ?? 0) + 1);
+        }
+    }
+
+    const predicatesByField = new Map<string, ParsedPredicate>();
+    const remaining: AstNode[] = [];
+
+    for (const {child, allOf} of clauses) {
+        if (!allOf || (clauseCounts.get(allOf.field) ?? 0) < 2) {
+            remaining.push(child);
+            continue;
+        }
+
+        const predicate = predicatesByField.get(allOf.field) ?? {field: allOf.field, operator: 'is-all', values: []};
+        predicate.values.push(allOf.value);
+        predicatesByField.set(allOf.field, predicate);
+    }
+
+    if (!predicatesByField.size) {
+        return null;
+    }
+
+    return {predicates: [...predicatesByField.values()], remaining};
+}
+
 function canonicalizeClauses(clauses: string[]): string[] {
     return [...clauses].sort((left, right) => left.localeCompare(right));
 }

--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -47,7 +47,7 @@ describe('memberFields', () => {
     });
 
     it('keeps the expected operators for key member fields', () => {
-        expect(memberFields.label.operators).toEqual(['is-any', 'is-not-any']);
+        expect(memberFields.label.operators).toEqual(['is-any', 'is-all', 'is-not-any']);
         expect(memberFields.tier_id.operators).toEqual(['is-any', 'is-not-any']);
         expect(memberFields['newsletters.:slug'].operators).toEqual(['is']);
         expect(memberFields.newsletter_feedback.operators).toEqual(['1', '0']);

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -11,6 +11,7 @@ const TEXT_OPERATORS = ['is', 'contains', 'does-not-contain', 'starts-with', 'en
 const NUMBER_OPERATORS = ['is', 'is-greater', 'is-less'] as const;
 const SCALAR_OPERATORS = ['is', 'is-not'] as const;
 const SET_OPERATORS = ['is-any', 'is-not-any'] as const;
+const LABEL_SET_OPERATORS = ['is-any', 'is-all', 'is-not-any'] as const;
 const SUBSCRIPTION_STATUS_OPTIONS: Array<{value: string; label: string}> = [
     {value: 'active', label: 'Active'},
     {value: 'trialing', label: 'Trialing'},
@@ -141,7 +142,7 @@ const baseMemberFields = defineFields({
         codec: textCodec()
     },
     label: {
-        operators: SET_OPERATORS,
+        operators: LABEL_SET_OPERATORS,
         ui: {
             label: 'Label',
             type: 'multiselect',

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -143,6 +143,7 @@ const baseMemberFields = defineFields({
     },
     label: {
         operators: LABEL_SET_OPERATORS,
+        parseKeys: ['labels'],
         ui: {
             label: 'Label',
             type: 'multiselect',

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -58,6 +58,12 @@ describe('member-filter-query', () => {
         ]);
     });
 
+    it('parses grouped label all-of filters using the labels alias key', () => {
+        expect(stripIds(parseMemberFilter('(labels:alpha+labels:vip)', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']}
+        ]);
+    });
+
     it('parses grouped label all-of filters alongside other predicates', () => {
         expect(stripIds(parseMemberFilter('(label:alpha+label:vip)+status:paid', 'UTC'))).toEqual([
             {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -65,6 +65,12 @@ describe('member-filter-query', () => {
         ]);
     });
 
+    it('parses grouped label all-of filters with quoted values containing special characters', () => {
+        expect(stripIds(parseMemberFilter('(label:\'a (b)\'+label:\'trail\\\')', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['a (b)', 'trail\\']}
+        ]);
+    });
+
     it('keeps ungrouped repeated positive label filters as separate predicates', () => {
         expect(stripIds(parseMemberFilter('label:alpha+label:vip', 'UTC'))).toEqual([
             {field: 'label', operator: 'is-any', values: ['alpha']},

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -52,6 +52,26 @@ describe('member-filter-query', () => {
         ]);
     });
 
+    it('parses grouped positive label filters into an all-of predicate', () => {
+        expect(stripIds(parseMemberFilter('(label:alpha+label:vip)', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']}
+        ]);
+    });
+
+    it('parses grouped label all-of filters alongside other predicates', () => {
+        expect(stripIds(parseMemberFilter('(label:alpha+label:vip)+status:paid', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+    });
+
+    it('keeps ungrouped repeated positive label filters as separate predicates', () => {
+        expect(stripIds(parseMemberFilter('label:alpha+label:vip', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-any', values: ['alpha']},
+            {field: 'label', operator: 'is-any', values: ['vip']}
+        ]);
+    });
+
     it('best-effort parses compat subscribed booleans into subscribed filters', () => {
         expect(stripIds(parseMemberFilter('subscribed:true', 'UTC'))).toEqual([
             {field: 'subscribed', operator: 'is', values: ['subscribed']}
@@ -137,6 +157,15 @@ describe('member-filter-query', () => {
         ];
 
         expect(serializeMemberFilters(predicates, 'UTC')).toBe('label:[alpha,vip]+status:paid');
+    });
+
+    it('serializes label all-of filters as repeated AND clauses', () => {
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['vip', 'alpha']},
+            {id: '2', field: 'status', operator: 'is', values: ['paid']}
+        ];
+
+        expect(serializeMemberFilters(predicates, 'UTC')).toBe('(label:alpha+label:vip)+status:paid');
     });
 
     it('round-trips canonical member examples', () => {

--- a/apps/posts/src/views/members/member-filter-query.ts
+++ b/apps/posts/src/views/members/member-filter-query.ts
@@ -224,41 +224,27 @@ const MEMBER_COMPOUND_MATCHERS: CompoundMatcher[] = [
     matchFeedbackGroupedNode
 ];
 
+/**
+ * NQL flattens redundant parentheses, so the AST for `(label:a+label:b)` is
+ * identical to `label:a+label:b`. To detect the outer grouping without
+ * re-implementing NQL's quoting rules, parse the filter with a probe predicate
+ * AND-ed alongside: the grouping is no longer redundant, so it survives as a
+ * nested `$and` in the probed AST.
+ */
 function hasOuterGrouping(filter: string): boolean {
-    const trimmed = filter.trim();
+    const probed = parseFilterToAst(`${filter.trim()}+__outer_grouping_probe__:1`);
 
-    if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) {
+    if (!probed) {
         return false;
     }
 
-    let depth = 0;
-    let quote: string | null = null;
+    const compound = getCompoundChildren(probed);
 
-    for (let index = 0; index < trimmed.length; index += 1) {
-        const char = trimmed[index];
-        const previousChar = trimmed[index - 1];
-
-        if ((char === '\'' || char === '"') && previousChar !== '\\') {
-            quote = quote === char ? null : quote ?? char;
-            continue;
-        }
-
-        if (quote) {
-            continue;
-        }
-
-        if (char === '(') {
-            depth += 1;
-        } else if (char === ')') {
-            depth -= 1;
-
-            if (depth === 0 && index < trimmed.length - 1) {
-                return false;
-            }
-        }
+    if (compound?.operator !== '$and' || compound.children.length !== 2) {
+        return false;
     }
 
-    return depth === 0;
+    return getCompoundChildren(compound.children[0])?.operator === '$and';
 }
 
 function parseMemberNode(node: AstNode, timezone: string, isGroupedContext = false): ParsedPredicate[] {

--- a/apps/posts/src/views/members/member-filter-query.ts
+++ b/apps/posts/src/views/members/member-filter-query.ts
@@ -183,13 +183,85 @@ function matchFeedbackGroupedNode(node: AstNode): ParsedPredicate | null {
     };
 }
 
+function extractLabelAllOfPredicate(children: AstNode[]): {predicate: ParsedPredicate; remaining: AstNode[]} | null {
+    const labelValues: string[] = [];
+    const remaining: AstNode[] = [];
+
+    for (const child of children) {
+        const keys = Object.keys(child);
+        const key = keys[0];
+        const value = child[key];
+
+        if (
+            keys.length === 1 &&
+            (key === 'label' || key === 'labels') &&
+            typeof value === 'string'
+        ) {
+            labelValues.push(value);
+            continue;
+        }
+
+        remaining.push(child);
+    }
+
+    if (labelValues.length < 2) {
+        return null;
+    }
+
+    return {
+        predicate: {
+            field: 'label',
+            operator: 'is-all',
+            values: labelValues
+        },
+        remaining
+    };
+}
+
 const MEMBER_COMPOUND_MATCHERS: CompoundMatcher[] = [
     matchSubscribedNode,
     matchNewsletterGroupedNode,
     matchFeedbackGroupedNode
 ];
 
-function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
+function hasOuterGrouping(filter: string): boolean {
+    const trimmed = filter.trim();
+
+    if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) {
+        return false;
+    }
+
+    let depth = 0;
+    let quote: string | null = null;
+
+    for (let index = 0; index < trimmed.length; index += 1) {
+        const char = trimmed[index];
+        const previousChar = trimmed[index - 1];
+
+        if ((char === '\'' || char === '"') && previousChar !== '\\') {
+            quote = quote === char ? null : quote ?? char;
+            continue;
+        }
+
+        if (quote) {
+            continue;
+        }
+
+        if (char === '(') {
+            depth += 1;
+        } else if (char === ')') {
+            depth -= 1;
+
+            if (depth === 0 && index < trimmed.length - 1) {
+                return false;
+            }
+        }
+    }
+
+    return depth === 0;
+}
+
+function parseMemberNode(node: AstNode, timezone: string, isGroupedContext = false): ParsedPredicate[] {
     for (const matcher of MEMBER_COMPOUND_MATCHERS) {
         const parsed = matcher(node);
 
@@ -201,7 +273,16 @@ function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
     const compound = getCompoundChildren(node);
 
     if (compound?.operator === '$and') {
-        return compound.children.flatMap(child => parseMemberNode(child, timezone));
+        const labelAllOf = isGroupedContext ? extractLabelAllOfPredicate(compound.children) : null;
+
+        if (labelAllOf) {
+            return [
+                labelAllOf.predicate,
+                ...labelAllOf.remaining.flatMap(child => parseMemberNode(child, timezone, true))
+            ];
+        }
+
+        return compound.children.flatMap(child => parseMemberNode(child, timezone, true));
     }
 
     return dispatchSimpleNodes([node], memberFields, timezone);
@@ -218,7 +299,7 @@ export function parseMemberFilter(filter: string | undefined, timezone: string):
         return [];
     }
 
-    return stampPredicates(parseMemberNode(ast, timezone));
+    return stampPredicates(parseMemberNode(ast, timezone, hasOuterGrouping(filter ?? '')));
 }
 
 export function hasTimezoneSensitiveMemberFilter(filter: string | undefined): boolean {

--- a/apps/posts/src/views/members/member-filter-query.ts
+++ b/apps/posts/src/views/members/member-filter-query.ts
@@ -1,4 +1,4 @@
-import {dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates, stampPredicates} from '../filters/filter-query-core';
+import {dispatchSimpleNodes, extractAllOfPredicates, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates, stampPredicates} from '../filters/filter-query-core';
 import {memberFields} from './member-fields';
 import {resolveField} from '../filters/resolve-field';
 import type {AstNode} from '../filters/filter-ast';
@@ -183,41 +183,6 @@ function matchFeedbackGroupedNode(node: AstNode): ParsedPredicate | null {
     };
 }
 
-function extractLabelAllOfPredicate(children: AstNode[]): {predicate: ParsedPredicate; remaining: AstNode[]} | null {
-    const labelValues: string[] = [];
-    const remaining: AstNode[] = [];
-
-    for (const child of children) {
-        const keys = Object.keys(child);
-        const key = keys[0];
-        const value = child[key];
-
-        if (
-            keys.length === 1 &&
-            (key === 'label' || key === 'labels') &&
-            typeof value === 'string'
-        ) {
-            labelValues.push(value);
-            continue;
-        }
-
-        remaining.push(child);
-    }
-
-    if (labelValues.length < 2) {
-        return null;
-    }
-
-    return {
-        predicate: {
-            field: 'label',
-            operator: 'is-all',
-            values: labelValues
-        },
-        remaining
-    };
-}
-
 const MEMBER_COMPOUND_MATCHERS: CompoundMatcher[] = [
     matchSubscribedNode,
     matchNewsletterGroupedNode,
@@ -259,12 +224,12 @@ function parseMemberNode(node: AstNode, timezone: string, isGroupedContext = fal
     const compound = getCompoundChildren(node);
 
     if (compound?.operator === '$and') {
-        const labelAllOf = isGroupedContext ? extractLabelAllOfPredicate(compound.children) : null;
+        const allOf = isGroupedContext ? extractAllOfPredicates(compound.children, memberFields, timezone) : null;
 
-        if (labelAllOf) {
+        if (allOf) {
             return [
-                labelAllOf.predicate,
-                ...labelAllOf.remaining.flatMap(child => parseMemberNode(child, timezone, true))
+                ...allOf.predicates,
+                ...allOf.remaining.flatMap(child => parseMemberNode(child, timezone, true))
             ];
         }
 

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -52,6 +52,11 @@ describe('useMemberFilterFields', () => {
         const emailPostField = emailFields.find(field => field.key === 'emails.post_id');
 
         expect(labelField?.operators?.map(operator => operator.value)).toEqual(memberFields.label.operators);
+        expect(labelField?.operators?.map(operator => operator.label)).toEqual([
+            'is any of',
+            'is all of',
+            'is none of'
+        ]);
         expect(labelField).toMatchObject({
             options: [],
             valueSource: labelValueSource

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -31,6 +31,7 @@ type SearchableFieldOverrides = Pick<FilterFieldConfig, 'options' | 'valueSource
 
 const MEMBER_OPERATOR_LABELS: Record<string, string> = {
     'is-any': 'is any of',
+    'is-all': 'is all of',
     'is-not-any': 'is none of',
     'does-not-contain': 'does not contain',
     ...DATE_OPERATOR_LABELS,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3664/add-is-all-of-operator-to-member-label-filters

Member label filters could only express "has any of these labels" or "has none of these labels", so there was no way to find members that carry every selected label.

- added an "is all of" operator to the member Label filter, serialized as grouped NQL (`(label:alpha+label:vip)`) so the backend ANDs the label clauses
- grouped all-of filters round-trip back into a single filter row, while ungrouped repeated label clauses still parse as separate any-of rows
- outer-grouping detection re-parses the filter with a probe predicate AND-ed alongside instead of using a hand-rolled paren/quote scanner, so NQL's own quoting rules apply (a string scanner misread trailing backslashes in quoted values, breaking round-trips)
- all-of handling is driven by field config rather than special-cased for labels: any set field that declares the `is-all` operator gets serialization and parsing for free, with alias keys (`labels`) coming from the existing `parseKeys` mechanism, so extending it to e.g. tiers is a one-line change
