### PR TITLE
Added gift subscriptions discovery section in membership settings

### DIFF
--- a/apps/admin-x-design-system/src/assets/icons/gift.svg
+++ b/apps/admin-x-design-system/src/assets/icons/gift.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="8" width="18" height="4" rx="1" />
+  <path d="M12 8v13" />
+  <path d="M19 12v7a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-7" />
+  <path d="M7.5 8a2.5 2.5 0 0 1 0-5A4.8 8 0 0 1 12 8a4.8 8 0 0 1 4.5-5 2.5 2.5 0 0 1 0 5" />
+</svg>

--- a/apps/admin-x-settings/src/components/settings/membership/gift-subscriptions.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/gift-subscriptions.tsx
@@ -1,0 +1,49 @@
+import React, {useState} from 'react';
+import TopLevelGroup from '../../top-level-group';
+import {Button, Heading, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {useGlobalData} from '../../providers/global-data-provider';
+
+const GiftSubscriptions: React.FC<{ keywords: string[] }> = ({keywords}) => {
+    const {siteData} = useGlobalData();
+    const [copied, setCopied] = useState(false);
+
+    const giftUrl = `${siteData?.url.replace(/\/$/, '')}/#/portal/gift`;
+
+    const copyGiftUrl = () => {
+        navigator.clipboard.writeText(giftUrl);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    const openPreview = () => {
+        window.open(giftUrl, '_blank');
+    };
+
+    return (
+        <TopLevelGroup
+            description={<>Allow your readers to share your work by purchasing a gift subscription for a friend or colleague. <a className='text-green' href="https://ghost.org/help/gift-subscriptions/" rel="noopener noreferrer" target="_blank">Learn more</a></>}
+            keywords={keywords}
+            navid='gift-subscriptions'
+            testId='gift-subscriptions'
+            title="Gift subscriptions"
+            hideEditButton
+        >
+            <SettingGroupContent columns={1}>
+                <div className='w-100'>
+                    <div className='flex items-center gap-2'>
+                        <Heading level={6}>Shareable link</Heading>
+                    </div>
+                    <div className='group relative mt-0 flex w-100 items-center justify-between overflow-hidden border-b border-transparent pt-1 pb-2 hover:border-grey-300 dark:hover:border-grey-600'>
+                        <span data-testid='gift-url'>{giftUrl}</span>
+                        <div className='invisible flex gap-1 bg-white pl-1 group-hover:visible dark:bg-black'>
+                            <Button color='clear' data-testid='preview-shareable-link' label={'Preview'} size='sm' onClick={openPreview} />
+                            <Button color='light-grey' data-testid='copy-shareable-link' label={copied ? 'Copied' : 'Copy link'} size='sm' onClick={copyGiftUrl} />
+                        </div>
+                    </div>
+                </div>
+            </SettingGroupContent>
+        </TopLevelGroup>
+    );
+};
+
+export default withErrorBoundary(GiftSubscriptions, 'Gift subscriptions');

--- a/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
@@ -1,4 +1,5 @@
 import Access from './access';
+import GiftSubscriptions from './gift-subscriptions';
 import MemberEmails from './member-emails';
 import Portal from './portal';
 import React from 'react';
@@ -14,6 +15,7 @@ export const searchKeywords = {
     access: ['membership', 'default', 'access', 'subscription', 'post', 'membership', 'comments', 'commenting', 'signup', 'sign up', 'spam', 'filters', 'prevention', 'prevent', 'block', 'domains', 'email', 'password protection', 'lock site', 'private site', 'private site mode', 'make this site private'],
     tiers: ['membership', 'tiers', 'payment', 'paid', 'stripe'],
     portal: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership', 'support', 'email', 'address', 'support email address', 'support address'],
+    giftSubscriptions: ['membership', 'gift', 'gifts', 'gift subscriptions', 'present', 'share', 'shareable link'],
     memberEmails: ['membership', 'signup', 'welcome email', 'welcome emails', 'email', 'new user', 'new member', 'account'],
     tips: ['growth', 'tips', 'donations', 'one time', 'payment']
 };
@@ -23,10 +25,12 @@ const MembershipSettings: React.FC = () => {
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
     const hasAutomations = useFeatureFlag('automations');
+    const hasGiftSubscriptions = useFeatureFlag('giftSubscriptions');
     const visibleSearchKeywords = [
         searchKeywords.access,
         searchKeywords.tiers,
         searchKeywords.portal,
+        ...(hasGiftSubscriptions && hasStripeEnabled ? [searchKeywords.giftSubscriptions] : []),
         ...(hasAutomations ? [] : [searchKeywords.memberEmails]),
         searchKeywords.tips
     ].flat();
@@ -37,6 +41,7 @@ const MembershipSettings: React.FC = () => {
             <SpamFilters keywords={searchKeywords.access} />
             <Tiers keywords={searchKeywords.tiers} />
             <Portal keywords={searchKeywords.portal} />
+            {hasGiftSubscriptions && hasStripeEnabled && <GiftSubscriptions keywords={searchKeywords.giftSubscriptions} />}
             {!hasAutomations && <MemberEmails keywords={searchKeywords.memberEmails} />}
             {hasTipsAndDonations && hasStripeEnabled && <TipsAndDonations keywords={searchKeywords.tips} />}
         </SearchableSection>

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -57,13 +57,15 @@ const Sidebar: React.FC = () => {
     const [hasTipsAndDonations, isPrivate] = getSettingValues(settings, ['donations_enabled', 'is_private']) as [string, boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
     const hasAutomations = useFeatureFlag('automations');
+    const hasGiftSubscriptions = useFeatureFlag('giftSubscriptions');
     const visibleMembershipSearchKeywords = React.useMemo(() => [
         membershipSearchKeywords.access,
         membershipSearchKeywords.tiers,
         membershipSearchKeywords.portal,
+        ...(hasGiftSubscriptions && hasStripeEnabled ? [membershipSearchKeywords.giftSubscriptions] : []),
         ...(hasAutomations ? [] : [membershipSearchKeywords.memberEmails]),
         membershipSearchKeywords.tips
-    ].flat(), [hasAutomations]);
+    ].flat(), [hasAutomations, hasGiftSubscriptions, hasStripeEnabled]);
 
     // Focus in on search field when pressing "/"
     useEffect(() => {
@@ -218,6 +220,7 @@ const Sidebar: React.FC = () => {
                     />
                     <NavItem icon='bills' keywords={membershipSearchKeywords.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
                     <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
+                    {hasGiftSubscriptions && hasStripeEnabled && <NavItem icon='gift' keywords={membershipSearchKeywords.giftSubscriptions} navid='gift-subscriptions' title="Gift subscriptions" onClick={handleSectionClick} />}
                     {!hasAutomations && <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />}
                     {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
                     <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3676/add-gift-subscriptions-discovery-link-in-settings

Mirrors the tips & donations pattern with a shareable link and preview/copy controls. Gated on the giftSubscriptions flag and Stripe being connected.

