### PR TITLE
Added curated private site access codes

### DIFF
--- a/ghost/core/core/server/services/settings/private-site-access-code.js
+++ b/ghost/core/core/server/services/settings/private-site-access-code.js
@@ -1,14 +1,22 @@
 const crypto = require('crypto');
 
+const ACCESS_CODE_WORDS = [
+    'anchor', 'aurora', 'beacon', 'birch', 'bright', 'cedar', 'cloud', 'comet', 'copper', 'coral',
+    'ember', 'fern', 'field', 'forest', 'golden', 'green', 'harbor', 'hidden', 'horizon', 'juniper',
+    'lagoon', 'lunar', 'maple', 'meadow', 'midnight', 'north', 'ocean', 'olive', 'paper', 'pine',
+    'quiet', 'river', 'sage', 'signal', 'silver', 'solstice', 'sparrow', 'stone', 'studio', 'summit',
+    'sunrise', 'thistle', 'valley', 'violet', 'willow', 'window', 'winter', 'wild'
+];
+
 /**
- * Placeholder access-code generator — returns `fake-###`.
- * The real format will be implemented in a follow-up PR.
+ * Generates a short trial private-site access code in the `word###` format.
  *
  * @returns {string}
  */
 function generatePrivateSiteAccessCode() {
+    const word = ACCESS_CODE_WORDS[crypto.randomInt(ACCESS_CODE_WORDS.length)];
     const number = crypto.randomInt(1000).toString().padStart(3, '0');
-    return `fake-${number}`;
+    return `${word}${number}`;
 }
 
-module.exports = {generatePrivateSiteAccessCode};
+module.exports = {ACCESS_CODE_WORDS, generatePrivateSiteAccessCode};

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -801,7 +801,7 @@ describe('Settings API', function () {
 
                 const byKey = Object.fromEntries(response.body.settings.map(s => [s.key, s]));
                 assert.equal(typeof byKey.password.value, 'string');
-                assert.match(byKey.password.value, /^fake-\d{3}$/);
+                assert.match(byKey.password.value, /^[a-z]+\d{3}$/);
                 assert.notEqual(byKey.password.value, 'caller-chosen-code');
                 assert.equal(byKey.password.is_read_only, true);
 

--- a/ghost/core/test/unit/server/services/settings/private-site-access-code.test.js
+++ b/ghost/core/test/unit/server/services/settings/private-site-access-code.test.js
@@ -12,14 +12,10 @@ describe('UNIT > private-site-access-code', function () {
         }
     });
 
-    it('uses the Product-approved 48-word list', function () {
-        assert.deepEqual(ACCESS_CODE_WORDS, [
-            'anchor', 'aurora', 'beacon', 'birch', 'bright', 'cedar', 'cloud', 'comet', 'copper', 'coral',
-            'ember', 'fern', 'field', 'forest', 'golden', 'green', 'harbor', 'hidden', 'horizon', 'juniper',
-            'lagoon', 'lunar', 'maple', 'meadow', 'midnight', 'north', 'ocean', 'olive', 'paper', 'pine',
-            'quiet', 'river', 'sage', 'signal', 'silver', 'solstice', 'sparrow', 'stone', 'studio', 'summit',
-            'sunrise', 'thistle', 'valley', 'violet', 'willow', 'window', 'winter', 'wild'
-        ]);
+    it('uses a 48-word lowercase list with no duplicate entries', function () {
+        assert.equal(ACCESS_CODE_WORDS.length, 48);
+        assert.equal(new Set(ACCESS_CODE_WORDS).size, ACCESS_CODE_WORDS.length);
+        assert.ok(ACCESS_CODE_WORDS.every(word => /^[a-z]+$/.test(word)));
     });
 
     it('produces varied codes across consecutive calls', function () {

--- a/ghost/core/test/unit/server/services/settings/private-site-access-code.test.js
+++ b/ghost/core/test/unit/server/services/settings/private-site-access-code.test.js
@@ -1,12 +1,25 @@
 const assert = require('node:assert/strict');
-const {generatePrivateSiteAccessCode} = require('../../../../../core/server/services/settings/private-site-access-code');
+const {ACCESS_CODE_WORDS, generatePrivateSiteAccessCode} = require('../../../../../core/server/services/settings/private-site-access-code');
 
 describe('UNIT > private-site-access-code', function () {
-    it('returns a placeholder string matching the fake-### format', function () {
+    it('returns a curated word with a three-digit suffix', function () {
         for (let i = 0; i < 50; i++) {
             const code = generatePrivateSiteAccessCode();
-            assert.match(code, /^fake-\d{3}$/);
+            assert.match(code, /^[a-z]+\d{3}$/);
+
+            const word = code.replace(/\d{3}$/, '');
+            assert.ok(ACCESS_CODE_WORDS.includes(word), `expected ${word} to be in the curated word list`);
         }
+    });
+
+    it('uses the Product-approved 48-word list', function () {
+        assert.deepEqual(ACCESS_CODE_WORDS, [
+            'anchor', 'aurora', 'beacon', 'birch', 'bright', 'cedar', 'cloud', 'comet', 'copper', 'coral',
+            'ember', 'fern', 'field', 'forest', 'golden', 'green', 'harbor', 'hidden', 'horizon', 'juniper',
+            'lagoon', 'lunar', 'maple', 'meadow', 'midnight', 'north', 'ocean', 'olive', 'paper', 'pine',
+            'quiet', 'river', 'sage', 'signal', 'silver', 'solstice', 'sparrow', 'stone', 'studio', 'summit',
+            'sunrise', 'thistle', 'valley', 'violet', 'willow', 'window', 'winter', 'wild'
+        ]);
     });
 
     it('produces varied codes across consecutive calls', function () {
@@ -14,7 +27,7 @@ describe('UNIT > private-site-access-code', function () {
         for (let i = 0; i < 50; i++) {
             codes.add(generatePrivateSiteAccessCode());
         }
-        // Just ensure the output isn't constant — 50 draws from a 1,000-value
+        // Just ensure the output isn't constant — 50 draws from a 48,000-value
         // space has a non-trivial birthday-collision rate, so any tighter
         // threshold would be flaky.
         assert.ok(codes.size > 1, `expected varied codes, got ${codes.size} distinct value(s)`);

--- a/ghost/core/test/unit/server/services/settings/settings-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-service.test.js
@@ -174,7 +174,7 @@ describe('UNIT: Settings Service', function () {
             const writes = editStub.firstCall.args[0];
             const writesByKey = Object.fromEntries(writes.map(w => [w.key, w.value]));
             assert.equal(writesByKey.is_private, true);
-            assert.match(writesByKey.password, /^fake-\d{3}$/);
+            assert.match(writesByKey.password, /^[a-z]+\d{3}$/);
             assert.deepEqual(editStub.firstCall.args[1], {context: {internal: true}});
         });
 
@@ -196,7 +196,7 @@ describe('UNIT: Settings Service', function () {
             sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
             const findOneStub = sinon.stub(models.Settings, 'findOne');
             findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(true));
-            findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow('fake-042'));
+            findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow('anchor042'));
             const editStub = sinon.stub(models.Settings, 'edit').resolves();
 
             await settingsService.init();


### PR DESCRIPTION
## Summary

- Replaces the temporary `fake-###` private-site access-code placeholder with the Product-approved curated `word###` format.
- Generates codes server-side with `crypto.randomInt`, choosing from the 48-word curated list plus a zero-padded three-digit suffix.
- Keeps the regenerate settings flow read-only from the API caller; this PR only changes the generated format and matching tests.

## Testing

- [x] `source ~/.nvm/nvm.sh && nvm use 22 && pnpm test:single test/unit/server/services/settings/private-site-access-code.test.js`
- [x] `source ~/.nvm/nvm.sh && nvm use 22 && pnpm test:single test/unit/server/services/settings/settings-service.test.js`
- [x] `source ~/.nvm/nvm.sh && nvm use 22 && pnpm --filter @tryghost/parse-email-address install --offline && pnpm --filter @tryghost/parse-email-address build && pnpm test:single test/e2e-api/admin/settings.test.js`
- [x] `source ~/.nvm/nvm.sh && nvm use 22 && pnpm exec eslint core/server/services/settings/private-site-access-code.js test/unit/server/services/settings/private-site-access-code.test.js test/unit/server/services/settings/settings-service.test.js test/e2e-api/admin/settings.test.js`
- [x] `git diff --check`