### PR TITLE
Removed stale secretlint entries from knip ignoreDependencies

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,9 +2,5 @@
     "$schema": "https://unpkg.com/knip@6/schema.json",
     "ignoreWorkspaces": [
         "ghost/admin"
-    ],
-    "ignoreDependencies": [
-        "secretlint",
-        "@secretlint/.*"
     ]
 }


### PR DESCRIPTION
## Summary

knip flagged these entries as stale (`Remove from ignoreDependencies` configuration hints) — it now resolves `secretlint` and `@secretlint/*` through `.secretlintrc.json` discovery, so the explicit `ignoreDependencies` entries are no longer needed.

## Test plan
- [x] `pnpm knip` no longer shows the configuration hints
- [x] `secretlint` and `@secretlint/*` are not flagged as unlisted/unused