### PR TITLE
Fixed broken wait-step test on main from publish-confirm merge skew

### DIFF
--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -317,6 +317,8 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
 
         fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
+        const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));
 
         const mutateCall = mockEditMutation.mutate.mock.calls.at(-1)![0];
         expect(mutateCall.actions).toContainEqual({id: 'action-wait', type: 'wait', data: {wait_hours: 72}});


### PR DESCRIPTION
## Summary

The `updates a wait step as the wait editor value changes` test in `apps/posts` has been failing on `main` since #28113 merged. This PR adds the two lines needed to click through the new "Update automation?" confirmation dialog.

## What happened

Two PRs landed within ~3 hours of each other:

- **#28051 ("Wired up ability to edit automation wait step durations")** added the test, which clicks `Publish changes` once and asserts on `mockEditMutation.mutate`.
- **#28113 ("Started confirming automation re-publish")** made `Publish changes` on an active automation open a confirmation dialog instead of mutating directly, and updated its own tests to click through the dialog.

The two PRs had no textual conflict, but #28113 was opened against a base commit (`87b6c6e588`) that predated #28051. GitHub doesn't require a rebase-and-retest before squash-merge, so neither branch ever ran CI with both changes — a classic semantic merge skew. The result is that `mockEditMutation.mutate.mock.calls` is empty when the test calls `.at(-1)![0]`, and the access throws.

The fix is the same pattern already used elsewhere in this file (e.g. line ~992).

## Test plan

- [x] `pnpm vitest run test/unit/views/automations/automation-editor.test.tsx` from `apps/posts` — all 45 tests pass