### PR TITLE
Expanded ghost/core unit test timeouts and retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,18 @@ jobs:
       - name: Run unit tests
         # ghost/core's unit tests run on vitest (see ghost/core/vitest.config.ts);
         # other packages run their own test:unit target.
-        run: pnpm nx run-many -t test:unit -p "${{ needs.job_setup.outputs.affected_projects_str }}"
+        #
+        # Retried up to 3 attempts: ghost/core's vitest run intermittently
+        # crashes a worker on loaded CI runners — an abnormal process exit,
+        # not a reported test failure. nx caches the projects that already
+        # passed, so a retry only re-runs the crashed one. Interim stopgap
+        # until the vitest worker/teardown issue is fixed.
+        run: |
+          for attempt in 1 2 3; do
+            pnpm nx run-many -t test:unit -p "${{ needs.job_setup.outputs.affected_projects_str }}" && exit 0
+            echo "::warning::Unit tests attempt ${attempt} failed — retrying"
+          done
+          exit 1
         env:
           FORCE_COLOR: 0
           NX_SKIP_LOG_GROUPING: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,11 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             pnpm nx run-many -t test:unit -p "${{ needs.job_setup.outputs.affected_projects_str }}" && exit 0
-            echo "::warning::Unit tests attempt ${attempt} failed — retrying"
+            if [ "${attempt}" -lt 3 ]; then
+              echo "::warning::Unit tests attempt ${attempt} failed — retrying"
+            else
+              echo "::error::Unit tests failed after ${attempt} attempts — no more retries"
+            fi
           done
           exit 1
         env:

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -33,13 +33,28 @@ export default defineConfig({
             '__vitest_snapshots__',
             path.basename(testPath) + snapExtension
         ),
-        testTimeout: 2000,
+        // 2000ms was inherited from mocha, where a shared require-cache kept
+        // per-test work cheap. Under vitest's `isolate: true` the first test
+        // in each file pays the cold-import cost of Ghost's server modules,
+        // so 2000ms is too tight on a loaded CI runner — the slowest test is
+        // ~1s locally and can multiply under contention. 5000ms (vitest's
+        // default) removes the timeout-flake class.
+        testTimeout: 5000,
         hookTimeout: 60000,
-        // `dot` keeps local/CI output compact. `github-actions` adds inline
-        // `::error::` annotations for failed tests — without it, CI logs only
-        // show vitest's dot stream, whose failure summary GitHub truncates,
-        // making it impossible to tell which test failed from the logs.
-        reporters: process.env.GITHUB_ACTIONS ? ['dot', 'github-actions'] : ['dot'],
+        // Retry a failed test up to twice (3 attempts total) before
+        // reporting it as failed. The suite is intermittently flaky on
+        // loaded CI runners; this absorbs transient test-level failures
+        // (e.g. a slow test brushing the timeout). It does not help
+        // worker-level crashes — those are retried at the CI step.
+        retry: 2,
+        // Local runs use the compact `dot` reporter. CI uses `default`
+        // instead — `dot` emits only a stream of dots, so when the run dies
+        // the log gives no clue which file was running, whereas `default`
+        // names each file. `github-actions` adds inline `::error::`
+        // annotations for failed tests.
+        reporters: process.env.GITHUB_ACTIONS
+            ? ['default', 'github-actions']
+            : ['dot'],
         coverage: {
             provider: 'v8',
             reporter: ['text-summary', 'html', 'cobertura'],


### PR DESCRIPTION
`ghost/core`'s unit tests fail intermittently on `main` CI. Two distinct things were found:

- The previously-skipped `cache-invalidation` test was a genuine timeout. `testTimeout` was 2000ms — a mocha holdover; under vitest's per-file isolation the cold-import cost makes that too tight on a loaded runner.
- The *remaining* failures are not clean timeouts — vitest's `github-actions` reporter emits no test-level annotation, so the ghost/core vitest process is exiting abnormally (a worker crash), not failing a reported test. It could not be reproduced locally (12/12 clean); it is specific to loaded CI runners.

This is interim stabilization, not the root fix:

- **`testTimeout` 2000ms → 5000ms** — clears the timeout-flake class with no loss of coverage.
- **`retry: 2` in vitest config** — retries a failed test up to twice (3 attempts), absorbing transient test-level failures.
- **CI step retry (up to 3 attempts)** on the "Run unit tests" step — masks the intermittent worker crash; nx caching means a retry only re-runs the crashed project.
- **CI console reporter `dot` → `default`** — `dot` emits only dots, so a crash leaves no clue which file was running; `default` names each file. `github-actions` annotations are kept for clean per-failure reporting.

The worker-crash root cause is expected to be addressed by the upcoming `isolate: false` infrastructure rework, which reworks the same vitest worker/teardown code.