### PR TITLE
Fixed admin-x-design-system test ESLint config

### DIFF
--- a/apps/admin-x-design-system/.eslintrc.cjs
+++ b/apps/admin-x-design-system/.eslintrc.cjs
@@ -1,6 +1,7 @@
 const tailwindCssConfig = `${__dirname}/../admin/src/index.css`;
 
 module.exports = {
+    root: true,
     extends: [
         'plugin:ghost/ts',
         'plugin:react/recommended',

--- a/apps/admin-x-design-system/test/.eslintrc.cjs
+++ b/apps/admin-x-design-system/test/.eslintrc.cjs
@@ -2,7 +2,7 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     plugins: ['ghost'],
     extends: [
-        'plugin:ghost/test'
+        'plugin:ghost/ts-test'
     ],
     rules: {
         // Enforce kebab-case (lowercase with hyphens) for all filenames

--- a/apps/admin-x-design-system/test/unit/hooks/use-sortable-indexed-list.test.ts
+++ b/apps/admin-x-design-system/test/unit/hooks/use-sortable-indexed-list.test.ts
@@ -29,7 +29,7 @@ describe('useSortableIndexedList', () => {
 
     it('should add a new item', () => {
         let items = initialItems;
-        const setItems = (newItems: any[]) => {
+        const setItems = (newItems: {name: string}[]) => {
             items = newItems;
         };
 
@@ -52,7 +52,7 @@ describe('useSortableIndexedList', () => {
 
     it('should update an item', () => {
         let items = initialItems;
-        const setItems = (newItems: any[]) => {
+        const setItems = (newItems: {name: string}[]) => {
             items = newItems;
         };
 
@@ -74,7 +74,7 @@ describe('useSortableIndexedList', () => {
 
     it('should remove an item', () => {
         let items = initialItems;
-        const setItems = (newItems: any[]) => {
+        const setItems = (newItems: {name: string}[]) => {
             items = newItems;
         };
 
@@ -96,7 +96,7 @@ describe('useSortableIndexedList', () => {
 
     it('should move an item', () => {
         let items = initialItems;
-        const setItems = (newItems: any[]) => {
+        const setItems = (newItems: {name: string}[]) => {
             items = newItems;
         };
 


### PR DESCRIPTION
## Summary

`apps/admin-x-design-system/test/.eslintrc.cjs` extended `plugin:ghost/test` — a JS-era, non-TypeScript-aware config — instead of `plugin:ghost/ts-test`. ESLint silently discards rules whose plugins aren't declared in the local config during the cascade, so the `@typescript-eslint` rules defined in the parent config never ran against the test files. The lint pass kept reporting green, hiding the misconfiguration.

This is the same misconfiguration previously found and fixed in `shade`; `admin-x-design-system` was set up this way during its original extraction and the bug stuck through the later TypeScript migration.

## Changes

- `test/.eslintrc.cjs`: extend `plugin:ghost/ts-test` instead of `plugin:ghost/test`, so the TypeScript-aware ruleset actually applies to the test files.
- `.eslintrc.cjs`: add `root: true` so the config resolution stops at the package boundary rather than cascading up the monorepo.
- Restoring the correct ruleset surfaced 4 pre-existing `@typescript-eslint/no-explicit-any` violations in `test/unit/hooks/use-sortable-indexed-list.test.ts` — the `setItems` callback params were typed `any[]`. Typed them as `{name: string}[]` to match `initialItems`.

## Testing

- `pnpm --filter @tryghost/admin-x-design-system lint` — passes
- `pnpm --filter @tryghost/admin-x-design-system test` — 23/23 pass, `tsc --noEmit` clean