### PR TITLE
Removed broken setupFiles reference in signup-form vite config

### DIFF
--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/signup-form",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/signup-form/vite.config.mts
+++ b/apps/signup-form/vite.config.mts
@@ -67,7 +67,6 @@ export default (function viteConfig() {
         test: {
             globals: true, // required for @testing-library/jest-dom extensions
             environment: 'jsdom',
-            setupFiles: './test/test-setup.js',
             include: ['./test/unit/*'],
             testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 10000,
             ...(process.env.CI && { // https://github.com/vitest-dev/vitest/issues/1674


### PR DESCRIPTION
## Summary

- `apps/signup-form/vite.config.mts` referenced a `setupFiles: './test/test-setup.js'` that has never existed in the repository, surfacing as an unresolved entry in `pnpm knip`.
- The app's `test:unit` script runs `pnpm build`, not vitest, so nothing was actually loading this config — the broken reference was inert but noisy.
- Removed only the `setupFiles` line; the rest of the vitest config is left in place so the block remains valid if anyone wires vitest back up.

## Test plan

- [x] `pnpm test:unit` in `apps/signup-form` exits 0 (it shells out to `pnpm build`).
- [x] `pnpm knip --include=unresolved --no-progress` no longer reports `./test/test-setup.js` against `apps/signup-form/vite.config.mts`.