### PR TITLE
Refactor welcome email design data flow

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email-design/email-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-preview.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import {GhostOrb} from '@tryghost/shade/components';
 import {cn} from '@tryghost/shade/utils';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {resolveAllColors, resolveImageCorners} from './design-utils';
-import {useGlobalData} from '../../providers/global-data-provider';
 import type {EmailDesignSettings} from './types';
 
 interface EmailPreviewProps {
     settings: EmailDesignSettings;
+    accentColor: string;
+    publicationIcon?: string | null;
+    siteTitle?: string | null;
     senderName?: string;
     senderEmail?: string;
     replyToEmail?: string;
@@ -127,13 +128,10 @@ const Footer: React.FC<{siteTitle?: string; footerLinkText?: string; emailFooter
 
 // --- Main component ---
 
-const EmailPreview: React.FC<EmailPreviewProps> = ({settings, senderName, senderEmail, replyToEmail, subject, showRecipientLine = true, showSubjectLine = true, headerImage, showPublicationIcon = false, showPublicationTitle = true, showBadge = true, emailFooter, footerLinkText, children}) => {
-    const {settings: globalSettings, siteData} = useGlobalData();
-    const [siteTitle, icon] = getSettingValues<string>(globalSettings, ['title', 'icon']);
-    const accentColor = siteData.accent_color;
-
+const EmailPreview: React.FC<EmailPreviewProps> = ({settings, accentColor, publicationIcon, siteTitle, senderName, senderEmail, replyToEmail, subject, showRecipientLine = true, showSubjectLine = true, headerImage, showPublicationIcon = false, showPublicationTitle = true, showBadge = true, emailFooter, footerLinkText, children}) => {
     const colors = resolveAllColors(settings, accentColor);
     const imageCornerClass = resolveImageCorners(settings.image_corners);
+    const resolvedSiteTitle = siteTitle || undefined;
 
     return (
         <div className="mx-auto flex max-h-full min-h-0 w-full max-w-[700px] flex-col overflow-hidden rounded-[4px] text-black shadow-sm">
@@ -152,17 +150,17 @@ const EmailPreview: React.FC<EmailPreviewProps> = ({settings, senderName, sender
 
                     <PublicationHeader
                         backgroundColor="transparent"
-                        iconUrl={icon}
-                        showIcon={showPublicationIcon && Boolean(icon)}
+                        iconUrl={publicationIcon}
+                        showIcon={showPublicationIcon && Boolean(publicationIcon)}
                         showTitle={showPublicationTitle}
-                        siteTitle={siteTitle}
+                        siteTitle={resolvedSiteTitle}
                         textColor={colors.headerTextColor}
                     />
                 </div>
 
                 {children}
 
-                <Footer color={colors.secondaryTextColor} emailFooter={emailFooter} footerLinkText={footerLinkText} showBadge={showBadge} siteTitle={siteTitle} textColor={colors.textColor} />
+                <Footer color={colors.secondaryTextColor} emailFooter={emailFooter} footerLinkText={footerLinkText} showBadge={showBadge} siteTitle={resolvedSiteTitle} textColor={colors.textColor} />
             </div>
         </div>
     );

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -334,8 +334,11 @@ const normalizeSenderValue = (value: string | null | undefined) => {
 
 const WelcomeEmailCustomizeModal = NiceModal.create(() => {
     const modal = useModal();
-    const {siteData, settings: globalSettings} = useGlobalData();
-    const [siteTitle, defaultEmailAddress, icon] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'icon']);
+    const {siteData, settings: globalSettings, config} = useGlobalData();
+    const [siteTitle, defaultEmailAddress, icon, supportEmailAddress] = getSettingValues<string>(
+        globalSettings,
+        ['title', 'default_email_address', 'icon', 'support_email_address']
+    );
 
     const handleError = useHandleError();
     const {data: designData, isLoading, isError} = useReadAutomatedEmailDesign();
@@ -356,7 +359,12 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
         replyToEmailPlaceholder,
         showSenderEmailInput,
         senderEmailDomain
-    } = useWelcomeEmailSenderDetails(automatedEmails);
+    } = useWelcomeEmailSenderDetails(automatedEmails, {
+        config,
+        defaultEmailAddress,
+        siteTitle,
+        supportEmailAddress
+    });
 
     const defaultGeneralSettings = useMemo<GeneralSettings>(() => ({
         senderName: senderNameInput,
@@ -524,9 +532,11 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                     <ErrorState message={fetchErrorMessage} />
                 ) : (
                     <EmailPreview
+                        accentColor={siteData.accent_color}
                         emailFooter={generalSettings.emailFooter}
                         footerLinkText="Manage your preferences"
                         headerImage={generalSettings.headerImage}
+                        publicationIcon={icon}
                         replyToEmail={generalSettings.replyToEmail || replyToEmailPlaceholder || ''}
                         senderEmail={generalSettings.senderEmail || senderEmailPlaceholder || defaultEmailAddress || ''}
                         senderName={generalSettings.senderName || senderNamePlaceholder || siteTitle || 'Your site'}
@@ -536,6 +546,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                         showPublicationTitle={generalSettings.showPublicationTitle}
                         showRecipientLine={false}
                         showSubjectLine={false}
+                        siteTitle={siteTitle}
                         subject={`Welcome to ${generalSettings.senderName || senderNamePlaceholder || siteTitle || 'our publication'}`}
                     >
                         <WelcomeEmailPreviewContent />

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -6,9 +6,11 @@ import MemberEmailEditor from './member-email-editor';
 import WelcomeEmailPreviewFrame from './welcome-email-preview-frame';
 import {Hint, Button as LegacyButton, Modal, TextField} from '@tryghost/admin-x-design-system';
 import {confirmIfDirty} from '@tryghost/admin-x-design-system';
+import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {getWelcomeEmailValidationErrors} from './welcome-email-validation';
 import {useBrowseAutomatedEmails, useEditAutomatedEmail, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useGlobalData} from '../../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 import {useWelcomeEmailPreview} from './use-welcome-email-preview';
 import {useWelcomeEmailSenderDetails} from '../../../../hooks/use-welcome-email-sender-details';
@@ -96,6 +98,8 @@ type PreviewMode = 'edit' | 'preview';
 
 const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType = 'free', automatedEmail}) => {
     const modal = useModal();
+    const {settings: globalSettings, config} = useGlobalData();
+    const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'support_email_address']);
     const {updateRoute} = useRouting();
     const {mutateAsync: editAutomatedEmail} = useEditAutomatedEmail();
     const {mutateAsync: previewWelcomeEmail} = usePreviewWelcomeEmail();
@@ -108,7 +112,12 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const hasEditorBeenFocused = useRef(false);
     const handleError = useHandleError();
     const automatedEmails = automatedEmailsData?.automated_emails || [];
-    const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useWelcomeEmailSenderDetails(automatedEmails);
+    const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useWelcomeEmailSenderDetails(automatedEmails, {
+        config,
+        defaultEmailAddress,
+        siteTitle,
+        supportEmailAddress
+    });
     const emailTypeLabel = emailType === 'paid' ? 'Paid' : 'Free';
     const modalTitle = `${emailTypeLabel} members welcome email`;
 

--- a/apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts
+++ b/apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts
@@ -1,15 +1,24 @@
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {resolveWelcomeEmailSenderDetails} from '../utils/welcome-email-sender-details';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
-import {useGlobalData} from '../components/providers/global-data-provider';
 import {useMemo} from 'react';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import type {Config} from '@tryghost/admin-x-framework/api/config';
 
 type AutomatedEmailSenderFields = Pick<AutomatedEmail, 'slug' | 'sender_name' | 'sender_email' | 'sender_reply_to'>;
 
-export const useWelcomeEmailSenderDetails = (automatedEmails: AutomatedEmailSenderFields[] = []) => {
-    const {settings, config} = useGlobalData();
-    const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(settings, ['title', 'default_email_address', 'support_email_address']);
+interface WelcomeEmailSenderDetailsOptions {
+    config: Config;
+    defaultEmailAddress?: string | null;
+    siteTitle?: string | null;
+    supportEmailAddress?: string | null;
+}
+
+export const useWelcomeEmailSenderDetails = (automatedEmails: AutomatedEmailSenderFields[] = [], {
+    config,
+    defaultEmailAddress,
+    siteTitle,
+    supportEmailAddress
+}: WelcomeEmailSenderDetailsOptions) => {
     const {data: newslettersData} = useBrowseNewsletters({
         searchParams: {
             filter: 'status:active',


### PR DESCRIPTION
## Summary

- moved welcome email sender detail inputs to modal/container call sites
- removed global data reads from the sender details hook
- passed site title, publication icon, and accent color into the email preview explicitly

## Verification

- pnpm --filter @tryghost/admin-x-settings test:unit -- test/unit/membership/welcome-email-customize-modal.test.tsx test/unit/email-design/design-payload.test.ts test/unit/email-design/section-title-color.test.tsx
- pnpm --filter @tryghost/admin-x-settings lint
- pnpm --filter @tryghost/admin-x-settings build