### PR TITLE
Changed @tryghost/express-test snapshot bridge to lazy load

### DIFF
--- a/ghost/core/test/utils/vitest-setup.ts
+++ b/ghost/core/test/utils/vitest-setup.ts
@@ -29,8 +29,26 @@ process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_
 // snapshots — no per-worker session overrides needed.
 require('../../core/server/overrides');
 
-const snapshotExports = require('@tryghost/express-test').snapshot;
-const {mochaHooks} = snapshotExports;
+// @tryghost/express-test's snapshot bridge is pulled in lazily — requiring it
+// is ~170ms per worker and only the hooks below ever read it. The mock-manager
+// just below uses the same shape.
+type SnapshotExports = {
+    snapshotManager?: {
+        setCurrentTest: (_info: {testPath?: string; testTitle: string}) => void;
+    };
+    mochaHooks?: {
+        beforeAll?: () => Promise<void>;
+        afterEach?: () => Promise<void>;
+        afterAll?: () => Promise<void>;
+    };
+};
+let snapshotExports: SnapshotExports | undefined;
+const getSnapshotExports = (): SnapshotExports => {
+    if (!snapshotExports) {
+        snapshotExports = require('@tryghost/express-test').snapshot;
+    }
+    return snapshotExports!;
+};
 
 // e2e-framework-mock-manager is pulled in lazily — it boots a fair
 // amount of Ghost-side machinery, which unit tests in the spike subtree
@@ -47,6 +65,7 @@ const getMockManager = () => {
 // globals. The hooks are plain async functions so they translate
 // directly. Order matches overrides.js for parity.
 beforeAll(async () => {
+    const {mochaHooks} = getSnapshotExports();
     if (mochaHooks?.beforeAll) {
         await mochaHooks.beforeAll();
     }
@@ -59,7 +78,7 @@ beforeAll(async () => {
 // mocha's `fullTitle()` (describe names + test name joined by spaces) or
 // committed .snap keys won't resolve.
 beforeEach((context: {task: {name: string; suite?: unknown; file?: {filepath?: string}}}) => {
-    const snapshotManager = snapshotExports.snapshotManager;
+    const {snapshotManager} = getSnapshotExports();
     if (!snapshotManager) {
         return;
     }
@@ -99,6 +118,7 @@ afterEach(async () => {
     clearTimeout(timeout);
 
     try {
+        const {mochaHooks} = getSnapshotExports();
         if (mochaHooks?.afterEach) {
             await mochaHooks.afterEach();
         }
@@ -111,6 +131,7 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
+    const {mochaHooks} = getSnapshotExports();
     if (mochaHooks?.afterAll) {
         await mochaHooks.afterAll();
     }


### PR DESCRIPTION
`ghost/core`'s `vitest-setup.ts` runs once per worker before any test executes. The top of the file synchronously `require()`d `@tryghost/express-test`'s `snapshot` export, which bridges Ghost's mocha-shaped `@tryghost/jest-snapshot` test files into Vitest's lifecycle (`mochaHooks.beforeAll/afterEach/afterAll` + `snapshotManager.setCurrentTest`). That require is ~170ms of import work per worker and lands in Vitest's "setup" phase, blocking test scheduling.

This replaces the eager require with a memoized `getSnapshotExports()` getter, mirroring the lazy `getMockManager()` pattern that already exists in the same file. Each hook calls the getter at execution time, so the cost moves out of the worker's startup window and any worker that ends up running zero tests (rare locally, more common on CI under `nx affected`) pays nothing.

Measured three back-to-back runs locally: wall clock 7.57s → ~6.7s, and Vitest's reported "setup" CPU dropped from ~13s to ~3.4s. The "tests" bucket is essentially unchanged, so this is a real reduction in import work rather than bucket-shifting. The full unit suite (550 files / 6575 tests, including the 3 snapshot-using ones) passes.