### PR TITLE
Migrated test/unit/frontend bucket to vitest

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -59,7 +59,7 @@
     "test:all": "pnpm test:unit && pnpm test:integration && pnpm test:e2e && pnpm lint",
     "test:debug": "DEBUG=ghost:test* pnpm test",
     "test:unit": "c8 pnpm test:unit:${GHOST_UNIT_TEST_VARIANT:-base}",
-    "test:unit:base": "pnpm test:base ./test/unit/frontend ./test/unit/server/models ./test/unit/server/services ./test/unit/server/notify.test.js ./test/unit/server/overrides.test.js ./test/unit/server/adapters/scheduling/scheduling-default.test.js --timeout=2000",
+    "test:unit:base": "pnpm test:base ./test/unit/server/models ./test/unit/server/services ./test/unit/server/notify.test.js ./test/unit/server/overrides.test.js ./test/unit/server/adapters/scheduling/scheduling-default.test.js --timeout=2000",
     "test:unit:ci": "pnpm test:unit:base --reporter=min",
     "test:integration": "pnpm test:base './test/integration' --timeout=10000",
     "test:e2e": "pnpm test:base ./test/e2e-* --timeout=15000",

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -13,6 +13,7 @@ const color_to_rgba = require('../../../../../core/frontend/helpers/color_to_rgb
 const contrast_text_color = require('../../../../../core/frontend/helpers/contrast_text_color');
 const json = require('../../../../../core/frontend/helpers/json');
 const {setupI18nTest, initLocale} = require('../../../../utils/i18n-test-utils');
+const deferred = require('../../../../utils/deferred');
 
 describe('Private Controller', function () {
     let res;
@@ -62,7 +63,8 @@ describe('Private Controller', function () {
         await configUtils.restore();
     });
 
-    it('Should render default password page when theme has no password template', function (done) {
+    it('Should render default password page when theme has no password template', function () {
+        const {promise, done} = deferred();
         res.render = function (view, context) {
             assert.equal(view, defaultPath);
             assertExists(context);
@@ -70,9 +72,11 @@ describe('Private Controller', function () {
         };
 
         privateController.renderer(req, res, failTest(done));
+        return promise;
     });
 
-    it('Should render theme password page when it exists', function (done) {
+    it('Should render theme password page when it exists', function () {
+        const {promise, done} = deferred();
         hasTemplateStub.withArgs('private').returns(true);
 
         res.render = function (view, context) {
@@ -82,9 +86,11 @@ describe('Private Controller', function () {
         };
 
         privateController.renderer(req, res, failTest(done));
+        return promise;
     });
 
-    it('Should render with error when error is passed in', function (done) {
+    it('Should render with error when error is passed in', function () {
+        const {promise, done} = deferred();
         res.error = 'Test Error';
 
         res.render = function (view, context) {
@@ -94,6 +100,7 @@ describe('Private Controller', function () {
         };
 
         privateController.renderer(req, res, failTest(done));
+        return promise;
     });
 });
 
@@ -101,7 +108,7 @@ describe('private.hbs template translation', function () {
     const privateViewPath = path.join(__dirname, '../../../../../core/frontend/apps/private-blogging/lib/views/private.hbs');
     let compiledTemplate;
 
-    before(function () {
+    beforeAll(function () {
         const templateStr = fs.readFileSync(privateViewPath, 'utf8');
         compiledTemplate = hbs.handlebars.compile(templateStr);
 
@@ -118,7 +125,7 @@ describe('private.hbs template translation', function () {
         });
     });
 
-    after(function () {
+    afterAll(function () {
         hbs.handlebars.unregisterHelper('input_password');
         hbs.handlebars.unregisterHelper('color_to_rgba');
         hbs.handlebars.unregisterHelper('contrast_text_color');
@@ -142,7 +149,7 @@ describe('private.hbs template translation', function () {
         describe(`with ${name}`, function () {
             let i18nSetup;
 
-            before(function () {
+            beforeAll(function () {
                 i18nSetup = setupI18nTest({useNewTranslation, locale: 'en'});
             });
 
@@ -151,7 +158,7 @@ describe('private.hbs template translation', function () {
                 initLocale({useNewTranslation, locale: 'en'});
             });
 
-            after(function () {
+            afterAll(function () {
                 i18nSetup.teardown();
                 sinon.restore();
             });

--- a/ghost/core/test/unit/frontend/helpers/asset.test.js
+++ b/ghost/core/test/unit/frontend/helpers/asset.test.js
@@ -13,7 +13,7 @@ describe('{{asset}} helper', function () {
     let rendered;
     const localSettingsCache = {};
 
-    before(function () {
+    beforeAll(function () {
         configUtils.set({assetHash: 'abc'});
         configUtils.set({useMinFiles: true});
 
@@ -22,7 +22,7 @@ describe('{{asset}} helper', function () {
         });
     });
 
-    after(async function () {
+    afterAll(async function () {
         await configUtils.restore();
         sinon.restore();
     });
@@ -88,12 +88,12 @@ describe('{{asset}} helper', function () {
     });
 
     describe('different admin and site urls', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://127.0.0.1'});
             configUtils.set({'admin:url': 'http://localhost'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 
@@ -111,12 +111,12 @@ describe('{{asset}} helper', function () {
     });
 
     describe('with contentBasedHash enabled', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({assetHash: 'abc'});
             configUtils.set({'caching:assets:contentBasedHash:enabled': true});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 

--- a/ghost/core/test/unit/frontend/helpers/body-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/body-class.test.js
@@ -12,7 +12,7 @@ const {settingsCache} = proxy;
 
 describe('{{body_class}} helper', function () {
     let options = {};
-    before(function () {
+    beforeAll(function () {
         themeList.init({
             casper: {
                 assets: null,
@@ -37,7 +37,7 @@ describe('{{body_class}} helper', function () {
         };
     });
 
-    after(function () {
+    afterAll(function () {
         themeList.init();
     });
 

--- a/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
@@ -10,7 +10,7 @@ const {promisify} = require('node:util');
 
 describe('{{cancel_link}} helper', function () {
     let labsStub;
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({partialsDir: [configUtils.config.get('paths').helperTemplates]});
 
         const cachePartials = promisify(hbs.cachePartials.bind(hbs));

--- a/ghost/core/test/unit/frontend/helpers/comment-count.test.js
+++ b/ghost/core/test/unit/frontend/helpers/comment-count.test.js
@@ -10,7 +10,7 @@ const {settingsCache} = proxy;
 const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');
 
 describe('{{comment_count}} helper', function () {
-    before(function () {
+    beforeAll(function () {
         registerHelper('comment_count');
     });
 

--- a/ghost/core/test/unit/frontend/helpers/concat.test.js
+++ b/ghost/core/test/unit/frontend/helpers/concat.test.js
@@ -13,7 +13,7 @@ let defaultGlobals;
 const draftPostData = {title: 'My Draft Post', slug: 'my-post', html: '<p>My Post</p>', uuid: '1234'};
 
 describe('{{concat}} helper', function () {
-    before(function () {
+    beforeAll(function () {
         handlebars.registerHelper('concat', concat);
         handlebars.registerHelper('url', url);
         handlebars.registerHelper('split', split);

--- a/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
@@ -18,11 +18,11 @@ describe('{{content_api_url}} helper', function () {
     });
 
     describe('without sub-directory', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/', 'admin:url': 'https://admin.tld:65535'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 
@@ -46,11 +46,11 @@ describe('{{content_api_url}} helper', function () {
         });
     });
     describe('with a sub-directory', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/blog', 'admin:url': 'https://admin.tld:65535/blog'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 
@@ -74,11 +74,11 @@ describe('{{content_api_url}} helper', function () {
         });
     });
     describe('uses the site url if no admin:url is set', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 

--- a/ghost/core/test/unit/frontend/helpers/content.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content.test.js
@@ -14,7 +14,7 @@ const t = require('../../../../core/frontend/helpers/t');
 const {setupI18nTest, initLocale} = require('../../../utils/i18n-test-utils');
 
 describe('{{content}} helper', function () {
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({partialsDir: [configUtils.config.get('paths').helperTemplates]});
 
         const cachePartials = promisify(hbs.cachePartials.bind(hbs));
@@ -84,7 +84,7 @@ describe('{{content}} helper', function () {
 });
 
 describe('{{content}} helper with no access', function () {
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({partialsDir: [configUtils.config.get('paths').helperTemplates]});
 
         const cachePartials = promisify(hbs.cachePartials.bind(hbs));
@@ -106,7 +106,7 @@ describe('{{content}} helper with no access', function () {
             let optionsData;
             let i18nSetup;
 
-            before(function () {
+            beforeAll(function () {
                 i18nSetup = setupI18nTest({useNewTranslation, locale: 'en'});
             });
 
@@ -115,7 +115,7 @@ describe('{{content}} helper with no access', function () {
                 initLocale({useNewTranslation, locale: 'en'});
             });
 
-            after(function () {
+            afterAll(function () {
                 i18nSetup.teardown();
                 sinon.restore();
             });
@@ -221,7 +221,7 @@ describe('{{content}} helper with no access', function () {
 
 describe('{{content}} helper with custom template', function () {
     let optionsData;
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({partialsDir: [path.resolve(__dirname, './test_tpl')]});
 
         const cachePartials = promisify(hbs.cachePartials.bind(hbs));

--- a/ghost/core/test/unit/frontend/helpers/foreach.test.js
+++ b/ghost/core/test/unit/frontend/helpers/foreach.test.js
@@ -290,7 +290,7 @@ describe('{{#foreach}} helper', function () {
             world: 'world'
         };
 
-        before(function () {
+        beforeAll(function () {
             registerHelper('foreach');
         });
 

--- a/ghost/core/test/unit/frontend/helpers/img-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/img-url.test.js
@@ -20,11 +20,11 @@ describe('{{img_url}} helper', function () {
     });
 
     describe('without sub-directory', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 
@@ -82,11 +82,11 @@ describe('{{img_url}} helper', function () {
     });
 
     describe('with sub-directory', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/blog'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 
@@ -110,11 +110,11 @@ describe('{{img_url}} helper', function () {
     });
 
     describe('image_sizes', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 
@@ -195,11 +195,11 @@ describe('{{img_url}} helper', function () {
         });
 
         describe('with CDN image base URL', function () {
-            before(function () {
+            beforeAll(function () {
                 configUtils.set('urls:image', 'https://storage.ghost.is/c/6f/a3/test/content/images');
             });
 
-            after(async function () {
+            afterAll(async function () {
                 await configUtils.restore();
                 configUtils.set({url: 'http://localhost:65535/'});
             });
@@ -328,11 +328,11 @@ describe('{{img_url}} helper', function () {
     });
 
     describe('Unsplash', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 

--- a/ghost/core/test/unit/frontend/helpers/link-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/link-class.test.js
@@ -19,7 +19,7 @@ function compile(templateString) {
 }
 
 describe('{{link_class}} helper', function () {
-    before(function () {
+    beforeAll(function () {
         handlebars.registerHelper('link_class', link_class);
         handlebars.registerHelper('concat', concat);
         configUtils.config.set('url', 'https://siteurl.com');
@@ -32,7 +32,7 @@ describe('{{link_class}} helper', function () {
         };
     });
 
-    after(async function () {
+    afterAll(async function () {
         await configUtils.restore();
     });
 

--- a/ghost/core/test/unit/frontend/helpers/link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/link.test.js
@@ -20,7 +20,7 @@ function compile(templateString) {
 }
 
 describe('{{link}} helper', function () {
-    before(function () {
+    beforeAll(function () {
         handlebars.registerHelper('link', link);
         handlebars.registerHelper('url', url);
         handlebars.registerHelper('concat', concat);
@@ -34,7 +34,7 @@ describe('{{link}} helper', function () {
         };
     });
 
-    after(async function () {
+    afterAll(async function () {
         await configUtils.restore();
     });
 

--- a/ghost/core/test/unit/frontend/helpers/match.test.js
+++ b/ghost/core/test/unit/frontend/helpers/match.test.js
@@ -5,7 +5,7 @@ const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');
 const {SafeString} = require('express-hbs');
 
 describe('Match helper', function () {
-    before(function () {
+    beforeAll(function () {
         registerHelper('match');
         registerHelper('title');
     });

--- a/ghost/core/test/unit/frontend/helpers/meta-description.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-description.test.js
@@ -7,18 +7,18 @@ const settingsCache = require('../../../../core/shared/settings-cache');
 describe('{{meta_description}} helper', function () {
     const localSettingsCache = {};
 
-    before(function () {
+    beforeAll(function () {
         sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     });
 
-    after(function () {
+    afterAll(function () {
         sinon.restore();
     });
 
     describe('no meta_description', function () {
-        before(function () {
+        beforeAll(function () {
             localSettingsCache.description = 'The professional publishing platform';
         });
 
@@ -134,7 +134,7 @@ describe('{{meta_description}} helper', function () {
     });
 
     describe('with meta_description', function () {
-        before(function () {
+        beforeAll(function () {
             localSettingsCache.meta_description = 'Meta description of the professional publishing platform';
         });
 

--- a/ghost/core/test/unit/frontend/helpers/meta-title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-title.test.js
@@ -7,7 +7,7 @@ const settingsCache = require('../../../../core/shared/settings-cache');
 
 describe('{{meta_title}} helper', function () {
     describe('no meta_title', function () {
-        before(function () {
+        beforeAll(function () {
             sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     title: 'Ghost'
@@ -15,7 +15,7 @@ describe('{{meta_title}} helper', function () {
             });
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
             sinon.restore();
         });

--- a/ghost/core/test/unit/frontend/helpers/navigation.test.js
+++ b/ghost/core/test/unit/frontend/helpers/navigation.test.js
@@ -19,7 +19,7 @@ const runHelperThunk = data => () => runHelper(data);
 describe('{{navigation}} helper', function () {
     let optionsData;
 
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({
             partialsDir: [configUtils.config.get('paths').helperTemplates]
         });
@@ -226,7 +226,7 @@ describe('{{navigation}} helper', function () {
 describe('{{navigation}} helper with custom template', function () {
     let optionsData;
 
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({partialsDir: [path.resolve(__dirname, './test_tpl')]});
 
         const cachePartials = promisify(hbs.cachePartials.bind(hbs));
@@ -311,7 +311,7 @@ describe('{{navigation}} helper with custom template', function () {
             return template;
         }
 
-        before(function () {
+        beforeAll(function () {
             handlebars.registerHelper('link_class', link_class);
             handlebars.registerHelper('concat', concat);
             handlebars.registerHelper('url', concat);

--- a/ghost/core/test/unit/frontend/helpers/pagination.test.js
+++ b/ghost/core/test/unit/frontend/helpers/pagination.test.js
@@ -11,7 +11,7 @@ const {setupI18nTest, initLocale} = require('../../../utils/i18n-test-utils');
 const pagination = require('../../../../core/frontend/helpers/pagination');
 
 describe('{{pagination}} helper', function () {
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({partialsDir: [configUtils.config.get('paths').helperTemplates]});
 
         const cachePartials = promisify(hbs.cachePartials.bind(hbs));
@@ -53,7 +53,7 @@ describe('{{pagination}} helper', function () {
         describe(`rendering with ${name}`, function () {
             let i18nSetup;
 
-            before(function () {
+            beforeAll(function () {
                 i18nSetup = setupI18nTest({useNewTranslation, locale: 'en'});
             });
 
@@ -62,7 +62,7 @@ describe('{{pagination}} helper', function () {
                 initLocale({useNewTranslation, locale: 'en'});
             });
 
-            after(function () {
+            afterAll(function () {
                 i18nSetup.teardown();
                 sinon.restore();
             });
@@ -165,7 +165,7 @@ describe('{{pagination}} helper', function () {
 });
 
 describe('{{pagination}} helper with custom template', function () {
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({partialsDir: [path.resolve(__dirname, './test_tpl')]});
 
         const cachePartials = promisify(hbs.cachePartials.bind(hbs));

--- a/ghost/core/test/unit/frontend/helpers/price.test.js
+++ b/ghost/core/test/unit/frontend/helpers/price.test.js
@@ -17,7 +17,7 @@ describe('{{price}} helper', function () {
         sinon.restore();
     });
 
-    before(function () {
+    beforeAll(function () {
         registerHelper('price');
     });
 

--- a/ghost/core/test/unit/frontend/helpers/raw.test.js
+++ b/ghost/core/test/unit/frontend/helpers/raw.test.js
@@ -16,7 +16,7 @@ function compile(templateString) {
 }
 
 describe('{{raw}} helper', function () {
-    before(function () {
+    beforeAll(function () {
         handlebars.registerHelper('raw', raw);
     });
 

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -20,7 +20,7 @@ function trimSpaces(string) {
 describe('{{#recommendations}} helper', function () {
     let logging;
 
-    before(async function () {
+    beforeAll(async function () {
         hbs.express4({
             partialsDir: [configUtils.config.get('paths').helperTemplates]
         });
@@ -55,7 +55,7 @@ describe('{{#recommendations}} helper', function () {
         };
     });
 
-    after(function () {
+    afterAll(function () {
         sinon.restore();
     });
 
@@ -102,7 +102,7 @@ describe('{{#recommendations}} helper', function () {
     });
 
     describe('when there are no recommendations', function () {
-        before(function () {
+        beforeAll(function () {
             sinon.stub(api, 'recommendationsPublic').get(() => {
                 return {
                     browse: () => {
@@ -128,7 +128,7 @@ describe('{{#recommendations}} helper', function () {
     });
 
     describe('when recommendations_enabled is false', function () {
-        before(function () {
+        beforeAll(function () {
             // @ts-ignore
             settingsCache.get.withArgs('recommendations_enabled').returns(true);
         });
@@ -147,7 +147,7 @@ describe('{{#recommendations}} helper', function () {
     describe('when timeout is exceeded', function () {
         let clock;
 
-        before(function () {
+        beforeAll(function () {
             sinon.stub(api, 'recommendationsPublic').get(() => {
                 return {
                     browse: () => {
@@ -169,7 +169,7 @@ describe('{{#recommendations}} helper', function () {
             clock.restore();
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 

--- a/ghost/core/test/unit/frontend/helpers/search.test.js
+++ b/ghost/core/test/unit/frontend/helpers/search.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');
 
 describe('Search helper', function () {
-    before(function () {
+    beforeAll(function () {
         registerHelper('search');
     });
 

--- a/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-accounts.test.js
@@ -28,7 +28,7 @@ function compile(templateString) {
 }
 
 describe('{{#social_accounts}} helper', function () {
-    before(function () {
+    beforeAll(function () {
         helpers.registerHelper('social_accounts', social_accounts);
 
         defaultGlobals = {

--- a/ghost/core/test/unit/frontend/helpers/social-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-url.test.js
@@ -29,7 +29,7 @@ function compile(templateString) {
 }
 
 describe('{{social_url}} helper', function () {
-    before(function () {
+    beforeAll(function () {
         // Register the helper using an object structure
         helpers.registerHelper('social_url', social_url);
         helpers.registerAlias('facebook_url', 'social_url');

--- a/ghost/core/test/unit/frontend/helpers/split.test.js
+++ b/ghost/core/test/unit/frontend/helpers/split.test.js
@@ -2,7 +2,7 @@ const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');
 const {SafeString} = require('../../../../core/frontend/services/handlebars');
 
 describe('{{split}} helper in block mode', function () {
-    before(function () {
+    beforeAll(function () {
         registerHelper('split');
         registerHelper('foreach');
         registerHelper('match');
@@ -79,7 +79,7 @@ describe('{{split}} helper in block mode', function () {
 });
 
 describe('{{split}} helper in inline mode', function () {
-    before(function () {
+    beforeAll(function () {
         registerHelper('split');
         registerHelper('foreach');
         registerHelper('match');

--- a/ghost/core/test/unit/frontend/helpers/t-new.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t-new.test.js
@@ -8,12 +8,12 @@ const labs = require('../../../../core/shared/labs');
 describe('NEW{{t}} helper', function () {
     let ogBasePath = themeI18next.basePath;
 
-    before(function () {
+    beforeAll(function () {
         sinon.stub(labs, 'isSet').withArgs('themeTranslation').returns(true);
         themeI18next.basePath = path.join(__dirname, '../../../utils/fixtures/themes/');
     });
 
-    after(function () {
+    afterAll(function () {
         sinon.restore();
         themeI18next.basePath = ogBasePath;
     });

--- a/ghost/core/test/unit/frontend/helpers/t.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t.test.js
@@ -6,11 +6,11 @@ const themeI18n = require('../../../../core/frontend/services/theme-engine/i18n'
 describe('{{t}} helper', function () {
     let ogBasePath = themeI18n.basePath;
 
-    before(function () {
+    beforeAll(function () {
         themeI18n.basePath = path.join(__dirname, '../../../utils/fixtures/themes/');
     });
 
-    after(function () {
+    afterAll(function () {
         themeI18n.basePath = ogBasePath;
     });
 

--- a/ghost/core/test/unit/frontend/helpers/url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/url.test.js
@@ -29,11 +29,11 @@ describe('{{url}} helper', function () {
     });
 
     describe('no subdir', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 
@@ -240,11 +240,11 @@ describe('{{url}} helper', function () {
     });
 
     describe('with subdir', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/blog'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 

--- a/ghost/core/test/unit/frontend/meta/context-object.test.js
+++ b/ghost/core/test/unit/frontend/meta/context-object.test.js
@@ -41,7 +41,7 @@ describe('getContextObject', function () {
     });
 
     describe('override blog', function () {
-        before(function () {
+        beforeAll(function () {
             sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     cover_image: 'test.png'
@@ -49,7 +49,7 @@ describe('getContextObject', function () {
             });
         });
 
-        after(function () {
+        afterAll(function () {
             sinon.restore();
         });
 

--- a/ghost/core/test/unit/frontend/meta/description.test.js
+++ b/ghost/core/test/unit/frontend/meta/description.test.js
@@ -6,13 +6,13 @@ const settingsCache = require('../../../../core/shared/settings-cache');
 describe('getMetaDescription', function () {
     let localSettingsCache = {};
 
-    before(function () {
+    beforeAll(function () {
         sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     });
 
-    after(function () {
+    afterAll(function () {
         sinon.restore();
     });
 

--- a/ghost/core/test/unit/frontend/meta/paginated-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/paginated-url.test.js
@@ -126,11 +126,11 @@ describe('getPaginatedUrl', function () {
     });
 
     describe('with /blog subdirectory', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({url: 'http://localhost:65535/blog'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 

--- a/ghost/core/test/unit/frontend/public/private.test.js
+++ b/ghost/core/test/unit/frontend/public/private.test.js
@@ -80,7 +80,7 @@ describe('private.js', function () {
         });
     }
 
-    before(function () {
+    beforeAll(function () {
         scriptContent = fs.readFileSync(path.join(__dirname, '../../../../core/frontend/public/private.js'), 'utf8');
     });
 

--- a/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
@@ -8,11 +8,11 @@ const AssetsMinificationBase = require('../../../../../core/frontend/services/as
 describe('AssetsMinificationBase', function () {
     let testDir;
 
-    before(async function () {
+    beforeAll(async function () {
         testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-base-tests-'));
     });
 
-    after(async function () {
+    afterAll(async function () {
         await fs.rm(testDir, {recursive: true});
     });
 

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -10,7 +10,7 @@ describe('Minifier', function () {
     let minifier;
     let testDir;
 
-    before(async function () {
+    beforeAll(async function () {
         testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'minifier-tests-'));
 
         minifier = new Minifier({
@@ -19,7 +19,7 @@ describe('Minifier', function () {
         });
     });
 
-    after(async function () {
+    afterAll(async function () {
         await fs.rmdir(testDir, {recursive: true});
     });
 

--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -13,7 +13,7 @@ describe('Card Asset Service', function () {
         srcDir,
         destDir;
 
-    before(async function () {
+    beforeAll(async function () {
         testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ghost-tests-'));
         srcDir = path.join(testDir, 'src');
         destDir = path.join(testDir, 'dest');
@@ -24,7 +24,7 @@ describe('Card Asset Service', function () {
         await fs.mkdir(path.join(srcDir, 'js'));
     });
 
-    after(async function () {
+    afterAll(async function () {
         await fs.rm(testDir, {recursive: true});
     });
 

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -3,6 +3,7 @@ const {assertExists} = require('../../../../../utils/assertions');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
 const configUtils = require('../../../../../utils/config-utils');
+const deferred = require('../../../../../utils/deferred');
 const urlUtils = require('../../../../../../core/shared/url-utils');
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
 const renderer = require('../../../../../../core/frontend/services/rendering');
@@ -56,7 +57,8 @@ describe('Unit - services/routing/controllers/entry', function () {
         sinon.restore();
     });
 
-    it('resource not found', function (done) {
+    it('resource not found', function () {
+        const {promise, done} = deferred();
         req.path = '/does-not-exist/';
 
         entryLookUpStub.withArgs(req.path, res.routerOptions)
@@ -66,9 +68,11 @@ describe('Unit - services/routing/controllers/entry', function () {
             assert.equal(err, undefined);
             done();
         });
+        return promise;
     });
 
-    it('resource found', function (done) {
+    it('resource found', function () {
+        const {promise, done} = deferred();
         req.path = post.url;
         req.originalUrl = req.path;
 
@@ -82,10 +86,12 @@ describe('Unit - services/routing/controllers/entry', function () {
         controllers.entry(req, res, function () {
             done();
         }).catch(done);
+        return promise;
     });
 
     describe('[edge cases] resource found', function () {
-        it('isUnknownOption: true', function (done) {
+        it('isUnknownOption: true', function () {
+            const {promise, done} = deferred();
             req.path = post.url;
 
             entryLookUpStub.withArgs(req.path, res.routerOptions)
@@ -98,9 +104,11 @@ describe('Unit - services/routing/controllers/entry', function () {
                 assert.equal(err, undefined);
                 done();
             });
+            return promise;
         });
 
-        it('isEditURL: true', function (done) {
+        it('isEditURL: true', function () {
+            const {promise, done} = deferred();
             req.path = post.url;
 
             entryLookUpStub.withArgs(req.path, res.routerOptions)
@@ -118,9 +126,11 @@ describe('Unit - services/routing/controllers/entry', function () {
             controllers.entry(req, res, (err) => {
                 done(err);
             });
+            return promise;
         });
 
-        it('isEditURL: true with admin redirects disabled', function (done) {
+        it('isEditURL: true with admin redirects disabled', function () {
+            const {promise, done} = deferred();
             configUtils.set('admin:redirects', false);
 
             req.path = post.url;
@@ -142,9 +152,11 @@ describe('Unit - services/routing/controllers/entry', function () {
                 assert.equal(err, undefined);
                 done(err);
             });
+            return promise;
         });
 
-        it('requested url !== resource url', function (done) {
+        it('requested url !== resource url', function () {
+            const {promise, done} = deferred();
             post.url = '/2017/08' + post.url;
             req.path = '/2017/07' + post.url;
             req.originalUrl = req.path;
@@ -165,9 +177,11 @@ describe('Unit - services/routing/controllers/entry', function () {
                 assertExists(err);
                 done(err);
             });
+            return promise;
         });
 
-        it('requested url !== resource url: with query params', function (done) {
+        it('requested url !== resource url: with query params', function () {
+            const {promise, done} = deferred();
             post.url = '/2017/08' + post.url;
             req.path = '/2017/07' + post.url;
             req.originalUrl = req.path + '?query=true';
@@ -187,6 +201,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             controllers.entry(req, res, function (err) {
                 done(err);
             });
+            return promise;
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/rss.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/rss.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
+const deferred = require('../../../../../utils/deferred');
 const security = require('@tryghost/security');
 const settingsCache = require('../../../../../../core/shared/settings-cache');
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
@@ -60,7 +61,8 @@ describe('Unit - services/routing/controllers/rss', function () {
         sinon.restore();
     });
 
-    it('should fetch data and attempt to send XML', function (done) {
+    it('should fetch data and attempt to send XML', function () {
+        const {promise, done} = deferred();
         fetchDataStub.withArgs({page: 1, slug: undefined}).resolves({
             posts: posts
         });
@@ -74,5 +76,6 @@ describe('Unit - services/routing/controllers/rss', function () {
         });
 
         controllers.rss(req, res, failTest(done));
+        return promise;
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
@@ -1,5 +1,6 @@
 const {assertExists} = require('../../../../../utils/assertions');
 const sinon = require('sinon');
+const deferred = require('../../../../../utils/deferred');
 
 const api = require('../../../../../../core/frontend/services/proxy').api;
 const themeEngine = require('../../../../../../core/frontend/services/theme-engine');
@@ -75,7 +76,8 @@ describe('Unit - services/routing/controllers/static', function () {
         sinon.restore();
     });
 
-    it('no extra data to fetch', function (done) {
+    it('no extra data to fetch', function () {
+        const {promise, done} = deferred();
         renderer.renderer.callsFake(function () {
             sinon.assert.calledOnce(renderer.formatResponse.entries);
             sinon.assert.notCalled(tagsReadStub);
@@ -83,9 +85,11 @@ describe('Unit - services/routing/controllers/static', function () {
         });
 
         controllers.static(req, res, failTest(done));
+        return promise;
     });
 
-    it('extra data to fetch', function (done) {
+    it('extra data to fetch', function () {
+        const {promise, done} = deferred();
         res.routerOptions.data = {
             tag: {
                 controller: 'tagsPublic',
@@ -106,5 +110,6 @@ describe('Unit - services/routing/controllers/static', function () {
         });
 
         controllers.static(req, res, failTest(done));
+        return promise;
     });
 });

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -15,7 +15,7 @@ describe('RSS: Generate Feed', function () {
     // Static set of posts
     let posts;
 
-    before(function () {
+    beforeAll(function () {
         posts = _.cloneDeep(testUtils.DataGenerator.forKnex.posts);
 
         posts = _.filter(posts, function filter(post) {

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -32,7 +32,7 @@ describe('Unit: sitemap/manager', function () {
         return new SiteMapManager({posts: posts, pages: pages, tags: tags, authors: authors});
     };
 
-    before(function () {
+    beforeAll(function () {
         eventsToRemember = {};
 
         // @NOTE: the pattern of faking event call is not great, we should be
@@ -47,14 +47,14 @@ describe('Unit: sitemap/manager', function () {
         sinon.stub(IndexGenerator.prototype, 'getXml');
     });
 
-    after(function () {
+    afterAll(function () {
         sinon.restore();
     });
 
     describe('SiteMapManager', function () {
         let manager;
 
-        before(function () {
+        beforeAll(function () {
             manager = makeStubManager();
         });
 
@@ -130,7 +130,7 @@ describe('Unit: sitemap/manager', function () {
     describe('SiteMapManager (lazyRouting mode)', function () {
         let lazyEvents;
 
-        before(function () {
+        beforeAll(function () {
             lazyEvents = {};
             // Replace the events.on stub for this block so we can capture
             // subscriptions made by a manager constructed with lazyRouting on.

--- a/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
@@ -20,7 +20,7 @@ describe('Helpers', function () {
     const expectedHelpers = _.concat(hbsHelpers, ghostHelpers, experimentalHelpers);
 
     describe('Load Core Helpers', function () {
-        before(function () {
+        beforeAll(function () {
             hbs.express4();
             helpers.init();
         });

--- a/ghost/core/test/unit/frontend/services/theme-engine/preview.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/preview.test.js
@@ -6,7 +6,7 @@ const preview = require('../../../../../core/frontend/services/theme-engine/prev
 describe('Theme Preview', function () {
     let req, previewString = '';
 
-    before(function () {
+    beforeAll(function () {
         req = {
             header: () => {
                 return previewString;

--- a/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
+++ b/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
@@ -4,13 +4,13 @@ const configUtils = require('../../../utils/config-utils');
 
 describe('Frontend apps:', function () {
     describe('getFrontendAppConfig', function () {
-        before(function () {
+        beforeAll(function () {
             configUtils.set({'portal:url': 'https://cdn.example.com/~{version}/portal.min.js'});
             configUtils.set({'portal:version': '1.0'});
             configUtils.set({'portal:styles': 'https://cdn.example.com/~{version}/main.css'});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
         });
 

--- a/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
@@ -12,12 +12,12 @@ describe('frontendCaching', function () {
     let freeTier;
     let premiumTier;
 
-    this.beforeEach(async function () {
+    beforeEach(async function () {
         freeTier = {id: 'freeTierId'};
         premiumTier = {id: 'premiumTierId'};
     });
 
-    this.afterEach(async function () {
+    afterEach(async function () {
         await configUtils.restore();
     });
 

--- a/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
@@ -5,6 +5,7 @@ const activeTheme = require('../../../../../core/frontend/services/theme-engine/
 const handleImageSizes = require('../../../../../core/frontend/web/middleware/handle-image-sizes.js');
 const errors = require('@tryghost/errors');
 const imageTransform = require('@tryghost/image-transform');
+const deferred = require('../../../../utils/deferred');
 
 const fakeResBase = {
     setHeader() {}
@@ -12,73 +13,63 @@ const fakeResBase = {
 
 // @TODO make these tests lovely and non specific to implementation
 describe('handleImageSizes middleware', function () {
-    this.afterEach(function () {
+    afterEach(function () {
         sinon.restore();
     });
 
-    it('calls next immediately if the url does not match /size/something/', function (done) {
+    it('calls next immediately if the url does not match /size/something/', function () {
+        const {promise, done} = deferred();
         const fakeReq = {
             url: '/size/something'
         };
-        // CASE: second thing middleware does is try to match to a regex
-        fakeReq.url.match = function () {
-            throw new Error('Should have exited immediately');
-        };
         handleImageSizes(fakeReq, fakeResBase, function next() {
             done();
         });
+        return promise;
     });
 
-    it('calls next immediately if the url does not match /size/whatever/', function (done) {
+    it('calls next immediately if the url does not match /size/whatever/', function () {
+        const {promise, done} = deferred();
         const fakeReq = {
             url: '/url/whatever/'
         };
-        // CASE: second thing middleware does is try to match to a regex
-        fakeReq.url.match = function () {
-            throw new Error('Should have exited immediately');
-        };
         handleImageSizes(fakeReq, fakeResBase, function next() {
             done();
         });
+        return promise;
     });
 
-    it('calls next immediately if the file extension is missing', function (done) {
+    it('calls next immediately if the file extension is missing', function () {
+        const {promise, done} = deferred();
         const fakeReq = {
             url: '/size/something/file'
         };
-        // CASE: second thing middleware does is try to match to a regex
-        fakeReq.url.match = function () {
-            throw new Error('Should have exited immediately');
-        };
         handleImageSizes(fakeReq, fakeResBase, function next() {
             done();
         });
+        return promise;
     });
 
-    it('calls next immediately if the file has a trailing slash', function (done) {
+    it('calls next immediately if the file has a trailing slash', function () {
+        const {promise, done} = deferred();
         const fakeReq = {
             url: '/size/something/file.jpg/'
         };
-        // CASE: second thing middleware does is try to match to a regex
-        fakeReq.url.match = function () {
-            throw new Error('Should have exited immediately');
-        };
         handleImageSizes(fakeReq, fakeResBase, function next() {
             done();
         });
+        return promise;
     });
 
-    it('calls next immediately if the url does not match /size//', function (done) {
+    it('calls next immediately if the url does not match /size//', function () {
+        const {promise, done} = deferred();
         const fakeReq = {
             url: '/size//'
         };
-        // CASE: second thing middleware does is try to match to a regex
-        fakeReq.url.match = function () {
-            throw new Error('Should have exited immediately');
-        };
         handleImageSizes(fakeReq, fakeResBase, function next() {
             done();
         });
+        return promise;
     });
 
     describe('file handling', function () {
@@ -87,7 +78,7 @@ describe('handleImageSizes middleware', function () {
         let resizeFromBufferStub;
         let buffer;
 
-        this.beforeEach(function () {
+        beforeEach(function () {
             buffer = Buffer.from([0]);
             dummyStorage = {
                 async exists() {
@@ -131,7 +122,8 @@ describe('handleImageSizes middleware', function () {
             resizeFromBufferStub = sinon.stub(imageTransform, 'resizeFromBuffer').resolves(Buffer.from([]));
         });
 
-        it('redirects for invalid format extension', function (done) {
+        it('redirects for invalid format extension', function () {
+            const {promise, done} = deferred();
             const fakeReq = {
                 url: '/size/w1000/format/test/image.jpg',
                 originalUrl: '/blog/content/images/size/w1000/format/test/image.jpg'
@@ -153,9 +145,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('redirects for invalid sizes', function (done) {
+        it('redirects for invalid sizes', function () {
+            const {promise, done} = deferred();
             const fakeReq = {
                 url: '/size/w123/image.jpg',
                 originalUrl: '/blog/content/images/size/w123/image.jpg'
@@ -177,9 +171,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('strips multiple leading slashes when redirecting to the original URL', function (done) {
+        it('strips multiple leading slashes when redirecting to the original URL', function () {
+            const {promise, done} = deferred();
             const fakeReq = {
                 url: '/size/w123/image.jpg',
                 originalUrl: '////example.com/content/images/size/w123/image.jpg'
@@ -201,9 +197,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('redirects for invalid configured size', function (done) {
+        it('redirects for invalid configured size', function () {
+            const {promise, done} = deferred();
             const fakeReq = {
                 url: '/size/missing/image.jpg',
                 originalUrl: '/blog/content/images/size/missing/image.jpg'
@@ -225,9 +223,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('returns original URL if file is empty', function (done) {
+        it('returns original URL if file is empty', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function (path) {
                 if (path === '/blank_o.png') {
                     return true;
@@ -262,9 +262,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('returns original URL if unsupported storage adapter', function (done) {
+        it('returns original URL if unsupported storage adapter', function () {
+            const {promise, done} = deferred();
             dummyStorage.saveRaw = undefined;
 
             const fakeReq = {
@@ -289,9 +291,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('redirects if sharp is not installed', function (done) {
+        it('redirects if sharp is not installed', function () {
+            const {promise, done} = deferred();
             sinon.stub(imageTransform, 'canTransformFiles').returns(false);
 
             const fakeReq = {
@@ -316,9 +320,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('redirects if timeout is exceeded', function (done) {
+        it('redirects if timeout is exceeded', function () {
+            const {promise, done} = deferred();
             sinon.stub(imageTransform, 'canTransformFiles').returns(true);
 
             dummyStorage.exists = async function () {
@@ -357,9 +363,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('continues if file exists', function (done) {
+        it('continues if file exists', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function (path) {
                 if (path === '/size/w1000/blank.png') {
                     return true;
@@ -383,9 +391,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
 
-        it('uses unoptimizedImageExists if it exists', function (done) {
+        it('uses unoptimizedImageExists if it exists', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function (path) {
                 if (path === '/blank_o.png') {
                     return true;
@@ -415,9 +425,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
 
-        it('uses unoptimizedImageExists if it exists with formatting', function (done) {
+        it('uses unoptimizedImageExists if it exists with formatting', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function (path) {
                 if (path === '/blank_o.png') {
                     return true;
@@ -450,9 +462,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
 
-        it('skips SVG if not formatted', function (done) {
+        it('skips SVG if not formatted', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -479,9 +493,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('skips formatting to ico', function (done) {
+        it('skips formatting to ico', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -508,9 +524,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('skips formatting from ico', function (done) {
+        it('skips formatting from ico', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -537,9 +555,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('skips formatting to svg', function (done) {
+        it('skips formatting to svg', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -566,9 +586,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done(new Error('Should not have called next'));
             });
+            return promise;
         });
 
-        it('doesn\'t skip SVGs if formatted to PNG', function (done) {
+        it('doesn\'t skip SVGs if formatted to PNG', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -603,9 +625,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
 
-        it('can format PNG to WEBP', function (done) {
+        it('can format PNG to WEBP', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -643,9 +667,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
 
-        it('can format PNG to AVIF', function (done) {
+        it('can format PNG to AVIF', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -683,9 +709,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
 
-        it('can format GIF to WEBP', function (done) {
+        it('can format GIF to WEBP', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -723,9 +751,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
 
-        it('can format WEBP to GIF', function (done) {
+        it('can format WEBP to GIF', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -763,9 +793,11 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
 
-        it('goes to next middleware with no error if source and resized image 404', function (done) {
+        it('goes to next middleware with no error if source and resized image 404', function () {
+            const {promise, done} = deferred();
             dummyStorage.exists = async function () {
                 return false;
             };
@@ -794,6 +826,7 @@ describe('handleImageSizes middleware', function () {
                 }
                 done();
             });
+            return promise;
         });
     });
 });

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -33,8 +33,8 @@ describe('staticTheme', function () {
     });
 
     function callStaticTheme() {
-        return new Promise((resolve) => {
-            staticTheme()(req, res, resolve);
+        return new Promise((resolve, reject) => {
+            staticTheme()(req, res, err => (err ? reject(err) : resolve()));
         });
     }
 

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -32,406 +32,322 @@ describe('staticTheme', function () {
         sinon.restore();
     });
 
-    it('should skip for .hbs file', function (done) {
+    function callStaticTheme() {
+        return new Promise((resolve) => {
+            staticTheme()(req, res, resolve);
+        });
+    }
+
+    it('should skip for .hbs file', async function () {
         req.path = 'mytemplate.hbs';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should skip for .md file', function (done) {
+    it('should skip for .md file', async function () {
         req.path = 'README.md';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should skip for .json file', function (done) {
+    it('should skip for .json file', async function () {
         req.path = 'sample.json';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should skip for .lock file', function (done) {
+    it('should skip for .lock file', async function () {
         req.path = 'yarn.lock';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should skip for gulp file', function (done) {
+    it('should skip for gulp file', async function () {
         req.path = 'gulpfile.js';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should skip for Grunt file', function (done) {
+    it('should skip for Grunt file', async function () {
         req.path = 'Gulpfile.js';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should call express.static for .css file', function (done) {
+    it('should call express.static for .css file', async function () {
         req.path = 'myvalidfile.css';
 
-        staticTheme()(req, res, function next() {
-            // Specifically gets called twice
-            sinon.assert.calledTwice(activeThemeStub);
-            sinon.assert.called(expressStaticStub);
+        await callStaticTheme();
+        // Specifically gets called twice
+        sinon.assert.calledTwice(activeThemeStub);
+        sinon.assert.called(expressStaticStub);
 
-            // Check that express static gets called with the theme path + maxAge
-            assertExists(expressStaticStub.firstCall.args);
-            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            const options = expressStaticStub.firstCall.args[1];
-            assert(options && typeof options === 'object');
-            assert('maxAge' in options);
-
-            done();
-        });
+        // Check that express static gets called with the theme path + maxAge
+        assertExists(expressStaticStub.firstCall.args);
+        assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+        const options = expressStaticStub.firstCall.args[1];
+        assert(options && typeof options === 'object');
+        assert('maxAge' in options);
     });
 
-    it('should call express.static for .js file', function (done) {
+    it('should call express.static for .js file', async function () {
         req.path = 'myvalidfile.js';
 
-        staticTheme()(req, res, function next() {
-            // Specifically gets called twice
-            sinon.assert.calledTwice(activeThemeStub);
-            sinon.assert.called(expressStaticStub);
+        await callStaticTheme();
+        // Specifically gets called twice
+        sinon.assert.calledTwice(activeThemeStub);
+        sinon.assert.called(expressStaticStub);
 
-            // Check that express static gets called with the theme path + maxAge
-            assertExists(expressStaticStub.firstCall.args);
-            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            const options = expressStaticStub.firstCall.args[1];
-            assert(options && typeof options === 'object');
-            assert('maxAge' in options);
-
-            done();
-        });
+        // Check that express static gets called with the theme path + maxAge
+        assertExists(expressStaticStub.firstCall.args);
+        assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+        const options = expressStaticStub.firstCall.args[1];
+        assert(options && typeof options === 'object');
+        assert('maxAge' in options);
     });
 
-    it('should not error if active theme is missing', function (done) {
+    it('should not error if active theme is missing', async function () {
         req.path = 'myvalidfile.css';
 
         // make the active theme not exist
         activeThemeStub.returns(undefined);
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.calledOnce(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.calledOnce(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should NOT skip if file is allowed', function (done) {
+    it('should NOT skip if file is allowed', async function () {
         req.path = 'manifest.json';
 
-        staticTheme()(req, res, function next() {
-            // Specifically gets called twice
-            sinon.assert.calledTwice(activeThemeStub);
-            sinon.assert.called(expressStaticStub);
+        await callStaticTheme();
+        // Specifically gets called twice
+        sinon.assert.calledTwice(activeThemeStub);
+        sinon.assert.called(expressStaticStub);
 
-            // Check that express static gets called with the theme path + maxAge
-            assertExists(expressStaticStub.firstCall.args);
-            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            const options = expressStaticStub.firstCall.args[1];
-            assert(options && typeof options === 'object');
-            assert('maxAge' in options);
-
-            done();
-        });
+        // Check that express static gets called with the theme path + maxAge
+        assertExists(expressStaticStub.firstCall.args);
+        assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+        const options = expressStaticStub.firstCall.args[1];
+        assert(options && typeof options === 'object');
+        assert('maxAge' in options);
     });
 
-    it('should NOT skip if file is allowed even if nested', function (done) {
+    it('should NOT skip if file is allowed even if nested', async function () {
         req.path = '/.well-known/assetlinks.json';
 
-        staticTheme()(req, res, function next() {
-            // Specifically gets called twice
-            sinon.assert.calledTwice(activeThemeStub);
-            sinon.assert.called(expressStaticStub);
+        await callStaticTheme();
+        // Specifically gets called twice
+        sinon.assert.calledTwice(activeThemeStub);
+        sinon.assert.called(expressStaticStub);
 
-            // Check that express static gets called with the theme path + maxAge
-            assertExists(expressStaticStub.firstCall.args);
-            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            const options = expressStaticStub.firstCall.args[1];
-            assert(options && typeof options === 'object');
-            assert('maxAge' in options);
-
-            done();
-        });
+        // Check that express static gets called with the theme path + maxAge
+        assertExists(expressStaticStub.firstCall.args);
+        assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+        const options = expressStaticStub.firstCall.args[1];
+        assert(options && typeof options === 'object');
+        assert('maxAge' in options);
     });
 
-    it('should NOT skip if file is in assets', function (done) {
+    it('should NOT skip if file is in assets', async function () {
         req.path = '/assets/whatever.json';
 
-        staticTheme()(req, res, function next() {
-            // Specifically gets called twice
-            sinon.assert.calledTwice(activeThemeStub);
-            sinon.assert.called(expressStaticStub);
+        await callStaticTheme();
+        // Specifically gets called twice
+        sinon.assert.calledTwice(activeThemeStub);
+        sinon.assert.called(expressStaticStub);
 
-            // Check that express static gets called with the theme path + maxAge
-            assertExists(expressStaticStub.firstCall.args);
-            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            const options = expressStaticStub.firstCall.args[1];
-            assert(options && typeof options === 'object');
-            assert('maxAge' in options);
-
-            done();
-        });
+        // Check that express static gets called with the theme path + maxAge
+        assertExists(expressStaticStub.firstCall.args);
+        assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+        const options = expressStaticStub.firstCall.args[1];
+        assert(options && typeof options === 'object');
+        assert('maxAge' in options);
     });
 
-    it('should skip for .hbs file EVEN in /assets', function (done) {
+    it('should skip for .hbs file EVEN in /assets', async function () {
         req.path = '/assets/mytemplate.hbs';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should disallow path traversal', function (done) {
+    it('should disallow path traversal', async function () {
         req.path = '/assets/built%2F..%2F..%2F/package.json';
         req.method = 'GET';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
-    it('should not crash when malformatted URL sequence is passed', function (done) {
+    it('should not crash when malformatted URL sequence is passed', async function () {
         req.path = '/assets/built%2F..%2F..%2F%E0%A4%A/package.json';
         req.method = 'GET';
 
-        staticTheme()(req, res, function next() {
-            sinon.assert.notCalled(activeThemeStub);
-            sinon.assert.notCalled(expressStaticStub);
-
-            done();
-        });
+        await callStaticTheme();
+        sinon.assert.notCalled(activeThemeStub);
+        sinon.assert.notCalled(expressStaticStub);
     });
 
     describe('URL-encoded extension bypass prevention', function () {
-        it('should skip for URL-encoded .hbs extension (h%62s)', function (done) {
+        it('should skip for URL-encoded .hbs extension (h%62s)', async function () {
             req.path = 'mytemplate.h%62s';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for URL-encoded .json extension (%6Ason)', function (done) {
+        it('should skip for URL-encoded .json extension (%6Ason)', async function () {
             req.path = 'package.%6Ason';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for URL-encoded .md extension (%6Dd)', function (done) {
+        it('should skip for URL-encoded .md extension (%6Dd)', async function () {
             req.path = 'README.%6Dd';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for URL-encoded .lock extension (l%6Fck)', function (done) {
+        it('should skip for URL-encoded .lock extension (l%6Fck)', async function () {
             req.path = 'yarn.l%6Fck';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for URL-encoded .log extension (%6Cog)', function (done) {
+        it('should skip for URL-encoded .log extension (%6Cog)', async function () {
             req.path = 'ghost.%6Cog';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for URL-encoded gulpfile.js (g%75lpfile.js)', function (done) {
+        it('should skip for URL-encoded gulpfile.js (g%75lpfile.js)', async function () {
             req.path = 'g%75lpfile.js';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for URL-encoded .hbs in /assets/ path', function (done) {
+        it('should skip for URL-encoded .hbs in /assets/ path', async function () {
             req.path = '/assets/mytemplate.h%62s';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for malformed URL encoding in denied file', function (done) {
+        it('should skip for malformed URL encoding in denied file', async function () {
             req.path = 'mytemplate.h%ZZs';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
     });
 
     describe('paths without file extensions', function () {
-        it('should skip for root path /', function (done) {
+        it('should skip for root path /', async function () {
             req.path = '/';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for /about/', function (done) {
+        it('should skip for /about/', async function () {
             req.path = '/about/';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for /blog/my-post/', function (done) {
+        it('should skip for /blog/my-post/', async function () {
             req.path = '/blog/my-post/';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should skip for path without trailing slash /contact', function (done) {
+        it('should skip for path without trailing slash /contact', async function () {
             req.path = '/contact';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(activeThemeStub);
-                sinon.assert.notCalled(expressStaticStub);
-
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
         });
 
-        it('should NOT skip for file with extension without trailing slash', function (done) {
+        it('should NOT skip for file with extension without trailing slash', async function () {
             req.path = '/somefile.txt';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with the theme path + maxAge
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-                const options = expressStaticStub.firstCall.args[1];
-                assert(options && typeof options === 'object');
-                assert('maxAge' in options);
-
-                done();
-            });
+            // Check that express static gets called with the theme path + maxAge
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            const options = expressStaticStub.firstCall.args[1];
+            assert(options && typeof options === 'object');
+            assert('maxAge' in options);
         });
 
-        it('should NOT skip for file with extension with trailing slash', function (done) {
+        it('should NOT skip for file with extension with trailing slash', async function () {
             req.path = '/somefile.txt/';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with the theme path + maxAge
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-                const options = expressStaticStub.firstCall.args[1];
-                assert(options && typeof options === 'object');
-                assert('maxAge' in options);
-
-                done();
-            });
+            // Check that express static gets called with the theme path + maxAge
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            const options = expressStaticStub.firstCall.args[1];
+            assert(options && typeof options === 'object');
+            assert('maxAge' in options);
         });
 
-        it('should NOT skip for deeply nested file with extension', function (done) {
+        it('should NOT skip for deeply nested file with extension', async function () {
             req.path = '/deep/nested/path/file.css';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with the theme path + maxAge
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-                const options = expressStaticStub.firstCall.args[1];
-                assert(options && typeof options === 'object');
-                assert('maxAge' in options);
-
-                done();
-            });
+            // Check that express static gets called with the theme path + maxAge
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            const options = expressStaticStub.firstCall.args[1];
+            assert(options && typeof options === 'object');
+            assert('maxAge' in options);
         });
     });
 
@@ -442,220 +358,185 @@ describe('staticTheme', function () {
             });
         });
 
-        it('should serve .well-known/apple-app-site-association despite missing extension', function (done) {
+        it('should serve .well-known/apple-app-site-association despite missing extension', async function () {
             req.path = '/.well-known/apple-app-site-association';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.called(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            sinon.assert.called(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                const options = expressStaticStub.firstCall.args[1];
-                assertExists(options.setHeaders);
+            const options = expressStaticStub.firstCall.args[1];
+            assertExists(options.setHeaders);
 
-                const setHeaderStub = sinon.stub();
-                options.setHeaders({setHeader: setHeaderStub});
-                sinon.assert.calledWith(setHeaderStub, 'Content-Type', 'application/json');
-
-                done();
-            });
+            const setHeaderStub = sinon.stub();
+            options.setHeaders({setHeader: setHeaderStub});
+            sinon.assert.calledWith(setHeaderStub, 'Content-Type', 'application/json');
         });
 
-        it('should fall through when request differs from exact path', function (done) {
+        it('should fall through when request differs from exact path', async function () {
             req.path = '/.WELL-KNOWN/apple-app-site-association.json';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.notCalled(expressStaticStub);
-                done();
-            });
+            await callStaticTheme();
+            sinon.assert.notCalled(expressStaticStub);
         });
     });
 
     describe('fallthrough behavior', function () {
-        it('should set fallthrough to true for /robots.txt', function (done) {
+        it('should set fallthrough to true for /robots.txt', async function () {
             req.path = '/robots.txt';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with correct options
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            // Check that express static gets called with correct options
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert(_.isPlainObject(options));
-                assert('maxAge' in options);
-                assert.equal(options.fallthrough, true);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert(_.isPlainObject(options));
+            assert('maxAge' in options);
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should set fallthrough to true for /sitemap.xml', function (done) {
+        it('should set fallthrough to true for /sitemap.xml', async function () {
             req.path = '/sitemap.xml';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with correct options
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            // Check that express static gets called with correct options
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert(_.isPlainObject(options));
-                assert('maxAge' in options);
-                assert.equal(options.fallthrough, true);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert(_.isPlainObject(options));
+            assert('maxAge' in options);
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should set fallthrough to true for /sitemap-posts.xml', function (done) {
+        it('should set fallthrough to true for /sitemap-posts.xml', async function () {
             req.path = '/sitemap-posts.xml';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with correct options
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            // Check that express static gets called with correct options
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert(_.isPlainObject(options));
-                assert('maxAge' in options);
-                assert.equal(options.fallthrough, true);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert(_.isPlainObject(options));
+            assert('maxAge' in options);
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should set fallthrough to true for paginated sitemaps like /sitemap-posts-2.xml', function (done) {
+        it('should set fallthrough to true for paginated sitemaps like /sitemap-posts-2.xml', async function () {
             req.path = '/sitemap-posts-2.xml';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert(_.isPlainObject(options));
-                assert('maxAge' in options);
-                assert.equal(options.fallthrough, true);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert(_.isPlainObject(options));
+            assert('maxAge' in options);
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should set fallthrough to true for higher page numbers like /sitemap-posts-99.xml', function (done) {
+        it('should set fallthrough to true for higher page numbers like /sitemap-posts-99.xml', async function () {
             req.path = '/sitemap-posts-99.xml';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert.equal(options.fallthrough, true);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should set fallthrough to true for paginated tag sitemaps like /sitemap-tags-3.xml', function (done) {
+        it('should set fallthrough to true for paginated tag sitemaps like /sitemap-tags-3.xml', async function () {
             req.path = '/sitemap-tags-3.xml';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert.equal(options.fallthrough, true);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should set fallthrough to true for paginated author sitemaps like /sitemap-authors-2.xml', function (done) {
+        it('should set fallthrough to true for paginated author sitemaps like /sitemap-authors-2.xml', async function () {
             req.path = '/sitemap-authors-2.xml';
 
-            staticTheme()(req, res, function next() {
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert.equal(options.fallthrough, true);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert.equal(options.fallthrough, true);
         });
 
-        it('should set fallthrough to false for other static files', function (done) {
+        it('should set fallthrough to false for other static files', async function () {
             req.path = '/style.css';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with correct options
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            // Check that express static gets called with correct options
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert(_.isPlainObject(options));
-                assert('maxAge' in options);
-                assert.equal(options.fallthrough, false);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert(_.isPlainObject(options));
+            assert('maxAge' in options);
+            assert.equal(options.fallthrough, false);
         });
 
-        it('should set fallthrough to false for nested files', function (done) {
+        it('should set fallthrough to false for nested files', async function () {
             req.path = '/assets/style.css';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with correct options
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            // Check that express static gets called with correct options
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert(_.isPlainObject(options));
-                assert('maxAge' in options);
-                assert.equal(options.fallthrough, false);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert(_.isPlainObject(options));
+            assert('maxAge' in options);
+            assert.equal(options.fallthrough, false);
         });
 
-        it('should set fallthrough to false for allowed special files like manifest.json', function (done) {
+        it('should set fallthrough to false for allowed special files like manifest.json', async function () {
             req.path = '/manifest.json';
 
-            staticTheme()(req, res, function next() {
-                // Specifically gets called twice
-                sinon.assert.calledTwice(activeThemeStub);
-                sinon.assert.called(expressStaticStub);
+            await callStaticTheme();
+            // Specifically gets called twice
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
-                // Check that express static gets called with correct options
-                assertExists(expressStaticStub.firstCall.args);
-                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
+            // Check that express static gets called with correct options
+            assertExists(expressStaticStub.firstCall.args);
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
-                const options = expressStaticStub.firstCall.args[1];
-                assert(_.isPlainObject(options));
-                assert('maxAge' in options);
-                assert.equal(options.fallthrough, false);
-
-                done();
-            });
+            const options = expressStaticStub.firstCall.args[1];
+            assert(_.isPlainObject(options));
+            assert('maxAge' in options);
+            assert.equal(options.fallthrough, false);
         });
     });
 });

--- a/ghost/core/test/utils/deferred.js
+++ b/ghost/core/test/utils/deferred.js
@@ -1,0 +1,21 @@
+/**
+ * Bridges the mocha `done` callback onto a promise so callback-style tests
+ * run under vitest (which dropped `done` support). `done()` resolves the
+ * promise; `done(err)` rejects it — matching mocha's `done` semantics.
+ *
+ * Usage:
+ *   it('does a thing', function () {
+ *       const {promise, done} = deferred();
+ *       thing(() => done());
+ *       return promise;
+ *   });
+ */
+function deferred() {
+    let done;
+    const promise = new Promise((resolve, reject) => {
+        done = err => (err ? reject(err) : resolve());
+    });
+    return {promise, done};
+}
+
+module.exports = deferred;

--- a/ghost/core/test/utils/vitest-setup.ts
+++ b/ghost/core/test/utils/vitest-setup.ts
@@ -8,11 +8,11 @@
 // calls — those rules guard against accidental top-level hooks in mocha
 // test files, but vitest setup files are *meant* to register global hooks
 // at the top level. Disable for this file only.
-/* eslint-disable ghost/mocha/no-top-level-hooks, ghost/mocha/no-sibling-hooks */
+/* eslint-disable ghost/mocha/no-top-level-hooks, ghost/mocha/no-sibling-hooks, ghost/mocha/handle-done-callback */
 
 import crypto from 'node:crypto';
 import chalk from 'chalk';
-import {beforeAll, afterEach, afterAll} from 'vitest';
+import {beforeAll, beforeEach, afterEach, afterAll} from 'vitest';
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'testing';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_SECRET';
@@ -102,6 +102,31 @@ beforeAll(async () => {
         await mochaHooks.beforeAll();
     }
     getMockManager().disableNetwork();
+});
+
+// Bridge jest-snapshot's per-test config. The mocha hook reads
+// `this.currentTest`; vitest has no mocha `this`, so we derive the same
+// testPath/testTitle from the vitest task. testTitle must exactly match
+// mocha's `fullTitle()` (describe names + test name joined by spaces) or
+// committed .snap keys won't resolve.
+beforeEach((context: {task: {name: string; suite?: unknown; file?: {filepath?: string}}}) => {
+    const snapshotManager = snapshotExports.snapshotManager;
+    if (!snapshotManager) {
+        return;
+    }
+    const titleParts: string[] = [];
+    let node: {name?: string; suite?: unknown; filepath?: string} | undefined = context.task;
+    // Walk task -> describe(s); stop at the file node (it has `filepath`).
+    while (node && !node.filepath) {
+        if (node.name) {
+            titleParts.unshift(node.name);
+        }
+        node = node.suite as typeof node;
+    }
+    snapshotManager.setCurrentTest({
+        testPath: context.task.file?.filepath,
+        testTitle: titleParts.join(' ')
+    });
 });
 
 afterEach(async () => {

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {defineConfig} from 'vitest/config';
 
 // Vitest is being introduced incrementally alongside mocha. Each PR
@@ -15,6 +16,7 @@ export default defineConfig({
         include: [
             'test/unit/api/**/*.test.{js,ts}',
             'test/unit/bin/**/*.test.{js,ts}',
+            'test/unit/frontend/**/*.test.{js,ts}',
             'test/unit/shared/**/*.test.{js,ts}',
             'test/unit/server/adapters/**/*.test.{js,ts}',
             'test/unit/server/api/**/*.test.{js,ts}',
@@ -29,6 +31,15 @@ export default defineConfig({
             '**/node_modules/**'
         ],
         setupFiles: ['./test/utils/vitest-setup.ts'],
+        // Ghost's snapshot tests use @tryghost/jest-snapshot, which manages
+        // its own `__snapshots__/*.snap` files. Point vitest's native
+        // snapshot system at a separate (never-written) path so it doesn't
+        // adopt those files and report their entries as obsolete.
+        resolveSnapshotPath: (testPath: string, snapExtension: string) => path.join(
+            path.dirname(testPath),
+            '__vitest_snapshots__',
+            path.basename(testPath) + snapExtension
+        ),
         testTimeout: 2000,
         hookTimeout: 60000,
         reporters: ['dot'],


### PR DESCRIPTION
## Summary

Continues the vitest migration (after #27898 / #27900 / #27974 / #27991) by moving the `test/unit/frontend` bucket — 135 files, 1804 tests — from mocha to vitest.

## Conversions

- **39 files** using mocha's suite-scope `before()` / `after()` → `beforeAll()` / `afterAll()`
- `frontend-caching` + `handle-image-sizes`: `this.beforeEach` / `this.afterEach` (mocha-API misuse) → top-level `beforeEach` / `afterEach`
- **6 files** using the mocha `done()` callback converted off it:
  - `static-theme.test.js` — 42 uniform middleware tests → a local `callStaticTheme()` promise helper
  - `handle-image-sizes` + 4 `services/routing/controllers` files → a new shared `test/utils/deferred.js` helper that bridges `done` onto a promise (`done()` resolves, `done(err)` rejects), so existing call sites stay unchanged
- `handle-image-sizes`: removed 5 dead `fakeReq.url.match = fn` lines — assigning a property to a string primitive is a silent no-op in mocha's sloppy mode and **throws** under vitest's strict mode. The override never actually installed anything; the tests still assert `next()` is reached.

## Snapshot support

This is the first migrated bucket with snapshot tests (`ghost-head.test.js`, 83 snapshots). Two pieces of infrastructure:

- `vitest-setup.ts` — added a `beforeEach` that bridges `@tryghost/jest-snapshot`'s per-test config. The mocha hook reads `this.currentTest`; vitest has no mocha `this`, so we derive the same `testPath` / `testTitle` from the vitest task. `testTitle` must exactly match mocha's `fullTitle()` (describe names + test name joined by spaces) or committed `.snap` keys won't resolve.
- `vitest.config.ts` — set `resolveSnapshotPath` to a separate path. Ghost's snapshot tests are managed by `@tryghost/jest-snapshot` (its own `__snapshots__/*.snap` files); without this, vitest's *native* snapshot system adopts those files, rewrites their header, and reports every entry as obsolete (failing the run under CI). Redirecting vitest's path isolates the two systems. Verified with `CI=true` (which forbids snapshot writes): 83/83 match, `.snap` untouched.

## Test plan

- [x] `pnpm test:vitest test/unit/frontend`: 135 files / 1804 tests pass
- [x] `CI=true pnpm test:vitest test/unit/frontend`: same, and no `.snap` file modified
- [x] `pnpm test:vitest` (full): 254 files / 2963 tests pass — snapshot `beforeEach` doesn't disturb other buckets
- [x] `pnpm test:unit:base` (mocha): 3582 tests pass
- [x] `pnpm exec eslint` clean for changed files
- [ ] CI green