### PR TITLE
Migrated test/unit/api bucket to vitest

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -59,7 +59,7 @@
     "test:all": "pnpm test:unit && pnpm test:integration && pnpm test:e2e && pnpm lint",
     "test:debug": "DEBUG=ghost:test* pnpm test",
     "test:unit": "c8 pnpm test:unit:${GHOST_UNIT_TEST_VARIANT:-base}",
-    "test:unit:base": "pnpm test:base ./test/unit/api ./test/unit/frontend ./test/unit/server/models ./test/unit/server/services ./test/unit/server/notify.test.js ./test/unit/server/overrides.test.js ./test/unit/server/adapters/scheduling/scheduling-default.test.js --timeout=2000",
+    "test:unit:base": "pnpm test:base ./test/unit/frontend ./test/unit/server/models ./test/unit/server/services ./test/unit/server/notify.test.js ./test/unit/server/overrides.test.js ./test/unit/server/adapters/scheduling/scheduling-default.test.js --timeout=2000",
     "test:unit:ci": "pnpm test:unit:base --reporter=min",
     "test:integration": "pnpm test:base './test/integration' --timeout=10000",
     "test:e2e": "pnpm test:base ./test/e2e-* --timeout=15000",

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
@@ -246,10 +246,8 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
         assert.deepEqual(frame.data.pages[0].tags, [{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
     });
 
-    it('throws error if HTML conversion fails', function () {
-        // JSDOM require is sometimes very slow on CI causing random timeouts
-        this.timeout(4000);
-
+    // JSDOM require is sometimes very slow on CI causing random timeouts
+    it('throws error if HTML conversion fails', {timeout: 4000}, function () {
         const frame = {
             options: {
                 source: 'html'

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -377,10 +377,8 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 assert.equal(postData.mobiledoc, null);
             });
 
-            it('transforms html when html is present in data and source options', function () {
-                // JSDOM require is sometimes very slow on CI causing random timeouts
-                this.timeout(10000);
-
+            // JSDOM require is sometimes very slow on CI causing random timeouts
+            it('transforms html when html is present in data and source options', {timeout: 10000}, function () {
                 const apiConfig = {};
                 const lexical = '{"root":{"children":[{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}';
                 const frame = {
@@ -409,10 +407,8 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 assert.equal(postData.mobiledoc, '{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"this is great feature"]]]]}');
             });
 
-            it('preserves html cards in transformed html', function () {
-                // JSDOM require is sometimes very slow on CI causing random timeouts
-                this.timeout(10000);
-
+            // JSDOM require is sometimes very slow on CI causing random timeouts
+            it('preserves html cards in transformed html', {timeout: 10000}, function () {
                 const apiConfig = {};
                 const frame = {
                     options: {
@@ -434,10 +430,8 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 assert.equal(postData.lexical, '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"this is great feature","type":"extended-text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1},{"type":"html","version":1,"html":"<div class=\\"custom\\">My Custom HTML</div>","visibility":{"web":{"nonMember":true,"memberSegment":"status:free,status:-free"},"email":{"memberSegment":"status:free,status:-free"}}},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"custom html preserved!","type":"extended-text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}');
             });
 
-            it('throws error when HTML conversion fails', function () {
-                // JSDOM require is sometimes very slow on CI causing random timeouts
-                this.timeout(10000);
-
+            // JSDOM require is sometimes very slow on CI causing random timeouts
+            it('throws error when HTML conversion fails', {timeout: 10000}, function () {
                 const frame = {
                     options: {
                         source: 'html'

--- a/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
@@ -6,8 +6,8 @@ const models = require('../../../../../../../core/server/models');
 
 describe('Unit: endpoints/utils/validators/input/pages', function () {
     beforeEach(function () {
-        const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
-        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());
+        const memberFindPageStub = sinon.stub(models.Member, 'findPage').rejects();
+        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).resolves();
     });
 
     afterEach(function () {

--- a/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
@@ -6,8 +6,8 @@ const models = require('../../../../../../../core/server/models');
 
 describe('Unit: endpoints/utils/validators/input/posts', function () {
     beforeEach(function () {
-        const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
-        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());
+        const memberFindPageStub = sinon.stub(models.Member, 'findPage').rejects();
+        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).resolves();
     });
 
     afterEach(function () {

--- a/ghost/core/test/unit/api/endpoints/members.test.js
+++ b/ghost/core/test/unit/api/endpoints/members.test.js
@@ -4,7 +4,7 @@ const rewire = require('rewire');
 describe('Members controller', function () {
     let models, membersController, mockMembersService, mockSettingsCache, mockMoment;
 
-    before(function () {
+    beforeAll(function () {
         models = require('../../../../core/server/models');
     });
 

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
             WEBHOOK_SECRET: 'TEST_STRIPE_WEBHOOK_SECRET'
         },
         include: [
+            'test/unit/api/**/*.test.{js,ts}',
             'test/unit/bin/**/*.test.{js,ts}',
             'test/unit/shared/**/*.test.{js,ts}',
             'test/unit/server/adapters/**/*.test.{js,ts}',


### PR DESCRIPTION
## Summary

Continues the vitest migration (after #27898 / #27900 / #27974) by moving the `test/unit/api` bucket — 33 files, 280 tests — from mocha to vitest.

## What's changed

- `vitest.config.ts` — added `test/unit/api/**` to `test.include`
- `package.json` — removed `./test/unit/api` from `test:unit:base` so vitest is the sole runner
- `members.test.js` — `before()` → `beforeAll()`
- `serializers/input/pages.test.js` + `serializers/input/posts.test.js` — four `this.timeout(N)` calls → the `it(name, {timeout: N}, fn)` options form
- `validators/input/pages.test.js` + `validators/input/posts.test.js` — see below

## Unhandled-rejection fix

`validators/input/{pages,posts}.test.js` had a `beforeEach` that stubbed `Member.findPage` with `.returns(Promise.reject())`. That **eagerly** creates a rejected promise at stub-setup time. When a test never exercises the stub, the promise is never consumed and Node flags it as an unhandled rejection — 60 of them across the two files (`{ type: 'Unhandled Rejection', message: undefined }`). Mocha silently ignored these; vitest surfaces them and fails the run.

Fix: switched to sinon's lazy `.rejects()` / `.resolves()`, which only create the promise when the stub is actually called.

## Test plan

- [x] `pnpm test:vitest test/unit/api` (from `ghost/core`): 33 files / 280 tests pass, zero unhandled rejections
- [x] `pnpm test:unit:base` (mocha): 5386 tests pass
- [x] `pnpm exec eslint` clean for changed files
- [ ] CI green