### PR TITLE
🐛 Fix Offer creation redemptionCount error handling

### DIFF
--- a/ghost/core/core/server/services/offers/domain/errors/index.js
+++ b/ghost/core/core/server/services/offers/domain/errors/index.js
@@ -26,6 +26,7 @@ class InvalidOfferCoupon extends InvalidPropError {}
 class InvalidOfferStatus extends InvalidPropError {}
 class InvalidOfferRedemptionType extends InvalidPropError {}
 class InvalidStripeCoupon extends InvalidPropError {}
+class InvalidOfferRedemptionCount extends InvalidPropError {}
 
 module.exports = {
     InvalidOfferName,
@@ -42,5 +43,6 @@ module.exports = {
     InvalidOfferCoupon,
     InvalidOfferStatus,
     InvalidOfferRedemptionType,
-    InvalidStripeCoupon
+    InvalidStripeCoupon,
+    InvalidOfferRedemptionCount
 };

--- a/ghost/core/core/server/services/offers/domain/models/offer.js
+++ b/ghost/core/core/server/services/offers/domain/models/offer.js
@@ -307,8 +307,7 @@ class Offer {
         const stripeCouponId = data.stripe_coupon_id ?? null;
 
         if (isNew && data.redemptionCount !== undefined) {
-            // TODO correct error
-            throw new errors.InvalidOfferCode({
+            throw new errors.InvalidOfferRedemptionCount({
                 message: 'An Offer cannot be created with redemptionCount'
             });
         }

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
@@ -270,7 +270,7 @@ describe('Offer', function () {
             await Offer.create({...data, redemptionCount: 2}, mockUniqueChecker).then(() => {
                 assert.fail('Expected an error');
             }, (err) => {
-                assert(err);
+                assert(err instanceof errors.InvalidOfferRedemptionCount);
             });
         });
 


### PR DESCRIPTION
This PR fixes a `TODO` by properly throwing an `InvalidOfferRedemptionCount` error instead of the incorrect `InvalidOfferCode` when an Offer is created with a `redemptionCount`.

### Changes
- Added `InvalidOfferRedemptionCount` error class to `domain/errors/index.js`.
- Updated `offer.js` to throw this new error when validating `redemptionCount` during offer creation.