### PR TITLE
Improved vitest test infra in ghost/core

### DIFF
--- a/ghost/core/test/unit/server/services/slack.test.js
+++ b/ghost/core/test/unit/server/services/slack.test.js
@@ -205,7 +205,10 @@ describe('Slack', function () {
             const wait = ms => new Promise((resolve) => {
                 setTimeout(resolve, ms);
             });
-            while (!loggingStub.calledOnce) {
+            // Bound the poll so a regression fails with a clear assertion
+            // below rather than stalling until the suite-wide test timeout.
+            const deadline = Date.now() + 1000;
+            while (!loggingStub.calledOnce && Date.now() < deadline) {
                 await wait(50);
             }
             sinon.assert.calledOnce(makeRequestStub);

--- a/ghost/core/test/utils/vitest-setup.ts
+++ b/ghost/core/test/utils/vitest-setup.ts
@@ -173,12 +173,17 @@ afterAll(async () => {
     // the threads pool, or a stuck event loop under forks.
     try {
         const db = require('../../core/server/data/db');
-        if (process.env.NODE_ENV === 'testing-mysql' && mysqlGenerated) {
-            await db.knex.raw(
-                `DROP DATABASE IF EXISTS \`${process.env.database__connection__database}\``
-            );
+        try {
+            if (process.env.NODE_ENV === 'testing-mysql' && mysqlGenerated) {
+                await db.knex.raw(
+                    `DROP DATABASE IF EXISTS \`${process.env.database__connection__database}\``
+                );
+            }
+        } finally {
+            // Destroy the pool even if the DROP above threw — a leaked pool
+            // is exactly what causes the FATAL crash / hang described above.
+            await db.knex.destroy();
         }
-        await db.knex.destroy();
     } catch (err) {
         // eslint-disable-next-line no-console
         console.warn('Failed to clean up test database:', (err as Error).message);


### PR DESCRIPTION
## Summary

Two minor robustness follow-ups to CodeRabbit feedback on #28009 (already merged).

### `vitest-setup.ts` — guarantee `knex.destroy()`
The `afterAll` hook does an optional `DROP DATABASE` (mysql path only) before destroying the knex pool. If that raw query threw, `knex.destroy()` was skipped — leaking the pool, which is the precise condition that causes the worker FATAL crash / hang the hook exists to prevent. Wrapped the DROP in an inner `try/finally` so the pool is always destroyed.

> Note: the `DROP DATABASE` branch only runs under `NODE_ENV=testing-mysql`; the vitest unit suite runs `testing` (sqlite), so this is defensive hardening of a path the unit run doesn't currently exercise.

### `slack.test.js` — bound the poll loop
"makes a request and errors" polled `while (!loggingStub.calledOnce)` with no exit. vitest's `testTimeout` already prevents an infinite hang, but on a regression the failure was an opaque timeout. Added a 1s deadline so it falls through to the `sinon.assert.calledOnce` below and fails with a clear message instead.

## Skipped finding

CodeRabbit also flagged that the `.secretlintrc.json` `allows` entry (the pre-existing test RSA key fingerprint) is global rather than path-scoped. Left as-is: it's a 28-char fingerprint with no realistic collision against a real secret, and path-scoped alternatives (`.secretlintignore`) don't apply to the pre-commit hook's stdin scan — which is why `allows` was used in the first place.

## Verification
`pnpm test:vitest test/unit/server/services/slack.test.js` — 10/10 pass.