### PR TITLE
Changed Docker image artifact upload to fork-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -982,6 +982,7 @@ jobs:
           cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', steps.strategy.outputs.image-full-name, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
 
       - name: Save full image as artifact
+        if: steps.strategy.outputs.use-artifact == 'true'
         run: |
           IMAGE_TAG=$(echo "${{ steps.meta-full.outputs.tags }}" | head -n1)
           echo "Saving image: $IMAGE_TAG"
@@ -990,6 +991,7 @@ jobs:
           ls -lh docker-image-production.tar.gz
 
       - name: Upload image artifact
+        if: steps.strategy.outputs.use-artifact == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-image-production


### PR DESCRIPTION
## Summary
- skips saving/uploading the production Docker image artifact when CI can push/pull from GHCR
- keeps the artifact transfer path for external fork and cross-repo PR runs where GHCR push is unavailable

## Expected savings
Based on recent successful same-org CI runs, the production image tarball is saved and uploaded even though downstream jobs pull the image from GHCR:

| Run | Save full image as artifact | Upload image artifact | Total |
| --- | ---: | ---: | ---: |
| 26312347409 | 26s | 9s | 35s |
| 26312115502 | 45s | 9s | 54s |
| 26312016790 | 41s | 9s | 50s |
| 26311870687 | 37s | 10s | 47s |

Expected same-org build-lane saving: about 35-55 seconds in `Build & Publish Artifacts`. This can also unblock `Build E2E Docker Image` sooner because that job depends on `job_build_artifacts`.

## Conditions
- Saves time when `steps.strategy.outputs.use-artifact == 'false'`, which is the normal same-org path where images are pushed to GHCR.
- Keeps existing behavior when `use-artifact == 'true'`, which covers external forks and cross-repo PRs that cannot push the image to GHCR.
- Release/tag pushes are unaffected because the strategy forces `use-artifact=false` and publishes images to GHCR.

## Testing
- not run; workflow-only condition change
