### PR TITLE
Cleaned up dead JSDoc imports in ghost/core

### DIFF
--- a/ghost/core/core/server/services/email-service/mailgun-email-provider.js
+++ b/ghost/core/core/server/services/email-service/mailgun-email-provider.js
@@ -33,7 +33,7 @@ class MailgunEmailProvider {
 
     /**
      * @param {object} dependencies
-     * @param {import('@tryghost/mailgun-client/lib/MailgunClient')} dependencies.mailgunClient - mailgun client to send emails
+     * @param {import('../lib/mailgun-client')} dependencies.mailgunClient - mailgun client to send emails
      * @param {Function} [dependencies.errorHandler] - custom error handler for logging exceptions
      */
     constructor({

--- a/ghost/core/core/server/services/link-tracking/full-post-link.js
+++ b/ghost/core/core/server/services/link-tracking/full-post-link.js
@@ -12,7 +12,7 @@ module.exports = class FullPostLink {
     /** @type {ObjectID} */
     post_id;
     
-    /** @type {import('@tryghost/link-redirects/lib/LinkRedirect')} */
+    /** @type {import('../link-redirection/link-redirect')} */
     link;
 
     /** @type {FullPostLinkCount} */
@@ -21,7 +21,7 @@ module.exports = class FullPostLink {
     /**
      * @param {object} data
      * @param {string|ObjectID} data.post_id
-     * @param {import('@tryghost/link-redirects/lib/LinkRedirect')} data.link
+     * @param {import('../link-redirection/link-redirect')} data.link
      * @param {FullPostLinkCount} data.count
      */
     constructor(data) {

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -117,8 +117,8 @@ module.exports = class RouterController {
      * @param {any} deps.StripePrice
      * @param {() => boolean} deps.allowSelfSignup
      * @param {any} deps.magicLinkService
-     * @param {import('@tryghost/members-stripe-service')} deps.stripeAPIService
-     * @param {import('@tryghost/member-attribution')} deps.memberAttributionService
+     * @param {import('../../../stripe/stripe-api')} deps.stripeAPIService
+     * @param {import('../../../member-attribution')} deps.memberAttributionService
      * @param {any} deps.tokenService
      * @param {any} deps.sendEmailWithMagicLink
      * @param {{isSet(name: string): boolean}} deps.labsService

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -341,7 +341,7 @@ module.exports = class MemberRepository {
      * @param {Object} [data.stripeCustomer]
      * @param {string} [data.offerId]
      * @param {string} [data.status]
-     * @param {import('@tryghost/member-attribution/lib/Attribution').AttributionResource} [data.attribution]
+     * @param {import('../../../member-attribution/attribution-builder').AttributionResource} [data.attribution]
      * @param {boolean} [data.email_disabled]
      * @param {*} options
      * @returns
@@ -1024,7 +1024,7 @@ module.exports = class MemberRepository {
      * @param {string} data.id - member ID
      * @param {Object} data.subscription
      * @param {string} data.offerId
-     * @param {import('@tryghost/member-attribution/lib/Attribution').AttributionResource} [data.attribution]
+     * @param {import('../../../member-attribution/attribution-builder').AttributionResource} [data.attribution]
      * @param {*} options
      * @returns
      */

--- a/ghost/core/core/server/services/members/members-api/repositories/product-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/product-repository.js
@@ -54,7 +54,7 @@ class ProductRepository {
      * @param {any} deps.Settings
      * @param {any} deps.StripeProduct
      * @param {any} deps.StripePrice
-     * @param {import('@tryghost/members-api/lib/services/stripe-api')} deps.stripeAPIService
+     * @param {import('../../../stripe/stripe-api')} deps.stripeAPIService
      */
     constructor({
         Product,

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -25,7 +25,7 @@ const messages = {
  */
 
 /**
- * @typedef {import('@tryghost/members-offers/lib/application/OfferMapper').OfferDTO} OfferDTO
+ * @typedef {import('../../../offers/application/offer-mapper').OfferDTO} OfferDTO
  */
 
 /**
@@ -37,13 +37,13 @@ module.exports = class MemberBREADService {
     /**
      * @param {object} deps
      * @param {import('../repositories/member-repository')} deps.memberRepository
-     * @param {import('@tryghost/members-offers/lib/application/OffersAPI')} deps.offersAPI
+     * @param {import('../../../offers/application/offers-api')} deps.offersAPI
      * @param {ILabsService} deps.labsService
      * @param {IEmailService} deps.emailService
      * @param {IStripeService} deps.stripeService
-     * @param {import('@tryghost/member-attribution/lib/service')} deps.memberAttributionService
-     * @param {import('@tryghost/email-suppression-list/lib/email-suppression-list').IEmailSuppressionList} deps.emailSuppressionList
-     * @param {import('@tryghost/settings-helpers')} deps.settingsHelpers
+     * @param {import('../../../member-attribution/member-attribution-service')} deps.memberAttributionService
+     * @param {import('../../../email-suppression-list/email-suppression-list').IEmailSuppressionList} deps.emailSuppressionList
+     * @param {import('../../../settings-helpers/settings-helpers')} deps.settingsHelpers
      * @param {import('./next-payment-calculator')} deps.nextPaymentCalculator
      * @param {IGiftServiceWrapper} deps.giftService
      */

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -562,7 +562,7 @@ class PaymentsService {
     }
 
     /**
-     * @param {import('@tryghost/members-offers/lib/application/OfferMapper').OfferDTO} offer
+     * @param {import('../../../offers/application/offer-mapper').OfferDTO} offer
      */
     async createCouponForOffer(offer) {
         /** @type {import('stripe').Stripe.CouponCreateParams} */

--- a/ghost/core/core/server/services/offers/offers-module.js
+++ b/ghost/core/core/server/services/offers/offers-module.js
@@ -9,7 +9,7 @@ const OffersAPI = require('./application/offers-api');
 class OffersModule {
     /**
      * @param {OffersAPI} offersAPI
-     * @param {import('@tryghost/express-dynamic-redirects')} redirectManager
+     * @param {import('../lib/dynamic-redirect-manager')} redirectManager
      * @param {any} repository
      */
     constructor(offersAPI, redirectManager, repository) {
@@ -54,7 +54,7 @@ class OffersModule {
 
     /**
      * @param {object} deps
-     * @param {import('@tryghost/express-dynamic-redirects')} deps.redirectManager
+     * @param {import('../lib/dynamic-redirect-manager')} deps.redirectManager
      * @param {any} deps.repository
      *
      * @returns {OffersModule}

--- a/ghost/core/core/shared/events/member-created-event.js
+++ b/ghost/core/core/shared/events/member-created-event.js
@@ -3,7 +3,7 @@
  * @prop {string} memberId
  * @prop {string} batchId
  * @prop {'import' | 'system' | 'api' | 'admin' | 'member'} source
- * @prop {import('@tryghost/member-attribution/lib/Attribution').Attribution} [attribution] Attribution
+ * @prop {import('../../server/services/member-attribution/attribution-builder').Attribution} [attribution] Attribution
  */
 
 module.exports = class MemberCreatedEvent {

--- a/ghost/core/core/shared/events/subscription-created-event.js
+++ b/ghost/core/core/shared/events/subscription-created-event.js
@@ -8,7 +8,7 @@
  * @prop {string} tierId
  * @prop {string} subscriptionId
  * @prop {string} offerId
- * @prop {import('@tryghost/member-attribution/lib/Attribution').Attribution} [attribution]
+ * @prop {import('../../server/services/member-attribution/attribution-builder').Attribution} [attribution]
  */
 
 module.exports = class SubscriptionCreatedEvent {


### PR DESCRIPTION
## Summary

Multiple JSDoc `@param` / `@typedef` / `@prop` / `@type` annotations across `ghost/core` referenced `@tryghost/*` packages that were long ago internalized into the local source tree, but the JSDoc imports were never updated. Because those packages aren't installed, the annotations were silently resolving to `any` in type-checks instead of the intended types.

Repointed each dead import to its local equivalent — no runtime impact, this only restores the type information that the JSDoc was originally trying to convey.

Specifically:
- `@tryghost/mailgun-client/lib/MailgunClient` → `../lib/mailgun-client`
- `@tryghost/link-redirects/lib/LinkRedirect` → `../link-redirection/link-redirect`
- `@tryghost/member-attribution(/lib/{Attribution,service})` → local `member-attribution{,/attribution-builder,/member-attribution-service}`
- `@tryghost/members-stripe-service`, `@tryghost/members-api/lib/services/stripe-api` → `../../../stripe/stripe-api`
- `@tryghost/members-offers/lib/application/{OfferMapper,OffersAPI}` → local `offers/application/{offer-mapper,offers-api}`
- `@tryghost/email-suppression-list/lib/email-suppression-list` → local file
- `@tryghost/settings-helpers` → `../../../settings-helpers/settings-helpers`
- `@tryghost/express-dynamic-redirects` → `../lib/dynamic-redirect-manager`

The `i18next` and `@sentry/types` JSDoc imports are left untouched — those packages aren't installed and need separate handling.

## Test plan
- [x] `pnpm knip` no longer flags any of the rewritten imports as unlisted
- [x] No runtime code paths changed (JSDoc-only edits)