### PR TITLE
Changed main E2E tests to run across ten shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1218,42 +1218,52 @@ jobs:
             projects: main
             analytics: 'false'
             shardIndex: 1
-            shardTotal: 8
+            shardTotal: 10
           - projectName: Main
             projects: main
             analytics: 'false'
             shardIndex: 2
-            shardTotal: 8
+            shardTotal: 10
           - projectName: Main
             projects: main
             analytics: 'false'
             shardIndex: 3
-            shardTotal: 8
+            shardTotal: 10
           - projectName: Main
             projects: main
             analytics: 'false'
             shardIndex: 4
-            shardTotal: 8
+            shardTotal: 10
           - projectName: Main
             projects: main
             analytics: 'false'
             shardIndex: 5
-            shardTotal: 8
+            shardTotal: 10
           - projectName: Main
             projects: main
             analytics: 'false'
             shardIndex: 6
-            shardTotal: 8
+            shardTotal: 10
           - projectName: Main
             projects: main
             analytics: 'false'
             shardIndex: 7
-            shardTotal: 8
+            shardTotal: 10
           - projectName: Main
             projects: main
             analytics: 'false'
             shardIndex: 8
-            shardTotal: 8
+            shardTotal: 10
+          - projectName: Main
+            projects: main
+            analytics: 'false'
+            shardIndex: 9
+            shardTotal: 10
+          - projectName: Main
+            projects: main
+            analytics: 'false'
+            shardIndex: 10
+            shardTotal: 10
           - projectName: Analytics
             projects: analytics
             analytics: 'true'


### PR DESCRIPTION
## Summary
- changes the main browser E2E matrix from 8 shards to 10 shards
- leaves analytics E2E at 2 shards
- keeps `TEST_WORKERS_COUNT=1` unchanged

## Expected impact
Historic successful CI runs show the current main E2E split is consistently bottlenecked by one or two slow shards:

| Current shard | Avg total | Avg setup | Avg test |
| --- | ---: | ---: | ---: |
| Main 2/8 | 11m08s | 1m56s | 9m12s |
| Main 6/8 | 9m52s | 2m09s | 7m43s |
| Main 8/8 | 9m24s | 1m58s | 7m26s |

Average main-shard setup is about 2m, so adding two shards adds roughly 4m of total runner setup, but wall-clock can improve if the slowest Playwright shard drops by more than the fixed setup cost on that lane.

Expected wall-clock saving: likely 1-2 minutes if Playwright's native file/test grouping spreads the current long shard better; best case is larger, but unlikely because the suite is not `fullyParallel` and large files remain chunky.

## Success criteria
Compare this PR's E2E matrix with recent baseline runs and check:

- max main shard duration drops from ~11-12m to ~9-10m
- total E2E runner minutes do not grow disproportionately
- no increase in E2E flakes or retries

If this only moves the bottleneck, the next better step is splitting or manually binning the large files instead of adding more shards.

## Testing
- not run locally; workflow matrix experiment
