### PR TITLE
Add socialweb account migration settings UI

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.23",
+  "version": "3.1.25",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/api/activitypub.test.ts
+++ b/apps/activitypub/src/api/activitypub.test.ts
@@ -1597,6 +1597,190 @@ describe('ActivityPubAPI', function () {
         });
     });
 
+    describe('accountAliases', function () {
+        test('It fetches account aliases', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                    response: JSONResponse({
+                        destination: {
+                            handle: '@index@example.com',
+                            apId: 'https://example.com/.ghost/activitypub/users/index'
+                        },
+                        aliases: [{
+                            apId: 'https://mastodon.social/users/old'
+                        }]
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.getAccountAliases();
+
+            expect(result).toEqual({
+                destination: {
+                    handle: '@index@example.com',
+                    apId: 'https://example.com/.ghost/activitypub/users/index'
+                },
+                aliases: [{
+                    apId: 'https://mastodon.social/users/old'
+                }]
+            });
+        });
+
+        test('It adds an account alias', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('POST');
+                        expect(init?.body).toEqual('{"sourceHandle":"@old@mastodon.social"}');
+                    },
+                    response: JSONResponse({
+                        destination: {
+                            handle: '@index@example.com',
+                            apId: 'https://example.com/.ghost/activitypub/users/index'
+                        },
+                        aliases: [{
+                            apId: 'https://mastodon.social/users/old'
+                        }]
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.addAccountAlias('@old@mastodon.social');
+
+            expect(result.aliases).toEqual([{
+                apId: 'https://mastodon.social/users/old'
+            }]);
+        });
+
+        test('It returns an empty alias response when adding an account alias has no response body', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                    response: new Response(null, {status: 204})
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.addAccountAlias('@old@mastodon.social');
+
+            expect(result).toEqual({
+                destination: {
+                    handle: '',
+                    apId: ''
+                },
+                aliases: []
+            });
+        });
+
+        test('It removes an account alias', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('DELETE');
+                        expect(init?.body).toEqual('{"actorUri":"https://mastodon.social/users/old"}');
+                    },
+                    response: JSONResponse({
+                        destination: {
+                            handle: '@index@example.com',
+                            apId: 'https://example.com/.ghost/activitypub/users/index'
+                        },
+                        aliases: []
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.removeAccountAlias('https://mastodon.social/users/old');
+
+            expect(result.aliases).toEqual([]);
+        });
+
+        test('It returns an empty alias response when removing an account alias has no response body', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                    response: new Response(null, {status: 204})
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.removeAccountAlias('https://mastodon.social/users/old');
+
+            expect(result).toEqual({
+                destination: {
+                    handle: '',
+                    apId: ''
+                },
+                aliases: []
+            });
+        });
+    });
+
     describe('enableBluesky', function () {
         test('It enables bluesky', async function () {
             const fakeFetch = Fetch({

--- a/apps/activitypub/src/api/activitypub.test.ts
+++ b/apps/activitypub/src/api/activitypub.test.ts
@@ -1607,7 +1607,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                [`https://activitypub.api/.ghost/activitypub/v1/aliases`]: {
                     response: JSONResponse({
                         destination: {
                             handle: '@index@example.com',
@@ -1649,7 +1649,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                [`https://activitypub.api/.ghost/activitypub/v1/aliases`]: {
                     async assert(_resource, init) {
                         expect(init?.method).toEqual('POST');
                         expect(init?.body).toEqual('{"sourceHandle":"@old@mastodon.social"}');
@@ -1689,7 +1689,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                [`https://activitypub.api/.ghost/activitypub/v1/aliases`]: {
                     response: new Response(null, {status: 204})
                 }
             });
@@ -1721,7 +1721,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                [`https://activitypub.api/.ghost/activitypub/v1/aliases`]: {
                     async assert(_resource, init) {
                         expect(init?.method).toEqual('DELETE');
                         expect(init?.body).toEqual('{"actorUri":"https://mastodon.social/users/old"}');
@@ -1757,7 +1757,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/account/aliases`]: {
+                [`https://activitypub.api/.ghost/activitypub/v1/aliases`]: {
                     response: new Response(null, {status: 204})
                 }
             });

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -518,21 +518,21 @@ export class ActivityPubAPI {
     }
 
     async getAccountAliases(): Promise<AccountAliasesResponse> {
-        const url = new URL('.ghost/activitypub/v1/account/aliases', this.apiUrl);
+        const url = new URL('.ghost/activitypub/v1/aliases', this.apiUrl);
         const json = await this.fetchJSON(url);
 
         return parseAccountAliasesResponse(json);
     }
 
     async addAccountAlias(sourceHandle: string): Promise<AccountAliasesResponse> {
-        const url = new URL('.ghost/activitypub/v1/account/aliases', this.apiUrl);
+        const url = new URL('.ghost/activitypub/v1/aliases', this.apiUrl);
         const json = await this.fetchJSON(url, 'POST', {sourceHandle});
 
         return parseAccountAliasesResponse(json);
     }
 
     async removeAccountAlias(actorUri: string): Promise<AccountAliasesResponse> {
-        const url = new URL('.ghost/activitypub/v1/account/aliases', this.apiUrl);
+        const url = new URL('.ghost/activitypub/v1/aliases', this.apiUrl);
         const json = await this.fetchJSON(url, 'DELETE', {actorUri});
 
         return parseAccountAliasesResponse(json);

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -102,6 +102,39 @@ export type AccountFollowsType = 'following' | 'followers';
 
 type GetAccountResponse = Account
 
+export interface AccountAlias {
+    apId: string;
+}
+
+export interface AccountAliasesResponse {
+    destination: {
+        handle: string;
+        apId: string;
+    };
+    aliases: AccountAlias[];
+}
+
+function emptyAccountAliasesResponse(): AccountAliasesResponse {
+    return {
+        destination: {
+            handle: '',
+            apId: ''
+        },
+        aliases: []
+    };
+}
+
+function parseAccountAliasesResponse(json: object | null): AccountAliasesResponse {
+    if (json === null || !('destination' in json)) {
+        return emptyAccountAliasesResponse();
+    }
+
+    return {
+        destination: json.destination as AccountAliasesResponse['destination'],
+        aliases: 'aliases' in json && Array.isArray(json.aliases) ? json.aliases as AccountAlias[] : []
+    };
+}
+
 export type FollowAccount = Pick<Account, 'id' | 'name' | 'handle' | 'avatarUrl' | 'blockedByMe' | 'domainBlockedByMe'> & {isFollowing: true};
 
 export interface GetAccountFollowsResponse {
@@ -482,6 +515,27 @@ export class ActivityPubAPI {
             accounts,
             next: nextPage
         };
+    }
+
+    async getAccountAliases(): Promise<AccountAliasesResponse> {
+        const url = new URL('.ghost/activitypub/v1/account/aliases', this.apiUrl);
+        const json = await this.fetchJSON(url);
+
+        return parseAccountAliasesResponse(json);
+    }
+
+    async addAccountAlias(sourceHandle: string): Promise<AccountAliasesResponse> {
+        const url = new URL('.ghost/activitypub/v1/account/aliases', this.apiUrl);
+        const json = await this.fetchJSON(url, 'POST', {sourceHandle});
+
+        return parseAccountAliasesResponse(json);
+    }
+
+    async removeAccountAlias(actorUri: string): Promise<AccountAliasesResponse> {
+        const url = new URL('.ghost/activitypub/v1/account/aliases', this.apiUrl);
+        const json = await this.fetchJSON(url, 'DELETE', {actorUri});
+
+        return parseAccountAliasesResponse(json);
     }
 
     async getFeed(next?: string): Promise<PaginatedPostsResponse> {

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -1,5 +1,6 @@
 import {
     type Account,
+    type AccountAliasesResponse,
     type AccountFollowsType,
     type AccountSearchResult,
     ActivityPubAPI,
@@ -74,6 +75,7 @@ const QUERY_KEYS = {
         return ['profile_posts', profileHandle];
     },
     account: (handle: string) => ['account', handle],
+    accountAliases: (handle: string) => ['account_aliases', handle],
     accountFollows: (handle: string, type: AccountFollowsType) => ['account_follows', handle, type],
     searchResults: (query: string) => ['search_results', query],
     suggestedProfiles: (handle: string, limit: number) => ['suggested_profiles', handle, limit],
@@ -1650,6 +1652,50 @@ export function useAccountFollowsForUser(profileHandle: string, type: AccountFol
         },
         getNextPageParam(prevPage) {
             return prevPage.next;
+        }
+    });
+}
+
+export function useAccountAliasesForUser(handle: string) {
+    return useQuery({
+        queryKey: QUERY_KEYS.accountAliases(handle),
+        async queryFn() {
+            const siteUrl = await getSiteUrl();
+            const api = createActivityPubAPI(handle, siteUrl);
+
+            return api.getAccountAliases();
+        }
+    });
+}
+
+export function useAddAccountAliasMutationForUser(handle: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        async mutationFn(sourceHandle: string) {
+            const siteUrl = await getSiteUrl();
+            const api = createActivityPubAPI(handle, siteUrl);
+
+            return api.addAccountAlias(sourceHandle);
+        },
+        onSuccess(response: AccountAliasesResponse) {
+            queryClient.setQueryData(QUERY_KEYS.accountAliases(handle), response);
+        }
+    });
+}
+
+export function useRemoveAccountAliasMutationForUser(handle: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        async mutationFn(actorUri: string) {
+            const siteUrl = await getSiteUrl();
+            const api = createActivityPubAPI(handle, siteUrl);
+
+            return api.removeAccountAlias(actorUri);
+        },
+        onSuccess(response: AccountAliasesResponse) {
+            queryClient.setQueryData(QUERY_KEYS.accountAliases(handle), response);
         }
     });
 }

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -3,6 +3,7 @@ import AppError from '@components/layout/error';
 import {Navigate, Outlet, RouteObject, lazyComponent} from '@tryghost/admin-x-framework';
 
 const basePath = import.meta.env.VITE_TEST ? '' : 'activitypub';
+const accountMigrationPath = 'preferences/move';
 
 export type CustomRouteObject = RouteObject & {
     pageTitle?: string;
@@ -104,6 +105,12 @@ export const routes: CustomRouteObject[] = [
             {
                 path: 'preferences/bluesky-sharing',
                 lazy: lazyComponent(() => import('./views/preferences/components/bluesky-sharing')),
+                showBackButton: true
+            },
+            {
+                path: accountMigrationPath,
+                lazy: lazyComponent(() => import('./views/preferences/components/mastodon-migration')),
+                pageTitle: 'Account migration',
                 showBackButton: true
             },
             {

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -109,7 +109,7 @@ export const routes: CustomRouteObject[] = [
             },
             {
                 path: accountMigrationPath,
-                lazy: lazyComponent(() => import('./views/preferences/components/mastodon-migration')),
+                lazy: lazyComponent(() => import('./views/preferences/components/account-migration')),
                 pageTitle: 'Account migration',
                 showBackButton: true
             },

--- a/apps/activitypub/src/views/preferences/components/account-migration.tsx
+++ b/apps/activitypub/src/views/preferences/components/account-migration.tsx
@@ -47,7 +47,7 @@ function getAliasErrorMessage(error: unknown) {
     return 'Something went wrong, please try again.';
 }
 
-const MastodonMigration: React.FC = () => {
+const AccountMigration: React.FC = () => {
     const {
         data: aliasData,
         isError: hasAliasLoadError,
@@ -198,4 +198,4 @@ const MastodonMigration: React.FC = () => {
     );
 };
 
-export default MastodonMigration;
+export default AccountMigration;

--- a/apps/activitypub/src/views/preferences/components/mastodon-migration.tsx
+++ b/apps/activitypub/src/views/preferences/components/mastodon-migration.tsx
@@ -1,0 +1,201 @@
+import Layout from '@src/components/layout';
+import React, {useState} from 'react';
+import {Button, Field, FieldDescription, FieldLabel, Input, LoadingIndicator, Skeleton} from '@tryghost/shade/components';
+import {H2} from '@tryghost/shade/primitives';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {useAccountAliasesForUser, useAddAccountAliasMutationForUser, useRemoveAccountAliasMutationForUser} from '@hooks/use-activity-pub-queries';
+
+const HANDLE_REGEX = /^@?[^@\s]+@[^@\s]+$/;
+
+function normalizeHandle(handle: string) {
+    const trimmedHandle = handle.trim();
+
+    return trimmedHandle.startsWith('@') ? trimmedHandle : `@${trimmedHandle}`;
+}
+
+function getAliasDisplayHandle(actorUri: string) {
+    try {
+        const url = new URL(actorUri);
+        const mastodonUserMatch = url.pathname.match(/^\/users\/([^/]+)\/?$/);
+
+        if (mastodonUserMatch) {
+            return `${decodeURIComponent(mastodonUserMatch[1])}@${url.hostname}`;
+        }
+
+        return `${url.hostname}${url.pathname}`;
+    } catch {
+        return actorUri;
+    }
+}
+
+function getAliasErrorMessage(error: unknown) {
+    if (
+        typeof error === 'object' &&
+        error !== null &&
+        'statusCode' in error &&
+        typeof error.statusCode === 'number'
+    ) {
+        if (error.statusCode === 400) {
+            return 'Enter a valid handle, like old@mastodon.social.';
+        }
+
+        if (error.statusCode === 404) {
+            return 'Could not find that profile. Check the handle and try again.';
+        }
+    }
+
+    return 'Something went wrong, please try again.';
+}
+
+const MastodonMigration: React.FC = () => {
+    const {
+        data: aliasData,
+        isError: hasAliasLoadError,
+        isLoading: isLoadingAliases,
+        refetch: refetchAliases
+    } = useAccountAliasesForUser('index');
+    const addAliasMutation = useAddAccountAliasMutationForUser('index');
+    const removeAliasMutation = useRemoveAccountAliasMutationForUser('index');
+    const [sourceHandle, setSourceHandle] = useState('');
+    const [handleError, setHandleError] = useState<string | null>(null);
+    const [aliasActionError, setAliasActionError] = useState<string | null>(null);
+    const [removingAlias, setRemovingAlias] = useState<string | null>(null);
+
+    const aliases = [...(aliasData?.aliases ?? [])].reverse();
+    const showAliasesSection = isLoadingAliases || hasAliasLoadError || aliases.length > 0;
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const trimmedHandle = sourceHandle.trim();
+
+        if (!HANDLE_REGEX.test(trimmedHandle)) {
+            setHandleError('Enter a valid handle, like old@mastodon.social.');
+            return;
+        }
+
+        setHandleError(null);
+        setAliasActionError(null);
+
+        try {
+            const normalizedHandle = normalizeHandle(trimmedHandle);
+            await addAliasMutation.mutateAsync(normalizedHandle);
+            setSourceHandle('');
+        } catch (error) {
+            setHandleError(getAliasErrorMessage(error));
+        }
+    };
+
+    const handleRemoveAlias = async (actorUri: string) => {
+        setAliasActionError(null);
+        setRemovingAlias(actorUri);
+
+        try {
+            await removeAliasMutation.mutateAsync(actorUri);
+        } catch {
+            setAliasActionError('Could not remove migration profile.');
+        } finally {
+            setRemovingAlias(null);
+        }
+    };
+
+    return (
+        <Layout>
+            <div className='mx-auto max-w-[620px] py-[min(4vh,48px)]'>
+                <div className='flex items-center justify-between gap-8'>
+                    <H2>Account migration</H2>
+                </div>
+
+                <div className='mt-3 text-base text-gray-800 dark:text-gray-600'>
+                    <p>
+                        You can move your followers from another social web account (eg. <a className='underline hover:text-black dark:hover:text-white' href='https://docs.joinmastodon.org/user/moving/#move' rel='noopener noreferrer' target='_blank'>Mastodon</a>) to this one by creating an account alias. This action is harmless and reversible. The account migration is initiated from the old account.
+                    </p>
+                </div>
+
+                <form className='mt-10' onSubmit={handleSubmit}>
+                    <Field>
+                        <FieldLabel htmlFor='account-migration-source-handle'>
+                            Old account handle
+                        </FieldLabel>
+                        <FieldDescription id='account-migration-source-handle-description'>
+                            Specify the username@domain of the account you want to move from
+                        </FieldDescription>
+                        <div className='flex flex-col gap-3 sm:flex-row'>
+                            <Input
+                                aria-describedby={handleError ? 'account-migration-source-handle-error' : 'account-migration-source-handle-description'}
+                                aria-invalid={handleError ? true : undefined}
+                                autoComplete='off'
+                                className='sm:flex-1'
+                                id='account-migration-source-handle'
+                                placeholder='username@domain'
+                                value={sourceHandle}
+                                data-1p-ignore
+                                onChange={event => setSourceHandle(event.target.value)}
+                            />
+                            <Button className='relative h-9 text-sm sm:w-auto' disabled={addAliasMutation.isLoading} type='submit'>
+                                <span className={addAliasMutation.isLoading ? 'invisible' : undefined}>Create alias</span>
+                                {addAliasMutation.isLoading && (
+                                    <span className='absolute inset-0 flex items-center justify-center'>
+                                        <LoadingIndicator color='light' size='sm' />
+                                        <span className='sr-only'>Creating alias...</span>
+                                    </span>
+                                )}
+                            </Button>
+                        </div>
+                        {handleError && (
+                            <p className='text-sm text-red' id='account-migration-source-handle-error'>
+                                {handleError}
+                            </p>
+                        )}
+                        {aliasActionError && (
+                            <p className='text-sm text-red' id='account-migration-alias-error'>
+                                {aliasActionError}
+                            </p>
+                        )}
+                    </Field>
+                </form>
+
+                {showAliasesSection && (
+                    <div className='mt-10' data-testid='account-migration-aliases'>
+                        <div className='pb-3'>
+                            <FieldLabel asChild>
+                                <div>Account aliases</div>
+                            </FieldLabel>
+                        </div>
+
+                        {isLoadingAliases ? (
+                            <div className='border-t border-gray-200 py-4 dark:border-gray-950'>
+                                <Skeleton className='h-5 w-48' />
+                            </div>
+                        ) : hasAliasLoadError ? (
+                            <div className='flex items-center justify-between gap-4 border-t border-gray-200 py-4 text-sm text-gray-700 dark:border-gray-950 dark:text-gray-600'>
+                                <span>Could not load account aliases.</span>
+                                <Button className='px-0 font-medium' variant='link' onClick={() => refetchAliases()}>
+                                    Retry
+                                </Button>
+                            </div>
+                        ) : (
+                            <div className='divide-y divide-gray-200 border-t border-gray-200 dark:divide-gray-950 dark:border-gray-950'>
+                                {aliases.map(alias => (
+                                    <div key={alias.apId} className='flex items-center justify-between gap-4 py-4'>
+                                        <div className='min-w-0 truncate text-base text-black dark:text-white'>{getAliasDisplayHandle(alias.apId)}</div>
+                                        <Button
+                                            className='shrink-0 px-0 font-medium text-gray-700 hover:text-red dark:text-gray-600 dark:hover:text-red'
+                                            disabled={removingAlias === alias.apId}
+                                            variant='link'
+                                            onClick={() => handleRemoveAlias(alias.apId)}
+                                        >
+                                            {removingAlias === alias.apId ? <LoadingIndicator size='sm' /> : <><LucideIcon.Trash2 size={15} /> Unlink</>}
+                                        </Button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </Layout>
+    );
+};
+
+export default MastodonMigration;

--- a/apps/activitypub/src/views/preferences/components/mastodon-migration.tsx
+++ b/apps/activitypub/src/views/preferences/components/mastodon-migration.tsx
@@ -1,6 +1,6 @@
 import Layout from '@src/components/layout';
 import React, {useState} from 'react';
-import {Button, Field, FieldDescription, FieldLabel, Input, LoadingIndicator, Skeleton} from '@tryghost/shade/components';
+import {Button, Field, FieldDescription, FieldError, FieldLabel, Input, LoadingIndicator, Skeleton} from '@tryghost/shade/components';
 import {H2} from '@tryghost/shade/primitives';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {useAccountAliasesForUser, useAddAccountAliasMutationForUser, useRemoveAccountAliasMutationForUser} from '@hooks/use-activity-pub-queries';
@@ -113,11 +113,11 @@ const MastodonMigration: React.FC = () => {
                 </div>
 
                 <form className='mt-10' onSubmit={handleSubmit}>
-                    <Field>
+                    <Field data-invalid={handleError ? true : undefined}>
                         <FieldLabel htmlFor='account-migration-source-handle'>
                             Old account handle
                         </FieldLabel>
-                        <FieldDescription id='account-migration-source-handle-description'>
+                        <FieldDescription className='-mt-1' id='account-migration-source-handle-description'>
                             Specify the username@domain of the account you want to move from
                         </FieldDescription>
                         <div className='flex flex-col gap-3 sm:flex-row'>
@@ -143,14 +143,14 @@ const MastodonMigration: React.FC = () => {
                             </Button>
                         </div>
                         {handleError && (
-                            <p className='text-sm text-red' id='account-migration-source-handle-error'>
+                            <FieldError id='account-migration-source-handle-error'>
                                 {handleError}
-                            </p>
+                            </FieldError>
                         )}
                         {aliasActionError && (
-                            <p className='text-sm text-red' id='account-migration-alias-error'>
+                            <FieldError id='account-migration-alias-error'>
                                 {aliasActionError}
-                            </p>
+                            </FieldError>
                         )}
                     </Field>
                 </form>

--- a/apps/activitypub/src/views/preferences/components/settings.tsx
+++ b/apps/activitypub/src/views/preferences/components/settings.tsx
@@ -5,6 +5,7 @@ import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger}
 import {H4} from '@tryghost/shade/primitives';
 import {Link} from '@tryghost/admin-x-framework';
 import {LucideIcon, cn} from '@tryghost/shade/utils';
+import {useAppBasePath} from '@src/hooks/use-app-base-path';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 interface SettingsProps {
@@ -21,14 +22,14 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
             <SettingSeparator />
             <SettingItem>
                 <SettingHeader>
-                    <SettingTitle>Account</SettingTitle>
+                    <SettingTitle>Profile</SettingTitle>
                     <SettingDescription>
                         Edit your profile information and account details
                     </SettingDescription>
                 </SettingHeader>
                 <Dialog open={isEditingProfile} onOpenChange={setIsEditingProfile}>
                     <DialogTrigger>
-                        <SettingAction><Button variant='secondary'>Edit profile</Button></SettingAction>
+                        <SettingAction><Button variant='secondary'>Edit</Button></SettingAction>
                     </DialogTrigger>
                     <DialogContent onOpenAutoFocus={e => e.preventDefault()}>
                         <DialogHeader>
@@ -54,6 +55,15 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
                 </SettingHeader>
                 <SettingAction className='flex items-center gap-2'>
                     {account?.blueskyEnabled ? <span className='font-medium text-black'>On</span> : <span>Off</span>}
+                    <LucideIcon.ChevronRight size={20} />
+                </SettingAction>
+            </SettingItem>
+            <SettingItem to='/preferences/move' withHover>
+                <SettingHeader>
+                    <SettingTitle>Account migration</SettingTitle>
+                    <SettingDescription>Move another social web account to this one</SettingDescription>
+                </SettingHeader>
+                <SettingAction className='flex items-center gap-2'>
                     <LucideIcon.ChevronRight size={20} />
                 </SettingAction>
             </SettingItem>
@@ -120,15 +130,17 @@ interface SettingItemProps {
 }
 
 const SettingItem: React.FC<SettingItemProps> = ({children, className = '', withHover = false, to, href, onClick}) => {
+    const basePath = useAppBasePath();
     const baseClasses = 'flex items-center justify-between py-3 gap-4';
     const hoverClasses = withHover ? 'relative cursor-pointer before:absolute before:inset-x-[-16px] before:inset-y-[-1px] before:rounded-md before:bg-gray-50 before:opacity-0 before:transition-opacity before:will-change-[opacity] hover:z-10 hover:cursor-pointer hover:border-b-transparent hover:before:opacity-100 dark:before:bg-gray-950' : '';
     const itemClasses = cn(baseClasses, hoverClasses, className);
+    const fullPath = to && to.startsWith('/') ? `${basePath}${to}` : to;
 
-    if (to) {
+    if (fullPath) {
         return (
             <Link
                 className={itemClasses}
-                to={to}
+                to={fullPath}
             >
                 {children}
             </Link>

--- a/apps/activitypub/test/acceptance/preferences.test.ts
+++ b/apps/activitypub/test/acceptance/preferences.test.ts
@@ -1,0 +1,163 @@
+import {expect, test} from '@playwright/test';
+import {mockApi} from '@tryghost/admin-x-framework/test/acceptance';
+import {mockInitialApiRequests} from '../utils/initial-api-requests';
+
+const account = {
+    id: 'alice',
+    handle: '@alice@fake.host',
+    name: 'Alice',
+    url: 'https://fake.host/@alice',
+    avatarUrl: 'https://fake.host/avatars/alice.jpg',
+    followingCount: 5,
+    followerCount: 10,
+    likedCount: 3
+};
+
+test.describe('Preferences', async () => {
+    test.beforeEach(async ({page}) => {
+        await mockInitialApiRequests(page);
+    });
+
+    test('I can add an old Mastodon handle for follower migration', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            getMyAccount: {
+                method: 'GET',
+                path: '/v1/account/me',
+                response: account
+            },
+            getAliases: {
+                method: 'GET',
+                path: '/v1/account/aliases',
+                response: {
+                    destination: {
+                        handle: '@alice@fake.host',
+                        apId: 'https://fake.host/.ghost/activitypub/users/index'
+                    },
+                    aliases: []
+                }
+            },
+            addAlias: {
+                method: 'POST',
+                path: '/v1/account/aliases',
+                response: {
+                    destination: {
+                        handle: '@alice@fake.host',
+                        apId: 'https://fake.host/.ghost/activitypub/users/index'
+                    },
+                    aliases: [{
+                        apId: 'https://mastodon.social/users/old'
+                    }]
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences');
+
+        await expect(page.getByRole('link', {name: /Account migration/})).toBeVisible();
+        await page.getByRole('link', {name: /Account migration/}).click();
+
+        await expect(page.getByRole('heading', {name: 'Account migration'})).toBeVisible();
+        await expect.poll(() => lastApiRequests.getAliases).toBeTruthy();
+        await expect(page.getByTestId('account-migration-aliases')).toHaveCount(0);
+        await page.getByLabel('Old account handle').fill('old@mastodon.social');
+        await page.getByRole('button', {name: 'Create alias'}).click();
+
+        await expect.poll(() => lastApiRequests.addAlias).toBeTruthy();
+        expect(lastApiRequests.addAlias?.body).toMatchObject({
+            sourceHandle: '@old@mastodon.social'
+        });
+        await expect(page.getByTestId('account-migration-aliases')).toContainText('old@mastodon.social');
+    });
+
+    test('I can see existing aliases newest first', async ({page}) => {
+        await mockApi({page, requests: {
+            getMyAccount: {
+                method: 'GET',
+                path: '/v1/account/me',
+                response: account
+            },
+            getAliases: {
+                method: 'GET',
+                path: '/v1/account/aliases',
+                response: {
+                    destination: {
+                        handle: '@alice@fake.host',
+                        apId: 'https://fake.host/.ghost/activitypub/users/index'
+                    },
+                    aliases: [
+                        {apId: 'https://mastodon.social/users/old'},
+                        {apId: 'https://mastodon.social/users/new'}
+                    ]
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/move');
+
+        const aliases = page.getByTestId('account-migration-aliases');
+        await expect(aliases).toContainText('new@mastodon.social');
+        await expect(aliases).toContainText('old@mastodon.social');
+
+        const aliasText = await aliases.textContent();
+        const newAliasIndex = aliasText?.indexOf('new@mastodon.social') ?? -1;
+        const oldAliasIndex = aliasText?.indexOf('old@mastodon.social') ?? -1;
+
+        expect(newAliasIndex).toBeGreaterThanOrEqual(0);
+        expect(oldAliasIndex).toBeGreaterThanOrEqual(0);
+        expect(newAliasIndex).toBeLessThan(oldAliasIndex);
+    });
+
+    test('I see an alias action error when unlinking fails', async ({page}) => {
+        await mockApi({page, requests: {
+            getMyAccount: {
+                method: 'GET',
+                path: '/v1/account/me',
+                response: account
+            },
+            getAliases: {
+                method: 'GET',
+                path: '/v1/account/aliases',
+                response: {
+                    destination: {
+                        handle: '@alice@fake.host',
+                        apId: 'https://fake.host/.ghost/activitypub/users/index'
+                    },
+                    aliases: [{apId: 'https://mastodon.social/users/old'}]
+                }
+            },
+            removeAlias: {
+                method: 'DELETE',
+                path: '/v1/account/aliases',
+                response: {},
+                responseStatus: 500
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/move');
+        await page.getByRole('button', {name: 'Unlink'}).click();
+
+        await expect(page.getByText('Could not remove migration profile.')).toBeVisible();
+        await expect(page.getByLabel('Old account handle')).not.toHaveAttribute('aria-invalid', 'true');
+    });
+
+    test('I see an error when account aliases cannot be loaded', async ({page}) => {
+        await mockApi({page, requests: {
+            getMyAccount: {
+                method: 'GET',
+                path: '/v1/account/me',
+                response: account
+            },
+            getAliases: {
+                method: 'GET',
+                path: '/v1/account/aliases',
+                response: {},
+                responseStatus: 500
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/move');
+
+        await expect(page.getByTestId('account-migration-aliases')).toContainText('Could not load account aliases.');
+        await expect(page.getByRole('button', {name: 'Retry'})).toBeVisible();
+    });
+});

--- a/apps/activitypub/test/acceptance/preferences.test.ts
+++ b/apps/activitypub/test/acceptance/preferences.test.ts
@@ -27,7 +27,7 @@ test.describe('Preferences', async () => {
             },
             getAliases: {
                 method: 'GET',
-                path: '/v1/account/aliases',
+                path: '/v1/aliases',
                 response: {
                     destination: {
                         handle: '@alice@fake.host',
@@ -38,7 +38,7 @@ test.describe('Preferences', async () => {
             },
             addAlias: {
                 method: 'POST',
-                path: '/v1/account/aliases',
+                path: '/v1/aliases',
                 response: {
                     destination: {
                         handle: '@alice@fake.host',
@@ -78,7 +78,7 @@ test.describe('Preferences', async () => {
             },
             getAliases: {
                 method: 'GET',
-                path: '/v1/account/aliases',
+                path: '/v1/aliases',
                 response: {
                     destination: {
                         handle: '@alice@fake.host',
@@ -116,7 +116,7 @@ test.describe('Preferences', async () => {
             },
             getAliases: {
                 method: 'GET',
-                path: '/v1/account/aliases',
+                path: '/v1/aliases',
                 response: {
                     destination: {
                         handle: '@alice@fake.host',
@@ -127,7 +127,7 @@ test.describe('Preferences', async () => {
             },
             removeAlias: {
                 method: 'DELETE',
-                path: '/v1/account/aliases',
+                path: '/v1/aliases',
                 response: {},
                 responseStatus: 500
             }
@@ -149,7 +149,7 @@ test.describe('Preferences', async () => {
             },
             getAliases: {
                 method: 'GET',
-                path: '/v1/account/aliases',
+                path: '/v1/aliases',
                 response: {},
                 responseStatus: 500
             }


### PR DESCRIPTION
Added support for inbound social web account migration, so that (eg) you can migrate a mastodon profile to Ghost, and the followers will move over:

Depends on: https://github.com/TryGhost/ActivityPub/pull/1804

https://docs.joinmastodon.org/user/moving/#move

<img width="2366" height="1196" alt="CleanShot 2026-05-18 at 12 57 08@2x" src="https://github.com/user-attachments/assets/85bf2bae-d405-4557-8e6b-a0ad946090b6" />

## Summary
- Add an ActivityPub preferences page for account migration aliases
- Add client API/query hooks for listing, creating, and removing aliases
- Show existing aliases newest-first and keep the aliases section hidden when there are none
- Add acceptance coverage for creating aliases, existing aliases, and load failures

## Why
Ghost Admin needs a UI for configuring the old Mastodon/social web account before the user starts the move from their old account. The UI calls the new ActivityPub alias API and keeps the workflow inside ActivityPub preferences.