### PR TITLE
Moved `bson-objectid` dependency to default pnpm catalog

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -69,7 +69,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "autoprefixer": "10.4.21",
-    "bson-objectid": "2.0.4",
+    "bson-objectid": "catalog:",
     "concurrently": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-i18next": "6.1.4",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -145,7 +145,7 @@
     "bookshelf": "1.2.0",
     "bookshelf-relations": "2.8.0",
     "brute-knex": "4.0.1",
-    "bson-objectid": "2.0.4",
+    "bson-objectid": "catalog:",
     "cache-manager": "4.1.0",
     "cache-manager-ioredis": "2.1.0",
     "chalk": "4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: 4.1.5
       version: 4.1.5
+    bson-objectid:
+      specifier: 2.0.4
+      version: 2.0.4
     c8:
       specifier: 10.1.3
       version: 10.1.3
@@ -1018,7 +1021,7 @@ importers:
         specifier: 10.4.21
         version: 10.4.21(postcss@8.5.6)
       bson-objectid:
-        specifier: 2.0.4
+        specifier: 'catalog:'
         version: 2.0.4
       concurrently:
         specifier: 'catalog:'
@@ -2300,7 +2303,7 @@ importers:
         specifier: 4.0.1
         version: 4.0.1(express@4.21.2)(mysql2@3.18.1(@types/node@22.19.18))(sqlite3@5.1.7)
       bson-objectid:
-        specifier: 2.0.4
+        specifier: 'catalog:'
         version: 2.0.4
       cache-manager:
         specifier: 4.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,7 @@ catalog:
   '@typescript-eslint/parser': 8.49.0
   '@vitejs/plugin-react': 4.7.0
   '@vitest/coverage-v8': 4.1.5
+  bson-objectid: 2.0.4
   c8: 10.1.3
   chai: 4.5.0
   clsx: 2.1.1


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1255
ref #27904
ref 9afbdc2a96c0751cc528b354ebd0d00262c9cae5

We should use the same version of `bson-objectid` everywhere. I think this is a useful change on its own, but also makes [an upcoming change][0] easier.

[0]: https://github.com/TryGhost/Ghost/pull/27904
