### PR TITLE
Wired up ability to edit automation wait step durations

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -204,6 +204,29 @@ type RemoveActionArgs = ReadonlyDeep<{
     actionId: string;
 }>;
 
+type UpdateWaitActionArgs = ReadonlyDeep<{
+    detail: AutomationDetail;
+    actionId: string;
+    waitHours: number;
+}>;
+
+export const updateWaitAction = ({detail, actionId, waitHours}: UpdateWaitActionArgs): AutomationDetail => {
+    if (!Number.isFinite(waitHours) || !Number.isInteger(waitHours) || waitHours <= 0) {
+        throw new Error(`updateWaitAction: waitHours must be a finite positive integer, received "${waitHours}"`);
+    }
+    const validWaitHours = waitHours;
+    const target = detail.actions.find(action => action.id === actionId);
+    if (!target) {
+        throw new Error(`updateWaitAction: unknown action id "${actionId}"`);
+    }
+    if (target.type !== 'wait') {
+        throw new Error(`updateWaitAction: action "${actionId}" is not a wait action`);
+    }
+    const updated: AutomationWaitAction = {...target, data: {wait_hours: validWaitHours}};
+    const actions = detail.actions.map(action => (action.id === actionId ? updated : action));
+    return {...detail, actions, edges: [...detail.edges]};
+};
+
 export const removeAction = ({detail, actionId}: RemoveActionArgs): AutomationDetail => {
     const remainingActions = detail.actions.filter(action => action.id !== actionId);
 

--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -211,19 +211,32 @@ type UpdateWaitActionArgs = ReadonlyDeep<{
 }>;
 
 export const updateWaitAction = ({detail, actionId, waitHours}: UpdateWaitActionArgs): AutomationDetail => {
-    if (!Number.isFinite(waitHours) || !Number.isInteger(waitHours) || waitHours <= 0) {
-        throw new Error(`updateWaitAction: waitHours must be a finite positive integer, received "${waitHours}"`);
+    if (!Number.isSafeInteger(waitHours) || waitHours <= 0) {
+        throw new Error(`updateWaitAction: waitHours must be a safe positive integer, received "${waitHours}"`);
     }
-    const validWaitHours = waitHours;
-    const target = detail.actions.find(action => action.id === actionId);
-    if (!target) {
+
+    let hasUpdated = false;
+    const actions = detail.actions.map((action) => {
+        if (action.id === actionId) {
+            if (action.type !== 'wait') {
+                throw new Error(`updateWaitAction: action "${actionId}" is not a wait action`);
+            }
+            hasUpdated = true;
+            return {
+                ...action,
+                data: {
+                    ...action.data,
+                    wait_hours: waitHours
+                }
+            };
+        }
+        return action;
+    });
+
+    if (!hasUpdated) {
         throw new Error(`updateWaitAction: unknown action id "${actionId}"`);
     }
-    if (target.type !== 'wait') {
-        throw new Error(`updateWaitAction: action "${actionId}" is not a wait action`);
-    }
-    const updated: AutomationWaitAction = {...target, data: {wait_hours: validWaitHours}};
-    const actions = detail.actions.map(action => (action.id === actionId ? updated : action));
+
     return {...detail, actions, edges: [...detail.edges]};
 };
 

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -6,7 +6,8 @@ import {
     InsertActionAnchor,
     insertSendEmailAction,
     insertWaitAction,
-    removeAction
+    removeAction,
+    updateWaitAction
 } from '../../../src/api/automations';
 
 const baseDetail = (actions: AutomationDetail['actions'], edges: AutomationDetail['edges']): AutomationDetail => ({
@@ -262,6 +263,102 @@ describe('automations api helpers', () => {
             );
 
             expect(() => removeAction({detail, actionId: 'does-not-exist'})).toThrow(/unknown action id "does-not-exist"/);
+        });
+    });
+
+    describe('updateWaitAction', () => {
+        it('updates wait_hours on the targeted wait action', () => {
+            const detail = baseDetail(
+                [
+                    {id: 'a', type: 'wait', data: {wait_hours: 24}},
+                    {id: 'b', type: 'wait', data: {wait_hours: 48}}
+                ],
+                [{source_action_id: 'a', target_action_id: 'b'}]
+            );
+
+            const next = updateWaitAction({detail, actionId: 'a', waitHours: 5});
+
+            expect(next.actions[0]).toEqual({id: 'a', type: 'wait', data: {wait_hours: 5}});
+        });
+
+        it('leaves other actions, edges, and top-level fields untouched', () => {
+            const detail = baseDetail(
+                [
+                    {id: 'a', type: 'wait', data: {wait_hours: 24}},
+                    {id: 'b', type: 'wait', data: {wait_hours: 48}}
+                ],
+                [{source_action_id: 'a', target_action_id: 'b'}]
+            );
+
+            const next = updateWaitAction({detail, actionId: 'a', waitHours: 72});
+
+            expect(next.actions[1]).toBe(detail.actions[1]);
+            expect(next.edges).toEqual(detail.edges);
+            expect(next.id).toBe(detail.id);
+            expect(next.slug).toBe(detail.slug);
+            expect(next.status).toBe(detail.status);
+        });
+
+        it('throws when actionId references a non-existent action', () => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            expect(() => updateWaitAction({detail, actionId: 'does-not-exist', waitHours: 1})).toThrow(/unknown action id "does-not-exist"/);
+        });
+
+        it('throws when the targeted action is not a wait action', () => {
+            const detail = baseDetail(
+                [
+                    {
+                        id: 'a',
+                        type: 'send_email',
+                        data: {
+                            email_subject: 'Hi',
+                            email_lexical: '{}',
+                            email_sender_name: null,
+                            email_sender_email: null,
+                            email_sender_reply_to: null,
+                            email_design_setting_id: 'placeholder'
+                        }
+                    }
+                ],
+                []
+            );
+
+            expect(() => updateWaitAction({detail, actionId: 'a', waitHours: 1})).toThrow(/is not a wait action/);
+        });
+
+        const expectInvalidWaitHoursRejected = (waitHours: number): void => {
+            const detail = baseDetail(
+                [{id: 'a', type: 'wait', data: {wait_hours: 24}}],
+                []
+            );
+
+            expect(() => updateWaitAction({detail, actionId: 'a', waitHours})).toThrow(/waitHours must be a finite positive integer/);
+            expect(detail.actions).toEqual([{id: 'a', type: 'wait', data: {wait_hours: 24}}]);
+            expect(detail.edges).toEqual([]);
+        };
+
+        it('throws when waitHours is zero', () => {
+            expectInvalidWaitHoursRejected(0);
+        });
+
+        it('throws when waitHours is negative', () => {
+            expectInvalidWaitHoursRejected(-1);
+        });
+
+        it('throws when waitHours is fractional', () => {
+            expectInvalidWaitHoursRejected(1.5);
+        });
+
+        it('throws when waitHours is Infinity', () => {
+            expectInvalidWaitHoursRejected(Number.POSITIVE_INFINITY);
+        });
+
+        it('throws when waitHours is NaN', () => {
+            expectInvalidWaitHoursRejected(Number.NaN);
         });
     });
 });

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -336,7 +336,7 @@ describe('automations api helpers', () => {
                 []
             );
 
-            expect(() => updateWaitAction({detail, actionId: 'a', waitHours})).toThrow(/waitHours must be a finite positive integer/);
+            expect(() => updateWaitAction({detail, actionId: 'a', waitHours})).toThrow(/waitHours must be a safe positive integer/);
             expect(detail.actions).toEqual([{id: 'a', type: 'wait', data: {wait_hours: 24}}]);
             expect(detail.edges).toEqual([]);
         };
@@ -351,6 +351,10 @@ describe('automations api helpers', () => {
 
         it('throws when waitHours is fractional', () => {
             expectInvalidWaitHoursRejected(1.5);
+        });
+
+        it('throws when waitHours is out of the double precision range', () => {
+            expectInvalidWaitHoursRejected(Number.MAX_SAFE_INTEGER + 1);
         });
 
         it('throws when waitHours is Infinity', () => {

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -2,10 +2,12 @@ import '@xyflow/react/dist/style.css';
 import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
-import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction} from '@tryghost/admin-x-framework/api/automations';
+import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction, updateWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
 import {Banner, Button, Checkbox, Input, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
+
+const MAX_WAIT_DAYS = 90;
 
 const NODE_X = 0;
 const NODE_WIDTH = 256;
@@ -358,7 +360,9 @@ type TriggerStepSidebarDetail = BaseStepSidebarDetail<'trigger', 'Trigger'> & {
     memberTiers: MemberTier[];
 };
 
-type WaitStepSidebarDetail = ActionStepSidebarDetail<AutomationWaitAction, 'Wait'>;
+type WaitStepSidebarDetail = ActionStepSidebarDetail<AutomationWaitAction, 'Wait'> & {
+    onUpdate: (waitHours: number) => void;
+};
 
 type SendEmailStepSidebarDetail = ActionStepSidebarDetail<AutomationSendEmailAction, 'Send email'>;
 
@@ -374,10 +378,11 @@ const automationSlugMemberTiers: Record<string, MemberTier[]> = {
 type StepSidebarDetailOptions = {
     automation: AutomationDetail;
     onDelete: (actionId: string) => void;
+    onUpdateWait: (actionId: string, waitHours: number) => void;
     stepId: string | null;
 };
 
-const getStepSidebarDetail = ({automation, stepId, onDelete}: StepSidebarDetailOptions): StepSidebarDetail | null => {
+const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait}: StepSidebarDetailOptions): StepSidebarDetail | null => {
     if (!stepId) {
         return null;
     }
@@ -406,6 +411,7 @@ const getStepSidebarDetail = ({automation, stepId, onDelete}: StepSidebarDetailO
             title: waitValue,
             action,
             onDelete: () => onDelete(action.id),
+            onUpdate: (waitHours: number) => onUpdateWait(action.id, waitHours),
             type: 'wait'
         };
     }
@@ -423,13 +429,6 @@ const getStepSidebarDetail = ({automation, stepId, onDelete}: StepSidebarDetailO
         throw new Error(`Unknown automation action type: ${_exhaustive}`);
     }
     }
-};
-
-const getWaitParts = (hours: number): {amount: string; unit: string} => {
-    if (hours % 24 === 0) {
-        return {amount: formatNumber(hours / 24), unit: hours === 24 ? 'Day' : 'Days'};
-    }
-    return {amount: formatNumber(hours), unit: hours === 1 ? 'Hour' : 'Hours'};
 };
 
 const SidebarField: React.FC<{label: string; children: React.ReactNode}> = ({label, children}) => (
@@ -489,16 +488,49 @@ const DeleteStepButton: React.FC<{onClick: () => void}> = ({onClick}) => (
     </Button>
 );
 
-const WaitSidebarBody: React.FC<{action: AutomationWaitAction; onDelete: () => void}> = ({action, onDelete}) => {
-    const wait = getWaitParts(action.data.wait_hours);
+const WaitSidebarBody: React.FC<{
+    action: AutomationWaitAction;
+    onUpdate: (waitHours: number) => void;
+    onDelete: () => void;
+}> = ({action, onUpdate, onDelete}) => {
+    if (action.data.wait_hours % 24 !== 0) {
+        throw new Error(`WaitSidebarBody: wait_hours must be a multiple of 24, received ${action.data.wait_hours}`);
+    }
+    const initialDays = action.data.wait_hours / 24;
+    const [daysText, setDaysText] = useState<string>(String(initialDays));
+
+    const days = Number(daysText);
+    const isValid = daysText.trim() !== '' && Number.isInteger(days) && days >= 1 && days <= MAX_WAIT_DAYS;
+    const unitLabel = days === 1 ? 'Day' : 'Days';
+
+    const handleBlur = () => {
+        if (!isValid) {
+            return;
+        }
+        const nextHours = days * 24;
+        if (nextHours !== action.data.wait_hours) {
+            onUpdate(nextHours);
+        }
+    };
 
     return (
         <div className='flex flex-1 flex-col gap-5'>
             <SidebarField label='Wait for'>
                 <div className='grid grid-cols-[6rem_1fr] gap-2'>
-                    <Input value={wait.amount} readOnly />
-                    <ReadOnlySelect value={wait.unit} />
+                    <Input
+                        aria-invalid={!isValid}
+                        inputMode='numeric'
+                        value={daysText}
+                        onBlur={handleBlur}
+                        onChange={e => setDaysText(e.target.value)}
+                    />
+                    <ReadOnlySelect value={unitLabel} />
                 </div>
+                {!isValid && (
+                    <span className='text-xs text-red'>
+                        Enter a whole number between 1 and {formatNumber(MAX_WAIT_DAYS)} days.
+                    </span>
+                )}
             </SidebarField>
             <div className='mt-auto pt-6'>
                 <DeleteStepButton onClick={onDelete} />
@@ -527,7 +559,7 @@ const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     case 'trigger':
         return <TriggerSidebarBody memberTiers={detail.memberTiers} />;
     case 'wait':
-        return <WaitSidebarBody action={detail.action} onDelete={detail.onDelete} />;
+        return <WaitSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onUpdate={detail.onUpdate} />;
     case 'send_email':
         return <SendEmailSidebarBody action={detail.action} onDelete={detail.onDelete} />;
     default: {
@@ -630,6 +662,13 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         onChange(next);
     }, [automation, onChange]);
 
+    const handleUpdateWait = useCallback((actionId: string, waitHours: number) => {
+        if (!automation) {
+            return;
+        }
+        onChange(updateWaitAction({detail: automation, actionId, waitHours}));
+    }, [automation, onChange]);
+
     const initialViewport = useRef(getInitialViewport(window.innerWidth));
 
     const graph = useMemo(() => {
@@ -648,6 +687,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,
         onDelete: handleDelete,
+        onUpdateWait: handleUpdateWait,
         stepId: selectedStepId
     }) : null;
     const clearDetail = useCallback(() => {

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -7,7 +7,8 @@ import {Background, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@x
 import {Banner, Button, Checkbox, Input, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 
-const MAX_WAIT_DAYS = 90;
+const MAX_WAIT_DAYS = 30;
+const WHOLE_NUMBER_PATTERN = /^\d+$/;
 
 const NODE_X = 0;
 const NODE_WIDTH = 256;
@@ -488,6 +489,14 @@ const DeleteStepButton: React.FC<{onClick: () => void}> = ({onClick}) => (
     </Button>
 );
 
+const getValidWaitDays = (value: string): number | null => {
+    const days = Number(value);
+    if (!WHOLE_NUMBER_PATTERN.test(value) || !Number.isInteger(days) || days < 1 || days > MAX_WAIT_DAYS) {
+        return null;
+    }
+    return days;
+};
+
 const WaitSidebarBody: React.FC<{
     action: AutomationWaitAction;
     onUpdate: (waitHours: number) => void;
@@ -500,17 +509,25 @@ const WaitSidebarBody: React.FC<{
     const [daysText, setDaysText] = useState<string>(String(initialDays));
 
     const days = Number(daysText);
-    const isValid = daysText.trim() !== '' && Number.isInteger(days) && days >= 1 && days <= MAX_WAIT_DAYS;
+    const isValid = getValidWaitDays(daysText) !== null;
     const unitLabel = days === 1 ? 'Day' : 'Days';
 
-    const handleBlur = () => {
-        if (!isValid) {
-            return;
-        }
-        const nextHours = days * 24;
+    const updateWaitDays = (nextDays: number) => {
+        const nextHours = nextDays * 24;
         if (nextHours !== action.data.wait_hours) {
             onUpdate(nextHours);
         }
+    };
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const nextDaysText = event.target.value;
+        setDaysText(nextDaysText);
+
+        const nextDays = getValidWaitDays(nextDaysText);
+        if (nextDays === null) {
+            return;
+        }
+        updateWaitDays(nextDays);
     };
 
     return (
@@ -521,8 +538,7 @@ const WaitSidebarBody: React.FC<{
                         aria-invalid={!isValid}
                         inputMode='numeric'
                         value={daysText}
-                        onBlur={handleBlur}
-                        onChange={e => setDaysText(e.target.value)}
+                        onChange={handleChange}
                     />
                     <ReadOnlySelect value={unitLabel} />
                 </div>

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -266,6 +266,38 @@ describe('AutomationEditor', () => {
         expect(within(sidebar).getByRole('button', {name: 'Delete step'})).toBeEnabled();
     });
 
+    it('resets the wait editor value when switching between wait steps', () => {
+        const fixture: AutomationDetail = {
+            ...automationDetail,
+            actions: [
+                {id: 'action-wait-one-day', type: 'wait', data: {wait_hours: 24}},
+                {id: 'action-wait-three-days', type: 'wait', data: {wait_hours: 72}},
+                automationDetail.actions[1]
+            ],
+            edges: [
+                {source_action_id: 'action-wait-one-day', target_action_id: 'action-wait-three-days'},
+                {source_action_id: 'action-wait-three-days', target_action_id: 'action-email'}
+            ]
+        };
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [fixture]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Wait: 1 day'}));
+        let sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).getByRole('heading', {name: '1 day'})).toBeInTheDocument();
+        expect(within(sidebar).getByDisplayValue('1')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Wait: 3 days'}));
+        sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).getByRole('heading', {name: '3 days'})).toBeInTheDocument();
+        expect(within(sidebar).getByDisplayValue('3')).toBeInTheDocument();
+    });
+
     it('closes the sidebar from a blank canvas click', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [automationDetail]},

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -298,6 +298,52 @@ describe('AutomationEditor', () => {
         expect(within(sidebar).getByDisplayValue('3')).toBeInTheDocument();
     });
 
+    it('updates a wait step as the wait editor value changes', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Wait: 1 day'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        const waitInput = within(sidebar).getByDisplayValue('1');
+
+        fireEvent.change(waitInput, {target: {value: '3'}});
+
+        expect(screen.getByRole('button', {name: 'Wait: 3 days'})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
+
+        const mutateCall = mockEditMutation.mutate.mock.calls.at(-1)![0];
+        expect(mutateCall.actions).toContainEqual({id: 'action-wait', type: 'wait', data: {wait_hours: 72}});
+    });
+
+    it('rejects non-decimal wait editor values', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Wait: 1 day'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        const waitInput = within(sidebar).getByDisplayValue('1');
+
+        for (const value of ['2e1', '+2']) {
+            fireEvent.change(waitInput, {target: {value}});
+
+            expect(waitInput).toHaveAttribute('aria-invalid', 'true');
+            expect(within(sidebar).getByText('Enter a whole number between 1 and 30 days.')).toBeInTheDocument();
+            expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
+        }
+    });
+
     it('closes the sidebar from a blank canvas click', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [automationDetail]},


### PR DESCRIPTION
Closes [NY-1254](https://linear.app/ghost/issue/NY-1254/on-step-click-open-sidebar-with-editdelete-actions)

- allows the user to update the number of days on wait steps
- our data model is `wait_hours` but this just handles days for now

<img width="1539" height="912" alt="edit-wait" src="https://github.com/user-attachments/assets/4791dcf9-21e0-4c91-b1ef-8d34b0d8bb0a" />
