### PR TITLE
Use per-file isolation for onboarding E2E tests

### DIFF
--- a/e2e/tests/admin/onboarding.test.ts
+++ b/e2e/tests/admin/onboarding.test.ts
@@ -12,8 +12,6 @@ const navigationSteps: Array<[string, RegExp]> = [
     ['build-audience', /\/ghost\/(?:\?[^#]*)?#\/members/]
 ];
 
-test.use({isolation: 'per-test'});
-
 async function getCurrentUser(page: Page) {
     const response = await page.request.get('/ghost/api/admin/users/me/?include=roles');
     expect(response.ok()).toBe(true);


### PR DESCRIPTION
## Summary

- Lets the onboarding E2E file use the default per-file Ghost environment instead of creating a fresh environment for every test.
- Keeps each test responsible for setting its own onboarding preference state before assertions.
- This targets a slow CI file observed at 158.4s in the E2E shard timing audit.

## Testing

- [x] `source "$HOME/.nvm/nvm.sh" && nvm use 22 >/dev/null && pnpm --filter @tryghost/e2e lint`
- [x] `source "$HOME/.nvm/nvm.sh" && nvm use 22 >/dev/null && pnpm --filter @tryghost/e2e test:types`