### PR TITLE
Fixed settingsCache.get stub leak in meta-title unit test

### DIFF
--- a/ghost/core/test/unit/frontend/helpers/meta-title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-title.test.js
@@ -154,6 +154,13 @@ describe('{{meta_title}} helper', function () {
     });
 
     describe('with meta_title', function () {
+        // The first test below stubs settingsCache.get and the rest of this
+        // block relies on that stub staying in place; restore it when the
+        // block finishes so the stub does not leak into other test files.
+        afterAll(function () {
+            sinon.restore();
+        });
+
         it('returns correct title for homepage when meta_title is defined', function () {
             sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {


### PR DESCRIPTION
`test/unit/frontend/helpers/meta-title.test.js` — the `with meta_title` block stubs `settingsCache.get` in its first test and its remaining tests rely on that stub staying in place, but the stub is never restored.

Under vitest's default per-file isolation this is harmless (each test file gets a fresh module registry). Under `isolate: false` — a shared module registry, which the ghost/core unit suite is being moved to for a ~12x speedup — the stub leaks into every later test file and collides with their own `sinon.stub(settingsCache, 'get')` calls (`TypeError: Attempted to wrap get which is already wrapped`).

Fix: restore sinon when the `with meta_title` block finishes, so the stub does not outlive the file. Verified — the leak no longer occurs across repeated full-suite runs under `isolate: false`.

This is one of a small set of test-isolation fixes landing ahead of the `isolate: false` switch; it is a no-op under the current `isolate: true`.