### PR TITLE
Changed Renovate to automerge more internal Docker digest pins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -210,7 +210,9 @@
         },
 
         // Allow internal Docker digest pins to automerge once the relevant
-        // CI checks have gone green.
+        // CI checks have gone green. Scoped to base images we control or
+        // pin purely for build reproducibility, so digest rotations don't
+        // change runtime behavior.
         {
             "description": "Automerge internal Docker digest updates after CI passes",
             "matchDatasources": [
@@ -218,7 +220,12 @@
             ],
             "matchPackageNames": [
                 "ghost/traffic-analytics",
-                "tinybirdco/tinybird-local"
+                "tinybirdco/tinybird-local",
+                "python",
+                "ghcr.io/astral-sh/uv",
+                "axllent/mailpit",
+                "caddy",
+                "stripe/stripe-cli"
             ],
             "matchUpdateTypes": [
                 "digest"


### PR DESCRIPTION
## Summary

Build-only Docker base image digest bumps go through Renovate's manual merge queue every week. Today only `ghost/traffic-analytics` and `tinybirdco/tinybird-local` are on the digest-automerge allowlist; `python`, `ghcr.io/astral-sh/uv`, `axllent/mailpit`, `caddy`, and `stripe/stripe-cli` rotate digests weekly and get hand-merged each time.

## What this changes

`.github/renovate.json5`: extends the existing "Automerge internal Docker digest updates after CI passes" rule to cover those five images. They're pinned purely for build reproducibility — a digest rotation can't change runtime behavior — so they're safe to automerge once CI is green, the same as the two images already on the list.

## Test plan

- [ ] CI passes (`renovate.json5` is parsed by Renovate, not Ghost CI — success here is JSON5 validity)
- [ ] After merge: the next digest bump for one of these images automerges once its CI checks are green