### PR TITLE
Fixed flaky admin settings acceptance tests

### DIFF
--- a/apps/admin-x-settings/test/acceptance/advanced/integrations/slack.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/integrations/slack.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/test';
-import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
+import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse, waitForApiRequest} from '@tryghost/admin-x-framework/test/acceptance';
 
 test.describe('Slack integration', async () => {
     test('Supports updating Slack settings', async ({page}) => {
@@ -76,7 +76,7 @@ test.describe('Slack integration', async () => {
                 {key: 'slack_url', value: 'https://hooks.slack.com/services/123456789/123456789/123456789'},
                 {key: 'slack_username', value: 'My site'}
             ])},
-            testSlack: {method: 'POST', path: '/slack/test/', responseStatus: 204, response: ''}
+            testSlack: {method: 'POST', path: '/slack/test/', response: {}}
         }});
 
         await page.goto('/');
@@ -100,6 +100,7 @@ test.describe('Slack integration', async () => {
         await slackModal.getByLabel('Username').fill('My site');
         await slackModal.getByRole('button', {name: 'Send test notification'}).click();
 
+        await waitForApiRequest(lastApiRequests, 'testSlack');
         await expect(page.getByTestId('toast-info')).toHaveText(/Check your Slack channel for the test message/);
 
         expect(lastApiRequests.editSettings?.body).toEqual({
@@ -108,6 +109,5 @@ test.describe('Slack integration', async () => {
                 {key: 'slack_username', value: 'My site'}
             ]
         });
-        expect(lastApiRequests.testSlack).toBeTruthy();
     });
 });

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -281,8 +281,8 @@ test.describe('Member emails settings', async () => {
             const previewSubject = modal.getByTestId('welcome-email-preview-subject');
             await expect(previewSubject).toHaveValue('Welcome {first_name}');
 
-            await previewSubject.press('End');
-            await previewSubject.type('!');
+            await previewSubject.fill('Welcome {first_name}!');
+            await expect(previewSubject).toHaveValue('Welcome {first_name}!');
             await modal.getByRole('button', {name: 'Save'}).click();
 
             await expect.poll(() => lastApiRequests.editAutomatedEmail?.body).toMatchObject({
@@ -736,18 +736,19 @@ test.describe('Member emails settings', async () => {
 
             const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
             await editor.click({timeout: 5000});
-            await page.keyboard.press('ControlOrMeta+a');
-            await page.keyboard.press('Backspace');
+            await editor.fill('');
+            await expect(editor).toBeEmpty();
             await openSlashMenu(page, 'bookmark');
             await page.keyboard.press('Enter');
 
             const bookmarkUrlInput = modal.getByTestId('bookmark-url');
             await expect(bookmarkUrlInput).toBeVisible({timeout: 10000});
             await bookmarkUrlInput.fill('https://ghost.org/');
+            await expect(bookmarkUrlInput).toHaveValue('https://ghost.org/');
             await bookmarkUrlInput.press('Enter');
 
-            await expect(modal.getByTestId('bookmark-title')).toContainText('Ghost: The Creator Economy Platform');
             await expect.poll(() => lastApiRequests.fetchOembed?.url || '').toContain('type=bookmark');
+            await expect(modal.getByTestId('bookmark-title')).toContainText('Ghost: The Creator Economy Platform');
         });
 
         test('welcome email editor inserts call to action card via slash menu', async ({page}) => {


### PR DESCRIPTION
## Summary
- corrected the Slack test mock to match the API response shape and wait for the test request before asserting the toast
- stabilized welcome email subject saving by asserting the input value before save
- made the bookmark metadata test clear the Koenig editor reliably and wait for oEmbed before asserting the rendered card

## Testing
- pnpm --filter @tryghost/admin-x-settings test:acceptance -- test/acceptance/advanced/integrations/slack.test.ts:72 test/acceptance/membership/member-welcome-emails.test.ts:243 test/acceptance/membership/member-welcome-emails.test.ts:704

## Notes
- A broader two-file acceptance run passed the touched tests but exposed an unrelated failure in `Welcome email modal does not start dirty but becomes dirty after edit` around Escape closing behavior.