### PR TITLE
Add Automations email design modal via Settings import

### DIFF
--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -20,6 +20,10 @@
       "require": "./dist/admin-x-settings.umd.cjs",
       "types": "./src/index.tsx"
     },
+    "./welcome-email-customize-modal": {
+      "types": "./src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx",
+      "import": "./src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx"
+    },
     "./src/*": {
       "import": "./src/*.tsx",
       "require": "./src/*.tsx"

--- a/apps/admin-x-settings/src/components/settings/email-design/email-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-preview.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import {GhostOrb} from '@tryghost/shade/components';
 import {cn} from '@tryghost/shade/utils';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {resolveAllColors, resolveImageCorners} from './design-utils';
-import {useGlobalData} from '../../providers/global-data-provider';
 import type {EmailDesignSettings} from './types';
 
 interface EmailPreviewProps {
     settings: EmailDesignSettings;
+    accentColor: string;
+    siteTitle?: string;
+    icon?: string | null;
     senderName?: string;
     senderEmail?: string;
     replyToEmail?: string;
@@ -127,11 +128,7 @@ const Footer: React.FC<{siteTitle?: string; footerLinkText?: string; emailFooter
 
 // --- Main component ---
 
-const EmailPreview: React.FC<EmailPreviewProps> = ({settings, senderName, senderEmail, replyToEmail, subject, showRecipientLine = true, showSubjectLine = true, headerImage, showPublicationIcon = false, showPublicationTitle = true, showBadge = true, emailFooter, footerLinkText, children}) => {
-    const {settings: globalSettings, siteData} = useGlobalData();
-    const [siteTitle, icon] = getSettingValues<string>(globalSettings, ['title', 'icon']);
-    const accentColor = siteData.accent_color;
-
+const EmailPreview: React.FC<EmailPreviewProps> = ({settings, accentColor, siteTitle, icon, senderName, senderEmail, replyToEmail, subject, showRecipientLine = true, showSubjectLine = true, headerImage, showPublicationIcon = false, showPublicationTitle = true, showBadge = true, emailFooter, footerLinkText, children}) => {
     const colors = resolveAllColors(settings, accentColor);
     const imageCornerClass = resolveImageCorners(settings.image_corners);
 

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -132,7 +132,7 @@ const MemberEmailsTable: React.FC<{
 };
 
 const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {settings, config} = useGlobalData();
+    const {settings, siteData, config} = useGlobalData();
     const [siteTitle] = getSettingValues<string>(settings, ['title']);
     const verifyEmailToken = useQueryParams().getParam('verifyEmail');
 
@@ -281,7 +281,11 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     color='clear'
                     label='Customize'
                     size='sm'
-                    onClick={() => NiceModal.show(WelcomeEmailCustomizeModal)}
+                    onClick={() => NiceModal.show(WelcomeEmailCustomizeModal, {
+                        config,
+                        settings,
+                        siteData
+                    })}
                 />
             )}
             description="Create and manage automated emails for your members"

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -21,16 +21,17 @@ import {
     LinkStyleField,
     SectionTitleColorField
 } from '../../email-design/design-fields';
+import {type Config} from '@tryghost/admin-x-framework/api/config';
 import {DEFAULT_EMAIL_DESIGN, type EmailDesignSettings} from '../../email-design/types';
 import {EmailDesignProvider} from '../../email-design/email-design-context';
 import {Input, LoadingIndicator, Separator, Switch, Tabs, TabsContent, TabsList, TabsTrigger, Textarea} from '@tryghost/shade/components';
+import {type Setting, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {type SiteData} from '@tryghost/admin-x-framework/api/site';
 import {WELCOME_EMAIL_SLUGS, type WelcomeEmailType, getDefaultWelcomeEmailValues} from './default-welcome-email-values';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmailSenders} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useGlobalData} from '../../../providers/global-data-provider';
 import {useWelcomeEmailSenderDetails} from '../../../../hooks/use-welcome-email-sender-details';
 
 interface GeneralSettings {
@@ -47,6 +48,19 @@ interface GeneralSettings {
 interface WelcomeEmailCustomizeFormState {
     designSettings: EmailDesignSettings;
     generalSettings: GeneralSettings;
+}
+
+export interface WelcomeEmailCustomizeModalProps {
+    title?: string;
+    settings: Setting[];
+    siteData: SiteData;
+    config: Config;
+}
+
+export interface WelcomeEmailCustomizeModalContentProps extends WelcomeEmailCustomizeModalProps {
+    open: boolean;
+    onClose: () => void;
+    afterClose?: () => void;
 }
 
 const SAVE_ERROR_TOAST_ID = 'welcome-email-design-save-error';
@@ -332,9 +346,15 @@ const normalizeSenderValue = (value: string | null | undefined) => {
     return trimmed || null;
 };
 
-const WelcomeEmailCustomizeModal = NiceModal.create(() => {
-    const modal = useModal();
-    const {siteData, settings: globalSettings} = useGlobalData();
+export const WelcomeEmailCustomizeModalContent: React.FC<WelcomeEmailCustomizeModalContentProps> = ({
+    afterClose,
+    onClose,
+    open,
+    title = 'Welcome emails',
+    settings: globalSettings,
+    siteData,
+    config
+}) => {
     const [siteTitle, defaultEmailAddress, icon] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'icon']);
 
     const handleError = useHandleError();
@@ -356,7 +376,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
         replyToEmailPlaceholder,
         showSenderEmailInput,
         senderEmailDomain
-    } = useWelcomeEmailSenderDetails(automatedEmails);
+    } = useWelcomeEmailSenderDetails(automatedEmails, {settings: globalSettings, config});
 
     const defaultGeneralSettings = useMemo<GeneralSettings>(() => ({
         senderName: senderNameInput,
@@ -498,10 +518,6 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
         }));
     }, [updateForm]);
 
-    const handleClose = useCallback(() => {
-        modal.hide();
-    }, [modal]);
-
     const fetchErrorMessage = 'Unable to load email design settings. Please try again.';
     const modalOkProps = hasSaveError ? {
         ...okProps,
@@ -512,21 +528,20 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
     return (
         <EmailDesignProvider accentColor={siteData.accent_color} settings={designSettings} onSettingsChange={handleDesignChange}>
             <EmailDesignModal
-                afterClose={() => {
-                    modal.resolveHide();
-                    modal.remove();
-                }}
+                afterClose={afterClose}
                 dirty={saveState === 'unsaved'}
                 isLoading={isLoading || isError}
                 okProps={modalOkProps}
-                open={modal.visible}
+                open={open}
                 preview={isError ? (
                     <ErrorState message={fetchErrorMessage} />
                 ) : (
                     <EmailPreview
+                        accentColor={siteData.accent_color}
                         emailFooter={generalSettings.emailFooter}
                         footerLinkText="Manage your preferences"
                         headerImage={generalSettings.headerImage}
+                        icon={icon}
                         replyToEmail={generalSettings.replyToEmail || replyToEmailPlaceholder || ''}
                         senderEmail={generalSettings.senderEmail || senderEmailPlaceholder || defaultEmailAddress || ''}
                         senderName={generalSettings.senderName || senderNamePlaceholder || siteTitle || 'Your site'}
@@ -536,6 +551,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                         showPublicationTitle={generalSettings.showPublicationTitle}
                         showRecipientLine={false}
                         showSubjectLine={false}
+                        siteTitle={siteTitle}
                         subject={`Welcome to ${generalSettings.senderName || senderNamePlaceholder || siteTitle || 'our publication'}`}
                     >
                         <WelcomeEmailPreviewContent />
@@ -558,11 +574,27 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                     />
                 }
                 testId="welcome-email-customize-modal"
-                title="Welcome emails"
-                onClose={handleClose}
+                title={title}
+                onClose={onClose}
                 onSave={() => handleSave({fakeWhenUnchanged: true})}
             />
         </EmailDesignProvider>
+    );
+};
+
+const WelcomeEmailCustomizeModal = NiceModal.create<WelcomeEmailCustomizeModalProps>((props) => {
+    const modal = useModal();
+
+    return (
+        <WelcomeEmailCustomizeModalContent
+            {...props}
+            afterClose={() => {
+                modal.resolveHide();
+                modal.remove();
+            }}
+            open={modal.visible}
+            onClose={() => modal.hide()}
+        />
     );
 });
 

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -9,6 +9,7 @@ import {confirmIfDirty} from '@tryghost/admin-x-design-system';
 import {getWelcomeEmailValidationErrors} from './welcome-email-validation';
 import {useBrowseAutomatedEmails, useEditAutomatedEmail, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useGlobalData} from '../../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 import {useWelcomeEmailPreview} from './use-welcome-email-preview';
 import {useWelcomeEmailSenderDetails} from '../../../../hooks/use-welcome-email-sender-details';
@@ -97,6 +98,7 @@ type PreviewMode = 'edit' | 'preview';
 const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType = 'free', automatedEmail}) => {
     const modal = useModal();
     const {updateRoute} = useRouting();
+    const {settings, config} = useGlobalData();
     const {mutateAsync: editAutomatedEmail} = useEditAutomatedEmail();
     const {mutateAsync: previewWelcomeEmail} = usePreviewWelcomeEmail();
     const {data: automatedEmailsData} = useBrowseAutomatedEmails();
@@ -108,7 +110,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const hasEditorBeenFocused = useRef(false);
     const handleError = useHandleError();
     const automatedEmails = automatedEmailsData?.automated_emails || [];
-    const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useWelcomeEmailSenderDetails(automatedEmails);
+    const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useWelcomeEmailSenderDetails(automatedEmails, {settings, config});
     const emailTypeLabel = emailType === 'paid' ? 'Paid' : 'Free';
     const modalTitle = `${emailTypeLabel} members welcome email`;
 

--- a/apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts
+++ b/apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts
@@ -1,14 +1,19 @@
+import {type Config} from '@tryghost/admin-x-framework/api/config';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {resolveWelcomeEmailSenderDetails} from '../utils/welcome-email-sender-details';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
-import {useGlobalData} from '../components/providers/global-data-provider';
 import {useMemo} from 'react';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import type {Setting} from '@tryghost/admin-x-framework/api/settings';
 
 type AutomatedEmailSenderFields = Pick<AutomatedEmail, 'slug' | 'sender_name' | 'sender_email' | 'sender_reply_to'>;
 
-export const useWelcomeEmailSenderDetails = (automatedEmails: AutomatedEmailSenderFields[] = []) => {
-    const {settings, config} = useGlobalData();
+interface WelcomeEmailSenderDetailsOptions {
+    settings: Setting[];
+    config: Config;
+}
+
+export const useWelcomeEmailSenderDetails = (automatedEmails: AutomatedEmailSenderFields[] = [], {settings, config}: WelcomeEmailSenderDetailsOptions) => {
     const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(settings, ['title', 'default_email_address', 'support_email_address']);
     const {data: newslettersData} = useBrowseNewsletters({
         searchParams: {

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -57,7 +57,9 @@
         "vitest": "catalog:"
     },
     "dependencies": {
+        "@ebay/nice-modal-react": "1.2.13",
         "@tryghost/admin-x-framework": "workspace:*",
+        "@tryghost/admin-x-settings": "workspace:*",
         "@tryghost/nql-lang": "catalog:",
         "@tryghost/shade": "workspace:*",
         "@xyflow/react": "12.8.6",

--- a/apps/posts/src/app.tsx
+++ b/apps/posts/src/app.tsx
@@ -1,3 +1,4 @@
+import NiceModal from '@ebay/nice-modal-react';
 import PostsAppContextProvider, {PostsAppContextType} from './providers/posts-app-context';
 import PostsErrorBoundary from '@components/errors/posts-error-boundary';
 import React from 'react';
@@ -30,9 +31,11 @@ const App: React.FC<AppProps> = ({framework, designSystem, fromAnalytics = false
             <PostsAppContextProvider value={appContextValue}>
                 <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
                     <PostsErrorBoundary>
-                        <ShadeApp className="shade-posts app-container" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
-                            <Outlet />
-                        </ShadeApp>
+                        <NiceModal.Provider>
+                            <ShadeApp className="shade-posts app-container" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
+                                <Outlet />
+                            </ShadeApp>
+                        </NiceModal.Provider>
                     </PostsErrorBoundary>
                 </RouterProvider>
             </PostsAppContextProvider>

--- a/apps/posts/src/views/Automations/automations.tsx
+++ b/apps/posts/src/views/Automations/automations.tsx
@@ -1,4 +1,5 @@
 import AutomationsList from './components/automations-list';
+import EmailDesignButton from './components/email-design-button';
 import MainLayout from '@components/layout/main-layout';
 import React from 'react';
 import {ListPage} from '@tryghost/shade/page-templates';
@@ -22,6 +23,9 @@ const Automations: React.FC = () => {
                         <PageHeader.Left>
                             <PageHeader.Title>Automations</PageHeader.Title>
                         </PageHeader.Left>
+                        <PageHeader.Actions>
+                            <EmailDesignButton />
+                        </PageHeader.Actions>
                     </PageHeader>
                 </ListPage.Header>
                 <ListPage.Body>

--- a/apps/posts/src/views/Automations/components/email-design-button.tsx
+++ b/apps/posts/src/views/Automations/components/email-design-button.tsx
@@ -1,0 +1,44 @@
+import React, {useState} from 'react';
+import {Button} from '@tryghost/shade/components';
+import {WelcomeEmailCustomizeModalContent} from '@tryghost/admin-x-settings/welcome-email-customize-modal';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
+
+const EmailDesignButton: React.FC = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const settings = useBrowseSettings();
+    const site = useBrowseSite();
+    const config = useBrowseConfig();
+
+    const isLoading = settings.isLoading || site.isLoading || config.isLoading;
+    const isError = settings.isError || site.isError || config.isError;
+
+    const handleClick = () => {
+        if (!settings.data || !site.data || !config.data) {
+            return;
+        }
+
+        setIsOpen(true);
+    };
+
+    return (
+        <>
+            <Button disabled={isLoading || isError} variant='outline' onClick={handleClick}>
+                Email design
+            </Button>
+            {settings.data && site.data && config.data ? (
+                <WelcomeEmailCustomizeModalContent
+                    config={config.data.config}
+                    open={isOpen}
+                    settings={settings.data.settings}
+                    siteData={site.data.site}
+                    title='Email design'
+                    onClose={() => setIsOpen(false)}
+                />
+            ) : null}
+        </>
+    );
+};
+
+export default EmailDesignButton;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1156,9 +1156,15 @@ importers:
 
   apps/posts:
     dependencies:
+      '@ebay/nice-modal-react':
+        specifier: 1.2.13
+        version: 1.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tryghost/admin-x-framework':
         specifier: workspace:*
         version: link:../admin-x-framework
+      '@tryghost/admin-x-settings':
+        specifier: workspace:*
+        version: link:../admin-x-settings
       '@tryghost/nql-lang':
         specifier: 'catalog:'
         version: 0.6.4


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/NY-1252/

## Summary

- refactors the Settings welcome email design modal so its data is supplied by the launch surface instead of Settings global data
- exports the refactored Settings modal content for direct reuse
- adds an Email design button to Automations that opens the shared Settings modal implementation