### PR TITLE
Added comment dislike server support

### DIFF
--- a/ghost/core/core/server/api/endpoints/comment-dislikes.js
+++ b/ghost/core/core/server/api/endpoints/comment-dislikes.js
@@ -1,0 +1,34 @@
+// Endpoint for the admin API to return dislikers for a comment
+
+const commentsService = require('../../services/comments');
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'comment_dislikes',
+    browse: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id',
+            'page',
+            'limit'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        // Use comment permissions - browsing dislikes is part of comment moderation
+        permissions: {
+            docName: 'comments'
+        },
+        query(frame) {
+            return commentsService.controller.getCommentDislikes(frame);
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/comment-replies.js
+++ b/ghost/core/core/server/api/endpoints/comment-replies.js
@@ -1,7 +1,7 @@
 // This is a new endpoint for the admin API to return replies to a comment with pagination
 
 const commentsService = require('../../services/comments');
-const ALLOWED_INCLUDES = ['member', 'replies', 'replies.member', 'replies.count.likes', 'replies.liked', 'count.replies', 'count.direct_replies', 'count.likes', 'liked', 'post', 'parent', 'in_reply_to'];
+const ALLOWED_INCLUDES = ['member', 'replies', 'replies.member', 'replies.count.likes', 'replies.count.dislikes', 'replies.liked', 'replies.disliked', 'count.replies', 'count.direct_replies', 'count.likes', 'count.dislikes', 'liked', 'disliked', 'post', 'parent', 'in_reply_to'];
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {

--- a/ghost/core/core/server/api/endpoints/comments-members.js
+++ b/ghost/core/core/server/api/endpoints/comments-members.js
@@ -1,5 +1,15 @@
 const commentsService = require('../../services/comments');
-const ALLOWED_INCLUDES = ['member', 'replies', 'replies.member', 'replies.count.likes', 'replies.liked', 'count.replies', 'count.direct_replies', 'count.likes', 'liked', 'post', 'parent'];
+const ALLOWED_INCLUDES = ['member', 'replies', 'replies.member', 'replies.count.likes', 'replies.liked', 'replies.disliked', 'count.replies', 'count.direct_replies', 'count.likes', 'liked', 'disliked', 'post', 'parent'];
+
+function withDislikesCapability(response) {
+    response.meta = response.meta || {};
+    response.meta.capabilities = {
+        ...response.meta.capabilities,
+        dislikes: true
+    };
+
+    return response;
+}
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
@@ -25,8 +35,9 @@ const controller = {
             }
         },
         permissions: false,
-        query(frame) {
-            return commentsService.controller.browse(frame);
+        async query(frame) {
+            const response = await commentsService.controller.browse(frame);
+            return withDislikesCapability(response);
         }
     },
 
@@ -187,6 +198,37 @@ const controller = {
         permissions: false,
         async query(frame) {
             return await commentsService.controller.unlike(frame);
+        }
+    },
+
+    dislike: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id'
+        ],
+        validation: {
+        },
+        permissions: false,
+        async query(frame) {
+            return await commentsService.controller.dislike(frame);
+        }
+    },
+
+    undislike: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id'
+        ],
+        validation: {},
+        permissions: false,
+        async query(frame) {
+            return await commentsService.controller.undislike(frame);
         }
     },
 

--- a/ghost/core/core/server/api/endpoints/comments.js
+++ b/ghost/core/core/server/api/endpoints/comments.js
@@ -1,6 +1,16 @@
 const commentsService = require('../../services/comments');
 const errors = require('@tryghost/errors');
 
+function withDislikesCapability(response) {
+    response.meta = response.meta || {};
+    response.meta.capabilities = {
+        ...response.meta.capabilities,
+        dislikes: true
+    };
+
+    return response;
+}
+
 function validateCommentData(data) {
     if (!data.post_id && !data.parent_id) {
         throw new errors.ValidationError({
@@ -76,7 +86,7 @@ const controller = {
         permissions: true,
         async query(frame) {
             const result = await commentsService.controller.adminBrowse(frame);
-            return result;
+            return withDislikesCapability(result);
         }
     },
     browseAll: {
@@ -96,7 +106,7 @@ const controller = {
         },
         async query(frame) {
             const result = await commentsService.controller.adminBrowseAll(frame);
-            return result;
+            return withDislikesCapability(result);
         }
     },
     add: {

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -229,6 +229,10 @@ module.exports = {
         return apiFramework.pipeline(require('./comment-likes'), localUtils);
     },
 
+    get commentDislikes() {
+        return apiFramework.pipeline(require('./comment-dislikes'), localUtils);
+    },
+
     get links() {
         return apiFramework.pipeline(require('./links'), localUtils);
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/comments.js
@@ -4,13 +4,19 @@ module.exports = {
             return;
         }
 
-        // Map the 'liked' relation to 'count.liked'
+        // Map reaction shortcut relations to count relations
         frame.options.withRelated = frame.options.withRelated.map((relation) => {
             if (relation === 'liked') {
                 return 'count.liked';
             }
             if (relation === 'replies.liked') {
                 return 'replies.count.liked';
+            }
+            if (relation === 'disliked') {
+                return 'count.disliked';
+            }
+            if (relation === 'replies.disliked') {
+                return 'replies.count.disliked';
             }
             return relation;
         });

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -51,6 +51,7 @@ const countFieldsAdmin = [
     'replies',
     'direct_replies',
     'likes',
+    'dislikes',
     'reports'
 ];
 
@@ -134,8 +135,13 @@ const commentMapper = (model, frame) => {
         response.liked = jsonModel.count.liked > 0;
     }
 
+    if (jsonModel.count && jsonModel.count.disliked !== undefined) {
+        response.disliked = jsonModel.count.disliked > 0;
+    }
+
     if (jsonModel.count) {
-        response.count = _.pick(jsonModel.count, isPublicRequest ? countFields : countFieldsAdmin);
+        const countFieldsForRequest = isPublicRequest ? countFields : countFieldsAdmin;
+        response.count = _.pick(jsonModel.count, countFieldsForRequest);
     }
 
     if (includesHtml && isPublicRequest && jsonModel.status !== 'published') {

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -132,6 +132,7 @@ const Comment = ghostBookshelf.Model.extend({
     orderAttributes: function orderAttributes() {
         let keys = ghostBookshelf.Model.prototype.orderAttributes.call(this, arguments);
         keys.push('count__likes');
+        keys.push('count__net_score');
         keys.push('count__reports');
         return keys;
     },
@@ -201,11 +202,19 @@ const Comment = ghostBookshelf.Model.extend({
         // our bookshelf eager-load plugin doesn't use the `withRelated` options
         if (['findAll', 'findPage', 'edit', 'findOne', 'destroy'].indexOf(methodName) !== -1) {
             if (!options.withRelated || options.withRelated.length === 0) {
+                const reactionRelations = ['count.likes', 'count.liked', 'count.disliked', 'count.net_score'];
+                const replyReactionRelations = ['replies.count.likes', 'replies.count.liked', 'replies.count.disliked'];
+
+                if (options.isAdmin) {
+                    reactionRelations.push('count.dislikes');
+                    replyReactionRelations.push('replies.count.dislikes');
+                }
+
                 if (options.parentId) {
                     // Do not include replies for replies
                     options.withRelated = [
                         // Relations
-                        'in_reply_to', 'member', 'count.direct_replies', 'count.likes', 'count.liked'
+                        'in_reply_to', 'member', 'count.direct_replies', ...reactionRelations
                     ];
 
                     // Add count.reports for admin requests only
@@ -215,9 +224,9 @@ const Comment = ghostBookshelf.Model.extend({
                 } else {
                     options.withRelated = [
                         // Relations
-                        'member', 'in_reply_to', 'count.replies', 'count.direct_replies', 'count.likes', 'count.liked',
+                        'member', 'in_reply_to', 'count.replies', 'count.direct_replies', ...reactionRelations,
                         'replies', 'replies.member', 'replies.in_reply_to',
-                        'replies.count.direct_replies', 'replies.count.likes', 'replies.count.liked'
+                        'replies.count.direct_replies', ...replyReactionRelations
                     ];
 
                     // Add count.reports for admin requests only
@@ -240,7 +249,7 @@ const Comment = ghostBookshelf.Model.extend({
         // Identify reply-related relations to load separately in batch
         const replyRelationKeys = [
             'replies', 'replies.member', 'replies.in_reply_to',
-            'replies.count.direct_replies', 'replies.count.likes', 'replies.count.liked'
+            'replies.count.direct_replies', 'replies.count.likes', 'replies.count.dislikes', 'replies.count.liked', 'replies.count.disliked'
         ];
         if (options.isAdmin) {
             replyRelationKeys.push('replies.count.reports');
@@ -313,6 +322,7 @@ const Comment = ghostBookshelf.Model.extend({
                     qb.count('comment_likes.id')
                         .from('comment_likes')
                         .whereRaw('comment_likes.comment_id = comments.id')
+                        .where('comment_likes.score', 1)
                         .as('count__likes');
                 });
             },
@@ -323,6 +333,7 @@ const Comment = ghostBookshelf.Model.extend({
                             .from('comment_likes')
                             .whereRaw('comment_likes.comment_id = comments.id')
                             .where('comment_likes.member_id', options.context.member.id)
+                            .where('comment_likes.score', 1)
                             .as('count__liked');
                         return;
                     }
@@ -330,6 +341,38 @@ const Comment = ghostBookshelf.Model.extend({
                     // Return zero
                     qb.select(ghostBookshelf.knex.raw('0')).as('count__liked');
                 });
+            },
+            dislikes(modelOrCollection) {
+                modelOrCollection.query('columns', 'comments.*', (qb) => {
+                    qb.count('comment_likes.id')
+                        .from('comment_likes')
+                        .whereRaw('comment_likes.comment_id = comments.id')
+                        .where('comment_likes.score', -1)
+                        .as('count__dislikes');
+                });
+            },
+            disliked(modelOrCollection, options) {
+                modelOrCollection.query('columns', 'comments.*', (qb) => {
+                    if (options.context && options.context.member && options.context.member.id) {
+                        qb.count('comment_likes.id')
+                            .from('comment_likes')
+                            .whereRaw('comment_likes.comment_id = comments.id')
+                            .where('comment_likes.member_id', options.context.member.id)
+                            .where('comment_likes.score', -1)
+                            .as('count__disliked');
+                        return;
+                    }
+
+                    // Return zero
+                    qb.select(ghostBookshelf.knex.raw('0')).as('count__disliked');
+                });
+            },
+            net_score(modelOrCollection) {
+                modelOrCollection.query('columns', 'comments.*', ghostBookshelf.knex.raw(`(
+                    SELECT COALESCE(SUM(comment_likes.score), 0)
+                    FROM comment_likes
+                    WHERE comment_likes.comment_id = comments.id
+                ) as count__net_score`));
             },
             reports(modelOrCollection) {
                 modelOrCollection.query('columns', 'comments.*', (qb) => {

--- a/ghost/core/core/server/services/comments/comments-controller.js
+++ b/ghost/core/core/server/services/comments/comments-controller.js
@@ -414,4 +414,70 @@ module.exports = class CommentsController {
             limit: frame.options.limit
         });
     }
+
+    /**
+     * @param {Frame} frame
+     */
+    async dislike(frame) {
+        this.#checkMember(frame);
+
+        const result = await this.service.dislikeComment(
+            frame.options.id,
+            frame.options?.context?.member,
+            frame.options
+        );
+
+        const comment = await this.service.getCommentByID(frame.options.id);
+
+        if (comment) {
+            const postId = comment.get('post_id');
+            const parentId = comment.get('parent_id');
+            const pathsToInvalidate = [
+                postId ? `/api/members/comments/post/${postId}/` : null,
+                parentId ? `/api/members/comments/${parentId}/replies/` : null
+            ].filter(path => path !== null);
+            frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
+        }
+
+        return result;
+    }
+
+    /**
+     * @param {Frame} frame
+     */
+    async undislike(frame) {
+        this.#checkMember(frame);
+
+        const result = await this.service.undislikeComment(
+            frame.options.id,
+            frame.options?.context?.member,
+            frame.options
+        );
+
+        const comment = await this.service.getCommentByID(frame.options.id);
+
+        if (comment) {
+            const postId = comment.get('post_id');
+            const parentId = comment.get('parent_id');
+            const pathsToInvalidate = [
+                postId ? `/api/members/comments/post/${postId}/` : null,
+                parentId ? `/api/members/comments/${parentId}/replies/` : null
+            ].filter(path => path !== null);
+            frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
+        }
+
+        return result;
+    }
+
+    /**
+     * Get dislikes for a specific comment (admin only)
+     * @param {Frame} frame
+     */
+    async getCommentDislikes(frame) {
+        const commentId = frame.options.id;
+        return await this.service.getCommentDislikes(commentId, {
+            page: frame.options.page,
+            limit: frame.options.limit
+        });
+    }
 };

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -9,6 +9,8 @@ const messages = {
     memberNotFound: 'Unable to find member',
     likeNotFound: 'Unable to find like',
     alreadyLiked: 'This comment was liked already',
+    dislikeNotFound: 'Unable to find dislike',
+    alreadyDisliked: 'This comment was disliked already',
     replyToReply: 'Can not reply to a reply',
     commentsNotEnabled: 'Comments are not enabled for this site.',
     cannotCommentOnPost: 'You do not have permission to comment on this post.',
@@ -18,6 +20,9 @@ const messages = {
     invalidPinnedValue: 'Pinned must be a boolean value',
     commentsPinningNotEnabled: 'Comment pinning is not enabled for this site.'
 };
+
+const COMMENT_LIKE_SCORE = 1;
+const COMMENT_DISLIKE_SCORE = -1;
 
 function withPinnedSelect(options = {}) {
     if (!options.columns?.includes('pinned')) {
@@ -39,13 +44,13 @@ class CommentsService {
         this.models = models;
 
         /** @private */
+        this.labs = labs;
+
+        /** @private */
         this.settingsCache = settingsCache;
 
         /** @private */
         this.contentGating = contentGating;
-
-        /** @private */
-        this.labs = labs;
 
         const Emails = require('./comments-service-emails');
         /** @private */
@@ -102,6 +107,84 @@ class CommentsService {
     }
 
     /** @private */
+    async #withTransaction(options, operation) {
+        if (options.transacting) {
+            return await operation(options);
+        }
+
+        return await this.models.Base.transaction(async (transacting) => {
+            return await operation({
+                ...options,
+                transacting
+            });
+        });
+    }
+
+    /** @private */
+    async #getMemberCommentVotes(commentId, memberId, options) {
+        const votes = await this.models.CommentLike.findAll({
+            ...options,
+            filter: `comment_id:'${commentId}'+member_id:'${memberId}'`,
+            order: 'created_at asc'
+        });
+
+        return votes.models || [];
+    }
+
+    /** @private */
+    async #destroyCommentVotes(votes, options) {
+        await Promise.all(votes.map(vote => vote.destroy(options)));
+    }
+
+    /** @private */
+    async #setCommentVote(commentId, member, targetScore, alreadyMessage, options = {}) {
+        const memberModel = await this.models.Member.findOne({
+            id: member.id
+        }, {
+            require: true,
+            ...options,
+            withRelated: ['products']
+        });
+
+        this.checkCommentAccess(memberModel);
+
+        return await this.#withTransaction(options, async (transactionOptions) => {
+            const votes = await this.#getMemberCommentVotes(commentId, memberModel.id, transactionOptions);
+            const alreadyHasSingleTargetVote = votes.length === 1 && Number(votes[0].get('score')) === targetScore;
+
+            if (alreadyHasSingleTargetVote) {
+                throw new errors.BadRequestError({
+                    message: tpl(alreadyMessage)
+                });
+            }
+
+            await this.#destroyCommentVotes(votes, transactionOptions);
+
+            return await this.models.CommentLike.add({
+                member_id: memberModel.id,
+                comment_id: commentId,
+                score: targetScore
+            }, transactionOptions);
+        });
+    }
+
+    /** @private */
+    async #clearCommentVote(commentId, member, targetScore, notFoundMessage, options = {}) {
+        await this.#withTransaction(options, async (transactionOptions) => {
+            const votes = await this.#getMemberCommentVotes(commentId, member.id, transactionOptions);
+            const votesToRemove = votes.filter(vote => Number(vote.get('score')) === targetScore);
+
+            if (votesToRemove.length === 0) {
+                throw new errors.NotFoundError({
+                    message: tpl(notFoundMessage)
+                });
+            }
+
+            await this.#destroyCommentVotes(votesToRemove, transactionOptions);
+        });
+    }
+
+    /** @private */
     async sendNewCommentNotifications(comment) {
         await this.emails.notifyPostAuthors(comment);
 
@@ -116,53 +199,25 @@ class CommentsService {
     async likeComment(commentId, member, options = {}) {
         this.checkEnabled();
 
-        const memberModel = await this.models.Member.findOne({
-            id: member.id
-        }, {
-            require: true,
-            ...options,
-            withRelated: ['products']
-        });
-
-        this.checkCommentAccess(memberModel);
-
-        const data = {
-            member_id: memberModel.id,
-            comment_id: commentId
-        };
-
-        const existing = await this.models.CommentLike.findOne(data, options);
-
-        if (existing) {
-            throw new errors.BadRequestError({
-                message: tpl(messages.alreadyLiked)
-            });
-        }
-
-        return await this.models.CommentLike.add(data, options);
+        return await this.#setCommentVote(commentId, member, COMMENT_LIKE_SCORE, messages.alreadyLiked, options);
     }
 
     async unlikeComment(commentId, member, options = {}) {
         this.checkEnabled();
 
-        try {
-            await this.models.CommentLike.destroy({
-                ...options,
-                destroyBy: {
-                    member_id: member.id,
-                    comment_id: commentId
-                },
-                require: true
-            });
-        } catch (err) {
-            if (err instanceof this.models.CommentLike.NotFoundError) {
-                return Promise.reject(new errors.NotFoundError({
-                    message: tpl(messages.likeNotFound)
-                }));
-            }
+        await this.#clearCommentVote(commentId, member, COMMENT_LIKE_SCORE, messages.likeNotFound, options);
+    }
 
-            throw err;
-        }
+    async dislikeComment(commentId, member, options = {}) {
+        this.checkEnabled();
+
+        return await this.#setCommentVote(commentId, member, COMMENT_DISLIKE_SCORE, messages.alreadyDisliked, options);
+    }
+
+    async undislikeComment(commentId, member, options = {}) {
+        this.checkEnabled();
+
+        await this.#clearCommentVote(commentId, member, COMMENT_DISLIKE_SCORE, messages.dislikeNotFound, options);
     }
 
     async reportComment(commentId, reporter) {
@@ -222,8 +277,10 @@ class CommentsService {
      * @param {AdminBrowseAllOptions} options
      */
     async getAdminAllComments({includeNested, filter, mongoTransformer, reportCount, order, page, limit}) {
+        const withRelated = ['member', 'post', 'post.tags', 'post.authors', 'count.replies', 'count.direct_replies', 'count.likes', 'count.dislikes', 'count.net_score', 'count.reports', 'in_reply_to', 'parent'];
+
         return await this.models.Comment.findPage({
-            withRelated: ['member', 'post', 'post.tags', 'post.authors', 'count.replies', 'count.direct_replies', 'count.likes', 'count.reports', 'in_reply_to', 'parent'],
+            withRelated,
             filter,
             mongoTransformer,
             reportCount,
@@ -346,7 +403,32 @@ class CommentsService {
 
         const {page, limit} = options;
         const result = await this.models.CommentLike.findPage({
-            filter: `comment_id:'${commentId}'`,
+            filter: `comment_id:'${commentId}'+score:${COMMENT_LIKE_SCORE}`,
+            withRelated: ['member'],
+            order: 'created_at desc',
+            page,
+            limit
+        });
+
+        return result;
+    }
+
+    /**
+     * Get dislikes for a comment (admin only)
+     * @param {string} commentId - The ID of the Comment to get dislikes for
+     * @param {any} options - Query options (page, limit)
+     */
+    async getCommentDislikes(commentId, options = {}) {
+        const comment = await this.models.Comment.findOne({id: commentId});
+        if (!comment) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.commentNotFound)
+            });
+        }
+
+        const {page, limit} = options;
+        const result = await this.models.CommentLike.findPage({
+            filter: `comment_id:'${commentId}'+score:${COMMENT_DISLIKE_SCORE}`,
             withRelated: ['member'],
             order: 'created_at desc',
             page,

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -46,6 +46,7 @@ module.exports = function apiRoutes() {
     router.get('/comments/:id/replies', mw.authAdminApi, http(api.commentReplies.browse));
     router.get('/comments/:id/reports', mw.authAdminApi, http(api.commentReports.browse));
     router.get('/comments/:id/likes', mw.authAdminApi, http(api.commentLikes.browse));
+    router.get('/comments/:id/dislikes', mw.authAdminApi, http(api.commentDislikes.browse));
     router.get('/comments/post/:post_id', mw.authAdminApi, http(api.comments.browse));
     router.post('/comments', mw.authAdminApi, http(api.comments.add));
     router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));

--- a/ghost/core/core/server/web/comments/routes.js
+++ b/ghost/core/core/server/web/comments/routes.js
@@ -57,6 +57,8 @@ module.exports = function apiRoutes() {
     router.delete('/:id', checkMemberCommenting, http(api.commentsMembers.destroy));
     router.post('/:id/like', checkMemberCommenting, http(api.commentsMembers.like));
     router.delete('/:id/like', checkMemberCommenting, http(api.commentsMembers.unlike));
+    router.post('/:id/dislike', checkMemberCommenting, http(api.commentsMembers.dislike));
+    router.delete('/:id/dislike', checkMemberCommenting, http(api.commentsMembers.undislike));
 
     // Report is allowed even for members with commenting disabled (moderation action)
     router.post('/:id/report', http(api.commentsMembers.report));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -42,6 +42,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -82,6 +83,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -100,6 +104,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -139,6 +144,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -179,6 +185,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -197,6 +206,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -237,6 +247,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -255,6 +268,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -295,6 +309,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -313,6 +330,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -354,6 +372,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -394,6 +413,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -412,6 +434,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -452,6 +475,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -470,6 +496,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": 0,
         "reports": Any<Number>,
@@ -522,6 +549,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -540,6 +570,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -580,6 +611,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -598,6 +632,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -639,6 +674,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -679,6 +715,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -697,6 +736,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": 0,
         "reports": Any<Number>,
@@ -750,6 +790,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -790,6 +831,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -808,6 +852,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -848,6 +893,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -866,6 +914,7 @@ Object {
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -907,6 +956,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     Object {
       "count": Object {
         "direct_replies": Any<Number>,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": Any<Number>,
         "reports": Any<Number>,
@@ -947,6 +997,9 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 2,
       "next": 2,
@@ -954,6 +1007,91 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
       "pages": 3,
       "prev": null,
       "total": 5,
+    },
+  },
+}
+`;
+
+exports[`Admin Comments API Comment Dislikes Can browse comment dislikes 1: [body] 1`] = `
+Object {
+  "comment_dislikes": Array [
+    Object {
+      "comment_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "member": Object {
+        "avatar_image": null,
+        "can_comment": true,
+        "commenting": Object {
+          "disabled": false,
+          "disabled_reason": null,
+          "disabled_until": null,
+        },
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "email": "member2@test.com",
+        "email_count": 0,
+        "email_disabled": false,
+        "email_open_rate": 50,
+        "email_opened_count": 0,
+        "enable_comment_notifications": true,
+        "expertise": null,
+        "geolocation": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "last_commented_at": Nullable<StringMatching>,
+        "last_seen_at": Nullable<StringMatching>,
+        "name": null,
+        "note": null,
+        "status": "free",
+        "transient_id": Any<String>,
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "member_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+    Object {
+      "comment_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "member": Object {
+        "avatar_image": null,
+        "can_comment": true,
+        "commenting": Object {
+          "disabled": false,
+          "disabled_reason": null,
+          "disabled_until": null,
+        },
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "email": "paid@test.com",
+        "email_count": 0,
+        "email_disabled": false,
+        "email_open_rate": 80,
+        "email_opened_count": 0,
+        "enable_comment_notifications": true,
+        "expertise": null,
+        "geolocation": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "last_commented_at": Nullable<StringMatching>,
+        "last_seen_at": Nullable<StringMatching>,
+        "name": "Egon Spengler",
+        "note": null,
+        "status": "paid",
+        "transient_id": Any<String>,
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "member_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 2,
     },
   },
 }
@@ -1207,6 +1345,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1234,7 +1373,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "461",
+  "content-length": "478",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1252,6 +1391,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1279,7 +1419,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "436",
+  "content-length": "453",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1297,6 +1437,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1324,7 +1465,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "477",
+  "content-length": "494",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1342,6 +1483,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1369,7 +1511,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "454",
+  "content-length": "471",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1419,11 +1561,13 @@ Object {
     Object {
       "count": Object {
         "direct_replies": 3,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": 3,
         "reports": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1450,10 +1594,12 @@ Object {
         Object {
           "count": Object {
             "direct_replies": 0,
+            "dislikes": 0,
             "likes": Any<Number>,
             "reports": 0,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": Any<String>,
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1481,10 +1627,12 @@ Object {
         Object {
           "count": Object {
             "direct_replies": 0,
+            "dislikes": 0,
             "likes": Any<Number>,
             "reports": 0,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": Any<String>,
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1512,10 +1660,12 @@ Object {
         Object {
           "count": Object {
             "direct_replies": 0,
+            "dislikes": 0,
             "likes": Any<Number>,
             "reports": 0,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": Any<String>,
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1551,6 +1701,9 @@ exports[`Admin Comments API browse by post does not return deleted comments 1: [
 Object {
   "comments": Array [],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1569,11 +1722,13 @@ Object {
     Object {
       "count": Object {
         "direct_replies": 2,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": 2,
         "reports": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "Comment 1",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1600,10 +1755,12 @@ Object {
         Object {
           "count": Object {
             "direct_replies": 0,
+            "dislikes": 0,
             "likes": 0,
             "reports": 0,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "Reply 2",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1631,10 +1788,12 @@ Object {
         Object {
           "count": Object {
             "direct_replies": 0,
+            "dislikes": 0,
             "likes": 0,
             "reports": 0,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "Reply 3",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1664,6 +1823,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1680,6 +1842,9 @@ exports[`Admin Comments API browse by post excludes deleted comments when all re
 Object {
   "comments": Array [],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1698,11 +1863,13 @@ Object {
     Object {
       "count": Object {
         "direct_replies": 2,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": 2,
         "reports": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "Comment 1",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1729,10 +1896,12 @@ Object {
         Object {
           "count": Object {
             "direct_replies": 0,
+            "dislikes": 0,
             "likes": 0,
             "reports": 0,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "Reply 1",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1760,10 +1929,12 @@ Object {
         Object {
           "count": Object {
             "direct_replies": 0,
+            "dislikes": 0,
             "likes": 0,
             "reports": 0,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "Reply 3",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1793,6 +1964,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1811,11 +1985,13 @@ Object {
     Object {
       "count": Object {
         "direct_replies": 1,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": 1,
         "reports": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1842,10 +2018,12 @@ Object {
         Object {
           "count": Object {
             "direct_replies": 0,
+            "dislikes": 0,
             "likes": 0,
             "reports": 0,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "Reply 1",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1875,6 +2053,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1893,11 +2074,13 @@ Object {
     Object {
       "count": Object {
         "direct_replies": 0,
+        "dislikes": 0,
         "likes": Any<Number>,
         "replies": 0,
         "reports": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -2074,6 +2074,12 @@ describe(`Admin Comments API`, function () {
                 member_id: fixtureManager.get('members', 2).id,
                 created_at: new Date('2023-01-01')
             });
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 3).id,
+                score: -1,
+                created_at: new Date('2023-12-01')
+            });
 
             await adminApi.get(`/comments/${comment.id}/likes/`)
                 .expectStatus(200)
@@ -2246,6 +2252,57 @@ describe(`Admin Comments API`, function () {
                     errors: [{
                         id: anyUuid
                     }]
+                });
+        });
+    });
+
+    describe('Comment Dislikes', function () {
+        const dislikeMatcher = {
+            id: anyObjectId,
+            comment_id: anyObjectId,
+            member_id: anyObjectId,
+            created_at: anyISODateTime,
+            updated_at: anyISODateTime,
+            member: {
+                id: anyObjectId,
+                uuid: anyUuid,
+                created_at: anyISODateTime,
+                updated_at: anyISODateTime,
+                transient_id: anyString,
+                last_seen_at: nullable(anyISODateTime),
+                last_commented_at: nullable(anyISODateTime)
+            }
+        };
+
+        it('Can browse comment dislikes', async function () {
+            const comment = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: '<p>Disliked comment</p>'
+            });
+
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 1).id,
+                score: -1,
+                created_at: new Date('2023-06-01')
+            });
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 2).id,
+                score: -1,
+                created_at: new Date('2023-01-01')
+            });
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 3).id,
+                score: 1,
+                created_at: new Date('2023-12-01')
+            });
+
+            await adminApi.get(`/comments/${comment.id}/dislikes/`)
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    comment_dislikes: [dislikeMatcher, dislikeMatcher]
                 });
         });
     });

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -10,6 +10,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a message</p><p></p><p>New line</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -37,7 +38,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "479",
+  "content-length": "496",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -57,6 +58,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -84,7 +86,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "470",
+  "content-length": "487",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -166,6 +168,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -191,6 +194,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -213,6 +217,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -235,6 +240,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -252,7 +260,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1440",
+  "content-length": "1524",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -270,6 +278,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -292,6 +301,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -319,6 +329,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -339,6 +350,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -356,7 +370,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1440",
+  "content-length": "1524",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -374,6 +388,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -396,6 +411,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -423,6 +439,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -443,6 +460,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -460,7 +480,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1440",
+  "content-length": "1524",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -478,6 +498,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -503,6 +524,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -525,6 +547,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -547,6 +570,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -564,7 +590,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1440",
+  "content-length": "1524",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -582,6 +608,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a message</p><p></p><p>New line</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -609,12 +636,70 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "479",
+  "content-length": "496",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
   "vary": "Origin, Accept-Encoding",
   "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\//,
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can dislike a comment without exposing public dislike counts 1: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin",
+  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can dislike a comment without exposing public dislike counts 2: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "direct_replies": 0,
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": true,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Egon Spengler",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "parent_id": Nullable<StringMatching>,
+      "pinned": Any<Boolean>,
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can dislike a comment without exposing public dislike counts 3: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "484",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
   "x-powered-by": "Express",
 }
 `;
@@ -629,6 +714,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "html": "Updated comment",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -656,7 +742,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "470",
+  "content-length": "487",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -708,6 +794,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -735,7 +822,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "467",
+  "content-length": "484",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -765,6 +852,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -792,7 +880,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "478",
+  "content-length": "495",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -841,6 +929,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "html": "Illegal comment update",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -868,7 +957,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "477",
+  "content-length": "494",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -938,6 +1027,64 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated Can remove a dislike 1: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin",
+  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can remove a dislike 2: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "direct_replies": 0,
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "parent_id": Nullable<StringMatching>,
+      "pinned": Any<Boolean>,
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can remove a dislike 3: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "474",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated Can remove a like (unlike) 1: [headers] 1`] = `
 Object {
   "access-control-allow-credentials": "true",
@@ -960,6 +1107,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -987,7 +1135,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "457",
+  "content-length": "474",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1005,6 +1153,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1032,7 +1181,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "470",
+  "content-length": "487",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1052,6 +1201,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1079,7 +1229,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "470",
+  "content-length": "487",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1099,6 +1249,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1126,7 +1277,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "470",
+  "content-length": "487",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1146,6 +1297,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1173,7 +1325,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "470",
+  "content-length": "487",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1203,6 +1355,7 @@ Object {
         "likes": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1239,7 +1392,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "536",
+  "content-length": "553",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1256,6 +1409,7 @@ Object {
         "likes": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1279,6 +1433,7 @@ Object {
         "likes": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1302,6 +1457,7 @@ Object {
         "likes": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1325,6 +1481,7 @@ Object {
         "likes": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1348,6 +1505,7 @@ Object {
         "likes": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1371,6 +1529,7 @@ Object {
         "likes": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1394,6 +1553,7 @@ Object {
         "likes": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1430,7 +1590,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3167",
+  "content-length": "3286",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1521,6 +1681,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1543,6 +1704,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1566,6 +1728,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1589,6 +1752,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1612,6 +1776,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1635,6 +1800,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1664,7 +1830,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2650",
+  "content-length": "2752",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1682,6 +1848,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1704,6 +1871,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1726,6 +1894,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1743,7 +1914,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "962",
+  "content-length": "1029",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1755,6 +1926,9 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1772,7 +1946,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "103",
+  "content-length": "136",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1784,6 +1958,9 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1801,7 +1978,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "103",
+  "content-length": "136",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1819,6 +1996,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1839,6 +2017,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1856,7 +2037,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "549",
+  "content-length": "599",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1868,6 +2049,9 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1885,7 +2069,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "103",
+  "content-length": "136",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1897,6 +2081,9 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1914,7 +2101,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "103",
+  "content-length": "136",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1932,6 +2119,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1952,6 +2140,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1969,7 +2160,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "549",
+  "content-length": "599",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1987,6 +2178,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2009,6 +2201,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2031,6 +2224,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2048,7 +2244,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "962",
+  "content-length": "1029",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2066,6 +2262,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2088,6 +2285,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2110,6 +2308,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2127,7 +2328,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "961",
+  "content-length": "1028",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2145,6 +2346,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2167,6 +2369,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is what was replied to</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2190,6 +2393,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply to a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2212,6 +2416,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2229,7 +2436,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1501",
+  "content-length": "1585",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2247,6 +2454,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2274,7 +2482,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "523",
+  "content-length": "540",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2294,6 +2502,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2321,7 +2530,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "488",
+  "content-length": "505",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2341,6 +2550,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2368,7 +2578,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "488",
+  "content-length": "505",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2388,6 +2598,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2415,7 +2626,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "508",
+  "content-length": "525",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2433,6 +2644,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2460,7 +2672,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "508",
+  "content-length": "525",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2478,6 +2690,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2505,7 +2718,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "488",
+  "content-length": "505",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2525,6 +2738,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2552,7 +2766,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "466",
+  "content-length": "483",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2572,6 +2786,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2599,7 +2814,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "535",
+  "content-length": "552",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2619,6 +2834,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2646,7 +2862,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "535",
+  "content-length": "552",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2664,6 +2880,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2686,6 +2903,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2708,6 +2926,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2725,7 +2946,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "986",
+  "content-length": "1053",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2743,6 +2964,7 @@ Object {
         "replies": Any<Number>,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2765,6 +2987,7 @@ Object {
             "likes": Any<Number>,
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -2787,6 +3010,9 @@ Object {
     },
   ],
   "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2804,7 +3030,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "986",
+  "content-length": "1053",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2836,6 +3062,37 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "250",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when not authenticated cannot dislike a comment 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Unable to find member",
+      "property": null,
+      "type": "UnauthorizedError",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when not authenticated cannot dislike a comment 2: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "211",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2936,6 +3193,37 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when not authenticated cannot undislike a comment 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Unable to find member",
+      "property": null,
+      "type": "UnauthorizedError",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when not authenticated cannot undislike a comment 2: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "211",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when not authenticated cannot unlike a comment 1: [body] 1`] = `
 Object {
   "errors": Array [
@@ -2977,6 +3265,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "<p>This is a message</p><p></p><p>New line</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -3004,7 +3293,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "479",
+  "content-length": "496",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -3024,6 +3313,7 @@ Object {
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -3051,7 +3341,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "470",
+  "content-length": "487",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -86,7 +86,21 @@ const dbFns = {
     addLike: async (data) => {
         return await models.CommentLike.add({
             comment_id: data.comment_id,
-            member_id: data.member_id
+            member_id: data.member_id,
+            score: data.score ?? 1
+        });
+    },
+    /**
+     * @param {Object} data
+     * @param {string} data.comment_id
+     * @param {string} data.member_id
+     * @returns {Promise<any>}
+     */
+    addDislike: async (data) => {
+        return await models.CommentLike.add({
+            comment_id: data.comment_id,
+            member_id: data.member_id,
+            score: -1
         });
     },
     /**
@@ -406,6 +420,16 @@ describe('Comments API', function () {
                 ]);
             });
 
+            it('advertises dislike support on comment list responses', async function () {
+                const {body} = await membersAgent
+                    .get(`/api/comments/post/${postId}/`)
+                    .expectStatus(200);
+
+                assert.deepEqual(body.meta.capabilities, {
+                    dislikes: true
+                });
+            });
+
             it('excludes hidden comments', async function () {
                 const hiddenComment = await dbFns.addComment({
                     post_id: postId,
@@ -569,6 +593,26 @@ describe('Comments API', function () {
                 });
 
                 await testBasicErrorResponse('delete', `/api/comments/${comment.get('id')}/like/`, 401);
+            });
+
+            it('cannot dislike a comment', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+
+                await testBasicErrorResponse('post', `/api/comments/${comment.get('id')}/dislike/`, 401);
+            });
+
+            it('cannot undislike a comment', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+                await dbFns.addDislike({
+                    comment_id: comment.get('id'),
+                    member_id: fixtureManager.get('members', 0).id
+                });
+
+                await testBasicErrorResponse('delete', `/api/comments/${comment.get('id')}/dislike/`, 401);
             });
         });
 
@@ -1222,6 +1266,88 @@ describe('Comments API', function () {
                         assert.equal(body.comments[0].liked, true);
                         assert.equal(body.comments[0].count.likes, 1);
                     });
+            });
+
+            it('Can dislike a comment without exposing public dislike counts', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+
+                await membersAgent
+                    .post(`/api/comments/${comment.get('id')}/dislike/`)
+                    .expectStatus(204)
+                    .matchHeaderSnapshot({
+                        etag: anyEtag
+                    })
+                    .expectEmptyBody();
+
+                await testGetComments(`/api/comments/${comment.get('id')}/`, [commentMatcher])
+                    .expect(({body}) => {
+                        assert.equal(body.comments[0].disliked, true);
+                        assert.equal(Object.prototype.hasOwnProperty.call(body.comments[0].count, 'dislikes'), false);
+                    });
+            });
+
+            it('Can remove a dislike', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: loggedInMember.id
+                });
+                await dbFns.addDislike({
+                    comment_id: comment.get('id'),
+                    member_id: loggedInMember.id
+                });
+
+                await testBasicEmptyResponse('delete', `/api/comments/${comment.get('id')}/dislike/`, 204);
+
+                await testGetComments(`/api/comments/${comment.get('id')}/`, [commentMatcher])
+                    .expect(({body}) => {
+                        assert.equal(body.comments[0].disliked, false);
+                        assert.equal(Object.prototype.hasOwnProperty.call(body.comments[0].count, 'dislikes'), false);
+                    });
+            });
+
+            it('can order by net score without exposing the net score', async function () {
+                const bestComment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: '<p>Best comment</p>'
+                });
+                const likedComment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 1).id,
+                    html: '<p>Liked comment</p>'
+                });
+                const dislikedComment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id,
+                    html: '<p>Disliked comment</p>'
+                });
+
+                await dbFns.addLike({
+                    comment_id: bestComment.get('id'),
+                    member_id: fixtureManager.get('members', 0).id
+                });
+                await dbFns.addLike({
+                    comment_id: bestComment.get('id'),
+                    member_id: fixtureManager.get('members', 1).id
+                });
+                await dbFns.addLike({
+                    comment_id: likedComment.get('id'),
+                    member_id: fixtureManager.get('members', 0).id
+                });
+                await dbFns.addDislike({
+                    comment_id: dislikedComment.get('id'),
+                    member_id: fixtureManager.get('members', 0).id
+                });
+
+                const {body} = await membersAgent
+                    .get(`/api/comments/post/${postId}/?order=${encodeURIComponent('count__net_score desc, created_at desc')}`)
+                    .expectStatus(200);
+
+                assert.deepEqual(body.comments.map(comment => comment.id), [
+                    bestComment.get('id'),
+                    likedComment.get('id'),
+                    dislikedComment.get('id')
+                ]);
+                assert.equal(Object.prototype.hasOwnProperty.call(body.comments[0].count, 'dislikes'), false);
+                assert.equal(Object.prototype.hasOwnProperty.call(body.comments[0].count, 'net_score'), false);
             });
 
             it('Cannot like a comment multiple times', async function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/comments.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/comments.test.js
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
+
+describe('Unit: endpoints/utils/serializers/input/comments', function () {
+    describe('all', function () {
+        it('converts member reaction includes to count relations', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    context: {},
+                    withRelated: ['liked', 'disliked', 'replies.liked', 'replies.disliked', 'member']
+                }
+            };
+
+            serializers.input.comments.all(apiConfig, frame);
+
+            assert.deepEqual(frame.options.withRelated, [
+                'count.liked',
+                'count.disliked',
+                'replies.count.liked',
+                'replies.count.disliked',
+                'member'
+            ]);
+        });
+
+        it('loads post routing relations when post is included', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    context: {},
+                    withRelated: ['post']
+                }
+            };
+
+            serializers.input.comments.all(apiConfig, frame);
+
+            assert.deepEqual(frame.options.withRelated, ['post', 'post.tags', 'post.authors']);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const models = require('../../../../core/server/models');
+
+describe('Unit: models/comment', function () {
+    describe('defaultRelations', function () {
+        it('includes member dislike state but not public dislike counts by default', function () {
+            const options = {};
+
+            models.Comment.defaultRelations('findPage', options);
+
+            assert.ok(options.withRelated.includes('count.likes'));
+            assert.ok(!options.withRelated.includes('count.dislikes'));
+            assert.ok(options.withRelated.includes('count.disliked'));
+            assert.ok(options.withRelated.includes('count.net_score'));
+        });
+
+        it('includes dislike count relations for admin requests', function () {
+            const options = {
+                isAdmin: true
+            };
+
+            models.Comment.defaultRelations('findPage', options);
+
+            assert.ok(options.withRelated.includes('count.likes'));
+            assert.ok(options.withRelated.includes('count.dislikes'));
+            assert.ok(options.withRelated.includes('count.disliked'));
+            assert.ok(options.withRelated.includes('count.net_score'));
+        });
+    });
+
+    describe('orderAttributes', function () {
+        it('does not expose dislike count ordering directly', function () {
+            const attributes = models.Comment.forge().orderAttributes();
+
+            assert.ok(attributes.includes('count__likes'));
+            assert.ok(attributes.includes('count__net_score'));
+            assert.ok(!attributes.includes('count__dislikes'));
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/comments/comments-controller.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-controller.test.js
@@ -1,0 +1,110 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const errors = require('@tryghost/errors');
+const CommentsController = require('../../../../../core/server/services/comments/comments-controller');
+
+describe('Comments Service: CommentsController', function () {
+    function createFrame(overrides = {}) {
+        return {
+            options: {
+                id: 'comment-id',
+                context: {
+                    member: {
+                        id: 'member-id'
+                    }
+                },
+                ...overrides.options
+            },
+            data: overrides.data || {},
+            setHeader: sinon.stub()
+        };
+    }
+
+    function createController({comment = {post_id: 'post-id', parent_id: 'parent-id'}} = {}) {
+        const commentModel = comment && {
+            get: key => comment[key]
+        };
+        const service = {
+            likeComment: sinon.stub().resolves({id: 'like-id'}),
+            unlikeComment: sinon.stub().resolves(),
+            dislikeComment: sinon.stub().resolves({id: 'dislike-id'}),
+            undislikeComment: sinon.stub().resolves(),
+            getCommentByID: sinon.stub().resolves(commentModel),
+            getCommentDislikes: sinon.stub().resolves({data: []})
+        };
+        const stats = {};
+
+        return {
+            controller: new CommentsController(service, stats),
+            service
+        };
+    }
+
+    it('rejects member reaction actions without a member context', async function () {
+        const {controller, service} = createController();
+        const frame = createFrame({options: {context: {}}});
+
+        await assert.rejects(
+            () => controller.dislike(frame),
+            errors.UnauthorizedError
+        );
+
+        sinon.assert.notCalled(service.dislikeComment);
+    });
+
+    it('sets cache invalidation headers after adding a dislike', async function () {
+        const {controller, service} = createController();
+        const frame = createFrame();
+
+        const result = await controller.dislike(frame);
+
+        assert.deepEqual(result, {id: 'dislike-id'});
+        sinon.assert.calledWith(
+            service.dislikeComment,
+            'comment-id',
+            {id: 'member-id'},
+            frame.options
+        );
+        sinon.assert.calledWith(
+            frame.setHeader,
+            'X-Cache-Invalidate',
+            '/api/members/comments/post/post-id/, /api/members/comments/parent-id/replies/'
+        );
+    });
+
+    it('sets cache invalidation headers after removing a dislike', async function () {
+        const {controller, service} = createController();
+        const frame = createFrame();
+
+        await controller.undislike(frame);
+
+        sinon.assert.calledWith(
+            service.undislikeComment,
+            'comment-id',
+            {id: 'member-id'},
+            frame.options
+        );
+        sinon.assert.calledWith(
+            frame.setHeader,
+            'X-Cache-Invalidate',
+            '/api/members/comments/post/post-id/, /api/members/comments/parent-id/replies/'
+        );
+    });
+
+    it('passes pagination to the comment dislikes list', async function () {
+        const {controller, service} = createController();
+        const frame = createFrame({
+            options: {
+                page: 3,
+                limit: 15
+            }
+        });
+
+        await controller.getCommentDislikes(frame);
+
+        sinon.assert.calledWith(service.getCommentDislikes, 'comment-id', {
+            page: 3,
+            limit: 15
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/comments/comments-service.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service.test.js
@@ -1,0 +1,211 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const errors = require('@tryghost/errors');
+const CommentsService = require('../../../../../core/server/services/comments/comments-service');
+
+describe('Comments Service: CommentsService', function () {
+    function voteModel({id, score}) {
+        return {
+            id,
+            get: sinon.stub().withArgs('score').returns(score),
+            destroy: sinon.stub().resolves()
+        };
+    }
+
+    function createClassInstance({labs = {}, commentsEnabled = 'all'} = {}) {
+        const memberModel = {
+            id: 'member-id',
+            get: sinon.stub().withArgs('status').returns('paid')
+        };
+        const models = {
+            Base: {
+                transaction: sinon.stub().callsFake(async (callback) => {
+                    return await callback('transaction');
+                })
+            },
+            Member: {
+                findOne: sinon.stub().resolves(memberModel)
+            },
+            Comment: {
+                findPage: sinon.stub().resolves({data: [], meta: {}})
+            },
+            CommentLike: {
+                findAll: sinon.stub().resolves({models: []}),
+                add: sinon.stub().resolves({id: 'like-id'}),
+                edit: sinon.stub().resolves({id: 'like-id'}),
+                destroy: sinon.stub().resolves()
+            }
+        };
+
+        const labsStub = {
+            isSet: sinon.stub().callsFake(flag => labs[flag] || false)
+        };
+
+        const instance = new CommentsService({
+            config: {},
+            logging: {},
+            models,
+            mailer: {},
+            settingsCache: {
+                get: sinon.stub().withArgs('comments_enabled').returns(commentsEnabled)
+            },
+            settingsHelpers: {},
+            urlService: {},
+            urlUtils: {},
+            contentGating: {},
+            labs: labsStub
+        });
+
+        return {instance, models, memberModel, labs: labsStub};
+    }
+
+    describe('likeComment', function () {
+        it('adds a like score when there is no existing vote', async function () {
+            const {instance, models} = createClassInstance();
+
+            await instance.likeComment('comment-id', {id: 'member-id'}, {context: {member: {id: 'member-id'}}});
+
+            sinon.assert.calledWith(models.CommentLike.findAll, sinon.match({
+                filter: 'comment_id:\'comment-id\'+member_id:\'member-id\''
+            }));
+            sinon.assert.calledWith(models.CommentLike.add, {
+                member_id: 'member-id',
+                comment_id: 'comment-id',
+                score: 1
+            });
+        });
+
+        it('replaces duplicate existing votes with one like score', async function () {
+            const {instance, models} = createClassInstance();
+            const votes = [
+                voteModel({id: 'vote-1', score: -1}),
+                voteModel({id: 'vote-2', score: -1}),
+                voteModel({id: 'vote-3', score: 1})
+            ];
+            models.CommentLike.findAll.resolves({models: votes});
+
+            await instance.likeComment('comment-id', {id: 'member-id'}, {context: {member: {id: 'member-id'}}});
+
+            votes.forEach((vote) => {
+                sinon.assert.calledOnce(vote.destroy);
+                sinon.assert.calledWith(vote.destroy, sinon.match({
+                    transacting: 'transaction'
+                }));
+            });
+            sinon.assert.calledWith(models.CommentLike.add, {
+                member_id: 'member-id',
+                comment_id: 'comment-id',
+                score: 1
+            });
+        });
+
+        it('rejects one existing like without rewriting the row', async function () {
+            const {instance, models} = createClassInstance();
+            const vote = voteModel({id: 'vote-1', score: 1});
+            models.CommentLike.findAll.resolves({models: [vote]});
+
+            await assert.rejects(
+                () => instance.likeComment('comment-id', {id: 'member-id'}, {context: {member: {id: 'member-id'}}}),
+                errors.BadRequestError
+            );
+
+            sinon.assert.notCalled(vote.destroy);
+            sinon.assert.notCalled(models.CommentLike.add);
+        });
+    });
+
+    describe('dislikeComment', function () {
+        it('replaces an existing like score with a dislike score', async function () {
+            const {instance, models} = createClassInstance();
+            const vote = voteModel({id: 'vote-id', score: 1});
+            models.CommentLike.findAll.resolves({models: [vote]});
+
+            await instance.dislikeComment('comment-id', {id: 'member-id'}, {context: {member: {id: 'member-id'}}});
+
+            sinon.assert.calledOnce(vote.destroy);
+            sinon.assert.calledWith(models.CommentLike.add, {
+                member_id: 'member-id',
+                comment_id: 'comment-id',
+                score: -1
+            });
+        });
+
+        it('does not depend on a labs flag', async function () {
+            const {instance, models} = createClassInstance();
+
+            await instance.dislikeComment('comment-id', {id: 'member-id'});
+
+            sinon.assert.calledOnce(models.Member.findOne);
+            sinon.assert.calledWith(models.CommentLike.add, {
+                member_id: 'member-id',
+                comment_id: 'comment-id',
+                score: -1
+            });
+        });
+    });
+
+    describe('unlikeComment', function () {
+        it('removes every positive duplicate vote', async function () {
+            const {instance, models} = createClassInstance();
+            const positiveVotes = [
+                voteModel({id: 'vote-1', score: 1}),
+                voteModel({id: 'vote-2', score: 1})
+            ];
+            const negativeVote = voteModel({id: 'vote-3', score: -1});
+            models.CommentLike.findAll.resolves({models: [...positiveVotes, negativeVote]});
+
+            await instance.unlikeComment('comment-id', {id: 'member-id'});
+
+            positiveVotes.forEach((vote) => {
+                sinon.assert.calledOnce(vote.destroy);
+            });
+            sinon.assert.notCalled(negativeVote.destroy);
+        });
+    });
+
+    describe('undislikeComment', function () {
+        it('removes every negative duplicate vote', async function () {
+            const {instance, models} = createClassInstance();
+            const positiveVote = voteModel({id: 'vote-1', score: 1});
+            const negativeVotes = [
+                voteModel({id: 'vote-2', score: -1}),
+                voteModel({id: 'vote-3', score: -1})
+            ];
+            models.CommentLike.findAll.resolves({models: [positiveVote, ...negativeVotes]});
+
+            await instance.undislikeComment('comment-id', {id: 'member-id'});
+
+            sinon.assert.notCalled(positiveVote.destroy);
+            negativeVotes.forEach((vote) => {
+                sinon.assert.calledOnce(vote.destroy);
+            });
+        });
+    });
+
+    describe('getComments', function () {
+        it('preserves net score ordering without a labs flag', async function () {
+            const {instance, models} = createClassInstance();
+
+            await instance.getComments({order: 'count__net_score desc, created_at desc'});
+
+            sinon.assert.calledWith(models.Comment.findPage, sinon.match({
+                order: 'count__net_score desc, created_at desc'
+            }));
+        });
+    });
+
+    describe('getAdminAllComments', function () {
+        it('loads dislike counts for admin moderation', async function () {
+            const {instance, models} = createClassInstance();
+
+            await instance.getAdminAllComments({
+                includeNested: true,
+                order: 'created_at desc'
+            });
+
+            sinon.assert.calledWith(models.Comment.findPage, sinon.match({
+                withRelated: sinon.match(value => value.includes('count.dislikes') && value.includes('count.net_score'))
+            }));
+        });
+    });
+});


### PR DESCRIPTION
## Stack

- [#28019 Added score column to comment likes](https://github.com/TryGhost/Ghost/pull/28019) - migration prerequisite
- [#28020 Added comment dislike server support](https://github.com/TryGhost/Ghost/pull/28020) - server layer, this PR
- [#28021 Added capability-gated comment dislike UI](https://github.com/TryGhost/Ghost/pull/28021) - independently based on main

## Summary

- Implements likes and dislikes through `comment_likes.score` using `1` for likes and `-1` for dislikes.
- Cleans up duplicate member/comment vote rows before applying a vote, without using `findOne` for vote lookup.
- Counts likes, dislikes, and net score from `score` and adds dislike endpoints plus admin dislike browsing without labs middleware.
- Adds `meta.capabilities.dislikes` to comment browse responses so clients can probe support without a setting.
- Keeps public aggregate dislike counts out of the members comments API while allowing Admin API dislike counts and member lists.

## Verification

- `pnpm --dir ghost/core test:single test/unit/server/services/comments/comments-service.test.js`
- `pnpm --dir ghost/core test:single test/unit/server/models/comment.test.js`
- `pnpm --dir ghost/core test:single test/unit/server/services/comments/comments-controller.test.js`
- `pnpm --dir ghost/core test:single test/unit/api/canary/utils/serializers/input/comments.test.js`
- `pnpm --dir ghost/core test:single test/e2e-api/members-comments/comments.test.js`
- `pnpm --dir ghost/core test:single test/e2e-api/admin/comments.test.js`
- `pnpm --dir ghost/core test:single test/unit/server/data/schema/integrity.test.js`
