### PR TITLE
Exported less from private blogging middleware

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/lib/middleware.js
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/middleware.js
@@ -56,6 +56,21 @@ function getRedirectUrl(query) {
     }
 }
 
+function authenticatePrivateSession(req, res, next) {
+    const hash = req.session.token || '';
+    const salt = req.session.salt || '';
+    const isVerified = verifySessionHash(salt, hash);
+
+    if (isVerified) {
+        return next();
+    } else {
+        let redirectUrl = urlUtils.urlFor({relativeUrl: privateRoute});
+        redirectUrl += '?r=' + encodeURIComponent(req.url);
+
+        return res.redirect(redirectUrl);
+    }
+}
+
 const privateBlogging = {
     checkIsPrivate: function checkIsPrivate(req, res, next) {
         let isPrivateBlog = settingsCache.get('is_private');
@@ -112,7 +127,7 @@ const privateBlogging = {
         }
 
         // NOTE: Redirect to /private if the session does not exist.
-        privateBlogging.authenticatePrivateSession(req, res, function onSessionVerified() {
+        authenticatePrivateSession(req, res, function onSessionVerified() {
             // CASE: RSS is disabled for private blogging e.g. they create overhead
             if (req.path.match(/\/rss\/$/)) {
                 return next(new errors.NotFoundError({
@@ -122,21 +137,6 @@ const privateBlogging = {
 
             next();
         });
-    },
-
-    authenticatePrivateSession: function authenticatePrivateSession(req, res, next) {
-        const hash = req.session.token || '';
-        const salt = req.session.salt || '';
-        const isVerified = verifySessionHash(salt, hash);
-
-        if (isVerified) {
-            return next();
-        } else {
-            let redirectUrl = urlUtils.urlFor({relativeUrl: privateRoute});
-            redirectUrl += '?r=' + encodeURIComponent(req.url);
-
-            return res.redirect(redirectUrl);
-        }
     },
 
     // This is here so a call to /private/ after a session is verified will redirect to home;
@@ -198,7 +198,7 @@ const privateBlogging = {
         }
 
         // CASE: 404 - redirect this page back to /private/ if the user isn't verified
-        return privateBlogging.authenticatePrivateSession(req, res, function onSessionVerified() {
+        return authenticatePrivateSession(req, res, function onSessionVerified() {
             // CASE: User is logged in, render an error
             return next(err);
         });

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -103,14 +103,6 @@ describe('Private Blogging', function () {
         });
 
         describe('Logged Out behavior', function () {
-            it('authenticatePrivateSession should redirect', function () {
-                req.path = req.url = '/welcome/';
-                privateBlogging.authenticatePrivateSession(req, res, next);
-                sinon.assert.notCalled(next);
-                sinon.assert.called(res.redirect);
-                sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome%2F');
-            });
-
             it('handle404 should redirect', function () {
                 req.path = req.url = '/welcome/';
                 privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
@@ -387,14 +379,6 @@ describe('Private Blogging', function () {
                     sinon.assert.called(next);
                 });
 
-                it('authenticatePrivateSession should redirect', function () {
-                    req.url = '/welcome';
-
-                    privateBlogging.authenticatePrivateSession(req, res, next);
-                    sinon.assert.called(res.redirect);
-                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
-                });
-
                 it('filterPrivateRoutes should redirect', function () {
                     req.path = req.url = '/welcome';
 
@@ -423,26 +407,6 @@ describe('Private Blogging', function () {
                     token: hash('rightpassword', salt),
                     salt
                 };
-            });
-
-            it('authenticatePrivateSession should return next', function () {
-                privateBlogging.authenticatePrivateSession(req, res, next);
-                sinon.assert.called(next);
-            });
-
-            it('authenticatePrivateSession should redirect when stored access code is empty', function () {
-                const salt = Date.now().toString();
-                settingsStub.withArgs('password').returns('');
-                req.url = '/welcome';
-                req.session = {
-                    token: hash('', salt),
-                    salt
-                };
-
-                privateBlogging.authenticatePrivateSession(req, res, next);
-                sinon.assert.notCalled(next);
-                sinon.assert.called(res.redirect);
-                sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
             });
 
             it('filterPrivateRoutes should redirect when stored access code is empty', function () {

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -394,6 +394,24 @@ describe('Private Blogging', function () {
                     sinon.assert.called(res.redirect);
                     sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
                 });
+
+                it('filterPrivateRoutes should redirect', function () {
+                    req.path = req.url = '/welcome';
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    sinon.assert.notCalled(next);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
+                });
+
+                it('handle404 should redirect', function () {
+                    req.path = req.url = '/welcome';
+
+                    privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
+                    sinon.assert.notCalled(next);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
+                });
             });
         });
 
@@ -424,6 +442,36 @@ describe('Private Blogging', function () {
                 privateBlogging.authenticatePrivateSession(req, res, next);
                 sinon.assert.notCalled(next);
                 sinon.assert.called(res.redirect);
+                sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
+            });
+
+            it('filterPrivateRoutes should redirect when stored access code is empty', function () {
+                const salt = Date.now().toString();
+                settingsStub.withArgs('password').returns('');
+                req.path = req.url = '/welcome';
+                req.session = {
+                    token: hash('', salt),
+                    salt
+                };
+
+                privateBlogging.filterPrivateRoutes(req, res, next);
+                sinon.assert.notCalled(next);
+                sinon.assert.calledOnce(res.redirect);
+                sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
+            });
+
+            it('handle404 should redirect when stored access code is empty', function () {
+                const salt = Date.now().toString();
+                settingsStub.withArgs('password').returns('');
+                req.path = req.url = '/welcome';
+                req.session = {
+                    token: hash('', salt),
+                    salt
+                };
+
+                privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
+                sinon.assert.notCalled(next);
+                sinon.assert.calledOnce(res.redirect);
                 sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
             });
 


### PR DESCRIPTION
no ref

*I recommend reviewing this change commit-by-commit.*

The private blogging middleware exported `authenticatePrivateSession`, which was only used internally. This change, which should have no user impact, makes it private instead of exporting it. Most significantly, that meant updating a few tests.
