### PR TITLE
Added github-actions reporter to vitest CI runs

### DIFF
--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -47,7 +47,11 @@ export default defineConfig({
         ),
         testTimeout: 2000,
         hookTimeout: 60000,
-        reporters: ['dot'],
+        // `dot` keeps local/CI output compact. `github-actions` adds inline
+        // `::error::` annotations for failed tests — without it, CI logs only
+        // show vitest's dot stream, whose failure summary GitHub truncates,
+        // making it impossible to tell which test failed from the logs.
+        reporters: process.env.GITHUB_ACTIONS ? ['dot', 'github-actions'] : ['dot'],
         coverage: {
             provider: 'v8',
             reporter: ['text-summary', 'html', 'cobertura'],


### PR DESCRIPTION
vitest's `dot` reporter writes its progress and its failure summary as one continuous single-line stream. GitHub Actions truncates long log lines, so when a vitest test fails in CI the summary block (`⎯⎯ Failed Tests ⎯⎯`, the test name, the assertion diff) gets cut off — the logs show the step exited 1, but not *which* test failed.

This adds the `github-actions` reporter alongside `dot`, gated on `GITHUB_ACTIONS` so local runs keep the compact dot-only output. The reporter emits inline `::error::` annotations pinned to the failing file and line, which surface directly on the job and the PR diff.

Found while debugging a unit-test failure on another PR, where the truncated log made it impossible to identify the failing test without reproducing the whole suite locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)