### PR TITLE
Removed comment moderation labs flag

### DIFF
--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -78,14 +78,13 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const hasMemberViews = memberViews.length > 0;
     const memberCount = useMemberCount();
     const routing = useEmberRouting();
-    const commentModerationEnabled = useFeatureFlag('commentModeration');
     const automationsEnabled = useFeatureFlag('automations');
     const isMembersRouteActive = useIsActiveLink({path: 'members', activeOnSubpath: true});
 
     const showTags = currentUser && canManageTags(currentUser);
     const showMembers = currentUser && canManageMembers(currentUser);
     const commentsEnabled = getSettingValue<string>(settingsData?.settings, 'comments_enabled');
-    const showComments = !!showMembers && commentModerationEnabled && commentsEnabled !== 'off';
+    const showComments = !!showMembers && commentsEnabled !== 'off';
     const isDraftPostsRouteActive = routing.isRouteActive('posts', {type: 'draft'});
     const isScheduledPostsRouteActive = routing.isRouteActive('posts', {type: 'scheduled'});
     const isPublishedPostsRouteActive = routing.isRouteActive('posts', {type: 'published'});

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
+++ b/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
@@ -44,7 +44,7 @@ const AdminContextMenu: React.FC<Props> = ({comment, close, showAuthorActions = 
 
     return (
         <div className="flex w-full flex-col gap-0.5">
-            {labs?.commentModeration && adminCommentUrl && (
+            {adminCommentUrl && (
                 <a
                     className={itemClassName}
                     data-testid="view-in-admin-button"

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -304,7 +304,7 @@ test.describe('Admin moderation', async () => {
     });
 
     test.describe('View in admin link', () => {
-        test('shows View in admin link when commentModeration flag is enabled', async ({page}) => {
+        test('shows View in admin link for admins', async ({page}) => {
             mockedApi.addComment({id: 'test-comment-id', html: '<p>This is a comment</p>'});
 
             await mockAdminAuthFrame({page, admin});
@@ -315,10 +315,7 @@ test.describe('Admin moderation', async () => {
                 publication: 'Publisher Weekly',
                 title: 'Member discussion',
                 count: true,
-                admin,
-                labs: {
-                    commentModeration: true
-                }
+                admin
             });
 
             const moreButtons = frame.getByTestId('more-button');
@@ -328,27 +325,6 @@ test.describe('Admin moderation', async () => {
             await expect(viewInAdminLink).toBeVisible();
             await expect(viewInAdminLink).toHaveAttribute('href', `${admin}#/comments/?id=is:test-comment-id`);
             await expect(viewInAdminLink).toHaveAttribute('target', '_blank');
-        });
-
-        test('hides View in admin link when commentModeration flag is not set', async ({page}) => {
-            mockedApi.addComment({html: '<p>This is a comment</p>'});
-
-            await mockAdminAuthFrame({page, admin});
-
-            const {frame} = await initialize({
-                mockedApi,
-                page,
-                publication: 'Publisher Weekly',
-                title: 'Member discussion',
-                count: true,
-                admin,
-                labs: {}
-            });
-
-            const moreButtons = frame.getByTestId('more-button');
-            await moreButtons.nth(0).click();
-
-            await expect(frame.getByTestId('view-in-admin-button')).not.toBeVisible();
         });
     });
 });

--- a/e2e/tests/admin/comments/thread-sidebar.test.ts
+++ b/e2e/tests/admin/comments/thread-sidebar.test.ts
@@ -17,8 +17,6 @@ test.describe('Ghost Admin - Thread Sidebar', () => {
     let post: Awaited<ReturnType<PostFactory['create']>>;
     let member: Awaited<ReturnType<MemberFactory['create']>>;
 
-    test.use({labs: {commentModeration: true}});
-
     test.beforeEach(async ({page}) => {
         postFactory = createPostFactory(page.request);
         memberFactory = createMemberFactory(page.request);

--- a/ghost/admin/app/components/gh-member-details.hbs
+++ b/ghost/admin/app/components/gh-member-details.hbs
@@ -50,7 +50,7 @@
                         <span>Not seen yet</span>
                     {{/if}}
                 </p>
-                {{#if (and this.feature.commentModeration (eq @member.canComment false))}}
+                {{#if (eq @member.canComment false)}}
                     <p class="gh-member-commenting-disabled">
                         {{svg-jar "comment-disabled"}}
                         Comments disabled

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -67,7 +67,6 @@ export default class FeatureService extends Service {
     @feature('lexicalIndicators') lexicalIndicators;
     @feature('editorExcerpt') editorExcerpt;
     @feature('tagsX') tagsX;
-    @feature('commentModeration') commentModeration;
     @feature('giftSubscriptions') giftSubscriptions;
     _user = null;
 

--- a/ghost/admin/app/templates/member.hbs
+++ b/ghost/admin/app/templates/member.hbs
@@ -78,29 +78,27 @@
                                     <span>Sign out of all devices</span>
                                 </button>
                             </li>
-                            {{#if this.feature.commentModeration}}
-                                <li>
-                                    {{#if (not-eq this.member.canComment false)}}
-                                        <button
-                                            type="button"
-                                            class="mr2"
-                                            {{on "click" this.confirmDisableCommenting}}
-                                            data-test-button="disable-commenting"
-                                        >
-                                            <span>Disable commenting</span>
-                                        </button>
-                                    {{else}}
-                                        <button
-                                            type="button"
-                                            class="mr2"
-                                            {{on "click" this.confirmEnableCommenting}}
-                                            data-test-button="enable-commenting"
-                                        >
-                                            <span>Enable commenting</span>
-                                        </button>
-                                    {{/if}}
-                                </li>
-                            {{/if}}
+                            <li>
+                                {{#if (not-eq this.member.canComment false)}}
+                                    <button
+                                        type="button"
+                                        class="mr2"
+                                        {{on "click" this.confirmDisableCommenting}}
+                                        data-test-button="disable-commenting"
+                                    >
+                                        <span>Disable commenting</span>
+                                    </button>
+                                {{else}}
+                                    <button
+                                        type="button"
+                                        class="mr2"
+                                        {{on "click" this.confirmEnableCommenting}}
+                                        data-test-button="enable-commenting"
+                                    >
+                                        <span>Enable commenting</span>
+                                    </button>
+                                {{/if}}
+                            </li>
                             <li>
                                 <button
                                     type="button"

--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -6,7 +6,7 @@ const toPlain = require('../../lib/common/to-plain');
 const {t} = require('../i18n');
 
 class CommentsServiceEmails {
-    constructor({config, logging, models, mailer, settingsCache, settingsHelpers, urlService, urlUtils, labs}) {
+    constructor({config, logging, models, mailer, settingsCache, settingsHelpers, urlService, urlUtils}) {
         this.config = config;
         this.logging = logging;
         this.models = models;
@@ -15,7 +15,6 @@ class CommentsServiceEmails {
         this.settingsHelpers = settingsHelpers;
         this.urlService = urlService;
         this.urlUtils = urlUtils;
-        this.labs = labs;
         this.commentsServiceEmailRenderer = new CommentsServiceEmailRenderer({t});
     }
 
@@ -157,8 +156,6 @@ class CommentsServiceEmails {
 
         const memberName = member.get('name') || 'Anonymous';
 
-        const commentModerationEnabled = this.labs.isSet('commentModeration');
-
         const templateData = {
             siteTitle: this.settingsCache.get('title'),
             siteUrl: this.urlUtils.getSiteUrl(),
@@ -181,7 +178,6 @@ class CommentsServiceEmails {
             fromEmail: this.notificationFromAddress,
             toEmail: to,
             staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${owner.get('slug')}/email-notifications`),
-            commentModerationEnabled,
             moderationUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/comments/?id=is:${comment.get('id')}`)
         };
 

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -62,8 +62,7 @@ class CommentsService {
             settingsCache,
             settingsHelpers,
             urlService,
-            urlUtils,
-            labs
+            urlUtils
         });
     }
 

--- a/ghost/core/core/server/services/comments/email-templates/report.hbs
+++ b/ghost/core/core/server/services/comments/email-templates/report.hbs
@@ -116,7 +116,7 @@
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 25px; margin: 0; margin-bottom: 15px;">Hey there,</p>
-                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">{{reporter}} has reported the comment below on <a href="{{postUrl}}" target="_blank" style="font-weight: bold; text-decoration: underline; color: #15212A;">{{postTitle}}</a>.{{#unless commentModerationEnabled}} This comment will remain visible until you choose to remove it, which can be done directly on the post.{{/unless}}</p>
+                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">{{reporter}} has reported the comment below on <a href="{{postUrl}}" target="_blank" style="font-weight: bold; text-decoration: underline; color: #15212A;">{{postTitle}}</a>.</p>
 
                         <table width="100" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background: #F9F9FA; border-radius: 7px;">
                         <tbody>
@@ -152,11 +152,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      {{#if commentModerationEnabled}}
                                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{moderationUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">Review comment</a> </td>
-                                      {{else}}
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View comment</a> </td>
-                                      {{/if}}
                                     </tr>
                                   </tbody>
                                 </table>

--- a/ghost/core/core/server/services/comments/email-templates/report.txt.js
+++ b/ghost/core/core/server/services/comments/email-templates/report.txt.js
@@ -1,13 +1,7 @@
 module.exports = function (data) {
-    let visibilityNote = 'This comment will remain visible until you choose to remove it.';
-    if (!data.commentModerationEnabled) {
-        visibilityNote = 'This comment will remain visible until you choose to remove it, which can be done directly on the post.';
-    }
+    const visibilityNote = 'This comment will remain visible until you choose to remove it.';
 
-    let actionLinks = data.postUrl;
-    if (data.commentModerationEnabled) {
-        actionLinks = `View comment: ${data.postUrl}\nModerate comment: ${data.moderationUrl}`;
-    }
+    const actionLinks = `View comment: ${data.postUrl}\nModerate comment: ${data.moderationUrl}`;
 
     // Be careful when you indent the email, because whitespaces are visible in emails!
     return `Hey there,

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -23,7 +23,6 @@ const messages = {
 const GA_FEATURES = [
     'customFonts',
     'explore',
-    'commentModeration',
     'commentsThreads',
     'commentsPinning',
     'featurebaseFeedback',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -12,7 +12,6 @@ Object {
       "additionalPaymentMethods": true,
       "adminUIRefresh": true,
       "automations": true,
-      "commentModeration": true,
       "commentsPinning": true,
       "commentsThreads": true,
       "customFonts": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1803,7 +1803,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5485",
+  "content-length": "5458",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
## Summary
- removed the GA comment moderation labs flag from labs output
- made comment moderation UI and email paths unconditional
- updated tests and config snapshot to stop setting or expecting the flag