### PR TITLE
Changed E2E report merging to run only on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1356,7 +1356,7 @@ jobs:
 
   job_merge_e2e_reports:
     name: Merge Reports
-    if: always()
+    if: always() && needs.job_e2e_tests.result == 'failure'
     needs: [job_e2e_tests, job_setup]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
- skips the E2E report merge job when the E2E matrix succeeds
- keeps report generation for failed E2E runs, where blob reports are uploaded and useful for debugging

## Expected savings
Based on recent successful CI runs, `Merge Reports` currently still runs on green E2E even though no blob reports exist to merge:

| Run | Merge Reports duration |
| --- | ---: |
| 26312347409 | 48s |
| 26312115502 | 60s |
| 26312016790 | 52s |
| 26311870687 | 52s |

Expected green-run wall-clock saving: about 50-60 seconds, mostly checkout, Node setup, and `pnpm install` before discovering there are no reports.

## Conditions
- Saves time only when `job_e2e_tests` succeeds.
- No behavior change for failed E2E runs; failed shards still upload blob reports and this job still merges/uploads the HTML report.
- No behavior change when the E2E lane is skipped; the merge job remains skipped.

## Testing
- not run; workflow-only condition change
