### PR TITLE
Converted 5 deferred done() callback tests to async/await + vitest

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -59,7 +59,7 @@
     "test:all": "pnpm test:unit && pnpm test:integration && pnpm test:e2e && pnpm lint",
     "test:debug": "DEBUG=ghost:test* pnpm test",
     "test:unit": "c8 pnpm test:unit:${GHOST_UNIT_TEST_VARIANT:-base}",
-    "test:unit:base": "pnpm test:base ./test/unit/api ./test/unit/frontend ./test/unit/server/models ./test/unit/server/services ./test/unit/server/notify.test.js ./test/unit/server/overrides.test.js ./test/unit/server/adapters/scheduling/scheduling-default.test.js ./test/unit/server/adapters/storage/local-images-storage.test.js ./test/unit/server/lib/image/blog-icon.test.js ./test/unit/server/lib/image/gravatar.test.js ./test/unit/server/lib/package-json/parse.test.js ./test/unit/server/web/api/middleware/cors.test.js --timeout=2000",
+    "test:unit:base": "pnpm test:base ./test/unit/api ./test/unit/frontend ./test/unit/server/models ./test/unit/server/services ./test/unit/server/notify.test.js ./test/unit/server/overrides.test.js ./test/unit/server/adapters/scheduling/scheduling-default.test.js --timeout=2000",
     "test:unit:ci": "pnpm test:unit:base --reporter=min",
     "test:integration": "pnpm test:base './test/integration' --timeout=10000",
     "test:e2e": "pnpm test:base ./test/e2e-* --timeout=15000",

--- a/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
@@ -51,62 +51,44 @@ describe('Local Images Storage', function () {
         fakeDate(9, 2013);
     });
 
-    it('should send correct path to image when date is in Sep 2013', function (done) {
-        localFileStore.save(image).then(function (url) {
-            assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
-
-            done();
-        }).catch(done);
+    it('should send correct path to image when date is in Sep 2013', async function () {
+        const url = await localFileStore.save(image);
+        assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
     });
 
-    it('should send correct path to image when original file has spaces', function (done) {
+    it('should send correct path to image when original file has spaces', async function () {
         image.name = 'AN IMAGE.jpg';
-        localFileStore.save(image).then(function (url) {
-            assert.equal(url, '/content/images/2013/09/AN-IMAGE.jpg');
-
-            done();
-        }).catch(done);
+        const url = await localFileStore.save(image);
+        assert.equal(url, '/content/images/2013/09/AN-IMAGE.jpg');
     });
 
-    it('should allow "@" symbol to image for Apple hi-res (retina) modifier', function (done) {
+    it('should allow "@" symbol to image for Apple hi-res (retina) modifier', async function () {
         image.name = 'photo@2x.jpg';
-        localFileStore.save(image).then(function (url) {
-            assert.equal(url, '/content/images/2013/09/photo@2x.jpg');
-
-            done();
-        }).catch(done);
+        const url = await localFileStore.save(image);
+        assert.equal(url, '/content/images/2013/09/photo@2x.jpg');
     });
 
-    it('should send correct path to image when date is in Jan 2014', function (done) {
+    it('should send correct path to image when date is in Jan 2014', async function () {
         fakeDate(1, 2014);
 
-        localFileStore.save(image).then(function (url) {
-            assert.equal(url, '/content/images/2014/01/IMAGE.jpg');
-
-            done();
-        }).catch(done);
+        const url = await localFileStore.save(image);
+        assert.equal(url, '/content/images/2014/01/IMAGE.jpg');
     });
 
-    it('should create month and year directory', function (done) {
-        localFileStore.save(image).then(function () {
-            sinon.assert.calledOnce(fsMkdirsStub);
-            assert.equal(fsMkdirsStub.args[0][0], path.resolve('./content/images/2013/09'));
-
-            done();
-        }).catch(done);
+    it('should create month and year directory', async function () {
+        await localFileStore.save(image);
+        sinon.assert.calledOnce(fsMkdirsStub);
+        assert.equal(fsMkdirsStub.args[0][0], path.resolve('./content/images/2013/09'));
     });
 
-    it('should copy temp file to new location', function (done) {
-        localFileStore.save(image).then(function () {
-            sinon.assert.calledOnce(fsCopyStub);
-            assert.equal(fsCopyStub.args[0][0], 'tmp/123456.jpg');
-            assert.equal(fsCopyStub.args[0][1], path.resolve('./content/images/2013/09/IMAGE.jpg'));
-
-            done();
-        }).catch(done);
+    it('should copy temp file to new location', async function () {
+        await localFileStore.save(image);
+        sinon.assert.calledOnce(fsCopyStub);
+        assert.equal(fsCopyStub.args[0][0], 'tmp/123456.jpg');
+        assert.equal(fsCopyStub.args[0][1], path.resolve('./content/images/2013/09/IMAGE.jpg'));
     });
 
-    it('can upload two different images with the same name without overwriting the first', function (done) {
+    it('can upload two different images with the same name without overwriting the first', async function () {
         fsStatStub.withArgs(path.resolve('./content/images/2013/09/IMAGE.jpg')).resolves();
         fsStatStub.withArgs(path.resolve('./content/images/2013/09/IMAGE-1.jpg')).rejects();
 
@@ -115,14 +97,11 @@ describe('Local Images Storage', function () {
         fsStatStub.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE.jpg')).resolves();
         fsStatStub.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-1.jpg')).rejects();
 
-        localFileStore.save(image).then(function (url) {
-            assert.equal(url, '/content/images/2013/09/IMAGE-1.jpg');
-
-            done();
-        }).catch(done);
+        const url = await localFileStore.save(image);
+        assert.equal(url, '/content/images/2013/09/IMAGE-1.jpg');
     });
 
-    it('can upload five different images with the same name without overwriting the first', function (done) {
+    it('can upload five different images with the same name without overwriting the first', async function () {
         fsStatStub.withArgs(path.resolve('./content/images/2013/09/IMAGE.jpg')).resolves();
         fsStatStub.withArgs(path.resolve('./content/images/2013/09/IMAGE-1.jpg')).resolves();
         fsStatStub.withArgs(path.resolve('./content/images/2013/09/IMAGE-2.jpg')).resolves();
@@ -136,11 +115,8 @@ describe('Local Images Storage', function () {
         fsStatStub.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-3.jpg')).resolves();
         fsStatStub.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-4.jpg')).rejects();
 
-        localFileStore.save(image).then(function (url) {
-            assert.equal(url, '/content/images/2013/09/IMAGE-4.jpg');
-
-            done();
-        }).catch(done);
+        const url = await localFileStore.save(image);
+        assert.equal(url, '/content/images/2013/09/IMAGE-4.jpg');
     });
 
     describe('read image', function () {
@@ -149,61 +125,48 @@ describe('Local Images Storage', function () {
             localFileStore.storagePath = path.join(__dirname, '../../../../utils/fixtures/images/');
         });
 
-        it('success', function (done) {
-            localFileStore.read({path: 'ghost-logo.png'})
-                .then(function (bytes) {
-                    assert.equal(bytes.length, 8638);
-                    done();
-                });
+        it('success', async function () {
+            const bytes = await localFileStore.read({path: 'ghost-logo.png'});
+            assert.equal(bytes.length, 8638);
         });
 
-        it('success (leading and trailing slashes)', function (done) {
-            localFileStore.read({path: '/ghost-logo.png/'})
-                .then(function (bytes) {
-                    assert.equal(bytes.length, 8638);
-                    done();
-                });
+        it('success (leading and trailing slashes)', async function () {
+            const bytes = await localFileStore.read({path: '/ghost-logo.png/'});
+            assert.equal(bytes.length, 8638);
         });
 
-        it('image does not exist', function (done) {
-            localFileStore.read({path: 'does-not-exist.png'})
-                .then(function () {
-                    done(new Error('image should not exist'));
-                })
-                .catch(function (err) {
+        it('image does not exist', async function () {
+            await assert.rejects(
+                localFileStore.read({path: 'does-not-exist.png'}),
+                (err) => {
                     assert.equal((err instanceof errors.NotFoundError), true);
                     assert.equal(err.code, 'ENOENT');
-                    done();
-                });
+                    return true;
+                }
+            );
         });
     });
 
     describe('validate extentions', function () {
-        it('name contains a .\d as extension', function (done) {
-            localFileStore.save({
+        it('name contains a .\d as extension', async function () {
+            const url = await localFileStore.save({
                 name: 'test-1.1.1'
-            }).then(function (url) {
-                assertExists(url.match(/test-1.1.1/));
-                done();
-            }).catch(done);
+            });
+            assertExists(url.match(/test-1.1.1/));
         });
 
-        it('name contains a .zip as extension', function (done) {
-            localFileStore.save({
+        it('name contains a .zip as extension', async function () {
+            const url = await localFileStore.save({
                 name: 'test-1.1.1.zip'
-            }).then(function (url) {
-                assertExists(url.match(/test-1.1.1.zip/));
-                done();
-            }).catch(done);
+            });
+            assertExists(url.match(/test-1.1.1.zip/));
         });
 
-        it('name contains a .jpeg as extension', function (done) {
-            localFileStore.save({
+        it('name contains a .jpeg as extension', async function () {
+            const url = await localFileStore.save({
                 name: 'test-1.1.1.jpeg'
-            }).then(function (url) {
-                assertExists(url.match(/test-1.1.1.jpeg/));
-                done();
-            }).catch(done);
+            });
+            assertExists(url.match(/test-1.1.1.jpeg/));
         });
     });
 
@@ -213,12 +176,9 @@ describe('Local Images Storage', function () {
             configUtils.set('paths:contentPath', configPaths.appRoot + '/var/ghostcms');
         });
 
-        it('should send the correct path to image', function (done) {
-            localFileStore.save(image).then(function (url) {
-                assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
-
-                done();
-            }).catch(done);
+        it('should send the correct path to image', async function () {
+            const url = await localFileStore.save(image);
+            assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
         });
     });
 
@@ -236,23 +196,20 @@ describe('Local Images Storage', function () {
             path.sep = truePathSep;
         });
 
-        it('should return url in proper format for windows', function (done) {
+        it('should return url in proper format for windows', async function () {
             path.sep = '\\';
             pathJoinStub.returns('content\\images\\2013\\09\\IMAGE.jpg');
 
-            localFileStore.save(image).then(function (url) {
-                if (truePathSep === '\\') {
-                    assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
-                } else {
-                    // if this unit test is run on an OS that uses forward slash separators,
-                    // localfilesystem.save() will use a path.relative() call on
-                    // one path with backslash separators and one path with forward
-                    // slashes and it returns a path that needs to be normalized
-                    assert.equal(path.normalize(url), '/content/images/2013/09/IMAGE.jpg');
-                }
-
-                done();
-            }).catch(done);
+            const url = await localFileStore.save(image);
+            if (truePathSep === '\\') {
+                assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
+            } else {
+                // if this unit test is run on an OS that uses forward slash separators,
+                // localfilesystem.save() will use a path.relative() call on
+                // one path with backslash separators and one path with forward
+                // slashes and it returns a path that needs to be normalized
+                assert.equal(path.normalize(url), '/content/images/2013/09/IMAGE.jpg');
+            }
         });
     });
 });

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -224,55 +224,44 @@ describe('lib/image: blog icon', function () {
     });
 
     describe('getIconDimensions', function () {
-        it('[success] returns .ico dimensions', function (done) {
+        it('[success] returns .ico dimensions', async function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
-            blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon.ico'))
-                .then(function (result) {
-                    assertExists(result);
-                    assert.deepEqual(result, {
-                        width: 48,
-                        height: 48
-                    });
-                    done();
-                }).catch(done);
+            const result = await blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon.ico'));
+            assertExists(result);
+            assert.deepEqual(result, {
+                width: 48,
+                height: 48
+            });
         });
 
-        it('[success] returns .png dimensions', function (done) {
+        it('[success] returns .png dimensions', async function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
-            blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon.png'))
-                .then(function (result) {
-                    assertExists(result);
-                    assert.deepEqual(result, {
-                        width: 100,
-                        height: 100
-                    });
-                    done();
-                }).catch(done);
+            const result = await blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon.png'));
+            assertExists(result);
+            assert.deepEqual(result, {
+                width: 100,
+                height: 100
+            });
         });
 
-        it('[success] returns .ico dimensions for icon with multiple sizes', function (done) {
+        it('[success] returns .ico dimensions for icon with multiple sizes', async function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
-            blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon_multi_sizes.ico'))
-                .then(function (result) {
-                    assertExists(result);
-                    assert.deepEqual(result, {
-                        width: 64,
-                        height: 64
-                    });
-                    done();
-                }).catch(done);
+            const result = await blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon_multi_sizes.ico'));
+            assertExists(result);
+            assert.deepEqual(result, {
+                width: 64,
+                height: 64
+            });
         });
 
-        it('[failure] return error message', function (done) {
+        it('[failure] return error message', async function () {
             const blogIcon = new BlogIcon({config: {}, tpl: key => key
                 , storageUtils: {}, urlUtils: {}, settingsCache: {}});
 
-            blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon_multi_sizes_FILE_DOES_NOT_EXIST.ico'))
-                .catch(function (error) {
-                    assertExists(error);
-                    assert.equal(error.message, 'Could not fetch icon dimensions.');
-                    done();
-                });
+            await assert.rejects(
+                blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon_multi_sizes_FILE_DOES_NOT_EXIST.ico')),
+                {message: 'Could not fetch icon dimensions.'}
+            );
         });
     });
 });

--- a/ghost/core/test/unit/server/lib/image/gravatar.test.js
+++ b/ghost/core/test/unit/server/lib/image/gravatar.test.js
@@ -21,7 +21,7 @@ describe('lib/image: gravatar', function () {
         }), 'https://www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=180&r=r&d=blank');
     });
 
-    it('can successfully lookup a gravatar url', function (done) {
+    it('can successfully lookup a gravatar url', async function () {
         const gravatar = new Gravatar({config: {
             isPrivacyDisabled: () => false,
             get: (config) => {
@@ -31,16 +31,13 @@ describe('lib/image: gravatar', function () {
             }
         }, request: () => {}});
 
-        gravatar.lookup({email: 'exists@example.com'}).then(function (result) {
-            assertExists(result);
-            assertExists(result.image);
-            assert.equal(result.image, 'https://www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&r=x&d=mp');
-
-            done();
-        }).catch(done);
+        const result = await gravatar.lookup({email: 'exists@example.com'});
+        assertExists(result);
+        assertExists(result.image);
+        assert.equal(result.image, 'https://www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&r=x&d=mp');
     });
 
-    it('can handle a non existant gravatar', function (done) {
+    it('can handle a non existant gravatar', async function () {
         const gravatar = new Gravatar({config: {
             isPrivacyDisabled: () => false,
             get: (config) => {
@@ -52,12 +49,9 @@ describe('lib/image: gravatar', function () {
             return Promise.reject({statusCode: 404});
         }});
 
-        gravatar.lookup({email: 'invalid@example.com'}).then(function (result) {
-            assertExists(result);
-            assert.equal(result.image, undefined);
-
-            done();
-        }).catch(done);
+        const result = await gravatar.lookup({email: 'invalid@example.com'});
+        assertExists(result);
+        assert.equal(result.image, undefined);
     });
 
     it('will timeout', function () {

--- a/ghost/core/test/unit/server/lib/package-json/parse.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/parse.test.js
@@ -5,121 +5,92 @@ const fs = require('fs-extra');
 const parse = require('../../../../../core/server/lib/package-json/parse');
 
 describe('package-json parse', function () {
-    it('should parse valid package.json', function (done) {
-        let pkgJson;
-        let tmpFile;
-
-        tmpFile = tmp.fileSync();
-        pkgJson = JSON.stringify({
+    it('should parse valid package.json', async function () {
+        const tmpFile = tmp.fileSync();
+        const pkgJson = JSON.stringify({
             name: 'test',
             version: '0.0.0'
         });
 
         fs.writeSync(tmpFile.fd, pkgJson);
 
-        parse(tmpFile.name)
-            .then(function (pkg) {
-                assert.deepEqual(pkg, {
-                    name: 'test',
-                    version: '0.0.0'
-                });
-
-                done();
-            })
-            .catch(done)
-            .finally(tmpFile.removeCallback);
+        try {
+            const pkg = await parse(tmpFile.name);
+            assert.deepEqual(pkg, {
+                name: 'test',
+                version: '0.0.0'
+            });
+        } finally {
+            tmpFile.removeCallback();
+        }
     });
 
-    it('should fail when name is missing', function (done) {
-        let pkgJson;
-        let tmpFile;
-
-        tmpFile = tmp.fileSync();
-        pkgJson = JSON.stringify({
+    it('should fail when name is missing', async function () {
+        const tmpFile = tmp.fileSync();
+        const pkgJson = JSON.stringify({
             version: '0.0.0'
         });
 
         fs.writeSync(tmpFile.fd, pkgJson);
 
-        parse(tmpFile.name)
-            .then(function () {
-                done(new Error('packageJSON.parse succeeded, but should\'ve failed'));
-            })
-            .catch(function (err) {
+        try {
+            await assert.rejects(parse(tmpFile.name), (err) => {
                 assert.equal(err.message, '"name" or "version" is missing from theme package.json file.');
                 assert.equal(err.context, tmpFile.name);
                 assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
-
-                done();
-            })
-            .catch(done)
-            .finally(tmpFile.removeCallback);
+                return true;
+            });
+        } finally {
+            tmpFile.removeCallback();
+        }
     });
 
-    it('should fail when version is missing', function (done) {
-        let pkgJson;
-        let tmpFile;
-
-        tmpFile = tmp.fileSync();
-        pkgJson = JSON.stringify({
+    it('should fail when version is missing', async function () {
+        const tmpFile = tmp.fileSync();
+        const pkgJson = JSON.stringify({
             name: 'test'
         });
 
         fs.writeSync(tmpFile.fd, pkgJson);
 
-        parse(tmpFile.name)
-            .then(function () {
-                done(new Error('packageJSON.parse succeeded, but should\'ve failed'));
-            })
-            .catch(function (err) {
+        try {
+            await assert.rejects(parse(tmpFile.name), (err) => {
                 assert.equal(err.message, '"name" or "version" is missing from theme package.json file.');
                 assert.equal(err.context, tmpFile.name);
                 assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
-
-                done();
-            })
-            .catch(done)
-            .finally(tmpFile.removeCallback);
+                return true;
+            });
+        } finally {
+            tmpFile.removeCallback();
+        }
     });
 
-    it('should fail when JSON is invalid', function (done) {
-        let pkgJson;
-        let tmpFile;
-
-        tmpFile = tmp.fileSync();
-        pkgJson = '{name:"test"}';
+    it('should fail when JSON is invalid', async function () {
+        const tmpFile = tmp.fileSync();
+        const pkgJson = '{name:"test"}';
 
         fs.writeSync(tmpFile.fd, pkgJson);
 
-        parse(tmpFile.name)
-            .then(function () {
-                done(new Error('packageJSON.parse succeeded, but should\'ve failed'));
-            })
-            .catch(function (err) {
+        try {
+            await assert.rejects(parse(tmpFile.name), (err) => {
                 assert.equal(err.message, 'Theme package.json file is malformed');
                 assert.equal(err.context, tmpFile.name);
                 assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
-
-                done();
-            })
-            .catch(done)
-            .finally(tmpFile.removeCallback);
+                return true;
+            });
+        } finally {
+            tmpFile.removeCallback();
+        }
     });
 
-    it('should fail when file is missing', function (done) {
+    it('should fail when file is missing', async function () {
         const tmpFile = tmp.fileSync();
 
         tmpFile.removeCallback();
-        parse(tmpFile.name)
-            .then(function () {
-                done(new Error('packageJSON.parse succeeded, but should\'ve failed'));
-            })
-            .catch(function (err) {
-                assert.equal(err.message, 'Could not read package.json file');
-                assert.equal(err.context, tmpFile.name);
-
-                done();
-            })
-            .catch(done);
+        await assert.rejects(parse(tmpFile.name), (err) => {
+            assert.equal(err.message, 'Could not read package.json file');
+            assert.equal(err.context, tmpFile.name);
+            return true;
+        });
     });
 });

--- a/ghost/core/test/unit/server/web/api/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/cors.test.js
@@ -40,18 +40,16 @@ describe('cors', function () {
         cors = rewire('../../../../../../core/server/web/api/middleware/cors').corsMiddleware;
     });
 
-    it('should not be enabled without a request origin header', function (done) {
+    it('should not be enabled without a request origin header', function () {
         req.get = sinon.stub().withArgs('origin').returns(null);
 
         cors(req, res, next);
 
         sinon.assert.calledOnce(next);
         assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
-
-        done();
     });
 
-    it('should be enabled when origin is 127.0.0.1', function (done) {
+    it('should be enabled when origin is 127.0.0.1', function () {
         const origin = 'http://127.0.0.1:2368';
 
         req.get = sinon.stub().withArgs('origin').returns(origin);
@@ -62,11 +60,9 @@ describe('cors', function () {
 
         sinon.assert.calledOnce(res.end);
         assert.equal(res.headers['Access-Control-Allow-Origin'], origin);
-
-        done();
     });
 
-    it('should be enabled when origin is localhost', function (done) {
+    it('should be enabled when origin is localhost', function () {
         const origin = 'http://localhost:2368';
 
         req.get = sinon.stub().withArgs('origin').returns(origin);
@@ -77,11 +73,9 @@ describe('cors', function () {
 
         sinon.assert.calledOnce(res.end);
         assert.equal(res.headers['Access-Control-Allow-Origin'], origin);
-
-        done();
     });
 
-    it('should not be enabled the if origin is not allowed', function (done) {
+    it('should not be enabled the if origin is not allowed', function () {
         const origin = 'http://not-trusted.com';
 
         req.get = sinon.stub().withArgs('origin').returns(origin);
@@ -92,11 +86,9 @@ describe('cors', function () {
 
         sinon.assert.calledOnce(next);
         assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
-
-        done();
     });
 
-    it('should be enabled if the origin matches config.url', function (done) {
+    it('should be enabled if the origin matches config.url', function () {
         const origin = 'http://my.blog';
 
         configUtils.set({url: origin});
@@ -109,11 +101,9 @@ describe('cors', function () {
 
         sinon.assert.calledOnce(res.end);
         assert.equal(res.headers['Access-Control-Allow-Origin'], origin);
-
-        done();
     });
 
-    it('should be enabled if the origin matches config.admin.url', function (done) {
+    it('should be enabled if the origin matches config.admin.url', function () {
         const origin = 'http://admin:2222';
 
         configUtils.set({
@@ -131,23 +121,25 @@ describe('cors', function () {
 
         sinon.assert.called(res.end);
         assert.equal(res.headers['Access-Control-Allow-Origin'], origin);
-
-        done();
     });
 
-    it('should add origin value to the vary header', function (done) {
-        corsCaching(req, res, function () {
-            sinon.assert.calledOnce(res.vary);
-            sinon.assert.calledWith(res.vary, 'Origin');
-            done();
+    it('should add origin value to the vary header', async function () {
+        await new Promise((resolve) => {
+            corsCaching(req, res, function () {
+                sinon.assert.calledOnce(res.vary);
+                sinon.assert.calledWith(res.vary, 'Origin');
+                resolve();
+            });
         });
     });
 
-    it('should NOT add origin value to the vary header when not an OPTIONS request', function (done) {
+    it('should NOT add origin value to the vary header when not an OPTIONS request', async function () {
         req.method = 'GET';
-        corsCaching(req, res, function () {
-            sinon.assert.notCalled(res.vary);
-            done();
+        await new Promise((resolve) => {
+            corsCaching(req, res, function () {
+                sinon.assert.notCalled(res.vary);
+                resolve();
+            });
         });
     });
 });

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -21,15 +21,10 @@ export default defineConfig({
             'test/unit/server/lib/**/*.test.{js,ts}',
             'test/unit/server/web/**/*.test.{js,ts}'
         ],
-        // Files using the mocha `done()` callback — vitest 4.x removed
-        // support. Pending follow-up PR that converts these to promises.
+        // Fake-timer + nock + retry-loop interactions in this file don't
+        // translate cleanly to vitest's hook ordering; deferred to a follow-up.
         exclude: [
             'test/unit/server/adapters/scheduling/scheduling-default.test.js',
-            'test/unit/server/adapters/storage/local-images-storage.test.js',
-            'test/unit/server/lib/image/blog-icon.test.js',
-            'test/unit/server/lib/image/gravatar.test.js',
-            'test/unit/server/lib/package-json/parse.test.js',
-            'test/unit/server/web/api/middleware/cors.test.js',
             '**/node_modules/**'
         ],
         setupFiles: ['./test/utils/vitest-setup.ts'],


### PR DESCRIPTION
## Summary

Continues the vitest migration started in #27898 / #27900. Converts 5 of the 6 test files that were deferred because they used mocha's `done()` callback (vitest 4.x dropped support), and moves them from mocha to vitest.

The 6th file — `test/unit/server/adapters/scheduling/scheduling-default.test.js` — stays in mocha. Its fake-timer + nock + retry-loop interactions don't translate cleanly to vitest's hook ordering (see "Deferred file" below).

## Files migrated to vitest

| File | done() calls |
| --- | --- |
| `test/unit/server/adapters/storage/local-images-storage.test.js` | 17 |
| `test/unit/server/lib/image/blog-icon.test.js` | 4 |
| `test/unit/server/lib/image/gravatar.test.js` | 2 |
| `test/unit/server/lib/package-json/parse.test.js` | 9 |
| `test/unit/server/web/api/middleware/cors.test.js` | 8 |

~40 callbacks total. Behavior is unchanged — patterns used:
- `.then(fn).catch(done)` → `await … ; assertions inline`
- `.then(fail).catch(check)` (negative cases) → `await assert.rejects(promise, validator)`
- callback-style middleware (`corsCaching(req, res, () => done())`) → wrap in `new Promise(resolve => …)` and `await`
- tmp-file cleanup via `.finally(tmpFile.removeCallback)` → `try { … } finally { tmpFile.removeCallback(); }`

## Mechanics

- Dropped 5 files from `vitest.config.ts` → `test.exclude`
- Removed the 5 files from `test:unit:base` in `package.json` so mocha no longer runs them
- Vitest is now the sole runner for these files (matches the model established in #27900)

## Deferred file

`test/unit/server/adapters/scheduling/scheduling-default.test.js` remains excluded from vitest. The hard problem is that several tests use a `(function retry() { if (cond) done(); else setTimeout(retry, N); })()` polling pattern combined with `sinon.useFakeTimers({shouldAdvanceTime: true})` and nock-intercepted got requests. Naive ports — `while (!cond) await wait(N)` or `clock.tickAsync()` — hang under vitest because the awaited timer doesn't drive the request promise to settle the way the recursive sync setTimeout does in mocha. The fix likely needs either a different test structure or selective real-timer use; tackling it alongside the other 5 files would have made this PR much noisier. Filed as next-up follow-up.

## Test plan

- [x] `pnpm test:vitest` (from `ghost/core`): 86 files / 879 passed + 3 skipped
- [x] `pnpm test:unit:base` (mocha): 5643 tests pass
- [x] `pnpm exec eslint` clean for changed files
- [ ] CI green