### PR TITLE
Fixed intermittent checkout / submodule auth failures in CI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -267,6 +267,26 @@
                 "/^css/"
             ],
             "enabled": false
+        },
+
+        // Hold actions/checkout on v5. v6 reworked credential handling to use
+        // `[includeIf "gitdir:..."]` instead of writing the auth header directly
+        // into `.git/config`, which causes sporadic
+        // `fatal: could not read Username for 'https://github.com'` failures —
+        // especially on submodule direct-commit fetches. Revisit when upstream
+        // ships a fix.
+        //   - https://github.com/actions/checkout/issues/2393
+        //   - https://github.com/actions/checkout/issues/2351
+        //   - https://github.com/actions/checkout/issues/2321
+        {
+            "description": "Block actions/checkout major bumps until v6 credential regression is fixed",
+            "matchPackageNames": [
+                "actions/checkout"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "enabled": false
         }
     ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,8 +585,15 @@ jobs:
     name: Legacy tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          submodules: true
+      # Theme submodules (Casper, Source) live in separate public repos.
+      # The workflow's GITHUB_TOKEN that checkout writes as the global
+      # http.extraheader is scoped to TryGhost/Ghost only — GitHub rejects
+      # the cross-repo auth header (returning 401 instead of falling back
+      # to anonymous) and the submodule clone fails with
+      # `fatal: could not read Username for 'https://github.com'`.
+      # Clear the extraheader for this one command so the clones go anonymous.
+      - name: Initialize theme submodules
+        run: git -c http.https://github.com/.extraheader= submodule update --init --recursive
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         env:
@@ -800,8 +807,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          submodules: true
+
+      # See note above on `Legacy tests` — theme submodules clone anonymously
+      # to avoid cross-repo auth rejections from the workflow's GITHUB_TOKEN.
+      - name: Initialize theme submodules
+        run: git -c http.https://github.com/.extraheader= submodule update --init --recursive
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout current commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ env.HEAD_COMMIT }}
           fetch-depth: 0
@@ -213,7 +213,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout PR head commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -234,7 +234,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout PR head commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -254,7 +254,7 @@ jobs:
     if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.affected_projects_str != ''
     name: Lint
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1000
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -294,7 +294,7 @@ jobs:
       needs.job_setup.outputs.is_tag == 'true'
       || needs.job_setup.outputs.changed_i18n_apps == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -320,7 +320,7 @@ jobs:
       CI: true
       COVERAGE: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -359,7 +359,7 @@ jobs:
         node: ${{ fromJSON(needs.job_setup.outputs.node_test_matrix) }}
     name: Unit tests (Node ${{ matrix.node }})
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1000
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -465,7 +465,7 @@ jobs:
       NODE_ENV: ${{ matrix.env.NODE_ENV }}
     name: Acceptance tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         env:
@@ -584,7 +584,7 @@ jobs:
       NODE_ENV: ${{ matrix.env.NODE_ENV }}
     name: Legacy tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: true
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -648,7 +648,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         env:
@@ -703,7 +703,7 @@ jobs:
         ports:
           - 7181:7181
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Install Tinybird CLI
         run: curl -fsSL https://tinybird.co/install.sh | sh
       - name: Build project
@@ -799,7 +799,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: true
 
@@ -1064,7 +1064,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
@@ -1110,7 +1110,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Download public app artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -1282,7 +1282,7 @@ jobs:
             shardTotal: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Docker Registry Mirrors
         uses: ./.github/actions/setup-docker-registry-mirrors
@@ -1379,7 +1379,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -1463,7 +1463,7 @@ jobs:
     ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Restore Admin coverage
         if: contains(needs.job_admin-tests.result, 'success')
@@ -1563,7 +1563,7 @@ jobs:
             package_path: 'apps/announcement-bar'
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Set up Node.js
@@ -1625,7 +1625,7 @@ jobs:
             cdn_paths: 'https://cdn.jsdelivr.net/ghost/announcement-bar@~CURRENT_MINOR/umd/announcement-bar.min.js'
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Set up Node.js
@@ -1715,7 +1715,7 @@ jobs:
     ]
     if: always() && github.repository == 'TryGhost/Ghost' && github.event_name == 'push' && needs.job_setup.outputs.changed_tinybird_datafiles == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Trigger and watch traffic analytics infra Tinybird workflow
         if: github.repository == 'TryGhost/Ghost'
         env:
@@ -1843,7 +1843,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.CANARY_DOCKER_BUILD }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Install gh-aw extension
         uses: github/gh-aw/actions/setup-cli@ce1794953e0ec42adc41b6fca05e02ab49ee21c3 # v0.68.3
         with:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -26,14 +26,18 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          submodules: true
 
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: inputs.base-ref != 'latest'
         with:
           ref: ${{ inputs.base-ref }}
           fetch-depth: 0
-          submodules: true
+
+      # Theme submodules (Casper, Source) clone anonymously — the workflow
+      # GITHUB_TOKEN is scoped to Ghost only and GitHub rejects the
+      # cross-repo auth header. Clear the extraheader for this command.
+      - name: Initialize theme submodules
+        run: git -c http.https://github.com/.extraheader= submodule update --init --recursive
 
       - name: Checkout most recent tag
         run: git checkout "$(git describe --tags --abbrev=0 --match=v*)"

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -21,14 +21,14 @@ jobs:
     if: github.repository == 'TryGhost/Ghost'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: inputs.base-ref == 'latest'
         with:
           ref: main
           fetch-depth: 0
           submodules: true
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: inputs.base-ref != 'latest'
         with:
           ref: ${{ inputs.base-ref }}

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -41,7 +41,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0

--- a/.github/workflows/publish-tb-cli.yml
+++ b/.github/workflows/publish-tb-cli.yml
@@ -21,7 +21,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           # Deploy key (via ssh-agent) is used for git push — it bypasses
           # branch protection and triggers downstream workflows (unlike GITHUB_TOKEN)


### PR DESCRIPTION
## Summary

CI on `main` has been hitting two distinct intermittent checkout failures, both surfacing as:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

This PR addresses both.

### Failure A — Parent repo fetch (rare)

Example: [run 26335629378](https://github.com/TryGhost/Ghost/actions/runs/26335629378/job/77528829537) — Acceptance tests (sqlite3) failed on the first `git fetch origin <sha>` for `TryGhost/Ghost` itself, retried 3× and gave up.

Root cause: `actions/checkout@v6` reworked credential handling to use `[includeIf "gitdir:..."]` in `.git/config` instead of writing `http.extraheader` directly. The `gitdir:` condition matches the path that git resolves at runtime, which can mismatch what checkout wrote — see open upstream issues:

- [actions/checkout#2393](https://github.com/actions/checkout/issues/2393)
- [actions/checkout#2351](https://github.com/actions/checkout/issues/2351)
- [actions/checkout#2321](https://github.com/actions/checkout/issues/2321)

**Fix:** pin `actions/checkout` back to `v5.0.1` (commit `93cb6efe18208431cddfb8368fd83d5badbf9bfd`). v5 writes `http.extraheader` directly into `.git/config` and is unaffected. No patch has shipped on v6 in the ~4 months since v6.0.2.

A Renovate `packageRule` blocks `actions/checkout` major bumps so the pin sticks until upstream ships a fix.

### Failure B — Theme submodule clone (dominant pattern)

Examples: [run 26326297044](https://github.com/TryGhost/Ghost/actions/runs/26326297044), [run 26336530016](https://github.com/TryGhost/Ghost/actions/runs/26336530016/job/77531123542). Parent fetch succeeded, then submodule clone of `TryGhost/Casper` failed instantly with the same error. **Happens on v5 and v6 identically** — my initial v5-only PR still failed on this in its own CI.

Root cause: theme submodules (`Casper`, `Source`) live in **separate public TryGhost repos**. `actions/checkout` writes the workflow's `GITHUB_TOKEN` as a global `http.https://github.com/.extraheader` before fetching submodules. The token is scoped to `TryGhost/Ghost` only. GitHub receives a request for `TryGhost/Casper` with that header and returns 401 rather than falling back to anonymous — even though Casper is public and an anonymous clone would succeed.

`release.yml:52-54` already documents and works around this exact problem:

```yaml
# Fetch submodules separately via HTTPS — the deploy key is scoped to
# Ghost only and can't authenticate against Casper/Source over SSH
- run: git submodule update --init
```

**Fix:** apply the same pattern to the three CI jobs that use `submodules: true`. Remove `submodules: true` from the `actions/checkout` call and follow with an explicit step that clears the auth header for that one command:

```yaml
- uses: actions/checkout@v5.0.1

- name: Initialize theme submodules
  run: git -c http.https://github.com/.extraheader= submodule update --init --recursive
```

`git -c http.https://github.com/.extraheader=` propagates the cleared value to submodule child processes via `GIT_CONFIG_PARAMETERS`, so the clones go anonymous and GitHub serves them without auth.

Applied to: `ci.yml` (Legacy tests, Build E2E Docker Image), `create-release-branch.yml` (both checkout variants).

## Why this got worse recently

Failure B is GitHub.com server-side behavior — intermittently rejecting the cross-repo auth header. It's likely been a low-rate failure for a while but became visible recently as CI volume increased. The release.yml comment dates from when the project first hit this on its release workflow.

Failure A is the v6 includeIf regression, introduced in `f1888ef9fa8` (2026-04-08) when checkout was bumped v5→v6.

## Files changed

- `.github/workflows/ci.yml` — v5 pin (26 sites), submodules: true → anonymous init (2 sites)
- `.github/workflows/release.yml` — v5 pin
- `.github/workflows/create-release-branch.yml` — v5 pin, submodules: true → anonymous init (2 sites)
- `.github/workflows/devcontainer-build.yml` — v5 pin
- `.github/workflows/publish-tb-cli.yml` — v5 pin
- `.github/workflows/copilot-setup-steps.yml` — v5 pin
- `.github/renovate.json5` — block actions/checkout major bumps

## Test plan

- [ ] CI passes green on this PR (it didn't on the previous push — was the v5-only fix)
- [ ] Monitor `main` for a few days after merge to confirm both failure modes disappear
- [ ] Confirm Renovate doesn't reopen a v6 PR