### PR TITLE
Cleaned up dead JSDoc imports in ghost/core

### DIFF
--- a/ghost/core/core/server/services/auth/session/session-service.js
+++ b/ghost/core/core/server/services/auth/session/session-service.js
@@ -56,9 +56,9 @@ const AUTH_CODE_CHALLENGE_BYTES = 16;
  * @param {(req: Req) => string} deps.getOriginOfRequest
  * @param {((key: 'require_email_mfa') => boolean) & ((key: 'admin_session_secret' | 'title') => string)} deps.getSettingsCache
  * @param {() => string} deps.getBlogLogo
- * @param {import('../../core/core/server/services/mail').GhostMailer} deps.mailer
- * @param {import('../../core/core/server/services/i18n').t} deps.t
- * @param {import('../../core/core/shared/url-utils')} deps.urlUtils
+ * @param {import('../../mail').GhostMailer} deps.mailer
+ * @param {import('../../i18n').t} deps.t
+ * @param {import('../../../../shared/url-utils')} deps.urlUtils
  * @param {() => boolean} deps.isStaffDeviceVerificationDisabled
  * @returns {SessionService}
  */

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -61,7 +61,7 @@ module.exports = class MemberRepository {
      * @param {any} deps.StripeCustomerSubscription
      * @param {any} deps.OfferRedemption
      * @param {any} deps.Outbox
-     * @param {import('../../services/stripe-api')} deps.stripeAPIService
+     * @param {import('../../../stripe/stripe-api')} deps.stripeAPIService
      * @param {any} deps.productRepository
      * @param {any} deps.offersAPI
      * @param {ITokenService} deps.tokenService

--- a/ghost/core/core/server/services/oembed/nft-oembed-provider.js
+++ b/ghost/core/core/server/services/oembed/nft-oembed-provider.js
@@ -1,6 +1,6 @@
 /**
- * @typedef {import('./oembed').ICustomProvider} ICustomProvider
- * @typedef {import('./oembed').IExternalRequest} IExternalRequest
+ * @typedef {import('./oembed-service').ICustomProvider} ICustomProvider
+ * @typedef {import('./oembed-service').IExternalRequest} IExternalRequest
  */
 
 const OPENSEA_ETH_PATH_REGEX = /^\/assets\/ethereum\/(0x[a-f0-9]+)\/(\d+)/;

--- a/ghost/core/core/server/services/oembed/twitter-oembed-provider.js
+++ b/ghost/core/core/server/services/oembed/twitter-oembed-provider.js
@@ -1,8 +1,8 @@
 const logging = require('@tryghost/logging');
 
 /**
- * @typedef {import('./oembed').ICustomProvider} ICustomProvider
- * @typedef {import('./oembed').IExternalRequest} IExternalRequest
+ * @typedef {import('./oembed-service').ICustomProvider} ICustomProvider
+ * @typedef {import('./oembed-service').IExternalRequest} IExternalRequest
  */
 
 const TWITTER_PATH_REGEX = /\/status\/(\d+)/;

--- a/ghost/core/core/server/services/offers/application/unique-checker.js
+++ b/ghost/core/core/server/services/offers/application/unique-checker.js
@@ -1,6 +1,6 @@
 class UniqueChecker {
     /**
-     * @param {import('./OfferRepository')} repository
+     * @param {import('../offer-bookshelf-repository')} repository
      * @param {import('knex').Transaction} transaction
      */
     constructor(repository, transaction) {

--- a/ghost/core/core/server/services/stripe/services/webhook/subscription-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/subscription-event-service.js
@@ -12,7 +12,7 @@ const _ = require('lodash');
 module.exports = class SubscriptionEventService {
     /**
      * @param {object} deps
-     * @param {import('../../repositories/MemberRepository')} deps.memberRepository
+     * @param {import('../../../members/members-api/repositories/member-repository')} deps.memberRepository
      */
     constructor(deps) {
         this.deps = deps;

--- a/ghost/core/test/unit/server/services/stats/subscriptions.test.js
+++ b/ghost/core/test/unit/server/services/stats/subscriptions.test.js
@@ -229,7 +229,7 @@ describe('SubscriptionStatsService', function () {
              * @param {string} cadence
              * @param {string} date
              *
-             * @returns {(result: import('../../lib/subscriptions').SubscriptionHistoryEntry) => boolean}
+             * @returns {(result: import('../../../../../core/server/services/stats/subscription-stats-service').SubscriptionHistoryEntry) => boolean}
              **/
             const finder = (tier, cadence, date) => (result) => {
                 return result.tier === tier && result.cadence === cadence && result.date === date;
@@ -319,7 +319,7 @@ describe('SubscriptionStatsService', function () {
              * @param {string} cadence
              * @param {string} date
              *
-             * @returns {(result: import('../../lib/subscriptions').SubscriptionHistoryEntry) => boolean}
+             * @returns {(result: import('../../../../../core/server/services/stats/subscription-stats-service').SubscriptionHistoryEntry) => boolean}
              **/
             const finder = (tier, cadence, date) => (resultItem) => {
                 return resultItem.tier === tier && resultItem.cadence === cadence && resultItem.date === date;


### PR DESCRIPTION
## Summary

Third batch of JSDoc-only cleanups, continuing the work from #27948 and #27952. Repoints another set of stale `import('...')` references that knip surfaces under unresolved imports — these were never updated when the referenced packages were internalised into ghost/core's source tree.

Files / typedefs repointed:

- `services/auth/session/session-service.js` — `mailer`, `t`, `urlUtils` now reference `../../mail`, `../../i18n`, `../../../../shared/url-utils`.
- `services/members/members-api/repositories/member-repository.js` — `stripeAPIService` now references `../../../stripe/stripe-api` (matches the path adopted in #27948).
- `services/oembed/nft-oembed-provider.js` and `services/oembed/twitter-oembed-provider.js` — `ICustomProvider` and `IExternalRequest` typedefs now resolve against `./oembed-service`, where they're actually defined.
- `services/offers/application/unique-checker.js` — `repository` param now references `../offer-bookshelf-repository`, matching the JSDoc that OffersAPI already uses for the same value.
- `services/stripe/services/webhook/subscription-event-service.js` — `memberRepository` typed against `../../../members/members-api/repositories/member-repository`.
- `test/unit/server/services/stats/subscriptions.test.js` — `SubscriptionHistoryEntry` typedef now imported from `subscription-stats-service`, where the typedef lives.

JSDoc-only — no runtime behaviour changes.

## Test plan

- [ ] `pnpm knip --include=unresolved` no longer reports the seven files above (only the unrelated `comments-ui` postcss, `signup-form` test-setup, and the `defaults.json` false positive remain).