### PR TITLE
Added optional dev supervisor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ yarn-error.log*
 
 # Runtime data
 pids
+.ghost-dev
 *.pid
 *.seed
 *.pid.lock

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -18,7 +18,7 @@
     "react-dom": "17.0.2"
   },
   "scripts": {
-    "dev": "concurrently \"vite preview -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "test": "vitest run",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -15,7 +15,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "concurrently \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
     "dev:test": "vite build && vite preview --port 7175",
     "build": "vite build",
     "build:watch": "vite build --watch",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -14,7 +14,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "concurrently \"pnpm preview -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"pnpm preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "preview": "vite preview",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -14,8 +14,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "concurrently \"vite --port 6173\" \"vite preview -l silent\" \"vite build --watch\"",
-    "preview": "concurrently \"vite preview -l silent\" \"vite build --watch\"",
+    "dev": "concurrently --kill-others --names dev,preview,build \"vite --port 6173\" \"vite preview -l silent\" \"vite build --watch\"",
+    "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch\"",
     "dev:test": "vite build && vite preview --port 6175",
     "build": "tsc && vite build",
     "lint": "pnpm run lint:js",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -21,7 +21,7 @@
     "react-dom": "17.0.2"
   },
   "scripts": {
-    "dev": "concurrently \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
+    "dev": "concurrently --kill-others --names preview,build,tailwind \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
     "build": "vite build && pnpm tailwind:base",
     "build:watch": "vite build --watch",
     "tailwind": "pnpm tailwind:base --watch ",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:stripe": "./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev",
     "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' ./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev",
+    "dev:supervisor": "node scripts/dev-supervisor.js",
+    "dev:status": "node scripts/dev-supervisor.js status",
     "fix": "pnpm store prune && rimraf -g '**/node_modules' && pnpm install && pnpm nx reset",
     "knex-migrator": "pnpm --filter ghost run knex-migrator",
     "setup": "pnpm install && git submodule update --init --recursive",

--- a/scripts/dev-supervisor.js
+++ b/scripts/dev-supervisor.js
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {spawn, spawnSync} = require('child_process');
+
+const rootDir = path.resolve(__dirname, '..');
+const stateDir = path.join(rootDir, '.ghost-dev');
+const stateFile = path.join(stateDir, 'dev-supervisor.json');
+const pnpmBin = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+
+function ensureStateDir() {
+    fs.mkdirSync(stateDir, {recursive: true});
+}
+
+function writeState(state) {
+    ensureStateDir();
+    fs.writeFileSync(stateFile, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function readState() {
+    try {
+        return JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    } catch (error) {
+        return null;
+    }
+}
+
+function removeState() {
+    try {
+        fs.unlinkSync(stateFile);
+    } catch (error) {
+        // Nothing to remove.
+    }
+}
+
+function processExists(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function signalProcessGroup(pgid, signal) {
+    if (process.platform === 'win32') {
+        try {
+            process.kill(pgid, signal);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    try {
+        process.kill(-pgid, signal);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function processGroupExists(pgid) {
+    if (process.platform === 'win32') {
+        return processExists(pgid);
+    }
+
+    try {
+        process.kill(-pgid, 0);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function dockerComposeArgs() {
+    const args = ['compose', '-f', 'compose.dev.yaml'];
+    const extraComposeFiles = String(process.env.DEV_COMPOSE_FILES || '').trim();
+
+    if (extraComposeFiles) {
+        args.push(...extraComposeFiles.split(/\s+/));
+    }
+
+    return args;
+}
+
+function runDockerDown() {
+    const result = spawnSync('docker', [...dockerComposeArgs(), 'down'], {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: process.env,
+        stdio: 'inherit'
+    });
+
+    return result.status === 0;
+}
+
+function printCommand(command, args, env) {
+    const daemonMode = env.NX_DAEMON === 'false' ? 'disabled' : 'default';
+    console.log(`[dev-supervisor] Starting: ${command} ${args.join(' ')}`);
+    console.log(`[dev-supervisor] Nx daemon: ${daemonMode}`);
+    if (env.NX_DAEMON === 'false') {
+        console.log('[dev-supervisor] Set GHOST_DEV_NX_DAEMON=1 to compare with the daemon enabled.');
+    }
+}
+
+function psOutput() {
+    const result = spawnSync('ps', ['-axo', 'pid,ppid,pgid,stat,%cpu,%mem,etime,command'], {
+        cwd: rootDir,
+        encoding: 'utf8'
+    });
+
+    if (result.error) {
+        return `Unable to run ps: ${result.error.message}\n`;
+    }
+
+    return result.stdout || '';
+}
+
+function printMatchingProcesses() {
+    const repoPids = repoProcessIds();
+    const patterns = [
+        'pnpm .*dev',
+        'nx',
+        'vite',
+        'ember',
+        'nodemon',
+        'concurrently',
+        'tsc',
+        'tailwind',
+        'dev-supervisor'
+    ];
+    const matcher = new RegExp(patterns.join('|'), 'i');
+    const lines = psOutput().split('\n').filter((line) => {
+        const pid = Number(line.trim().split(/\s+/)[0]);
+        return pid !== process.pid && pid !== process.ppid && repoPids.has(pid) && matcher.test(line);
+    });
+
+    if (!lines.length) {
+        console.log('No matching Ghost repo-local dev processes found.');
+        return;
+    }
+
+    console.log(lines.join('\n'));
+}
+
+function repoProcessIds() {
+    const result = spawnSync('lsof', ['-nP', '-a', '-d', 'cwd'], {
+        cwd: rootDir,
+        encoding: 'utf8'
+    });
+
+    if (result.error || !result.stdout) {
+        return new Set();
+    }
+
+    const pids = new Set();
+
+    for (const line of result.stdout.split('\n').slice(1)) {
+        const parts = line.trim().split(/\s+/);
+        const pid = Number(parts[1]);
+        const cwd = parts.slice(8).join(' ');
+
+        if (pid && (cwd === rootDir || cwd.startsWith(`${rootDir}${path.sep}`))) {
+            pids.add(pid);
+        }
+    }
+
+    return pids;
+}
+
+function printNxDaemonStatus() {
+    const result = spawnSync(pnpmBin, ['nx', 'daemon'], {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: process.env
+    });
+
+    const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    if (output) {
+        console.log(output);
+    } else if (result.error) {
+        console.log(`Unable to inspect Nx daemon: ${result.error.message}`);
+    }
+}
+
+async function cleanupHelper() {
+    const pgidIndex = process.argv.indexOf('--pgid');
+    const pgid = pgidIndex === -1 ? null : Number(process.argv[pgidIndex + 1]);
+
+    if (!pgid) {
+        process.exit(0);
+    }
+
+    await sleep(8000);
+
+    if (processGroupExists(pgid)) {
+        signalProcessGroup(pgid, 'SIGTERM');
+    }
+
+    runDockerDown();
+
+    await sleep(3000);
+
+    if (processGroupExists(pgid)) {
+        signalProcessGroup(pgid, 'SIGKILL');
+    }
+}
+
+function spawnCleanupHelper(pgid) {
+    let helper;
+
+    try {
+        helper = spawn(process.execPath, [__filename, 'cleanup-helper', '--pgid', String(pgid)], {
+            cwd: rootDir,
+            detached: true,
+            stdio: 'ignore'
+        });
+    } catch (error) {
+        console.error(`[dev-supervisor] Failed to start cleanup helper: ${error.message}`);
+        return;
+    }
+
+    helper.on('error', (error) => {
+        console.error(`[dev-supervisor] Cleanup helper failed to start: ${error.message}`);
+    });
+
+    helper.unref();
+}
+
+function status() {
+    const state = readState();
+
+    console.log('Ghost dev supervisor');
+    if (state) {
+        const running = processExists(state.childPid);
+        console.log(`State file: ${stateFile}`);
+        console.log(`Started: ${state.startedAt}`);
+        console.log(`Supervisor PID: ${state.supervisorPid}`);
+        console.log(`Child PID/PGID: ${state.childPid}`);
+        console.log(`Command: ${state.command} ${state.args.join(' ')}`);
+        console.log(`Nx daemon for supervised dev: ${state.nxDaemon}`);
+        console.log(`Child process running: ${running ? 'yes' : 'no'}`);
+    } else {
+        console.log(`State file: ${stateFile} (not present)`);
+    }
+
+    console.log('\nNx daemon');
+    printNxDaemonStatus();
+
+    console.log('\nMatching local dev processes');
+    printMatchingProcesses();
+}
+
+function start() {
+    const args = ['nx', 'run', 'ghost-monorepo:docker:dev'];
+    const env = {
+        ...process.env
+    };
+
+    if (!['1', 'true', 'yes'].includes(String(process.env.GHOST_DEV_NX_DAEMON || '').toLowerCase())) {
+        env.NX_DAEMON = 'false';
+    }
+
+    printCommand(pnpmBin, args, env);
+
+    const child = spawn(pnpmBin, args, {
+        cwd: rootDir,
+        detached: process.platform !== 'win32',
+        env,
+        stdio: 'inherit'
+    });
+
+    child.on('error', (error) => {
+        console.error(`[dev-supervisor] Failed to start dev command: ${error.message}`);
+        removeState();
+        process.exit(1);
+    });
+
+    writeState({
+        startedAt: new Date().toISOString(),
+        platform: `${os.platform()}-${os.arch()}`,
+        supervisorPid: process.pid,
+        childPid: child.pid,
+        command: pnpmBin,
+        args,
+        nxDaemon: env.NX_DAEMON === 'false' ? 'disabled' : 'default'
+    });
+
+    let shuttingDown = false;
+
+    function shutdown(signal) {
+        if (shuttingDown) {
+            return;
+        }
+
+        shuttingDown = true;
+        console.log(`\n[dev-supervisor] Received ${signal}; forwarding to dev process group ${child.pid}.`);
+
+        signalProcessGroup(child.pid, signal === 'SIGINT' ? 'SIGINT' : 'SIGTERM');
+        spawnCleanupHelper(child.pid);
+
+        setTimeout(() => {
+            if (processGroupExists(child.pid)) {
+                console.log('[dev-supervisor] Dev process group is still running; sending SIGTERM.');
+                signalProcessGroup(child.pid, 'SIGTERM');
+            }
+
+            console.log('[dev-supervisor] Ensuring Docker dev services are stopped.');
+            runDockerDown();
+        }, 8000).unref();
+
+        setTimeout(() => {
+            if (processGroupExists(child.pid)) {
+                console.log('[dev-supervisor] Dev process group is still running; sending SIGKILL.');
+                signalProcessGroup(child.pid, 'SIGKILL');
+            }
+        }, 11000).unref();
+    }
+
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGHUP', () => shutdown('SIGHUP'));
+
+    child.on('exit', (code, signal) => {
+        removeState();
+
+        if (shuttingDown) {
+            process.exit(0);
+        }
+
+        if (signal) {
+            console.log(`[dev-supervisor] Dev process exited from ${signal}.`);
+            process.exit(1);
+        }
+
+        process.exit(code || 0);
+    });
+}
+
+const command = process.argv[2];
+
+if (command === 'status') {
+    status();
+} else if (command === 'cleanup-helper') {
+    cleanupHelper().catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });
+} else {
+    start();
+}


### PR DESCRIPTION
## Summary
- Added optional `pnpm dev:supervisor` wrapper for testing supervised PNPM/Nx dev shutdown.
- Added `pnpm dev:status` diagnostics for repo-local dev processes.
- Hardened public app `concurrently` dev scripts to stop sibling processes together.

## Testing
- `node --check scripts/dev-supervisor.js`
- `pnpm dev:status`
- Started `pnpm dev:supervisor`, verified dev stack came up, sent SIGINT, verified `pnpm dev:status` reported no repo-local dev processes and Compose services were stopped.