### PR TITLE
Added access code regeneration endpoint

### DIFF
--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -62,7 +62,7 @@ export const useEditSettings = createMutation<SettingsResponseType, Setting[]>({
 
 export const useRegenerateAccessCode = createMutation<SettingsResponseType, null>({
     method: 'POST',
-    path: () => '/settings/regenerate_access_code/',
+    path: () => '/settings/access_code/regenerate/',
     updateQueries: {
         dataType,
         emberUpdateType: 'createOrUpdate',

--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -60,6 +60,26 @@ export const useEditSettings = createMutation<SettingsResponseType, Setting[]>({
     }
 });
 
+export const useRegenerateAccessCode = createMutation<SettingsResponseType, null>({
+    method: 'POST',
+    path: () => '/settings/regenerate_access_code/',
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'createOrUpdate',
+        update: newData => ({
+            ...newData,
+            settings: newData.settings
+        })
+    },
+    invalidateQueries: {
+        filters: {
+            predicate(query) {
+                return query.queryKey[0] !== dataType;
+            }
+        }
+    }
+});
+
 export const useDeleteStripeSettings = createMutation<unknown, null>({
     method: 'DELETE',
     path: () => '/settings/stripe/connect/',

--- a/apps/admin-x-settings/src/components/settings/membership/access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/access.tsx
@@ -5,7 +5,7 @@ import {Banner, Button as ShadeButton} from '@tryghost/shade/components';
 import {type GroupBase, type MultiValue} from 'react-select';
 import {Hint, MultiSelect, type MultiSelectOption, Select, Separator, SettingGroupContent, TextField, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {RefreshCw} from 'lucide-react';
-import {getSettingValues, isSettingReadOnly, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
+import {getSettingValues, isSettingReadOnly, useRegenerateAccessCode} from '@tryghost/admin-x-framework/api/settings';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useLimiter} from '../../../hooks/use-limiter';
@@ -92,7 +92,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const limiter = useLimiter();
     const isTrialMode = limiter?.isDisabled('publicSiteAccess');
     const isPrivateLocked = isSettingReadOnly(settings, 'is_private') || isSettingReadOnly(settings, 'password');
-    const {mutateAsync: editSettings} = useEditSettings();
+    const {mutateAsync: regenerateAccessCode} = useRegenerateAccessCode();
     const [isRegenerating, setIsRegenerating] = React.useState(false);
     const {
         localSettings,
@@ -148,7 +148,13 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const handleRegenerateAccessCode = async () => {
         setIsRegenerating(true);
         try {
-            await editSettings([{key: 'password', value: null}]);
+            const response = await regenerateAccessCode(null);
+            const regeneratedAccessCode = response.settings.find(setting => setting.key === 'password')?.value;
+
+            if (typeof regeneratedAccessCode === 'string') {
+                updateSetting('password', regeneratedAccessCode);
+                clearError('password');
+            }
         } catch {
             showToast({
                 type: 'error',
@@ -204,6 +210,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                                     <button
                                         aria-label='Regenerate access code'
                                         className='mr-[5px] flex size-5 cursor-pointer items-center justify-center p-0 text-grey-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-grey-400'
+                                        data-testid='regenerate-access-code'
                                         disabled={isRegenerating}
                                         title='Regenerate access code'
                                         type='button'

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -133,7 +133,7 @@ test.describe('Access settings', async () => {
             },
             regenerateAccessCode: {
                 method: 'POST',
-                path: '/settings/regenerate_access_code/',
+                path: '/settings/access_code/regenerate/',
                 response: updatedSettingsResponse([
                     {key: 'is_private', value: true, is_read_only: true},
                     {key: 'password', value: 'fake-456', is_read_only: true}

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -1,5 +1,18 @@
-import {chooseOptionInSelect, getOptionsFromSelect, globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
+import {chooseOptionInSelect, getOptionsFromSelect, globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse, waitForApiRequest} from '@tryghost/admin-x-framework/test/acceptance';
 import {expect, test} from '@playwright/test';
+
+const createConfigWithLimits = (limits: Record<string, unknown>) => ({
+    ...globalDataRequests.browseConfig,
+    response: {
+        config: {
+            ...responseFixtures.config.config,
+            hostSettings: {
+                ...responseFixtures.config.config.hostSettings,
+                limits
+            }
+        }
+    }
+});
 
 test.describe('Access settings', async () => {
     test('Supports switching site visibility between public and private', async ({page}) => {
@@ -100,6 +113,45 @@ test.describe('Access settings', async () => {
                 {key: 'comments_enabled', value: 'all'}
             ]
         });
+    });
+
+    test('Regenerates locked private-site access code server-side', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: createConfigWithLimits({
+                publicSiteAccess: {
+                    disabled: true,
+                    error: 'This plan does not include public site access'
+                }
+            }),
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: updatedSettingsResponse([
+                    {key: 'is_private', value: true, is_read_only: true},
+                    {key: 'password', value: 'fake-123', is_read_only: true}
+                ])
+            },
+            regenerateAccessCode: {
+                method: 'POST',
+                path: '/settings/regenerate_access_code/',
+                response: updatedSettingsResponse([
+                    {key: 'is_private', value: true, is_read_only: true},
+                    {key: 'password', value: 'fake-456', is_read_only: true}
+                ])
+            }
+        }});
+
+        await page.goto('/');
+
+        const accessSection = page.getByTestId('access');
+        const accessCode = accessSection.getByTestId('site-access-code');
+
+        await expect(accessCode).toHaveValue('fake-123');
+        await accessSection.getByTestId('regenerate-access-code').click();
+
+        const request = await waitForApiRequest(lastApiRequests, 'regenerateAccessCode');
+        expect(request.body).toBeNull();
+        await expect(accessCode).toHaveValue('fake-456');
     });
 
     test('Disables other sections when signup is disabled', async ({page}) => {

--- a/ghost/core/core/server/api/endpoints/settings.js
+++ b/ghost/core/core/server/api/endpoints/settings.js
@@ -147,6 +147,22 @@ const controller = {
         }
     },
 
+    regenerateAccessCode: {
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: {
+            method: 'edit'
+        },
+        async query(frame) {
+            await settingsService.regeneratePrivateSiteAccessCode();
+            frame.setHeader('X-Cache-Invalidate', '/*');
+
+            // We need to return all settings here, because we have calculated settings that might change
+            return await settingsBREADService.browse(frame.options.context);
+        }
+    },
+
     upload: {
         headers: {
             cacheInvalidate: true

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/settings.js
@@ -91,6 +91,7 @@ module.exports = {
     browse: serializeSettings,
     read: serializeSettings,
     edit: serializeSettings,
+    regenerateAccessCode: serializeSettings,
     verifyKeyUpdate: serializeSettings,
 
     download: serializeData,

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -131,6 +131,22 @@ module.exports = {
     },
 
     /**
+     * Generate and persist a new private site access code.
+     *
+     * The code is always generated server-side. Callers cannot provide their
+     * own value, and the write runs with internal context so it can regenerate
+     * a read-only access code without opening up generic settings edits.
+     *
+     * @returns {Promise<*>}
+     */
+    async regeneratePrivateSiteAccessCode() {
+        return await models.Settings.edit([{
+            key: 'password',
+            value: generatePrivateSiteAccessCode()
+        }], {context: {internal: true}});
+    },
+
+    /**
      * Restore the cache, used during e2e testing only
      */
     reset() {

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -87,6 +87,7 @@ module.exports = function apiRoutes() {
 
     router.get('/settings', mw.authAdminApi, http(api.settings.browse));
     router.put('/settings', mw.authAdminApi, http(api.settings.edit));
+    router.post('/settings/regenerate_access_code', mw.authAdminApi, http(api.settings.regenerateAccessCode));
     router.put('/settings/verifications/', mw.authAdminApi, http(api.settings.verifyKeyUpdate));
     router.delete('/settings/stripe/connect', mw.authAdminApi, http(api.settings.disconnectStripeConnectIntegration));
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -87,7 +87,7 @@ module.exports = function apiRoutes() {
 
     router.get('/settings', mw.authAdminApi, http(api.settings.browse));
     router.put('/settings', mw.authAdminApi, http(api.settings.edit));
-    router.post('/settings/regenerate_access_code', mw.authAdminApi, http(api.settings.regenerateAccessCode));
+    router.post('/settings/access_code/regenerate', mw.authAdminApi, http(api.settings.regenerateAccessCode));
     router.put('/settings/verifications/', mw.authAdminApi, http(api.settings.verifyKeyUpdate));
     router.delete('/settings/stripe/connect', mw.authAdminApi, http(api.settings.disconnectStripeConnectIntegration));
 

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -790,6 +790,29 @@ describe('Settings API', function () {
                 });
         });
 
+        it('regenerates the access code server-side when settings edits are locked', async function () {
+            stubPublicSiteAccessDisabled(true);
+            const passwordSetting = await models.Settings.findOne({key: 'password'}, {context: {internal: true}});
+
+            try {
+                const response = await agent.post('settings/regenerate_access_code/')
+                    .body({password: 'caller-chosen-code'})
+                    .expectStatus(200);
+
+                const byKey = Object.fromEntries(response.body.settings.map(s => [s.key, s]));
+                assert.equal(typeof byKey.password.value, 'string');
+                assert.match(byKey.password.value, /^fake-\d{3}$/);
+                assert.notEqual(byKey.password.value, 'caller-chosen-code');
+                assert.equal(byKey.password.is_read_only, true);
+
+                emailMockReceiver.assertSentEmailCount(0);
+            } finally {
+                const originalPasswordSetting = passwordSetting.toJSON();
+                await models.Base.knex('settings').where({key: 'password'}).update({value: originalPasswordSetting.value});
+                settingsCache.set('password', originalPasswordSetting);
+            }
+        });
+
         it('does not mark is_private or password as is_read_only when the limit is not disabled', async function () {
             stubPublicSiteAccessDisabled(false);
 

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -795,7 +795,7 @@ describe('Settings API', function () {
             const passwordSetting = await models.Settings.findOne({key: 'password'}, {context: {internal: true}});
 
             try {
-                const response = await agent.post('settings/regenerate_access_code/')
+                const response = await agent.post('settings/access_code/regenerate/')
                     .body({password: 'caller-chosen-code'})
                     .expectStatus(200);
 

--- a/ghost/core/test/unit/server/services/settings/settings-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-service.test.js
@@ -218,4 +218,18 @@ describe('UNIT: Settings Service', function () {
             assert.equal(writes[0].key, 'password');
         });
     });
+
+    describe('regeneratePrivateSiteAccessCode', function () {
+        it('generates a new access code server-side and writes with internal context', async function () {
+            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+
+            await settingsService.regeneratePrivateSiteAccessCode();
+
+            sinon.assert.calledOnce(editStub);
+            assert.equal(editStub.firstCall.args[0].length, 1);
+            assert.equal(editStub.firstCall.args[0][0].key, 'password');
+            assert.match(editStub.firstCall.args[0][0].value, /^fake-\d{3}$/);
+            assert.deepEqual(editStub.firstCall.args[1], {context: {internal: true}});
+        });
+    });
 });


### PR DESCRIPTION
## Context

Trial private sites mark the private-site access code setting as read-only, so the Access settings UI cannot regenerate it through the generic settings edit path without getting blocked.

## Summary

- Adds an explicit `POST /settings/regenerate_access_code` action that generates a new private-site access code server-side.
- Writes the regenerated code with internal settings context after the normal Admin settings permissions check, without accepting a caller-provided code value.
- Updates Admin-X Access settings to call the action directly, keeping generic settings edits locked while allowing the regenerate button to work.

## Testing

- [x] `source ~/.nvm/nvm.sh && nvm use 22 && pnpm test:single test/unit/server/services/settings/settings-service.test.js`
- [x] `source ~/.nvm/nvm.sh && nvm use 22 && pnpm test:single test/e2e-api/admin/settings.test.js`
- [x] `source ~/.nvm/nvm.sh && nvm use 22 && pnpm --filter @tryghost/admin-x-settings test:acceptance -- membership/access.test.ts`

## Notes

- The endpoint is intentionally an action rather than a generic settings update so clients cannot choose the replacement access code.
- This PR only covers regeneration; the broader trial private-site rollout work remains in the separate Zuul/Daisy/product follow-ups.
