### PR TITLE
Added exhaustiveness check for automation editor edit state

### DIFF
--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -106,6 +106,8 @@ const AutomationEditor: React.FC = () => {
     let isTurnOffButtonEnabled = true;
     let turnOffButtonChildren: React.ReactNode = 'Turn off';
     switch (editState) {
+    case 'idle':
+        break;
     case 'saving':
         isEditRequestActive = true;
         isSaveButtonEnabled = false;
@@ -162,6 +164,10 @@ const AutomationEditor: React.FC = () => {
         isTurnOffButtonEnabled = true;
         turnOffButtonChildren = 'Retry';
         break;
+    default: {
+        const _exhaustive: never = editState;
+        throw new Error(`Unhandled edit state: ${_exhaustive}`);
+    }
     }
 
     const onConfirmUnpublishOpenChange = (open: boolean): void => {


### PR DESCRIPTION
no ref

This change should have no user impact. If we add new edit states, we want TypeScript to ensure we handle them.

I think this is a useful change on its own, but we plan to add a few more edit states soon.
