### PR TITLE
Added a warning badge variant and updated comments header

### DIFF
--- a/apps/posts/src/views/comments/components/comment-content.tsx
+++ b/apps/posts/src/views/comments/components/comment-content.tsx
@@ -42,7 +42,7 @@ function CommentContent({item}: {item: Comment}) {
     }, [item.html, isExpanded]);
 
     return (
-        <div className={`mt-1 flex flex-col gap-2`}>
+        <div className={`mt-2 flex flex-col gap-2`}>
             <div className={`flex max-w-full flex-col items-start ${item.status === 'hidden' && 'opacity-50'}`}>
                 <div
                     dangerouslySetInnerHTML={{__html: item.html || ''}}

--- a/apps/posts/src/views/comments/components/comment-header.tsx
+++ b/apps/posts/src/views/comments/components/comment-header.tsx
@@ -1,4 +1,4 @@
-import {Badge, Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {Badge, Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, badgeVariants} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatTimestamp} from '@tryghost/shade/utils';
 import type {MouseEvent} from 'react';
 
@@ -28,10 +28,9 @@ interface CommentHeaderProps {
     className?: string;
 }
 
-const pinnedBadgeClassName = 'inline-flex items-center gap-1 rounded-full border border-amber-300/70 bg-amber-50 px-2 py-0.5 font-sans text-xs font-medium leading-none text-amber-800 dark:border-amber-400/30 dark:bg-amber-400/10 dark:text-amber-100';
 const pinnedButtonClassName = cn(
-    pinnedBadgeClassName,
-    'hover:border-amber-400 hover:bg-amber-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 dark:hover:border-amber-400/50 dark:hover:bg-amber-400/20'
+    badgeVariants({variant: 'warning'}),
+    'gap-1 hover:bg-state-warning/30'
 );
 
 export function CommentHeader({
@@ -53,9 +52,9 @@ export function CommentHeader({
     };
 
     return (
-        <div className={cn('flex items-baseline gap-4', className)}>
+        <div className={cn('flex items-center gap-2', className)}>
             <div className={cn(
-                'mb-1 flex min-w-0 items-center gap-x-1 text-sm',
+                'flex min-w-0 items-center gap-x-1 text-sm',
                 isHidden && 'opacity-50'
             )}>
                 <div className='whitespace-nowrap'>
@@ -146,7 +145,7 @@ export function CommentHeader({
                         </span>
                     </button>
                 ) : (
-                    <Badge className={pinnedBadgeClassName} variant='outline'>
+                    <Badge className='gap-1' variant='warning'>
                         <LucideIcon.Pin className="size-3" />
                         Pinned
                     </Badge>

--- a/apps/shade/src/components/ui/badge.stories.tsx
+++ b/apps/shade/src/components/ui/badge.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
     argTypes: {
         variant: {
             control: {type: 'select'},
-            options: ['default', 'secondary', 'destructive', 'success', 'outline']
+            options: ['default', 'secondary', 'destructive', 'success', 'warning', 'outline']
         }
     }
 } satisfies Meta<typeof Badge>;
@@ -50,6 +50,13 @@ export const Success: Story = {
     }
 };
 
+export const Warning: Story = {
+    args: {
+        variant: 'warning',
+        children: 'Warning'
+    }
+};
+
 export const Outline: Story = {
     args: {
         variant: 'outline',
@@ -64,6 +71,7 @@ export const AllVariants: Story = {
             <Badge variant="secondary">Secondary</Badge>
             <Badge variant="destructive">Error</Badge>
             <Badge variant="success">Success</Badge>
+            <Badge variant="warning">Warning</Badge>
             <Badge variant="outline">Outline</Badge>
         </div>
     )

--- a/apps/shade/src/components/ui/badge.tsx
+++ b/apps/shade/src/components/ui/badge.tsx
@@ -16,6 +16,8 @@ const badgeVariants = cva(
                     'border-transparent bg-destructive/20 text-destructive',
                 success:
                     'border-transparent bg-green/20 text-green',
+                warning:
+                    'border-transparent bg-state-warning/20 text-yellow-600',
                 outline: 'text-foreground'
             }
         },

--- a/apps/shade/test/unit/components/ui/badge.test.tsx
+++ b/apps/shade/test/unit/components/ui/badge.test.tsx
@@ -34,6 +34,13 @@ describe('Badge Component', () => {
         assert.ok(badge.className.includes('bg-green'), 'Should have success variant class');
     });
 
+    it('applies warning variant correctly', () => {
+        render(<Badge variant="warning">Warning Badge</Badge>);
+        const badge = screen.getByText('Warning Badge');
+        
+        assert.ok(badge.className.includes('bg-state-warning'), 'Should have warning variant class');
+    });
+
     it('applies outline variant correctly', () => {
         render(<Badge variant="outline">Outline Badge</Badge>);
         const badge = screen.getByText('Outline Badge');


### PR DESCRIPTION
No ref

- Added a new warning Badge variant
- Used the new badge for pin/unpin comment
- Tweaked header styles to improve the badge layout

New variant
<img width="414" height="229" alt="Screenshot 2026-05-20 at 12 17 55" src="https://github.com/user-attachments/assets/2e53a7db-4b60-40c0-b420-6ca4155a8c14" />

Comment header updates
| Before | After |
|--------|--------|
| <img width="477" height="170" alt="Screenshot 2026-05-20 at 12 16 46" src="https://github.com/user-attachments/assets/3d261b8e-b8d1-49e5-abde-aaa6501b2745" /> | <img width="463" height="164" alt="Screenshot 2026-05-20 at 12 16 02" src="https://github.com/user-attachments/assets/bfcc7780-eecc-4317-b628-b41da1f3fd63" /> |
