### PR TITLE
Fixed ActivityPub videos opening fullscreen on mobile

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.26",
+  "version": "3.1.27",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/utils/content-formatters.ts
+++ b/apps/activitypub/src/utils/content-formatters.ts
@@ -139,25 +139,22 @@ export const openLinksInNewTab = (content: string) => {
     return div.innerHTML;
 };
 
-export const disableVideoCardAutoplay = (content: string) => {
+export const enforceVideoCardInlinePlayback = (content: string) => {
     const div = document.createElement('div');
     div.innerHTML = content;
 
-    const autoplayVideos = div.querySelectorAll('.kg-video-card video[autoplay]');
+    const videos = div.querySelectorAll('.kg-video-card video');
 
-    for (let i = 0; i < autoplayVideos.length; i++) {
-        const video = autoplayVideos[i] as HTMLVideoElement;
-        const card = video.closest('.kg-video-card');
-
-        video.removeAttribute('autoplay');
-        video.removeAttribute('loop');
-        video.autoplay = false;
-        video.loop = false;
+    for (let i = 0; i < videos.length; i++) {
+        const video = videos[i] as HTMLVideoElement;
         video.setAttribute('playsinline', '');
         video.setAttribute('webkit-playsinline', '');
         video.setAttribute('x5-playsinline', '');
 
-        card?.querySelector('.kg-video-player-container')?.classList.remove('kg-video-hide');
+        if (video.hasAttribute('autoplay')) {
+            video.setAttribute('muted', '');
+            video.muted = true;
+        }
     }
 
     return div.innerHTML;

--- a/apps/activitypub/src/utils/content-formatters.ts
+++ b/apps/activitypub/src/utils/content-formatters.ts
@@ -139,6 +139,30 @@ export const openLinksInNewTab = (content: string) => {
     return div.innerHTML;
 };
 
+export const disableVideoCardAutoplay = (content: string) => {
+    const div = document.createElement('div');
+    div.innerHTML = content;
+
+    const autoplayVideos = div.querySelectorAll('.kg-video-card video[autoplay]');
+
+    for (let i = 0; i < autoplayVideos.length; i++) {
+        const video = autoplayVideos[i] as HTMLVideoElement;
+        const card = video.closest('.kg-video-card');
+
+        video.removeAttribute('autoplay');
+        video.removeAttribute('loop');
+        video.autoplay = false;
+        video.loop = false;
+        video.setAttribute('playsinline', '');
+        video.setAttribute('webkit-playsinline', '');
+        video.setAttribute('x5-playsinline', '');
+
+        card?.querySelector('.kg-video-player-container')?.classList.remove('kg-video-hide');
+    }
+
+    return div.innerHTML;
+};
+
 export const formatFollowNumber = (n: number) => {
     if (n < 10000) {
         return n.toLocaleString();

--- a/apps/activitypub/src/views/inbox/components/reader.tsx
+++ b/apps/activitypub/src/views/inbox/components/reader.tsx
@@ -20,7 +20,7 @@ import articleBodyStyles from '@src/components/article-body-styles';
 import getReadingTime from '../../../utils/get-reading-time';
 import {Activity} from '@src/api/activitypub';
 import {cardsCSS, cardsJS} from '@src/utils/cards-assets';
-import {escapeHtml, isSafeUrl, openLinksInNewTab} from '@src/utils/content-formatters';
+import {disableVideoCardAutoplay, escapeHtml, isSafeUrl, openLinksInNewTab} from '@src/utils/content-formatters';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../../utils/pending-activity';
 import {useDebounce} from 'use-debounce';
@@ -68,6 +68,8 @@ const ArticleBody: React.FC<{
     const darkMode = (document.documentElement.classList.contains('dark') && backgroundColor === 'SYSTEM') || backgroundColor === 'DARK';
 
     const cssContent = articleBodyStyles();
+    const shouldDisableVideoCardAutoplay = typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+    const articleHtml = openLinksInNewTab(shouldDisableVideoCardAutoplay ? disableVideoCardAutoplay(html) : html);
 
     const htmlContent = `
         <html class="has-${!darkMode ? 'dark' : 'light'}-text has-${fontStyle}-body ${backgroundColor === 'SEPIA' && 'has-sepia-bg'}">
@@ -194,7 +196,7 @@ const ArticleBody: React.FC<{
                 ` : ''}
             </header>
             <div class='gh-content gh-canvas is-body'>
-                ${openLinksInNewTab(html)}
+                ${articleHtml}
             </div>
             <script>
                 (function () {

--- a/apps/activitypub/src/views/inbox/components/reader.tsx
+++ b/apps/activitypub/src/views/inbox/components/reader.tsx
@@ -1,5 +1,5 @@
 import Customizer, {COLOR_OPTIONS, type ColorOption, type FontSize, useCustomizerSettings} from './customizer';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import ShowRepliesButton from '@src/components/global/show-replies-button';
 import getUsername from '../../../utils/get-username';
 import {LoadingIndicator, Skeleton} from '@tryghost/shade/components';
@@ -69,7 +69,10 @@ const ArticleBody: React.FC<{
 
     const cssContent = articleBodyStyles();
     const shouldDisableVideoCardAutoplay = typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
-    const articleHtml = openLinksInNewTab(shouldDisableVideoCardAutoplay ? disableVideoCardAutoplay(html) : html);
+    const articleHtml = useMemo(() => {
+        const transformedHtml = shouldDisableVideoCardAutoplay ? disableVideoCardAutoplay(html) : html;
+        return openLinksInNewTab(transformedHtml);
+    }, [html, shouldDisableVideoCardAutoplay]);
 
     const htmlContent = `
         <html class="has-${!darkMode ? 'dark' : 'light'}-text has-${fontStyle}-body ${backgroundColor === 'SEPIA' && 'has-sepia-bg'}">

--- a/apps/activitypub/src/views/inbox/components/reader.tsx
+++ b/apps/activitypub/src/views/inbox/components/reader.tsx
@@ -20,7 +20,7 @@ import articleBodyStyles from '@src/components/article-body-styles';
 import getReadingTime from '../../../utils/get-reading-time';
 import {Activity} from '@src/api/activitypub';
 import {cardsCSS, cardsJS} from '@src/utils/cards-assets';
-import {disableVideoCardAutoplay, escapeHtml, isSafeUrl, openLinksInNewTab} from '@src/utils/content-formatters';
+import {enforceVideoCardInlinePlayback, escapeHtml, isSafeUrl, openLinksInNewTab} from '@src/utils/content-formatters';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../../utils/pending-activity';
 import {useDebounce} from 'use-debounce';
@@ -68,11 +68,11 @@ const ArticleBody: React.FC<{
     const darkMode = (document.documentElement.classList.contains('dark') && backgroundColor === 'SYSTEM') || backgroundColor === 'DARK';
 
     const cssContent = articleBodyStyles();
-    const shouldDisableVideoCardAutoplay = typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+    const shouldEnforceVideoCardInlinePlayback = typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
     const articleHtml = useMemo(() => {
-        const transformedHtml = shouldDisableVideoCardAutoplay ? disableVideoCardAutoplay(html) : html;
+        const transformedHtml = shouldEnforceVideoCardInlinePlayback ? enforceVideoCardInlinePlayback(html) : html;
         return openLinksInNewTab(transformedHtml);
-    }, [html, shouldDisableVideoCardAutoplay]);
+    }, [html, shouldEnforceVideoCardInlinePlayback]);
 
     const htmlContent = `
         <html class="has-${!darkMode ? 'dark' : 'light'}-text has-${fontStyle}-body ${backgroundColor === 'SEPIA' && 'has-sepia-bg'}">

--- a/apps/activitypub/test/unit/utils/content-formatters.test.ts
+++ b/apps/activitypub/test/unit/utils/content-formatters.test.ts
@@ -2,11 +2,11 @@
  * @vitest-environment jsdom
  */
 
-import {disableVideoCardAutoplay} from '../../../src/utils/content-formatters';
+import {enforceVideoCardInlinePlayback} from '../../../src/utils/content-formatters';
 
-describe('disableVideoCardAutoplay', function () {
-    it('makes autoplay video cards manual and inline-playable', function () {
-        const result = disableVideoCardAutoplay(`
+describe('enforceVideoCardInlinePlayback', function () {
+    it('keeps autoplay video cards autoplaying and inline-playable', function () {
+        const result = enforceVideoCardInlinePlayback(`
             <figure class="kg-card kg-video-card">
                 <div class="kg-video-container">
                     <video src="/video.mp4" autoplay loop muted playsinline></video>
@@ -21,22 +21,22 @@ describe('disableVideoCardAutoplay', function () {
         const video = div.querySelector('video') as HTMLVideoElement;
         const playerContainer = div.querySelector('.kg-video-player-container');
 
-        expect(video.hasAttribute('autoplay')).toBe(false);
-        expect(video.hasAttribute('loop')).toBe(false);
-        expect(video.autoplay).toBe(false);
-        expect(video.loop).toBe(false);
+        expect(video.hasAttribute('autoplay')).toBe(true);
+        expect(video.hasAttribute('loop')).toBe(true);
+        expect(video.autoplay).toBe(true);
+        expect(video.loop).toBe(true);
         expect(video.hasAttribute('muted')).toBe(true);
         expect(video.hasAttribute('playsinline')).toBe(true);
         expect(video.hasAttribute('webkit-playsinline')).toBe(true);
         expect(video.hasAttribute('x5-playsinline')).toBe(true);
-        expect(playerContainer?.classList.contains('kg-video-hide')).toBe(false);
+        expect(playerContainer?.classList.contains('kg-video-hide')).toBe(true);
     });
 
-    it('leaves non-autoplay video cards unchanged', function () {
-        const result = disableVideoCardAutoplay(`
+    it('adds inline playback attributes to non-autoplay video cards', function () {
+        const result = enforceVideoCardInlinePlayback(`
             <figure class="kg-card kg-video-card">
                 <div class="kg-video-container">
-                    <video src="/video.mp4" loop muted playsinline></video>
+                    <video src="/video.mp4" loop muted></video>
                     <div class="kg-video-player-container kg-video-hide"></div>
                 </div>
             </figure>
@@ -50,7 +50,9 @@ describe('disableVideoCardAutoplay', function () {
 
         expect(video.hasAttribute('autoplay')).toBe(false);
         expect(video.hasAttribute('loop')).toBe(true);
-        expect(video.hasAttribute('webkit-playsinline')).toBe(false);
+        expect(video.hasAttribute('playsinline')).toBe(true);
+        expect(video.hasAttribute('webkit-playsinline')).toBe(true);
+        expect(video.hasAttribute('x5-playsinline')).toBe(true);
         expect(playerContainer?.classList.contains('kg-video-hide')).toBe(true);
     });
 });

--- a/apps/activitypub/test/unit/utils/content-formatters.test.ts
+++ b/apps/activitypub/test/unit/utils/content-formatters.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import {disableVideoCardAutoplay} from '../../../src/utils/content-formatters';
+
+describe('disableVideoCardAutoplay', function () {
+    it('makes autoplay video cards manual and inline-playable', function () {
+        const result = disableVideoCardAutoplay(`
+            <figure class="kg-card kg-video-card">
+                <div class="kg-video-container">
+                    <video src="/video.mp4" autoplay loop muted playsinline></video>
+                    <div class="kg-video-player-container kg-video-hide"></div>
+                </div>
+            </figure>
+        `);
+
+        const div = document.createElement('div');
+        div.innerHTML = result;
+
+        const video = div.querySelector('video') as HTMLVideoElement;
+        const playerContainer = div.querySelector('.kg-video-player-container');
+
+        expect(video.hasAttribute('autoplay')).toBe(false);
+        expect(video.hasAttribute('loop')).toBe(false);
+        expect(video.autoplay).toBe(false);
+        expect(video.loop).toBe(false);
+        expect(video.hasAttribute('muted')).toBe(true);
+        expect(video.hasAttribute('playsinline')).toBe(true);
+        expect(video.hasAttribute('webkit-playsinline')).toBe(true);
+        expect(video.hasAttribute('x5-playsinline')).toBe(true);
+        expect(playerContainer?.classList.contains('kg-video-hide')).toBe(false);
+    });
+
+    it('leaves non-autoplay video cards unchanged', function () {
+        const result = disableVideoCardAutoplay(`
+            <figure class="kg-card kg-video-card">
+                <div class="kg-video-container">
+                    <video src="/video.mp4" loop muted playsinline></video>
+                    <div class="kg-video-player-container kg-video-hide"></div>
+                </div>
+            </figure>
+        `);
+
+        const div = document.createElement('div');
+        div.innerHTML = result;
+
+        const video = div.querySelector('video') as HTMLVideoElement;
+        const playerContainer = div.querySelector('.kg-video-player-container');
+
+        expect(video.hasAttribute('autoplay')).toBe(false);
+        expect(video.hasAttribute('loop')).toBe(true);
+        expect(video.hasAttribute('webkit-playsinline')).toBe(false);
+        expect(playerContainer?.classList.contains('kg-video-hide')).toBe(true);
+    });
+});

--- a/apps/activitypub/test/unit/utils/content-formatters.test.ts
+++ b/apps/activitypub/test/unit/utils/content-formatters.test.ts
@@ -9,7 +9,7 @@ describe('enforceVideoCardInlinePlayback', function () {
         const result = enforceVideoCardInlinePlayback(`
             <figure class="kg-card kg-video-card">
                 <div class="kg-video-container">
-                    <video src="/video.mp4" autoplay loop muted playsinline></video>
+                    <video src="/video.mp4" autoplay loop playsinline></video>
                     <div class="kg-video-player-container kg-video-hide"></div>
                 </div>
             </figure>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1383/videos-autoplay-fullscreen-on-mobile-in-activitypub

Video cards should still autoplay on desktop when selected, but mobile reader views should open without triggering fullscreen playback.
