### PR TITLE
Migrated test/unit/server/models bucket to vitest

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -59,7 +59,7 @@
     "test:all": "pnpm test:unit && pnpm test:integration && pnpm test:e2e && pnpm lint",
     "test:debug": "DEBUG=ghost:test* pnpm test",
     "test:unit": "c8 pnpm test:unit:${GHOST_UNIT_TEST_VARIANT:-base}",
-    "test:unit:base": "pnpm test:base ./test/unit/server/models ./test/unit/server/services ./test/unit/server/notify.test.js ./test/unit/server/overrides.test.js ./test/unit/server/adapters/scheduling/scheduling-default.test.js --timeout=2000",
+    "test:unit:base": "pnpm test:base ./test/unit/server/services ./test/unit/server/notify.test.js ./test/unit/server/overrides.test.js ./test/unit/server/adapters/scheduling/scheduling-default.test.js --timeout=2000",
     "test:unit:ci": "pnpm test:unit:base --reporter=min",
     "test:integration": "pnpm test:base './test/integration' --timeout=10000",
     "test:e2e": "pnpm test:base ./test/e2e-* --timeout=15000",

--- a/ghost/core/test/unit/server/models/integration.test.js
+++ b/ghost/core/test/unit/server/models/integration.test.js
@@ -32,12 +32,12 @@ describe('Unit: models/integration', function () {
         const mockDb = require('mock-knex');
         let tracker;
 
-        before(function () {
+        beforeAll(function () {
             mockDb.mock(knex);
             tracker = mockDb.getTracker();
         });
 
-        after(function () {
+        afterAll(function () {
             mockDb.unmock(knex);
         });
 
@@ -66,12 +66,12 @@ describe('Unit: models/integration', function () {
         const mockDb = require('mock-knex');
         let tracker;
 
-        before(function () {
+        beforeAll(function () {
             mockDb.mock(knex);
             tracker = mockDb.getTracker();
         });
 
-        after(function () {
+        afterAll(function () {
             mockDb.unmock(knex);
         });
 

--- a/ghost/core/test/unit/server/models/invite.test.js
+++ b/ghost/core/test/unit/server/models/invite.test.js
@@ -21,7 +21,7 @@ describe('Unit: models/invite', function () {
             let roleModel;
             let loadedPermissions;
 
-            before(function () {
+            beforeAll(function () {
                 inviteModel = {};
                 context = {};
                 unsafeAttrs = {role_id: 'role_id'};

--- a/ghost/core/test/unit/server/models/newsletter.test.js
+++ b/ghost/core/test/unit/server/models/newsletter.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/newsletter', function () {
-    after(function () {
+    afterAll(function () {
         sinon.restore();
     });
 

--- a/ghost/core/test/unit/server/models/permission.test.js
+++ b/ghost/core/test/unit/server/models/permission.test.js
@@ -4,7 +4,7 @@ const models = require('../../../../core/server/models');
 const configUtils = require('../../../utils/config-utils');
 
 describe('Unit: models/permission', function () {
-    after(async function () {
+    afterAll(async function () {
         sinon.restore();
         await configUtils.restore();
     });

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -13,7 +13,7 @@ describe('Unit: models/post', function () {
     const mockDb = require('mock-knex');
     let tracker;
 
-    before(function () {
+    beforeAll(function () {
         mockDb.mock(knex);
         tracker = mockDb.getTracker();
     });
@@ -22,7 +22,7 @@ describe('Unit: models/post', function () {
         sinon.restore();
     });
 
-    after(function () {
+    afterAll(function () {
         mockDb.unmock(knex);
     });
 
@@ -419,7 +419,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
         sinon.restore();
     });
 
-    after(function () {
+    afterAll(function () {
         sinon.restore();
     });
 

--- a/ghost/core/test/unit/server/models/single-use-token.test.js
+++ b/ghost/core/test/unit/server/models/single-use-token.test.js
@@ -8,12 +8,12 @@ let clock;
 let sandbox;
 
 describe('Unit: models/single-use-token', function () {
-    before(function () {
+    beforeAll(function () {
         sandbox = sinon.createSandbox();
         clock = sandbox.useFakeTimers();
     });
 
-    after(function () {
+    afterAll(function () {
         clock.restore();
         sandbox.restore();
     });

--- a/ghost/core/test/unit/server/models/tag.test.js
+++ b/ghost/core/test/unit/server/models/tag.test.js
@@ -12,16 +12,16 @@ describe('Unit: models/tag', function () {
         const mockDb = require('mock-knex');
         let tracker;
 
-        before(function () {
+        beforeAll(function () {
             mockDb.mock(knex);
             tracker = mockDb.getTracker();
         });
 
-        after(function () {
+        afterAll(function () {
             sinon.restore();
         });
 
-        after(function () {
+        afterAll(function () {
             mockDb.unmock(knex);
         });
 

--- a/ghost/core/test/utils/vitest-setup.ts
+++ b/ghost/core/test/utils/vitest-setup.ts
@@ -18,8 +18,8 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'testing';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_SECRET';
 
 // Generate unique session values for database and port BEFORE loading
-// Ghost. With pool=forks each test file is its own process, so each
-// fork gets its own session — but values already set externally
+// Ghost. This setup file runs once per test file (isolated environment),
+// so each file gets its own session — but values already set externally
 // (CI, user shell) are respected.
 const sessionId = crypto.randomBytes(4).toString('hex');
 const sqliteGenerated = !process.env.database__connection__filename;

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'node',
-        pool: 'forks',
+        // The `forks` pool deadlocks at teardown once the run is large enough
+        // (main process + a final idle worker, both parked in the event loop,
+        // no summary printed). `threads` tears workers down with
+        // worker.terminate() and is unaffected; it's also faster here.
+        pool: 'threads',
         env: {
             NODE_ENV: 'testing',
             WEBHOOK_SECRET: 'TEST_STRIPE_WEBHOOK_SECRET'

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
             'test/unit/server/api/**/*.test.{js,ts}',
             'test/unit/server/data/**/*.test.{js,ts}',
             'test/unit/server/lib/**/*.test.{js,ts}',
+            'test/unit/server/models/**/*.test.{js,ts}',
             'test/unit/server/web/**/*.test.{js,ts}'
         ],
         // Fake-timer + nock + retry-loop interactions in this file don't


### PR DESCRIPTION
## Summary

Continues the vitest migration (after #27898 / #27900 / #27974 / #27991 / #27992) by moving the `test/unit/server/models` bucket — 34 files, 269 tests — from mocha to vitest. Also fixes a vitest teardown hang that the growing suite exposed (see below).

## Bucket migration

- `vitest.config.ts` — added `test/unit/server/models/**` to `test.include`
- `package.json` — removed `./test/unit/server/models` from `test:unit:base`
- 7 files using mocha's suite-scope `before()` / `after()` → `beforeAll()` / `afterAll()`

Clean bucket — no `done()` callbacks, `this.*` mocha-API patterns, or snapshot tests.

## Teardown hang fix (`forks` → `threads` pool)

Once the vitest run is large enough — the models bucket plus ~30+ other files, and up — the `forks` pool **deadlocks at teardown**: every test passes, but no summary prints and the process never exits. CI's vitest step hung indefinitely.

Investigation:
- A node diagnostic report (`SIGUSR2`) on the hung run showed the main process and a single remaining worker **both parked in the event loop with empty JS stacks** — a child-process / IPC deadlock, not a hanging test or an open handle. Destroying the knex pool in teardown made no difference.
- Bisecting ruled out file count: 254 files with no models bucket exit fine; the hang appears once the models bucket runs alongside enough other files. Reproduced both locally and in CI.

Fix: switched `pool: 'forks'` → `pool: 'threads'`. The threads pool tears workers down with `worker.terminate()`, sidestepping the child-process exit path the deadlock lives in. Full suite now runs **288 files / 3232 tests, exits cleanly in ~27s** (also faster than forks), stable across repeated runs with no shared-process pollution.

## Test plan

- [x] `pnpm test:vitest` (full, from `ghost/core`): 288 files / 3232 tests pass, clean exit — run twice, stable
- [x] `pnpm test:vitest test/unit/server/models`: 34 files / 269 tests pass
- [x] `pnpm test:unit:base` (mocha): 3317 tests pass
- [x] `pnpm exec eslint` clean for changed files
- [ ] CI green