### PR TITLE
Added "Your email" field to gift purchase flow

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.48",
+  "version": "2.68.49",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -340,8 +340,12 @@ async function continueGiftSubscription({state, api}) {
 
 async function checkoutGift({data, state, api}) {
     try {
-        const {tierId, cadence} = data;
-        await api.member.checkoutGift({tierId, cadence});
+        const {tierId, cadence, email} = data;
+        await api.member.checkoutGift({
+            tierId,
+            cadence,
+            ...(email ? {email} : {})
+        });
         return {
             action: 'checkoutGift:success'
         };

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -110,10 +110,6 @@ export const GiftPageStyles = `
     margin-top: 24px;
 }
 
-.gh-portal-gift-checkout-email + .gh-portal-gift-checkout-section {
-    margin-top: 36px;
-}
-
 .gh-portal-gift-checkout-label {
     font-size: 1.2rem;
     font-weight: 500;
@@ -841,6 +837,7 @@ const GiftPage = () => {
                             )}
 
                             <div className='gh-portal-gift-checkout-section'>
+                                <div className='gh-portal-gift-checkout-label'>{isSingleTier ? t('Membership details') : t('Tier')}</div>
                                 <GiftPriceSwitch
                                     selectedInterval={activeInterval}
                                     setSelectedInterval={setSelectedInterval}
@@ -848,7 +845,6 @@ const GiftPage = () => {
                             </div>
 
                             <div className='gh-portal-gift-checkout-section'>
-                                <div className='gh-portal-gift-checkout-label'>{isSingleTier ? t('Membership details') : t('Tier')}</div>
                                 <div
                                     className={'gh-portal-gift-checkout-tiers' + (isSingleTier ? ' single' : '')}
                                     role={isSingleTier ? undefined : 'radiogroup'}

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -3,12 +3,14 @@ import AppContext from '../../app-context';
 import CloseButton from '../common/close-button';
 import ActionButton from '../common/action-button';
 import GiftCard from '../common/gift-card';
+import InputField from '../common/input-field';
 import LoadingPage from './loading-page';
 import CheckmarkIcon from '../../images/icons/checkmark.svg?react';
 import giftCardNoiseUrl from '../../images/gift-card-noise.webp';
 import giftCardOrbUrl from '../../images/gift-card-orb.webp';
 import {getAvailableProducts, getCurrencySymbol, formatNumber, getStripeAmount, isCookiesDisabled, getActiveInterval} from '../../utils/helpers';
 import {getGiftDurationLabel} from '../../utils/gift-redemption-notification';
+import {ValidateInputForm} from '../../utils/form';
 import {t} from '../../utils/i18n';
 import useCardTilt from '../../utils/use-card-tilt';
 
@@ -119,6 +121,24 @@ export const GiftPageStyles = `
 
 .gh-portal-gift-checkout .gh-portal-products-pricetoggle {
     margin: 0;
+}
+
+.gh-portal-gift-checkout-email .gh-portal-input-labelcontainer {
+    margin-bottom: 12px;
+}
+
+.gh-portal-gift-checkout-email .gh-portal-input-label {
+    font-size: 1.2rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--grey6);
+    margin-bottom: 0;
+}
+
+.gh-portal-gift-checkout-email .gh-portal-input {
+    height: 48px;
+    margin-bottom: 0;
 }
 
 .gh-portal-gift-checkout-tiers {
@@ -652,9 +672,11 @@ function getTierPriceLabel(product, selectedInterval) {
 }
 
 const GiftPage = () => {
-    const {site, brandColor, action, doAction} = useContext(AppContext);
+    const {site, member, brandColor, action, doAction} = useContext(AppContext);
     const [selectedInterval, setSelectedInterval] = useState(null);
     const [selectedProductId, setSelectedProductId] = useState(null);
+    const [email, setEmail] = useState('');
+    const [errors, setErrors] = useState({});
     const {cardRef, containerProps: cardTiltProps} = useCardTilt();
     const leftRef = useRef(null);
     const innerRef = useRef(null);
@@ -734,14 +756,58 @@ const GiftPage = () => {
     const activeProduct = products.find(p => p.id === selectedProductId) || products[0];
     const isSingleTier = products.length === 1;
     const isPurchasing = action === 'checkoutGift:running';
-    const isDisabled = isCookiesDisabled() || isPurchasing;
+    const hasErrors = Object.values(errors).some(errorMessage => !!errorMessage);
+    const isDisabled = isCookiesDisabled() || isPurchasing || hasErrors;
+    const isLoggedIn = !!member;
+
+    const emailField = {
+        type: 'email',
+        value: email,
+        placeholder: t('jamie@example.com'),
+        label: t('Your email'),
+        name: 'email',
+        required: true,
+        errorMessage: errors.email || ''
+    };
+
+    const handleEmailChange = (event) => {
+        setErrors(currentErrors => ({
+            ...currentErrors,
+            email: ''
+        }));
+        setEmail(event.target.value);
+    };
+
+    const handleEmailKeyDown = (event) => {
+        if (event.keyCode === 13 && !isPurchasing) {
+            handlePurchase(event);
+        }
+    };
 
     const handlePurchase = (e) => {
         e.preventDefault();
 
+        if (isPurchasing) {
+            return;
+        }
+
+        const customerEmail = email.trim();
+
+        if (!isLoggedIn) {
+            const formErrors = ValidateInputForm({fields: [{...emailField, value: customerEmail}]});
+            const formHasErrors = Object.values(formErrors).some(errorMessage => !!errorMessage);
+
+            setErrors(formErrors);
+
+            if (formHasErrors) {
+                return;
+            }
+        }
+
         doAction('checkoutGift', {
             tierId: activeProduct.id,
-            cadence: activeInterval
+            cadence: activeInterval,
+            ...(!isLoggedIn ? {email: customerEmail} : {})
         });
     };
 
@@ -766,6 +832,16 @@ const GiftPage = () => {
                                     setSelectedInterval={setSelectedInterval}
                                 />
                             </div>
+
+                            {!isLoggedIn && (
+                                <div className='gh-portal-gift-checkout-section gh-portal-gift-checkout-email'>
+                                    <InputField
+                                        {...emailField}
+                                        onChange={handleEmailChange}
+                                        onKeyDown={handleEmailKeyDown}
+                                    />
+                                </div>
+                            )}
 
                             <div className='gh-portal-gift-checkout-section'>
                                 <div className='gh-portal-gift-checkout-label'>{isSingleTier ? t('Membership details') : t('Tier')}</div>

--- a/apps/portal/src/components/pages/gift-page.js
+++ b/apps/portal/src/components/pages/gift-page.js
@@ -110,6 +110,10 @@ export const GiftPageStyles = `
     margin-top: 24px;
 }
 
+.gh-portal-gift-checkout-email + .gh-portal-gift-checkout-section {
+    margin-top: 36px;
+}
+
 .gh-portal-gift-checkout-label {
     font-size: 1.2rem;
     font-weight: 500;
@@ -826,13 +830,6 @@ const GiftPage = () => {
                                 </p>
                             </header>
 
-                            <div className='gh-portal-gift-checkout-section'>
-                                <GiftPriceSwitch
-                                    selectedInterval={activeInterval}
-                                    setSelectedInterval={setSelectedInterval}
-                                />
-                            </div>
-
                             {!isLoggedIn && (
                                 <div className='gh-portal-gift-checkout-section gh-portal-gift-checkout-email'>
                                     <InputField
@@ -842,6 +839,13 @@ const GiftPage = () => {
                                     />
                                 </div>
                             )}
+
+                            <div className='gh-portal-gift-checkout-section'>
+                                <GiftPriceSwitch
+                                    selectedInterval={activeInterval}
+                                    setSelectedInterval={setSelectedInterval}
+                                />
+                            </div>
 
                             <div className='gh-portal-gift-checkout-section'>
                                 <div className='gh-portal-gift-checkout-label'>{isSingleTier ? t('Membership details') : t('Tier')}</div>

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -607,7 +607,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             });
         },
 
-        async checkoutGift({tierId, cadence} = {}) {
+        async checkoutGift({tierId, cadence, email: customerEmail} = {}) {
             const siteUrlObj = new URL(siteUrl);
             const url = endpointFor({type: 'members', resource: 'create-stripe-checkout-session'});
 
@@ -631,6 +631,10 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 cadence,
                 cancelUrl: cancelUrlObj.href
             };
+
+            if (customerEmail) {
+                body.customerEmail = customerEmail;
+            }
 
             const response = await makeRequest({
                 url,

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -561,6 +561,28 @@ describe('checkoutGift action', () => {
         expect(result.action).toBe('checkoutGift:success');
     });
 
+    test('passes customer email through to api.member.checkoutGift', async () => {
+        const mockApi = {
+            member: {
+                checkoutGift: vi.fn(() => Promise.resolve())
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'checkoutGift',
+            data: {tierId: 'tier_123', cadence: 'month', email: 'jamie@example.com'},
+            state: {},
+            api: mockApi
+        });
+
+        expect(mockApi.member.checkoutGift).toHaveBeenCalledWith({
+            tierId: 'tier_123',
+            cadence: 'month',
+            email: 'jamie@example.com'
+        });
+        expect(result.action).toBe('checkoutGift:success');
+    });
+
     test('returns failed action with notification on error', async () => {
         const mockApi = {
             member: {

--- a/apps/portal/test/api.test.js
+++ b/apps/portal/test/api.test.js
@@ -114,3 +114,65 @@ describe('Portal API gift redemption', () => {
         await expect(ghostApi.gift.redeem({token: 'gift-token-123'})).rejects.toEqual(new HumanReadableError('This gift has already been redeemed.'));
     });
 });
+
+describe('Portal API gift checkout', () => {
+    let originalLocation;
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        originalLocation = window.location;
+        delete window.location;
+        window.location = {
+            href: 'https://example.com/#/portal/gift',
+            assign: vi.fn()
+        };
+    });
+
+    afterEach(() => {
+        window.location = originalLocation;
+    });
+
+    test('passes customer email when creating a gift checkout session', async () => {
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+
+        vi.spyOn(window, 'fetch').mockImplementation((url) => {
+            if (url.includes('/members/api/session/')) {
+                return Promise.resolve(new Response('identity-token', {status: 200}));
+            }
+
+            return Promise.resolve(new Response(JSON.stringify({
+                url: 'https://checkout.stripe.com/gift-session'
+            }), {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }));
+        });
+
+        await ghostApi.member.checkoutGift({
+            tierId: 'tier_123',
+            cadence: 'month',
+            email: 'jamie@example.com'
+        });
+
+        expect(window.fetch).toHaveBeenLastCalledWith('https://example.com/members/api/create-stripe-checkout-session/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                identity: 'identity-token',
+                metadata: {
+                    requestSrc: 'portal'
+                },
+                type: 'gift',
+                tierId: 'tier_123',
+                cadence: 'month',
+                cancelUrl: 'https://example.com/#/portal/gift',
+                customerEmail: 'jamie@example.com'
+            })
+        });
+        expect(window.location.assign).toHaveBeenCalledWith('https://checkout.stripe.com/gift-session');
+    });
+});

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -172,10 +172,11 @@ class PaymentsService {
      * @param {object} params.metadata
      * @param {object} [params.member]
      * @param {boolean} params.isAuthenticated
+     * @param {string} [params.email]
      *
      * @returns {Promise<string>}
      */
-    async getGiftPaymentLink({tier, cadence, duration, metadata, successUrl, cancelUrl, member, isAuthenticated}) {
+    async getGiftPaymentLink({tier, cadence, duration, metadata, successUrl, cancelUrl, member, isAuthenticated, email}) {
         let customer = null;
         if (member && isAuthenticated) {
             customer = await this.getCustomerForMember(member);
@@ -208,7 +209,8 @@ class PaymentsService {
             },
             successUrl: successUrlObj.toString(),
             cancelUrl,
-            customer
+            customer,
+            customerEmail: !customer && email ? email : null
         };
 
         const session = await this.stripeAPIService.createGiftCheckoutSession(data);

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -695,10 +695,11 @@ module.exports = class StripeAPI {
      * @param {string} options.successUrl
      * @param {string} options.cancelUrl
      * @param {ICustomer|null} options.customer
+     * @param {string} [options.customerEmail]
      *
      * @returns {Promise<ICheckoutSession>}
      */
-    async createGiftCheckoutSession({amount, currency, tierName, cadence, duration, metadata, successUrl, cancelUrl, customer}) {
+    async createGiftCheckoutSession({amount, currency, tierName, cadence, duration, metadata, successUrl, cancelUrl, customer, customerEmail}) {
         await this._rateLimitBucket.throttle();
 
         const cadenceLabel = duration === 1 ? `1 ${cadence}` : `${duration} ${cadence}s`;
@@ -712,6 +713,7 @@ module.exports = class StripeAPI {
             },
             metadata,
             customer: customer ? customer.id : undefined,
+            customer_email: !customer && customerEmail ? customerEmail : undefined,
             submit_type: 'pay',
             line_items: [{
                 price_data: {

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -770,6 +770,26 @@ describe('RouterController', function () {
                 }));
             });
 
+            it('passes customerEmail through for logged-out gift checkout', async function () {
+                const controller = createGiftController({tiersService: paidTierService()});
+
+                await controller.createCheckoutSession({
+                    body: {
+                        type: 'gift',
+                        tierId: 'tier_123',
+                        cadence: 'month',
+                        customerEmail: 'jamie@example.com',
+                        metadata: {}
+                    }
+                }, mockRes);
+
+                sinon.assert.calledOnce(getGiftLinkSpy);
+                sinon.assert.calledWith(getGiftLinkSpy, sinon.match({
+                    email: 'jamie@example.com',
+                    isAuthenticated: false
+                }));
+            });
+
             it('rejects when giftSubscriptions labs flag is disabled', async function () {
                 labsService.isSet = sinon.stub().returns(false);
                 const controller = createGiftController();

--- a/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
@@ -417,5 +417,38 @@ describe('PaymentsService', function () {
             sinon.assert.calledWith(service.getCustomerForMember, mockMember);
             assert.equal(getStripeArgs().customer, mockCustomer);
         });
+
+        it('passes customer email to Stripe for logged-out gift purchases', async function () {
+            const tier = await createTier();
+
+            await service.getGiftPaymentLink({
+                ...defaultGiftOptions,
+                tier,
+                cadence: 'month',
+                email: 'jamie@example.com'
+            });
+
+            assert.equal(getStripeArgs().customerEmail, 'jamie@example.com');
+        });
+
+        it('does not pass customer email when an authenticated customer is available', async function () {
+            const mockCustomer = {id: 'cus_123', email: 'member@example.com'};
+            sinon.stub(service, 'getCustomerForMember').resolves(mockCustomer);
+
+            const tier = await createTier();
+            const mockMember = {id: 'member_123', get: sinon.stub().returns('member@example.com')};
+
+            await service.getGiftPaymentLink({
+                ...defaultGiftOptions,
+                tier,
+                cadence: 'month',
+                member: mockMember,
+                isAuthenticated: true,
+                email: 'jamie@example.com'
+            });
+
+            assert.equal(getStripeArgs().customer, mockCustomer);
+            assert.equal(getStripeArgs().customerEmail, null);
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -785,6 +785,45 @@ describe('StripeAPI', function () {
             assert.equal(args.customer, mockCustomerId);
         });
 
+        it('passes customer email when no customer is provided', async function () {
+            await api.createGiftCheckoutSession({
+                amount: 5000,
+                currency: 'usd',
+                tierName: 'Pro',
+                cadence: 'year',
+                duration: 1,
+                successUrl: '/gift-success',
+                cancelUrl: '/gift-cancel',
+                metadata: {},
+                customerEmail: mockCustomerEmail
+            });
+
+            const args = mockStripe.checkout.sessions.create.firstCall.firstArg;
+
+            assert.equal(args.customer, undefined);
+            assert.equal(args.customer_email, mockCustomerEmail);
+        });
+
+        it('uses only customer when both customer and customer email are provided', async function () {
+            await api.createGiftCheckoutSession({
+                amount: 5000,
+                currency: 'usd',
+                tierName: 'Pro',
+                cadence: 'year',
+                duration: 1,
+                successUrl: '/gift-success',
+                cancelUrl: '/gift-cancel',
+                metadata: {},
+                customer: {id: mockCustomerId},
+                customerEmail: mockCustomerEmail
+            });
+
+            const args = mockStripe.checkout.sessions.create.firstCall.firstArg;
+
+            assert.equal(args.customer, mockCustomerId);
+            assert.equal(args.customer_email, undefined);
+        });
+
         it('does not include invoice_creation or custom_fields', async function () {
             await api.createGiftCheckoutSession({
                 amount: 5000,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3670

During gift purchase, the Stripe checkout flow asks for an email. As gift subscriptions are sometimes delivered by email, it may not be always clear which email to enter: is it my email address, or the email address of the recipient?

To remove the confusion, we now explicitly ask for "Your email" in the gift purchase flow to logged out members. The Stripe checkout form then always has the email field pre-filled, for both logged-out members (email entered manually) and logged-in members (email already in database).