### PR TITLE
Fixed hidden comments collapsing threaded replies

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -517,17 +517,17 @@ function hasDescendantReply(replies: Comment[], commentId: string) {
     return replies.some(reply => reply.in_reply_to_id === commentId);
 }
 
-function isTombstoneReply(reply: Comment) {
-    return ['hidden', 'deleted'].includes(reply.status);
+function isTombstoneReply(reply: Comment, isAdmin: boolean) {
+    return reply.status === 'deleted' || (!isAdmin && reply.status === 'hidden');
 }
 
-function pruneOrphanTombstoneReplies(replies: Comment[], deletedReply: Comment | undefined) {
+function pruneOrphanTombstoneReplies(replies: Comment[], deletedReply: Comment | undefined, isAdmin: boolean) {
     let prunedReplies = replies;
     let ancestorId = deletedReply?.in_reply_to_id;
 
     while (ancestorId) {
         const ancestor = prunedReplies.find(reply => reply.id === ancestorId);
-        if (!ancestor || !isTombstoneReply(ancestor) || hasDescendantReply(prunedReplies, ancestor.id)) {
+        if (!ancestor || !isTombstoneReply(ancestor, isAdmin) || hasDescendantReply(prunedReplies, ancestor.id)) {
             break;
         }
 
@@ -592,7 +592,7 @@ async function deleteComment({state, api, data: comment, dispatchAction}: {state
 
                 return replies;
             }, []);
-            const updatedReplies = pruneOrphanTombstoneReplies(repliesAfterDelete, replyToDelete);
+            const updatedReplies = pruneOrphanTombstoneReplies(repliesAfterDelete, replyToDelete, state.isAdmin);
             const hasDeletedReply = originalLength !== updatedReplies.length || keepTombstone;
 
             const updatedTopLevelComment = {

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -521,19 +521,21 @@ function isTombstoneReply(reply: Comment, isAdmin: boolean) {
     return reply.status === 'deleted' || (!isAdmin && reply.status === 'hidden');
 }
 
-function pruneOrphanTombstoneReplies(replies: Comment[], deletedReply: Comment | undefined, isAdmin: boolean) {
+function pruneOrphanTombstoneReplies(replies: Comment[], isAdmin: boolean) {
     let prunedReplies = replies;
-    let ancestorId = deletedReply?.in_reply_to_id;
+    let removedReply = false;
 
-    while (ancestorId) {
-        const ancestor = prunedReplies.find(reply => reply.id === ancestorId);
-        if (!ancestor || !isTombstoneReply(ancestor, isAdmin) || hasDescendantReply(prunedReplies, ancestor.id)) {
-            break;
-        }
+    do {
+        removedReply = false;
+        prunedReplies = prunedReplies.filter((reply) => {
+            if (!isTombstoneReply(reply, isAdmin) || hasDescendantReply(prunedReplies, reply.id)) {
+                return true;
+            }
 
-        ancestorId = ancestor.in_reply_to_id;
-        prunedReplies = prunedReplies.filter(reply => reply.id !== ancestor.id);
-    }
+            removedReply = true;
+            return false;
+        });
+    } while (removedReply);
 
     return prunedReplies;
 }
@@ -592,7 +594,7 @@ async function deleteComment({state, api, data: comment, dispatchAction}: {state
 
                 return replies;
             }, []);
-            const updatedReplies = pruneOrphanTombstoneReplies(repliesAfterDelete, replyToDelete, state.isAdmin);
+            const updatedReplies = pruneOrphanTombstoneReplies(repliesAfterDelete, state.isAdmin);
             const hasDeletedReply = originalLength !== updatedReplies.length || keepTombstone;
 
             const updatedTopLevelComment = {

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -513,6 +513,35 @@ async function reportComment({api, data: comment}: {api: GhostApi, data: {id: st
     return {};
 }
 
+function hasDescendantReply(replies: Comment[], commentId: string) {
+    return replies.some(reply => reply.in_reply_to_id === commentId);
+}
+
+function isTombstoneReply(reply: Comment) {
+    return ['hidden', 'deleted'].includes(reply.status);
+}
+
+function pruneOrphanTombstoneReplies(replies: Comment[], deletedReply: Comment | undefined) {
+    let prunedReplies = replies;
+    let ancestorId = deletedReply?.in_reply_to_id;
+
+    while (ancestorId) {
+        const ancestor = prunedReplies.find(reply => reply.id === ancestorId);
+        if (!ancestor || !isTombstoneReply(ancestor) || hasDescendantReply(prunedReplies, ancestor.id)) {
+            break;
+        }
+
+        ancestorId = ancestor.in_reply_to_id;
+        prunedReplies = prunedReplies.filter(reply => reply.id !== ancestor.id);
+    }
+
+    return prunedReplies;
+}
+
+function decrementCount(count: number | undefined) {
+    return Math.max((count || 0) - 1, 0);
+}
+
 async function deleteComment({state, api, data: comment, dispatchAction}: {state: EditableAppContext, api: GhostApi, data: {id: string}, dispatchAction: DispatchActionType}) {
     await api.comments.edit({
         comment: {
@@ -545,18 +574,40 @@ async function deleteComment({state, api, data: comment, dispatchAction}: {state
             }
 
             const originalLength = topLevelComment.replies.length;
-            const updatedReplies = topLevelComment.replies.filter(reply => reply.id !== comment.id);
-            const hasDeletedReply = originalLength !== updatedReplies.length;
+            const replyToDelete = topLevelComment.replies.find(reply => reply.id === comment.id);
+            const keepTombstone = replyToDelete ? hasDescendantReply(topLevelComment.replies, replyToDelete.id) : false;
+            const repliesAfterDelete = topLevelComment.replies.reduce<Comment[]>((replies, reply) => {
+                if (reply.id !== comment.id) {
+                    replies.push(reply);
+                    return replies;
+                }
+
+                if (keepTombstone) {
+                    replies.push({
+                        ...reply,
+                        status: 'deleted',
+                        html: null
+                    });
+                }
+
+                return replies;
+            }, []);
+            const updatedReplies = pruneOrphanTombstoneReplies(repliesAfterDelete, replyToDelete);
+            const hasDeletedReply = originalLength !== updatedReplies.length || keepTombstone;
 
             const updatedTopLevelComment = {
                 ...topLevelComment,
                 replies: updatedReplies
             };
 
-            // When a reply is deleted we need to update the parent's count so
-            // pagination displays the correct number of replies still to load
-            if (hasDeletedReply && topLevelComment.count?.replies) {
-                topLevelComment.count.replies = topLevelComment.count.replies - 1;
+            if (hasDeletedReply && replyToDelete && !['hidden', 'deleted'].includes(replyToDelete.status)) {
+                const wasDirectReply = !replyToDelete.in_reply_to_id || replyToDelete.in_reply_to_id === topLevelComment.id;
+
+                updatedTopLevelComment.count = {
+                    ...updatedTopLevelComment.count,
+                    replies: decrementCount(updatedTopLevelComment.count?.replies),
+                    direct_replies: wasDirectReply ? decrementCount(updatedTopLevelComment.count?.direct_replies) : updatedTopLevelComment.count?.direct_replies
+                };
             }
 
             return updatedTopLevelComment;

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -27,6 +27,7 @@ export type Comment = {
     votePending?: boolean,
     count: {
         replies: number,
+        direct_replies?: number,
         likes: number
     },
     member: Member | null,

--- a/apps/comments-ui/test/unit/actions.test.js
+++ b/apps/comments-ui/test/unit/actions.test.js
@@ -81,6 +81,234 @@ describe('Actions', function () {
         });
     });
 
+    describe('deleteComment', function () {
+        it('keeps a deleted reply as a tombstone when it has descendants', async function () {
+            const state = {
+                commentCount: 3,
+                comments: [
+                    makeComment({
+                        id: 'root',
+                        count: {
+                            replies: 2,
+                            direct_replies: 1,
+                            likes: 0
+                        },
+                        replies: [
+                            makeComment({
+                                id: 'reply-1',
+                                status: 'published',
+                                html: '<p>Reply 1</p>',
+                                in_reply_to_id: null
+                            }),
+                            makeComment({
+                                id: 'reply-2',
+                                status: 'published',
+                                html: '<p>Reply 2</p>',
+                                in_reply_to_id: 'reply-1'
+                            })
+                        ]
+                    })
+                ]
+            };
+            const api = {
+                comments: {
+                    edit: vi.fn(() => Promise.resolve())
+                }
+            };
+
+            const newState = await Actions.deleteComment({state, api, data: {id: 'reply-1'}, dispatchAction: vi.fn()});
+
+            expect(api.comments.edit).toHaveBeenCalledWith({
+                comment: {
+                    id: 'reply-1',
+                    status: 'deleted'
+                }
+            });
+            expect(newState.comments[0].replies).toMatchObject([
+                {
+                    id: 'reply-1',
+                    status: 'deleted',
+                    html: null
+                },
+                {
+                    id: 'reply-2',
+                    status: 'published',
+                    in_reply_to_id: 'reply-1'
+                }
+            ]);
+            expect(newState.comments[0].count).toMatchObject({
+                replies: 1,
+                direct_replies: 0
+            });
+        });
+
+        it('removes a deleted reply when it has no descendants', async function () {
+            const state = {
+                commentCount: 2,
+                comments: [
+                    makeComment({
+                        id: 'root',
+                        count: {
+                            replies: 1,
+                            direct_replies: 1,
+                            likes: 0
+                        },
+                        replies: [
+                            makeComment({
+                                id: 'reply-1',
+                                status: 'published',
+                                html: '<p>Reply 1</p>',
+                                in_reply_to_id: null
+                            })
+                        ]
+                    })
+                ]
+            };
+            const api = {
+                comments: {
+                    edit: vi.fn(() => Promise.resolve())
+                }
+            };
+
+            const newState = await Actions.deleteComment({state, api, data: {id: 'reply-1'}, dispatchAction: vi.fn()});
+
+            expect(newState.comments[0].replies).toEqual([]);
+            expect(newState.comments[0].count).toMatchObject({
+                replies: 0,
+                direct_replies: 0
+            });
+        });
+
+        it('decrements direct_replies for direct replies that point to the top-level comment', async function () {
+            const state = {
+                commentCount: 2,
+                comments: [
+                    makeComment({
+                        id: 'root',
+                        count: {
+                            replies: 1,
+                            direct_replies: 1,
+                            likes: 0
+                        },
+                        replies: [
+                            makeComment({
+                                id: 'reply-1',
+                                status: 'published',
+                                html: '<p>Reply 1</p>',
+                                in_reply_to_id: 'root'
+                            })
+                        ]
+                    })
+                ]
+            };
+            const api = {
+                comments: {
+                    edit: vi.fn(() => Promise.resolve())
+                }
+            };
+
+            const newState = await Actions.deleteComment({state, api, data: {id: 'reply-1'}, dispatchAction: vi.fn()});
+
+            expect(newState.comments[0].replies).toEqual([]);
+            expect(newState.comments[0].count).toMatchObject({
+                replies: 0,
+                direct_replies: 0
+            });
+        });
+
+        it('removes ancestor tombstones that lose their visible descendants', async function () {
+            const state = {
+                commentCount: 2,
+                comments: [
+                    makeComment({
+                        id: 'root',
+                        count: {
+                            replies: 1,
+                            direct_replies: 0,
+                            likes: 0
+                        },
+                        replies: [
+                            makeComment({
+                                id: 'reply-1',
+                                status: 'deleted',
+                                html: null,
+                                in_reply_to_id: null
+                            }),
+                            makeComment({
+                                id: 'reply-2',
+                                status: 'published',
+                                html: '<p>Reply 2</p>',
+                                in_reply_to_id: 'reply-1'
+                            })
+                        ]
+                    })
+                ]
+            };
+            const api = {
+                comments: {
+                    edit: vi.fn(() => Promise.resolve())
+                }
+            };
+
+            const newState = await Actions.deleteComment({state, api, data: {id: 'reply-2'}, dispatchAction: vi.fn()});
+
+            expect(newState.comments[0].replies).toEqual([]);
+            expect(newState.comments[0].count).toMatchObject({
+                replies: 0,
+                direct_replies: 0
+            });
+        });
+
+        it('does not remove unrelated tombstones without loaded descendants', async function () {
+            const state = {
+                commentCount: 2,
+                comments: [
+                    makeComment({
+                        id: 'root',
+                        count: {
+                            replies: 1,
+                            direct_replies: 1,
+                            likes: 0
+                        },
+                        replies: [
+                            makeComment({
+                                id: 'reply-1',
+                                status: 'deleted',
+                                html: null,
+                                in_reply_to_id: null
+                            }),
+                            makeComment({
+                                id: 'reply-2',
+                                status: 'published',
+                                html: '<p>Reply 2</p>',
+                                in_reply_to_id: null
+                            })
+                        ]
+                    })
+                ]
+            };
+            const api = {
+                comments: {
+                    edit: vi.fn(() => Promise.resolve())
+                }
+            };
+
+            const newState = await Actions.deleteComment({state, api, data: {id: 'reply-2'}, dispatchAction: vi.fn()});
+
+            expect(newState.comments[0].replies).toMatchObject([
+                {
+                    id: 'reply-1',
+                    status: 'deleted',
+                    html: null
+                }
+            ]);
+            expect(newState.comments[0].count).toMatchObject({
+                replies: 0,
+                direct_replies: 0
+            });
+        });
+    });
+
     describe('updateCommentLikeState', function () {
         it('restores a previous dislike when a like swap is rolled back', async function () {
             const state = {

--- a/apps/comments-ui/test/unit/actions.test.js
+++ b/apps/comments-ui/test/unit/actions.test.js
@@ -309,7 +309,7 @@ describe('Actions', function () {
             });
         });
 
-        it('does not remove unrelated tombstones without loaded descendants', async function () {
+        it('removes unrelated tombstones without loaded descendants', async function () {
             const state = {
                 commentCount: 2,
                 comments: [
@@ -345,13 +345,7 @@ describe('Actions', function () {
 
             const newState = await Actions.deleteComment({state, api, data: {id: 'reply-2'}, dispatchAction: vi.fn()});
 
-            expect(newState.comments[0].replies).toMatchObject([
-                {
-                    id: 'reply-1',
-                    status: 'deleted',
-                    html: null
-                }
-            ]);
+            expect(newState.comments[0].replies).toEqual([]);
             expect(newState.comments[0].count).toMatchObject({
                 replies: 0,
                 direct_replies: 0

--- a/apps/comments-ui/test/unit/actions.test.js
+++ b/apps/comments-ui/test/unit/actions.test.js
@@ -259,6 +259,56 @@ describe('Actions', function () {
             });
         });
 
+        it('keeps hidden admin replies when their last descendant is deleted', async function () {
+            const state = {
+                isAdmin: true,
+                commentCount: 2,
+                comments: [
+                    makeComment({
+                        id: 'root',
+                        count: {
+                            replies: 1,
+                            direct_replies: 0,
+                            likes: 0
+                        },
+                        replies: [
+                            makeComment({
+                                id: 'reply-1',
+                                status: 'hidden',
+                                html: '<p>Hidden admin-visible reply</p>',
+                                in_reply_to_id: null
+                            }),
+                            makeComment({
+                                id: 'reply-2',
+                                status: 'published',
+                                html: '<p>Reply 2</p>',
+                                in_reply_to_id: 'reply-1'
+                            })
+                        ]
+                    })
+                ]
+            };
+            const api = {
+                comments: {
+                    edit: vi.fn(() => Promise.resolve())
+                }
+            };
+
+            const newState = await Actions.deleteComment({state, api, data: {id: 'reply-2'}, dispatchAction: vi.fn()});
+
+            expect(newState.comments[0].replies).toMatchObject([
+                {
+                    id: 'reply-1',
+                    status: 'hidden',
+                    html: '<p>Hidden admin-visible reply</p>'
+                }
+            ]);
+            expect(newState.comments[0].count).toMatchObject({
+                replies: 0,
+                direct_replies: 0
+            });
+        });
+
         it('does not remove unrelated tombstones without loaded descendants', async function () {
             const state = {
                 commentCount: 2,

--- a/apps/comments-ui/test/unit/utils/thread-graph.test.ts
+++ b/apps/comments-ui/test/unit/utils/thread-graph.test.ts
@@ -60,7 +60,7 @@ describe('buildThreadedReplies', function () {
         expect(threadedReplies[0].nestedReplies[1].siblingCount).toEqual(2);
     });
 
-    it('keeps replies with missing parents at the root', function () {
+    it('treats replies with missing parents as root replies', function () {
         const threadParentComment = buildComment({
             id: 'root',
             replies: [
@@ -68,7 +68,27 @@ describe('buildThreadedReplies', function () {
             ]
         });
 
-        expect(buildThreadedReplies(threadParentComment).map(reply => reply.id)).toEqual(['reply-1']);
+        const threadedReplies = buildThreadedReplies(threadParentComment);
+
+        expect(threadedReplies.map(reply => reply.id)).toEqual(['reply-1']);
+        expect(threadedReplies[0].nestedReplies).toEqual([]);
+    });
+
+    it('preserves nesting through hidden and deleted placeholder replies', function () {
+        const threadParentComment = buildComment({
+            id: 'root',
+            replies: [
+                {id: 'reply-1', in_reply_to_id: null, status: 'hidden'},
+                {id: 'reply-2', in_reply_to_id: 'reply-1', status: 'deleted'},
+                {id: 'reply-3', in_reply_to_id: 'reply-2', status: 'published'}
+            ]
+        });
+
+        const threadedReplies = buildThreadedReplies(threadParentComment);
+
+        expect(threadedReplies.map(reply => reply.id)).toEqual(['reply-1']);
+        expect(threadedReplies[0].nestedReplies.map(reply => reply.id)).toEqual(['reply-2']);
+        expect(threadedReplies[0].nestedReplies[0].nestedReplies.map(reply => reply.id)).toEqual(['reply-3']);
     });
 });
 

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -7,6 +7,46 @@ const messages = {
     emptyComment: 'The body of a comment cannot be empty'
 };
 
+function getDisplayableCommentIdsQuery(excludedStatuses, {parentId, parentIds, postId} = {}) {
+    const statusPlaceholders = excludedStatuses.map(() => '?').join(',');
+    const scopedParentIds = parentId ? [parentId] : parentIds;
+    const scopeFilter = {
+        sql: [
+            scopedParentIds?.length ? `AND comments.parent_id IN (${scopedParentIds.map(() => '?').join(',')})` : '',
+            postId ? 'AND comments.post_id = ?' : ''
+        ].filter(Boolean).join('\n              '),
+        bindings: [
+            ...(scopedParentIds?.length ? scopedParentIds : []),
+            ...(postId ? [postId] : [])
+        ]
+    };
+
+    return ghostBookshelf.knex.raw(`
+        WITH RECURSIVE displayable_comment_paths(visible_id, comment_id) AS (
+            SELECT comments.id, comments.id
+            FROM comments
+            WHERE comments.status NOT IN (${statusPlaceholders})
+              ${scopeFilter.sql}
+
+            UNION
+
+            SELECT displayable_comment_paths.visible_id,
+                CASE
+                    WHEN comments.in_reply_to_id IS NOT NULL THEN comments.in_reply_to_id
+                    ELSE comments.parent_id
+                END
+            FROM comments
+            INNER JOIN displayable_comment_paths ON comments.id = displayable_comment_paths.comment_id
+            WHERE (comments.in_reply_to_id IS NOT NULL OR comments.parent_id IS NOT NULL)
+              ${scopeFilter.sql}
+        )
+
+        SELECT comment_id AS id
+        FROM displayable_comment_paths
+        GROUP BY comment_id
+    `, [...excludedStatuses, ...scopeFilter.bindings, ...scopeFilter.bindings]);
+}
+
 /**
  * Remove empty paragraps from the start and end
  * + remove duplicate empty paragrapsh (only one empty line allowed)
@@ -64,16 +104,8 @@ const Comment = ghostBookshelf.Model.extend({
                 // Browse All: simply exclude statuses, no thread structure preservation
                 qb.whereNotIn('comments.status', excludedStatuses);
             } else {
-                // Default: preserve thread structure by including deleted parents with replies
-                qb.where(function () {
-                    this.whereNotIn('comments.status', excludedStatuses)
-                        .orWhereExists(function () {
-                            this.select(1)
-                                .from('comments as replies')
-                                .whereRaw('replies.parent_id = comments.id')
-                                .whereNotIn('replies.status', excludedStatuses);
-                        });
-                });
+                // Default: preserve thread structure by including tombstones with visible descendants
+                qb.whereIn('comments.id', getDisplayableCommentIdsQuery(excludedStatuses, {parentId: options.parentId, postId: options.post_id}));
             }
 
             // Filter by report count (extracted from filter in controller)
@@ -173,19 +205,17 @@ const Comment = ghostBookshelf.Model.extend({
         return softDelete();
     },
 
-    applyRepliesWithRelatedOption(withRelated, isAdmin) {
+    applyRepliesWithRelatedOption(withRelated, isAdmin, parentIds) {
         // we want to apply filters when fetching replies so we don't expose data that should be hidden
         // - public requests never return hidden or deleted replies
         // - admin requests never return deleted replies but do return hidden replies
+        // - unpublished replies are returned as tombstones when they preserve the path to visible descendants
         const repliesOptionIndex = withRelated.indexOf('replies');
         if (repliesOptionIndex > -1) {
+            const excludedStatuses = isAdmin ? ['deleted'] : ['hidden', 'deleted'];
             withRelated[repliesOptionIndex] = {
                 replies: (qb) => {
-                    if (isAdmin) {
-                        qb.where('status', '!=', 'deleted');
-                    } else {
-                        qb.where('status', 'published');
-                    }
+                    qb.whereIn('comments.id', getDisplayableCommentIdsQuery(excludedStatuses, {parentIds}));
                 }
             };
         }
@@ -237,7 +267,9 @@ const Comment = ghostBookshelf.Model.extend({
                 }
             }
 
-            this.applyRepliesWithRelatedOption(options.withRelated, options.isAdmin);
+            if (methodName !== 'findPage') {
+                this.applyRepliesWithRelatedOption(options.withRelated, options.isAdmin);
+            }
         }
 
         return options;
@@ -270,15 +302,15 @@ const Comment = ghostBookshelf.Model.extend({
             return true;
         });
 
-        // Apply status filtering on the batch relations
-        this.applyRepliesWithRelatedOption(relationsToLoadInBatch, options.isAdmin);
-
         // Base findPage WITHOUT reply relations
         const result = await ghostBookshelf.Model.findPage.call(this, options);
 
         // Batch-load reply relations for ALL comments at once using Collection.load()
         // instead of the previous N+1 per-model model.load() loop
         if (result.data.length > 0 && relationsToLoadInBatch.length > 0) {
+            const parentIds = result.data.map(model => model.id);
+            this.applyRepliesWithRelatedOption(relationsToLoadInBatch, options.isAdmin, parentIds);
+
             const collection = ghostBookshelf.Collection.forge(result.data, {model: this});
             await collection.load(relationsToLoadInBatch, _.omit(options, 'withRelated', 'columns', 'selectRaw'));
         }
@@ -291,6 +323,8 @@ const Comment = ghostBookshelf.Model.extend({
             replies(modelOrCollection, options) {
                 const excludedCommentStatuses = options.isAdmin ? ['deleted'] : ['hidden', 'deleted'];
 
+                // Counts represent visible comment content, not structural tombstones. The API can still
+                // return hidden/deleted ancestors in `replies` when they preserve paths to visible descendants.
                 modelOrCollection.query('columns', 'comments.*', (qb) => {
                     qb.count('r.id')
                         .from('comments AS r')
@@ -303,6 +337,8 @@ const Comment = ghostBookshelf.Model.extend({
                 const excludedCommentStatuses = options.isAdmin ? ['deleted'] : ['hidden', 'deleted'];
                 const statusPlaceholders = excludedCommentStatuses.map(() => '?').join(',');
 
+                // Counts represent visible comment content, not structural tombstones. The API can still
+                // return hidden/deleted ancestors in `replies` when they preserve paths to visible descendants.
                 // Split into two separate indexed subqueries instead of a single OR-based query.
                 // An OR between parent_id and in_reply_to_id defeats MySQL index usage,
                 // causing full table scans. Two separate subqueries each use their own index.
@@ -397,6 +433,9 @@ const Comment = ghostBookshelf.Model.extend({
         options.push('browseAll');
         options.push('reportCount');
         options.push('pinnedFirst');
+        if (methodName === 'findPage') {
+            options.push('post_id');
+        }
         options.push('selectRaw');
 
         return options;

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -268,7 +268,8 @@ const Comment = ghostBookshelf.Model.extend({
             }
 
             if (methodName !== 'findPage') {
-                this.applyRepliesWithRelatedOption(options.withRelated, options.isAdmin);
+                const parentIds = options.id ? [options.id] : undefined;
+                this.applyRepliesWithRelatedOption(options.withRelated, options.isAdmin, parentIds);
             }
         }
 

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -770,6 +770,178 @@ describe(`Admin Comments API`, function () {
                 });
         });
 
+        it('includes deleted reply tombstones when they have visible descendants', async function () {
+            const root = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: 'Comment 1',
+                status: 'published'
+            });
+
+            const deletedReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                html: 'Deleted reply',
+                status: 'deleted'
+            });
+
+            const hiddenReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                in_reply_to_id: deletedReply.get('id'),
+                html: 'Hidden reply',
+                status: 'hidden'
+            });
+
+            const res = await adminApi.get('/comments/post/' + postId + '/');
+            const replies = res.body.comments[0].replies;
+
+            assert.deepEqual(replies.map(reply => reply.id), [deletedReply.get('id'), hiddenReply.get('id')]);
+            assert.equal(replies[0].html, null);
+            assert.equal(replies[1].html, 'Hidden reply');
+            assert.equal(replies[1].in_reply_to_id, deletedReply.get('id'));
+        });
+
+        it('includes deleted comments when only a nested descendant is visible', async function () {
+            const root = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: 'Deleted comment',
+                status: 'deleted'
+            });
+
+            const deletedReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                html: 'Deleted reply',
+                status: 'deleted'
+            });
+
+            const hiddenReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                in_reply_to_id: deletedReply.get('id'),
+                html: 'Hidden reply',
+                status: 'hidden'
+            });
+
+            const res = await adminApi.get('/comments/post/' + postId + '/');
+            const comment = res.body.comments[0];
+
+            assert.equal(res.body.comments.length, 1);
+            assert.equal(comment.id, root.get('id'));
+            assert.equal(comment.html, null);
+            assert.equal(comment.count.replies, 1);
+            assert.equal(comment.count.direct_replies, 0);
+            assert.deepEqual(comment.replies.map(reply => reply.id), [deletedReply.get('id'), hiddenReply.get('id')]);
+            assert.equal(comment.replies[0].html, null);
+            assert.equal(comment.replies[1].html, 'Hidden reply');
+            assert.equal(res.body.meta.pagination.total, 1);
+        });
+
+        it('reply endpoint includes deleted tombstones when they have visible descendants', async function () {
+            const root = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: 'Comment 1',
+                status: 'published'
+            });
+
+            const deletedReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                html: 'Deleted reply',
+                status: 'deleted'
+            });
+
+            const hiddenReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                in_reply_to_id: deletedReply.get('id'),
+                html: 'Hidden reply',
+                status: 'hidden'
+            });
+
+            const res = await adminApi.get(`/comments/${root.get('id')}/replies/`);
+            const replies = res.body.comments;
+
+            assert.deepEqual(replies.map(reply => reply.id), [deletedReply.get('id'), hiddenReply.get('id')]);
+            assert.equal(replies[0].html, null);
+            assert.equal(replies[1].html, 'Hidden reply');
+            assert.equal(replies[1].in_reply_to_id, deletedReply.get('id'));
+            assert.equal(replies[0].count.direct_replies, 1);
+            assert.equal(res.body.meta.pagination.total, 2);
+        });
+
+        it('reply endpoint paginates deleted tombstones before the visible descendant that makes them displayable', async function () {
+            const root = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: 'Comment 1',
+                status: 'published'
+            });
+
+            const deletedReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                html: 'Deleted reply',
+                status: 'deleted'
+            });
+
+            const hiddenReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                in_reply_to_id: deletedReply.get('id'),
+                html: 'Hidden reply',
+                status: 'hidden'
+            });
+
+            const firstPage = await adminApi.get(`/comments/${root.get('id')}/replies/?limit=1`);
+            assert.deepEqual(firstPage.body.comments.map(reply => reply.id), [deletedReply.get('id')]);
+            assert.equal(firstPage.body.comments[0].html, null);
+            assert.equal(firstPage.body.meta.pagination.total, 2);
+            assert.equal(firstPage.body.meta.pagination.next, 2);
+
+            const secondPage = await adminApi.get(`/comments/${root.get('id')}/replies/?limit=1&page=2`);
+            assert.deepEqual(secondPage.body.comments.map(reply => reply.id), [hiddenReply.get('id')]);
+            assert.equal(secondPage.body.comments[0].html, 'Hidden reply');
+            assert.equal(secondPage.body.meta.pagination.total, 2);
+            assert.equal(secondPage.body.meta.pagination.next, null);
+        });
+
+        it('reply endpoint excludes deleted leaf replies while keeping visible siblings', async function () {
+            const root = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: 'Comment 1',
+                status: 'published'
+            });
+
+            await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                html: 'Deleted reply',
+                status: 'deleted'
+            });
+
+            const hiddenReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                html: 'Hidden reply',
+                status: 'hidden'
+            });
+
+            const publishedReply = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                parent_id: root.get('id'),
+                html: 'Published reply',
+                status: 'published'
+            });
+
+            const res = await adminApi.get(`/comments/${root.get('id')}/replies/`);
+            const replies = res.body.comments;
+
+            assert.deepEqual(replies.map(reply => reply.id), [hiddenReply.get('id'), publishedReply.get('id')]);
+            assert.equal(replies[0].html, 'Hidden reply');
+            assert.equal(replies[1].html, 'Published reply');
+            assert.equal(res.body.meta.pagination.total, 2);
+        });
+
         it('includes hidden replies but not deleted replies in count', async function () {
             await dbFns.addCommentWithReplies({
                 member_id: fixtureManager.get('members', 0).id,

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -1922,6 +1922,65 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated browse by post excludes deleted and hidden reply tombstones when they have no published descendants 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "direct_replies": Any<Number>,
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "parent_id": Nullable<StringMatching>,
+      "pinned": Any<Boolean>,
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+  "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post excludes deleted and hidden reply tombstones when they have no published descendants 2: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "599",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated browse by post excludes deleted comments 1: [body] 1`] = `
 Object {
   "comments": Array [],
@@ -2161,6 +2220,138 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "599",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post includes deleted and hidden reply tombstones when they have published descendants 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "direct_replies": Any<Number>,
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "parent_id": Nullable<StringMatching>,
+      "pinned": Any<Boolean>,
+      "replies": Array [
+        Object {
+          "count": Object {
+            "direct_replies": 0,
+            "likes": Any<Number>,
+          },
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
+          "edited_at": null,
+          "html": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": Nullable<StringMatching>,
+          "in_reply_to_snippet": null,
+          "liked": Any<Boolean>,
+          "member": Object {
+            "avatar_image": null,
+            "expertise": null,
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": null,
+            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+          },
+          "parent_id": Nullable<StringMatching>,
+          "pinned": Any<Boolean>,
+          "status": "hidden",
+        },
+        Object {
+          "count": Object {
+            "direct_replies": 1,
+            "likes": Any<Number>,
+          },
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
+          "edited_at": null,
+          "html": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": Nullable<StringMatching>,
+          "in_reply_to_snippet": "[removed]",
+          "liked": Any<Boolean>,
+          "member": Object {
+            "avatar_image": null,
+            "expertise": null,
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": null,
+            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+          },
+          "parent_id": Nullable<StringMatching>,
+          "pinned": Any<Boolean>,
+          "status": "deleted",
+        },
+        Object {
+          "count": Object {
+            "direct_replies": 0,
+            "likes": Any<Number>,
+          },
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "disliked": false,
+          "edited_at": null,
+          "html": "<p>This is published</p>",
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": Nullable<StringMatching>,
+          "in_reply_to_snippet": "[removed]",
+          "liked": Any<Boolean>,
+          "member": Object {
+            "avatar_image": null,
+            "expertise": null,
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": null,
+            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+          },
+          "parent_id": Nullable<StringMatching>,
+          "pinned": Any<Boolean>,
+          "status": "published",
+        },
+      ],
+      "status": "published",
+    },
+  ],
+  "meta": Object {
+    "capabilities": Object {
+      "dislikes": true,
+    },
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post includes deleted and hidden reply tombstones when they have published descendants 2: [headers] 1`] = `
+Object {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1978",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -765,6 +765,44 @@ describe('Comments API', function () {
                     assert.equal(result.body.meta.pagination.total, 1);
                 });
 
+                it('includes hidden comments when only a nested descendant is published', async function () {
+                    const root = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 0).id,
+                        status: 'hidden',
+                        html: 'This is a hidden comment'
+                    });
+
+                    const hiddenReply = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 1).id,
+                        parent_id: root.get('id'),
+                        status: 'hidden',
+                        html: '<p>This is hidden</p>'
+                    });
+
+                    const publishedReply = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 1).id,
+                        parent_id: root.get('id'),
+                        in_reply_to_id: hiddenReply.get('id'),
+                        status: 'published',
+                        html: '<p>This is published</p>'
+                    });
+
+                    const result = await membersAgent
+                        .get(`/api/comments/post/${postId}/`)
+                        .expectStatus(200);
+                    const comment = result.body.comments[0];
+
+                    assert.equal(result.body.comments.length, 1);
+                    assert.equal(comment.id, root.get('id'));
+                    assert.equal(comment.html, null);
+                    assert.equal(comment.count.replies, 1);
+                    assert.equal(comment.count.direct_replies, 0);
+                    assert.deepEqual(comment.replies.map(reply => reply.id), [hiddenReply.get('id'), publishedReply.get('id')]);
+                    assert.equal(comment.replies[0].html, null);
+                    assert.equal(comment.replies[1].html, '<p>This is published</p>');
+                    assert.equal(result.body.meta.pagination.total, 1);
+                });
+
                 it('excludes hidden comments if all replies are hidden or deleted', async function () {
                     await dbFns.addCommentWithReplies({
                         member_id: fixtureManager.get('members', 0).id,
@@ -807,6 +845,66 @@ describe('Comments API', function () {
                     });
 
                     const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 0})]);
+                    assert.equal(result.body.comments[0].replies.length, 0);
+                });
+
+                it('includes deleted and hidden reply tombstones when they have published descendants', async function () {
+                    const root = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 0).id
+                    });
+
+                    const hiddenReply = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 1).id,
+                        parent_id: root.get('id'),
+                        status: 'hidden',
+                        html: '<p>This is hidden</p>'
+                    });
+
+                    const deletedReply = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 1).id,
+                        parent_id: root.get('id'),
+                        in_reply_to_id: hiddenReply.get('id'),
+                        status: 'deleted',
+                        html: '<p>This is deleted</p>'
+                    });
+
+                    const publishedReply = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 1).id,
+                        parent_id: root.get('id'),
+                        in_reply_to_id: deletedReply.get('id'),
+                        status: 'published',
+                        html: '<p>This is published</p>'
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 3, commentMatcher: labsCommentMatcher})]);
+                    const replies = result.body.comments[0].replies;
+
+                    assert.deepEqual(replies.map(reply => reply.id), [hiddenReply.get('id'), deletedReply.get('id'), publishedReply.get('id')]);
+                    assert.equal(replies[0].html, null);
+                    assert.equal(replies[1].html, null);
+                    assert.equal(replies[2].html, '<p>This is published</p>');
+                    assert.equal(replies[2].in_reply_to_id, deletedReply.get('id'));
+                });
+
+                it('excludes deleted and hidden reply tombstones when they have no published descendants', async function () {
+                    const root = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 0).id
+                    });
+
+                    const hiddenReply = await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 1).id,
+                        parent_id: root.get('id'),
+                        status: 'hidden'
+                    });
+
+                    await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 1).id,
+                        parent_id: root.get('id'),
+                        in_reply_to_id: hiddenReply.get('id'),
+                        status: 'deleted'
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 0, commentMatcher: labsCommentMatcher})]);
                     assert.equal(result.body.comments[0].replies.length, 0);
                 });
 
@@ -1224,6 +1322,174 @@ describe('Comments API', function () {
                 assert.equal(result.body.comments[0].count.replies, 2);
                 // count.direct_replies = direct replies excluding hidden/deleted: only replyA
                 assert.equal(result.body.comments[0].count.direct_replies, 1);
+            });
+
+            it('count.replies and count.direct_replies exclude hidden/deleted tombstones returned for structure', async function () {
+                const member0 = fixtureManager.get('members', 0).id;
+                const member1 = fixtureManager.get('members', 1).id;
+
+                const root = await dbFns.addComment({
+                    member_id: member0,
+                    html: '<p>Root</p>'
+                });
+
+                const hiddenReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    status: 'hidden',
+                    html: '<p>Hidden reply</p>'
+                });
+
+                const deletedReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    in_reply_to_id: hiddenReply.get('id'),
+                    status: 'deleted',
+                    html: '<p>Deleted reply</p>'
+                });
+
+                const publishedReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    in_reply_to_id: deletedReply.get('id'),
+                    status: 'published',
+                    html: '<p>Published reply</p>'
+                });
+
+                const result = await membersAgent.get(`/api/comments/${root.get('id')}/`);
+                const comment = result.body.comments[0];
+
+                assert.deepEqual(comment.replies.map(reply => reply.id), [hiddenReply.get('id'), deletedReply.get('id'), publishedReply.get('id')]);
+                assert.equal(comment.count.replies, 1);
+                assert.equal(comment.count.direct_replies, 0);
+            });
+
+            it('reply endpoint includes deleted and hidden tombstones when they have published descendants', async function () {
+                const member0 = fixtureManager.get('members', 0).id;
+                const member1 = fixtureManager.get('members', 1).id;
+
+                const root = await dbFns.addComment({
+                    member_id: member0,
+                    html: '<p>Root</p>'
+                });
+
+                const hiddenReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    status: 'hidden',
+                    html: '<p>Hidden reply</p>'
+                });
+
+                const deletedReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    in_reply_to_id: hiddenReply.get('id'),
+                    status: 'deleted',
+                    html: '<p>Deleted reply</p>'
+                });
+
+                const publishedReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    in_reply_to_id: deletedReply.get('id'),
+                    status: 'published',
+                    html: '<p>Published reply</p>'
+                });
+
+                const result = await membersAgent.get(`/api/comments/${root.get('id')}/replies/`);
+                const replies = result.body.comments;
+
+                assert.deepEqual(replies.map(reply => reply.id), [hiddenReply.get('id'), deletedReply.get('id'), publishedReply.get('id')]);
+                assert.equal(replies[0].html, null);
+                assert.equal(replies[1].html, null);
+                assert.equal(replies[2].html, '<p>Published reply</p>');
+                assert.equal(replies[0].count.direct_replies, 0);
+                assert.equal(replies[1].count.direct_replies, 1);
+                assert.equal(result.body.meta.pagination.total, 3);
+            });
+
+            it('reply endpoint paginates tombstones before the published descendant that makes them displayable', async function () {
+                const member0 = fixtureManager.get('members', 0).id;
+                const member1 = fixtureManager.get('members', 1).id;
+
+                const root = await dbFns.addComment({
+                    member_id: member0,
+                    html: '<p>Root</p>'
+                });
+
+                const hiddenReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    status: 'hidden',
+                    html: '<p>Hidden reply</p>'
+                });
+
+                const deletedReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    in_reply_to_id: hiddenReply.get('id'),
+                    status: 'deleted',
+                    html: '<p>Deleted reply</p>'
+                });
+
+                const publishedReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    in_reply_to_id: deletedReply.get('id'),
+                    status: 'published',
+                    html: '<p>Published reply</p>'
+                });
+
+                const firstPage = await membersAgent.get(`/api/comments/${root.get('id')}/replies/?limit=2`);
+                assert.deepEqual(firstPage.body.comments.map(reply => reply.id), [hiddenReply.get('id'), deletedReply.get('id')]);
+                assert.equal(firstPage.body.comments[0].html, null);
+                assert.equal(firstPage.body.comments[1].html, null);
+                assert.equal(firstPage.body.meta.pagination.total, 3);
+                assert.equal(firstPage.body.meta.pagination.next, 2);
+
+                const secondPage = await membersAgent.get(`/api/comments/${root.get('id')}/replies/?limit=2&page=2`);
+                assert.deepEqual(secondPage.body.comments.map(reply => reply.id), [publishedReply.get('id')]);
+                assert.equal(secondPage.body.comments[0].html, '<p>Published reply</p>');
+                assert.equal(secondPage.body.meta.pagination.total, 3);
+                assert.equal(secondPage.body.meta.pagination.next, null);
+            });
+
+            it('reply endpoint excludes deleted and hidden leaf replies while keeping published siblings', async function () {
+                const member0 = fixtureManager.get('members', 0).id;
+                const member1 = fixtureManager.get('members', 1).id;
+
+                const root = await dbFns.addComment({
+                    member_id: member0,
+                    html: '<p>Root</p>'
+                });
+
+                await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    status: 'hidden',
+                    html: '<p>Hidden reply</p>'
+                });
+
+                await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    status: 'deleted',
+                    html: '<p>Deleted reply</p>'
+                });
+
+                const publishedReply = await dbFns.addComment({
+                    member_id: member1,
+                    parent_id: root.get('id'),
+                    status: 'published',
+                    html: '<p>Published reply</p>'
+                });
+
+                const result = await membersAgent.get(`/api/comments/${root.get('id')}/replies/`);
+                const replies = result.body.comments;
+
+                assert.deepEqual(replies.map(reply => reply.id), [publishedReply.get('id')]);
+                assert.equal(replies[0].html, '<p>Published reply</p>');
+                assert.equal(result.body.meta.pagination.total, 1);
             });
 
             it('Can reply to a comment with www domain', async function () {

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -26,6 +26,29 @@ describe('Unit: models/comment', function () {
             assert.ok(options.withRelated.includes('count.disliked'));
             assert.ok(options.withRelated.includes('count.net_score'));
         });
+
+        it('scopes non-page reply tombstone filtering to the loaded comment', function () {
+            const options = {
+                id: 'root-comment-id'
+            };
+
+            models.Comment.defaultRelations('findOne', options);
+
+            const repliesRelation = options.withRelated.find((relation) => {
+                return typeof relation === 'object' && relation.replies;
+            });
+            let query;
+            const qb = {
+                whereIn(_column, rawQuery) {
+                    query = rawQuery.toSQL();
+                }
+            };
+
+            repliesRelation.replies(qb);
+
+            assert.match(query.sql, /comments\.parent_id IN \(\?\)/);
+            assert.equal(query.bindings.filter(binding => binding === 'root-comment-id').length, 2);
+        });
     });
 
     describe('orderAttributes', function () {


### PR DESCRIPTION
## Summary

- Stack follow-up fixes on top of TryGhost/Ghost#28024 for hidden/deleted threaded comment tombstones
- Scope non-page reply tombstone CTEs to the loaded comment to avoid broad table materialization
- Preserve admin-visible hidden replies during local delete handling
- Prune structural leaf tombstones from comments-ui state when they no longer have loaded descendants
- Bump `@tryghost/comments-ui` to `1.5.4`

## Context

This is stacked on #28024, which introduces the server-side threaded comment tombstone selection. These commits address the follow-up review findings around query scope, local comments-ui state after deleting replies in deep threads, and the package version bump needed for the public comments-ui change.

ref https://linear.app/ghost/issue/BER-3677/hidden-comments-collapse-thread-nesting-incorrectly

## Testing

- `pnpm --dir ghost/core test:single test/unit/server/models/comment.test.js`
- `pnpm --filter @tryghost/comments-ui test:unit -- actions.test.js thread-graph.test.ts comment.test.jsx`
