### PR TITLE
Fixed ghost-admin build by declaring missing lodash and aligning codemirror

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -66,7 +66,7 @@
     "broccoli-terser-sourcemap": "4.1.1",
     "chai": "catalog:",
     "chai-dom": "1.12.1",
-    "codemirror": "5.48.2",
+    "codemirror": "5.65.21",
     "cssnano": "4.1.10",
     "element-resize-detector": "1.2.4",
     "ember-ajax": "5.1.2",
@@ -166,6 +166,7 @@
     "*.js": "eslint"
   },
   "dependencies": {
+    "lodash": "catalog:",
     "path-browserify": "1.0.1",
     "webpack": "5.105.4"
   },

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -198,7 +198,7 @@
     "knex": "2.4.2",
     "knex-migrator": "5.3.2",
     "leaky-bucket": "2.2.0",
-    "lodash": "4.18.1",
+    "lodash": "catalog:",
     "luxon": "3.7.2",
     "mailgun.js": "10.4.0",
     "metascraper": "5.45.15",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,11 @@
         "dependencies": {
           "@babel/runtime": "^7.26.10"
         }
+      },
+      "@tryghost/nql@0.12.10": {
+        "dependencies": {
+          "lodash": "^4.18.0"
+        }
       }
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ catalogs:
     jsonc-parser:
       specifier: 3.3.1
       version: 3.3.1
+    lodash:
+      specifier: 4.18.1
+      version: 4.18.1
     mocha:
       specifier: 11.7.5
       version: 11.7.5
@@ -233,7 +236,7 @@ overrides:
   underscore@>=1.3.2 <1.12.1: ^1.12.1
   '@xmldom/xmldom@<0.8.13': ^0.8.13
 
-packageExtensionsChecksum: sha256-gFsvptlcVXY90ntXWh9ANUP1/LYyeqXjWoDGw6BCfOY=
+packageExtensionsChecksum: sha256-VoukEtG/3ZKlZLtw2HjOKS0hPvjiZTwZtAPotZw7zcw=
 
 importers:
 
@@ -1737,6 +1740,9 @@ importers:
 
   ghost/admin:
     dependencies:
+      lodash:
+        specifier: 'catalog:'
+        version: 4.18.1
       path-browserify:
         specifier: 1.0.1
         version: 1.0.1
@@ -1856,7 +1862,7 @@ importers:
         specifier: 1.12.1
         version: 1.12.1(chai@4.5.0)
       codemirror:
-        specifier: ^5.58.2
+        specifier: 5.65.21
         version: 5.65.21
       cssnano:
         specifier: 4.1.10
@@ -2453,7 +2459,7 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       lodash:
-        specifier: 4.18.1
+        specifier: 'catalog:'
         version: 4.18.1
       luxon:
         specifier: 3.7.2
@@ -29257,6 +29263,7 @@ snapshots:
       '@tryghost/mongo-knex': 0.9.4
       '@tryghost/mongo-utils': 0.6.3
       '@tryghost/nql-lang': 0.6.4
+      lodash: 4.18.1
       mingo: 2.5.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,6 +50,7 @@ catalog:
   glob: 10.5.0
   jsdom: 29.1.1
   jsonc-parser: 3.3.1
+  lodash: 4.18.1
   mocha: 11.7.5
   msw: 2.12.14
   postcss: 8.5.6


### PR DESCRIPTION
## Summary

`pnpm nx build ghost-admin` was failing on `main`. Three related issues, all surfaced by recent dependency hygiene work:

- **`Cannot find module 'lodash/camelCase'`** in `ghost/admin/lib/asset-delivery/index.js`. The addon required `lodash` but `ghost/admin` never declared it — it had been resolving through hoisting until `shamefully-hoist=false` (dc2ae810f4) tightened isolation.
- **`Module not found: Can't resolve 'lodash'`** in `@tryghost/nql/lib/utils.js` via ember-auto-import's webpack pass. `@tryghost/nql@0.12.10` has a phantom `lodash` dep — declared nowhere in its own `package.json`, but `require`d at runtime.
- **`Missing symlinked npm packages: codemirror — Specified: 5.48.2 — Symlinked: 5.65.21`**. The security override added in #27683 forces codemirror to `^5.58.2`, but `ghost/admin`'s spec was still `5.48.2`, so ember-cli-dependency-checker flagged the mismatch.

## Changes

- Added `lodash: 4.18.1` to the workspace catalog (`pnpm-workspace.yaml`).
- Switched `ghost/core` to `lodash: catalog:` (was a duplicate `4.18.1` pin).
- Declared `lodash: catalog:` in `ghost/admin` so `asset-delivery` can `require('lodash/camelCase')`.
- Bumped `ghost/admin`'s `codemirror` spec from `5.48.2` → `5.65.21` to match the version the override actually installs.
- Added a `packageExtensions` entry for `@tryghost/nql@0.12.10` declaring its missing `lodash` dep, so pnpm installs it into the package's own `node_modules` and webpack can resolve it.

The `packageExtensions` patch is the short-term fix. The proper long-term fix is to declare `lodash` in `@tryghost/nql`'s own `dependencies` upstream and bump the catalog when published.

## Test plan

- [x] `pnpm nx build ghost-admin` succeeds locally
- [ ] CI green