### PR TITLE
Added CI guard against pnpm patched dependencies

### DIFF
--- a/.github/scripts/check-no-patched-dependencies.js
+++ b/.github/scripts/check-no-patched-dependencies.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+
+// pnpm patch is unsupported in this repo.
+//
+// `pnpm patch` writes a patch file under `patches/` and references it via
+// `patchedDependencies`. Ghost's production image (Dockerfile.production)
+// installs from the packed ghost/core archive, which does NOT contain the
+// repo-root `patches/` directory — so `pnpm install --prod` aborts with
+// `ENOENT: ... patches/<name>.patch` and Build & Publish fails.
+//
+// pnpm 10 allows `patchedDependencies` in either package.json or
+// pnpm-workspace.yaml, so both are checked. This guard runs in CI (the Lint
+// job) so a patch can never reach main again — see PR #28009, which shipped
+// one and broke the production build.
+
+const repoRoot = path.join(__dirname, '..', '..');
+const offenders = [];
+
+// 1. package.json -> pnpm.patchedDependencies
+const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+const fromPkg = pkg.pnpm && pkg.pnpm.patchedDependencies;
+if (fromPkg && Object.keys(fromPkg).length > 0) {
+    offenders.push(`package.json -> pnpm.patchedDependencies (${Object.keys(fromPkg).join(', ')})`);
+}
+
+// 2. pnpm-workspace.yaml -> patchedDependencies
+// Lightweight text scan so this can run before `pnpm install` (no YAML dep).
+const workspaceFile = path.join(repoRoot, 'pnpm-workspace.yaml');
+if (fs.existsSync(workspaceFile)) {
+    const lines = fs.readFileSync(workspaceFile, 'utf8').split('\n');
+    const idx = lines.findIndex(line => /^patchedDependencies:/.test(line));
+    if (idx !== -1) {
+        const inline = lines[idx].slice('patchedDependencies:'.length).trim();
+        const hasInlineEntries = inline !== '' && inline !== '{}';
+        const hasBlockEntries = /^\s+\S/.test(lines[idx + 1] || '');
+        if (hasInlineEntries || hasBlockEntries) {
+            offenders.push('pnpm-workspace.yaml -> patchedDependencies');
+        }
+    }
+}
+
+if (offenders.length > 0) {
+    console.error('::error::pnpm patched dependencies are not allowed (breaks the production build)');
+    console.error(`
+pnpm patched dependencies were found:
+${offenders.map(o => `  - ${o}`).join('\n')}
+
+Ghost's production image (Dockerfile.production) installs from the packed
+ghost/core archive, which does not include the repo-root patches/ directory.
+\`pnpm install --prod\` then fails with ENOENT on the patch file, breaking
+Build & Publish.
+
+Remove the patch and use a supported alternative instead:
+  - a thin wrapper module around the dependency
+  - an upstream fix
+  - a dependency version bump
+`);
+    process.exit(1);
+}
+
+console.log('OK: no pnpm patched dependencies.');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
+      - name: Check for pnpm patched dependencies
+        run: node .github/scripts/check-no-patched-dependencies.js
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Adds a CI check that fails if the repo declares pnpm `patchedDependencies`, preventing a recurrence of the broken production build fixed in #28011 (introduced by #28009).

`pnpm patch` is structurally incompatible with Ghost's production build: `Dockerfile.production` installs from the packed `ghost/core` archive, which doesn't include the repo-root `patches/` directory — so `pnpm install --prod` aborts with `ENOENT` on the patch file. There's no "correct" way to use it, so the check is a flat hard-fail: **`pnpm patch` is not supported in this repo.**

## What it does

- New script `.github/scripts/check-no-patched-dependencies.js` — fails if `patchedDependencies` is declared in **either** `package.json` (`pnpm.patchedDependencies`) or `pnpm-workspace.yaml` (pnpm 10 allows both).
- Wired into the **Lint** job, before `pnpm install`, so it fails in seconds rather than after a ~7-minute Docker build.
- It only targets `patchedDependencies` — that's the only pnpm config field that references external files. `overrides`, `packageExtensions`, and `onlyBuiltDependencies` are pure in-`package.json` config and install fine in the prod image.

## Complementary action (not code)

The other half of preventing this — making **Build & Publish Artifacts** a *required* status check on `main` — is a branch-protection setting, not a code change. #28009 merged red because that job's failure only caused its dependent E2E jobs to *skip*, and skipped required checks count as passing. That has to be set in repo Settings → Branches.