### PR TITLE
🐛 Fixed Mastodon settings input overwriting

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/social-accounts.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/social-accounts.tsx
@@ -58,8 +58,21 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
         }
 
         try {
-            const {storedValue} = normalizeSocialInput(key, value);
+            normalizeSocialInput(key, value);
+
+            if (errors[key]) {
+                setErrors(current => ({...current, [key]: ''}));
+            }
+        } catch {
+            setErrors(current => ({...current, [key]: getSocialValidationError(key, value)}));
+        }
+    };
+
+    const handleSocialBlur = (key: SocialPlatformKey, value: string) => {
+        try {
+            const {displayValue, storedValue} = normalizeSocialInput(key, value);
             updateSetting(key, storedValue);
+            setUrls(current => ({...current, [key]: displayValue}));
 
             if (errors[key]) {
                 setErrors(current => ({...current, [key]: ''}));
@@ -81,6 +94,14 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
         setErrors(formErrors);
 
         if (Object.keys(formErrors).length === 0) {
+            visiblePlatforms.forEach((config) => {
+                try {
+                    const {storedValue} = normalizeSocialInput(config.key, urls[config.key]);
+                    updateSetting(config.key, storedValue);
+                } catch {
+                    // Ignored since we verified errors above
+                }
+            });
             handleSave();
         }
     };
@@ -109,6 +130,7 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         placeholder={config.placeholder}
                         title={config.publicationTitle}
                         value={urls[config.key]}
+                        onBlur={event => handleSocialBlur(config.key, event.target.value)}
                         onChange={event => handleSocialChange(config.key, event.target.value)}
                     />
                 ))}


### PR DESCRIPTION
This PR fixes a frustrating issue where typing a Mastodon handle (e.g., `@username@instance.tld`) in the social settings would immediately overwrite the input and cause the cursor to jump mid-typing.

To fix this:
1. We still validate `onChange` so users see formatting errors immediately, but we don't overwrite or format the value yet.
2. The actual normalization/formatting and state updates are deferred to `onBlur` (when clicking away).
3. Added a final normalization check `onSave` in case the user hits save directly.

This matches how other social media fields in Ghost behave and makes typing handles smooth.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works