### PR TITLE
Updated Nx config to disable the daemon

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,6 +14,7 @@
         ]
     },
     "parallel": 4,
+    "useDaemonProcess": false,
     "targetDefaults": {
         "build": {
             "dependsOn": [


### PR DESCRIPTION
## Summary

- Reintroduced the top-level `useDaemonProcess: false` setting in `nx.json`.
- Keeps local long-running Nx dev tasks from relying on the daemon.

## Context

The Nx daemon can fail to bind its Unix socket from sandboxed environments and leave the workspace with a stale `.nx/workspace-data/d/disabled` marker. Since `pnpm dev` mostly runs long-lived tasks, the daemon startup optimization is not worth the recovery failure mode for local development.

## Validation

- `pnpm nx report`
- `pnpm nx show projects --json`