### PR TITLE
Improved production Docker image loading in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -979,7 +979,7 @@ jobs:
             NODE_VERSION=${{ env.NODE_VERSION }}
             GHOST_BUILD_VERSION=${{ env.GHOST_BUILD_VERSION }}
           push: ${{ steps.strategy.outputs.should-push }}
-          load: true
+          load: ${{ steps.strategy.outputs.should-push == 'false' }}
           tags: ${{ steps.meta-full.outputs.tags }}
           labels: ${{ steps.meta-full.outputs.labels }}
           cache-from: type=registry,ref=${{ steps.strategy.outputs.image-full-name }}:cache-main
@@ -1003,6 +1003,7 @@ jobs:
           retention-days: 1
 
       - name: Inspect image size and layers
+        if: steps.strategy.outputs.use-artifact == 'true'
         shell: bash
         run: |
           IMAGE_TAG=$(echo "${{ steps.meta-full.outputs.tags }}" | head -n1)


### PR DESCRIPTION
## Summary
- avoids loading the pushed full production image into the local Docker daemon on trusted CI runs
- skips the non-gating Docker image size/layer summary on trusted runs, because it depends on the image being loaded locally
- keeps local loading and image inspection for artifact-based fork/cross-repo PR runs

## Why
The full image is already pushed to GHCR on trusted runs. Loading it locally is only needed for artifact transfer/reporting and was adding roughly 45-60s of export/import overhead after BuildKit cache hits.

The skipped reporting is informational only: it runs `docker inspect` and `docker history` to write image size and layer details to the GitHub Step Summary. It does not enforce thresholds, alert, or gate CI.

## Testing
- git diff --check -- .github/workflows/ci.yml