### PR TITLE
Fixed broken pnpm-lock.yaml after Tailwind catalog move

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.6.0)(typescript@5.9.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.6.0)(typescript@5.9.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/activitypub:
     dependencies:


### PR DESCRIPTION
## Problem

CI is failing on `main` at the `pnpm install --frozen-lockfile` step — before any test runs:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY
Broken lockfile: no entry for 'vitest@4.1.5(...)(lightningcss@1.31.1)...' in pnpm-lock.yaml
```

## Cause

The Tailwind catalog move (`ee123bbc08`) regenerated `pnpm-lock.yaml`, and the resolution picked up a transitive `lightningcss` bump (`1.31.1` → `1.32.0`) as a side effect. The rewrite was incomplete: all 123 package snapshots were rewritten to `lightningcss@1.32.0`, but the **root importer's `vitest` devDependency** kept the stale `1.31.1` peer hash in its resolved `version:` string.

That left the lockfile internally inconsistent — `--frozen-lockfile` can't find a snapshot keyed by the stale `1.31.1` variant and aborts, so every CI run on `main` fails at install.

This is unrelated to the in-flight Mocha → Vitest unit test migration; the install step never gets far enough to run tests.

## Fix

Update the one straggler line so the root importer's `vitest` entry references `lightningcss@1.32.0`, matching every package snapshot.

## Verification

`pnpm install --frozen-lockfile --ignore-scripts` (the exact CI command) now passes:

```
Lockfile is up to date, resolution step is skipped
Already up to date
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)