### PR TITLE
Changed Shade field spacing

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.25",
+  "version": "3.1.26",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/preferences/components/account-migration.tsx
+++ b/apps/activitypub/src/views/preferences/components/account-migration.tsx
@@ -117,7 +117,7 @@ const AccountMigration: React.FC = () => {
                         <FieldLabel htmlFor='account-migration-source-handle'>
                             Old account handle
                         </FieldLabel>
-                        <FieldDescription className='-mt-1' id='account-migration-source-handle-description'>
+                        <FieldDescription id='account-migration-source-handle-description'>
                             Specify the username@domain of the account you want to move from
                         </FieldDescription>
                         <div className='flex flex-col gap-3 sm:flex-row'>

--- a/apps/shade/src/components/ui/field.tsx
+++ b/apps/shade/src/components/ui/field.tsx
@@ -27,7 +27,7 @@ function FieldLegend({
     return (
         <legend
             className={cn(
-                'mb-3 font-medium',
+                'mb-2 font-medium',
                 'data-[variant=legend]:text-base',
                 'data-[variant=label]:text-sm',
                 className
@@ -53,7 +53,7 @@ function FieldGroup({className, ...props}: React.ComponentProps<'div'>) {
 }
 
 const fieldVariants = cva(
-    'group/field flex w-full gap-3 data-[invalid=true]:text-destructive',
+    'group/field flex w-full gap-2 data-[invalid=true]:text-destructive',
     {
         variants: {
             orientation: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1384/reduce-gap-between-fieldlabel-and-fielddescription

- tightened the default vertical spacing in Shade field and legend layout
- removed the local negative margin from the ActivityPub account migration description
- included the ActivityPub package patch version bump generated by the commit hook

## Why
Field descriptions were carrying more vertical space than needed, which led consumers to compensate with local spacing overrides. Moving the tighter spacing into Shade keeps the layout consistent at the shared component level.