### PR TITLE
Unblock security and stale dependency PRs in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,6 +55,18 @@
         "* 22-23 * * 1-5",
         "* 0-4 * * 2-6"
     ],
+    // CVE-driven updates bypass the weekend schedule, the npm release-age
+    // gate, and the dashboard-approval gate, and stay rebased against main
+    // so conflicts don't strand them. Automerge is configured per
+    // update-type in packageRules below so security majors still wait for
+    // human review.
+    "vulnerabilityAlerts": {
+        "schedule": ["at any time"],
+        "rebaseWhen": "behind-base-branch",
+        "minimumReleaseAge": "0 days",
+        "dependencyDashboardApproval": false,
+        "labels": ["dependencies", "security"]
+    },
     "ignoreDeps": [
         // https://github.com/TryGhost/Ghost/commit/2b9e494dfcb95c40f596ccf54ec3151c25d53601
         // `got` 10.x has a Node 10 bug that makes it pretty much unusable for now
@@ -210,7 +222,9 @@
         },
 
         // Allow internal Docker digest pins to automerge once the relevant
-        // CI checks have gone green.
+        // CI checks have gone green. Scoped to base images we control or
+        // pin purely for build reproducibility, so digest rotations don't
+        // change runtime behavior.
         {
             "description": "Automerge internal Docker digest updates after CI passes",
             "matchDatasources": [
@@ -218,11 +232,33 @@
             ],
             "matchPackageNames": [
                 "ghost/traffic-analytics",
-                "tinybirdco/tinybird-local"
+                "tinybirdco/tinybird-local",
+                "python",
+                "ghcr.io/astral-sh/uv",
+                "axllent/mailpit",
+                "caddy",
+                "stripe/stripe-cli"
             ],
             "matchUpdateTypes": [
                 "digest"
             ],
+            "automerge": true,
+            "automergeType": "pr"
+        },
+
+        // Security patches and minors automerge after CI passes regardless
+        // of any other automerge exclusion (e.g. the CSS preprocessor rule
+        // in the shared preset). Security majors are intentionally left
+        // for human merge — they still open immediately thanks to the
+        // `vulnerabilityAlerts` block above.
+        {
+            "description": "Automerge non-major security updates after CI passes",
+            "matchUpdateTypes": [
+                "patch",
+                "minor",
+                "digest"
+            ],
+            "isVulnerabilityAlert": true,
             "automerge": true,
             "automergeType": "pr"
         },


### PR DESCRIPTION
## Summary

Adjusts `.github/renovate.json5` to fix two recurring failure modes observed in the last 60 days of Renovate PRs:

1. **CVE patches sit for weeks behind the weekend schedule and dashboard gates.** Example: [#27595](https://github.com/TryGhost/Ghost/pull/27595) (postcss 8.5.6→8.5.10, two medium CVEs, 23+ days open with green CI then conflicts). Also [#25456](https://github.com/TryGhost/Ghost/pull/25456) (js-yaml SECURITY) merged after 141 days.
2. **Build-only Docker base image digest bumps go through the manual queue every week.** Only `ghost/traffic-analytics` and `tinybirdco/tinybird-local` are on the digest-automerge allowlist today; `python`, `ghcr.io/astral-sh/uv`, `axllent/mailpit`, `caddy`, and `stripe/stripe-cli` all rotate weekly and get hand-merged.

### What this PR changes

- **New `vulnerabilityAlerts` block.** Security PRs bypass the weekend schedule, the npm release-age gate, and the major-bump dashboard-approval gate. They're rebased on every Renovate run so they stay mergeable — this is what unblocks [#27595](https://github.com/TryGhost/Ghost/pull/27595) and similar excluded-package security PRs.
- **New packageRule: automerge non-major security updates.** Security patch/minor/digest updates automerge after CI passes regardless of any other exclusion (e.g. the CSS preprocessor rule in the shared preset). Security majors still need a human merge but open immediately.
- **Extended digest-automerge allowlist.** Adds `python`, `ghcr.io/astral-sh/uv`, `axllent/mailpit`, `caddy`, `stripe/stripe-cli` — all images we pin purely for build reproducibility.

### What this PR deliberately does **not** change

- The dashboard-approval gate for non-security major bumps (kept; rationale documented in the existing config).
- The CSS preprocessor automerge exclusion for non-security bumps (kept; postcss has historically broken our build).
- The schedule windows (kept).
- The `branchConcurrentLimit: 10` and `recreateWhen: "never"` settings (kept).
- `:maintainLockFilesWeekly` and `security:minimumReleaseAgeNpm` (kept; the security override above only relaxes the release-age gate for CVE updates).

### Expected impact

If this had been in place on 2026-04-27:
- [#27595](https://github.com/TryGhost/Ghost/pull/27595) (postcss SECURITY) would have been rebased and automerged that week via the `vulnerabilityAlerts` path.
- [#27585](https://github.com/TryGhost/Ghost/pull/27585) (file-type v21 SECURITY, major) would have opened immediately without needing dashboard approval; it would then wait for a human review (correct).
- ~14 weekly Docker digest manual merges would not have occurred.

## Test plan

- [ ] CI passes on this PR (renovate.json5 is parsed by Renovate, not by Ghost CI, so success here is JSON5 validity)
- [ ] After merge: confirm the next Renovate run produces an updated dependency dashboard with the new `vulnerabilityAlerts` config reflected on any open security PRs
- [ ] Spot-check: any existing security PR should pick up the new schedule + rebase behavior on the next Renovate cycle without needing to be reopened