### PR TITLE
Cleaned up final phantom-dep findings in knip

### DIFF
--- a/ghost/core/core/server/services/i18n.js
+++ b/ghost/core/core/server/services/i18n.js
@@ -1,6 +1,5 @@
 const debug = require('@tryghost/debug')('i18n');
 
-/** @type {import('i18next').i18n} */
 let i18nInstance;
 
 module.exports.init = function () {

--- a/ghost/core/core/shared/sentry-knex-tracing-integration.js
+++ b/ghost/core/core/shared/sentry-knex-tracing-integration.js
@@ -3,13 +3,11 @@
  */
 
 /**
- * @typedef {import('@sentry/types').Integration} SentryIntegration
- */
-
-/**
  * Sentry Knex tracing integration
  *
- * @implements {SentryIntegration}
+ * Implements the Sentry `Integration` interface. The type is not annotated via
+ * JSDoc because `Integration` is only exported from `@sentry/types`, which is
+ * not a direct dependency of ghost/core (only `@sentry/node` is).
  */
 class SentryKnexTracingIntegration {
     static id = 'Knex';

--- a/knip.json
+++ b/knip.json
@@ -2,5 +2,8 @@
     "$schema": "https://unpkg.com/knip@6/schema.json",
     "ignoreWorkspaces": [
         "ghost/admin"
+    ],
+    "ignore": [
+        "ghost/core/test/utils/fixtures/themes/**/assets/built/**"
     ]
 }


### PR DESCRIPTION
## Summary

Closes out the unlisted-dependencies tail surfaced after PR #27948. After this PR, `pnpm knip --include=unlisted` reports 0 findings.

- **`i18n.js`**: dropped the `/** @type {import('i18next').i18n} */` annotation. `i18next` isn't a declared dep of `ghost/core` and adding it just for a type ref isn't warranted — the variable holds `require('@tryghost/i18n')`, Ghost's own wrapper.
- **`sentry-knex-tracing-integration.js`**: removed the `@typedef SentryIntegration` and `@implements` annotations. The `Integration` type is only exported from `@sentry/types`, which isn't a direct dep of `ghost/core` (only `@sentry/node` is). Replaced with a prose comment.
- **`knip.json`**: added an ignore glob for `ghost/core/test/utils/fixtures/themes/**/assets/built/**`. Knip was scanning the minified theme fixture bundles and treating their internal `ev-emitter` references as unresolved imports — false positives.

## Test plan
- [x] `pnpm knip --include=unlisted` returns 0 findings