### PR TITLE
🎨 Added warning log for signin attempts on unknown members

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1043,6 +1043,7 @@ module.exports = class RouterController {
         const member = await this._memberRepository.get({email: normalizedEmail});
 
         if (!member) {
+            logging.warn(`[Members] Signin attempted for unknown member (domain: ${normalizedEmail.split('@')[1]})`);
             // Return a fake otcRef when OTC was requested so the response
             // shape is identical regardless of whether a member exists
             return includeOTC ? {otcRef: crypto.randomUUID()} : {};

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -1743,6 +1743,65 @@ describe('RouterController', function () {
         });
     });
 
+    describe('_handleSignin', function () {
+        let logging;
+
+        beforeEach(function () {
+            logging = require('@tryghost/logging');
+            sinon.stub(logging, 'warn');
+        });
+
+        const createController = (memberRepositoryStub) => {
+            return new RouterController({
+                memberRepository: memberRepositoryStub,
+                sendEmailWithMagicLink: sinon.stub().resolves({}),
+                magicLinkService: {},
+                settingsCache: {get: sinon.stub().returns([])},
+                settingsHelpers,
+                emailAddressService
+            });
+        };
+
+        it('logs a warning when signin is attempted for an unknown member', async function () {
+            const controller = createController({get: sinon.stub().resolves(null)});
+            const req = {body: {emailType: 'signin'}};
+
+            await controller._handleSignin(req, 'unknown@example.com');
+
+            sinon.assert.calledOnce(logging.warn);
+            assert.match(logging.warn.firstCall.args[0], /Signin attempted for unknown member/);
+            assert.match(logging.warn.firstCall.args[0], /example\.com/);
+        });
+
+        it('does not log a warning when signin is attempted for an existing member', async function () {
+            const member = {id: 'member_1', email: 'existing@example.com'};
+            const sendEmailStub = sinon.stub().resolves({});
+            const controller = new RouterController({
+                memberRepository: {get: sinon.stub().resolves(member)},
+                sendEmailWithMagicLink: sendEmailStub,
+                magicLinkService: {},
+                settingsCache: {get: sinon.stub().returns([])},
+                settingsHelpers,
+                emailAddressService
+            });
+            const req = {body: {emailType: 'signin'}};
+
+            await controller._handleSignin(req, 'existing@example.com');
+
+            sinon.assert.notCalled(logging.warn);
+        });
+
+        it('does not include the full email address in the warning log', async function () {
+            const controller = createController({get: sinon.stub().resolves(null)});
+            const req = {body: {emailType: 'signin'}};
+
+            await controller._handleSignin(req, 'secret@example.com');
+
+            sinon.assert.calledOnce(logging.warn);
+            assert.equal(logging.warn.firstCall.args[0].includes('secret'), false);
+        });
+    });
+
     describe('_generateSuccessUrl', function () {
         let urlUtilsStub;
 


### PR DESCRIPTION
When a signin magic link is requested for an email with no associated member, Ghost silently returns 201 without sending an email. This makes it hard for admins to diagnose why users report not receiving magic links. The log only records the email domain to avoid storing personal data.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
