### PR TITLE
Declared postcss-import as a comments-ui devDependency

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -79,6 +79,7 @@
     "jsdom": "catalog:",
     "moment": "2.30.1",
     "postcss": "catalog:",
+    "postcss-import": "16.1.1",
     "sinon": "21.1.1",
     "tailwindcss": "3.4.18",
     "vite": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1047,6 +1047,9 @@ importers:
       postcss:
         specifier: 'catalog:'
         version: 8.5.6
+      postcss-import:
+        specifier: 16.1.1
+        version: 16.1.1(postcss@8.5.6)
       sinon:
         specifier: 21.1.1
         version: 21.1.1


### PR DESCRIPTION
## Summary

- `apps/comments-ui/postcss.config.cjs` lists `'postcss-import': {}` as a plugin, but the package is not declared in `apps/comments-ui/package.json`.
- The build only worked because pnpm's hoisted `node_modules` layout exposed `postcss-import` transitively. That's fragile and would break under strict resolution or any reshuffle of sibling deps.
- Declared `postcss-import@16.1.1` in `devDependencies`, matching the version already used by `apps/signup-form` and `apps/admin-x-design-system` (no new package added to the lockfile).

## Test plan

- [x] `pnpm install` succeeds with no new peer-dep warnings
- [x] `pnpm build` in `apps/comments-ui` completes successfully and emits `umd/comments-ui.min.js`
- [x] `pnpm knip --include=unresolved --no-progress` no longer flags `postcss-import` as unresolved