### PR TITLE
Prevented hardcoded /ghost/ paths in admin packages with shared ESLint rule

### DIFF
--- a/apps/.eslintrc-no-hardcoded-ghost-paths.cjs
+++ b/apps/.eslintrc-no-hardcoded-ghost-paths.cjs
@@ -1,0 +1,53 @@
+/**
+ * Shared ESLint rule: ban hardcoded "/ghost/..." string literals.
+ *
+ * Any literal that starts with "/ghost/" is site-root-relative, so it
+ * silently strips any /blog/ (or other) subdirectory prefix on installs
+ * that run Ghost under one. The bug surfaces anywhere such a literal is
+ * used — location.href assignments, fetch URLs, JSX hrefs, etc. — so
+ * the rule catches the literal at its source, not at any specific
+ * usage site.
+ *
+ * Fix by building the path from getGhostPaths() in
+ * @tryghost/admin-x-framework/helpers (use adminRoot for admin paths,
+ * apiRoot for API calls). The helper reads window.location.pathname
+ * once to derive the correct subdir, so all downstream construction is
+ * subdir-safe.
+ *
+ * Test fixtures and assertions intentionally hardcode /ghost/... paths
+ * to verify what production code emits — the override at the bottom
+ * exempts them.
+ */
+module.exports = {
+    rules: {
+        'no-restricted-syntax': ['error',
+            {
+                selector: 'Literal[value=/^\\/ghost\\//]',
+                message: 'Hardcoded /ghost/... paths break subdirectory installs. Use getGhostPaths() from @tryghost/admin-x-framework/helpers.'
+            },
+            {
+                selector: 'TemplateLiteral[quasis.0.value.raw=/^\\/ghost\\//]',
+                message: 'Hardcoded /ghost/... paths break subdirectory installs. Use getGhostPaths() from @tryghost/admin-x-framework/helpers.'
+            }
+        ]
+    },
+    overrides: [
+        {
+            files: [
+                'test/**/*.{ts,tsx,js,jsx}',
+                'tests/**/*.{ts,tsx,js,jsx}',
+                'src/**/*.test.{ts,tsx,js,jsx}',
+                // Test utilities live under src/test in some packages (MSW
+                // handlers, fixtures, etc.) and intentionally pin literal
+                // /ghost/... URLs.
+                'src/test/**/*.{ts,tsx,js,jsx}',
+                // Ember admin's Mirage mock server pins literal /ghost/...
+                // routes; that's by definition not a real install.
+                'mirage/**/*.{ts,tsx,js,jsx}'
+            ],
+            rules: {
+                'no-restricted-syntax': 'off'
+            }
+        }
+    ]
+};

--- a/apps/activitypub/.eslintrc.cjs
+++ b/apps/activitypub/.eslintrc.cjs
@@ -6,7 +6,8 @@ module.exports = {
     extends: [
         'plugin:ghost/ts',
         'plugin:react/recommended',
-        'plugin:react-hooks/recommended'
+        'plugin:react-hooks/recommended',
+        '../.eslintrc-no-hardcoded-ghost-paths.cjs'
     ],
     plugins: [
         'ghost',

--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.26",
+  "version": "3.1.27",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -23,6 +23,7 @@ import {
     useQueryClient
 } from '@tanstack/react-query';
 import {formatPendingActivityContent, generatePendingActivity, generatePendingActivityId} from '../utils/pending-activity';
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {mapPostToActivity} from '../utils/posts';
 import {toast} from 'sonner';
 import {useCallback, useEffect, useState} from 'react';
@@ -34,7 +35,7 @@ let SITE_URL: string;
 
 async function getSiteUrl() {
     if (!SITE_URL) {
-        const response = await fetch('/ghost/api/admin/site/');
+        const response = await fetch(`${getGhostPaths().apiRoot}/site/`);
         const json = await response.json();
         SITE_URL = json.site.url;
     }
@@ -45,7 +46,7 @@ async function getSiteUrl() {
 function createActivityPubAPI(handle: string, siteUrl: string) {
     return new ActivityPubAPI(
         new URL(siteUrl),
-        new URL('/ghost/api/admin/identities/', window.location.origin),
+        new URL(`${getGhostPaths().apiRoot}/identities/`, window.location.origin),
         handle
     );
 }

--- a/apps/admin-x-design-system/.eslintrc.cjs
+++ b/apps/admin-x-design-system/.eslintrc.cjs
@@ -4,7 +4,8 @@ module.exports = {
     extends: [
         'plugin:ghost/ts',
         'plugin:react/recommended',
-        'plugin:react-hooks/recommended'
+        'plugin:react-hooks/recommended',
+        '../.eslintrc-no-hardcoded-ghost-paths.cjs'
     ],
     plugins: [
         'ghost',

--- a/apps/admin-x-framework/.eslintrc.cjs
+++ b/apps/admin-x-framework/.eslintrc.cjs
@@ -2,7 +2,8 @@ module.exports = {
     extends: [
         'plugin:ghost/ts',
         'plugin:react/recommended',
-        'plugin:react-hooks/recommended'
+        'plugin:react-hooks/recommended',
+        '../.eslintrc-no-hardcoded-ghost-paths.cjs'
     ],
     plugins: [
         'ghost',

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -169,6 +169,10 @@ export const useFetchApi = () => {
                 totalSeconds: retryingMs / 1000,
                 endpoint: endpoint.toString()
             };
+            // Substring check, not URL construction. Subdir installs include
+            // /ghost/api/ in their path too, so the literal works in both
+            // cases.
+            // eslint-disable-next-line no-restricted-syntax
             if (endpoint.toString().includes('/ghost/api/')) {
                 data.server = response?.headers.get('server');
             }

--- a/apps/admin-x-framework/src/utils/errors.ts
+++ b/apps/admin-x-framework/src/utils/errors.ts
@@ -24,6 +24,10 @@ export class APIError extends Error {
         message?: string,
         errorOptions?: ErrorOptions
     ) {
+        // Substring check + regex split, not URL construction. Subdir
+        // installs include /ghost/api/admin/ in their path too, so this
+        // works in both cases.
+        // eslint-disable-next-line no-restricted-syntax
         if (!message && response && response.url.includes('/ghost/api/admin/')) {
             message = `Something went wrong while loading ${response.url.replace(/.+\/ghost\/api\/admin\//, '').replace(/\W.*/, '').replace('_', ' ')}, please try again.`;
         }

--- a/apps/admin-x-framework/src/utils/helpers.ts
+++ b/apps/admin-x-framework/src/utils/helpers.ts
@@ -8,6 +8,10 @@ export interface IGhostPaths {
 
 export function getGhostPaths(): IGhostPaths {
     const path = window.location.pathname;
+    // This is the one place /ghost/ may appear as a literal: getGhostPaths
+    // derives the subdirectory prefix by searching the current pathname for
+    // it, then every other admin URL is built relative to that prefix.
+    // eslint-disable-next-line no-restricted-syntax
     const subdir = path.substr(0, path.search('/ghost/'));
     const adminRoot = `${subdir}/ghost/`;
     const assetRoot = `${subdir}/ghost/assets/`;

--- a/apps/admin-x-settings/.eslintrc.cjs
+++ b/apps/admin-x-settings/.eslintrc.cjs
@@ -6,7 +6,8 @@ module.exports = {
     extends: [
         'plugin:ghost/ts',
         'plugin:react/recommended',
-        'plugin:react-hooks/recommended'
+        'plugin:react-hooks/recommended',
+        '../.eslintrc-no-hardcoded-ghost-paths.cjs'
     ],
     plugins: [
         'ghost',

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offer-helpers.ts
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offer-helpers.ts
@@ -1,3 +1,5 @@
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+
 const MAX_RETENTION_OFFER_NAME_LENGTH = 40;
 
 export const formatOfferTimestamp = (timestamp: string): string => {
@@ -10,7 +12,7 @@ export const formatOfferTimestamp = (timestamp: string): string => {
 };
 
 export const createOfferRedemptionsFilterUrl = (offerIds: string[]): string => {
-    const baseHref = '/ghost/#/members';
+    const baseHref = `${getGhostPaths().adminRoot}#/members`;
     const filterValue = `offer_redemptions:[${offerIds.join(',')}]`;
     return `${baseHref}?filter=${encodeURIComponent(filterValue)}`;
 };

--- a/apps/posts/.eslintrc.cjs
+++ b/apps/posts/.eslintrc.cjs
@@ -6,7 +6,8 @@ module.exports = {
     extends: [
         'plugin:ghost/ts',
         'plugin:react/recommended',
-        'plugin:react-hooks/recommended'
+        'plugin:react-hooks/recommended',
+        '../.eslintrc-no-hardcoded-ghost-paths.cjs'
     ],
     plugins: [
         'ghost',

--- a/apps/shade/.eslintrc.cjs
+++ b/apps/shade/.eslintrc.cjs
@@ -6,7 +6,8 @@ module.exports = {
         'plugin:ghost/ts',
         'plugin:react/recommended',
         'plugin:react-hooks/recommended',
-        'plugin:storybook/recommended'
+        'plugin:storybook/recommended',
+        '../.eslintrc-no-hardcoded-ghost-paths.cjs'
     ],
     plugins: [
         'ghost',

--- a/apps/stats/.eslintrc.cjs
+++ b/apps/stats/.eslintrc.cjs
@@ -6,7 +6,8 @@ module.exports = {
     extends: [
         'plugin:ghost/ts',
         'plugin:react/recommended',
-        'plugin:react-hooks/recommended'
+        'plugin:react-hooks/recommended',
+        '../.eslintrc-no-hardcoded-ghost-paths.cjs'
     ],
     plugins: [
         'ghost',

--- a/ghost/admin/.eslintrc.js
+++ b/ghost/admin/.eslintrc.js
@@ -24,7 +24,8 @@ module.exports = {
         'react'
     ],
     extends: [
-        'plugin:ghost/ember'
+        'plugin:ghost/ember',
+        '../../apps/.eslintrc-no-hardcoded-ghost-paths.cjs'
     ],
     rules: {
         'ghost/filenames/match-exported-class': ['off'],

--- a/ghost/admin/app/utils/ghost-paths.js
+++ b/ghost/admin/app/utils/ghost-paths.js
@@ -15,6 +15,10 @@ let makeRoute = function (root, args) {
 
 export default function () {
     let path = window.location.pathname;
+    // This is the one place /ghost/ may appear as a literal: ghost-paths
+    // derives the subdirectory prefix by searching the current pathname for
+    // it, then every other admin URL is built relative to that prefix.
+    // eslint-disable-next-line no-restricted-syntax
     let subdir = path.substr(0, path.search('/ghost/'));
     let adminRoot = `${subdir}/ghost/`;
     let assetRoot = `${subdir}/ghost/assets/`;


### PR DESCRIPTION
## Problem

String literals beginning with `/ghost/` are site-root-relative and silently break on installs that run Ghost under a subdirectory (e.g. `/blog/ghost/...`). Any code that hardcodes such a path in admin client code is a latent bug: it works on the canonical configuration but strips the subdirectory prefix everywhere else. There was no automated guard catching this pattern, and a few violations had crept into the admin apps.

## Solution

Adds a shared ESLint guard-rail across all admin packages (`apps/admin-x-*`, `apps/posts`, `apps/stats`, `apps/shade`, `apps/activitypub`, `ghost/admin`) that rejects any string or template literal starting with `/ghost/`. The rule lives in a single shared config (`apps/.eslintrc-no-hardcoded-ghost-paths.cjs`) using two `no-restricted-syntax` selectors, one for string `Literal` nodes and one for `TemplateLiteral` nodes whose first quasi starts with `/ghost/`. Each admin app's eslintrc extends from it. Test, mirage, and test-utility paths are exempted via an override since literal admin paths are intentional there. `apps/admin` already had an equivalent inline rule and is left alone.

The pre-existing violations the rule surfaced are now fixed: instead of constructing admin URLs from raw `/ghost/...` strings, callers route through `getGhostPaths()` (or its admin equivalent) which respects the configured admin root and subdirectory. The canonical sites that *must* reference the literal `/ghost/` segment (subdirectory detection, response-URL substring checks) carry inline disables with comments explaining why.

From here, anyone adding a new hardcoded admin path in these packages will get a lint failure pointing them at the helper. The rule is intentionally conservative: it only flags literals that begin with `/ghost/`, so dynamically constructed URLs and unrelated strings are unaffected.