### PR TITLE
Harden Billing app readiness handling

### DIFF
--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -73,7 +73,14 @@ export default class GhBillingIframe extends Component {
     }
 
     _postMessageToBillingIframe(message) {
-        this.billing.getBillingIframe().contentWindow.postMessage(message, this.billing.getBillingAppOrigin() || '*');
+        const billingIframeWindow = this.billing.getBillingIframe()?.contentWindow;
+        const billingAppOrigin = this.billing.getBillingAppOrigin();
+
+        if (!billingIframeWindow || !billingAppOrigin) {
+            return;
+        }
+
+        billingIframeWindow.postMessage(message, billingAppOrigin);
     }
 
     _handleTokenRequest() {

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -37,22 +37,43 @@ export default class GhBillingIframe extends Component {
             return;
         }
 
-        // only process messages coming from the billing iframe
-        if (event?.data && this.billing.getIframeURL().includes(event?.origin)) {
-            this.billing.markBillingAppLoaded();
-
-            if (event.data?.request === 'token') {
-                this._handleTokenRequest();
-            }
-
-            if (event.data?.request === 'forceUpgradeInfo') {
-                this._handleForceUpgradeRequest();
-            }
-
-            if (event.data?.subscription) {
-                await this._handleSubscriptionUpdate(event.data);
-            }
+        if (!this.billing.isValidBillingIframeMessage(event)) {
+            return;
         }
+
+        const data = event.data;
+
+        if (data?.request === 'billingAppReady') {
+            this.billing.markBillingAppLoaded(data);
+
+            if (data?.route) {
+                this.billing.handleRouteChangeInIframe(data.route);
+            }
+
+            return;
+        }
+
+        this.billing.recordBillingAppPreReadyMessage(data);
+
+        if (data?.route) {
+            this.billing.handleRouteChangeInIframe(data.route);
+        }
+
+        if (data?.request === 'token') {
+            this._handleTokenRequest();
+        }
+
+        if (data?.request === 'forceUpgradeInfo') {
+            this._handleForceUpgradeRequest();
+        }
+
+        if (data?.subscription) {
+            await this._handleSubscriptionUpdate(data);
+        }
+    }
+
+    _postMessageToBillingIframe(message) {
+        this.billing.getBillingIframe().contentWindow.postMessage(message, this.billing.getBillingAppOrigin() || '*');
     }
 
     _handleTokenRequest() {
@@ -61,10 +82,10 @@ export default class GhBillingIframe extends Component {
             this.isOwner = false;
 
             // Avoid letting the BMA waiting for a message and send an empty token response instead
-            this.billing.getBillingIframe().contentWindow.postMessage({
+            this._postMessageToBillingIframe({
                 request: 'token',
                 response: null
-            }, '*');
+            });
         };
 
         if (!this.session.user?.isOwnerOnly) {
@@ -75,10 +96,10 @@ export default class GhBillingIframe extends Component {
         const ghostIdentityUrl = this.ghostPaths.url.api('identities');
         this.ajax.request(ghostIdentityUrl).then((response) => {
             const token = response?.identities?.[0]?.token;
-            this.billing.getBillingIframe().contentWindow.postMessage({
+            this._postMessageToBillingIframe({
                 request: 'token',
                 response: token
-            }, '*');
+            });
 
             this.isOwner = true;
         }).catch((error) => {
@@ -101,14 +122,14 @@ export default class GhBillingIframe extends Component {
                 email: owner?.email
             };
         }
-        this.billing.getBillingIframe().contentWindow.postMessage({
+        this._postMessageToBillingIframe({
             request: 'forceUpgradeInfo',
             response: {
                 forceUpgrade: this.config.hostSettings?.forceUpgrade,
                 isOwner: this.isOwner,
                 ownerUser
             }
-        }, '*');
+        });
     }
 
     async _handleSubscriptionUpdate(data) {

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -209,7 +209,11 @@ export default class BillingService extends Service {
 
         const billingIframeWindow = this.getBillingIframe()?.contentWindow;
 
-        if (billingIframeWindow && event.source !== billingIframeWindow) {
+        if (!billingIframeWindow) {
+            return false;
+        }
+
+        if (event.source !== billingIframeWindow) {
             return false;
         }
 

--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -24,6 +24,11 @@ export default class BillingService extends Service {
 
     @tracked billingAppLoaded = false;
     @tracked billingAppLoadFailureReported = false;
+    @tracked billingAppPreReadyMessageCount = 0;
+    @tracked billingAppPreReadyMessageTypes = [];
+    @tracked billingAppLastPreReadyMessageType = null;
+    @tracked billingAppReadyReceivedAt = null;
+    @tracked billingAppReadyPayload = null;
 
     billingAppLoadTimeout = null;
     billingAppRetryTimeout = null;
@@ -34,18 +39,6 @@ export default class BillingService extends Service {
     billingAppIframeLoadFired = false;
 
     _loadListenerAttachedTo = null;
-
-    constructor() {
-        super(...arguments);
-
-        if (this.config.hostSettings?.billing?.url) {
-            window.addEventListener('message', (event) => {
-                if (event && event.data && event.data.route) {
-                    this.handleRouteChangeInIframe(event.data.route);
-                }
-            });
-        }
-    }
 
     willDestroy() {
         super.willDestroy(...arguments);
@@ -79,6 +72,7 @@ export default class BillingService extends Service {
             this.billingAppLoaded = false;
             this.billingAppLoadAttempts = 0;
             this.billingAppLoadFailureReported = false;
+            this.resetBillingAppLoadDiagnostics();
         }
 
         this.billingAppLoadAttempts += 1;
@@ -116,6 +110,7 @@ export default class BillingService extends Service {
         }
         this.billingAppIframeLoadFired = false;
         this.billingAppIframeSrcSetAt = Date.now();
+        this.resetBillingAppLoadDiagnostics();
         iframe.src = this.getIframeURL();
     }
 
@@ -129,9 +124,96 @@ export default class BillingService extends Service {
         this.setBillingIframeSrc();
     }
 
-    markBillingAppLoaded() {
+    markBillingAppLoaded(payload = null) {
         this.billingAppLoaded = true;
+        this.billingAppLoadFailureReported = false;
+        this.billingAppReadyReceivedAt = Date.now();
+        this.billingAppReadyPayload = payload;
         this.clearBillingAppLoadMonitor();
+    }
+
+    resetBillingAppLoadDiagnostics() {
+        this.billingAppPreReadyMessageCount = 0;
+        this.billingAppPreReadyMessageTypes = [];
+        this.billingAppLastPreReadyMessageType = null;
+        this.billingAppReadyReceivedAt = null;
+        this.billingAppReadyPayload = null;
+    }
+
+    recordBillingAppPreReadyMessage(data) {
+        if (this.billingAppLoaded || this.billingAppReadyReceivedAt || this.billingAppLoadFailureReported) {
+            return;
+        }
+
+        if (!this.billingAppLoadTimeout && !this.billingAppRetryTimeout) {
+            return;
+        }
+
+        const messageType = this.getBillingAppMessageType(data);
+
+        this.billingAppPreReadyMessageCount += 1;
+        this.billingAppLastPreReadyMessageType = messageType;
+
+        if (!this.billingAppPreReadyMessageTypes.includes(messageType)) {
+            this.billingAppPreReadyMessageTypes = [
+                ...this.billingAppPreReadyMessageTypes,
+                messageType
+            ];
+        }
+    }
+
+    getBillingAppMessageType(data) {
+        if (data?.request) {
+            return data.request;
+        }
+
+        if (data?.route) {
+            return 'route';
+        }
+
+        if (data?.subscription) {
+            return 'subscription';
+        }
+
+        if (data?.query) {
+            return data.query;
+        }
+
+        return 'unknown';
+    }
+
+    getBillingAppOrigin() {
+        const iframeURL = this.getIframeURL({fetchOwner: false});
+
+        if (!iframeURL) {
+            return null;
+        }
+
+        try {
+            return new URL(iframeURL).origin;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    isValidBillingIframeMessage(event) {
+        if (!event?.data) {
+            return false;
+        }
+
+        const billingAppOrigin = this.getBillingAppOrigin();
+
+        if (!billingAppOrigin || event.origin !== billingAppOrigin) {
+            return false;
+        }
+
+        const billingIframeWindow = this.getBillingIframe()?.contentWindow;
+
+        if (billingIframeWindow && event.source !== billingIframeWindow) {
+            return false;
+        }
+
+        return true;
     }
 
     clearBillingAppLoadMonitor() {
@@ -159,6 +241,8 @@ export default class BillingService extends Service {
 
         const iframe = this.getBillingIframe();
         const visibilityState = document.visibilityState;
+        const iframeSrc = iframe?.src || null;
+        const configuredBillingOrigin = this.getBillingAppOrigin();
 
         // Fields are kept flat on `billing_monitor` because Sentry's default
         // `normalizeDepth` of 3 stringifies anything deeper to '[Object]',
@@ -203,6 +287,8 @@ export default class BillingService extends Service {
                         is_force_upgrade: !!this.config.hostSettings?.forceUpgrade,
                         location_hash: window.location.hash,
                         retry_delays_ms: this.billingAppLoadRetryDelaysMs,
+                        iframe_src: iframeSrc,
+                        configured_billing_origin: configuredBillingOrigin,
                         document_visibility_state: visibilityState,
                         iframe_offset_parent_visible: iframe ? iframe.offsetParent !== null : null,
                         iframe_computed_display: computedDisplay,
@@ -211,6 +297,10 @@ export default class BillingService extends Service {
                         iframe_rect_height: rectHeight,
                         iframe_load_fired: this.billingAppIframeLoadFired,
                         ms_since_src_set: this.billingAppIframeSrcSetAt ? Date.now() - this.billingAppIframeSrcSetAt : null,
+                        non_ready_message_count: this.billingAppPreReadyMessageCount,
+                        non_ready_message_types: this.billingAppPreReadyMessageTypes.join(','),
+                        last_non_ready_message_type: this.billingAppLastPreReadyMessageType,
+                        ready_received: false,
                         navigator_online: navigator.onLine,
                         connection_effective_type: navigator.connection?.effectiveType ?? null,
                         bma_boot_accessible: bmaBootAccessible,
@@ -228,9 +318,13 @@ export default class BillingService extends Service {
         });
     }
 
-    getIframeURL() {
+    getIframeURL(options = {}) {
+        const {fetchOwner = true} = options;
+
         // initiate getting owner user in the background
-        this.getOwnerUser();
+        if (fetchOwner) {
+            this.getOwnerUser();
+        }
 
         let url = this.config.hostSettings?.billing?.url;
 

--- a/ghost/admin/tests/integration/components/gh-billing-iframe-test.js
+++ b/ghost/admin/tests/integration/components/gh-billing-iframe-test.js
@@ -114,4 +114,17 @@ describe('Integration: Component: gh-billing-iframe', function () {
         expect(markBillingAppLoaded.called).to.be.false;
         expect(billing.billingAppLoaded).to.be.false;
     });
+
+    it('ignores messages when the billing iframe window is unavailable', async function () {
+        const markBillingAppLoaded = sinon.spy(billing, 'markBillingAppLoaded');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        sinon.stub(billing, 'getBillingIframe').returns(null);
+
+        await postBillingMessage({request: 'billingAppReady'}, {source: window});
+
+        expect(markBillingAppLoaded.called).to.be.false;
+        expect(billing.billingAppLoaded).to.be.false;
+    });
 });

--- a/ghost/admin/tests/integration/components/gh-billing-iframe-test.js
+++ b/ghost/admin/tests/integration/components/gh-billing-iframe-test.js
@@ -1,0 +1,117 @@
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {find, render, settled} from '@ember/test-helpers';
+import {setupRenderingTest} from 'ember-mocha';
+
+describe('Integration: Component: gh-billing-iframe', function () {
+    setupRenderingTest();
+
+    let billing;
+
+    async function postBillingMessage(data, options = {}) {
+        const iframe = find('#billing-frame');
+
+        window.dispatchEvent(new MessageEvent('message', {
+            data,
+            origin: options.origin ?? 'https://billing.example.test',
+            source: options.source ?? iframe.contentWindow
+        }));
+
+        await settled();
+    }
+
+    beforeEach(function () {
+        billing = this.owner.lookup('service:billing');
+
+        sinon.stub(billing, 'getIframeURL').returns('https://billing.example.test/pro');
+        sinon.stub(billing, 'startBillingAppLoadMonitor');
+    });
+
+    afterEach(function () {
+        billing.clearBillingAppLoadMonitor();
+        sinon.restore();
+    });
+
+    it('marks the billing app loaded after billingAppReady from the validated iframe', async function () {
+        const markBillingAppLoaded = sinon.spy(billing, 'markBillingAppLoaded');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage({
+            request: 'billingAppReady',
+            route: '/plans',
+            state: 'content',
+            release: 'test',
+            timestamp: Date.now()
+        });
+
+        expect(markBillingAppLoaded.calledOnce).to.be.true;
+        expect(markBillingAppLoaded.firstCall.args[0]).to.include({
+            request: 'billingAppReady',
+            route: '/plans',
+            state: 'content',
+            release: 'test'
+        });
+        expect(billing.billingAppLoaded).to.be.true;
+    });
+
+    it('handles valid non-ready token messages without marking the billing app loaded', async function () {
+        const markBillingAppLoaded = sinon.spy(billing, 'markBillingAppLoaded');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        const iframe = find('#billing-frame');
+        const postMessage = sinon.stub(iframe.contentWindow, 'postMessage');
+
+        await postBillingMessage({request: 'token'});
+
+        expect(markBillingAppLoaded.called).to.be.false;
+        expect(billing.billingAppLoaded).to.be.false;
+        expect(postMessage.calledOnceWithExactly({
+            request: 'token',
+            response: null
+        }, 'https://billing.example.test')).to.be.true;
+    });
+
+    it('handles valid route messages without marking the billing app loaded', async function () {
+        const markBillingAppLoaded = sinon.spy(billing, 'markBillingAppLoaded');
+        const handleRouteChangeInIframe = sinon.spy(billing, 'handleRouteChangeInIframe');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage({route: '/plans'});
+
+        expect(markBillingAppLoaded.called).to.be.false;
+        expect(handleRouteChangeInIframe.calledOnceWithExactly('/plans')).to.be.true;
+        expect(billing.billingAppLoaded).to.be.false;
+    });
+
+    it('ignores messages from an invalid origin', async function () {
+        const markBillingAppLoaded = sinon.spy(billing, 'markBillingAppLoaded');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        const iframe = find('#billing-frame');
+        const postMessage = sinon.stub(iframe.contentWindow, 'postMessage');
+
+        await postBillingMessage({request: 'token'}, {origin: 'https://evil.example.test'});
+        await postBillingMessage({request: 'billingAppReady'}, {origin: 'https://evil.example.test'});
+
+        expect(markBillingAppLoaded.called).to.be.false;
+        expect(postMessage.called).to.be.false;
+        expect(billing.billingAppLoaded).to.be.false;
+    });
+
+    it('ignores messages from the wrong source window', async function () {
+        const markBillingAppLoaded = sinon.spy(billing, 'markBillingAppLoaded');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage({request: 'billingAppReady'}, {source: window});
+
+        expect(markBillingAppLoaded.called).to.be.false;
+        expect(billing.billingAppLoaded).to.be.false;
+    });
+});

--- a/ghost/admin/tests/integration/components/gh-billing-modal-test.js
+++ b/ghost/admin/tests/integration/components/gh-billing-modal-test.js
@@ -9,14 +9,36 @@ describe('Integration: Component: gh-billing-modal', function () {
     setupRenderingTest();
 
     let billing;
+    let configManager;
+    let limit;
+    let stateBridge;
+
+    async function postBillingMessage(data) {
+        const iframe = find('#billing-frame');
+
+        window.dispatchEvent(new MessageEvent('message', {
+            data,
+            origin: 'https://billing.example.test',
+            source: iframe.contentWindow
+        }));
+
+        await settled();
+    }
 
     beforeEach(function () {
         billing = this.owner.lookup('service:billing');
+        configManager = this.owner.lookup('service:config-manager');
+        limit = this.owner.lookup('service:limit');
+        stateBridge = this.owner.lookup('service:state-bridge');
+
         billing.billingAppLoaded = false;
         billing.billingAppLoadFailureReported = false;
 
         sinon.stub(billing, 'getIframeURL').returns('https://billing.example.test');
         sinon.stub(billing, 'startBillingAppLoadMonitor');
+        sinon.stub(configManager, 'fetch').resolves();
+        sinon.stub(limit, 'reload');
+        sinon.stub(stateBridge, 'triggerSubscriptionChange');
     });
 
     afterEach(function () {
@@ -24,17 +46,48 @@ describe('Integration: Component: gh-billing-modal', function () {
         sinon.restore();
     });
 
-    it('shows a loading state until the billing app sends its first message', async function () {
+    it('shows a loading state until the billing app sends billingAppReady', async function () {
         await render(hbs`<GhBillingModal @billingWindowOpen={{true}} />`);
 
         expect(find('[data-test-billing-loading]')).to.exist;
         expect(find('[data-test-billing-load-error]')).to.not.exist;
 
-        billing.markBillingAppLoaded();
-        await settled();
+        await postBillingMessage({
+            request: 'billingAppReady',
+            route: '/plans',
+            state: 'loading',
+            release: 'test',
+            timestamp: Date.now()
+        });
 
         expect(find('[data-test-billing-loading]')).to.not.exist;
         expect(find('[data-test-billing-load-error]')).to.not.exist;
+    });
+
+    it('keeps the loading state for valid non-ready billing app messages', async function () {
+        await render(hbs`<GhBillingModal @billingWindowOpen={{true}} />`);
+
+        await postBillingMessage({request: 'token'});
+        expect(find('[data-test-billing-loading]')).to.exist;
+
+        await postBillingMessage({request: 'forceUpgradeInfo'});
+        expect(find('[data-test-billing-loading]')).to.exist;
+
+        await postBillingMessage({route: '/plans'});
+        expect(find('[data-test-billing-loading]')).to.exist;
+
+        await postBillingMessage({
+            subscription: {
+                status: 'active'
+            }
+        });
+        expect(find('[data-test-billing-loading]')).to.exist;
+
+        await postBillingMessage({
+            request: 'billingAppReady',
+            state: 'content'
+        });
+        expect(find('[data-test-billing-loading]')).to.not.exist;
     });
 
     it('shows a customer-facing error when the billing app does not become ready', async function () {

--- a/ghost/admin/tests/unit/services/billing-test.js
+++ b/ghost/admin/tests/unit/services/billing-test.js
@@ -129,8 +129,14 @@ describe('Unit: Service: billing', function () {
             attempts: 2,
             has_billing_url: true,
             is_force_upgrade: false,
+            iframe_src: null,
+            configured_billing_origin: 'https://billing.example.test',
             iframe_load_fired: true,
             billing_window_open: true,
+            non_ready_message_count: 0,
+            non_ready_message_types: '',
+            last_non_ready_message_type: null,
+            ready_received: false,
             navigator_online: navigator.onLine,
             document_visibility_state: document.visibilityState,
             bma_boot_accessible: false,
@@ -138,6 +144,70 @@ describe('Unit: Service: billing', function () {
             bma_boot_threw: false
         });
         expect(billingMonitor.ms_since_src_set).to.be.a('number').and.to.be.at.least(1234);
+    });
+
+    it('reports pre-ready message diagnostics to Sentry', async function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        sinon.stub(service, 'getBillingIframe').returns(null);
+        service.billingAppLoadAttempts = 2;
+        service.billingAppLoadTimeout = setTimeout(() => {}, 10000);
+        service.billingAppIframeSrcSetAt = Date.now() - 100;
+
+        service.recordBillingAppPreReadyMessage({request: 'token'});
+        service.recordBillingAppPreReadyMessage({route: '/plans'});
+        service.recordBillingAppPreReadyMessage({
+            subscription: {
+                status: 'active'
+            }
+        });
+        service.reportBillingAppLoadFailure();
+
+        await waitUntil(() => testkit.reports().length > 0);
+
+        const billingMonitor = testkit.reports()[0].originalReport.contexts.ghost.billing_monitor;
+        expect(billingMonitor).to.deep.include({
+            non_ready_message_count: 3,
+            non_ready_message_types: 'token,route,subscription',
+            last_non_ready_message_type: 'subscription',
+            ready_received: false
+        });
+    });
+
+    it('resets billing app load diagnostics when a fresh iframe load starts', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const iframe = {src: '', addEventListener: sinon.stub()};
+        sinon.stub(service, 'getBillingIframe').returns(iframe);
+
+        service.billingAppLoadTimeout = setTimeout(() => {}, 10000);
+        service.recordBillingAppPreReadyMessage({request: 'token'});
+        service.markBillingAppLoaded({request: 'billingAppReady'});
+
+        service.setBillingIframeSrc();
+
+        expect(service.billingAppPreReadyMessageCount).to.equal(0);
+        expect(service.billingAppPreReadyMessageTypes).to.deep.equal([]);
+        expect(service.billingAppLastPreReadyMessageType).to.be.null;
+        expect(service.billingAppReadyReceivedAt).to.be.null;
+        expect(service.billingAppReadyPayload).to.be.null;
+    });
+
+    it('treats late billingAppReady as recovery after a reported load failure', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const readyPayload = {
+            request: 'billingAppReady',
+            state: 'content'
+        };
+        service.billingAppLoadFailureReported = true;
+
+        service.markBillingAppLoaded(readyPayload);
+
+        expect(service.billingAppLoaded).to.be.true;
+        expect(service.billingAppLoadFailureReported).to.be.false;
+        expect(service.billingAppReadyReceivedAt).to.be.a('number');
+        expect(service.billingAppReadyPayload).to.equal(readyPayload);
     });
 
     it('does not report when the billing app becomes ready before the timeout', function () {


### PR DESCRIPTION
## Summary
- require validated `billingAppReady` before hiding the Admin Billing fallback
- validate Billing iframe message origin and source before privileged handling
- track pre-ready Billing messages and include diagnostics in Sentry load-failure reports

## Why
BMA now sends an explicit readiness message after rendering a visible shell. Admin should not treat earlier token, route, force-upgrade, or subscription messages as proof that BMA owns a visible state.

ref https://app.incident.io/ghost/incidents/284

## Testing
- `pnpm --dir ghost/admin exec ember test --filter='billing'`
- `pnpm --dir ghost/admin exec eslint app/components/gh-billing-iframe.js app/services/billing.js tests/integration/components/gh-billing-modal-test.js tests/integration/components/gh-billing-iframe-test.js tests/unit/services/billing-test.js`