### PR TITLE
Improved dark mode and canvas position in the automations editor

### DIFF
--- a/apps/posts/src/views/Automations/components/add-step-edge.tsx
+++ b/apps/posts/src/views/Automations/components/add-step-edge.tsx
@@ -13,7 +13,7 @@ export type AddStepEdgeData = {
 };
 
 const INSERT_BUTTON_CLASSES = 'border-transparent bg-blue-500 text-white shadow-sm hover:bg-blue-600';
-const DEFAULT_EDGE_STROKE = 'var(--color-grey-500)';
+const DEFAULT_EDGE_STROKE = 'var(--xy-edge-stroke)';
 const HOVERED_EDGE_STROKE = 'var(--color-blue-500)';
 
 const AddStepEdge: React.FC<EdgeProps> = ({

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -317,7 +317,7 @@ const getInitialViewport = (canvasWidth: number): {x: number; y: number; zoom: n
     zoom: 1
 });
 
-interface AutomationCanvasProps {
+type AutomationCanvasProps = {
     automation?: AutomationDetail;
     isLoading: boolean;
     isError: boolean;

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -1,6 +1,6 @@
 import '@xyflow/react/dist/style.css';
 import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
 import {AutomationAction, AutomationDetail, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
@@ -8,8 +8,12 @@ import {Banner, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Toolt
 import {LucideIcon, cn} from '@tryghost/shade/utils';
 
 const NODE_X = 0;
+const NODE_WIDTH = 256;
+const NODE_COLUMN_CENTER_X = NODE_X + (NODE_WIDTH / 2);
 const NODE_GAP_Y = 180;
+const INITIAL_VIEWPORT_Y = 40;
 const DISABLED_REASON = `Limit of ${MAX_AUTOMATION_ACTIONS} steps reached`;
+const DEFAULT_EDGE_STROKE = 'var(--xy-edge-stroke)';
 
 // React Flow node IDs for the trigger and tail nodes. The canvas builds the visual graph using
 // these; they are not action IDs and never reach the API.
@@ -55,7 +59,7 @@ const HiddenHandle: React.FC<{type: 'source' | 'target'; position: Position}> = 
 
 const NodeShell: React.FC<React.PropsWithChildren<{className?: string}>> = ({children, className}) => (
     <div
-        className={cn('flex w-64 items-center gap-3 rounded-lg bg-white px-4 py-3 text-left text-sm shadow-sm', className)}
+        className={cn('flex w-64 items-center gap-3 rounded-lg border border-border-default bg-surface-elevated px-4 py-3 text-left text-sm text-foreground shadow-sm', className)}
     >
         {children}
     </div>
@@ -65,11 +69,11 @@ const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
     const Icon = data.icon;
     return (
         <>
-            <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-grey-100 text-grey-700'>
+            <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary'>
                 <Icon className='size-4' />
             </div>
             <div className='flex min-w-0 flex-col text-left'>
-                <span className='text-xs text-grey-600'>{data.label}</span>
+                <span className='text-xs text-text-secondary'>{data.label}</span>
                 {data.value && <span className='truncate font-medium'>{data.value}</span>}
             </div>
         </>
@@ -101,7 +105,7 @@ const TailNode: React.FC<NodeProps<TailFlowNode>> = ({data}) => {
         data.onPick(type, data.anchor);
     };
 
-    const triggerClassName = 'flex h-12 w-64 items-center justify-center rounded-lg border border-dashed border-grey-300 bg-white transition-colors hover:border-grey-400 focus-visible:border-grey-500 focus-visible:outline-none dark:border-grey-800 dark:bg-grey-950 dark:hover:border-grey-700';
+    const triggerClassName = 'flex h-12 w-64 items-center justify-center rounded-lg border border-dashed border-border-default bg-surface-page transition-colors hover:border-border-strong focus-visible:border-border-strong focus-visible:outline-none';
 
     if (data.disabled) {
         const content = (
@@ -111,7 +115,7 @@ const TailNode: React.FC<NodeProps<TailFlowNode>> = ({data}) => {
                 data-testid='add-step-tail-button'
             >
                 <HiddenHandle position={Position.Top} type='target' />
-                <LucideIcon.Plus className='size-5 text-grey-500' strokeWidth={1.5} />
+                <LucideIcon.Plus className='size-5 text-text-secondary' strokeWidth={1.5} />
             </div>
         );
         if (!data.disabledReason) {
@@ -137,7 +141,7 @@ const TailNode: React.FC<NodeProps<TailFlowNode>> = ({data}) => {
                 data-testid='add-step-tail-button'
             >
                 <HiddenHandle position={Position.Top} type='target' />
-                <LucideIcon.Plus className='size-5 text-grey-500' strokeWidth={1.5} />
+                <LucideIcon.Plus className='size-5 text-text-secondary' strokeWidth={1.5} />
             </PopoverTrigger>
             <PopoverContent align='center' className='p-0' side='top'>
                 <StepPicker onPick={handlePick} />
@@ -301,13 +305,19 @@ const buildGraph = ({automation, disabled, onPick}: BuildGraphParams): {nodes: A
         target: TAIL_CANVAS_ID,
         type: 'smoothstep',
         focusable: false,
-        style: {stroke: 'var(--color-grey-500)'}
+        style: {stroke: DEFAULT_EDGE_STROKE}
     });
 
     return {nodes, edges};
 };
 
-type AutomationCanvasProps = {
+const getInitialViewport = (canvasWidth: number): {x: number; y: number; zoom: number} => ({
+    x: Math.round((canvasWidth / 2) - NODE_COLUMN_CENTER_X),
+    y: INITIAL_VIEWPORT_Y,
+    zoom: 1
+});
+
+interface AutomationCanvasProps {
     automation?: AutomationDetail;
     isLoading: boolean;
     isError: boolean;
@@ -333,7 +343,9 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         onChange(next);
     }, [automation, onChange]);
 
-    const graph = React.useMemo(() => {
+    const initialViewport = useMemo(() => getInitialViewport(window.innerWidth), []);
+
+    const graph = useMemo(() => {
         if (!automation) {
             return null;
         }
@@ -344,15 +356,9 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         });
     }, [automation, handlePick]);
 
-    // Fit only the trigger + first two action nodes on initial render so a deep chain doesn't zoom
-    // out to a postage stamp. Below that, the user pans/scrolls to see the rest.
-    const initialFitNodes = React.useMemo(() => (
-        graph?.nodes.slice(0, 3).map(node => ({id: node.id})) ?? []
-    ), [graph]);
-
     if (isLoading) {
         return (
-            <div className='flex flex-1 items-center justify-center bg-grey-75' data-testid='automation-canvas-loading'>
+            <div className='flex flex-1 items-center justify-center bg-surface-page' data-testid='automation-canvas-loading'>
                 <LoadingIndicator size='lg' />
             </div>
         );
@@ -360,7 +366,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
 
     if (isError || !automation || !graph) {
         return (
-            <div className='flex flex-1 items-start justify-center bg-grey-75 px-4 py-8'>
+            <div className='flex flex-1 items-start justify-center bg-surface-page px-4 py-8'>
                 <Banner className='max-w-md' role='alert' variant='destructive'>
                     <div className='flex items-start gap-3'>
                         <LucideIcon.CircleAlert className='mt-0.5 size-5 text-red' />
@@ -375,12 +381,13 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
     }
 
     return (
-        <div className='flex-1 bg-grey-75' data-testid='automation-canvas'>
+        <div className='flex-1 bg-surface-page' data-testid='automation-canvas'>
             <ReactFlow
+                className='[--xy-background-color:var(--surface-page)] [--xy-background-pattern-color:var(--border-subtle)] [--xy-edge-stroke:var(--border-subtle)] dark:[--xy-background-pattern-color:var(--color-grey-900)] dark:[--xy-edge-stroke:var(--color-grey-800)]'
+                defaultViewport={initialViewport}
                 edges={graph.edges}
                 edgesFocusable={false}
                 edgeTypes={edgeTypes}
-                fitViewOptions={{maxZoom: 1, minZoom: 1, padding: 0.2, nodes: initialFitNodes}}
                 nodes={graph.nodes}
                 nodesConnectable={false}
                 nodesDraggable={false}
@@ -388,10 +395,9 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
                 nodeTypes={nodeTypes}
                 proOptions={{hideAttribution: true}}
                 zoomOnScroll={false}
-                fitView
                 panOnScroll
             >
-                <Background color='var(--color-grey-400)' />
+                <Background />
             </ReactFlow>
         </div>
     );

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -1,18 +1,18 @@
 import '@xyflow/react/dist/style.css';
 import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
 import {AutomationAction, AutomationDetail, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
 import {Banner, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
-import {LucideIcon, cn} from '@tryghost/shade/utils';
+import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 
 const NODE_X = 0;
 const NODE_WIDTH = 256;
 const NODE_COLUMN_CENTER_X = NODE_X + (NODE_WIDTH / 2);
 const NODE_GAP_Y = 180;
 const INITIAL_VIEWPORT_Y = 40;
-const DISABLED_REASON = `Limit of ${MAX_AUTOMATION_ACTIONS} steps reached`;
+const DISABLED_REASON = `Limit of ${formatNumber(MAX_AUTOMATION_ACTIONS)} steps reached`;
 const DEFAULT_EDGE_STROKE = 'var(--xy-edge-stroke)';
 
 // React Flow node IDs for the trigger and tail nodes. The canvas builds the visual graph using
@@ -343,7 +343,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         onChange(next);
     }, [automation, onChange]);
 
-    const initialViewport = useMemo(() => getInitialViewport(window.innerWidth), []);
+    const initialViewport = useRef(getInitialViewport(window.innerWidth));
 
     const graph = useMemo(() => {
         if (!automation) {
@@ -384,7 +384,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         <div className='flex-1 bg-surface-page' data-testid='automation-canvas'>
             <ReactFlow
                 className='[--xy-background-color:var(--surface-page)] [--xy-background-pattern-color:var(--border-subtle)] [--xy-edge-stroke:var(--border-subtle)] dark:[--xy-background-pattern-color:var(--color-grey-900)] dark:[--xy-edge-stroke:var(--color-grey-800)]'
-                defaultViewport={initialViewport}
+                defaultViewport={initialViewport.current}
                 edges={graph.edges}
                 edgesFocusable={false}
                 edgeTypes={edgeTypes}

--- a/apps/posts/src/views/Automations/components/step-picker.tsx
+++ b/apps/posts/src/views/Automations/components/step-picker.tsx
@@ -16,16 +16,16 @@ interface PickerOptionProps {
 
 const PickerOption: React.FC<PickerOptionProps> = ({icon: Icon, label, description, onClick}) => (
     <button
-        className='flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm hover:bg-grey-100 focus-visible:bg-grey-100 focus-visible:outline-none dark:hover:bg-grey-925 dark:focus-visible:bg-grey-925'
+        className='flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none'
         type='button'
         onClick={onClick}
     >
-        <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-grey-100 text-grey-700 dark:bg-grey-900 dark:text-grey-300'>
+        <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary'>
             <Icon className='size-4' />
         </div>
         <div className='flex min-w-0 flex-col'>
             <span className='font-medium'>{label}</span>
-            <span className='text-xs text-grey-600 dark:text-grey-500'>{description}</span>
+            <span className='text-xs text-text-secondary'>{description}</span>
         </div>
     </button>
 );

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -160,7 +160,7 @@ const AutomationEditor: React.FC = () => {
     };
 
     return (
-        <div className='flex h-full w-full flex-col' data-testid='automation-editor'>
+        <div className='fixed inset-0 z-50 flex flex-col bg-background' data-testid='automation-editor'>
             <AutomationHeader
                 automation={draft}
                 isLoadingAutomation={isLoadingAutomation}


### PR DESCRIPTION
no ref

- makes some quick improvements to dark mode for the automations editor. This included passing the colors into react flow via its provided css variables to make it a little easier.
- makes the workflow start closer to the top of the screen, there was a weird gap
- hides the sidebar so the canvas takes up the full screen. this is just with css currently, i think we may need to tweak some of the sidebar setup so things are correct for e.g. screen readers


not perfect or anything yet, just gets things a bit closer
<img width="1600" height="1042" alt="Screenshot 2026-05-18 at 3 52 20 PM" src="https://github.com/user-attachments/assets/5d6261f1-739a-4e82-ae91-75bf3657f69b" />
