### PR TITLE
Added score column to comment likes

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.42/2026-05-21-06-56-05-add-score-to-comment-likes.js
+++ b/ghost/core/core/server/data/migrations/versions/6.42/2026-05-21-06-56-05-add-score-to-comment-likes.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('comment_likes', 'score', {
+    type: 'integer',
+    nullable: false,
+    defaultTo: 1
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -994,6 +994,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         comment_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'comments.id', cascadeDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'members.id', cascadeDelete: true},
+        score: {type: 'integer', nullable: false, defaultTo: 1},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false}
     },

--- a/ghost/core/core/server/models/comment-like.js
+++ b/ghost/core/core/server/models/comment-like.js
@@ -1,10 +1,13 @@
+const _ = require('lodash');
 const ghostBookshelf = require('./base');
 
 const CommentLike = ghostBookshelf.Model.extend({
     tableName: 'comment_likes',
 
     defaults: function defaults() {
-        return {};
+        return {
+            score: 1
+        };
     },
 
     comment() {
@@ -13,6 +16,10 @@ const CommentLike = ghostBookshelf.Model.extend({
 
     member() {
         return this.belongsTo('Member', 'member_id');
+    },
+
+    serialize(options) {
+        return _.omit(ghostBookshelf.Model.prototype.serialize.call(this, options), 'score');
     },
 
     emitChange: function emitChange(event, options) {

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.41.2-rc.0",
+  "version": "6.42.0-rc.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '022588f95456319debb9a270b24b4564';
+    const currentSchemaHash = 'fafc9d5ad026f5eef11f9229a34994eb';
     const currentFixturesHash = '823aa0e8a8f083e80e271c47836a7e5d';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
## Stack

- [#28019 Added score column to comment likes](https://github.com/TryGhost/Ghost/pull/28019) - migration only, this PR
- [#28020 Added comment dislike server support](https://github.com/TryGhost/Ghost/pull/28020) - stacked on #28019
- [#28021 Added capability-gated comment dislike UI](https://github.com/TryGhost/Ghost/pull/28021) - independently based on main

## Summary

- Adds a `score` column to `comment_likes`, defaulting to `1` for existing rows and old-code inserts.
- Updates `schema.js` and the schema integrity hash.
- Leaves the rollout migration-only: no `comment_dislikes` table, no server references, and no uniqueness index.

## Verification

- `pnpm --dir ghost/core test:single test/unit/server/data/schema/integrity.test.js`
- `pnpm --dir ghost/core exec knex-migrator migrate --v 6.40 --force`
