### PR TITLE
Fixed browser-sensitive admin CI tests

### DIFF
--- a/.github/actions/load-docker-image/action.yml
+++ b/.github/actions/load-docker-image/action.yml
@@ -46,7 +46,7 @@ runs:
       env:
         IMAGE_TAGS: ${{ inputs.image-tags }}
       run: |
-        IMAGE_TAG=$(printf '%s\n' "$IMAGE_TAGS" | head -n1)
+        IMAGE_TAG="${IMAGE_TAGS%%$'\n'*}"
         echo "Pulling image from registry: $IMAGE_TAG"
 
         max_attempts=5
@@ -73,7 +73,7 @@ runs:
       env:
         IMAGE_TAGS: ${{ inputs.image-tags }}
       run: |
-        IMAGE_TAG=$(printf '%s\n' "$IMAGE_TAGS" | head -n1)
+        IMAGE_TAG="${IMAGE_TAGS%%$'\n'*}"
         echo "Checking for image: $IMAGE_TAG"
         echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 

--- a/ghost/admin/tests/acceptance/search-test.js
+++ b/ghost/admin/tests/acceptance/search-test.js
@@ -30,7 +30,7 @@ const assertSearchModalClosed = () => {
 
 // Helper functions for common test operations
 const openSearch = async () => {
-    await triggerKeyEvent(document, 'keydown', 'K', {
+    await triggerKeyEvent(document, 'keydown', 75, {
         metaKey: ctrlOrCmd === 'command',
         ctrlKey: ctrlOrCmd === 'ctrl'
     });

--- a/ghost/admin/tests/integration/components/gh-billing-iframe-test.js
+++ b/ghost/admin/tests/integration/components/gh-billing-iframe-test.js
@@ -1,3 +1,4 @@
+import GhBillingIframe from 'ghost-admin/components/gh-billing-iframe';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import {describe, it} from 'mocha';
@@ -62,8 +63,7 @@ describe('Integration: Component: gh-billing-iframe', function () {
 
         await render(hbs`<GhBillingIframe />`);
 
-        const iframe = find('#billing-frame');
-        const postMessage = sinon.stub(iframe.contentWindow, 'postMessage');
+        const postMessage = sinon.stub(GhBillingIframe.prototype, '_postMessageToBillingIframe');
 
         await postBillingMessage({request: 'token'});
 
@@ -72,7 +72,7 @@ describe('Integration: Component: gh-billing-iframe', function () {
         expect(postMessage.calledOnceWithExactly({
             request: 'token',
             response: null
-        }, 'https://billing.example.test')).to.be.true;
+        })).to.be.true;
     });
 
     it('handles valid route messages without marking the billing app loaded', async function () {
@@ -93,8 +93,7 @@ describe('Integration: Component: gh-billing-iframe', function () {
 
         await render(hbs`<GhBillingIframe />`);
 
-        const iframe = find('#billing-frame');
-        const postMessage = sinon.stub(iframe.contentWindow, 'postMessage');
+        const postMessage = sinon.stub(GhBillingIframe.prototype, '_postMessageToBillingIframe');
 
         await postBillingMessage({request: 'token'}, {origin: 'https://evil.example.test'});
         await postBillingMessage({request: 'billingAppReady'}, {origin: 'https://evil.example.test'});


### PR DESCRIPTION
## Summary
- use the numeric keyCode path for the admin search shortcut test helper so keymaster sees the shortcut consistently across Chrome versions
- stub the billing iframe component's message wrapper instead of mutating cross-origin iframe contentWindow.postMessage
- avoid pipefail/SIGPIPE when selecting the first Docker image tag from multiline image tag input

## Context
This came out of investigating failures on https://github.com/TryGhost/Ghost/pull/28047 while testing Blacksmith runners. The changes are not Blacksmith-specific; they harden tests and CI shell behavior that can vary by browser/runtime.

## Testing
- pnpm exec ember exam --split 1 --filter='Acceptance: Search'
- pnpm exec ember exam --split 1 --filter='Integration: Component: gh-billing-iframe'