### PR TITLE
Pin Node runtime for pnpm installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,16 @@
   "description": "The professional publishing platform",
   "private": true,
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "engines": {
+    "node": "^22.13.1"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "22.18.0",
+      "onFail": "download"
+    }
+  },
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,6 @@
   "engines": {
     "node": "^22.13.1"
   },
-  "devEngines": {
-    "runtime": {
-      "name": "node",
-      "version": "22.18.0",
-      "onFail": "download"
-    }
-  },
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       lint-staged:
         specifier: 16.4.0
         version: 16.4.0
+      node:
+        specifier: runtime:22.18.0
+        version: runtime:22.18.0
       nx:
         specifier: 22.0.4
         version: 22.0.4(@swc/core@1.15.21(@swc/helpers@0.5.21))
@@ -17353,6 +17356,115 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  node@runtime:22.18.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-e7da8wj8n2PlaJaODvDhYAuxBavi0q+ZIXrHLpok/9A=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-LBKRPLpnr3fe2KOZ3z/ZHC5/hijHB52kC7n/M78A38A=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-nIqh5f9XgLOMwRNOImPYTi9DCOuEwCUV468zk2ygLNw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-1BXu6pCi/bYMZt04ayWKy/xNH6RyCo313qc2n7283e4=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-V4MJFFgdw2QOjZU3i3bGkQhg9CUxlZ5OiOtEXgzZgrA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-armv7l.tar.gz
+          targets:
+            - cpu: armv7l
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-OPlly6pecw29Oxr+iVz9uG2pY3FHSCfQXYR9M4oMnJc=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-81eLDnzfJHBF9u63Zv69dJQpVDUhYRAstgQKTUw7TDw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-oucDcl2Gg76Gu12pZ7+CcvRRi9rxDyE4nissnq6ujIo=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-Ajr7PSXEx9EMtuuKZIZcNHtW1LB+ZpBgbQIRMKkZImM=
+            prefix: node-v22.18.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-yV2KfhyZ5mnMCMnxF24GjB9QhHw3kI/LjDW2JII2ZRE=
+            prefix: node-v22.18.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-8uVGNF9ynY6CyCoIjmFudt8UMwxT08/su6tR94PwjPQ=
+            prefix: node-v22.18.0-win-x86
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-x86.zip
+          targets:
+            - cpu: x86
+              os: win32
+    version: 22.18.0
+    hasBin: true
 
   nodemailer-mailgun-transport@2.1.5:
     resolution: {integrity: sha512-hF7POkaxFgMvYEd5aHLaQJI2511ld+aQlQi7JH6bGjhjlZ33cIbTB9PimlIrLu5XC3z76Kde6e65OIwL9lOdTA==}
@@ -41606,6 +41718,8 @@ snapshots:
       which: 2.0.2
 
   node-releases@2.0.36: {}
+
+  node@runtime:22.18.0: {}
 
   nodemailer-mailgun-transport@2.1.5(babel-core@6.26.3)(handlebars@4.7.9)(lodash@4.18.1)(underscore@1.13.8):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,9 +294,6 @@ importers:
       lint-staged:
         specifier: 16.4.0
         version: 16.4.0
-      node:
-        specifier: runtime:22.18.0
-        version: runtime:22.18.0
       nx:
         specifier: 22.0.4
         version: 22.0.4(@swc/core@1.15.21(@swc/helpers@0.5.21))
@@ -17356,115 +17353,6 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
-
-  node@runtime:22.18.0:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-e7da8wj8n2PlaJaODvDhYAuxBavi0q+ZIXrHLpok/9A=
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-aix-ppc64.tar.gz
-          targets:
-            - cpu: ppc64
-              os: aix
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-LBKRPLpnr3fe2KOZ3z/ZHC5/hijHB52kC7n/M78A38A=
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-darwin-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-nIqh5f9XgLOMwRNOImPYTi9DCOuEwCUV468zk2ygLNw=
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-darwin-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-1BXu6pCi/bYMZt04ayWKy/xNH6RyCo313qc2n7283e4=
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-V4MJFFgdw2QOjZU3i3bGkQhg9CUxlZ5OiOtEXgzZgrA=
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-armv7l.tar.gz
-          targets:
-            - cpu: armv7l
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-OPlly6pecw29Oxr+iVz9uG2pY3FHSCfQXYR9M4oMnJc=
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-ppc64le.tar.gz
-          targets:
-            - cpu: ppc64le
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-81eLDnzfJHBF9u63Zv69dJQpVDUhYRAstgQKTUw7TDw=
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-s390x.tar.gz
-          targets:
-            - cpu: s390x
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-oucDcl2Gg76Gu12pZ7+CcvRRi9rxDyE4nissnq6ujIo=
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-Ajr7PSXEx9EMtuuKZIZcNHtW1LB+ZpBgbQIRMKkZImM=
-            prefix: node-v22.18.0-win-arm64
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-arm64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-yV2KfhyZ5mnMCMnxF24GjB9QhHw3kI/LjDW2JII2ZRE=
-            prefix: node-v22.18.0-win-x64
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-8uVGNF9ynY6CyCoIjmFudt8UMwxT08/su6tR94PwjPQ=
-            prefix: node-v22.18.0-win-x86
-            type: binary
-            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-x86.zip
-          targets:
-            - cpu: x86
-              os: win32
-    version: 22.18.0
-    hasBin: true
 
   nodemailer-mailgun-transport@2.1.5:
     resolution: {integrity: sha512-hF7POkaxFgMvYEd5aHLaQJI2511ld+aQlQi7JH6bGjhjlZ33cIbTB9PimlIrLu5XC3z76Kde6e65OIwL9lOdTA==}
@@ -41718,8 +41606,6 @@ snapshots:
       which: 2.0.2
 
   node-releases@2.0.36: {}
-
-  node@runtime:22.18.0: {}
 
   nodemailer-mailgun-transport@2.1.5(babel-core@6.26.3)(handlebars@4.7.9)(lodash@4.18.1)(underscore@1.13.8):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a root `engines.node` range matching Ghost core (`^22.13.1`) so tooling that reads the workspace root can detect that this repo is Node 22-only.
- Keeps the change intentionally narrow: no pnpm `devEngines.runtime` pin and no lockfile metadata changes.
- This is intended to help dependency artifact generation, including Renovate lockfile updates, align with Ghost's Node 22 runtime instead of falling back to Node 24.

## Testing

- [x] `[ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh" && nvm use 22.18.0 >/dev/null && pnpm install --frozen-lockfile --ignore-scripts`
