### PR TITLE
Improved i18n CI install time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Determine Affected Projects
         id: affected
@@ -302,10 +302,10 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter @tryghost/i18n... --ignore-scripts
 
       - name: Run i18n tests
-        run: pnpm nx run @tryghost/i18n:test
+        run: pnpm --filter @tryghost/i18n test
 
   job_admin-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

- Skips lifecycle scripts in the setup job dependency install.
- Filters the i18n job install to `@tryghost/i18n...` so it does not install the full monorepo.
- Runs the i18n package test directly with `pnpm --filter @tryghost/i18n test`.

## Why

The i18n job only needs the i18n workspace dependency graph, but CI was doing a full monorepo install before running this isolated check. Local `act` validation showed the job dropping from 243.80s to 159.84s for the same workflow job, with the filtered i18n install step taking 14.2s.

## Testing

- `git diff --check -- .github/workflows/ci.yml`
- `act push -W .github/workflows/ci.yml -j job_i18n --eventpath /tmp/act-ci-baseline-push.json --container-architecture linux/amd64 --pull=false --action-offline-mode --no-cache-server`