### PR TITLE
Skipped file deduplication in S3 storage adapter

### DIFF
--- a/ghost/core/core/server/adapters/storage/S3Storage.ts
+++ b/ghost/core/core/server/adapters/storage/S3Storage.ts
@@ -149,6 +149,20 @@ export default class S3Storage extends StorageBase {
         this.client = options.s3Client || new S3Client(clientConfig);
     }
 
+    getUniqueFileName(file: {name: string; path?: string}, targetDir: string): Promise<string> {
+        const sanitize = (s: string) => s.replace(/[^\w@.]/gi, '-');
+        const ext = path.extname(file.name);
+        let name: string;
+
+        if (!ext.match(/\.\d+$/)) {
+            name = sanitize(path.basename(file.name, ext));
+            return Promise.resolve(path.join(targetDir, name + ext));
+        } else {
+            name = sanitize(path.basename(file.name));
+            return Promise.resolve(path.join(targetDir, name));
+        }
+    }
+
     async save(file: UploadFile, targetDir?: string): Promise<string> {
         const dir = targetDir || this.getTargetDir();
         const relativePath = await this.getUniqueFileName(file, dir);


### PR DESCRIPTION
Overrides `getUniqueFileName` in `S3Storage` to skip the recursive
existence-check loop from the base class. Uploading the same filename
now writes to the same S3/GCS key instead of appending `-1`, `-2`, etc.

This is a test change to verify whether our GCS credentials have
overwrite permissions. Deploy to a single site, upload the same file
twice, and observe whether the second upload succeeds or errors.