### PR TITLE
Removed build dependency from @tryghost/posts test:unit

### DIFF
--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -81,9 +81,7 @@
                 ]
             },
             "test:unit": {
-                "dependsOn": [
-                    "^build"
-                ]
+                "dependsOn": []
             }
         }
     }

--- a/apps/posts/vitest.config.ts
+++ b/apps/posts/vitest.config.ts
@@ -1,3 +1,30 @@
-import {createVitestConfig} from '@tryghost/admin-x-framework/test/vitest-config';
+import path from 'path';
+import {mergeConfig} from 'vitest/config';
+// Import the helper from source rather than the package entry — at test
+// time `apps/admin-x-framework/dist/` may not exist, and the resolve.alias
+// entries below only take effect after this config has loaded.
+import {createVitestConfig} from '../admin-x-framework/src/test/vitest-config';
 
-export default createVitestConfig({root: __dirname});
+const root = __dirname;
+const workspaceRoot = path.resolve(root, '../..');
+
+// Cross-package workspace aliases so `test:unit` can run without `nx build`
+// having produced `apps/shade/es` or `apps/admin-x-framework/dist`. The
+// package `exports` of those workspaces point at built artifacts; for tests
+// we resolve to source directly. Tracked in PLA-42 — this config is the pilot
+// for the pattern.
+const workspaceSrcAliases = [
+    {find: /^@tryghost\/shade$/, replacement: path.resolve(workspaceRoot, 'apps/shade/src/index.ts')},
+    {find: /^@tryghost\/shade\/(.+)$/, replacement: path.resolve(workspaceRoot, 'apps/shade/src') + '/$1.ts'},
+    {find: /^@tryghost\/admin-x-framework$/, replacement: path.resolve(workspaceRoot, 'apps/admin-x-framework/src/index.ts')},
+    {find: /^@tryghost\/admin-x-framework\/(.+)$/, replacement: path.resolve(workspaceRoot, 'apps/admin-x-framework/src') + '/$1.ts'},
+    // `@/` is shade's internal alias (apps/shade/tsconfig.json `paths`). When
+    // we resolve shade source here, those imports also need a target.
+    {find: /^@\/(.+)$/, replacement: path.resolve(workspaceRoot, 'apps/shade/src') + '/$1'}
+];
+
+export default mergeConfig(createVitestConfig({root}), {
+    resolve: {
+        alias: workspaceSrcAliases
+    }
+});


### PR DESCRIPTION
Pilot for **[PLA-42](https://linear.app/ghost/issue/PLA-42)** (full write-up in `docs/test-unit-build-dep-removal.md`).

`test:unit dependsOn: build` on `nx.json` means every CI job that runs `test:unit` triggers the upstream build cascade — even though for most apps the tests don't need built artifacts. The CI unit-test job, plus `ghost:test:ci:{e2e,integration,legacy}` and the per-app Playwright matrix, each re-pay this cost. `apps/posts`'s `nx.targets.test:unit` overrides with `^build`, so its test job specifically builds `shade` + `admin-x-framework` first.

The dep exists for a real reason: `import {…} from '@tryghost/shade/patterns'` reads shade's `package.json` `exports` and lands on `./es/patterns.js`. If `es/` doesn't exist (no prior build), resolution fails before any TS is read.

This PR replaces that resolution path with `vitest.config.ts` aliases pointing at source:

```ts
{find: /^@tryghost\/shade\/(.+)$/, replacement: '<workspace>/apps/shade/src/$1.ts'}
```

…and analogous regex aliases for `@tryghost/admin-x-framework/*` and shade's internal `@/*` alias. The `createVitestConfig` helper is imported via a relative source path (`../admin-x-framework/src/test/vitest-config`) so the config itself loads without admin-x-framework being built. `nx.targets.test:unit.dependsOn` is then set to `[]`, so `test:unit` runs without triggering the upstream build cascade.

## Verification

Wiped `apps/shade/{es,types}` and `apps/admin-x-framework/{dist,types}`, then:

```
pnpm nx run @tryghost/posts:test:unit --skip-nx-cache
```

- No upstream builds were triggered.
- Suite ran to 215/216 in 6.4s — matching pristine main with built upstream artifacts.

## Known pre-existing failure (not from this PR)

`test/unit/views/automations/automation-editor.test.tsx > AutomationEditor > updates a wait step as the wait editor value changes` fails identically on pristine main (config + upstream both restored), so it's not introduced here. The test was added in #28051; subsequent CI runs on main were all `cancelled` before completion, so we don't have a clean post-#28051 main signal. Worth a separate investigation by whoever owns automations.

## Next

If this pattern is acceptable, the same shape applies to:

- `apps/stats` (7 cross-package imports in tests)
- `apps/activitypub` (8)
- `apps/admin-x-settings` (53)

Each is an independent follow-up PR. Once those are done, `ghost/core` can drop `^build` from its own `nx.targets.test:unit` (only in-repo workspace dep is `@tryghost/i18n`, no build script). `build:assets` stays on ghost/core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)