### PR TITLE
Added sidebar for viewing automation steps

### DIFF
--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -2,9 +2,9 @@ import '@xyflow/react/dist/style.css';
 import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
-import {AutomationAction, AutomationDetail, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction} from '@tryghost/admin-x-framework/api/automations';
+import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
-import {Banner, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {Banner, Button, Checkbox, Input, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 
 const NODE_X = 0;
@@ -29,10 +29,15 @@ const toApiAnchor = ({sourceId, targetId}: CanvasAnchor): InsertActionAnchor => 
     nextActionId: targetId === TAIL_CANVAS_ID ? undefined : targetId
 });
 
-type StepNodeData = {
+type StepNodeDisplayData = {
     icon: React.ElementType;
     label: string;
     value?: string;
+};
+
+type StepNodeData = StepNodeDisplayData & {
+    selected: boolean;
+    onSelect: () => void;
 };
 
 type TailNodeData = {
@@ -57,12 +62,20 @@ const HiddenHandle: React.FC<{type: 'source' | 'target'; position: Position}> = 
     <Handle isConnectable={false} position={position} style={HIDDEN_HANDLE_STYLE} type={type} />
 );
 
-const NodeShell: React.FC<React.PropsWithChildren<{className?: string}>> = ({children, className}) => (
-    <div
-        className={cn('flex w-64 items-center gap-3 rounded-lg border border-border-default bg-surface-elevated px-4 py-3 text-left text-sm text-foreground shadow-sm', className)}
+const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: StepNodeData}>> = ({children, className, data}) => (
+    <button
+        aria-label={data.value ? `${data.label}: ${data.value}` : data.label}
+        aria-pressed={data.selected}
+        className={cn(
+            'flex w-64 items-center gap-3 rounded-lg border border-border-default bg-surface-elevated px-4 py-3 text-left text-sm text-foreground shadow-sm transition-colors hover:border-border-strong focus-visible:border-border-strong focus-visible:outline-none',
+            data.selected && 'border-blue-500 shadow-[inset_0_0_0_1px_var(--color-blue-500),0_1px_2px_0_rgb(0_0_0_/_0.05)]',
+            className
+        )}
+        type='button'
+        onClick={data.onSelect}
     >
         {children}
-    </div>
+    </button>
 );
 
 const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
@@ -81,7 +94,7 @@ const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
 };
 
 const TriggerNode = React.memo<NodeProps<StepFlowNode>>(({data}) => (
-    <NodeShell>
+    <NodeShell data={data}>
         <StepNodeContent data={data} />
         <HiddenHandle position={Position.Bottom} type='source' />
     </NodeShell>
@@ -89,7 +102,7 @@ const TriggerNode = React.memo<NodeProps<StepFlowNode>>(({data}) => (
 TriggerNode.displayName = 'TriggerNode';
 
 const StepNode = React.memo<NodeProps<StepFlowNode>>(({data}) => (
-    <NodeShell>
+    <NodeShell data={data}>
         <HiddenHandle position={Position.Top} type='target' />
         <StepNodeContent data={data} />
         <HiddenHandle position={Position.Bottom} type='source' />
@@ -171,7 +184,7 @@ export const formatWait = (hours: number): string => {
     return hours === 1 ? '1 hour' : `${hours} hours`;
 };
 
-const buildActionData = (action: AutomationAction): StepNodeData => {
+const buildActionData = (action: AutomationAction): StepNodeDisplayData => {
     switch (action.type) {
     case 'wait':
         return {icon: LucideIcon.Clock, label: 'Wait', value: formatWait(action.data.wait_hours)};
@@ -229,9 +242,11 @@ type BuildGraphParams = {
     automation: AutomationDetail;
     disabled: boolean;
     onPick: (type: StepPickerType, anchor: CanvasAnchor) => void;
+    onSelectStep: (stepId: string) => void;
+    selectedStepId: string | null;
 }
 
-const buildGraph = ({automation, disabled, onPick}: BuildGraphParams): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
+const buildGraph = ({automation, disabled, onPick, onSelectStep, selectedStepId}: BuildGraphParams): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
     const ordered = getInitialActionOrder(automation);
     const baseNodeProps = {
         draggable: false,
@@ -252,7 +267,13 @@ const buildGraph = ({automation, disabled, onPick}: BuildGraphParams): {nodes: A
             id: TRIGGER_CANVAS_ID,
             type: 'trigger',
             position: {x: NODE_X, y: 0},
-            data: {icon: LucideIcon.Zap, label: 'Trigger', value: 'Member signs up'},
+            data: {
+                icon: LucideIcon.Zap,
+                label: 'Trigger',
+                value: 'Member signs up',
+                selected: selectedStepId === TRIGGER_CANVAS_ID,
+                onSelect: () => onSelectStep(TRIGGER_CANVAS_ID)
+            },
             ...baseNodeProps
         }
     ];
@@ -262,7 +283,11 @@ const buildGraph = ({automation, disabled, onPick}: BuildGraphParams): {nodes: A
             id: action.id,
             type: 'step',
             position: {x: NODE_X, y: NODE_GAP_Y * (index + 1)},
-            data: buildActionData(action),
+            data: {
+                ...buildActionData(action),
+                selected: selectedStepId === action.id,
+                onSelect: () => onSelectStep(action.id)
+            },
             ...baseNodeProps
         });
     });
@@ -317,12 +342,234 @@ const getInitialViewport = (canvasWidth: number): {x: number; y: number; zoom: n
     zoom: 1
 });
 
+type TriggerStepSidebarDetail = {
+    icon: React.ElementType;
+    label: 'Trigger';
+    title: string;
+    memberTiers: MemberTier[];
+    type: 'trigger';
+};
+
+type WaitStepSidebarDetail = {
+    action: AutomationWaitAction;
+    icon: React.ElementType;
+    label: 'Wait';
+    title: string;
+    type: 'wait';
+};
+
+type SendEmailStepSidebarDetail = {
+    action: AutomationSendEmailAction;
+    icon: React.ElementType;
+    label: 'Send email';
+    title: string;
+    type: 'send_email';
+};
+
+type StepSidebarDetail = TriggerStepSidebarDetail | WaitStepSidebarDetail | SendEmailStepSidebarDetail;
+
+type MemberTier = 'free' | 'paid';
+
+const automationSlugMemberTiers: Record<string, MemberTier[]> = {
+    'member-welcome-email-free': ['free'],
+    'member-welcome-email-paid': ['paid']
+};
+
+const getStepSidebarDetail = (automation: AutomationDetail, stepId: string | null): StepSidebarDetail | null => {
+    if (!stepId) {
+        return null;
+    }
+
+    if (stepId === TRIGGER_CANVAS_ID) {
+        return {
+            icon: LucideIcon.Zap,
+            label: 'Trigger',
+            title: 'Member signs up',
+            memberTiers: automationSlugMemberTiers[automation.slug] ?? [],
+            type: 'trigger'
+        };
+    }
+
+    const action = automation.actions.find(item => item.id === stepId);
+    if (!action) {
+        return null;
+    }
+
+    switch (action.type) {
+    case 'wait': {
+        const waitValue = formatWait(action.data.wait_hours);
+        return {
+            icon: LucideIcon.Clock,
+            label: 'Wait',
+            title: waitValue,
+            action,
+            type: 'wait'
+        };
+    }
+    case 'send_email':
+        return {
+            icon: LucideIcon.Mail,
+            label: 'Send email',
+            title: action.data.email_subject || 'No subject',
+            action,
+            type: 'send_email'
+        };
+    default: {
+        const _exhaustive: never = action;
+        throw new Error(`Unknown automation action type: ${_exhaustive}`);
+    }
+    }
+};
+
+const getWaitParts = (hours: number): {amount: string; unit: string} => {
+    if (hours % 24 === 0) {
+        return {amount: formatNumber(hours / 24), unit: hours === 24 ? 'Day' : 'Days'};
+    }
+    return {amount: formatNumber(hours), unit: hours === 1 ? 'Hour' : 'Hours'};
+};
+
+const SidebarField: React.FC<{label: string; children: React.ReactNode}> = ({label, children}) => (
+    <label className='flex flex-col gap-2'>
+        <span className='text-xs font-medium text-text-secondary'>{label}</span>
+        {children}
+    </label>
+);
+
+const ReadOnlySelect: React.FC<{value: string}> = ({value}) => (
+    <Select value={value}>
+        <SelectTrigger disabled>
+            <span>{value}</span>
+        </SelectTrigger>
+    </Select>
+);
+
+const DisabledPanelButton: React.FC<React.PropsWithChildren<{variant?: 'default' | 'destructive'}>> = ({children, variant = 'default'}) => (
+    <Button
+        className={cn('w-full', variant === 'destructive' && 'border-red text-red')}
+        type='button'
+        variant='outline'
+        disabled
+    >
+        {children}
+    </Button>
+);
+
+const TriggerSidebarBody: React.FC<{memberTiers: MemberTier[]}> = ({memberTiers}) => (
+    <div className='flex flex-col gap-5'>
+        <SidebarField label='Trigger'>
+            <ReadOnlySelect value='New member sign up' />
+        </SidebarField>
+        <div className='flex flex-col gap-2'>
+            <span className='text-xs font-medium text-text-secondary'>Members</span>
+            <Label className='flex items-center gap-2 text-sm font-normal text-foreground'>
+                <Checkbox checked={memberTiers.includes('free')} disabled />
+                Free
+            </Label>
+            <Label className='flex items-center gap-2 text-sm font-normal text-foreground'>
+                <Checkbox checked={memberTiers.includes('paid')} disabled />
+                Paid
+            </Label>
+        </div>
+    </div>
+);
+
+const WaitSidebarBody: React.FC<{action: AutomationWaitAction}> = ({action}) => {
+    const wait = getWaitParts(action.data.wait_hours);
+
+    return (
+        <div className='flex flex-1 flex-col gap-5'>
+            <SidebarField label='Wait for'>
+                <div className='grid grid-cols-[6rem_1fr] gap-2'>
+                    <Input value={wait.amount} readOnly />
+                    <ReadOnlySelect value={wait.unit} />
+                </div>
+            </SidebarField>
+            <div className='mt-auto pt-6'>
+                <DisabledPanelButton variant='destructive'>
+                    <LucideIcon.Trash2 className='size-4' />
+                    Delete step
+                </DisabledPanelButton>
+            </div>
+        </div>
+    );
+};
+
+const SendEmailSidebarBody: React.FC<{action: AutomationSendEmailAction}> = ({action}) => (
+    <div className='flex flex-1 flex-col gap-5'>
+        <SidebarField label='Subject line'>
+            <Input value={action.data.email_subject || 'No subject'} readOnly />
+        </SidebarField>
+        <DisabledPanelButton>
+            <LucideIcon.Pencil className='size-4' />
+            Edit email
+        </DisabledPanelButton>
+        <div className='mt-auto pt-6'>
+            <DisabledPanelButton variant='destructive'>
+                <LucideIcon.Trash2 className='size-4' />
+                Delete step
+            </DisabledPanelButton>
+        </div>
+    </div>
+);
+
+const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
+    switch (detail.type) {
+    case 'trigger':
+        return <TriggerSidebarBody memberTiers={detail.memberTiers} />;
+    case 'wait':
+        return <WaitSidebarBody action={detail.action} />;
+    case 'send_email':
+        return <SendEmailSidebarBody action={detail.action} />;
+    default: {
+        const _exhaustive: never = detail;
+        throw new Error(`Unknown sidebar type: ${_exhaustive}`);
+    }
+    }
+};
+
+const StepSidebarContent: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
+    const Icon = detail.icon;
+
+    return (
+        <div className='flex min-h-full flex-col gap-6'>
+            <div className='flex items-start gap-4'>
+                <div className='flex min-w-0 items-center gap-3'>
+                    <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary'>
+                        <Icon className='size-4' />
+                    </div>
+                    <div className='min-w-0'>
+                        <span className='block text-xs text-text-secondary'>{detail.label}</span>
+                        <h2 className='truncate text-base leading-tight font-semibold text-foreground'>{detail.title}</h2>
+                    </div>
+                </div>
+            </div>
+
+            <StepSidebarBody detail={detail} />
+        </div>
+    );
+};
+
+const StepSidebar: React.FC<{detail: StepSidebarDetail | null}> = ({detail}) => (
+    <aside
+        aria-hidden={!detail}
+        aria-label='Step details'
+        className={cn(
+            'absolute inset-y-0 right-0 z-[1] flex w-[calc(100%-6rem)] max-w-none translate-x-full flex-col gap-6 overflow-y-auto border-l border-border-default bg-background p-6 shadow-lg transition-transform duration-200 ease-out sm:w-[36rem]',
+            detail ? 'translate-x-0' : 'pointer-events-none'
+        )}
+        data-state={detail ? 'open' : 'closed'}
+        data-testid='automation-step-sidebar'
+    >
+        {detail && <StepSidebarContent detail={detail} />}
+    </aside>
+);
+
 type AutomationCanvasProps = {
     automation?: AutomationDetail;
     isLoading: boolean;
     isError: boolean;
     onChange: (next: AutomationDetail) => void;
-}
+};
 
 const insertActionByType = {
     wait: insertWaitAction,
@@ -330,6 +577,8 @@ const insertActionByType = {
 };
 
 const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError, onChange}) => {
+    const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+
     const handlePick = useCallback((type: StepPickerType, anchor: CanvasAnchor) => {
         if (!automation) {
             return;
@@ -352,9 +601,13 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         return buildGraph({
             automation,
             disabled: automation.actions.length >= MAX_AUTOMATION_ACTIONS,
-            onPick: handlePick
+            onPick: handlePick,
+            onSelectStep: setSelectedStepId,
+            selectedStepId
         });
-    }, [automation, handlePick]);
+    }, [automation, handlePick, selectedStepId]);
+
+    const sidebarDetail = automation ? getStepSidebarDetail(automation, selectedStepId) : null;
 
     if (isLoading) {
         return (
@@ -381,7 +634,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
     }
 
     return (
-        <div className='flex-1 bg-surface-page' data-testid='automation-canvas'>
+        <div className='relative flex-1 overflow-hidden bg-surface-page' data-testid='automation-canvas'>
             <ReactFlow
                 className='[--xy-background-color:var(--surface-page)] [--xy-background-pattern-color:var(--border-subtle)] [--xy-edge-stroke:var(--border-subtle)] dark:[--xy-background-pattern-color:var(--color-grey-900)] dark:[--xy-edge-stroke:var(--color-grey-800)]'
                 defaultViewport={initialViewport.current}
@@ -396,9 +649,16 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
                 proOptions={{hideAttribution: true}}
                 zoomOnScroll={false}
                 panOnScroll
+                onNodeClick={(_, node) => {
+                    if (node.id !== TAIL_CANVAS_ID) {
+                        setSelectedStepId(node.id);
+                    }
+                }}
+                onPaneClick={() => setSelectedStepId(null)}
             >
                 <Background />
             </ReactFlow>
+            <StepSidebar detail={sidebarDetail} />
         </div>
     );
 };

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -1,6 +1,6 @@
 import '@xyflow/react/dist/style.css';
 import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
-import React, {useCallback, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
 import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
@@ -549,20 +549,39 @@ const StepSidebarContent: React.FC<{detail: StepSidebarDetail}> = ({detail}) => 
     );
 };
 
-const StepSidebar: React.FC<{detail: StepSidebarDetail | null}> = ({detail}) => (
-    <aside
-        aria-hidden={!detail}
-        aria-label='Step details'
-        className={cn(
-            'absolute inset-y-0 right-0 z-[1] flex w-[calc(100%-6rem)] max-w-none translate-x-full flex-col gap-6 overflow-y-auto border-l border-border-default bg-background p-6 shadow-lg transition-transform duration-200 ease-out sm:w-[36rem]',
-            detail ? 'translate-x-0' : 'pointer-events-none'
-        )}
-        data-state={detail ? 'open' : 'closed'}
-        data-testid='automation-step-sidebar'
-    >
-        {detail && <StepSidebarContent detail={detail} />}
-    </aside>
-);
+const StepSidebar: React.FC<{detail: StepSidebarDetail | null; onClose: () => void}> = ({detail, onClose}) => {
+    useEffect(() => {
+        if (!detail) {
+            return;
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [detail, onClose]);
+
+    return (
+        <aside
+            aria-hidden={!detail}
+            aria-label='Step details'
+            className={cn(
+                'absolute inset-y-0 right-0 z-[1] flex w-[calc(100%-6rem)] max-w-none translate-x-full flex-col gap-6 overflow-y-auto border-l border-border-default bg-background p-6 shadow-lg transition-transform duration-200 ease-out sm:w-[36rem]',
+                detail ? 'translate-x-0' : 'pointer-events-none'
+            )}
+            data-state={detail ? 'open' : 'closed'}
+            data-testid='automation-step-sidebar'
+        >
+            {detail && <StepSidebarContent detail={detail} />}
+        </aside>
+    );
+};
 
 type AutomationCanvasProps = {
     automation?: AutomationDetail;
@@ -608,6 +627,9 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
     }, [automation, handlePick, selectedStepId]);
 
     const sidebarDetail = automation ? getStepSidebarDetail(automation, selectedStepId) : null;
+    const clearDetail = useCallback(() => {
+        setSelectedStepId(null);
+    }, []);
 
     if (isLoading) {
         return (
@@ -654,11 +676,11 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
                         setSelectedStepId(node.id);
                     }
                 }}
-                onPaneClick={() => setSelectedStepId(null)}
+                onPaneClick={clearDetail}
             >
                 <Background />
             </ReactFlow>
-            <StepSidebar detail={sidebarDetail} />
+            <StepSidebar detail={sidebarDetail} onClose={clearDetail} />
         </div>
     );
 };

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -29,8 +29,11 @@ type StubEdge = {id: string; source: string; target: string; type?: string; data
 type StubReactFlowProps = {
     nodes: StubNode[];
     edges?: StubEdge[];
+    className?: string;
     nodeTypes?: Record<string, React.ComponentType<NodeRenderProps>>;
     edgeTypes?: Record<string, React.ComponentType<EdgeRenderProps>>;
+    onNodeClick?: (event: React.MouseEvent<HTMLDivElement>, node: StubNode) => void;
+    onPaneClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
 };
 type NodeRenderProps = {id: string; data: Record<string, unknown>; type: string};
 type EdgeRenderProps = {id: string; data: Record<string, unknown>; sourceX: number; sourceY: number; targetX: number; targetY: number; sourcePosition: string; targetPosition: string};
@@ -39,13 +42,21 @@ vi.mock('@xyflow/react', async () => {
     const actual = await vi.importActual<typeof import('@xyflow/react')>('@xyflow/react');
     return {
         ...actual,
-        ReactFlow: ({nodes, edges, nodeTypes, edgeTypes}: StubReactFlowProps) => (
-            <div data-testid='react-flow-mock'>
+        ReactFlow: ({nodes, edges, className, nodeTypes, edgeTypes, onNodeClick, onPaneClick}: StubReactFlowProps) => (
+            <div className={className} data-testid='react-flow-mock' onClick={onPaneClick}>
                 {nodes.map((node) => {
                     const nodeType = node.type ?? 'default';
                     const Custom = nodeTypes?.[nodeType];
                     return (
-                        <div key={node.id} data-node-id={node.id} data-node-type={nodeType}>
+                        <div
+                            key={node.id}
+                            data-node-id={node.id}
+                            data-node-type={nodeType}
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                onNodeClick?.(event, node);
+                            }}
+                        >
                             {Custom ? <Custom data={node.data ?? {}} id={node.id} type={nodeType} /> : null}
                         </div>
                     );
@@ -176,6 +187,102 @@ describe('AutomationEditor', () => {
             ['action-wait', 'action-email'],
             ['action-email', '__tail__']
         ]);
+    });
+
+    it('opens a read-only sidebar for the trigger step', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const trigger = screen.getByRole('button', {name: 'Trigger: Member signs up'});
+        fireEvent.click(trigger);
+
+        expect(trigger).toHaveAttribute('aria-pressed', 'true');
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).getByRole('heading', {name: 'Member signs up'})).toBeInTheDocument();
+        expect(within(sidebar).getByText('New member sign up')).toBeInTheDocument();
+        expect(within(sidebar).getByRole('checkbox', {name: 'Free'})).toBeChecked();
+        expect(within(sidebar).getByRole('checkbox', {name: 'Paid'})).not.toBeChecked();
+        expect(within(sidebar).queryByRole('button', {name: /Delete/})).not.toBeInTheDocument();
+        expect(within(sidebar).queryByRole('button', {name: /Edit/})).not.toBeInTheDocument();
+    });
+
+    it('shows paid member eligibility for the paid welcome automation trigger', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {
+                automations: [{
+                    ...automationDetail,
+                    slug: 'member-welcome-email-paid',
+                    name: 'Welcome Email (Paid)'
+                }]
+            },
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Trigger: Member signs up'}));
+
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).getByRole('checkbox', {name: 'Free'})).not.toBeChecked();
+        expect(within(sidebar).getByRole('checkbox', {name: 'Paid'})).toBeChecked();
+    });
+
+    it('switches the read-only sidebar content when another step is clicked', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const waitStep = screen.getByRole('button', {name: 'Wait: 1 day'});
+        fireEvent.click(waitStep);
+
+        let sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(waitStep).toHaveAttribute('aria-pressed', 'true');
+        expect(within(sidebar).getByRole('heading', {name: '1 day'})).toBeInTheDocument();
+        expect(within(sidebar).getByText('Wait')).toBeInTheDocument();
+        expect(within(sidebar).getByText('Wait for')).toBeInTheDocument();
+        expect(within(sidebar).getByRole('button', {name: 'Delete step'})).toBeDisabled();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        fireEvent.click(emailStep);
+
+        sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(waitStep).toHaveAttribute('aria-pressed', 'false');
+        expect(emailStep).toHaveAttribute('aria-pressed', 'true');
+        expect(within(sidebar).getByRole('heading', {name: 'Welcome to The Blueprint'})).toBeInTheDocument();
+        expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toBeInTheDocument();
+        expect(within(sidebar).queryByText('Sender')).not.toBeInTheDocument();
+        expect(within(sidebar).queryByText('Reply-to')).not.toBeInTheDocument();
+        expect(within(sidebar).getByRole('button', {name: 'Edit email'})).toBeDisabled();
+        expect(within(sidebar).getByRole('button', {name: 'Delete step'})).toBeDisabled();
+    });
+
+    it('closes the sidebar from a blank canvas click', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const trigger = screen.getByRole('button', {name: 'Trigger: Member signs up'});
+        fireEvent.click(trigger);
+        expect(screen.getByRole('complementary', {name: 'Step details'})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Close step sidebar'})).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('react-flow-mock'));
+        expect(screen.queryByRole('complementary', {name: 'Step details'})).not.toBeInTheDocument();
+        expect(trigger).toHaveAttribute('aria-pressed', 'false');
     });
 
     it('disables the publish button when the read query fails', () => {

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -285,6 +285,24 @@ describe('AutomationEditor', () => {
         expect(trigger).toHaveAttribute('aria-pressed', 'false');
     });
 
+    it('closes the sidebar with Escape', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const waitStep = screen.getByRole('button', {name: 'Wait: 1 day'});
+        fireEvent.click(waitStep);
+
+        fireEvent.keyDown(document, {key: 'Escape'});
+
+        expect(screen.queryByRole('complementary', {name: 'Step details'})).not.toBeInTheDocument();
+        expect(waitStep).toHaveAttribute('aria-pressed', 'false');
+    });
+
     it('disables the publish button when the read query fails', () => {
         mockUseReadAutomation.mockReturnValue({
             data: undefined,


### PR DESCRIPTION
towards [NY-1254](https://linear.app/ghost/issue/NY-1254/on-step-click-open-sidebar-with-editdelete-actions)

- clicking a step opens a sidebar with step details
- for now, trigger just shows free/paid, is not editable or deleteable
- wait and send email show their respective information and buttons, but the buttons and inputs don't do anything

<img width="1591" height="1034" alt="image" src="https://github.com/user-attachments/assets/227e572f-b697-424a-98c0-80374ac6d4fd" />
