### PR TITLE
Moved email content editor to automations

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -206,8 +206,8 @@ type UpdateWaitActionArgs = ReadonlyDeep<{
 type UpdateSendEmailActionArgs = ReadonlyDeep<{
     detail: AutomationDetail;
     actionId: string;
-    emailSubject?: string;
-    emailLexical?: string;
+    emailSubject: string;
+    emailLexical: string;
 }>;
 
 export const updateWaitAction = ({detail, actionId, waitHours}: UpdateWaitActionArgs): AutomationDetail => {
@@ -241,22 +241,29 @@ export const updateWaitAction = ({detail, actionId, waitHours}: UpdateWaitAction
 };
 
 export const updateSendEmailAction = ({detail, actionId, emailSubject, emailLexical}: UpdateSendEmailActionArgs): AutomationDetail => {
-    const target = detail.actions.find(action => action.id === actionId);
-    if (!target) {
+    let hasUpdated = false;
+    const actions = detail.actions.map((action) => {
+        if (action.id === actionId) {
+            if (action.type !== 'send_email') {
+                throw new Error(`updateSendEmailAction: action "${actionId}" is not a send_email action`);
+            }
+            hasUpdated = true;
+            return {
+                ...action,
+                data: {
+                    ...action.data,
+                    email_subject: emailSubject,
+                    email_lexical: emailLexical
+                }
+            };
+        }
+        return action;
+    });
+
+    if (!hasUpdated) {
         throw new Error(`updateSendEmailAction: unknown action id "${actionId}"`);
     }
-    if (target.type !== 'send_email') {
-        throw new Error(`updateSendEmailAction: action "${actionId}" is not a send_email action`);
-    }
-    const updated: AutomationSendEmailAction = {
-        ...target,
-        data: {
-            ...target.data,
-            ...(emailSubject !== undefined ? {email_subject: emailSubject} : {}),
-            ...(emailLexical !== undefined ? {email_lexical: emailLexical} : {})
-        }
-    };
-    const actions = detail.actions.map(action => (action.id === actionId ? updated : action));
+
     return {...detail, actions, edges: [...detail.edges]};
 };
 

--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -92,16 +92,9 @@ export const useEditAutomation = createMutation<AutomationDetailResponseType, Ed
 
 const generateActionId = (): string => ObjectId().toHexString();
 
-// TODO NY-1253: replace this placeholder when email content can be edited.
-const PLACEHOLDER_EMAIL_LEXICAL = JSON.stringify({
+const EMPTY_EMAIL_LEXICAL = JSON.stringify({
     root: {
-        children: [{
-            type: 'paragraph',
-            children: [{
-                type: 'text',
-                text: 'Untitled email body.'
-            }]
-        }],
+        children: [],
         direction: null,
         format: '',
         indent: 0,
@@ -121,7 +114,7 @@ const buildSendEmailAction = (): AutomationSendEmailAction => ({
     type: 'send_email',
     data: {
         email_subject: 'Untitled email',
-        email_lexical: PLACEHOLDER_EMAIL_LEXICAL,
+        email_lexical: EMPTY_EMAIL_LEXICAL,
         email_sender_name: null,
         email_sender_email: null,
         email_sender_reply_to: null,
@@ -210,6 +203,13 @@ type UpdateWaitActionArgs = ReadonlyDeep<{
     waitHours: number;
 }>;
 
+type UpdateSendEmailActionArgs = ReadonlyDeep<{
+    detail: AutomationDetail;
+    actionId: string;
+    emailSubject?: string;
+    emailLexical?: string;
+}>;
+
 export const updateWaitAction = ({detail, actionId, waitHours}: UpdateWaitActionArgs): AutomationDetail => {
     if (!Number.isSafeInteger(waitHours) || waitHours <= 0) {
         throw new Error(`updateWaitAction: waitHours must be a safe positive integer, received "${waitHours}"`);
@@ -237,6 +237,26 @@ export const updateWaitAction = ({detail, actionId, waitHours}: UpdateWaitAction
         throw new Error(`updateWaitAction: unknown action id "${actionId}"`);
     }
 
+    return {...detail, actions, edges: [...detail.edges]};
+};
+
+export const updateSendEmailAction = ({detail, actionId, emailSubject, emailLexical}: UpdateSendEmailActionArgs): AutomationDetail => {
+    const target = detail.actions.find(action => action.id === actionId);
+    if (!target) {
+        throw new Error(`updateSendEmailAction: unknown action id "${actionId}"`);
+    }
+    if (target.type !== 'send_email') {
+        throw new Error(`updateSendEmailAction: action "${actionId}" is not a send_email action`);
+    }
+    const updated: AutomationSendEmailAction = {
+        ...target,
+        data: {
+            ...target.data,
+            ...(emailSubject !== undefined ? {email_subject: emailSubject} : {}),
+            ...(emailLexical !== undefined ? {email_lexical: emailLexical} : {})
+        }
+    };
+    const actions = detail.actions.map(action => (action.id === actionId ? updated : action));
     return {...detail, actions, edges: [...detail.edges]};
 };
 

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -7,6 +7,7 @@ import {
     insertSendEmailAction,
     insertWaitAction,
     removeAction,
+    updateSendEmailAction,
     updateWaitAction
 } from '../../../src/api/automations';
 
@@ -173,7 +174,7 @@ describe('automations api helpers', () => {
     });
 
     describe('insertSendEmailAction', () => {
-        it('creates a send_email action with placeholder defaults', () => {
+        it('creates a send_email action with a blank body and default subject', () => {
             const detail = baseDetail([], []);
 
             const next = insertSendEmailAction({detail, anchor: {}});
@@ -183,7 +184,7 @@ describe('automations api helpers', () => {
             expectSendEmailAction(newAction);
             expect(newAction.data.email_subject).toBe('Untitled email');
             expect(() => JSON.parse(newAction.data.email_lexical)).not.toThrow();
-            expect(JSON.parse(newAction.data.email_lexical).root.children.length).toBeGreaterThan(0);
+            expect(JSON.parse(newAction.data.email_lexical).root.children).toEqual([]);
             expect(newAction.data.email_design_setting_id).toBe('placeholder');
         });
 
@@ -363,6 +364,88 @@ describe('automations api helpers', () => {
 
         it('throws when waitHours is NaN', () => {
             expectInvalidWaitHoursRejected(Number.NaN);
+        });
+    });
+
+    describe('updateSendEmailAction', () => {
+        const sendEmailAction = (id: string, overrides: Partial<AutomationSendEmailAction['data']> = {}): AutomationSendEmailAction => ({
+            id,
+            type: 'send_email',
+            data: {
+                email_subject: 'Original subject',
+                email_lexical: '{"root":{"children":[]}}',
+                email_sender_name: null,
+                email_sender_email: null,
+                email_sender_reply_to: null,
+                email_design_setting_id: 'placeholder',
+                ...overrides
+            }
+        });
+
+        it('updates subject and lexical on the targeted send_email action', () => {
+            const detail = baseDetail([sendEmailAction('a')], []);
+
+            const next = updateSendEmailAction({
+                detail,
+                actionId: 'a',
+                emailSubject: 'New subject',
+                emailLexical: '{"root":{"children":[{"type":"paragraph"}]}}'
+            });
+
+            const updated = next.actions[0];
+            expectSendEmailAction(updated);
+            expect(updated.data.email_subject).toBe('New subject');
+            expect(updated.data.email_lexical).toBe('{"root":{"children":[{"type":"paragraph"}]}}');
+        });
+
+        it('only updates the provided fields, preserving the rest of data', () => {
+            const detail = baseDetail([sendEmailAction('a', {email_sender_name: 'Jane'})], []);
+
+            const next = updateSendEmailAction({detail, actionId: 'a', emailSubject: 'Just the subject'});
+
+            const updated = next.actions[0];
+            expectSendEmailAction(updated);
+            expect(updated.data.email_subject).toBe('Just the subject');
+            expect(updated.data.email_lexical).toBe('{"root":{"children":[]}}');
+            expect(updated.data.email_sender_name).toBe('Jane');
+            expect(updated.data.email_design_setting_id).toBe('placeholder');
+        });
+
+        it('does not mutate the original detail or action', () => {
+            const detail = baseDetail([sendEmailAction('a')], []);
+
+            updateSendEmailAction({detail, actionId: 'a', emailSubject: 'Changed'});
+
+            const original = detail.actions[0];
+            expectSendEmailAction(original);
+            expect(original.data.email_subject).toBe('Original subject');
+        });
+
+        it('leaves other actions, edges, and top-level fields untouched', () => {
+            const detail = baseDetail(
+                [sendEmailAction('a'), {id: 'b', type: 'wait', data: {wait_hours: 24}}],
+                [{source_action_id: 'a', target_action_id: 'b'}]
+            );
+
+            const next = updateSendEmailAction({detail, actionId: 'a', emailSubject: 'New'});
+
+            expect(next.actions[1]).toBe(detail.actions[1]);
+            expect(next.edges).toEqual(detail.edges);
+            expect(next.id).toBe(detail.id);
+            expect(next.slug).toBe(detail.slug);
+            expect(next.status).toBe(detail.status);
+        });
+
+        it('throws when actionId references a non-existent action', () => {
+            const detail = baseDetail([sendEmailAction('a')], []);
+
+            expect(() => updateSendEmailAction({detail, actionId: 'nope', emailSubject: 'x'})).toThrow(/unknown action id "nope"/);
+        });
+
+        it('throws when the targeted action is not a send_email action', () => {
+            const detail = baseDetail([{id: 'a', type: 'wait', data: {wait_hours: 24}}], []);
+
+            expect(() => updateSendEmailAction({detail, actionId: 'a', emailSubject: 'x'})).toThrow(/is not a send_email action/);
         });
     });
 });

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -398,15 +398,20 @@ describe('automations api helpers', () => {
             expect(updated.data.email_lexical).toBe('{"root":{"children":[{"type":"paragraph"}]}}');
         });
 
-        it('only updates the provided fields, preserving the rest of data', () => {
+        it('updates subject and lexical, preserving the rest of data', () => {
             const detail = baseDetail([sendEmailAction('a', {email_sender_name: 'Jane'})], []);
 
-            const next = updateSendEmailAction({detail, actionId: 'a', emailSubject: 'Just the subject'});
+            const next = updateSendEmailAction({
+                detail,
+                actionId: 'a',
+                emailSubject: 'Just the subject',
+                emailLexical: '{"root":{"children":[{"type":"paragraph"}]}}'
+            });
 
             const updated = next.actions[0];
             expectSendEmailAction(updated);
             expect(updated.data.email_subject).toBe('Just the subject');
-            expect(updated.data.email_lexical).toBe('{"root":{"children":[]}}');
+            expect(updated.data.email_lexical).toBe('{"root":{"children":[{"type":"paragraph"}]}}');
             expect(updated.data.email_sender_name).toBe('Jane');
             expect(updated.data.email_design_setting_id).toBe('placeholder');
         });
@@ -414,7 +419,7 @@ describe('automations api helpers', () => {
         it('does not mutate the original detail or action', () => {
             const detail = baseDetail([sendEmailAction('a')], []);
 
-            updateSendEmailAction({detail, actionId: 'a', emailSubject: 'Changed'});
+            updateSendEmailAction({detail, actionId: 'a', emailSubject: 'Changed', emailLexical: '{"root":{"children":[{"type":"paragraph"}]}}'});
 
             const original = detail.actions[0];
             expectSendEmailAction(original);
@@ -427,7 +432,7 @@ describe('automations api helpers', () => {
                 [{source_action_id: 'a', target_action_id: 'b'}]
             );
 
-            const next = updateSendEmailAction({detail, actionId: 'a', emailSubject: 'New'});
+            const next = updateSendEmailAction({detail, actionId: 'a', emailSubject: 'New', emailLexical: '{"root":{"children":[]}}'});
 
             expect(next.actions[1]).toBe(detail.actions[1]);
             expect(next.edges).toEqual(detail.edges);
@@ -439,13 +444,13 @@ describe('automations api helpers', () => {
         it('throws when actionId references a non-existent action', () => {
             const detail = baseDetail([sendEmailAction('a')], []);
 
-            expect(() => updateSendEmailAction({detail, actionId: 'nope', emailSubject: 'x'})).toThrow(/unknown action id "nope"/);
+            expect(() => updateSendEmailAction({detail, actionId: 'nope', emailSubject: 'x', emailLexical: '{"root":{"children":[]}}'})).toThrow(/unknown action id "nope"/);
         });
 
         it('throws when the targeted action is not a send_email action', () => {
             const detail = baseDetail([{id: 'a', type: 'wait', data: {wait_hours: 24}}], []);
 
-            expect(() => updateSendEmailAction({detail, actionId: 'a', emailSubject: 'x'})).toThrow(/is not a send_email action/);
+            expect(() => updateSendEmailAction({detail, actionId: 'a', emailSubject: 'x', emailLexical: '{"root":{"children":[]}}'})).toThrow(/is not a send_email action/);
         });
     });
 });

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -61,6 +61,7 @@
         "@ebay/nice-modal-react": "1.2.13",
         "@tryghost/color-utils": "catalog:",
         "@tryghost/admin-x-framework": "workspace:*",
+        "@tryghost/koenig-lexical": "catalog:",
         "@tryghost/nql-lang": "catalog:",
         "@tryghost/shade": "workspace:*",
         "@xyflow/react": "12.8.6",

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -1,8 +1,9 @@
 import '@xyflow/react/dist/style.css';
 import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
+import EmailContentModal from './email-modal/email-content-modal';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
-import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction, updateWaitAction} from '@tryghost/admin-x-framework/api/automations';
+import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction, updateSendEmailAction, updateWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
 import {Banner, Button, Checkbox, Input, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
@@ -365,7 +366,10 @@ type WaitStepSidebarDetail = ActionStepSidebarDetail<AutomationWaitAction, 'Wait
     onUpdate: (waitHours: number) => void;
 };
 
-type SendEmailStepSidebarDetail = ActionStepSidebarDetail<AutomationSendEmailAction, 'Send email'>;
+type SendEmailStepSidebarDetail = ActionStepSidebarDetail<AutomationSendEmailAction, 'Send email'> & {
+    onUpdateSubject: (subject: string) => void;
+    onEditEmail: () => void;
+};
 
 type StepSidebarDetail = TriggerStepSidebarDetail | WaitStepSidebarDetail | SendEmailStepSidebarDetail;
 
@@ -380,10 +384,12 @@ type StepSidebarDetailOptions = {
     automation: AutomationDetail;
     onDelete: (actionId: string) => void;
     onUpdateWait: (actionId: string, waitHours: number) => void;
+    onUpdateSubject: (actionId: string, subject: string) => void;
+    onEditEmail: (actionId: string) => void;
     stepId: string | null;
 };
 
-const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait}: StepSidebarDetailOptions): StepSidebarDetail | null => {
+const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
     if (!stepId) {
         return null;
     }
@@ -423,6 +429,8 @@ const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait}: Step
             title: action.data.email_subject || 'No subject',
             action,
             onDelete: () => onDelete(action.id),
+            onUpdateSubject: (subject: string) => onUpdateSubject(action.id, subject),
+            onEditEmail: () => onEditEmail(action.id),
             type: 'send_email'
         };
     default: {
@@ -445,17 +453,6 @@ const ReadOnlySelect: React.FC<{value: string}> = ({value}) => (
             <span>{value}</span>
         </SelectTrigger>
     </Select>
-);
-
-const DisabledPanelButton: React.FC<React.PropsWithChildren<{variant?: 'default' | 'destructive'}>> = ({children, variant = 'default'}) => (
-    <Button
-        className={cn('w-full', variant === 'destructive' && 'border-red text-red')}
-        type='button'
-        variant='outline'
-        disabled
-    >
-        {children}
-    </Button>
 );
 
 const TriggerSidebarBody: React.FC<{memberTiers: MemberTier[]}> = ({memberTiers}) => (
@@ -555,15 +552,29 @@ const WaitSidebarBody: React.FC<{
     );
 };
 
-const SendEmailSidebarBody: React.FC<{action: AutomationSendEmailAction; onDelete: () => void}> = ({action, onDelete}) => (
+const SendEmailSidebarBody: React.FC<{
+    action: AutomationSendEmailAction;
+    onUpdateSubject: (subject: string) => void;
+    onEditEmail: () => void;
+    onDelete: () => void;
+}> = ({action, onUpdateSubject, onEditEmail, onDelete}) => (
     <div className='flex flex-1 flex-col gap-5'>
         <SidebarField label='Subject line'>
-            <Input value={action.data.email_subject || 'No subject'} readOnly />
+            <Input
+                placeholder='Subject line'
+                value={action.data.email_subject}
+                onChange={e => onUpdateSubject(e.target.value)}
+            />
         </SidebarField>
-        <DisabledPanelButton>
+        <Button
+            className='w-full'
+            type='button'
+            variant='outline'
+            onClick={onEditEmail}
+        >
             <LucideIcon.Pencil className='size-4' />
             Edit email
-        </DisabledPanelButton>
+        </Button>
         <div className='mt-auto pt-6'>
             <DeleteStepButton onClick={onDelete} />
         </div>
@@ -577,7 +588,7 @@ const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     case 'wait':
         return <WaitSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onUpdate={detail.onUpdate} />;
     case 'send_email':
-        return <SendEmailSidebarBody action={detail.action} onDelete={detail.onDelete} />;
+        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
     default: {
         const _exhaustive: never = detail;
         throw new Error(`Unknown sidebar type: ${_exhaustive}`);
@@ -655,6 +666,7 @@ const insertActionByType = {
 
 const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError, onChange}) => {
     const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+    const [emailModalActionId, setEmailModalActionId] = useState<string | null>(null);
 
     const handlePick = useCallback((type: StepPickerType, anchor: CanvasAnchor) => {
         if (!automation) {
@@ -685,6 +697,21 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         onChange(updateWaitAction({detail: automation, actionId, waitHours}));
     }, [automation, onChange]);
 
+    const handleUpdateSubject = useCallback((actionId: string, subject: string) => {
+        if (!automation) {
+            return;
+        }
+        onChange(updateSendEmailAction({detail: automation, actionId, emailSubject: subject}));
+    }, [automation, onChange]);
+
+    const handleEditEmail = useCallback((actionId: string) => {
+        setEmailModalActionId(actionId);
+    }, []);
+
+    const emailModalAction = emailModalActionId && automation
+        ? automation.actions.find((action): action is AutomationSendEmailAction => action.id === emailModalActionId && action.type === 'send_email')
+        : undefined;
+
     const initialViewport = useRef(getInitialViewport(window.innerWidth));
 
     const graph = useMemo(() => {
@@ -704,6 +731,8 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         automation,
         onDelete: handleDelete,
         onUpdateWait: handleUpdateWait,
+        onUpdateSubject: handleUpdateSubject,
+        onEditEmail: handleEditEmail,
         stepId: selectedStepId
     }) : null;
     const clearDetail = useCallback(() => {
@@ -760,6 +789,18 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
                 <Background />
             </ReactFlow>
             <StepSidebar detail={sidebarDetail} onClose={clearDetail} />
+            {emailModalAction && automation && (
+                <EmailContentModal
+                    initialLexical={emailModalAction.data.email_lexical || ''}
+                    initialSubject={emailModalAction.data.email_subject || ''}
+                    onClose={() => setEmailModalActionId(null)}
+                    onSave={({subject, lexical}) => {
+                        // Commit the edited content into the local draft; persisted on Publish.
+                        onChange(updateSendEmailAction({detail: automation, actionId: emailModalAction.id, emailSubject: subject, emailLexical: lexical}));
+                        setEmailModalActionId(null);
+                    }}
+                />
+            )}
         </div>
     );
 };

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -618,7 +618,7 @@ const StepSidebarContent: React.FC<{detail: StepSidebarDetail}> = ({detail}) => 
     );
 };
 
-const StepSidebar: React.FC<{detail: StepSidebarDetail | null; onClose: () => void}> = ({detail, onClose}) => {
+const StepSidebar: React.FC<{detail: StepSidebarDetail | null; isEmailModalOpen: boolean; onClose: () => void}> = ({detail, isEmailModalOpen, onClose}) => {
     useEffect(() => {
         if (!detail) {
             return;
@@ -626,6 +626,9 @@ const StepSidebar: React.FC<{detail: StepSidebarDetail | null; onClose: () => vo
 
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
+                if (isEmailModalOpen) {
+                    return;
+                }
                 onClose();
             }
         };
@@ -634,7 +637,7 @@ const StepSidebar: React.FC<{detail: StepSidebarDetail | null; onClose: () => vo
         return () => {
             document.removeEventListener('keydown', handleKeyDown);
         };
-    }, [detail, onClose]);
+    }, [detail, isEmailModalOpen, onClose]);
 
     return (
         <aside
@@ -804,7 +807,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             >
                 <Background />
             </ReactFlow>
-            <StepSidebar detail={sidebarDetail} onClose={clearDetail} />
+            <StepSidebar detail={sidebarDetail} isEmailModalOpen={Boolean(emailModalAction)} onClose={clearDetail} />
             {emailModalAction && automation && (
                 <EmailContentModal
                     initialLexical={emailModalAction.data.email_lexical}

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -659,14 +659,19 @@ type AutomationCanvasProps = {
     onChange: (next: AutomationDetail) => void;
 };
 
+type SelectedStep = {
+    id: string;
+    isEditingEmail: boolean;
+};
+
 const insertActionByType = {
     wait: insertWaitAction,
     send_email: insertSendEmailAction
 };
 
 const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError, onChange}) => {
-    const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
-    const [emailModalActionId, setEmailModalActionId] = useState<string | null>(null);
+    const [selectedStep, setSelectedStep] = useState<SelectedStep | null>(null);
+    const selectedStepId = selectedStep?.id ?? null;
 
     const handlePick = useCallback((type: StepPickerType, anchor: CanvasAnchor) => {
         if (!automation) {
@@ -686,7 +691,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             return;
         }
         const next = removeAction({detail: automation, actionId});
-        setSelectedStepId(null);
+        setSelectedStep(null);
         onChange(next);
     }, [automation, onChange]);
 
@@ -701,15 +706,19 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         if (!automation) {
             return;
         }
-        onChange(updateSendEmailAction({detail: automation, actionId, emailSubject: subject}));
+        const action = automation.actions.find((item): item is AutomationSendEmailAction => item.id === actionId && item.type === 'send_email');
+        if (!action) {
+            return;
+        }
+        onChange(updateSendEmailAction({detail: automation, actionId, emailSubject: subject, emailLexical: action.data.email_lexical}));
     }, [automation, onChange]);
 
-    const handleEditEmail = useCallback((actionId: string) => {
-        setEmailModalActionId(actionId);
-    }, []);
+    const handleEditEmail = (actionId: string) => {
+        setSelectedStep({id: actionId, isEditingEmail: true});
+    };
 
-    const emailModalAction = emailModalActionId && automation
-        ? automation.actions.find((action): action is AutomationSendEmailAction => action.id === emailModalActionId && action.type === 'send_email')
+    const emailModalAction = selectedStep?.isEditingEmail && automation
+        ? automation.actions.find((action): action is AutomationSendEmailAction => action.id === selectedStep.id && action.type === 'send_email')
         : undefined;
 
     const initialViewport = useRef(getInitialViewport(window.innerWidth));
@@ -722,7 +731,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             automation,
             disabled: automation.actions.length >= MAX_AUTOMATION_ACTIONS,
             onPick: handlePick,
-            onSelectStep: setSelectedStepId,
+            onSelectStep: id => setSelectedStep({id, isEditingEmail: false}),
             selectedStepId
         });
     }, [automation, handlePick, selectedStepId]);
@@ -736,8 +745,15 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         stepId: selectedStepId
     }) : null;
     const clearDetail = useCallback(() => {
-        setSelectedStepId(null);
+        setSelectedStep(null);
     }, []);
+
+    const closeEmailModal = () => {
+        if (!emailModalAction) {
+            return;
+        }
+        setSelectedStep({id: emailModalAction.id, isEditingEmail: false});
+    };
 
     if (isLoading) {
         return (
@@ -781,7 +797,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
                 panOnScroll
                 onNodeClick={(_, node) => {
                     if (node.id !== TAIL_CANVAS_ID) {
-                        setSelectedStepId(node.id);
+                        setSelectedStep({id: node.id, isEditingEmail: false});
                     }
                 }}
                 onPaneClick={clearDetail}
@@ -791,13 +807,12 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             <StepSidebar detail={sidebarDetail} onClose={clearDetail} />
             {emailModalAction && automation && (
                 <EmailContentModal
-                    initialLexical={emailModalAction.data.email_lexical || ''}
-                    initialSubject={emailModalAction.data.email_subject || ''}
-                    onClose={() => setEmailModalActionId(null)}
+                    initialLexical={emailModalAction.data.email_lexical}
+                    initialSubject={emailModalAction.data.email_subject}
+                    onClose={closeEmailModal}
                     onSave={({subject, lexical}) => {
-                        // Commit the edited content into the local draft; persisted on Publish.
                         onChange(updateSendEmailAction({detail: automation, actionId: emailModalAction.id, emailSubject: subject, emailLexical: lexical}));
-                        setEmailModalActionId(null);
+                        setSelectedStep({id: emailModalAction.id, isEditingEmail: false});
                     }}
                 />
             )}

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -228,6 +228,11 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialSubject, in
                 <DialogContent
                     aria-describedby={undefined}
                     className='top-0 left-0 h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 grid-rows-[1fr] gap-0 rounded-none border-0 p-0 shadow-none outline-hidden sm:rounded-none dark:bg-[#151719]'
+                    onEscapeKeyDown={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        attemptClose();
+                    }}
                 >
                     <DialogTitle className='sr-only'>Edit email</DialogTitle>
                     <EmailPreviewModalContent

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -1,0 +1,365 @@
+import EmailEditor from './email-editor';
+import EmailPreviewFrame from './preview-frame';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import TestEmailDropdown from './test-email-dropdown';
+import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, Dialog, DialogContent, DialogTitle, Input, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
+import {LucideIcon, cn} from '@tryghost/shade/utils';
+import {WELCOME_EMAIL_SLUGS} from './sender-details';
+import {getEmailValidationErrors} from './validation';
+import {useBrowseAutomatedEmails, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import {useEmailPreview} from './use-email-preview';
+import {useEmailSenderDetails} from './use-sender-details';
+import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+
+interface EmailPreviewModalContentProps {
+    title: string;
+    centeredHeaderContent?: React.ReactNode;
+    headerActions?: React.ReactNode;
+    children: React.ReactNode;
+    className?: string;
+    isEditMode?: boolean;
+}
+
+const EmailPreviewModalContent = React.forwardRef<
+    HTMLDivElement,
+    EmailPreviewModalContentProps
+>(({title, centeredHeaderContent, headerActions, children, className, isEditMode = false}, ref) => (
+    <div
+        ref={ref}
+        className={cn(
+            'flex h-full w-full flex-col gap-0 overflow-hidden p-0',
+            isEditMode ? 'bg-white' : 'bg-gray-100',
+            'dark:bg-gray-975',
+            className
+        )}
+    >
+        <div className="sticky top-0 grid shrink-0 grid-cols-[1fr_auto_1fr] items-center border-b border-gray-200 bg-white px-5 py-3 dark:border-gray-900 dark:bg-gray-975">
+            <h3 className="justify-self-start text-xl font-semibold">
+                {title}
+            </h3>
+            <div className="justify-self-center">
+                {centeredHeaderContent}
+            </div>
+            <div className="flex items-center gap-2 justify-self-end">
+                {headerActions}
+            </div>
+        </div>
+        <div className="flex min-h-0 grow flex-col overflow-y-auto [scrollbar-gutter:stable]">
+            {children}
+        </div>
+    </div>
+));
+EmailPreviewModalContent.displayName = 'EmailPreviewModalContent';
+
+interface EmailPreviewEmailHeaderProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+const EmailPreviewEmailHeader: React.FC<EmailPreviewEmailHeaderProps> = ({children, className}) => (
+    <div className={cn(
+        'relative z-20 isolate mx-auto w-full max-w-[780px] rounded-t-lg border border-b-0 border-gray-200 bg-white px-6 py-4 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:bg-grey-975',
+        className
+    )}>
+        {children}
+    </div>
+);
+
+interface EmailPreviewBodyProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+const EmailPreviewBody: React.FC<EmailPreviewBodyProps> = ({children, className}) => (
+    <div className={cn(
+        'flex mx-auto w-full rounded-b-lg transition-[max-width,height,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:shadow-none grow max-w-[780px]',
+        className
+    )}>
+        {children}
+    </div>
+);
+
+export interface EmailContentModalProps {
+    initialSubject: string;
+    initialLexical: string;
+    onClose: () => void;
+    onSave: (data: {subject: string; lexical: string}) => void;
+}
+
+type PreviewMode = 'edit' | 'preview';
+
+const EmailContentModal: React.FC<EmailContentModalProps> = ({initialSubject, initialLexical, onClose, onSave}) => {
+    const {mutateAsync: previewWelcomeEmail} = usePreviewWelcomeEmail();
+    const {data: automatedEmailsData} = useBrowseAutomatedEmails();
+    const [showTestDropdown, setShowTestDropdown] = useState(false);
+    const [mode, setMode] = useState<PreviewMode>('edit');
+    const [previewSubjectOverride, setPreviewSubjectOverride] = useState<string | null>(null);
+    const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    const normalizedLexical = useRef<string>(initialLexical || '');
+    const hasEditorBeenFocused = useRef(false);
+    const handleError = useHandleError();
+    const automatedEmails = automatedEmailsData?.automated_emails || [];
+    const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useEmailSenderDetails(automatedEmails);
+
+    // Preview & test reuse the legacy welcome-email endpoints, which are keyed by
+    // an automated-email id. Borrow the free welcome email's id (falling back to
+    // the first record) so unsaved automation content can be rendered/sent.
+    const previewAutomatedEmailId = (
+        automatedEmails.find(email => email.slug === WELCOME_EMAIL_SLUGS.free)
+        || automatedEmails[0]
+    )?.id || '';
+
+    const {formState, saveState, updateForm, setFormState, setErrors, handleSave, okProps, errors, validate} = useForm({
+        initialState: {
+            subject: initialSubject || '',
+            lexical: initialLexical || ''
+        },
+        savingDelay: 500,
+        onSave: async (state) => {
+            onSave({subject: state.subject, lexical: state.lexical});
+        },
+        onSaveError: handleError,
+        onValidate: getEmailValidationErrors
+    });
+    const saveButtonLabel = okProps.label || 'Save';
+    const {previewFrameState, enterPreview, exitPreview} = useEmailPreview({
+        automatedEmailId: previewAutomatedEmailId,
+        previewWelcomeEmail,
+        setErrors
+    });
+
+    const isDirty = saveState === 'unsaved';
+
+    // Single close funnel: Esc, overlay click, and the Close button all route here.
+    const attemptClose = useCallback(() => {
+        if (isDirty) {
+            setConfirmDiscardOpen(true);
+        } else {
+            onClose();
+        }
+    }, [isDirty, onClose]);
+
+    // Commit to the automation draft, then close the modal.
+    const handleSaveAndClose = useCallback(async () => {
+        const result = await handleSave({fakeWhenUnchanged: true});
+        if (result) {
+            onClose();
+        }
+    }, [handleSave, onClose]);
+
+    // Close dropdown when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setShowTestDropdown(false);
+            }
+        };
+
+        if (showTestDropdown) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [showTestDropdown]);
+
+    const handleSaveAndCloseRef = useRef(handleSaveAndClose);
+    useEffect(() => {
+        handleSaveAndCloseRef.current = handleSaveAndClose;
+    }, [handleSaveAndClose]);
+
+    useEffect(() => {
+        const handleCMDS = (e: KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+                e.preventDefault();
+                handleSaveAndCloseRef.current();
+            }
+        };
+        window.addEventListener('keydown', handleCMDS);
+        return () => {
+            window.removeEventListener('keydown', handleCMDS);
+        };
+    }, []);
+
+    const handleModeChange = useCallback((nextMode: PreviewMode) => {
+        setMode(nextMode);
+
+        if (nextMode === 'preview') {
+            setPreviewSubjectOverride(null);
+            enterPreview(formState);
+        } else {
+            setShowTestDropdown(false);
+            setPreviewSubjectOverride(null);
+            exitPreview();
+        }
+    }, [enterPreview, exitPreview, formState]);
+
+    // The editor normalizes content on mount (e.g., processing {name} templates),
+    // which triggers onChange even without user edits. We track whether the editor
+    // has ever been focused - normalization happens before focus is possible, so any
+    // onChange before first focus is normalization. After focus, we compare against
+    // the normalized baseline to determine dirty state.
+    const handleEditorChange = useCallback((lexical: string) => {
+        if (!hasEditorBeenFocused.current) {
+            // Editor hasn't been focused yet = must be normalization
+            normalizedLexical.current = lexical;
+            setFormState(state => ({...state, lexical}));
+            return;
+        }
+
+        // Editor has been focused = compare to baseline
+        if (lexical !== normalizedLexical.current) {
+            updateForm(state => ({...state, lexical}));
+        } else {
+            // Content reverted to normalized state - don't mark dirty
+            setFormState(state => ({...state, lexical}));
+        }
+    }, [setFormState, updateForm]);
+
+    return (
+        <>
+            <Dialog open onOpenChange={(next) => {
+                if (!next) {
+                    attemptClose();
+                }
+            }}>
+                <DialogContent
+                    aria-describedby={undefined}
+                    className='top-0 left-0 h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 grid-rows-[1fr] gap-0 rounded-none border-0 p-0 shadow-none outline-hidden sm:rounded-none dark:bg-[#151719]'
+                >
+                    <DialogTitle className='sr-only'>Edit email</DialogTitle>
+                    <EmailPreviewModalContent
+                        centeredHeaderContent={
+                            <Tabs
+                                data-testid='email-mode-toggle'
+                                value={mode}
+                                variant='segmented-sm'
+                                onValueChange={value => value && handleModeChange(value as PreviewMode)}
+                            >
+                                <TabsList className='grid w-[240px] grid-cols-2 bg-gray-100 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]'>
+                                    <TabsTrigger className='w-full justify-center data-[state=active]:bg-white dark:data-[state=active]:bg-white dark:data-[state=active]:text-black' data-testid='email-mode-edit' value='edit'>Email content</TabsTrigger>
+                                    <TabsTrigger className='w-full justify-center' data-testid='email-mode-preview' value='preview'>Preview</TabsTrigger>
+                                </TabsList>
+                            </Tabs>
+                        }
+                        headerActions={
+                            <>
+                                <Button variant="outline" onClick={attemptClose}>Close</Button>
+                                <Button
+                                    disabled={okProps.disabled}
+                                    onClick={handleSaveAndClose}
+                                >
+                                    {saveButtonLabel}
+                                </Button>
+                            </>
+                        }
+                        isEditMode={mode === 'edit'}
+                        title='Edit email'
+                    >
+                        <div className='flex grow flex-col items-center p-6'>
+                            {mode === 'preview' && (
+                                <EmailPreviewEmailHeader className='border-x-0 border-t-0 border-b'>
+                                    <div className='flex flex-col gap-2'>
+                                        <div className='flex items-center py-1'>
+                                            <div className='w-20 shrink-0 text-sm font-semibold'>From:</div>
+                                            <div className='min-w-0 grow pr-4 text-sm'>
+                                                <span className='flex gap-1 truncate whitespace-nowrap'>
+                                                    <span>{resolvedSenderName}</span>
+                                                    <span className='text-gray-500 dark:text-gray-400'>{`<${resolvedSenderEmail}>`}</span>
+                                                </span>
+                                            </div>
+                                            <div ref={dropdownRef} className='relative'>
+                                                <Button variant="outline" onClick={() => setShowTestDropdown(!showTestDropdown)}>
+                                                    <LucideIcon.Send className='size-4' />
+                                                    Test
+                                                </Button>
+                                                {showTestDropdown && (
+                                                    <TestEmailDropdown automatedEmailId={previewAutomatedEmailId} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
+                                                )}
+                                            </div>
+                                        </div>
+                                        {hasDistinctReplyTo && (
+                                            <div className='flex items-center'>
+                                                <div className='w-20 shrink-0 text-sm font-semibold'>Reply-to:</div>
+                                                <div className='grow text-sm text-gray-500 dark:text-gray-400'>
+                                                    {resolvedReplyToEmail}
+                                                </div>
+                                            </div>
+                                        )}
+                                        <div className='flex items-center'>
+                                            <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
+                                            <div className='grow'>
+                                                <Input
+                                                    className='w-full'
+                                                    data-testid='email-preview-subject'
+                                                    value={previewSubjectOverride ?? formState.subject}
+                                                    onChange={(e) => {
+                                                        const nextSubject = e.target.value;
+                                                        setPreviewSubjectOverride(nextSubject);
+                                                        updateForm(state => ({...state, subject: nextSubject}));
+                                                    }}
+                                                />
+                                                {errors.subject && <span className='mt-2 block text-xs text-destructive'>{errors.subject}</span>}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </EmailPreviewEmailHeader>
+                            )}
+                            <EmailPreviewBody className={cn(
+                                mode === 'preview' && 'shadow-sm bg-white dark:bg-grey-975',
+                                mode === 'edit' && 'px-6',
+                                mode === 'edit' && 'rounded-lg',
+                                mode === 'edit' && errors.lexical && 'border border-red-500'
+                            )}>
+                                <div
+                                    className={cn(
+                                        'mx-auto w-full max-w-[600px] pt-10 pb-8 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none',
+                                        mode === 'preview' && 'hidden'
+                                    )}
+                                    data-testid='email-editor'
+                                    onFocus={() => {
+                                        hasEditorBeenFocused.current = true;
+                                    }}
+                                >
+                                    <EmailEditor
+                                        className='automation-email-editor'
+                                        placeholder='Write your email content...'
+                                        value={formState.lexical}
+                                        onChange={handleEditorChange}
+                                    />
+                                </div>
+                                {mode === 'preview' && (
+                                    <EmailPreviewFrame previewState={previewFrameState} />
+                                )}
+                            </EmailPreviewBody>
+                            {mode === 'edit' && errors.lexical && <span className='mt-2 block max-w-[740px] text-xs text-destructive'>{errors.lexical}</span>}
+                        </div>
+                    </EmailPreviewModalContent>
+                </DialogContent>
+            </Dialog>
+            <AlertDialog open={confirmDiscardOpen} onOpenChange={setConfirmDiscardOpen}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Discard changes?</AlertDialogTitle>
+                        <AlertDialogDescription>Your changes to this email haven&apos;t been saved.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Keep editing</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={() => {
+                                setConfirmDiscardOpen(false);
+                                onClose();
+                            }}
+                        >
+                            Discard
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
+    );
+};
+
+export default EmailContentModal;

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -2,7 +2,7 @@ import EmailEditor from './email-editor';
 import EmailPreviewFrame from './preview-frame';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import TestEmailDropdown from './test-email-dropdown';
-import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, Dialog, DialogContent, DialogTitle, Input, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, Dialog, DialogContent, DialogTitle, Input, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn} from '@tryghost/shade/utils';
 import {WELCOME_EMAIL_SLUGS} from './sender-details';
 import {getEmailValidationErrors} from './validation';
@@ -347,14 +347,15 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialSubject, in
                     </AlertDialogHeader>
                     <AlertDialogFooter>
                         <AlertDialogCancel>Keep editing</AlertDialogCancel>
-                        <AlertDialogAction
+                        <Button
+                            variant='destructive'
                             onClick={() => {
                                 setConfirmDiscardOpen(false);
                                 onClose();
                             }}
                         >
                             Discard
-                        </AlertDialogAction>
+                        </Button>
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>

--- a/apps/posts/src/views/Automations/components/email-modal/email-editor.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-editor.tsx
@@ -1,0 +1,161 @@
+import React, {Suspense, useCallback, useMemo, useRef} from 'react';
+import {LoadingIndicator} from '@tryghost/shade/components';
+import {cn} from '@tryghost/shade/utils';
+import {focusKoenigEditorOnBottomClick, useFramework} from '@tryghost/admin-x-framework';
+import {getSettingValues, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import {koenigFileUploadTypes, useKoenigFetchEmbed, useKoenigFileUpload, usePinturaConfig} from '@tryghost/admin-x-framework/hooks';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useEmailLinkSuggestions} from './use-link-suggestions';
+
+export interface EmailEditorProps {
+    value?: string;
+    placeholder?: string;
+    className?: string;
+    onChange?: (value: string) => void;
+}
+
+// The editor API handle, typed as whatever focusKoenigEditorOnBottomClick accepts.
+type KoenigAPI = Parameters<typeof focusKoenigEditorOnBottomClick>[0];
+
+const fileUploader = {
+    useFileUpload: useKoenigFileUpload,
+    fileTypes: koenigFileUploadTypes
+};
+
+// Lazy-load the editor as its own chunk; the ESM import lets Vite dedupe React.
+const EmailEditorComponent = React.lazy(() => import('@tryghost/koenig-lexical').then(module => ({default: module.EmailEditor})));
+
+// Inline fallback if the editor chunk fails to load — kept lightweight so a
+// failure shows inside the modal rather than replacing the whole view.
+class EditorErrorBoundary extends React.Component<{children: React.ReactNode}, {hasError: boolean}> {
+    state = {hasError: false};
+
+    static getDerivedStateFromError() {
+        return {hasError: true};
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return <div className='p-6 text-sm text-destructive'>Something went wrong loading the editor.</div>;
+        }
+        return this.props.children;
+    }
+}
+
+const baseEditorStyles = cn(
+    // Base typography
+    'text-[1.6rem] leading-[1.6] tracking-[-0.01em] pb-10',
+    // Dark mode
+    'dark:text-white dark:selection:bg-[rgba(88,101,116,0.99)]',
+    // Placeholder styling
+    '[&_.koenig-lexical-editor-input-placeholder]:font-sans! [&_.koenig-lexical-editor-input-placeholder]:text-[1.6rem] [&_.koenig-lexical-editor-input-placeholder]:tracking-tight',
+    // Headings dark mode
+    '[&_:is(h2,h3)]:dark:text-white',
+    // Inputs
+    '[&_.koenig-lexical_input]:text-[1.4rem]',
+    // Plus icon
+    '[&_[data-kg-plus-button]]:top-[-4px]',
+    // Settings panel
+    '[&_[data-kg-card-selected]]:isolate',
+    // Content typography
+    '[&_:is(p,blockquote,aside,ul,ol)]:tracking-tight',
+    // Reset content typography inside card captions to match Koenig's caption styles
+    '[&_figcaption_:is(p,blockquote,aside,ul,ol)]:text-[1.4rem] [&_figcaption_:is(p,blockquote,aside,ul,ol)]:tracking-[.025em]',
+    '[&_figcaption_p]:mb-0',
+    '[&_:is(h1)]:text-[36px] [&_:is(h2)]:text-[32px] [&_:is(h3)]:text-[26px] [&_:is(h4)]:text-[21px] [&_:is(h5)]:text-[19px] [&_:is(h6)]:text-[19px] [&_:is(h1,h2,h3,h4,h5,h6)]:mb-[0.5em]',
+    // Horizontal ruler
+    '[&_:is(hr)]:pt-0',
+    // Paragraph spacing & bold
+    '[&_p]:mb-4 [&_strong]:font-semibold',
+    // Keep settings panel copy compact
+    '[&_[data-kg-settings-panel]_p]:!mb-0',
+    // Nested-editor (callout, etc.) fixes: align placeholder with text
+    '[&_.not-kg-prose>div]:font-sans! [&_.not-kg-prose>div]:tracking-tight! [&_.not-kg-prose>div]:text-[1.6rem]! [&_.not-kg-prose>div]:leading-[1.6]!',
+    '[&_.kg-inherit-styles_p]:mb-0!',
+    '[&_.kg-inherit-styles]:pt-[3px]!',
+    // CTA card: keep sponsor label at its intended 12.5px size
+    '[&_.koenig-lexical-cta-label_p]:!text-[12.5px]'
+);
+
+const EmailEditor: React.FC<EmailEditorProps> = ({
+    value,
+    placeholder,
+    className,
+    onChange
+}) => {
+    const editorAPIRef = useRef<KoenigAPI | null>(null);
+    // Capture the initial value once — the editor owns its own state after mount
+    const initialEditorState = useRef(value);
+    const {unsplashConfig} = useFramework();
+    const pinturaConfig = usePinturaConfig();
+    const {data: settingsData} = useBrowseSettings();
+    const {data: configData} = useBrowseConfig();
+    const settings = settingsData?.settings || [];
+    const config = configData?.config;
+    const {fetchAutocompleteLinks, searchLinks} = useEmailLinkSuggestions();
+    const fetchEmbed = useKoenigFetchEmbed();
+    const tenorConfig = config?.tenor?.googleApiKey ? config.tenor : null;
+    const [transistorEnabled] = getSettingValues<boolean>(settings, ['transistor']);
+
+    const cardConfig = useMemo(() => ({
+        unsplash: unsplashConfig,
+        pinturaConfig,
+        tenor: tenorConfig,
+        fetchEmbed,
+        fetchAutocompleteLinks,
+        searchLinks,
+        feature: {
+            transistor: transistorEnabled
+        },
+        visibilitySettings: 'none'
+    }), [unsplashConfig, pinturaConfig, tenorConfig, fetchEmbed, fetchAutocompleteLinks, searchLinks, transistorEnabled]);
+
+    const registerEditorAPI = useCallback((api: unknown) => {
+        editorAPIRef.current = api as KoenigAPI | null;
+    }, []);
+
+    // Koenig's onChange passes the Lexical state as a plain object,
+    // but the API expects a JSON string
+    const handleChange = useCallback((data: unknown) => {
+        if (onChange && data && typeof data === 'object') {
+            onChange(JSON.stringify(data));
+        }
+    }, [onChange]);
+
+    // Stop Cmd+K from bubbling to global search handler
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+            e.stopPropagation();
+        }
+    }, []);
+
+    const handleEditorMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (!editorAPIRef.current) {
+            return;
+        }
+        focusKoenigEditorOnBottomClick(editorAPIRef.current, event);
+    };
+
+    return (
+        <div className="h-full" onKeyDown={handleKeyDown} onMouseDown={handleEditorMouseDown}>
+            <EditorErrorBoundary>
+                <Suspense fallback={<LoadingIndicator size='lg' />}>
+                    <div className={cn('koenig-react-editor w-full', baseEditorStyles, className)}>
+                        <EmailEditorComponent
+                            cardConfig={cardConfig}
+                            className="koenig-lexical koenig-lexical-editor-input"
+                            darkMode={false}
+                            fileUploader={fileUploader}
+                            initialEditorState={initialEditorState.current}
+                            placeholderText={placeholder}
+                            registerAPI={registerEditorAPI}
+                            onChange={handleChange}
+                        />
+                    </div>
+                </Suspense>
+            </EditorErrorBoundary>
+        </div>
+    );
+};
+
+export default React.memo(EmailEditor);

--- a/apps/posts/src/views/Automations/components/email-modal/koenig-lexical.d.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/koenig-lexical.d.ts
@@ -1,0 +1,18 @@
+// @tryghost/koenig-lexical ships no type declarations. We load it dynamically
+// and only use its self-contained EmailEditor, so declare just that surface.
+declare module '@tryghost/koenig-lexical' {
+    import type {ComponentType} from 'react';
+
+    export interface EmailEditorProps {
+        cardConfig?: unknown;
+        className?: string;
+        darkMode?: boolean;
+        fileUploader?: unknown;
+        initialEditorState?: string;
+        placeholderText?: string;
+        registerAPI?: (api: unknown) => void;
+        onChange?: (state: unknown) => void;
+    }
+
+    export const EmailEditor: ComponentType<EmailEditorProps>;
+}

--- a/apps/posts/src/views/Automations/components/email-modal/newsletter-emails.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/newsletter-emails.ts
@@ -1,0 +1,41 @@
+import {type Config, hasSendingDomain, isManagedEmail} from '@tryghost/admin-x-framework/api/config';
+import {type Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
+
+export const renderSenderEmail = (newsletter: Pick<Newsletter, 'sender_email'>, config: Config, defaultEmailAddress: string|undefined) => {
+    if (isManagedEmail(config) && !hasSendingDomain(config) && defaultEmailAddress) {
+        // Not changeable: sender_email is ignored
+        return defaultEmailAddress;
+    }
+
+    return newsletter.sender_email || defaultEmailAddress || '';
+};
+
+export const renderReplyToEmail = (newsletter: Pick<Newsletter, 'sender_email' | 'sender_reply_to'>, config: Config, supportEmailAddress: string|undefined, defaultEmailAddress: string|undefined) => {
+    if (newsletter.sender_reply_to === 'newsletter') {
+        if (isManagedEmail(config)) {
+            // No reply-to set
+            // sender_reply_to currently doesn't allow empty values, we need to set it to 'newsletter'
+            return '';
+        }
+        return renderSenderEmail(newsletter, config, defaultEmailAddress);
+    }
+
+    if (newsletter.sender_reply_to === 'support') {
+        return supportEmailAddress || defaultEmailAddress || '';
+    }
+
+    return newsletter.sender_reply_to;
+};
+
+export const renderReplyToEmailPlaceholder = (newsletter: Pick<Newsletter, 'sender_email' | 'sender_reply_to'>, config: Config, supportEmailAddress: string|undefined, defaultEmailAddress: string|undefined) => {
+    const replyTo = renderReplyToEmail(newsletter, config, supportEmailAddress, defaultEmailAddress);
+    if (replyTo) {
+        return replyTo;
+    }
+
+    if (newsletter.sender_reply_to === 'newsletter') {
+        return renderSenderEmail(newsletter, config, defaultEmailAddress) || supportEmailAddress || defaultEmailAddress || '';
+    }
+
+    return supportEmailAddress || defaultEmailAddress || '';
+};

--- a/apps/posts/src/views/Automations/components/email-modal/preview-frame.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/preview-frame.tsx
@@ -1,0 +1,156 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {LoadingIndicator} from '@tryghost/shade/components';
+import {cn} from '@tryghost/shade/utils';
+import type {EmailPreviewFrameState} from './use-email-preview';
+
+interface EmailPreviewFrameProps {
+    previewState: EmailPreviewFrameState;
+}
+
+const EmailPreviewFrame: React.FC<EmailPreviewFrameProps> = ({previewState}) => {
+    const [previewHeight, setPreviewHeight] = useState<number | null>(null);
+    const [isPreviewReady, setIsPreviewReady] = useState(false);
+    const isPreviewReadyRef = useRef(false);
+    const previewIframeRef = useRef<HTMLIFrameElement>(null);
+    const previewResizeObserverRef = useRef<ResizeObserver | null>(null);
+    const previewMeasureFrameRef = useRef<number | null>(null);
+    const previewRevealFrameRef = useRef<number | null>(null);
+
+    function cleanupPreviewMeasurement() {
+        previewResizeObserverRef.current?.disconnect();
+        previewResizeObserverRef.current = null;
+
+        if (previewMeasureFrameRef.current !== null) {
+            window.cancelAnimationFrame(previewMeasureFrameRef.current);
+            previewMeasureFrameRef.current = null;
+        }
+
+        if (previewRevealFrameRef.current !== null) {
+            window.cancelAnimationFrame(previewRevealFrameRef.current);
+            previewRevealFrameRef.current = null;
+        }
+    }
+
+    const previewHtml = previewState.status === 'success' ? previewState.html : '';
+
+    useEffect(() => {
+        cleanupPreviewMeasurement();
+        isPreviewReadyRef.current = false;
+        setIsPreviewReady(false);
+        setPreviewHeight(null);
+
+        return () => {
+            cleanupPreviewMeasurement();
+        };
+    }, [previewHtml, previewState.status]);
+
+    function syncPreviewHeight() {
+        const iframe = previewIframeRef.current;
+        const doc = iframe?.contentDocument;
+
+        if (!iframe || !doc) {
+            return;
+        }
+
+        doc.documentElement.style.overflowY = 'hidden';
+        doc.body.style.overflowY = 'hidden';
+
+        const nextHeight = Math.max(
+            doc.documentElement?.scrollHeight || 0,
+            doc.body?.scrollHeight || 0,
+            doc.documentElement?.offsetHeight || 0,
+            doc.body?.offsetHeight || 0
+        );
+
+        if (nextHeight > 0) {
+            setPreviewHeight(previousHeight => (previousHeight === nextHeight ? previousHeight : nextHeight));
+
+            if (!isPreviewReadyRef.current && previewRevealFrameRef.current === null) {
+                previewRevealFrameRef.current = window.requestAnimationFrame(() => {
+                    previewRevealFrameRef.current = window.requestAnimationFrame(() => {
+                        previewRevealFrameRef.current = null;
+                        isPreviewReadyRef.current = true;
+                        setIsPreviewReady(true);
+                    });
+                });
+            }
+        }
+    }
+
+    function queuePreviewHeightSync() {
+        if (previewMeasureFrameRef.current !== null) {
+            window.cancelAnimationFrame(previewMeasureFrameRef.current);
+        }
+
+        previewMeasureFrameRef.current = window.requestAnimationFrame(() => {
+            previewMeasureFrameRef.current = null;
+            syncPreviewHeight();
+        });
+    }
+
+    function handlePreviewLoad() {
+        const iframe = previewIframeRef.current;
+        const doc = iframe?.contentDocument;
+
+        if (!iframe || !doc) {
+            return;
+        }
+
+        cleanupPreviewMeasurement();
+        queuePreviewHeightSync();
+
+        if (typeof ResizeObserver !== 'undefined') {
+            const observer = new ResizeObserver(() => {
+                queuePreviewHeightSync();
+            });
+
+            observer.observe(doc.documentElement);
+            observer.observe(doc.body);
+            previewResizeObserverRef.current = observer;
+        }
+    }
+
+    const showPreviewLoading = previewState.status === 'loading' || (previewState.status === 'success' && !isPreviewReady);
+
+    return (
+        <div className='relative w-full' data-testid='email-preview'>
+            {showPreviewLoading && (
+                <div
+                    className='flex min-h-full items-start justify-center pt-24'
+                    data-testid='email-preview-loading'
+                    style={previewHeight ? {height: `${previewHeight}px`} : undefined}
+                >
+                    <LoadingIndicator size='md' />
+                </div>
+            )}
+            {previewState.status === 'success' && (
+                <div
+                    aria-hidden={!isPreviewReady}
+                    className={cn(
+                        'w-full',
+                        !isPreviewReady && 'pointer-events-none absolute left-0 top-0 opacity-0'
+                    )}
+                >
+                    {/* Keep the iframe hidden until it has been measured to avoid a visible resize jump. */}
+                    <iframe
+                        ref={previewIframeRef}
+                        className='w-full rounded bg-white'
+                        data-testid='email-preview-iframe'
+                        sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+                        srcDoc={previewState.html}
+                        style={{height: previewHeight ? `${previewHeight}px` : '600px'}}
+                        title='Email preview'
+                        onLoad={handlePreviewLoad}
+                    />
+                </div>
+            )}
+            {(previewState.status === 'error' || previewState.status === 'invalid') && (
+                <div className='flex h-full items-center justify-center px-4' data-testid='email-preview-error'>
+                    <span className='text-sm text-destructive'>{previewState.message}</span>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default EmailPreviewFrame;

--- a/apps/posts/src/views/Automations/components/email-modal/sender-details.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/sender-details.ts
@@ -1,0 +1,77 @@
+import {type Config, hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
+import {renderReplyToEmailPlaceholder, renderSenderEmail} from './newsletter-emails';
+import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import type {Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
+
+// Slugs for the auto-created welcome email records, used to borrow sender
+// identity for the preview/test render. Mirrors WELCOME_EMAIL_SLUGS in settings.
+export const WELCOME_EMAIL_SLUGS = {
+    free: 'member-welcome-email-free',
+    paid: 'member-welcome-email-paid'
+};
+
+type AutomatedEmailSenderFields = Pick<AutomatedEmail, 'slug' | 'sender_name' | 'sender_email' | 'sender_reply_to'>;
+type NewsletterSenderFields = Pick<Newsletter, 'sender_name' | 'sender_email' | 'sender_reply_to'>;
+
+export interface ResolveEmailSenderDetailsInput {
+    automatedEmails?: AutomatedEmailSenderFields[];
+    config: Config;
+    defaultEmailAddress?: string | null;
+    newsletter?: NewsletterSenderFields | null;
+    siteTitle?: string | null;
+    supportEmailAddress?: string | null;
+}
+
+const trimValue = (value: string | null | undefined) => value?.trim() || '';
+
+const firstNonEmpty = (...values: Array<string | null | undefined>) => {
+    const normalized = values.map(trimValue);
+    return normalized.find(Boolean) || '';
+};
+
+export const resolveEmailSenderDetails = ({
+    automatedEmails = [],
+    config,
+    defaultEmailAddress,
+    newsletter,
+    siteTitle,
+    supportEmailAddress
+}: ResolveEmailSenderDetailsInput) => {
+    const freeEmail = automatedEmails.find(email => email.slug === WELCOME_EMAIL_SLUGS.free);
+    const paidEmail = automatedEmails.find(email => email.slug === WELCOME_EMAIL_SLUGS.paid);
+
+    const senderNameInput = firstNonEmpty(freeEmail?.sender_name, paidEmail?.sender_name);
+    const senderEmailInput = firstNonEmpty(freeEmail?.sender_email, paidEmail?.sender_email);
+    const replyToEmailInput = firstNonEmpty(freeEmail?.sender_reply_to, paidEmail?.sender_reply_to);
+
+    const defaultNewsletterSenderName = trimValue(newsletter?.sender_name);
+    const defaultNewsletterSenderEmail = newsletter ? trimValue(renderSenderEmail(newsletter, config, defaultEmailAddress || undefined)) : '';
+    const defaultNewsletterReplyTo = newsletter ? trimValue(renderReplyToEmailPlaceholder(newsletter, config, supportEmailAddress || undefined, defaultEmailAddress || undefined)) : '';
+
+    const senderNamePlaceholder = defaultNewsletterSenderName || trimValue(siteTitle) || 'Your site name';
+    const senderEmailPlaceholder = defaultNewsletterSenderEmail || trimValue(defaultEmailAddress);
+    const replyToEmailPlaceholder = defaultNewsletterReplyTo || trimValue(supportEmailAddress) || trimValue(defaultEmailAddress);
+
+    const resolvedSenderName = senderNameInput || senderNamePlaceholder || 'Your Site';
+    const resolvedSenderEmail = senderEmailInput || senderEmailPlaceholder || '';
+    const resolvedReplyToEmail = replyToEmailInput || replyToEmailPlaceholder || '';
+    const hasDistinctReplyTo = resolvedReplyToEmail !== '' && resolvedReplyToEmail !== resolvedSenderEmail;
+
+    const managedEmail = isManagedEmail(config);
+    const hasManagedSendingDomain = hasSendingDomain(config);
+
+    return {
+        hasDistinctReplyTo,
+        replyToEmailInput,
+        replyToEmailPlaceholder,
+        resolvedReplyToEmail,
+        resolvedSenderEmail,
+        resolvedSenderName,
+        senderEmailDomain: hasManagedSendingDomain ? sendingDomain(config) : null,
+        senderEmailInput,
+        senderEmailPlaceholder,
+        senderNameInput,
+        senderNamePlaceholder,
+        showSenderEmailInput: !managedEmail || hasManagedSendingDomain
+    };
+};

--- a/apps/posts/src/views/Automations/components/email-modal/test-email-dropdown.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/test-email-dropdown.tsx
@@ -1,0 +1,122 @@
+import validator from 'validator';
+import {Button, Input} from '@tryghost/shade/components';
+import {JSONError} from '@tryghost/admin-x-framework/errors';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useEffect, useRef, useState} from 'react';
+import {useSendTestWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+
+export interface TestEmailDropdownProps {
+  automatedEmailId: string
+  subject: string
+  lexical: string
+  validateForm: () => boolean
+  onClose: () => void
+}
+
+const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
+    automatedEmailId,
+    subject,
+    lexical,
+    validateForm,
+    onClose
+}) => {
+    const {data: currentUser} = useCurrentUser();
+    const {mutateAsync: sendTestEmail} = useSendTestWelcomeEmail();
+
+    const [testEmail, setTestEmail] = useState(currentUser?.email || '');
+    const [testEmailError, setTestEmailError] = useState('');
+    const [sendState, setSendState] = useState<'idle' | 'sending' | 'sent'>('idle');
+    const sendStateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    useEffect(() => {
+        return () => {
+            if (sendStateTimeoutRef.current) {
+                clearTimeout(sendStateTimeoutRef.current);
+            }
+        };
+    }, []);
+
+    // Update test email when current user data loads
+    useEffect(() => {
+        if (currentUser?.email) {
+            setTestEmail(currentUser.email);
+        }
+    }, [currentUser?.email]);
+
+    // Close dropdown on Escape and stop propagation to prevent modal from *also* closing
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.stopPropagation();
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown, true);
+        return () => document.removeEventListener('keydown', handleKeyDown, true);
+    }, [onClose]);
+
+    const handleSendTestEmail = async () => {
+        setTestEmailError('');
+
+        if (!validator.isEmail(testEmail)) {
+            setTestEmailError('Please enter a valid email address');
+            return;
+        }
+
+        // check that subject and lexical are valid
+        if (!validateForm()) {
+            setTestEmailError('Please complete the required fields');
+            return;
+        }
+
+        setSendState('sending');
+
+        try {
+            await sendTestEmail({
+                id: automatedEmailId,
+                email: testEmail,
+                subject,
+                lexical
+            });
+            setSendState('sent');
+            if (sendStateTimeoutRef.current) {
+                clearTimeout(sendStateTimeoutRef.current);
+            }
+            sendStateTimeoutRef.current = setTimeout(() => setSendState('idle'), 2000);
+        } catch (error) {
+            setSendState('idle');
+            let message;
+            if (error instanceof JSONError && error.data && error.data.errors[0]) {
+                message = error.data.errors[0].context || error.data.errors[0].message;
+            } else if (error instanceof Error) {
+                message = error.message;
+            }
+            setTestEmailError(message || 'Failed to send test email');
+        }
+    };
+
+    return (
+        <div className='absolute top-full right-0 z-10 mt-2 w-[260px] rounded border border-grey-250 bg-white p-4 shadow-lg dark:border-grey-925 dark:bg-grey-975' data-testid='test-email-dropdown'>
+            <div className='mb-3'>
+                <label className='mb-2 block text-sm font-semibold' htmlFor='test-email-input'>Send test email</label>
+                <Input
+                    id='test-email-input'
+                    placeholder='you@yoursite.com'
+                    value={testEmail}
+                    onChange={(e) => {
+                        setTestEmail(e.target.value);
+                    }}
+                />
+            </div>
+            <Button
+                className='w-full'
+                disabled={sendState === 'sending'}
+                onClick={handleSendTestEmail}
+            >
+                {sendState === 'sent' ? 'Sent' : sendState === 'sending' ? 'Sending...' : 'Send'}
+            </Button>
+            {testEmailError && <span className='mt-2 block text-xs text-destructive'>{testEmailError}</span>}
+        </div>
+    );
+};
+
+export default TestEmailDropdown;

--- a/apps/posts/src/views/Automations/components/email-modal/use-email-preview.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/use-email-preview.ts
@@ -1,0 +1,140 @@
+import {JSONError} from '@tryghost/admin-x-framework/errors';
+import {useRef, useState} from 'react';
+
+import {type EmailDraft, getEmailValidationErrors} from './validation';
+
+export type EmailPreview = {
+    html: string;
+    plaintext: string;
+    subject: string;
+};
+
+export type EmailPreviewResponse = {
+    automated_emails?: EmailPreview[];
+};
+
+export type EmailPreviewState =
+    | {status: 'idle'}
+    | {status: 'loading'}
+    | {status: 'success'; preview: EmailPreview}
+    | {status: 'error'; message: string}
+    | {status: 'invalid'; message: string};
+
+export type EmailPreviewFrameState =
+    | {status: 'loading'}
+    | {status: 'success'; html: string}
+    | {status: 'error' | 'invalid'; message: string};
+
+const preparePreviewHtml = (html: string) => {
+    if (typeof DOMParser === 'undefined') {
+        return html;
+    }
+
+    const parser = new DOMParser();
+    const parsed = parser.parseFromString(html, 'text/html');
+
+    parsed.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((link) => {
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+    });
+
+    return `<!doctype html>${parsed.documentElement.outerHTML}`;
+};
+
+const getPreviewErrorMessage = (error: unknown) => {
+    const fallbackMessage = 'Failed to render preview';
+
+    if (error instanceof JSONError && error.data?.errors?.[0]) {
+        return error.data.errors[0].context || error.data.errors[0].message || fallbackMessage;
+    }
+
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return fallbackMessage;
+};
+
+export const useEmailPreview = ({automatedEmailId, previewWelcomeEmail, setErrors}: {
+    automatedEmailId: string;
+    previewWelcomeEmail: (payload: EmailDraft & {id: string}) => Promise<EmailPreviewResponse>;
+    setErrors: (errors: Record<string, string>) => void;
+}) => {
+    const [previewState, setPreviewState] = useState<EmailPreviewState>({status: 'idle'});
+    const previewRequestIdRef = useRef(0);
+
+    const exitPreview = () => {
+        previewRequestIdRef.current += 1;
+        setPreviewState({status: 'idle'});
+    };
+
+    const enterPreview = async (draft: EmailDraft) => {
+        const requestId = previewRequestIdRef.current + 1;
+        previewRequestIdRef.current = requestId;
+
+        const validationErrors = getEmailValidationErrors(draft);
+        setErrors(validationErrors);
+
+        const hasValidationErrors = Boolean(validationErrors.subject || validationErrors.lexical);
+        if (hasValidationErrors) {
+            setPreviewState({
+                status: 'invalid',
+                message: validationErrors.subject || validationErrors.lexical
+            });
+            return;
+        }
+
+        setPreviewState({status: 'loading'});
+
+        try {
+            // Only the latest preview request is allowed to update preview state.
+            const response = await previewWelcomeEmail({
+                id: automatedEmailId,
+                subject: draft.subject,
+                lexical: draft.lexical
+            });
+
+            if (previewRequestIdRef.current !== requestId) {
+                return;
+            }
+
+            const preview = response.automated_emails?.[0];
+
+            if (!preview?.html || !preview?.plaintext || !preview?.subject) {
+                throw new Error('Preview response was incomplete');
+            }
+
+            setPreviewState({
+                status: 'success',
+                preview: {
+                    ...preview,
+                    html: preparePreviewHtml(preview.html)
+                }
+            });
+        } catch (error) {
+            if (previewRequestIdRef.current !== requestId) {
+                return;
+            }
+
+            setPreviewState({
+                status: 'error',
+                message: getPreviewErrorMessage(error)
+            });
+        }
+    };
+
+    let previewFrameState: EmailPreviewFrameState = {status: 'loading'};
+
+    if (previewState.status === 'success') {
+        previewFrameState = {status: 'success', html: previewState.preview.html};
+    } else if (previewState.status === 'error' || previewState.status === 'invalid') {
+        previewFrameState = {status: previewState.status, message: previewState.message};
+    }
+
+    return {
+        previewFrameState,
+        previewState,
+        enterPreview,
+        exitPreview
+    };
+};

--- a/apps/posts/src/views/Automations/components/email-modal/use-link-suggestions.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/use-link-suggestions.ts
@@ -9,7 +9,7 @@ export const useEmailLinkSuggestions = () => {
     const {data: settingsData} = useBrowseSettings();
     const {data: siteData} = useBrowseSite();
     const settings = settingsData?.settings || [];
-    const siteUrl = (siteData?.site?.url as string) || '';
+    const siteUrl = siteData?.site?.url || '';
     const [
         membersSignupAccess = 'all',
         donationsEnabled = false,

--- a/apps/posts/src/views/Automations/components/email-modal/use-link-suggestions.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/use-link-suggestions.ts
@@ -1,0 +1,29 @@
+import {getSettingValues, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
+import {useKoenigLinkSuggestions} from '@tryghost/admin-x-framework';
+
+// Provides Koenig link autocomplete config for the email editor. Reads settings
+// and site directly from framework hooks (no global data provider required) and
+// falls back to safe defaults while those requests are still loading.
+export const useEmailLinkSuggestions = () => {
+    const {data: settingsData} = useBrowseSettings();
+    const {data: siteData} = useBrowseSite();
+    const settings = settingsData?.settings || [];
+    const siteUrl = (siteData?.site?.url as string) || '';
+    const [
+        membersSignupAccess = 'all',
+        donationsEnabled = false,
+        recommendationsEnabled = false
+    ] = getSettingValues(settings, [
+        'members_signup_access',
+        'donations_enabled',
+        'recommendations_enabled'
+    ]);
+
+    return useKoenigLinkSuggestions({
+        siteUrl,
+        membersSignupAccess: typeof membersSignupAccess === 'string' ? membersSignupAccess : 'all',
+        donationsEnabled: Boolean(donationsEnabled),
+        recommendationsEnabled: Boolean(recommendationsEnabled)
+    });
+};

--- a/apps/posts/src/views/Automations/components/email-modal/use-sender-details.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/use-sender-details.ts
@@ -1,0 +1,36 @@
+import {getSettingValues, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import {resolveEmailSenderDetails} from './sender-details';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
+import {useMemo} from 'react';
+import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import type {Config} from '@tryghost/admin-x-framework/api/config';
+
+type AutomatedEmailSenderFields = Pick<AutomatedEmail, 'slug' | 'sender_name' | 'sender_email' | 'sender_reply_to'>;
+
+// Resolves the sender identity for the preview/test render. Reads settings and
+// config directly from framework hooks so it works on routes that don't mount a
+// global data provider.
+export const useEmailSenderDetails = (automatedEmails: AutomatedEmailSenderFields[] = []) => {
+    const {data: settingsData} = useBrowseSettings();
+    const {data: configData} = useBrowseConfig();
+    const settings = settingsData?.settings || [];
+    const config = useMemo(() => (configData?.config || {}) as Config, [configData]);
+    const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(settings, ['title', 'default_email_address', 'support_email_address']);
+    const {data: newslettersData} = useBrowseNewsletters({
+        searchParams: {
+            filter: 'status:active',
+            limit: '1'
+        }
+    });
+    const defaultNewsletter = newslettersData?.newsletters?.[0];
+
+    return useMemo(() => resolveEmailSenderDetails({
+        automatedEmails,
+        config,
+        defaultEmailAddress,
+        newsletter: defaultNewsletter,
+        siteTitle,
+        supportEmailAddress
+    }), [automatedEmails, config, defaultEmailAddress, defaultNewsletter, siteTitle, supportEmailAddress]);
+};

--- a/apps/posts/src/views/Automations/components/email-modal/validation.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/validation.ts
@@ -3,6 +3,9 @@ export type EmailDraft = {
     lexical: string;
 };
 
+/**
+ * Lexical data is considered empty if it has no children or only has an empty paragraph.
+ */
 const isEmptyLexical = (lexical: string | null | undefined): boolean => {
     if (!lexical) {
         return true;
@@ -12,7 +15,6 @@ const isEmptyLexical = (lexical: string | null | undefined): boolean => {
         const parsed = JSON.parse(lexical);
         const children = parsed?.root?.children;
 
-        // Empty if no children or only an empty paragraph
         if (!children || children.length === 0) {
             return true;
         }

--- a/apps/posts/src/views/Automations/components/email-modal/validation.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/validation.ts
@@ -1,0 +1,43 @@
+export type EmailDraft = {
+    subject: string;
+    lexical: string;
+};
+
+const isEmptyLexical = (lexical: string | null | undefined): boolean => {
+    if (!lexical) {
+        return true;
+    }
+
+    try {
+        const parsed = JSON.parse(lexical);
+        const children = parsed?.root?.children;
+
+        // Empty if no children or only an empty paragraph
+        if (!children || children.length === 0) {
+            return true;
+        }
+        if (children.length === 1 &&
+            children[0].type === 'paragraph' &&
+            (!children[0].children || children[0].children.length === 0)) {
+            return true;
+        }
+
+        return false;
+    } catch {
+        return true;
+    }
+};
+
+export const getEmailValidationErrors = (state: EmailDraft): Record<string, string> => {
+    const newErrors: Record<string, string> = {};
+
+    if (!state.subject?.trim()) {
+        newErrors.subject = 'A subject is required';
+    }
+
+    if (isEmptyLexical(state.lexical)) {
+        newErrors.lexical = 'Email content is required';
+    }
+
+    return newErrors;
+};

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -5,6 +5,25 @@ import {RouterProvider, createMemoryRouter} from 'react-router';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 
+// Stub the email content editor modal — its real internals (Koenig + email API
+// hooks) are out of scope here. The stub exposes the seed props and a save button
+// so we can assert the canvas wiring (open → seed → onSave → draft → publish).
+vi.mock('@src/views/Automations/components/email-modal/email-content-modal', () => ({
+    default: ({initialSubject, initialLexical, onClose, onSave}: {
+        initialSubject: string;
+        initialLexical: string;
+        onClose: () => void;
+        onSave: (data: {subject: string; lexical: string}) => void;
+    }) => (
+        <div data-testid='email-content-modal'>
+            <span data-testid='modal-initial-subject'>{initialSubject}</span>
+            <span data-testid='modal-initial-lexical'>{initialLexical}</span>
+            <button data-testid='modal-save' type='button' onClick={() => onSave({subject: 'Edited via modal', lexical: '{"root":{"children":[{"type":"paragraph"}]}}'})}>save</button>
+            <button data-testid='modal-close' type='button' onClick={onClose}>close</button>
+        </div>
+    )
+}));
+
 const mockUseReadAutomation = vi.fn();
 const mockEditMutation = {
     mutate: vi.fn(),
@@ -274,8 +293,112 @@ describe('AutomationEditor', () => {
         expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toBeInTheDocument();
         expect(within(sidebar).queryByText('Sender')).not.toBeInTheDocument();
         expect(within(sidebar).queryByText('Reply-to')).not.toBeInTheDocument();
-        expect(within(sidebar).getByRole('button', {name: 'Edit email'})).toBeDisabled();
+        expect(within(sidebar).getByRole('button', {name: 'Edit email'})).toBeEnabled();
         expect(within(sidebar).getByRole('button', {name: 'Delete step'})).toBeEnabled();
+    });
+
+    it('persists an edited subject from the sidebar on publish', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        const subjectInput = within(sidebar).getByDisplayValue('Welcome to The Blueprint');
+
+        fireEvent.change(subjectInput, {target: {value: 'Updated subject'}});
+        fireEvent.blur(subjectInput);
+
+        const publish = screen.getByRole('button', {name: 'Publish changes'});
+        expect(publish).toBeEnabled();
+        fireEvent.click(publish);
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));
+
+        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 'automation-id-1',
+                status: 'active',
+                actions: expect.arrayContaining([
+                    expect.objectContaining({
+                        id: 'action-email',
+                        type: 'send_email',
+                        data: expect.objectContaining({email_subject: 'Updated subject'})
+                    })
+                ])
+            }),
+            expect.any(Object)
+        );
+    });
+
+    it('opens the email editor modal seeded from the step and commits edits to the draft (not the API) until publish', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
+
+        // The modal opens, seeded from the step's current content.
+        expect(screen.getByTestId('email-content-modal')).toBeInTheDocument();
+        expect(screen.getByTestId('modal-initial-subject')).toHaveTextContent('Welcome to The Blueprint');
+        expect(screen.getByTestId('modal-initial-lexical')).toHaveTextContent('{"root":{"children":[]}}');
+
+        // Saving in the modal commits to the local draft only — no API call.
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByTestId('modal-save'));
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+        // The modal closes after saving.
+        expect(screen.queryByTestId('email-content-modal')).not.toBeInTheDocument();
+
+        // Publishing persists the edited content.
+        fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
+        const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));
+        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                actions: expect.arrayContaining([
+                    expect.objectContaining({
+                        id: 'action-email',
+                        data: expect.objectContaining({
+                            email_subject: 'Edited via modal',
+                            email_lexical: '{"root":{"children":[{"type":"paragraph"}]}}'
+                        })
+                    })
+                ])
+            }),
+            expect.any(Object)
+        );
+    });
+
+    it('reflects a subject edited in the modal back in the sidebar input', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toBeInTheDocument();
+
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
+        fireEvent.click(screen.getByTestId('modal-save'));
+
+        expect(within(sidebar).getByDisplayValue('Edited via modal')).toBeInTheDocument();
+        expect(within(sidebar).queryByDisplayValue('Welcome to The Blueprint')).not.toBeInTheDocument();
     });
 
     it('resets the wait editor value when switching between wait steps', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1187,6 +1187,9 @@ importers:
       '@tryghost/color-utils':
         specifier: 'catalog:'
         version: 0.2.16
+      '@tryghost/koenig-lexical':
+        specifier: 'catalog:'
+        version: 1.8.1
       '@tryghost/nql-lang':
         specifier: 'catalog:'
         version: 0.6.4


### PR DESCRIPTION
closes [NY-1253](https://linear.app/ghost/issue/NY-1253/move-email-content-editor-modal-from-settings-to-automations)

- copies the email content editor from settings to automations
- tries to keep things 1:1 with the editor there, but doesn't use `@ebay/nice-modal-react` and uses shade instead