### PR TITLE
Removed test:unit scripts from projects with no Vitest unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,11 @@ jobs:
             tinybird-datafiles:
               - 'ghost/core/core/server/data/tinybird/**'
               - '!ghost/core/core/server/data/tinybird/**/*.md'
+            unit-test-globals:
+              - 'vitest.config.mjs'
+            core-unit-test-globals:
+              - 'ghost/core/vitest.config.ts'
+              - 'ghost/core/test/utils/vitest-*.ts'
             any-code:
               - '!**/*.md'
               - '!.devcontainer/**'
@@ -172,6 +177,16 @@ jobs:
           AFFECTED_PROJECTS_STR=$(pnpm -s nx show projects ${AFFECTED_ARG} --sep=, | tr -d '\n')
           echo "affected_projects_str=$AFFECTED_PROJECTS_STR" >> "$GITHUB_OUTPUT"
 
+          UNIT_TEST_AFFECTED_ARG="$AFFECTED_ARG"
+          if [[ "${{ steps.changed.outputs.unit-test-globals }}" == 'true' ]]; then
+            UNIT_TEST_AFFECTED_ARG=""
+          fi
+          UNIT_TEST_PROJECTS_STR=$(pnpm -s nx show projects ${UNIT_TEST_AFFECTED_ARG} --withTarget test:unit --sep=, | tr -d '\n')
+          if [[ "${{ steps.changed.outputs.core-unit-test-globals }}" == 'true' ]]; then
+            UNIT_TEST_PROJECTS_STR=$(printf '%s\n%s\n' "$UNIT_TEST_PROJECTS_STR" "ghost" | awk 'NF && !seen[$0]++' | paste -sd, -)
+          fi
+          echo "unit_test_projects_str=$UNIT_TEST_PROJECTS_STR" >> "$GITHUB_OUTPUT"
+
           # "i18n" tag = packages whose source is scanned by @tryghost/i18n's
           # translate:* scripts (not packages that merely import @tryghost/i18n).
           I18N_PROJECTS=$(pnpm -s nx show projects ${AFFECTED_ARG} --projects 'tag:i18n' --sep=, | tr -d '\n')
@@ -186,6 +201,7 @@ jobs:
     outputs:
       affected_projects: ${{ steps.affected.outputs.affected_projects }}
       affected_projects_str: ${{ steps.affected.outputs.affected_projects_str }}
+      unit_test_projects_str: ${{ steps.affected.outputs.unit_test_projects_str }}
       affected_playwright_projects: ${{ steps.affected.outputs.affected_playwright_projects }}
       changed_i18n_apps: ${{ steps.affected.outputs.affected_i18n_projects != '' }}
       changed_core: ${{ steps.changed.outputs.core }}
@@ -353,7 +369,7 @@ jobs:
   job_unit-tests:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.affected_projects_str != ''
+    if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.unit_test_projects_str != ''
     strategy:
       matrix:
         node: ${{ fromJSON(needs.job_setup.outputs.node_test_matrix) }}
@@ -393,7 +409,7 @@ jobs:
         # until the vitest worker/teardown issue is fixed.
         run: |
           for attempt in 1 2 3; do
-            pnpm nx run-many -t test:unit -p "${{ needs.job_setup.outputs.affected_projects_str }}" && exit 0
+            pnpm nx run-many -t test:unit -p "${{ needs.job_setup.outputs.unit_test_projects_str }}" && exit 0
             if [ "${attempt}" -lt 3 ]; then
               echo "::warning::Unit tests attempt ${attempt} failed — retrying"
             else

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/signup-form",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -20,7 +20,6 @@
     "build": "tsc && vite build",
     "lint": "pnpm run lint:js",
     "lint:js": "eslint --ext .js,.ts,.cjs,.tsx --cache src test",
-    "test:unit": "pnpm build",
     "test:acceptance": "NODE_OPTIONS='--experimental-specifier-resolution=node --no-warnings' VITE_TEST=true playwright test",
     "test:acceptance:slowmo": "TIMEOUT=100000 PLAYWRIGHT_SLOWMO=100 pnpm test:acceptance --headed",
     "test:acceptance:full": "ALL_BROWSERS=1 pnpm test:acceptance",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/sodo-search",
-  "version": "1.8.20",
+  "version": "1.8.21",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -27,8 +27,6 @@
     "tailwind": "pnpm tailwind:base --watch ",
     "tailwind:base": "tailwindcss -i ./src/index.css -o ./umd/main.css --minify",
     "test": "vitest run",
-    "test:ci": "pnpm test --coverage",
-    "test:unit": "pnpm test:ci",
     "lint": "eslint src --ext .js --cache",
     "preship": "pnpm lint",
     "ship": "node ../../.github/scripts/release-apps.js",

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -19,7 +19,6 @@
     "dev": "ember serve",
     "build": "ember build --environment=production --silent",
     "build:dev": "pnpm build --environment=development",
-    "test:unit": "true",
     "test": "ember exam --split 2 --parallel",
     "lint:js": "eslint . --cache",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
Three workspaces had a `test:unit` script that didn't actually run unit tests, which inflated the `ci_test_unit` matrix from 13 real test runs to 16 and made the intent of those projects' test wiring hard to read.

- `apps/signup-form`: `test:unit` was `pnpm build` — running the build, not tests. There was a single `test/unit/hello.test.js` (0 bytes) that never executed under that script. Removed the script and the placeholder file.
- `apps/sodo-search`: `test:unit` chained through `test:ci` to `vitest run --coverage` against zero unit test files. The project's actual tests are Playwright (`test/e2e/*.test.ts`) and run in the separate `unit_tests_playwright` matrix — unaffected by this change. Removed both `test:unit` and `test:ci` (the latter has no other callers).
- `ghost-admin`: `test:unit` was `true` (no-op). ghost-admin's tests run via `ember exam` under its own `test` target, invoked by the dedicated `ghost-admin:test` CI job. Removed.

After this change, `pnpm nx run-many -t test:unit` runs 13 projects instead of 16. Nx skips projects without the target — no extra wiring or exemption list to maintain. If/when one of these workspaces adds real Vitest tests, adding the `test:unit` script back is a one-line change.

Versions bumped on `signup-form` and `sodo-search` per the app-version-bump check. `ghost-admin` is `private: true` and not in `.github/scripts/check-app-version-bump.js`'s `MONITORED_APPS`, so no bump needed.