### PR TITLE
✨ Added Danger Zone action to reset all authentication

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -71,10 +71,6 @@ const features: Feature[] = [{
     title: 'Comments Pinning',
     description: 'Allow staff to pin top-level comments in Comments-UI and Admin',
     flag: 'commentsPinning'
-}, {
-    title: 'Danger Zone: Reset all authentication',
-    description: 'Adds a button to Settings → Advanced → Danger Zone that rotates every API key, locks every staff user, and destroys every active staff session in one action',
-    flag: 'dangerZoneResetAuth'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -25,7 +25,8 @@ const GA_FEATURES = [
     'explore',
     'commentModeration',
     'featurebaseFeedback',
-    'giftSubscriptions'
+    'giftSubscriptions',
+    'dangerZoneResetAuth'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -52,8 +53,7 @@ const PRIVATE_FEATURES = [
     'pictureImageFormats',
     'smarterCounts',
     'commentsThreads',
-    'commentsPinning',
-    'dangerZoneResetAuth'
+    'commentsPinning'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1803,7 +1803,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5406",
+  "content-length": "5435",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
Ghost now includes a one-click "Reset all authentication" action in Settings → Advanced → Danger Zone. After a suspected credential compromise (a leaked API key, a former staff member who shouldn't retain access, a stolen admin session) owners can rotate every API key, lock every staff user, and destroy every active staff session at once.

Active staff users hit the standard password-reset flow on their next sign-in. Suspended staff users stay suspended but still have their password rotated, so a leaked credential can't be reused if they're ever unsuspended. Members aren't affected.

The action records the operator who triggered it in the audit log.