### PR TITLE
Fix legacy Admin API blockquote Lexical rendering

### DIFF
--- a/ghost/core/core/server/lib/lexical.js
+++ b/ghost/core/core/server/lib/lexical.js
@@ -18,6 +18,34 @@ function populateNodes() {
     nodes = DEFAULT_NODES;
 }
 
+function normalizeLegacyLexicalNodeTypes(lexicalState) {
+    if (!lexicalState || typeof lexicalState !== 'object') {
+        return lexicalState;
+    }
+
+    const visitNode = (node) => {
+        if (!node || typeof node !== 'object') {
+            return;
+        }
+
+        if (node.type === 'blockquote') {
+            node.type = 'extended-quote';
+        }
+
+        if (Array.isArray(node.children)) {
+            node.children.forEach(visitNode);
+        }
+    };
+
+    if (lexicalState.root) {
+        visitNode(lexicalState.root);
+    } else {
+        visitNode(lexicalState);
+    }
+
+    return lexicalState;
+}
+
 module.exports = {
     get blankDocument() {
         return {
@@ -80,6 +108,8 @@ module.exports = {
             serializePosts = require('../api/endpoints/utils/serializers/output/posts').all;
         }
 
+        const lexicalState = normalizeLegacyLexicalNodeTypes(typeof lexical === 'string' ? JSON.parse(lexical) : lexical);
+
         const options = Object.assign({
             siteUuid: settingsCache.get('site_uuid'),
             siteUrl: config.get('url'),
@@ -103,7 +133,7 @@ module.exports = {
             nodeRenderers: this.customNodeRenderers
         }, userOptions);
 
-        return await this.lexicalHtmlRenderer.render(lexical, options);
+        return await this.lexicalHtmlRenderer.render(JSON.stringify(lexicalState), options);
     },
 
     get nodes() {

--- a/ghost/core/test/unit/server/lib/lexical.test.js
+++ b/ghost/core/test/unit/server/lib/lexical.test.js
@@ -53,6 +53,41 @@ describe('lib/lexical', function () {
             assert(rendered.includes('<div class="kg-card kg-audio-card">'));
         });
 
+        it('renders blockquote nodes created with the legacy type alias', async function () {
+            const legacyBlockquote = JSON.stringify({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'Legacy blockquote',
+                                    type: 'extended-text',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'blockquote',
+                            version: 1
+                        }
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+
+            const renderedHtml = await lexicalLib.render(legacyBlockquote);
+            assert.equal(renderedHtml, '<blockquote>Legacy blockquote</blockquote>');
+        });
+
         it(`calls custom renderers`, async function () {
             const {JSDOM} = jsdom;
             const dom = new JSDOM();


### PR DESCRIPTION
## Summary
Normalize legacy Lexical `type: "blockquote"` nodes to Ghost's expected `extended-quote` type before HTML rendering. This prevents Admin API content from returning empty `html` when posts are created with the legacy alias.

## Why this change
Ghost's canonical stored Koenig quote node type is `extended-quote`, but some content arrives with `blockquote`. The Lexical HTML renderer ignores the legacy alias, so the rendered HTML can come back empty even when the content is valid.

## What changed
- Added a small normalization step in `ghost/core/core/server/lib/lexical.js` to recursively map `blockquote` -> `extended-quote` before rendering.
- Added a regression test covering legacy `blockquote` input in `ghost/core/test/unit/server/lib/lexical.test.js`.

## Verification
- `node --check ghost/core/core/server/lib/lexical.js`
- `node --check ghost/core/test/unit/server/lib/lexical.test.js`

I could not run the full focused Mocha test in this environment because `mocha` is not installed here (`sh: mocha: command not found`).