### PR TITLE
Fixed false update state for API feature image captions

### DIFF
--- a/ghost/admin/app/components/gh-editor-feature-image.js
+++ b/ghost/admin/app/components/gh-editor-feature-image.js
@@ -20,6 +20,8 @@ function isLexicalPlainTextSpan(element) {
 }
 
 function normalizeCaptionHtml(html) {
+    // Lexical wraps plain text in spans with `white-space: pre-wrap` on load.
+    // Ignore those wrappers so API-loaded captions do not mark the post as unsaved.
     const cleanedHtml = cleanCaptionHtml(html);
     const domParser = new DOMParser();
     const doc = domParser.parseFromString(cleanedHtml, 'text/html');

--- a/ghost/admin/app/components/gh-editor-feature-image.js
+++ b/ghost/admin/app/components/gh-editor-feature-image.js
@@ -11,6 +11,28 @@ function hasParagraphWrapper(html) {
     return doc.body?.firstElementChild?.tagName === 'P';
 }
 
+function cleanCaptionHtml(html) {
+    return cleanBasicHtml(html || '', {firstChildInnerContent: true});
+}
+
+function isLexicalPlainTextSpan(element) {
+    return element.tagName === 'SPAN' && element.style.length === 1 && element.style.whiteSpace === 'pre-wrap';
+}
+
+function normalizeCaptionHtml(html) {
+    const cleanedHtml = cleanCaptionHtml(html);
+    const domParser = new DOMParser();
+    const doc = domParser.parseFromString(cleanedHtml, 'text/html');
+
+    doc.body.querySelectorAll('span').forEach((element) => {
+        if (isLexicalPlainTextSpan(element)) {
+            element.replaceWith(...element.childNodes);
+        }
+    });
+
+    return doc.body.innerHTML.trim();
+}
+
 export default class GhEditorFeatureImageComponent extends Component {
     @service settings;
 
@@ -31,7 +53,11 @@ export default class GhEditorFeatureImageComponent extends Component {
 
     @action
     setCaption(html) {
-        const cleanedHtml = cleanBasicHtml(html || '', {firstChildInnerContent: true});
+        const cleanedHtml = cleanCaptionHtml(html);
+        if (normalizeCaptionHtml(cleanedHtml) === normalizeCaptionHtml(this.caption)) {
+            return;
+        }
+
         this.args.updateCaption(cleanedHtml);
     }
 

--- a/ghost/admin/tests/acceptance/editor/feature-image-test.js
+++ b/ghost/admin/tests/acceptance/editor/feature-image-test.js
@@ -21,6 +21,19 @@ describe('Acceptance: Feature Image', function () {
         expect(await find('.gh-editor-feature-image-caption').textContent).to.contain('Hello dogggos');
     });
 
+    it('does not enable update button when a feature image caption is loaded from the API', async function () {
+        const post = this.server.create('post', {
+            status: 'published',
+            featureImage: 'https://static.ghost.org/v4.0.0/images/feature-image.jpg',
+            featureImageCaption: 'Feature image caption from the API'
+        });
+
+        await visit(`/editor/post/${post.id}`);
+
+        expect(find('.gh-editor-feature-image-caption')).to.have.rendered.text('Feature image caption from the API');
+        expect(find('[data-test-button="publish-save"]').disabled).to.be.true;
+    });
+
     it('does not attempt to save if already deleted and goes back to posts', async function () {
         // avoids an infinite loop when the post is deleted and the save button is clicked, potential race condition
         const post = this.server.create('post', {status: 'published', featureImage: 'https://static.ghost.org/v4.0.0/images/feature-image.jpg', featureImageCaption: '<span style="white-space: pre-wrap;">Hello dogggos</span>'});


### PR DESCRIPTION
## Summary

- Prevented the feature image caption editor from writing Lexical hydration-only markup back to `featureImageCaption` when opening API-created posts.
- Added an acceptance regression test proving the `Update` button remains disabled when a plain text feature image caption is loaded from the API.

## Root cause

The nested caption editor normalizes plain text captions into Lexical-generated HTML on initialization. That initial normalization was written directly back to the Ember Data post model, marking published posts as dirty before any user edit.

## Validation

- `pnpm --dir ghost/admin exec eslint app/components/gh-editor-feature-image.js tests/acceptance/editor/feature-image-test.js`
- `pnpm --dir ghost/admin exec ember exam --split 1 --parallel=1 --filter='Acceptance: Feature Image'`

closes [ONC-1765](https://linear.app/ghost/issue/ONC-1765/oss-issue-update-button-incorrectly-enabled-on-load-when-feature-image)
closes #28094
