### PR TITLE
Added email design customization to automations

### DIFF
--- a/apps/admin-x-settings/src/components/providers/global-data-provider.tsx
+++ b/apps/admin-x-settings/src/components/providers/global-data-provider.tsx
@@ -7,14 +7,20 @@ import {type SiteData, useBrowseSite} from '@tryghost/admin-x-framework/api/site
 import {type User} from '@tryghost/admin-x-framework/api/users';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
 
-interface GlobalData {
+export interface GlobalData {
     settings: Setting[]
     siteData: SiteData
     config: Config
     currentUser: User
 }
 
-const GlobalDataContext = createContext<GlobalData | undefined>(undefined);
+export const GlobalDataContext = createContext<GlobalData | undefined>(undefined);
+
+export const GlobalDataStaticProvider = ({children, value}: { children: ReactNode, value: GlobalData }) => (
+    <GlobalDataContext.Provider value={value}>
+        {children}
+    </GlobalDataContext.Provider>
+);
 
 const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     const settings = useBrowseSettings();

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -49,6 +49,10 @@ interface WelcomeEmailCustomizeFormState {
     generalSettings: GeneralSettings;
 }
 
+interface WelcomeEmailCustomizeModalProps {
+    title?: string;
+}
+
 const SAVE_ERROR_TOAST_ID = 'welcome-email-design-save-error';
 const WELCOME_EMAIL_DESIGN_FIELDS = new Set(Object.keys(DEFAULT_EMAIL_DESIGN));
 
@@ -332,7 +336,7 @@ const normalizeSenderValue = (value: string | null | undefined) => {
     return trimmed || null;
 };
 
-const WelcomeEmailCustomizeModal = NiceModal.create(() => {
+const WelcomeEmailCustomizeModal = NiceModal.create<WelcomeEmailCustomizeModalProps>(({title = 'Welcome emails'}) => {
     const modal = useModal();
     const {siteData, settings: globalSettings} = useGlobalData();
     const [siteTitle, defaultEmailAddress, icon] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'icon']);
@@ -558,7 +562,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                     />
                 }
                 testId="welcome-email-customize-modal"
-                title="Welcome emails"
+                title={title}
                 onClose={handleClose}
                 onSave={() => handleSave({fakeWhenUnchanged: true})}
             />

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -57,7 +57,9 @@
         "vitest": "catalog:"
     },
     "dependencies": {
+        "@ebay/nice-modal-react": "1.2.13",
         "@tryghost/admin-x-framework": "workspace:*",
+        "@tryghost/admin-x-settings": "workspace:*",
         "@tryghost/nql-lang": "catalog:",
         "@tryghost/shade": "workspace:*",
         "@xyflow/react": "12.8.6",

--- a/apps/posts/src/views/Automations/automations.tsx
+++ b/apps/posts/src/views/Automations/automations.tsx
@@ -1,5 +1,6 @@
 import AutomationsList from './components/automations-list';
-import MainLayout from '@components/layout/main-layout';
+import CustomizeWelcomeEmailsButton from './components/customize-welcome-emails-button';
+import MainLayout from '@src/components/layout/main-layout';
 import React from 'react';
 import {ListPage} from '@tryghost/shade/page-templates';
 import {PageHeader} from '@tryghost/shade/patterns';
@@ -22,6 +23,9 @@ const Automations: React.FC = () => {
                         <PageHeader.Left>
                             <PageHeader.Title>Automations</PageHeader.Title>
                         </PageHeader.Left>
+                        <PageHeader.Actions>
+                            <CustomizeWelcomeEmailsButton />
+                        </PageHeader.Actions>
                     </PageHeader>
                 </ListPage.Header>
                 <ListPage.Body>

--- a/apps/posts/src/views/Automations/components/customize-welcome-emails-button.tsx
+++ b/apps/posts/src/views/Automations/components/customize-welcome-emails-button.tsx
@@ -1,0 +1,50 @@
+import NiceModal from '@ebay/nice-modal-react';
+import React from 'react';
+import WelcomeEmailCustomizeModal from '@tryghost/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal';
+import {Button} from '@tryghost/shade/components';
+import {GlobalDataStaticProvider} from '@tryghost/admin-x-settings/src/components/providers/global-data-provider';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+
+const CustomizeWelcomeEmailsButton: React.FC = () => {
+    const settings = useBrowseSettings();
+    const site = useBrowseSite();
+    const config = useBrowseConfig();
+    const currentUser = useCurrentUser();
+
+    const requests = [settings, site, config, currentUser];
+    const error = requests.map(request => request.error).find(Boolean);
+
+    if (error) {
+        throw error;
+    }
+
+    const isLoading = requests.some(request => request.isLoading);
+
+    if (isLoading) {
+        return (
+            <Button disabled={true} variant='outline'>
+                Email design
+            </Button>
+        );
+    }
+
+    return (
+        <GlobalDataStaticProvider value={{
+            settings: settings.data!.settings,
+            siteData: site.data!.site,
+            config: config.data!.config,
+            currentUser: currentUser.data!
+        }}>
+            <NiceModal.Provider>
+                <Button variant='outline' onClick={() => NiceModal.show(WelcomeEmailCustomizeModal, {title: 'Email design'})}>
+                    Email design
+                </Button>
+            </NiceModal.Provider>
+        </GlobalDataStaticProvider>
+    );
+};
+
+export default CustomizeWelcomeEmailsButton;

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -364,6 +364,18 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
     });
 
+    it('does not show the Email design button on the detail page', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        expect(screen.queryByRole('button', {name: 'Email design'})).not.toBeInTheDocument();
+    });
+
     it('hides the dropdown for inactive automations', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},

--- a/apps/posts/test/unit/views/automations/automations.test.tsx
+++ b/apps/posts/test/unit/views/automations/automations.test.tsx
@@ -1,0 +1,72 @@
+import Automations from '@src/views/Automations/automations';
+import NiceModal from '@ebay/nice-modal-react';
+import React from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {fireEvent, render, screen} from '@testing-library/react';
+
+const mockUseBrowseAutomations = vi.fn();
+const mockUseBrowseSettings = vi.fn();
+const mockUseBrowseSite = vi.fn();
+const mockUseBrowseConfig = vi.fn();
+const mockUseCurrentUser = vi.fn();
+
+vi.mock('@tryghost/admin-x-framework/api/automations', () => ({
+    useBrowseAutomations: (...args: unknown[]) => mockUseBrowseAutomations(...args)
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/settings', () => ({
+    useBrowseSettings: () => mockUseBrowseSettings()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/site', () => ({
+    useBrowseSite: () => mockUseBrowseSite()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/config', () => ({
+    useBrowseConfig: () => mockUseBrowseConfig()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/current-user', () => ({
+    useCurrentUser: () => mockUseCurrentUser()
+}));
+
+vi.mock('@tryghost/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal', () => ({
+    default: function WelcomeEmailCustomizeModal() {
+        return null;
+    }
+}));
+
+vi.mock('@tryghost/admin-x-settings/src/components/providers/global-data-provider', () => ({
+    GlobalDataStaticProvider: ({children}: {children: React.ReactNode}) => <>{children}</>
+}));
+
+vi.mock('@src/components/layout/main-layout', () => ({
+    default: ({children}: {children: React.ReactNode}) => <>{children}</>
+}));
+
+const loadedRequest = (data: unknown) => ({
+    data,
+    error: null,
+    isLoading: false
+});
+
+describe('Automations', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseBrowseAutomations.mockReturnValue(loadedRequest({automations: []}));
+        mockUseBrowseSettings.mockReturnValue(loadedRequest({settings: []}));
+        mockUseBrowseSite.mockReturnValue(loadedRequest({site: {}}));
+        mockUseBrowseConfig.mockReturnValue(loadedRequest({config: {}}));
+        mockUseCurrentUser.mockReturnValue(loadedRequest({id: 'user-id'}));
+    });
+
+    it('shows an Email design button in the header that opens the welcome email customize modal', () => {
+        const showSpy = vi.spyOn(NiceModal, 'show').mockResolvedValue(undefined);
+
+        render(<Automations />);
+
+        fireEvent.click(screen.getByRole('button', {name: 'Email design'}));
+
+        expect(showSpy).toHaveBeenCalledWith(expect.any(Function), {title: 'Email design'});
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1156,9 +1156,15 @@ importers:
 
   apps/posts:
     dependencies:
+      '@ebay/nice-modal-react':
+        specifier: 1.2.13
+        version: 1.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tryghost/admin-x-framework':
         specifier: workspace:*
         version: link:../admin-x-framework
+      '@tryghost/admin-x-settings':
+        specifier: workspace:*
+        version: link:../admin-x-settings
       '@tryghost/nql-lang':
         specifier: 'catalog:'
         version: 0.6.4


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1252/move-email-design-customization-modal-from-settings-to-automations

## Summary

- Added an Email design action to the Automations list page
- Reused the existing Welcome emails customization modal from settings with a contextual modal title
- Added a static global data provider so the shared settings modal can run from the posts app