### PR TITLE
Added tsx loading for bree job workers under Vitest

### DIFF
--- a/ghost/core/test/utils/vitest-setup.ts
+++ b/ghost/core/test/utils/vitest-setup.ts
@@ -21,6 +21,27 @@ import {beforeAll, beforeEach, afterEach, afterAll} from 'vitest';
 // resolution. Must run before any Ghost source is required below.
 require('tsx/cjs');
 
+// bree runs "offloaded" jobs in worker threads, which can't see the
+// require('tsx/cjs') hook above (it's registered only in this thread) and so
+// can't require()/import Ghost's .ts server source. A new Worker inherits the
+// process.execArgv snapshot from process *startup* — mutating the live array
+// does not propagate — so we (1) add tsx's loader to execArgv and (2) patch
+// Worker to pass the live execArgv explicitly to every spawned worker.
+if (!process.execArgv.some(arg => arg.includes('tsx'))) {
+    const {pathToFileURL} = require('node:url');
+    process.execArgv.push('--import', pathToFileURL(require.resolve('tsx')).href);
+}
+const workerThreads = require('node:worker_threads');
+if (!workerThreads.Worker.__tsxPatched) {
+    const OriginalWorker = workerThreads.Worker;
+    workerThreads.Worker = class extends OriginalWorker {
+        constructor(filename: string, options: {execArgv?: string[]} = {}) {
+            super(filename, {...options, execArgv: options.execArgv ?? process.execArgv});
+        }
+    };
+    workerThreads.Worker.__tsxPatched = true;
+}
+
 process.env.NODE_ENV = process.env.NODE_ENV || 'testing';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_SECRET';
 


### PR DESCRIPTION
Extends the tsx scoping from the unified watch-mode work (#28038) so **bree job workers** can load Ghost's `.ts` server source under Vitest.

## Background

#28038 scoped tsx to `ghost/core`'s Vitest workers via `require('tsx/cjs')` (instead of a global `NODE_OPTIONS='--import tsx'`, which broke the app projects). That hook is registered only in the test's own thread — it doesn't reach the **worker threads** bree spawns for "offloaded" jobs, so a job worker requiring `.ts` server source fails with `Cannot find module`.

This surfaced in the Phase A spike for the Mocha retirement: `test/integration/jobs/update-check.test.js` failed because the update-check job runs in a bree worker.

## The fix

A `Worker` inherits the `process.execArgv` snapshot taken at process **startup** — mutating the live array does not propagate to spawned workers. So the fix:

1. Adds tsx's loader to `process.execArgv`.
2. Patches `worker_threads.Worker` so every spawned worker is passed the live `execArgv` explicitly.

Both are scoped to `ghost/core`'s Vitest setup file — no effect on the app projects.

## Why now

No current test hits this — no unit test offloads a `.ts`-loading job. But the integration and e2e suites run jobs heavily, so this unblocks migrating them off Mocha.

## Testing

- `test/integration/jobs/update-check.test.js` (which spawns a bree job worker) now passes under Vitest.
- Full `ghost/core` unit suite green — 550 files / 6573 tests — confirming the `Worker` patch causes no regression.
