### PR TITLE
Improved production Docker build caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -951,6 +951,8 @@ jobs:
 
       - name: Build & push core image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        env:
+          BUILDKIT_PROGRESS: plain
         with:
           context: /tmp/ghost-production
           file: Dockerfile.production
@@ -967,6 +969,8 @@ jobs:
 
       - name: Build & push full image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        env:
+          BUILDKIT_PROGRESS: plain
         with:
           context: /tmp/ghost-production
           file: Dockerfile.production

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -12,9 +12,7 @@ ARG NODE_VERSION=22.18.0
 # ---- Core: server + production deps ----
 FROM node:$NODE_VERSION-bookworm-slim AS core
 
-ARG GHOST_BUILD_VERSION=""
 ENV NODE_ENV=production
-ENV GHOST_BUILD_VERSION=${GHOST_BUILD_VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2 fontconfig && \
@@ -25,9 +23,10 @@ RUN apt-get update && \
 
 WORKDIR /home/ghost
 
-COPY --exclude=core/built/admin . .
-
 RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY components ./components
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
     apt-get update && \
@@ -36,14 +35,20 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
     (cd node_modules/sqlite3 && npm run install) && \
     apt-get purge -y build-essential python3 && \
     apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    mkdir -p default log && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --exclude=core/built/admin . .
+
+RUN mkdir -p default log && \
     cp -R content base_content && \
     cp -R content/themes/casper default/casper && \
     ([ -d content/themes/source ] && cp -R content/themes/source default/source || true) && \
     chown ghost:ghost /home/ghost && \
     chown -R nobody:nogroup /home/ghost/* && \
     chown -R ghost:ghost /home/ghost/content /home/ghost/log
+
+ARG GHOST_BUILD_VERSION=""
+ENV GHOST_BUILD_VERSION=${GHOST_BUILD_VERSION}
 
 USER ghost
 ENV LD_PRELOAD=libjemalloc.so.2


### PR DESCRIPTION
## Summary
- enables plain BuildKit progress for the production Docker build steps so cache behavior is visible in CI logs
- copies only dependency metadata and component tarballs before `pnpm install --prod`
- copies the rest of the app after the production dependency install layer
- moves `GHOST_BUILD_VERSION` until after the expensive install/setup layers so per-commit build versions do not invalidate dependency installation

## Expected impact
The current Dockerfile copies the whole packed app and sets `GHOST_BUILD_VERSION` before running production dependency installation. Because PR builds set `GHOST_BUILD_VERSION` to the package version plus short SHA, that per-commit value can invalidate the `pnpm install --prod` layer even when production dependencies are unchanged.

This should make the expensive dependency layer reusable when only app source/admin assets change. The CI logs should also show clearer `CACHED`/rebuilt layer behavior for the `Build & push core image` and `Build & push full image` steps.

## Follow-up ideas kept for later
- inspect the first few CI runs after this change and compare Docker layer cache hits/misses with the historic `Build & push core image` and `Build & push full image` timings
- consider whether PR E2E needs the exact release-grade image path, or whether main/tags can keep release fidelity while PRs use a faster image path
- consider a `docker bake`/single multi-target build if the two separate build-push-action calls still duplicate work

## Testing
- `pnpm --filter ghost archive`
- `docker buildx build --check --target core -f Dockerfile.production ghost/core/package`
- `docker buildx build --check --target full -f Dockerfile.production ghost/core/package`
- `git diff --check`
