### PR TITLE
Added warning when leaving automation editor with unsaved edits

### DIFF
--- a/apps/admin-x-framework/src/hooks.ts
+++ b/apps/admin-x-framework/src/hooks.ts
@@ -1,4 +1,5 @@
 export {default as useFilterableApi} from './hooks/use-filterable-api';
+export {useConfirmUnload} from './hooks/use-confirm-unload';
 export {default as useForm} from './hooks/use-form';
 export type {Dirtyable, ErrorMessages, FormHook, OkProps, SaveHandler, SaveState} from './hooks/use-form';
 export {default as useHandleError} from './hooks/use-handle-error';

--- a/apps/admin-x-framework/src/hooks/use-confirm-unload.ts
+++ b/apps/admin-x-framework/src/hooks/use-confirm-unload.ts
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+export function useConfirmUnload(shouldConfirmUnload: boolean): void {
+    React.useEffect(() => {
+        if (!shouldConfirmUnload) {
+            return;
+        }
+
+        const handleBeforeUnload = (event: BeforeUnloadEvent): void => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+        };
+    }, [shouldConfirmUnload]);
+}

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -8,6 +8,7 @@ export {AppContext, AppProvider, useAppContext} from './providers/app-provider';
 
 // Hooks
 export {useActiveVisitors} from './hooks/use-active-visitors';
+export {useConfirmUnload} from './hooks/use-confirm-unload';
 export {default as useForm} from './hooks/use-form';
 export type {Dirtyable, ErrorMessages, FormHook, OkProps, SaveHandler, SaveState} from './hooks/use-form';
 export {default as useHandleError} from './hooks/use-handle-error';

--- a/apps/admin-x-framework/test/unit/hooks/use-confirm-unload.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-confirm-unload.test.ts
@@ -1,0 +1,75 @@
+import {renderHook} from '@testing-library/react';
+import {useConfirmUnload} from '../../../src/hooks/use-confirm-unload';
+
+const runListener = (listener: null | EventListenerOrEventListenerObject, event: any) => {
+    if (typeof listener === 'function') {
+        listener(event);
+    } else if (listener) {
+        listener.handleEvent(event);
+    }
+};
+
+describe('useConfirmUnload', () => {
+    let listener: null | EventListenerOrEventListenerObject = null;
+
+    beforeEach(() => {
+        listener = null;
+
+        vi.spyOn(window, 'addEventListener').mockImplementation((type, newListener) => {
+            expect(type, 'test only supports beforeunload').toBe('beforeunload');
+            expect(listener, 'multiple listeners should not be added').toBe(null);
+            listener = newListener;
+        });
+
+        vi.spyOn(window, 'removeEventListener').mockImplementation((type, listenerToRemove) => {
+            expect(type, 'test only supports beforeunload').toBe('beforeunload');
+            expect(listenerToRemove, 'removing the wrong listener').toBe(listener);
+            listener = null;
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('does not add a beforeunload handler when confirmation is disabled', () => {
+        renderHook(() => useConfirmUnload(false));
+
+        expect(listener).toBeNull();
+    });
+
+    it('adds a beforeunload handler that discourages navigation when confirmation is enabled', () => {
+        renderHook(() => useConfirmUnload(true));
+
+        expect(listener).not.toBeNull();
+
+        const event = {
+            preventDefault: vi.fn(),
+            returnValue: undefined
+        };
+        runListener(listener, event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.returnValue).toBe('');
+    });
+
+    it('removes the beforeunload handler when confirmation is disabled after being enabled', () => {
+        const {rerender} = renderHook(({shouldConfirmUnload}) => useConfirmUnload(shouldConfirmUnload), {
+            initialProps: {shouldConfirmUnload: true}
+        });
+        expect(listener, 'test setup').not.toBeNull();
+
+        rerender({shouldConfirmUnload: false});
+
+        expect(listener).toBeNull();
+    });
+
+    it('removes the beforeunload handler on unmount', () => {
+        const {unmount} = renderHook(() => useConfirmUnload(true));
+        expect(listener, 'test setup').not.toBeNull();
+
+        unmount();
+
+        expect(listener).toBeNull();
+    });
+});

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, type ButtonProps, LoadingIndicator} from '@tryghost/shade/components';
 import {AutomationDetail, AutomationStatus, useEditAutomation, useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
 import {dequal} from 'dequal';
-import {useParams} from '@tryghost/admin-x-framework';
+import {useConfirmUnload, useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
 
 const editableSlice = (automation: AutomationDetail) => ({
@@ -158,6 +158,8 @@ const AutomationEditor: React.FC = () => {
             }
         });
     };
+
+    useConfirmUnload(isEditRequestActive || hasUnsavedChanges);
 
     return (
         <div className='fixed inset-0 z-50 flex flex-col bg-background' data-testid='automation-editor'>


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1297

https://github.com/user-attachments/assets/26ea9c8d-f529-49ba-a32e-664d1b773bda

Before this change, publishers could leave the automations editor (e.g., by closing the browser tab) when their draft had unsaved changes or when an edit request was active.

Now, they get a browser-level warning message. This is the best we can do to keep them on the page.

(Note that we plan to add in-app confirmation dialogs in other places, such as when you click the in-app back button. This is related but separate.)
