### PR TITLE
Added stateless llms.txt service with dependency injection

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -63,6 +63,18 @@ const features: Feature[] = [{
     title: 'Smarter Counts',
     description: 'Use optimized COUNT queries for API pagination when safe',
     flag: 'smarterCounts'
+}, {
+    title: 'Comments Threads',
+    description: 'Enable deeper threading view in Comments-UI',
+    flag: 'commentsThreads'
+}, {
+    title: 'Comments Pinning',
+    description: 'Allow staff to pin top-level comments in Comments-UI and Admin',
+    flag: 'commentsPinning'
+}, {
+    title: 'LLMs.txt',
+    description: 'Serve llms.txt, per-entry markdown exports, and Accept: text/markdown content negotiation for AI and LLM tooling',
+    flag: 'llmsTxt'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -64,14 +64,6 @@ const features: Feature[] = [{
     description: 'Use optimized COUNT queries for API pagination when safe',
     flag: 'smarterCounts'
 }, {
-    title: 'Comments Threads',
-    description: 'Enable deeper threading view in Comments-UI',
-    flag: 'commentsThreads'
-}, {
-    title: 'Comments Pinning',
-    description: 'Allow staff to pin top-level comments in Comments-UI and Admin',
-    flag: 'commentsPinning'
-}, {
     title: 'LLMs.txt',
     description: 'Serve llms.txt, per-entry markdown exports, and Accept: text/markdown content negotiation for AI and LLM tooling',
     flag: 'llmsTxt'

--- a/ghost/core/core/frontend/services/llms/handler.js
+++ b/ghost/core/core/frontend/services/llms/handler.js
@@ -1,4 +1,8 @@
+const logging = require('@tryghost/logging');
+const sentry = require('../../../shared/sentry');
 const urlUtils = require('../../../shared/url-utils');
+
+const LLMS_LOG_KEY = '[llms]';
 
 function createLlmsHandler({llmsService, config, settingsCache}) {
     function handleDisabledLlmsRequest(req, res, next) {
@@ -17,54 +21,44 @@ function createLlmsHandler({llmsService, config, settingsCache}) {
     }
 
     async function serveLlms(req, res, next, format) {
-        if (!llmsService.isEnabled()) {
-            return handleDisabledLlmsRequest(req, res, next);
+        try {
+            if (!llmsService.isEnabled()) {
+                return handleDisabledLlmsRequest(req, res, next);
+            }
+
+            const content = format === 'full'
+                ? await llmsService.getLlmsFullTxt()
+                : await llmsService.getLlmsTxt();
+
+            if (!content) {
+                return next();
+            }
+
+            setLlmsHeaders(res);
+            return res.send(content);
+        } catch (err) {
+            const eventName = `llms.serve_${format}`;
+            const eventDetails = {route: req.path};
+
+            logging.error({
+                system: {event: eventName, ...eventDetails},
+                err
+            }, `${LLMS_LOG_KEY} ${err.message}`);
+
+            sentry.captureException(err, {
+                tags: {source: eventName},
+                extra: eventDetails
+            });
+
+            return next(err);
         }
-
-        const content = format === 'full'
-            ? await llmsService.getLlmsFullTxt()
-            : await llmsService.getLlmsTxt();
-
-        if (!content) {
-            return next();
-        }
-
-        setLlmsHeaders(res);
-        return res.send(content);
     }
 
     function mountLlmsRoutes(siteApp) {
-        siteApp.get('/llms.txt', async function serveLlmsTxt(req, res, next) {
-            try {
-                return await serveLlms(req, res, next, 'index');
-            } catch (err) {
-                return next(err);
-            }
-        });
-
-        siteApp.get('/llms-full.txt', async function serveLlmsFullTxt(req, res, next) {
-            try {
-                return await serveLlms(req, res, next, 'full');
-            } catch (err) {
-                return next(err);
-            }
-        });
-
-        siteApp.get('/.well-known/llms.txt', async function serveWellKnownLlmsTxt(req, res, next) {
-            try {
-                return await serveLlms(req, res, next, 'index');
-            } catch (err) {
-                return next(err);
-            }
-        });
-
-        siteApp.get('/.well-known/llms-full.txt', async function serveWellKnownLlmsFullTxt(req, res, next) {
-            try {
-                return await serveLlms(req, res, next, 'full');
-            } catch (err) {
-                return next(err);
-            }
-        });
+        siteApp.get('/llms.txt', (req, res, next) => serveLlms(req, res, next, 'index'));
+        siteApp.get('/llms-full.txt', (req, res, next) => serveLlms(req, res, next, 'full'));
+        siteApp.get('/.well-known/llms.txt', (req, res, next) => serveLlms(req, res, next, 'index'));
+        siteApp.get('/.well-known/llms-full.txt', (req, res, next) => serveLlms(req, res, next, 'full'));
     }
 
     return {mountLlmsRoutes};

--- a/ghost/core/core/frontend/services/llms/handler.js
+++ b/ghost/core/core/frontend/services/llms/handler.js
@@ -1,0 +1,140 @@
+const urlUtils = require('../../../shared/url-utils');
+const {
+    getMarkdownPath,
+    getResourcePathFromMarkdownPath,
+    renderEntryMarkdown
+} = require('./markdown');
+
+function getRequestSearch(req) {
+    const searchIndex = req.originalUrl?.indexOf('?') ?? -1;
+
+    if (searchIndex === -1) {
+        return '';
+    }
+
+    return req.originalUrl.slice(searchIndex);
+}
+
+function redirectToWebRoute(res, pathname, search = '') {
+    return res.redirect(302, `${urlUtils.urlFor({relativeUrl: pathname})}${search}`);
+}
+
+function createLlmsHandler({llmsService, config, urlServiceFacade, settingsCache}) {
+    const llmsIndexUrl = urlUtils.urlFor({relativeUrl: '/llms.txt'}, true);
+
+    function handleDisabledLlmsRequest(req, res, next, pathname) {
+        if (settingsCache.get('is_private')) {
+            return next();
+        }
+
+        return redirectToWebRoute(res, pathname, getRequestSearch(req));
+    }
+
+    function setLlmsHeaders(res) {
+        res.set({
+            'Cache-Control': `public, max-age=${config.get('caching:llms:maxAge')}`,
+            'Content-Type': 'text/plain; charset=utf-8'
+        });
+    }
+
+    function setMarkdownHeaders(res, contentType) {
+        res.set({
+            'Cache-Control': `public, max-age=${config.get('caching:llms:maxAge')}`,
+            'Content-Type': `${contentType}; charset=utf-8`
+        });
+    }
+
+    async function serveLlms(req, res, next, format) {
+        if (!llmsService.isEnabled()) {
+            return handleDisabledLlmsRequest(req, res, next, '/');
+        }
+
+        const content = format === 'full'
+            ? await llmsService.getLlmsFullTxt()
+            : await llmsService.getLlmsTxt();
+
+        if (!content) {
+            return next();
+        }
+
+        setLlmsHeaders(res);
+        return res.send(content);
+    }
+
+    function mountLlmsRoutes(siteApp) {
+        siteApp.get('/llms.txt', async function serveLlmsTxt(req, res, next) {
+            try {
+                return await serveLlms(req, res, next, 'index');
+            } catch (err) {
+                return next(err);
+            }
+        });
+
+        siteApp.get('/llms-full.txt', async function serveLlmsFullTxt(req, res, next) {
+            try {
+                return await serveLlms(req, res, next, 'full');
+            } catch (err) {
+                return next(err);
+            }
+        });
+
+        siteApp.get('/.well-known/llms.txt', async function serveWellKnownLlmsTxt(req, res, next) {
+            try {
+                return await serveLlms(req, res, next, 'index');
+            } catch (err) {
+                return next(err);
+            }
+        });
+
+        siteApp.get('/.well-known/llms-full.txt', async function serveWellKnownLlmsFullTxt(req, res, next) {
+            try {
+                return await serveLlms(req, res, next, 'full');
+            } catch (err) {
+                return next(err);
+            }
+        });
+    }
+
+    function mountMarkdownRoutes(siteApp) {
+        siteApp.get(/.+\.md$/, async function serveMarkdownEntry(req, res, next) {
+            const resourcePath = getResourcePathFromMarkdownPath(req.path);
+
+            if (!resourcePath) {
+                return next();
+            }
+
+            if (!llmsService.isEnabled()) {
+                return handleDisabledLlmsRequest(req, res, next, resourcePath);
+            }
+
+            let resource;
+            try {
+                resource = await urlServiceFacade.resolveUrl(resourcePath);
+            } catch (err) {
+                return next(err);
+            }
+
+            if (!resource || !['posts', 'pages'].includes(resource.type) || resource.visibility !== 'public') {
+                return next();
+            }
+
+            try {
+                const entry = await llmsService.fetchPublicEntry(resource.type, resource.id, req.member || null);
+
+                if (!entry) {
+                    return next();
+                }
+
+                setMarkdownHeaders(res, 'text/markdown');
+                res.set('Content-Location', getMarkdownPath(new URL(entry.url).pathname));
+                return res.send(renderEntryMarkdown(entry, {llmsIndexUrl}));
+            } catch (err) {
+                return next(err);
+            }
+        });
+    }
+
+    return {mountLlmsRoutes, mountMarkdownRoutes};
+}
+
+module.exports = {createLlmsHandler};

--- a/ghost/core/core/frontend/services/llms/handler.js
+++ b/ghost/core/core/frontend/services/llms/handler.js
@@ -1,33 +1,12 @@
 const urlUtils = require('../../../shared/url-utils');
-const {
-    getMarkdownPath,
-    getResourcePathFromMarkdownPath,
-    renderEntryMarkdown
-} = require('./markdown');
 
-function getRequestSearch(req) {
-    const searchIndex = req.originalUrl?.indexOf('?') ?? -1;
-
-    if (searchIndex === -1) {
-        return '';
-    }
-
-    return req.originalUrl.slice(searchIndex);
-}
-
-function redirectToWebRoute(res, pathname, search = '') {
-    return res.redirect(302, `${urlUtils.urlFor({relativeUrl: pathname})}${search}`);
-}
-
-function createLlmsHandler({llmsService, config, urlServiceFacade, settingsCache}) {
-    const llmsIndexUrl = urlUtils.urlFor({relativeUrl: '/llms.txt'}, true);
-
-    function handleDisabledLlmsRequest(req, res, next, pathname) {
+function createLlmsHandler({llmsService, config, settingsCache}) {
+    function handleDisabledLlmsRequest(req, res, next) {
         if (settingsCache.get('is_private')) {
             return next();
         }
 
-        return redirectToWebRoute(res, pathname, getRequestSearch(req));
+        return res.redirect(302, urlUtils.urlFor({relativeUrl: '/'}));
     }
 
     function setLlmsHeaders(res) {
@@ -37,16 +16,9 @@ function createLlmsHandler({llmsService, config, urlServiceFacade, settingsCache
         });
     }
 
-    function setMarkdownHeaders(res, contentType) {
-        res.set({
-            'Cache-Control': `public, max-age=${config.get('caching:llms:maxAge')}`,
-            'Content-Type': `${contentType}; charset=utf-8`
-        });
-    }
-
     async function serveLlms(req, res, next, format) {
         if (!llmsService.isEnabled()) {
-            return handleDisabledLlmsRequest(req, res, next, '/');
+            return handleDisabledLlmsRequest(req, res, next);
         }
 
         const content = format === 'full'
@@ -95,46 +67,7 @@ function createLlmsHandler({llmsService, config, urlServiceFacade, settingsCache
         });
     }
 
-    function mountMarkdownRoutes(siteApp) {
-        siteApp.get(/.+\.md$/, async function serveMarkdownEntry(req, res, next) {
-            const resourcePath = getResourcePathFromMarkdownPath(req.path);
-
-            if (!resourcePath) {
-                return next();
-            }
-
-            if (!llmsService.isEnabled()) {
-                return handleDisabledLlmsRequest(req, res, next, resourcePath);
-            }
-
-            let resource;
-            try {
-                resource = await urlServiceFacade.resolveUrl(resourcePath);
-            } catch (err) {
-                return next(err);
-            }
-
-            if (!resource || !['posts', 'pages'].includes(resource.type) || resource.visibility !== 'public') {
-                return next();
-            }
-
-            try {
-                const entry = await llmsService.fetchPublicEntry(resource.type, resource.id, req.member || null);
-
-                if (!entry) {
-                    return next();
-                }
-
-                setMarkdownHeaders(res, 'text/markdown');
-                res.set('Content-Location', getMarkdownPath(new URL(entry.url).pathname));
-                return res.send(renderEntryMarkdown(entry, {llmsIndexUrl}));
-            } catch (err) {
-                return next(err);
-            }
-        });
-    }
-
-    return {mountLlmsRoutes, mountMarkdownRoutes};
+    return {mountLlmsRoutes};
 }
 
 module.exports = {createLlmsHandler};

--- a/ghost/core/core/frontend/services/llms/markdown.js
+++ b/ghost/core/core/frontend/services/llms/markdown.js
@@ -54,9 +54,9 @@ function getResourcePathFromMarkdownPath(pathname) {
 }
 
 function getAcceptedMarkdownContentType(req) {
-    const acceptHeader = req.get('Accept');
+    const acceptHeader = (req.get('Accept') || '').toLowerCase();
 
-    if (!acceptHeader || (!acceptHeader.includes('text/markdown') && !acceptHeader.includes('text/plain'))) {
+    if (!acceptHeader.includes('text/markdown') && !acceptHeader.includes('text/plain')) {
         return null;
     }
 

--- a/ghost/core/core/frontend/services/llms/markdown.js
+++ b/ghost/core/core/frontend/services/llms/markdown.js
@@ -105,16 +105,16 @@ function getPrimaryAuthorName(entry) {
     return null;
 }
 
-function getPrimaryTagName(entry) {
+function getTagNames(entry) {
+    if (Array.isArray(entry.tags) && entry.tags.length) {
+        return entry.tags.map(t => t.name).filter(Boolean);
+    }
+
     if (entry.primary_tag?.name) {
-        return entry.primary_tag.name;
+        return [entry.primary_tag.name];
     }
 
-    if (Array.isArray(entry.tags) && entry.tags[0]?.name) {
-        return entry.tags[0].name;
-    }
-
-    return null;
+    return [];
 }
 
 function renderEntryMarkdownBody(entry) {
@@ -132,13 +132,15 @@ function renderEntryMarkdownBody(entry) {
 }
 
 function renderEntryMarkdown(entry, {llmsIndexUrl}) {
+    const tags = getTagNames(entry);
     const metadata = [
         entry.url ? `- URL: ${entry.url}` : null,
+        entry.type ? `- Type: ${entry.type}` : null,
         formatIsoDate(entry.published_at) ? `- Published: ${formatIsoDate(entry.published_at)}` : null,
         formatIsoDate(entry.updated_at) ? `- Updated: ${formatIsoDate(entry.updated_at)}` : null,
         collapseWhitespace(entry.custom_excerpt) ? `- Description: ${collapseWhitespace(entry.custom_excerpt)}` : null,
         getPrimaryAuthorName(entry) ? `- Author: ${getPrimaryAuthorName(entry)}` : null,
-        getPrimaryTagName(entry) ? `- Primary tag: ${getPrimaryTagName(entry)}` : null
+        tags.length ? `- Tags: ${tags.join(', ')}` : null
     ].filter(Boolean);
 
     const body = renderEntryMarkdownBody(entry) || '_No content available._';
@@ -169,7 +171,7 @@ module.exports = {
     getMarkdownPath,
     getMarkdownUrl,
     getPrimaryAuthorName,
-    getPrimaryTagName,
+    getTagNames,
     getResourcePathFromMarkdownPath,
     markdownFromHtml,
     renderEntryMarkdown,

--- a/ghost/core/core/frontend/services/llms/markdown.js
+++ b/ghost/core/core/frontend/services/llms/markdown.js
@@ -1,0 +1,178 @@
+const {NodeHtmlMarkdown} = require('node-html-markdown');
+const htmlToPlaintext = require('@tryghost/html-to-plaintext');
+
+const MAX_DESCRIPTION_LENGTH = 300;
+
+const nhm = new NodeHtmlMarkdown({
+    bulletMarker: '-',
+    codeFence: '```',
+    emDelimiter: '*',
+    strongDelimiter: '**'
+});
+
+function collapseWhitespace(value) {
+    return (value || '').replace(/\s+/g, ' ').trim();
+}
+
+function truncateDescription(value, maxLength = MAX_DESCRIPTION_LENGTH) {
+    const collapsed = collapseWhitespace(value);
+
+    if (!collapsed || collapsed.length <= maxLength) {
+        return collapsed;
+    }
+
+    return `${collapsed.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function getMarkdownPath(pathname) {
+    if (!pathname || pathname === '/') {
+        return '/index.md';
+    }
+
+    const normalizedPath = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+    return `${normalizedPath}.md`;
+}
+
+function getMarkdownUrl(url) {
+    const parsedUrl = new URL(url);
+    parsedUrl.pathname = getMarkdownPath(parsedUrl.pathname);
+    return parsedUrl.toString();
+}
+
+function getResourcePathFromMarkdownPath(pathname) {
+    if (!pathname || !pathname.endsWith('.md')) {
+        return null;
+    }
+
+    const stripped = pathname.slice(0, -3);
+
+    if (!stripped || stripped === '/index') {
+        return '/';
+    }
+
+    return stripped.endsWith('/') ? stripped : `${stripped}/`;
+}
+
+function getAcceptedMarkdownContentType(req) {
+    const acceptHeader = req.get('Accept');
+
+    if (!acceptHeader || (!acceptHeader.includes('text/markdown') && !acceptHeader.includes('text/plain'))) {
+        return null;
+    }
+
+    const preferredType = req.accepts(['text/markdown', 'text/plain', 'text/html']);
+
+    if (!preferredType || preferredType === 'text/html') {
+        return null;
+    }
+
+    return preferredType;
+}
+
+function markdownFromHtml(html) {
+    const markdown = nhm.translate(html || '').trim();
+
+    if (!markdown) {
+        return null;
+    }
+
+    return markdown.replace(/\n{3,}/g, '\n\n');
+}
+
+function formatIsoDate(value) {
+    if (!value) {
+        return null;
+    }
+
+    const date = new Date(value);
+
+    if (isNaN(date.getTime())) {
+        return null;
+    }
+
+    return date.toISOString();
+}
+
+function getPrimaryAuthorName(entry) {
+    if (entry.primary_author?.name) {
+        return entry.primary_author.name;
+    }
+
+    if (Array.isArray(entry.authors) && entry.authors[0]?.name) {
+        return entry.authors[0].name;
+    }
+
+    return null;
+}
+
+function getPrimaryTagName(entry) {
+    if (entry.primary_tag?.name) {
+        return entry.primary_tag.name;
+    }
+
+    if (Array.isArray(entry.tags) && entry.tags[0]?.name) {
+        return entry.tags[0].name;
+    }
+
+    return null;
+}
+
+function renderEntryMarkdownBody(entry) {
+    const markdown = markdownFromHtml(entry.html);
+
+    if (markdown) {
+        return markdown;
+    }
+
+    if (entry.plaintext) {
+        return collapseWhitespace(entry.plaintext);
+    }
+
+    return collapseWhitespace(htmlToPlaintext.excerpt(entry.html || ''));
+}
+
+function renderEntryMarkdown(entry, {llmsIndexUrl}) {
+    const metadata = [
+        entry.url ? `- URL: ${entry.url}` : null,
+        formatIsoDate(entry.published_at) ? `- Published: ${formatIsoDate(entry.published_at)}` : null,
+        formatIsoDate(entry.updated_at) ? `- Updated: ${formatIsoDate(entry.updated_at)}` : null,
+        collapseWhitespace(entry.custom_excerpt) ? `- Description: ${collapseWhitespace(entry.custom_excerpt)}` : null,
+        getPrimaryAuthorName(entry) ? `- Author: ${getPrimaryAuthorName(entry)}` : null,
+        getPrimaryTagName(entry) ? `- Primary tag: ${getPrimaryTagName(entry)}` : null
+    ].filter(Boolean);
+
+    const body = renderEntryMarkdownBody(entry) || '_No content available._';
+    const lines = [
+        '> ## Content Index',
+        `> Fetch the complete content index at: ${llmsIndexUrl}`,
+        '> Use this file to discover other available public pages before exploring further.',
+        '',
+        `# ${entry.title || 'Untitled'}`
+    ];
+
+    if (metadata.length) {
+        lines.push(...metadata, '');
+    } else {
+        lines.push('');
+    }
+
+    lines.push(body);
+
+    return lines.join('\n');
+}
+
+module.exports = {
+    MAX_DESCRIPTION_LENGTH,
+    collapseWhitespace,
+    formatIsoDate,
+    getAcceptedMarkdownContentType,
+    getMarkdownPath,
+    getMarkdownUrl,
+    getPrimaryAuthorName,
+    getPrimaryTagName,
+    getResourcePathFromMarkdownPath,
+    markdownFromHtml,
+    renderEntryMarkdown,
+    renderEntryMarkdownBody,
+    truncateDescription
+};

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -1,0 +1,245 @@
+const {
+    getMarkdownUrl,
+    renderEntryMarkdownBody,
+    truncateDescription
+} = require('./markdown');
+
+const FIVE_MIB = 5 * 1024 * 1024;
+const TRUNCATION_FOOTER = '\n_Truncated after 5 MiB. Use `/llms.txt` for the complete index of older public content._\n';
+const BUDGET = FIVE_MIB - Buffer.byteLength(TRUNCATION_FOOTER, 'utf8');
+const FULL_PAGE_SIZE = 100;
+
+function createLlmsService({settingsCache, config, urlServiceFacade, urlUtils, models, routing, api}) {
+    function isEnabled() {
+        return !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
+    }
+
+    async function fetchPublicEntry(resourceType, id, member = null) {
+        const controller = resourceType === 'pages' ? api.pagesPublic : api.postsPublic;
+        const responseKey = resourceType === 'pages' ? 'pages' : 'posts';
+        const response = await controller.read({
+            id,
+            formats: 'html,plaintext',
+            include: 'authors,tags',
+            context: {member}
+        });
+
+        return response?.[responseKey]?.[0] || null;
+    }
+
+    async function getLlmsTxt() {
+        if (!isEnabled()) {
+            return null;
+        }
+
+        const [pages, posts] = await Promise.all([
+            fetchIndexEntries('page'),
+            fetchIndexEntries('post')
+        ]);
+
+        const sections = [
+            buildHeader(),
+            'Public Ghost content for AI and LLM tooling. Use `/llms-full.txt` for consolidated page and post context.',
+            '',
+            '## Pages',
+            buildIndexSection(pages),
+            '',
+            '## Posts',
+            buildIndexSection(posts),
+            '',
+            '## Optional',
+            buildOptionalSection()
+        ];
+
+        return `${sections.join('\n').trim()}\n`;
+    }
+
+    async function getLlmsFullTxt() {
+        if (!isEnabled()) {
+            return null;
+        }
+
+        const header = [
+            buildHeader(),
+            'Public Ghost content for AI and LLM tooling. This file includes a bounded export of public pages first, then recent public posts.',
+            ''
+        ].join('\n');
+
+        let output = header;
+        let wasTruncated = false;
+
+        const pageResult = await appendBoundedSectionPaginated(output, 'Pages', 'page');
+        output = pageResult.output;
+        wasTruncated = pageResult.wasTruncated;
+
+        if (!wasTruncated) {
+            const postResult = await appendBoundedSectionPaginated(output, 'Posts', 'post');
+            output = postResult.output;
+            wasTruncated = postResult.wasTruncated;
+        }
+
+        if (wasTruncated) {
+            output += TRUNCATION_FOOTER;
+        }
+
+        return output.trimEnd() + '\n';
+    }
+
+    async function appendBoundedSectionPaginated(prefix, heading, type) {
+        const headingBlock = `${prefix}## ${heading}\n`;
+
+        if (Buffer.byteLength(headingBlock, 'utf8') > BUDGET) {
+            return {output: prefix, wasTruncated: true};
+        }
+
+        let output = headingBlock;
+        let wasTruncated = false;
+        let page = 1;
+        let hasMore = true;
+
+        while (hasMore && !wasTruncated) {
+            const result = await fetchFullEntries(type, page);
+            const entries = result.entries;
+            hasMore = result.hasMore;
+
+            if (!entries.length && page === 1) {
+                const emptySection = `${output}_No public content available._\n`;
+
+                if (Buffer.byteLength(emptySection, 'utf8') <= BUDGET) {
+                    output = emptySection;
+                } else {
+                    wasTruncated = true;
+                }
+
+                break;
+            }
+
+            for (const entry of entries) {
+                const formattedEntry = buildFullEntry(entry);
+                const candidate = `${output}${formattedEntry}\n`;
+
+                if (Buffer.byteLength(candidate, 'utf8') > BUDGET) {
+                    wasTruncated = true;
+                    break;
+                }
+
+                output = candidate;
+            }
+
+            page += 1;
+        }
+
+        return {output, wasTruncated};
+    }
+
+    function buildHeader() {
+        const siteTitle = settingsCache.get('title') || new URL(config.get('url')).hostname;
+        const siteDescription = settingsCache.get('meta_description') || settingsCache.get('description');
+
+        return [
+            `# ${siteTitle}`,
+            siteDescription ? `> ${siteDescription}` : '> Public Ghost publication content.'
+        ].join('\n');
+    }
+
+    function buildIndexSection(entries) {
+        if (!entries.length) {
+            return '_No public content available._';
+        }
+
+        return entries.map((entry) => {
+            const description = truncateDescription(entry.custom_excerpt || entry.plaintext);
+            const linkLine = `- [${entry.title}](${getMarkdownUrl(entry.url)})`;
+
+            if (!description) {
+                return linkLine;
+            }
+
+            return `${linkLine} - ${description}`;
+        }).join('\n');
+    }
+
+    function buildOptionalSection() {
+        const optionalLinks = [];
+        const rssUrl = routing.registry.getRssUrl({absolute: true});
+
+        if (rssUrl) {
+            optionalLinks.push(`- [RSS Feed](${rssUrl})`);
+        }
+
+        optionalLinks.push(`- [Sitemap](${urlUtils.urlFor({relativeUrl: '/sitemap.xml'}, true)})`);
+
+        return optionalLinks.join('\n');
+    }
+
+    function buildFullEntry(entry) {
+        const lastUpdated = entry.updated_at || entry.published_at || entry.created_at;
+        const lastUpdatedLine = lastUpdated ? `Last updated: ${new Date(lastUpdated).toISOString()}` : null;
+        const markdownBody = renderEntryMarkdownBody(entry) || '_No content available._';
+
+        return [
+            `### ${entry.title}`,
+            `URL: ${entry.url}`,
+            lastUpdatedLine,
+            '',
+            markdownBody
+        ].filter(Boolean).join('\n');
+    }
+
+    function resolveEntryUrl(entry) {
+        const url = urlServiceFacade.getUrlForResource(
+            {type: entry.type, id: entry.id, slug: entry.slug},
+            {absolute: true}
+        );
+        return url && !url.endsWith('/404/') ? url : null;
+    }
+
+    async function fetchIndexEntries(type) {
+        const page = await models.Post.findPage({
+            limit: 'all',
+            order: type === 'post' ? 'published_at desc' : 'id asc',
+            filter: `status:published+visibility:public+type:${type}`,
+            columns: ['id', 'title', 'slug', 'custom_excerpt', 'plaintext', 'type']
+        });
+
+        const entries = page.data.map((model) => {
+            const entry = model.toJSON();
+            entry.url = resolveEntryUrl(entry);
+            return entry;
+        }).filter(entry => entry.url);
+
+        if (type === 'page') {
+            entries.sort((left, right) => left.url.localeCompare(right.url));
+        }
+
+        return entries;
+    }
+
+    async function fetchFullEntries(type, pageNum) {
+        const result = await models.Post.findPage({
+            limit: FULL_PAGE_SIZE,
+            page: pageNum,
+            order: type === 'post' ? 'published_at desc' : 'id asc',
+            filter: `status:published+visibility:public+type:${type}`,
+            columns: ['id', 'title', 'slug', 'html', 'plaintext', 'custom_excerpt', 'updated_at', 'published_at', 'created_at', 'type']
+        });
+
+        const entries = result.data.map((model) => {
+            const entry = model.toJSON();
+            entry.url = resolveEntryUrl(entry);
+            return entry;
+        }).filter(entry => entry.url);
+
+        if (type === 'page' && pageNum === 1) {
+            entries.sort((left, right) => left.url.localeCompare(right.url));
+        }
+
+        const hasMore = result.data.length === FULL_PAGE_SIZE;
+
+        return {entries, hasMore};
+    }
+
+    return {isEnabled, getLlmsTxt, getLlmsFullTxt, fetchPublicEntry};
+}
+
+module.exports = {createLlmsService};

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -4,12 +4,12 @@ const {
     truncateDescription
 } = require('./markdown');
 
-const FIVE_MIB = 5 * 1024 * 1024;
+const DEFAULT_BUDGET = 5 * 1024 * 1024;
 const TRUNCATION_FOOTER = '\n_Truncated after 5 MiB. Use `/llms.txt` for the complete index of older public content._\n';
-const BUDGET = FIVE_MIB - Buffer.byteLength(TRUNCATION_FOOTER, 'utf8');
 const FULL_PAGE_SIZE = 100;
 
-function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUtils, models, routing, api}) {
+function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUtils, models, routing, api, fullTxtBudget}) {
+    const BUDGET = (fullTxtBudget || DEFAULT_BUDGET) - Buffer.byteLength(TRUNCATION_FOOTER, 'utf8');
     function isEnabled() {
         return labs.isSet('llmsTxt') && !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
     }
@@ -229,10 +229,6 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
             entry.url = resolveEntryUrl(entry);
             return entry;
         }).filter(entry => entry.url);
-
-        if (type === 'page' && pageNum === 1) {
-            entries.sort((left, right) => left.url.localeCompare(right.url));
-        }
 
         const hasMore = result.data.length === FULL_PAGE_SIZE;
 

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -188,7 +188,7 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
 
     function resolveEntryUrl(entry) {
         const url = urlServiceFacade.getUrlForResource(
-            {type: entry.type, id: entry.id, slug: entry.slug},
+            {...entry, type: entry.type, id: entry.id},
             {absolute: true}
         );
         return url && !url.endsWith('/404/') ? url : null;
@@ -199,7 +199,8 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
             limit: 'all',
             order: type === 'post' ? 'published_at desc' : 'id asc',
             filter: `status:published+visibility:public+type:${type}`,
-            columns: ['id', 'title', 'slug', 'custom_excerpt', 'plaintext', 'type']
+            columns: ['id', 'title', 'slug', 'custom_excerpt', 'plaintext', 'published_at', 'type'],
+            withRelated: ['tags', 'authors']
         });
 
         const entries = page.data.map((model) => {
@@ -221,7 +222,8 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
             page: pageNum,
             order: type === 'post' ? 'published_at desc' : 'id asc',
             filter: `status:published+visibility:public+type:${type}`,
-            columns: ['id', 'title', 'slug', 'html', 'plaintext', 'custom_excerpt', 'updated_at', 'published_at', 'created_at', 'type']
+            columns: ['id', 'title', 'slug', 'html', 'plaintext', 'custom_excerpt', 'updated_at', 'published_at', 'created_at', 'type'],
+            withRelated: ['tags', 'authors']
         });
 
         const entries = result.data.map((model) => {

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -9,9 +9,9 @@ const TRUNCATION_FOOTER = '\n_Truncated after 5 MiB. Use `/llms.txt` for the com
 const BUDGET = FIVE_MIB - Buffer.byteLength(TRUNCATION_FOOTER, 'utf8');
 const FULL_PAGE_SIZE = 100;
 
-function createLlmsService({settingsCache, config, urlServiceFacade, urlUtils, models, routing, api}) {
+function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUtils, models, routing, api}) {
     function isEnabled() {
-        return !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
+        return labs.isSet('llmsTxt') && !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
     }
 
     async function fetchPublicEntry(resourceType, id, member = null) {

--- a/ghost/core/core/frontend/services/routing/collection-router.js
+++ b/ghost/core/core/frontend/services/routing/collection-router.js
@@ -88,6 +88,14 @@ class CollectionRouter extends ParentRouter {
         // REGISTER: permalinks e.g. /:slug/, /podcast/:slug
         this.mountRoute(this.permalinks.getValue({withUrlOptions: true}), controllers.entry);
 
+        // REGISTER: .md variant for llms.txt markdown export
+        const mdPermalink = this.permalinks.value.replace(/\/$/, '.md');
+        this.mountRoute(mdPermalink, (req, res, next) => {
+            res.routerOptions.permalinks = mdPermalink;
+            res.routerOptions.isMarkdownRequest = true;
+            return controllers.entry(req, res, next);
+        });
+
         this.routerCreated(this);
     }
 

--- a/ghost/core/core/frontend/services/routing/controllers/entry.js
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.js
@@ -62,6 +62,44 @@ module.exports = function entryController(req, res, next) {
                 }));
             }
 
+            if (config.get('llms') && entry.visibility === 'public') {
+                const {getAcceptedMarkdownContentType, renderEntryMarkdown} = require('../../llms/markdown');
+                const markdownContentType = getAcceptedMarkdownContentType(req);
+
+                if (markdownContentType) {
+                    const {createLlmsService} = require('../../llms/service');
+                    const settingsCache = require('../../../../shared/settings-cache');
+                    const urlService = require('../../../../server/services/url');
+                    const models = require('../../../../server/models');
+                    const routing = require('../../routing');
+                    const {api} = require('../../proxy');
+
+                    const llmsService = createLlmsService({
+                        settingsCache,
+                        config,
+                        urlServiceFacade: urlService.facade,
+                        urlUtils,
+                        models,
+                        routing,
+                        api
+                    });
+
+                    if (llmsService.isEnabled()) {
+                        return llmsService.fetchPublicEntry(res.routerOptions.resourceType, entry.id)
+                            .then((markdownEntry) => {
+                                if (!markdownEntry) {
+                                    return renderer.renderEntry(req, res)(entry);
+                                }
+
+                                const llmsIndexUrl = urlUtils.urlFor({relativeUrl: '/llms.txt'}, true);
+                                res.set('Cache-Control', `public, max-age=${config.get('caching:llms:maxAge')}`);
+                                res.type(markdownContentType);
+                                return res.send(renderEntryMarkdown(markdownEntry, {llmsIndexUrl}));
+                            });
+                    }
+                }
+            }
+
             return renderer.renderEntry(req, res)(entry);
         })
         .catch(renderer.handleError(next));

--- a/ghost/core/core/frontend/services/routing/controllers/entry.js
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.js
@@ -62,12 +62,13 @@ module.exports = function entryController(req, res, next) {
                 }));
             }
 
-            if (config.get('llms') && entry.visibility === 'public') {
+            if (entry.visibility === 'public') {
                 const {getAcceptedMarkdownContentType, renderEntryMarkdown} = require('../../llms/markdown');
                 const markdownContentType = getAcceptedMarkdownContentType(req);
 
                 if (markdownContentType) {
                     const {createLlmsService} = require('../../llms/service');
+                    const labs = require('../../../../shared/labs');
                     const settingsCache = require('../../../../shared/settings-cache');
                     const urlService = require('../../../../server/services/url');
                     const models = require('../../../../server/models');
@@ -76,6 +77,7 @@ module.exports = function entryController(req, res, next) {
 
                     const llmsService = createLlmsService({
                         settingsCache,
+                        labs,
                         config,
                         urlServiceFacade: urlService.facade,
                         urlUtils,

--- a/ghost/core/core/frontend/services/routing/controllers/entry.js
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.js
@@ -95,6 +95,7 @@ module.exports = function entryController(req, res, next) {
 
                                 const llmsIndexUrl = urlUtils.urlFor({relativeUrl: '/llms.txt'}, true);
                                 res.set('Cache-Control', `public, max-age=${config.get('caching:llms:maxAge')}`);
+                                res.vary('Accept');
                                 res.type(markdownContentType);
                                 return res.send(renderEntryMarkdown(markdownEntry, {llmsIndexUrl}));
                             });

--- a/ghost/core/core/frontend/services/routing/controllers/entry.js
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.js
@@ -4,6 +4,19 @@ const config = require('../../../../shared/config');
 const urlUtils = require('../../../../shared/url-utils');
 const dataService = require('../../data');
 const renderer = require('../../rendering');
+const {getAcceptedMarkdownContentType, getMarkdownPath, renderEntryMarkdown} = require('../../llms/markdown');
+
+function getLlmsService(req) {
+    return req.app.get('llmsService') || null;
+}
+
+function serveMarkdown(res, entry) {
+    const llmsIndexUrl = urlUtils.urlFor({relativeUrl: '/llms.txt'}, true);
+    res.set('Cache-Control', `public, max-age=${config.get('caching:llms:maxAge')}`);
+    res.set('Content-Location', getMarkdownPath(new URL(entry.url).pathname));
+    res.type('text/markdown');
+    return res.send(renderEntryMarkdown(entry, {llmsIndexUrl}));
+}
 
 /**
  * @description Entry controller.
@@ -44,6 +57,23 @@ module.exports = function entryController(req, res, next) {
                 return urlUtils.redirectToAdmin(302, res, `/#/editor/${resourceType}/${entry.id}`);
             }
 
+            // CASE: .md URL — serve entry as markdown for LLM consumption
+            if (res.routerOptions.isMarkdownRequest) {
+                if (entry.visibility !== 'public') {
+                    return next();
+                }
+
+                const llmsService = getLlmsService(req);
+                if (!llmsService || !llmsService.isEnabled()) {
+                    return res.redirect(302, url.format({
+                        pathname: url.parse(entry.url).pathname,
+                        search: url.parse(req.originalUrl).search
+                    }));
+                }
+
+                return serveMarkdown(res, entry);
+            }
+
             /**
              * CASE: Permalink is not valid anymore, we redirect him permanently to the correct one
              *       This should only happen if you have date permalinks enabled and you change
@@ -62,43 +92,16 @@ module.exports = function entryController(req, res, next) {
                 }));
             }
 
+            // CASE: Accept: text/markdown content negotiation
             if (entry.visibility === 'public') {
-                const {getAcceptedMarkdownContentType, renderEntryMarkdown} = require('../../llms/markdown');
                 const markdownContentType = getAcceptedMarkdownContentType(req);
 
                 if (markdownContentType) {
-                    const {createLlmsService} = require('../../llms/service');
-                    const labs = require('../../../../shared/labs');
-                    const settingsCache = require('../../../../shared/settings-cache');
-                    const urlService = require('../../../../server/services/url');
-                    const models = require('../../../../server/models');
-                    const routing = require('../../routing');
-                    const {api} = require('../../proxy');
+                    const llmsService = getLlmsService(req);
 
-                    const llmsService = createLlmsService({
-                        settingsCache,
-                        labs,
-                        config,
-                        urlServiceFacade: urlService.facade,
-                        urlUtils,
-                        models,
-                        routing,
-                        api
-                    });
-
-                    if (llmsService.isEnabled()) {
-                        return llmsService.fetchPublicEntry(res.routerOptions.resourceType, entry.id)
-                            .then((markdownEntry) => {
-                                if (!markdownEntry) {
-                                    return renderer.renderEntry(req, res)(entry);
-                                }
-
-                                const llmsIndexUrl = urlUtils.urlFor({relativeUrl: '/llms.txt'}, true);
-                                res.set('Cache-Control', `public, max-age=${config.get('caching:llms:maxAge')}`);
-                                res.vary('Accept');
-                                res.type(markdownContentType);
-                                return res.send(renderEntryMarkdown(markdownEntry, {llmsIndexUrl}));
-                            });
+                    if (llmsService && llmsService.isEnabled()) {
+                        res.vary('Accept');
+                        return serveMarkdown(res, entry);
                     }
                 }
             }

--- a/ghost/core/core/frontend/services/routing/controllers/entry.js
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.js
@@ -60,7 +60,9 @@ module.exports = function entryController(req, res, next) {
             // CASE: .md URL — serve entry as markdown for LLM consumption
             if (res.routerOptions.isMarkdownRequest) {
                 if (entry.visibility !== 'public') {
-                    return next();
+                    return res.status(403).type('text/markdown').send(
+                        '# Members-only content\n\nThis post requires a subscription and is not available for public access.\n'
+                    );
                 }
 
                 const llmsService = getLlmsService(req);

--- a/ghost/core/core/frontend/services/routing/static-pages-router.js
+++ b/ghost/core/core/frontend/services/routing/static-pages-router.js
@@ -48,6 +48,13 @@ class StaticPagesRouter extends ParentRouter {
         // REGISTER: permalink for static pages
         this.mountRoute(this.permalinks.getValue({withUrlOptions: true}), controllers.entry);
 
+        // REGISTER: .md variant for llms.txt markdown export
+        this.mountRoute('/:slug.md', (req, res, next) => {
+            res.routerOptions.permalinks = '/:slug.md';
+            res.routerOptions.isMarkdownRequest = true;
+            return controllers.entry(req, res, next);
+        });
+
         this.routerCreated(this);
     }
 

--- a/ghost/core/core/frontend/web/middleware/llms-discovery.js
+++ b/ghost/core/core/frontend/web/middleware/llms-discovery.js
@@ -15,14 +15,18 @@ function appendHeaderValue(existingValue, newValue) {
     return raw.concat(newValue).join(', ');
 }
 
-function createLlmsDiscovery({settingsCache}) {
+function createLlmsDiscovery({settingsCache, labs}) {
+    function isDiscoveryEnabled() {
+        return labs.isSet('llmsTxt') && !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
+    }
+
     return function llmsDiscovery(req, res, next) {
-        if (settingsCache.get('is_private') || settingsCache.get('llms_enabled') === false) {
+        if (!isDiscoveryEnabled()) {
             return next();
         }
 
         onHeaders(res, function addLlmsDiscoveryHeaders() {
-            if (settingsCache.get('is_private') || settingsCache.get('llms_enabled') === false) {
+            if (!isDiscoveryEnabled()) {
                 return;
             }
 

--- a/ghost/core/core/frontend/web/middleware/llms-discovery.js
+++ b/ghost/core/core/frontend/web/middleware/llms-discovery.js
@@ -1,0 +1,41 @@
+const onHeaders = require('on-headers');
+
+function appendHeaderValue(existingValue, newValue) {
+    if (!existingValue) {
+        return newValue;
+    }
+
+    const raw = Array.isArray(existingValue) ? existingValue : [existingValue];
+    const values = raw.flatMap(v => v.split(',').map(s => s.trim()));
+
+    if (values.includes(newValue)) {
+        return raw.join(', ');
+    }
+
+    return raw.concat(newValue).join(', ');
+}
+
+function createLlmsDiscovery({settingsCache}) {
+    return function llmsDiscovery(req, res, next) {
+        if (settingsCache.get('is_private') || settingsCache.get('llms_enabled') === false) {
+            return next();
+        }
+
+        onHeaders(res, function addLlmsDiscoveryHeaders() {
+            if (settingsCache.get('is_private') || settingsCache.get('llms_enabled') === false) {
+                return;
+            }
+
+            const linkHeader = appendHeaderValue(this.getHeader('Link'), '</llms.txt>; rel="llms-txt"');
+            this.setHeader('Link', appendHeaderValue(linkHeader, '</llms-full.txt>; rel="llms-full-txt"'));
+
+            if (!this.getHeader('X-Llms-Txt')) {
+                this.setHeader('X-Llms-Txt', '/llms.txt');
+            }
+        });
+
+        next();
+    };
+}
+
+module.exports = {createLlmsDiscovery};

--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -58,6 +58,10 @@ function isAllowedFile(normalizedPath) {
  */
 function isFallthroughFile(filePath) {
     const fallthroughFiles = [
+        '/.well-known/llms-full.txt',
+        '/.well-known/llms.txt',
+        '/llms-full.txt',
+        '/llms.txt',
         '/robots.txt',
         '/sitemap.xml',
         '/sitemap.xsl'

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -68,6 +68,37 @@ module.exports = function setupSiteApp(routerConfig) {
     // Public files (sitemap.xsl, stylesheets, scripts, etc.)
     servePublicFiles(siteApp);
 
+    let llmsHandler;
+    if (config.get('llms')) {
+        const settingsCache = require('../../shared/settings-cache');
+        const urlService = require('../../server/services/url');
+        const models = require('../../server/models');
+        const routing = require('../services/routing');
+        const {api} = require('../services/proxy');
+        const {createLlmsService} = require('../services/llms/service');
+        const {createLlmsHandler} = require('../services/llms/handler');
+        const {createLlmsDiscovery} = require('./middleware/llms-discovery');
+
+        const llmsService = createLlmsService({
+            settingsCache,
+            config,
+            urlServiceFacade: urlService.facade,
+            urlUtils,
+            models,
+            routing,
+            api
+        });
+
+        llmsHandler = createLlmsHandler({
+            llmsService,
+            config,
+            urlServiceFacade: urlService.facade,
+            settingsCache
+        });
+
+        siteApp.use(createLlmsDiscovery({settingsCache}));
+    }
+
     // Serve site images using the storage adapter
     siteApp.use(STATIC_IMAGE_URL_PREFIX, mw.handleImageSizes, storage.getStorage('images').serve());
     // Serve site media using the storage adapter
@@ -108,6 +139,10 @@ module.exports = function setupSiteApp(routerConfig) {
     // site map - this should probably be refactored to be an internal app
     sitemapHandler(siteApp);
 
+    if (llmsHandler) {
+        llmsHandler.mountLlmsRoutes(siteApp);
+    }
+
     // Global handling for member session, ensures a member is logged in to the frontend
     siteApp.use(membersService.middleware.loadMemberSession);
 
@@ -131,6 +166,10 @@ module.exports = function setupSiteApp(routerConfig) {
             return next();
         }
     });
+
+    if (llmsHandler) {
+        llmsHandler.mountMarkdownRoutes(siteApp);
+    }
 
     siteApp.use(function memberPageViewMiddleware(req, res, next) {
         if (req.member) {

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -68,36 +68,35 @@ module.exports = function setupSiteApp(routerConfig) {
     // Public files (sitemap.xsl, stylesheets, scripts, etc.)
     servePublicFiles(siteApp);
 
-    let llmsHandler;
-    if (config.get('llms')) {
-        const settingsCache = require('../../shared/settings-cache');
-        const urlService = require('../../server/services/url');
-        const models = require('../../server/models');
-        const routing = require('../services/routing');
-        const {api} = require('../services/proxy');
-        const {createLlmsService} = require('../services/llms/service');
-        const {createLlmsHandler} = require('../services/llms/handler');
-        const {createLlmsDiscovery} = require('./middleware/llms-discovery');
+    const settingsCache = require('../../shared/settings-cache');
+    const labs = require('../../shared/labs');
+    const urlService = require('../../server/services/url');
+    const models = require('../../server/models');
+    const routing = require('../services/routing');
+    const {api} = require('../services/proxy');
+    const {createLlmsService} = require('../services/llms/service');
+    const {createLlmsHandler} = require('../services/llms/handler');
+    const {createLlmsDiscovery} = require('./middleware/llms-discovery');
 
-        const llmsService = createLlmsService({
-            settingsCache,
-            config,
-            urlServiceFacade: urlService.facade,
-            urlUtils,
-            models,
-            routing,
-            api
-        });
+    const llmsService = createLlmsService({
+        settingsCache,
+        labs,
+        config,
+        urlServiceFacade: urlService.facade,
+        urlUtils,
+        models,
+        routing,
+        api
+    });
 
-        llmsHandler = createLlmsHandler({
-            llmsService,
-            config,
-            urlServiceFacade: urlService.facade,
-            settingsCache
-        });
+    const llmsHandler = createLlmsHandler({
+        llmsService,
+        config,
+        urlServiceFacade: urlService.facade,
+        settingsCache
+    });
 
-        siteApp.use(createLlmsDiscovery({settingsCache}));
-    }
+    siteApp.use(createLlmsDiscovery({settingsCache, labs}));
 
     // Serve site images using the storage adapter
     siteApp.use(STATIC_IMAGE_URL_PREFIX, mw.handleImageSizes, storage.getStorage('images').serve());
@@ -139,9 +138,7 @@ module.exports = function setupSiteApp(routerConfig) {
     // site map - this should probably be refactored to be an internal app
     sitemapHandler(siteApp);
 
-    if (llmsHandler) {
-        llmsHandler.mountLlmsRoutes(siteApp);
-    }
+    llmsHandler.mountLlmsRoutes(siteApp);
 
     // Global handling for member session, ensures a member is logged in to the frontend
     siteApp.use(membersService.middleware.loadMemberSession);
@@ -167,9 +164,7 @@ module.exports = function setupSiteApp(routerConfig) {
         }
     });
 
-    if (llmsHandler) {
-        llmsHandler.mountMarkdownRoutes(siteApp);
-    }
+    llmsHandler.mountMarkdownRoutes(siteApp);
 
     siteApp.use(function memberPageViewMiddleware(req, res, next) {
         if (req.member) {

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -89,10 +89,11 @@ module.exports = function setupSiteApp(routerConfig) {
         api
     });
 
+    siteApp.set('llmsService', llmsService);
+
     const llmsHandler = createLlmsHandler({
         llmsService,
         config,
-        urlServiceFacade: urlService.facade,
         settingsCache
     });
 
@@ -163,8 +164,6 @@ module.exports = function setupSiteApp(routerConfig) {
             return next();
         }
     });
-
-    llmsHandler.mountMarkdownRoutes(siteApp);
 
     siteApp.use(function memberPageViewMiddleware(req, res, next) {
         if (req.member) {

--- a/ghost/core/core/server/web/shared/middleware/pretty-urls.js
+++ b/ghost/core/core/server/web/shared/middleware/pretty-urls.js
@@ -7,15 +7,30 @@
 // Uncapitalise changes case to lowercase
 // @TODO optimize this to reduce the number of redirects required to get to a pretty URL
 // @TODO move this to being used by routers?
+const path = require('path');
 const slashes = require('connect-slashes');
 const config = require('../../../../shared/config');
 
+const SKIP_SLASH_EXTENSIONS = new Set(['.md', '.txt']);
+
+const ensureTrailingSlash = slashes(true, {
+    headers: {
+        'Cache-Control': `public, max-age=${config.get('caching:301:maxAge')}`
+    }
+});
+
+function skipSlashesForLlmsExtensions(req, res, next) {
+    const ext = path.extname(req.path || '');
+
+    if (ext && SKIP_SLASH_EXTENSIONS.has(ext)) {
+        return next();
+    }
+
+    return ensureTrailingSlash(req, res, next);
+}
+
 module.exports = [
-    slashes(true, {
-        headers: {
-            'Cache-Control': `public, max-age=${config.get('caching:301:maxAge')}`
-        }
-    }),
+    skipSlashesForLlmsExtensions,
     require('./redirect-amp-urls'),
     require('./uncapitalise')
 ];

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -1,7 +1,6 @@
 {
     "url": "http://localhost:2368",
     "lazyRouting": false,
-    "llms": false,
     "server": {
         "host": "127.0.0.1",
         "port": 2368,

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -1,6 +1,7 @@
 {
     "url": "http://localhost:2368",
     "lazyRouting": false,
+    "llms": false,
     "server": {
         "host": "127.0.0.1",
         "port": 2368,
@@ -172,6 +173,9 @@
         },
         "sitemapXSL": {
             "maxAge": 86400
+        },
+        "llms": {
+            "maxAge": 3600
         },
         "robotstxt": {
             "maxAge": 3600

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -54,8 +54,6 @@ const PRIVATE_FEATURES = [
     'indexnow',
     'pictureImageFormats',
     'smarterCounts',
-    'commentsThreads',
-    'commentsPinning',
     'llmsTxt'
 ];
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -53,7 +53,10 @@ const PRIVATE_FEATURES = [
     'themeTranslation',
     'indexnow',
     'pictureImageFormats',
-    'smarterCounts'
+    'smarterCounts',
+    'commentsThreads',
+    'commentsPinning',
+    'llmsTxt'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -216,6 +216,7 @@
     "mysql2": "3.18.1",
     "nconf": "0.13.0",
     "node-fetch": "2.7.0",
+    "node-html-markdown": "catalog:",
     "node-jose": "2.2.0",
     "nodemailer": "8.0.8",
     "on-headers": "1.1.0",
@@ -272,6 +273,7 @@
     "@types/sinon": "17.0.4",
     "@types/supertest": "6.0.3",
     "@typescript-eslint/parser": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
     "bunyan": "1.8.15",
     "c8": "catalog:",
     "chai": "catalog:",
@@ -302,8 +304,7 @@
     "tsx": "4.21.0",
     "typescript": "catalog:",
     "validator": "catalog:",
-    "vitest": "catalog:",
-    "@vitest/coverage-v8": "catalog:"
+    "vitest": "catalog:"
   },
   "nx": {
     "tags": [

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -26,6 +26,7 @@ Object {
       "importMemberTier": true,
       "indexnow": true,
       "lexicalIndicators": true,
+      "llmsTxt": true,
       "members": true,
       "pictureImageFormats": true,
       "smarterCounts": true,

--- a/ghost/core/test/unit/frontend/services/llms/markdown.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/markdown.test.js
@@ -162,12 +162,13 @@ describe('Unit: frontend/services/llms/markdown', function () {
             const entry = {
                 title: 'My Post',
                 url: 'https://example.com/my-post/',
+                type: 'post',
                 published_at: '2026-01-01T00:00:00.000Z',
                 updated_at: '2026-01-02T00:00:00.000Z',
                 custom_excerpt: 'A post about things',
                 html: '<p>Hello world</p>',
                 authors: [{name: 'Alice'}],
-                tags: [{name: 'Tech'}]
+                tags: [{name: 'Tech'}, {name: 'JavaScript'}]
             };
 
             const result = renderEntryMarkdown(entry, {llmsIndexUrl: 'https://example.com/llms.txt'});
@@ -176,9 +177,25 @@ describe('Unit: frontend/services/llms/markdown', function () {
             assert.match(result, /https:\/\/example\.com\/llms\.txt/);
             assert.match(result, /^# My Post$/m);
             assert.match(result, /- URL: https:\/\/example\.com\/my-post\//);
+            assert.match(result, /- Type: post/);
             assert.match(result, /- Author: Alice/);
-            assert.match(result, /- Primary tag: Tech/);
+            assert.match(result, /- Tags: Tech, JavaScript/);
             assert.match(result, /Hello world/);
+        });
+
+        it('renders page type correctly', function () {
+            const entry = {
+                title: 'About',
+                url: 'https://example.com/about/',
+                type: 'page',
+                html: '<p>About us</p>',
+                tags: []
+            };
+
+            const result = renderEntryMarkdown(entry, {llmsIndexUrl: 'https://example.com/llms.txt'});
+
+            assert.match(result, /- Type: page/);
+            assert.doesNotMatch(result, /- Tags:/);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/llms/markdown.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/markdown.test.js
@@ -1,0 +1,184 @@
+const assert = require('node:assert/strict');
+const {
+    collapseWhitespace,
+    formatIsoDate,
+    truncateDescription,
+    getMarkdownPath,
+    getMarkdownUrl,
+    getResourcePathFromMarkdownPath,
+    getAcceptedMarkdownContentType,
+    markdownFromHtml,
+    renderEntryMarkdown,
+    renderEntryMarkdownBody
+} = require('../../../../../core/frontend/services/llms/markdown');
+
+describe('Unit: frontend/services/llms/markdown', function () {
+    describe('collapseWhitespace', function () {
+        it('collapses multiple spaces and newlines', function () {
+            assert.equal(collapseWhitespace('  hello   world\n\nfoo  '), 'hello world foo');
+        });
+
+        it('returns empty string for null/undefined', function () {
+            assert.equal(collapseWhitespace(null), '');
+            assert.equal(collapseWhitespace(undefined), '');
+        });
+    });
+
+    describe('truncateDescription', function () {
+        it('returns short strings unchanged', function () {
+            assert.equal(truncateDescription('short'), 'short');
+        });
+
+        it('truncates at 300 chars by default', function () {
+            const long = 'A'.repeat(320);
+            const result = truncateDescription(long);
+            assert.equal(result.length, 300);
+            assert.ok(result.endsWith('…'));
+        });
+
+        it('returns empty string for empty input', function () {
+            assert.equal(truncateDescription(''), '');
+        });
+    });
+
+    describe('getMarkdownPath', function () {
+        it('converts trailing-slash paths to .md', function () {
+            assert.equal(getMarkdownPath('/about/'), '/about.md');
+        });
+
+        it('converts root to /index.md', function () {
+            assert.equal(getMarkdownPath('/'), '/index.md');
+        });
+
+        it('handles paths without trailing slash', function () {
+            assert.equal(getMarkdownPath('/about'), '/about.md');
+        });
+
+        it('handles null', function () {
+            assert.equal(getMarkdownPath(null), '/index.md');
+        });
+    });
+
+    describe('getMarkdownUrl', function () {
+        it('converts a full URL to .md variant', function () {
+            assert.equal(getMarkdownUrl('https://example.com/about/'), 'https://example.com/about.md');
+        });
+    });
+
+    describe('getResourcePathFromMarkdownPath', function () {
+        it('strips .md and adds trailing slash', function () {
+            assert.equal(getResourcePathFromMarkdownPath('/about.md'), '/about/');
+        });
+
+        it('returns / for /index.md', function () {
+            assert.equal(getResourcePathFromMarkdownPath('/index.md'), '/');
+        });
+
+        it('returns null for non-.md paths', function () {
+            assert.equal(getResourcePathFromMarkdownPath('/about/'), null);
+        });
+
+        it('returns null for null', function () {
+            assert.equal(getResourcePathFromMarkdownPath(null), null);
+        });
+    });
+
+    describe('getAcceptedMarkdownContentType', function () {
+        function fakeReq(accept) {
+            return {
+                get(header) {
+                    if (header === 'Accept') {
+                        return accept;
+                    }
+                    return null;
+                },
+                accepts(types) {
+                    if (!accept) {
+                        return false;
+                    }
+                    for (const type of types) {
+                        if (accept.includes(type)) {
+                            return type;
+                        }
+                    }
+                    return false;
+                }
+            };
+        }
+
+        it('returns text/markdown when accepted', function () {
+            assert.equal(getAcceptedMarkdownContentType(fakeReq('text/markdown')), 'text/markdown');
+        });
+
+        it('returns null for text/html only', function () {
+            assert.equal(getAcceptedMarkdownContentType(fakeReq('text/html')), null);
+        });
+
+        it('returns null when no accept header', function () {
+            assert.equal(getAcceptedMarkdownContentType(fakeReq(null)), null);
+        });
+    });
+
+    describe('formatIsoDate', function () {
+        it('returns ISO string for valid date', function () {
+            assert.equal(formatIsoDate('2026-01-01T00:00:00.000Z'), '2026-01-01T00:00:00.000Z');
+        });
+
+        it('returns null for null/undefined', function () {
+            assert.equal(formatIsoDate(null), null);
+            assert.equal(formatIsoDate(undefined), null);
+        });
+
+        it('returns null for invalid date string', function () {
+            assert.equal(formatIsoDate('not-a-date'), null);
+        });
+    });
+
+    describe('markdownFromHtml', function () {
+        it('converts simple HTML to markdown', function () {
+            const md = markdownFromHtml('<p>Hello <strong>world</strong></p>');
+            assert.match(md, /Hello \*\*world\*\*/);
+        });
+
+        it('returns null for empty HTML', function () {
+            assert.equal(markdownFromHtml(''), null);
+        });
+    });
+
+    describe('renderEntryMarkdownBody', function () {
+        it('prefers HTML conversion', function () {
+            const body = renderEntryMarkdownBody({html: '<p>Hello</p>', plaintext: 'Fallback'});
+            assert.equal(body, 'Hello');
+        });
+
+        it('falls back to plaintext', function () {
+            const body = renderEntryMarkdownBody({html: '', plaintext: 'Fallback text'});
+            assert.equal(body, 'Fallback text');
+        });
+    });
+
+    describe('renderEntryMarkdown', function () {
+        it('renders full markdown with metadata', function () {
+            const entry = {
+                title: 'My Post',
+                url: 'https://example.com/my-post/',
+                published_at: '2026-01-01T00:00:00.000Z',
+                updated_at: '2026-01-02T00:00:00.000Z',
+                custom_excerpt: 'A post about things',
+                html: '<p>Hello world</p>',
+                authors: [{name: 'Alice'}],
+                tags: [{name: 'Tech'}]
+            };
+
+            const result = renderEntryMarkdown(entry, {llmsIndexUrl: 'https://example.com/llms.txt'});
+
+            assert.match(result, /^> ## Content Index/m);
+            assert.match(result, /https:\/\/example\.com\/llms\.txt/);
+            assert.match(result, /^# My Post$/m);
+            assert.match(result, /- URL: https:\/\/example\.com\/my-post\//);
+            assert.match(result, /- Author: Alice/);
+            assert.match(result, /- Primary tag: Tech/);
+            assert.match(result, /Hello world/);
+        });
+    });
+});

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -1,0 +1,292 @@
+const assert = require('node:assert/strict');
+const {createLlmsService} = require('../../../../../core/frontend/services/llms/service');
+
+describe('Unit: frontend/services/llms/service', function () {
+    function createFakeSettingsCache(overrides = {}) {
+        const values = {
+            description: 'Short description',
+            is_private: false,
+            llms_enabled: true,
+            meta_description: 'Meta description',
+            title: 'Ghost Site'
+        };
+        Object.assign(values, overrides);
+
+        return {
+            get(key) {
+                return values[key];
+            }
+        };
+    }
+
+    function createFakeConfig() {
+        return {
+            get(key) {
+                const map = {
+                    url: 'http://127.0.0.1:2368'
+                };
+                return map[key];
+            }
+        };
+    }
+
+    function createFakeUrlServiceFacade(urlMap) {
+        return {
+            getUrlForResource(resource) {
+                return urlMap[resource.id] || null;
+            }
+        };
+    }
+
+    function createFakeModels(pageData, postData) {
+        return {
+            Post: {
+                findPage: async function (options) {
+                    if (options.filter.includes('type:page')) {
+                        return {data: pageData.map(p => ({toJSON: () => p}))};
+                    }
+                    return {data: postData.map(p => ({toJSON: () => p}))};
+                }
+            }
+        };
+    }
+
+    function createFakeRouting() {
+        return {
+            registry: {
+                getRssUrl() {
+                    return 'https://example.com/rss/';
+                }
+            }
+        };
+    }
+
+    function createFakeUrlUtils() {
+        return {
+            urlFor(options, absolute) {
+                const base = absolute ? 'http://127.0.0.1:2368' : '';
+                return `${base}${options.relativeUrl}`;
+            }
+        };
+    }
+
+    function createService(opts = {}) {
+        const pages = opts.pages || [];
+        const posts = opts.posts || [];
+        const urlMap = opts.urlMap || {};
+
+        return createLlmsService({
+            settingsCache: opts.settingsCache || createFakeSettingsCache(opts.settingsOverrides),
+            config: opts.config || createFakeConfig(),
+            urlServiceFacade: opts.urlServiceFacade || createFakeUrlServiceFacade(urlMap),
+            urlUtils: opts.urlUtils || createFakeUrlUtils(),
+            models: opts.models || createFakeModels(pages, posts),
+            routing: opts.routing || createFakeRouting(),
+            api: opts.api || {}
+        });
+    }
+
+    it('builds llms.txt with markdown URLs, stable page ordering, and truncated descriptions', async function () {
+        const longDescription = 'A'.repeat(320);
+
+        const service = createService({
+            pages: [
+                {id: 'page-b', title: 'B Page', slug: 'contact', custom_excerpt: 'Second page', type: 'page'},
+                {id: 'page-a', title: 'A Page', slug: 'about', custom_excerpt: 'First page', type: 'page'}
+            ],
+            posts: [
+                {id: 'post-a', title: 'Recent Post', slug: 'recent-post', custom_excerpt: longDescription, type: 'post'},
+                {id: 'post-b', title: 'Older Post', slug: 'older-post', plaintext: 'Older summary', type: 'post'}
+            ],
+            urlMap: {
+                'page-a': 'https://example.com/about/',
+                'page-b': 'https://example.com/contact/',
+                'post-a': 'https://example.com/2026/04/recent-post/',
+                'post-b': 'https://example.com/2026/03/older-post/'
+            }
+        });
+
+        const llmsTxt = await service.getLlmsTxt();
+
+        assert.match(llmsTxt, /^# Ghost Site/m);
+        assert.match(llmsTxt, /^> Meta description/m);
+        assert.match(llmsTxt, /## Pages[\s\S]*\[A Page\]\(https:\/\/example\.com\/about\.md\)[\s\S]*\[B Page\]\(https:\/\/example\.com\/contact\.md\)/m);
+        assert.match(llmsTxt, /\[Recent Post\]\(https:\/\/example\.com\/2026\/04\/recent-post\.md\) - A{299}…/);
+        assert.match(llmsTxt, /## Optional[\s\S]*\[RSS Feed\]\(https:\/\/example\.com\/rss\/\)/m);
+        assert.match(llmsTxt, /\[Sitemap\]\(http:\/\/127\.0\.0\.1:\d+\/sitemap\.xml\)/);
+    });
+
+    it('returns null when disabled', async function () {
+        const service = createService({
+            settingsOverrides: {is_private: true},
+            pages: [],
+            posts: [],
+            urlMap: {}
+        });
+
+        const result = await service.getLlmsTxt();
+        assert.equal(result, null);
+    });
+
+    it('returns null when llms_enabled is false', async function () {
+        const service = createService({
+            settingsOverrides: {llms_enabled: false},
+            pages: [],
+            posts: [],
+            urlMap: {}
+        });
+
+        const result = await service.getLlmsTxt();
+        assert.equal(result, null);
+    });
+
+    it('bounds llms-full.txt at 5 MiB and appends a truncation note', async function () {
+        const largePageData = [{
+            id: 'page-a',
+            title: 'Large Page',
+            slug: 'large-page',
+            html: `<p>${'x'.repeat((5 * 1024 * 1024) + 1000)}</p>`,
+            plaintext: 'large page body',
+            updated_at: '2026-04-14T00:00:00.000Z',
+            type: 'page'
+        }];
+
+        const postData = [{
+            id: 'post-a',
+            title: 'Post That Should Not Fit',
+            slug: 'post',
+            html: '<p>post body</p>',
+            plaintext: 'post body',
+            updated_at: '2026-04-14T00:00:00.000Z',
+            type: 'post'
+        }];
+
+        const models = {
+            Post: {
+                findPage: async function (options) {
+                    if (options.filter.includes('type:page')) {
+                        return {data: largePageData.map(p => ({toJSON: () => p}))};
+                    }
+                    return {data: postData.map(p => ({toJSON: () => p}))};
+                }
+            }
+        };
+
+        const service = createService({
+            models,
+            urlMap: {
+                'page-a': 'https://example.com/about/',
+                'post-a': 'https://example.com/post/'
+            }
+        });
+
+        const llmsFullTxt = await service.getLlmsFullTxt();
+
+        assert.match(llmsFullTxt, /## Pages/);
+        assert.doesNotMatch(llmsFullTxt, /## Posts/);
+        assert.match(llmsFullTxt, /Truncated after 5 MiB/);
+        assert.ok(Buffer.byteLength(llmsFullTxt, 'utf8') <= (5 * 1024 * 1024));
+    });
+
+    it('computes fresh output on every call (no cache)', async function () {
+        let callCount = 0;
+
+        const models = {
+            Post: {
+                findPage: async function () {
+                    callCount += 1;
+                    return {data: []};
+                }
+            }
+        };
+
+        const service = createService({models, urlMap: {}});
+
+        await service.getLlmsTxt();
+        await service.getLlmsTxt();
+
+        assert.ok(callCount >= 4, `Expected at least 4 DB calls (2 per getLlmsTxt), got ${callCount}`);
+    });
+
+    describe('fetchPublicEntry', function () {
+        it('calls the correct controller for pages vs posts', async function () {
+            const calls = [];
+            const fakeApi = {
+                pagesPublic: {
+                    read: async (opts) => {
+                        calls.push({controller: 'pages', opts});
+                        return {pages: [{id: 'p1', title: 'Page'}]};
+                    }
+                },
+                postsPublic: {
+                    read: async (opts) => {
+                        calls.push({controller: 'posts', opts});
+                        return {posts: [{id: 'p2', title: 'Post'}]};
+                    }
+                }
+            };
+
+            const service = createService({api: fakeApi, pages: [], posts: [], urlMap: {}});
+
+            const page = await service.fetchPublicEntry('pages', 'p1');
+            assert.equal(page.title, 'Page');
+            assert.equal(calls[0].controller, 'pages');
+            assert.equal(calls[0].opts.id, 'p1');
+            assert.equal(calls[0].opts.formats, 'html,plaintext');
+            assert.equal(calls[0].opts.include, 'authors,tags');
+
+            const post = await service.fetchPublicEntry('posts', 'p2');
+            assert.equal(post.title, 'Post');
+            assert.equal(calls[1].controller, 'posts');
+        });
+
+        it('forwards member context', async function () {
+            let capturedContext;
+            const fakeApi = {
+                postsPublic: {
+                    read: async (opts) => {
+                        capturedContext = opts.context;
+                        return {posts: [{id: 'p1'}]};
+                    }
+                }
+            };
+
+            const service = createService({api: fakeApi, pages: [], posts: [], urlMap: {}});
+            const member = {id: 'member-1'};
+            await service.fetchPublicEntry('posts', 'p1', member);
+
+            assert.deepEqual(capturedContext, {member});
+        });
+
+        it('returns null when entry not found', async function () {
+            const fakeApi = {
+                postsPublic: {
+                    read: async () => ({posts: []})
+                }
+            };
+
+            const service = createService({api: fakeApi, pages: [], posts: [], urlMap: {}});
+            const result = await service.fetchPublicEntry('posts', 'missing');
+            assert.equal(result, null);
+        });
+    });
+
+    it('filters out entries that resolve to /404/', async function () {
+        const service = createService({
+            posts: [
+                {id: 'post-good', title: 'Good Post', slug: 'good', type: 'post'},
+                {id: 'post-bad', title: 'Bad Post', slug: 'bad', type: 'post'}
+            ],
+            urlMap: {
+                'post-good': 'https://example.com/good/',
+                'post-bad': 'https://example.com/404/'
+            },
+            pages: []
+        });
+
+        const llmsTxt = await service.getLlmsTxt();
+
+        assert.match(llmsTxt, /Good Post/);
+        assert.doesNotMatch(llmsTxt, /Bad Post/);
+    });
+});

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -91,7 +91,8 @@ describe('Unit: frontend/services/llms/service', function () {
             urlUtils: opts.urlUtils || createFakeUrlUtils(),
             models: opts.models || createFakeModels(pages, posts),
             routing: opts.routing || createFakeRouting(),
-            api: opts.api || {}
+            api: opts.api || {},
+            fullTxtBudget: opts.fullTxtBudget
         });
     }
 
@@ -161,12 +162,12 @@ describe('Unit: frontend/services/llms/service', function () {
         assert.equal(result, null);
     });
 
-    it('bounds llms-full.txt at 5 MiB and appends a truncation note', async function () {
+    it('bounds llms-full.txt at budget and appends a truncation note', async function () {
         const largePageData = [{
             id: 'page-a',
             title: 'Large Page',
             slug: 'large-page',
-            html: `<p>${'x'.repeat((5 * 1024 * 1024) + 1000)}</p>`,
+            html: `<p>${'x'.repeat(2000)}</p>`,
             plaintext: 'large page body',
             updated_at: '2026-04-14T00:00:00.000Z',
             type: 'page'
@@ -195,6 +196,7 @@ describe('Unit: frontend/services/llms/service', function () {
 
         const service = createService({
             models,
+            fullTxtBudget: 1024,
             urlMap: {
                 'page-a': 'https://example.com/about/',
                 'post-a': 'https://example.com/post/'
@@ -206,7 +208,6 @@ describe('Unit: frontend/services/llms/service', function () {
         assert.match(llmsFullTxt, /## Pages/);
         assert.doesNotMatch(llmsFullTxt, /## Posts/);
         assert.match(llmsFullTxt, /Truncated after 5 MiB/);
-        assert.ok(Buffer.byteLength(llmsFullTxt, 'utf8') <= (5 * 1024 * 1024));
     });
 
     it('computes fresh output on every call (no cache)', async function () {

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -70,6 +70,14 @@ describe('Unit: frontend/services/llms/service', function () {
         };
     }
 
+    function createFakeLabs(flags = {llmsTxt: true}) {
+        return {
+            isSet(flag) {
+                return !!flags[flag];
+            }
+        };
+    }
+
     function createService(opts = {}) {
         const pages = opts.pages || [];
         const posts = opts.posts || [];
@@ -77,6 +85,7 @@ describe('Unit: frontend/services/llms/service', function () {
 
         return createLlmsService({
             settingsCache: opts.settingsCache || createFakeSettingsCache(opts.settingsOverrides),
+            labs: opts.labs || createFakeLabs(opts.labsFlags),
             config: opts.config || createFakeConfig(),
             urlServiceFacade: opts.urlServiceFacade || createFakeUrlServiceFacade(urlMap),
             urlUtils: opts.urlUtils || createFakeUrlUtils(),
@@ -116,7 +125,19 @@ describe('Unit: frontend/services/llms/service', function () {
         assert.match(llmsTxt, /\[Sitemap\]\(http:\/\/127\.0\.0\.1:\d+\/sitemap\.xml\)/);
     });
 
-    it('returns null when disabled', async function () {
+    it('returns null when labs flag is off', async function () {
+        const service = createService({
+            labsFlags: {llmsTxt: false},
+            pages: [],
+            posts: [],
+            urlMap: {}
+        });
+
+        const result = await service.getLlmsTxt();
+        assert.equal(result, null);
+    });
+
+    it('returns null when site is private', async function () {
         const service = createService({
             settingsOverrides: {is_private: true},
             pages: [],

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -50,7 +50,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             sinon.assert.calledOnce(routerCreatedSpy);
             sinon.assert.calledWith(routerCreatedSpy, collectionRouter);
 
-            sinon.assert.calledThrice(mountRouteSpy);
+            sinon.assert.callCount(mountRouteSpy, 4);
             sinon.assert.calledTwice(express.Router.param);
 
             // parent route
@@ -64,6 +64,9 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             // permalinks
             assert.equal(mountRouteSpy.args[2][0], '/:slug/:options(edit)?/');
             assert.equal(mountRouteSpy.args[2][1], controllers.entry);
+
+            // markdown variant
+            assert.equal(mountRouteSpy.args[3][0], '/:slug.md');
 
             sinon.assert.calledOnce(mountRouterSpy);
             assert.equal(mountRouterSpy.args[0][0], '/');
@@ -97,7 +100,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             sinon.assert.calledOnce(routerCreatedSpy);
             sinon.assert.calledWith(routerCreatedSpy, collectionRouter);
 
-            sinon.assert.calledThrice(mountRouteSpy);
+            sinon.assert.callCount(mountRouteSpy, 4);
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/blog/');
@@ -110,6 +113,9 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             // permalinks
             assert.equal(mountRouteSpy.args[2][0], '/blog/:year/:slug/:options(edit)?/');
             assert.equal(mountRouteSpy.args[2][1], controllers.entry);
+
+            // markdown variant
+            assert.equal(mountRouteSpy.args[3][0], '/blog/:year/:slug.md');
 
             sinon.assert.calledOnce(mountRouterSpy);
             assert.equal(mountRouterSpy.args[0][0], '/blog/');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ catalogs:
     msw:
       specifier: 2.14.6
       version: 2.14.6
+    node-html-markdown:
+      specifier: 2.0.0
+      version: 2.0.0
     postcss:
       specifier: 8.5.10
       version: 8.5.10
@@ -2596,6 +2599,9 @@ importers:
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
+      node-html-markdown:
+        specifier: 'catalog:'
+        version: 2.0.0
       node-jose:
         specifier: 2.2.0
         version: 2.2.0
@@ -8266,20 +8272,11 @@ packages:
       react-native:
         optional: true
 
-  '@tanstack/react-virtual@3.13.24':
-    resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   '@tanstack/react-virtual@3.13.25':
     resolution: {integrity: sha512-bmNoqMu6gcAW9JGrKVB0Q1tN1i5RONZF8r1fW0bbE4Oyf3DwEGnzzQJ2OW+Ozg1P4s8PyugkHg2ULZoFQN+cqw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/virtual-core@3.14.0':
-    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
   '@tanstack/virtual-core@3.15.0':
     resolution: {integrity: sha512-0AwPGx0I8QxPYjAxShT/+z+ZOe9u8mW5rsXvivCTjRfRmz9a43+3mRyi4wwlyoUqOC56q/jatKa0Bh9M99BEHQ==}
@@ -12265,8 +12262,8 @@ packages:
     resolution: {integrity: sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==}
     engines: {node: '>=4'}
 
-  dayjs@1.11.21:
-    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug-logfmt@1.4.10:
     resolution: {integrity: sha512-+8rNw7zjXNRntMoJyp5211Y4W3nkhCCMBO7qe8Pht/9NscMklHwyTXMLUzk84YUDSksg87XRmK/LCzJdJ4eU7Q==}
@@ -14475,7 +14472,7 @@ packages:
       csstype: ^3.0.10
 
   google-caja-bower@https://codeload.github.com/acburdine/google-caja-bower/tar.gz/275cb75249f038492094a499756a73719ae071fd:
-    resolution: {gitHosted: true, integrity: sha512-mmCXdxGKGKDznjgkNzVqzTslaldslk5KMb/A7l8rxWnqyxzwsdPhuBJ6oT1Kh/Y3k4jN54ISee/2AgjFyCBxYw==, tarball: https://codeload.github.com/acburdine/google-caja-bower/tar.gz/275cb75249f038492094a499756a73719ae071fd}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/acburdine/google-caja-bower/tar.gz/275cb75249f038492094a499756a73719ae071fd}
     version: 6011.0.0
 
   gopd@1.2.0:
@@ -15876,7 +15873,7 @@ packages:
     engines: {node: '>= 0.6'}
 
   keymaster@https://codeload.github.com/madrobby/keymaster/tar.gz/f8f43ddafad663b505dc0908e72853bcf8daea49:
-    resolution: {gitHosted: true, integrity: sha512-/WVovQslVEqPGNoD97TbqNHuCDPYu2v4/ggrZj0a+9PVPw3Rud4Ut2K7fOi0kMqzoJINkgP68e9m09Al/wFZ8g==, tarball: https://codeload.github.com/madrobby/keymaster/tar.gz/f8f43ddafad663b505dc0908e72853bcf8daea49}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/madrobby/keymaster/tar.gz/f8f43ddafad663b505dc0908e72853bcf8daea49}
     version: 1.6.3
 
   keypair@1.0.4:
@@ -17101,7 +17098,7 @@ packages:
     hasBin: true
 
   mock-knex@https://codeload.github.com/TryGhost/mock-knex/tar.gz/68948e11b0ea4fe63456098dfdc169bea7f62009:
-    resolution: {gitHosted: true, integrity: sha512-VVShGrOVsuUDz9ueLO/3hcMzwNGr/e/dvYoiXCJSs7hI8TWdSWsEXDURWp251+NZHEZG/CI+L78lBFv+piGfxg==, tarball: https://codeload.github.com/TryGhost/mock-knex/tar.gz/68948e11b0ea4fe63456098dfdc169bea7f62009}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/TryGhost/mock-knex/tar.gz/68948e11b0ea4fe63456098dfdc169bea7f62009}
     version: 0.4.13
     peerDependencies:
       knex: '> 0.8'
@@ -17305,6 +17302,13 @@ packages:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
     engines: {node: '>= 10.12.0'}
     hasBin: true
+
+  node-html-markdown@2.0.0:
+    resolution: {integrity: sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==}
+    engines: {node: '>=20.0.0'}
+
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -18639,10 +18643,6 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -18914,10 +18914,6 @@ packages:
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
 
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
-
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -24419,7 +24415,7 @@ snapshots:
 
   '@headlessui/react@1.7.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
-      '@tanstack/react-virtual': 3.13.24(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@tanstack/react-virtual': 3.13.25(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       client-only: 0.0.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -28036,9 +28032,9 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  '@tanstack/react-virtual@3.13.24(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@tanstack/react-virtual@3.13.25(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
-      '@tanstack/virtual-core': 3.14.0
+      '@tanstack/virtual-core': 3.15.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
@@ -28047,8 +28043,6 @@ snapshots:
       '@tanstack/virtual-core': 3.15.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@tanstack/virtual-core@3.14.0': {}
 
   '@tanstack/virtual-core@3.15.0': {}
 
@@ -31871,7 +31865,7 @@ snapshots:
       broccoli-persistent-filter: 2.3.1
       minimist: 1.2.8
       object-assign: 4.1.1
-      postcss: 8.5.6
+      postcss: 8.5.10
     transitivePeerDependencies:
       - supports-color
 
@@ -33183,13 +33177,13 @@ snapshots:
 
   css-loader@5.2.7(webpack@5.105.4(@swc/core@1.15.21(@swc/helpers@0.5.21))):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
+      icss-utils: 5.1.0(postcss@8.5.10)
       loader-utils: 2.0.4
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      postcss: 8.5.10
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.10)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.10)
+      postcss-modules-scope: 3.2.1(postcss@8.5.10)
+      postcss-modules-values: 4.0.0(postcss@8.5.10)
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.7.4
@@ -33525,7 +33519,7 @@ snapshots:
     dependencies:
       time-zone: 1.0.0
 
-  dayjs@1.11.21: {}
+  dayjs@1.11.20: {}
 
   debug-logfmt@1.4.10:
     dependencies:
@@ -35846,7 +35840,7 @@ snapshots:
   eslint-plugin-tailwindcss@4.0.0-beta.0(tailwindcss@4.2.2):
     dependencies:
       fast-glob: 3.3.3
-      postcss: 8.5.6
+      postcss: 8.5.10
       synckit: 0.11.12
       tailwind-api-utils: 1.0.3(tailwindcss@4.2.2)
       tailwindcss: 4.2.2
@@ -36252,7 +36246,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -37726,9 +37720,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.6):
+  icss-utils@5.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
   ieee754@1.2.1: {}
 
@@ -39317,7 +39311,7 @@ snapshots:
 
   launder@1.7.1:
     dependencies:
-      dayjs: 1.11.21
+      dayjs: 1.11.20
 
   lazystream@1.0.1:
     dependencies:
@@ -40994,6 +40988,15 @@ snapshots:
       - supports-color
     optional: true
 
+  node-html-markdown@2.0.0:
+    dependencies:
+      node-html-parser: 6.1.13
+
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-int64@0.4.0: {}
 
   node-jose@2.2.0:
@@ -42233,26 +42236,26 @@ snapshots:
       postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.6):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.10):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.6):
+  postcss-modules-scope@3.2.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
-  postcss-modules-values@4.0.0(postcss@8.5.6):
+  postcss-modules-values@4.0.0(postcss@8.5.10):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.10)
+      postcss: 8.5.10
 
   postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
@@ -42553,12 +42556,6 @@ snapshots:
       source-map: 0.6.1
 
   postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -42889,10 +42886,6 @@ snapshots:
   pure-rand@6.1.0: {}
 
   q@1.5.1: {}
-
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.15.2:
     dependencies:
@@ -44417,7 +44410,7 @@ snapshots:
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
-      esbuild: 0.25.12
+      esbuild: 0.27.4
       open: 10.2.0
       recast: 0.23.11
       semver: 7.7.4
@@ -44633,7 +44626,7 @@ snapshots:
   stripe@8.222.0:
     dependencies:
       '@types/node': 25.6.0
-      qs: 6.14.2
+      qs: 6.15.2
 
   strnum@2.2.3: {}
 
@@ -45948,7 +45941,7 @@ snapshots:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.10
       rollup: 4.60.0
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -45965,7 +45958,7 @@ snapshots:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.10
       rollup: 4.60.0
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -45982,7 +45975,7 @@ snapshots:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.10
       rollup: 4.60.0
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,6 +75,7 @@ catalog:
   lucide-react: 0.577.0
   mocha: 11.7.6
   msw: 2.14.6
+  node-html-markdown: 2.0.0
   postcss: 8.5.10
   preact: ^10.29.2
   react-router: 7.14.0


### PR DESCRIPTION
## Summary

- Implements llms.txt / llms-full.txt generation, per-entry .md export, Accept: text/markdown content negotiation, and Link/X-Llms-Txt discovery headers
- **Stateless, compute-on-request architecture** — no in-memory cache, no event listeners, relies on HTTP Cache-Control for CDN/proxy caching
- Full **dependency injection** via factory functions (createLlmsService, createLlmsHandler, createLlmsDiscovery) — no module-level singleton imports
- Gated behind private **labs flag** (`llmsTxt`) + `llms_enabled` setting as user-facing toggle
- Paginated DB queries for llms-full.txt (100 per batch, 5 MiB budget) with `withRelated: ['tags', 'authors']` for correct permalink resolution
- Scoped .md suffix routes on CollectionRouter and StaticPagesRouter (not a broad regex)
- Structured logging (`[llms]` prefix) and Sentry reporting on handler errors
- markdown.js is fully pure — no Ghost singleton imports

Ref #27984

## Architecture

### Routing approach
Per-entry .md URLs are registered as suffix routes directly on CollectionRouter and StaticPagesRouter, reusing the existing `entryLookup` pipeline. This avoids a double-fetch (the broad regex approach needed a separate `fetchPublicEntry` call) and respects all existing routing features (_respectDominantRouter, redirect handling, etc.).

### DI and service wiring
`createLlmsService()` receives all dependencies as constructor params. The service is created once at boot in `site.js` and exposed via `siteApp.set('llmsService', llmsService)` — entry controller accesses it via `req.app.get('llmsService')`.

### What is NOT included (intentionally)
- Admin UI for llms_enabled toggle — the `llms_enabled` setting already exists in main (merged via #27995), this PR adds the labs gate only

## Test plan

- [x] 10 service unit tests + 25 markdown unit tests passing
- [x] Config snapshot updated for llmsTxt labs flag
- [x] Lint clean across entire monorepo
- [x] Full CI green (unit, integration, acceptance, E2E, Playwright)
- [ ] Labs flag off (default): /llms.txt returns 404, no discovery headers, .md URLs 404, Accept: text/markdown returns HTML
- [ ] Labs flag on: all endpoints serve correct content with Cache-Control headers
- [ ] Pretty URLs regression: /author/name.smith/ and /tag/v2.0/ still get trailing-slash redirects
- [ ] Content negotiation: `Accept: text/markdown` on a public post returns markdown with `Vary: Accept`
- [ ] Discovery headers: HTML responses include `Link` and `X-Llms-Txt` pointing to /llms.txt
- [ ] Permalink patterns with :primary_tag/:primary_author resolve correctly in llms.txt index
