### PR TITLE
Added trial private site UI lockdown for Access settings

### DIFF
--- a/apps/admin-x-design-system/src/global/form/select.tsx
+++ b/apps/admin-x-design-system/src/global/form/select.tsx
@@ -151,7 +151,7 @@ const Select: React.FC<SelectProps> = ({
         containerClasses = clsx(
             'dark:text-white',
             fullWidth && 'w-full',
-            disabled && 'cursor-not-allowed opacity-40'
+            disabled && 'cursor-not-allowed text-grey-600 dark:text-grey-800'
         );
     }
     containerClasses = clsx(
@@ -162,11 +162,13 @@ const Select: React.FC<SelectProps> = ({
     const customClasses = {
         control: clsx(
             controlClasses?.control,
-            'h-9 min-h-[36px] w-full appearance-none rounded-lg border outline-hidden md:h-[38px] md:min-h-[38px] dark:text-white',
+            'h-9 min-h-[36px] w-full appearance-none rounded-lg border outline-hidden md:h-[38px] md:min-h-[38px]',
             size === 'xs' ? 'py-0 pr-2 text-xs' : 'py-1 pr-4',
             clearBg ? '' : 'bg-grey-150 px-3 dark:bg-grey-900',
-            error ? 'border-red' : `border-transparent ${!clearBg && 'hover:bg-grey-100 dark:hover:bg-grey-925'}`,
+            disabled && !clearBg && 'bg-grey-50 shadow-[0_0_0_1px_rgba(255,255,255,0.45)] hover:bg-grey-50 dark:bg-grey-950 dark:shadow-[0_0_0_1px_rgba(255,255,255,0.18)] dark:hover:bg-grey-950',
+            error ? 'border-red' : `border-transparent ${!clearBg && !disabled && 'hover:bg-grey-100 dark:hover:bg-grey-925'}`,
             !disabled && 'cursor-pointer',
+            disabled ? 'dark:text-grey-800' : 'dark:text-white',
             (title && !clearBg) && 'mt-1.5'
         ),
         valueContainer: clsx('mr-1.5 gap-1', controlClasses?.valueContainer),

--- a/apps/admin-x-design-system/src/global/form/text-field.tsx
+++ b/apps/admin-x-design-system/src/global/form/text-field.tsx
@@ -72,12 +72,12 @@ const TextField: React.FC<TextFieldProps> = ({
     const bgClasses = !unstyled && clsx(
         'absolute inset-0 rounded-lg border text-grey-300 transition-colors peer-hover:bg-grey-100 peer-focus:border-green peer-focus:bg-white peer-focus:shadow-[0_0_0_2px_rgba(48,207,67,.25)] dark:peer-hover:bg-grey-925 dark:peer-focus:bg-grey-950',
         error ? `border-red bg-white dark:bg-grey-925` : 'border-transparent bg-grey-150 dark:bg-grey-900',
-        disabled && 'bg-grey-50 peer-hover:bg-grey-50 dark:bg-grey-950 dark:peer-hover:bg-grey-950'
+        disabled && 'bg-grey-50 shadow-[0_0_0_1px_rgba(255,255,255,0.45)] peer-hover:bg-grey-50 dark:bg-grey-950 dark:shadow-[0_0_0_1px_rgba(255,255,255,0.18)] dark:peer-hover:bg-grey-950'
     );
 
     const textFieldClasses = !unstyled && clsx(
         'peer z-[1] order-2 h-9 w-full bg-transparent px-3 py-1.5 text-sm placeholder:text-grey-500 md:h-[38px] md:py-2 md:text-md dark:placeholder:text-grey-700',
-        disabled ? 'cursor-not-allowed text-grey-600 opacity-60 dark:text-grey-800' : 'dark:text-white',
+        disabled ? 'cursor-not-allowed text-grey-600 dark:text-grey-800' : 'dark:text-white',
         rightPlaceholder ? 'w-0 grow rounded-l-lg' : 'rounded-lg',
         className
     );

--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -67,6 +67,10 @@ export type Config = {
             limitSocialWeb?: {
                 disabled: boolean,
                 error?: string
+            },
+            publicSiteAccess?: {
+                disabled: boolean,
+                error?: string
             }
         }
         billing?: {

--- a/apps/admin-x-settings/src/components/settings/membership/access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/access.tsx
@@ -8,6 +8,7 @@ import {RefreshCw} from 'lucide-react';
 import {getSettingValues, isSettingReadOnly, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useGlobalData} from '../../providers/global-data-provider';
+import {useLimiter} from '../../../hooks/use-limiter';
 
 const SITE_VISIBILITY_OPTIONS = [
     {
@@ -88,6 +89,8 @@ const COMMENTS_ENABLED_OPTIONS = [
 
 const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();
+    const limiter = useLimiter();
+    const isTrialMode = limiter?.isDisabled('publicSiteAccess');
     const isPrivateLocked = isSettingReadOnly(settings, 'is_private') || isSettingReadOnly(settings, 'password');
     const {mutateAsync: editSettings} = useEditSettings();
     const [isRegenerating, setIsRegenerating] = React.useState(false);
@@ -158,7 +161,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const form = (
         <SettingGroupContent className='gap-y-4' columns={1}>
-            {isPrivateLocked && (
+            {isTrialMode && (
                 <Banner className='mb-2 flex w-full cursor-default flex-col gap-4 border-0 p-6 pt-5 transition-none hover:translate-y-0 hover:scale-100 hover:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_28%),7px_6px_42px_8px_rgb(202_103_255_/_32%)] md:flex-row md:items-center md:justify-between dark:hover:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_36%),7px_6px_42px_8px_rgb(202_103_255_/_38%)]' size='lg' variant='gradient'>
                     <div>
                         <div className='text-base font-semibold'>Pre-launch mode</div>
@@ -300,7 +303,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             keywords={keywords}
             navid='members'
             saveState={saveState}
-            styles={isPrivateLocked ? 'overflow-hidden' : undefined}
+            styles={isTrialMode ? 'overflow-hidden' : undefined}
             testId='access'
             title='Access'
             hideEditButton

--- a/apps/admin-x-settings/src/components/settings/membership/access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/access.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
+import {Banner, Button as ShadeButton} from '@tryghost/shade/components';
 import {type GroupBase, type MultiValue} from 'react-select';
-import {Hint, MultiSelect, type MultiSelectOption, Select, Separator, SettingGroupContent, TextField, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {Hint, MultiSelect, type MultiSelectOption, Select, Separator, SettingGroupContent, TextField, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {RefreshCw} from 'lucide-react';
+import {getSettingValues, isSettingReadOnly, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useGlobalData} from '../../providers/global-data-provider';
 
@@ -86,6 +88,9 @@ const COMMENTS_ENABLED_OPTIONS = [
 
 const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();
+    const isPrivateLocked = isSettingReadOnly(settings, 'is_private') || isSettingReadOnly(settings, 'password');
+    const {mutateAsync: editSettings} = useEditSettings();
+    const [isRegenerating, setIsRegenerating] = React.useState(false);
     const {
         localSettings,
         isEditing,
@@ -113,6 +118,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
         'is_private', 'password', 'members_signup_access', 'default_content_visibility', 'default_content_visibility_tiers', 'comments_enabled'
     ]) as [boolean, string, string, string, string, string];
     const [savedIsPrivate, savedPublicHash] = getSettingValues(settings, ['is_private', 'public_hash']) as [boolean, string];
+    const effectiveIsPrivate = isPrivateLocked ? true : isPrivate;
 
     const {data: {tiers} = {}} = useBrowseTiers();
 
@@ -129,21 +135,48 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const contentVisibilityTiers = JSON.parse(defaultContentVisibilityTiers || '[]') as string[];
     const selectedTierOptions = tierOptionGroups.flatMap(group => group.options).filter(option => contentVisibilityTiers.includes(option.value));
-    const privateRssUrl = (savedIsPrivate && isPrivate && siteData?.url && savedPublicHash) ? `${siteData.url.replace(/\/$/, '')}/${savedPublicHash}/rss` : null;
+    const privateRssUrl = (savedIsPrivate && effectiveIsPrivate && siteData?.url && savedPublicHash) ? `${siteData.url.replace(/\/$/, '')}/${savedPublicHash}/rss` : null;
 
     const setSelectedTiers = (selectedOptions: MultiValue<MultiSelectOption>) => {
         const selectedTiers = selectedOptions.map(option => option.value);
         updateSetting('default_content_visibility_tiers', JSON.stringify(selectedTiers));
     };
 
+    const handleRegenerateAccessCode = async () => {
+        setIsRegenerating(true);
+        try {
+            await editSettings([{key: 'password', value: null}]);
+        } catch {
+            showToast({
+                type: 'error',
+                title: 'Could not regenerate access code'
+            });
+        } finally {
+            setIsRegenerating(false);
+        }
+    };
+
     const form = (
         <SettingGroupContent className='gap-y-4' columns={1}>
+            {isPrivateLocked && (
+                <Banner className='mb-2 flex w-full cursor-default flex-col gap-4 border-0 p-6 pt-5 transition-none hover:translate-y-0 hover:scale-100 hover:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_28%),7px_6px_42px_8px_rgb(202_103_255_/_32%)] md:flex-row md:items-center md:justify-between dark:hover:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_36%),7px_6px_42px_8px_rgb(202_103_255_/_38%)]' size='lg' variant='gradient'>
+                    <div>
+                        <div className='text-base font-semibold'>Pre-launch mode</div>
+                        <div className='mt-2 text-sm text-gray-700'>
+                            During your free trial, a private access code is required to browse your site. When you&apos;re ready to launch, pick a plan to upgrade your account and make everything public.
+                        </div>
+                    </div>
+                    <ShadeButton className='shrink-0 self-start md:self-center' asChild><a href="#/pro/billing/plans">Upgrade now</a></ShadeButton>
+                </Banner>
+            )}
             <div className="flex flex-col content-center items-center gap-4 md:flex-row">
                 <div className="w-full max-w-none min-w-[160px] md:w-2/3 md:max-w-[320px]">Who should be able to browse your site?</div>
                 <div className="w-full md:flex-1">
                     <Select
+                        containerClassName={isPrivateLocked ? 'relative z-10' : undefined}
+                        disabled={isPrivateLocked}
                         options={SITE_VISIBILITY_OPTIONS}
-                        selectedOption={SITE_VISIBILITY_OPTIONS.find(option => option.value === (isPrivate ? 'private' : 'public'))}
+                        selectedOption={SITE_VISIBILITY_OPTIONS.find(option => option.value === (effectiveIsPrivate ? 'private' : 'public'))}
                         testId='site-visibility-select'
                         onSelect={(option) => {
                             updateSetting('is_private', option?.value === 'private');
@@ -152,15 +185,31 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     />
                 </div>
             </div>
-            {isPrivate && (
+            {(effectiveIsPrivate || isPrivateLocked) && (
                 <div className="flex flex-col content-center items-center gap-4 md:flex-row md:items-start">
                     <div className="w-full max-w-none min-w-[160px] md:w-2/3 md:max-w-[320px] md:pt-3">What access code should visitors use?</div>
                     <div className="w-full md:flex-1">
                         <TextField
+                            containerClassName={isPrivateLocked ? 'relative z-10' : undefined}
                             data-testid='site-access-code'
+                            disabled={isPrivateLocked}
                             error={!!errors.password}
                             hint={errors.password}
                             placeholder="Enter access code"
+                            rightPlaceholder={(
+                                <span className='flex h-full items-center'>
+                                    <button
+                                        aria-label='Regenerate access code'
+                                        className='mr-[5px] flex size-5 cursor-pointer items-center justify-center p-0 text-grey-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-grey-400'
+                                        disabled={isRegenerating}
+                                        title='Regenerate access code'
+                                        type='button'
+                                        onClick={handleRegenerateAccessCode}
+                                    >
+                                        <RefreshCw aria-hidden={true} className='size-3.5' strokeWidth={1.5} />
+                                    </button>
+                                </span>
+                            )}
                             title='Access code'
                             value={password || ''}
                             hideTitle
@@ -170,7 +219,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                             }}
                             onKeyDown={() => clearError('password')}
                         />
-                        {privateRssUrl && (
+                        {privateRssUrl && !isPrivateLocked && (
                             <Hint className='mt-2'>
                                 <>A private RSS feed is available <a className='text-green' href={privateRssUrl} rel="noopener noreferrer" target='_blank'>here</a></>
                             </Hint>
@@ -251,6 +300,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             keywords={keywords}
             navid='members'
             saveState={saveState}
+            styles={isPrivateLocked ? 'overflow-hidden' : undefined}
             testId='access'
             title='Access'
             hideEditButton

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -1,7 +1,9 @@
 import GhostLogo from '../assets/images/orb-pink.png';
 import React, {useEffect, useRef} from 'react';
 import clsx from 'clsx';
+import {Badge} from '@tryghost/shade/components';
 import {Button, Icon, SettingNavItem, type SettingNavItemProps, SettingNavSection, TextField, useFocusContext} from '@tryghost/admin-x-design-system';
+import {LucideIcon} from '@tryghost/shade/utils';
 
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 
@@ -37,6 +39,13 @@ const NavItem: React.FC<Omit<SettingNavItemProps, 'isVisible' | 'isCurrent' | 'n
         {...props}
     />;
 };
+
+const PrivateBadge: React.FC = () => (
+    <Badge className="gap-1 border-transparent bg-orange-100 px-1.5 py-0 text-[11px] leading-5 font-semibold text-orange-700 shadow-[0_0_0_1px_rgba(255,255,255,0.55)] dark:bg-orange-500/20 dark:text-orange-300 dark:shadow-[0_0_0_1px_rgba(255,255,255,0.12)]" variant="secondary">
+        <LucideIcon.Lock className="size-3" strokeWidth={2.25} />
+        Private
+    </Badge>
+);
 
 const Sidebar: React.FC = () => {
     const {filter, setFilter, checkVisible, noResult, setNoResult} = useSearch();
@@ -108,7 +117,7 @@ const Sidebar: React.FC = () => {
     }, [filter]);
 
     const {settings, config} = useGlobalData();
-    const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [string];
+    const [hasTipsAndDonations, isPrivate] = getSettingValues(settings, ['donations_enabled', 'is_private']) as [string, boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
 
     const handleSectionClick = (e?: React.MouseEvent<HTMLAnchorElement>) => {
@@ -187,7 +196,18 @@ const Sidebar: React.FC = () => {
 
                 {/* Membership settings */}
                 <SettingNavSection isVisible={checkVisible([...Object.values(membershipSearchKeywords).flat(), ...emailSearchKeywords.newslettersNavMenu])} title="Membership">
-                    <NavItem icon='key' keywords={membershipSearchKeywords.access} navid={['members', 'spam-filters']} title="Access" onClick={handleSectionClick} />
+                    <NavItem
+                        icon='key'
+                        keywords={membershipSearchKeywords.access}
+                        navid={['members', 'spam-filters']}
+                        title={(
+                            <span className='flex min-w-0 flex-1 items-center justify-between gap-2'>
+                                <span className='min-w-0 truncate'>Access</span>
+                                {isPrivate && <PrivateBadge />}
+                            </span>
+                        )}
+                        onClick={handleSectionClick}
+                    />
                     <NavItem icon='bills' keywords={membershipSearchKeywords.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
                     <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
                     <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />

--- a/apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import {Button, Kbd, SidebarHeader} from "@tryghost/shade/components"
+import {Badge, Button, Kbd, SidebarHeader} from "@tryghost/shade/components"
 import {LucideIcon} from "@tryghost/shade/utils"
+import {getSettingValue, useBrowseSettings} from "@tryghost/admin-x-framework/api/settings";
 import { useBrowseSite } from "@tryghost/admin-x-framework/api/site";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { isContributorUser } from "@tryghost/admin-x-framework/api/users";
@@ -23,8 +24,10 @@ const openSearchModal = (event: React.MouseEvent<HTMLButtonElement>) => {
 function AppSidebarHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
     const { data: currentUser } = useCurrentUser();
     const site = useBrowseSite();
+    const settings = useBrowseSettings();
     const title = site.data?.site.title ?? "";
     const siteIcon = site.data?.site.icon ?? "https://static.ghost.org/v4.0.0/images/ghost-orb-1.png";
+    const isPrivate = getSettingValue<boolean>(settings.data?.settings, "is_private") ?? false;
     const showSearch = currentUser && !isContributorUser(currentUser);
 
     return (
@@ -39,8 +42,18 @@ function AppSidebarHeader({ ...props }: React.ComponentProps<typeof SidebarHeade
                                 className="h-full w-full rounded-md object-cover"
                                 />
                         </div>
-                        <div className="flex-1 overflow-hidden text-[15px] font-semibold text-ellipsis whitespace-nowrap text-foreground">
-                            {title}
+                        <div className="flex min-w-0 flex-1 items-center gap-2">
+                            <div className="min-w-0 overflow-hidden text-[15px] font-semibold text-ellipsis whitespace-nowrap text-foreground">
+                                {title}
+                            </div>
+                            {isPrivate && (
+                                <a aria-label="Open access settings" className="shrink-0" href="#/settings/members">
+                                    <Badge className="gap-1 border-transparent bg-orange-100 px-1.5 py-0 text-[11px] leading-5 font-semibold text-orange-700 transition-colors hover:bg-orange-200 dark:bg-orange-500/20 dark:text-orange-300 dark:hover:bg-orange-500/30" variant="secondary">
+                                        <LucideIcon.Lock className="size-3" strokeWidth={2.25} />
+                                        Private
+                                    </Badge>
+                                </a>
+                            )}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- When the `publicSiteAccess` host limit is active, the Access settings page shows a gradient "Pre-launch mode" banner with an upgrade CTA, disables the site visibility select (locked to Private), disables the access code text field, and exposes a regenerate button for the access code
- Two separate signals gate the UI: the `publicSiteAccess` limit (via `useLimiter`) drives trial-specific messaging (banner, CTA), while `isSettingReadOnly` drives generic field disabling — so trial copy won't appear if settings are ever marked read-only for a different reason
- Orange "Private" badge with lock icon appears on the Access nav item in the settings sidebar and next to the site title in the main admin sidebar header whenever the site is private
- Improved disabled styling for `Select` and `TextField` in the design system — uses muted backgrounds and subtle rings instead of opacity wash
- Added `publicSiteAccess` to the host settings limits type definition

Lifts the UI from the spike on `codex/trial-private-site-simulator-demo`, wired to real limit and settings signals instead of the localStorage simulator.

Depends on #27917 (merged) for the `is_read_only` field on settings. The regenerate endpoint is a follow-up (sends `password: null` via Settings edit for now).

## Test plan

- [ ] With `publicSiteAccess` limit active: banner shown, visibility select disabled and locked to Private, access code field disabled, regenerate button visible, RSS hint hidden
- [ ] Without the limit: all controls editable, no banner, no regenerate button change in behaviour
- [ ] Private badge visible in settings sidebar and admin sidebar header when site is private
- [ ] Design system: disabled Select and TextField render with muted bg + ring, no opacity wash
- [ ] Existing acceptance tests pass (79 passed, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
