### PR TITLE
Fixed browser-sensitive search modal tests

### DIFF
--- a/ghost/admin/tests/acceptance/search-test.js
+++ b/ghost/admin/tests/acceptance/search-test.js
@@ -1,7 +1,7 @@
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import {authenticateSession} from 'ember-simple-auth/test-support';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
-import {click, currentURL, find, findAll, triggerKeyEvent, visit} from '@ember/test-helpers';
+import {click, currentURL, find, findAll, settled, triggerKeyEvent, visit} from '@ember/test-helpers';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {getPosts} from '../../mirage/config/posts';
@@ -29,11 +29,16 @@ const assertSearchModalClosed = () => {
 };
 
 // Helper functions for common test operations
-const openSearch = async () => {
-    await triggerKeyEvent(document, 'keydown', 75, {
-        metaKey: ctrlOrCmd === 'command',
-        ctrlKey: ctrlOrCmd === 'ctrl'
-    });
+const assertSearchShortcutRegistered = (owner) => {
+    const applicationRoute = owner.lookup('route:application');
+    expect(applicationRoute.shortcuts[`${ctrlOrCmd}+k`].action).to.equal('openSearchModal');
+};
+
+const openSearch = async (owner) => {
+    const applicationRoute = owner.lookup('route:application');
+    applicationRoute.send('openSearchModal');
+
+    await settled();
     assertSearchModalOpen();
 };
 
@@ -191,27 +196,28 @@ describe('Acceptance: Search', function () {
             expect(searchService.provider.constructor.name).to.equal('SearchProviderFlexService');
         });
 
-        it('opens search modal with Ctrl/Cmd+K', async function () {
+        it('opens search modal from the Ctrl/Cmd+K shortcut action', async function () {
             await visit('/analytics');
+            assertSearchShortcutRegistered(this.owner);
             assertSearchModalClosed();
-            await openSearch();
+            await openSearch(this.owner);
         });
 
         it('closes search modal with Escape key', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await closeSearchWithEscape();
         });
 
         it('closes search modal when clicking outside', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await closeSearchWithBackdrop();
         });
 
         it('finds all content types when searching for "first"', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first');
 
             assertSearchGroups();
@@ -221,7 +227,7 @@ describe('Acceptance: Search', function () {
 
         it('shows "No results found" when search has no matches', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('xyz123nonexistent');
 
             assertNoResults();
@@ -231,7 +237,7 @@ describe('Acceptance: Search', function () {
             this.server.get('/posts/', getPosts, {timing: 200});
 
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first');
 
             assertSearchResults(['First user', 'First tag', 'First post', 'First page']);
@@ -239,7 +245,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates search results with arrow keys', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first'); // Get multiple results
 
             const searchOptions = getSearchOptions();
@@ -259,7 +265,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates to post editor when selecting a post with Enter', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first post');
 
             await selectWithEnter();
@@ -268,7 +274,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates to post editor when clicking a post', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first post');
 
             await selectWithClick();
@@ -277,7 +283,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates when clicking highlighted text in search result', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first post');
 
             const highlightedText = find(HIGHLIGHTED_TEXT);
@@ -289,7 +295,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates to page editor when selecting a page', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('page');
 
             await selectWithEnter();
@@ -299,7 +305,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates to tag settings when selecting a tag', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('tag');
 
             await selectWithEnter();
@@ -309,7 +315,7 @@ describe('Acceptance: Search', function () {
 
         it('shows status labels for draft and scheduled posts', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('post');
 
             const searchOptions = getSearchOptions();
@@ -338,7 +344,7 @@ describe('Acceptance: Search', function () {
 
         it('shows status label for draft page', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('First page');
 
             const searchOptions = getSearchOptions();
@@ -352,7 +358,7 @@ describe('Acceptance: Search', function () {
         // Staff settings are now part of AdminX
         it.skip('navigates to user settings when selecting a user', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('user');
 
             await selectWithEnter();
@@ -391,27 +397,28 @@ describe('Acceptance: Search', function () {
             expect(searchService.provider.constructor.name).to.equal('SearchProviderBasicService');
         });
 
-        it('opens search modal with Ctrl/Cmd+K', async function () {
+        it('opens search modal from the Ctrl/Cmd+K shortcut action', async function () {
             await visit('/analytics');
+            assertSearchShortcutRegistered(this.owner);
             assertSearchModalClosed();
-            await openSearch();
+            await openSearch(this.owner);
         });
 
         it('closes search modal with Escape key', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await closeSearchWithEscape();
         });
 
         it('closes search modal when clicking outside', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await closeSearchWithBackdrop();
         });
 
         it('finds all content types when searching for "first"', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first');
 
             assertSearchGroups();
@@ -421,7 +428,7 @@ describe('Acceptance: Search', function () {
 
         it('shows "No results found" when search has no matches', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('xyz123nonexistent');
 
             assertNoResults();
@@ -431,7 +438,7 @@ describe('Acceptance: Search', function () {
             this.server.get('/posts/', getPosts, {timing: 200});
 
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first');
 
             assertSearchResults(['First user', 'First tag', 'First post', 'First page']);
@@ -439,7 +446,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates search results with arrow keys', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first'); // Get multiple results
 
             const searchOptions = getSearchOptions();
@@ -459,7 +466,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates to post editor when selecting a post with Enter', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first post');
 
             await selectWithEnter();
@@ -468,7 +475,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates to post editor when clicking a post', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first post');
 
             await selectWithClick();
@@ -477,7 +484,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates when clicking highlighted text in search result', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('first post');
 
             const highlightedText = find(HIGHLIGHTED_TEXT);
@@ -489,7 +496,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates to page editor when selecting a page', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('page');
 
             await selectWithEnter();
@@ -499,7 +506,7 @@ describe('Acceptance: Search', function () {
 
         it('navigates to tag settings when selecting a tag', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('tag');
 
             await selectWithEnter();
@@ -509,7 +516,7 @@ describe('Acceptance: Search', function () {
 
         it('shows status labels for draft and scheduled posts', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('post');
 
             const searchOptions = getSearchOptions();
@@ -538,7 +545,7 @@ describe('Acceptance: Search', function () {
 
         it('shows status label for draft page', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('First page');
 
             const searchOptions = getSearchOptions();
@@ -552,7 +559,7 @@ describe('Acceptance: Search', function () {
         // Staff settings are now part of AdminX
         it.skip('navigates to user settings when selecting a user', async function () {
             await visit('/analytics');
-            await openSearch();
+            await openSearch(this.owner);
             await searchFor('user');
 
             await selectWithEnter();


### PR DESCRIPTION
## Summary
- verify the application route still registers Ctrl/Cmd+K to open the search modal
- open the search modal through the registered route action for the rest of the search behavior coverage
- avoids depending on Chrome-version-specific behavior in synthetic global keyboard events

## Context
This was found while validating Blacksmith runners in https://github.com/TryGhost/Ghost/pull/28047. Blacksmith's Admin tests lane uses system Chrome 144, where Ember's synthetic global keydown did not reliably exercise keymaster and all search modal tests failed before reaching the behavior under test.

The change is intentionally not Blacksmith-specific. This PR separates the browser-sensitive test hardening from the runner migration and lets it validate independently on the normal GitHub Actions path.

## Validation
- Blacksmith Admin tests - Chrome passed in https://github.com/TryGhost/Ghost/actions/runs/26305550325/job/77441618209 with this change
- pnpm exec ember exam --split 2 --partition 2 --filter='Acceptance: Search'
- pnpm exec eslint tests/acceptance/search-test.js