### PR TITLE
Skipped lifecycle scripts during Ghost archive deploy

### DIFF
--- a/ghost/core/scripts/pack.js
+++ b/ghost/core/scripts/pack.js
@@ -39,7 +39,8 @@ execFileSync(
         '--filter', 'ghost',
         'deploy', DEPLOY_DIR,
         '--prod',
-        '--config.inject-workspace-packages=true'
+        '--config.inject-workspace-packages=true',
+        '--config.ignore-scripts=true'
     ],
     {cwd: ROOT_DIR, stdio: 'inherit'}
 );


### PR DESCRIPTION
## Summary
- skips dependency lifecycle scripts during the temporary `pnpm deploy` used by `ghost archive`
- keeps the existing archive validation and install-time package metadata intact

## Why
`pack.js` removes `ghost/core/package/node_modules` before creating the Ghost-CLI archive, so native install work done during deploy is discarded. On Blacksmith this exposed a costly sqlite3 fallback compile when `prebuild-install` timed out; skipping scripts avoids that wasted work without making this Blacksmith-specific.

## Test
- `pnpm install --frozen-lockfile`
- `pnpm --filter ghost archive`
- `tar -tzf ghost/core/ghost-6.41.1-rc.0.tgz | rg '^(package/(package.json|pnpm-lock.yaml|pnpm-workspace.yaml|\.npmrc)|package/components/.*\.tgz|package/node_modules)' | head -40`