### PR TITLE
🐛 Fixed theme editor launch gate for allowlisted themes on limited plans

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
@@ -2,7 +2,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import {Button, Heading, LimitModal, Menu, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {type Theme, isDefaultOrLegacyTheme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
+import {type Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '../../../hooks/use-check-theme-limit-error';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -47,7 +47,16 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
             return;
         }
 
-        const limitError = await checkThemeLimitError(isDefaultOrLegacyTheme(activeTheme) ? '.' : activeTheme.name);
+        // The editor saves through POST /themes/upload/, where the server
+        // calls errorIfWouldGoOverLimit('customThemes', {value: '.'}) — a
+        // sentinel that's never in the allowlist, so every save by a limited
+        // customer is blocked regardless of which theme they're editing.
+        // Mirror that sentinel here so the launch gate is consistent with
+        // what happens at save time. Passing the theme name instead lets a
+        // limited customer enter the editor whenever the theme they're
+        // already on is in the allowlist, then surface a generic upload
+        // failure when they hit Save.
+        const limitError = await checkThemeLimitError('.');
 
         if (limitError) {
             NiceModal.show(LimitModal, {

--- a/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
@@ -138,7 +138,12 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
 
             setIsCheckingEditorLimit(true);
 
-            const error = await checkThemeLimitError(editingThemeName.toLowerCase());
+            // The editor's save uploads through POST /themes/upload/, which
+            // runs the limit check with a '.' sentinel — so any save by a
+            // limited customer is blocked regardless of allowlist. Use the
+            // same sentinel here so deep-linking to /theme/edit/:name blocks
+            // at launch rather than at first save.
+            const error = await checkThemeLimitError('.');
 
             if (isCancelled) {
                 return;

--- a/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import useCustomFonts from '../../../../hooks/use-custom-fonts';
 import {Button, type ButtonProps, ConfirmationModal, LimitModal, List, ListItem, Menu, ModalPage, showToast} from '@tryghost/admin-x-design-system';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
-import {type Theme, isActiveTheme, isDefaultOrLegacyTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
+import {type Theme, isActiveTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '../../../../hooks/use-check-theme-limit-error';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -127,7 +127,10 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     };
 
     const handleEditCode = async () => {
-        const limitError = await checkThemeLimitError(isDefaultOrLegacyTheme(theme) ? '.' : theme.name);
+        // See change-theme.tsx for why this passes '.' rather than the
+        // theme name: every save in the editor uploads via POST /themes/upload/,
+        // and the server's upload-side limit check uses the same '.' sentinel.
+        const limitError = await checkThemeLimitError('.');
 
         if (limitError) {
             NiceModal.show(LimitModal, {

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -802,6 +802,31 @@ test.describe('Theme settings', async () => {
         await expect(page.getByTestId('theme-code-editor-modal')).not.toBeVisible();
     });
 
+    test('Prevents direct access to theme editor route even for an allowlisted theme', async ({page}) => {
+        // Regression cover for the launch gate: the editor saves via POST
+        // /themes/upload/, which the server enforces with a '.' sentinel —
+        // so any save by a limited customer is blocked regardless of
+        // allowlist. The launch gate must mirror that, otherwise editing
+        // an allowlisted theme opens the editor only to fail on save with
+        // a generic "something went wrong" toast.
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: customThemesLimitConfig(
+                ['casper', 'source', 'edition'],
+                'Your plan does not include any custom themes. Please upgrade your plan to upload themes.'
+            )
+        }});
+
+        await page.goto('/#/settings/theme/edit/edition');
+
+        await page.waitForSelector('[data-testid="limit-modal"]', {timeout: 10000});
+
+        await expect(page.getByTestId('limit-modal')).toContainText(/Your plan does not include any custom themes/);
+        await expect(page.getByTestId('theme-code-editor-modal')).not.toBeVisible();
+    });
+
     test('Redirects malformed theme editor routes back to theme settings', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,


### PR DESCRIPTION
- the server's `POST /themes/upload/` blocks every save by a limited customer using a `.` sentinel that's never in the allowlist, so editing any theme on a plan with a `customThemes` limit enabled is rejected regardless of which theme is active
- the launch gate previously checked the active theme name against the allowlist, so customers whose current theme happened to be allowlisted could enter the editor only to hit a generic "something went wrong" toast on save
- the gate at all three editor entry points (Change theme menu, installed themes list, `/theme/edit/:name` deep link) now uses the same `.` sentinel as the upload endpoint, so the LimitModal fires at launch with the host's customThemes error message instead

<img width="800" height="597" alt="feature-gate" src="https://github.com/user-attachments/assets/05d1f7f4-3e45-4a26-8c6f-14b408ad64db" />


Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
