### PR TITLE
Released comments threading and pinned comments

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -64,10 +64,6 @@ const features: Feature[] = [{
     description: 'Use optimized COUNT queries for API pagination when safe',
     flag: 'smarterCounts'
 }, {
-    title: 'Comments Threads',
-    description: 'Enable deeper threading view in Comments-UI',
-    flag: 'commentsThreads'
-}, {
     title: 'Comments Pinning',
     description: 'Allow staff to pin top-level comments in Comments-UI and Admin',
     flag: 'commentsPinning'

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -63,10 +63,6 @@ const features: Feature[] = [{
     title: 'Smarter Counts',
     description: 'Use optimized COUNT queries for API pagination when safe',
     flag: 'smarterCounts'
-}, {
-    title: 'Comments Pinning',
-    description: 'Allow staff to pin top-level comments in Comments-UI and Admin',
-    flag: 'commentsPinning'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/e2e/tests/public/comment-replies.test.ts
+++ b/e2e/tests/public/comment-replies.test.ts
@@ -61,7 +61,7 @@ test.describe('Ghost Public - Comments - Replies', () => {
         await expect(postCommentsSection.comments.last()).toContainText('Reply to main comment 2');
     });
 
-    test('reply to reply comment', async ({page}) => {
+    test('reply to reply comment in threaded layout', async ({page}) => {
         const post = await postFactory.create({status: 'published'});
         const member = await memberFactory.create({status: 'free'});
         const paidTier = await tierFactory.getFirstPaidTier();
@@ -93,10 +93,9 @@ test.describe('Ghost Public - Comments - Replies', () => {
         await expect(postCommentsSection.comments).toHaveCount(3);
         await expect(postCommentsSection.comments.first()).toContainText('Main comment');
         await expect(postCommentsSection.comments.last()).toContainText('My reply');
-        await expect(postCommentsSection.comments.last()).toContainText('Replied to: Reply to main comment');
     });
 
-    test('show replies and load more replies', async ({page}) => {
+    test('show replies in threaded layout', async ({page}) => {
         const post = await postFactory.create({status: 'published'});
         const member = await memberFactory.create({status: 'free'});
 
@@ -122,13 +121,7 @@ test.describe('Ghost Public - Comments - Replies', () => {
         await postPage.waitForCommentsToLoad();
         const postCommentsSection = postPage.commentsSection;
 
-        await expect(postCommentsSection.comments).toHaveCount(4);
-        await expect(postCommentsSection.comments.last()).toContainText('reply 3 to comment 1');
-        await expect(postCommentsSection.showMoreRepliesButton).toBeVisible();
-        await expect(postCommentsSection.showMoreRepliesButton).toContainText('Show 2 more replies');
-
-        await postCommentsSection.showMoreRepliesButton.click();
-        await expect(postCommentsSection.comments.last()).toContainText('reply 5 to comment 1');
         await expect(postCommentsSection.comments).toHaveCount(6);
+        await expect(postCommentsSection.comments.last()).toContainText('reply 5 to comment 1');
     });
 });

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -24,6 +24,7 @@ const GA_FEATURES = [
     'customFonts',
     'explore',
     'commentModeration',
+    'commentsThreads',
     'featurebaseFeedback',
     'giftSubscriptions',
     'dangerZoneResetAuth'
@@ -52,7 +53,6 @@ const PRIVATE_FEATURES = [
     'indexnow',
     'pictureImageFormats',
     'smarterCounts',
-    'commentsThreads',
     'commentsPinning'
 ];
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -25,6 +25,7 @@ const GA_FEATURES = [
     'explore',
     'commentModeration',
     'commentsThreads',
+    'commentsPinning',
     'featurebaseFeedback',
     'giftSubscriptions',
     'dangerZoneResetAuth'
@@ -52,8 +53,7 @@ const PRIVATE_FEATURES = [
     'themeTranslation',
     'indexnow',
     'pictureImageFormats',
-    'smarterCounts',
-    'commentsPinning'
+    'smarterCounts'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1803,7 +1803,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5435",
+  "content-length": "5460",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1803,7 +1803,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5460",
+  "content-length": "5485",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
## Summary
- Released `commentsThreads` by moving it from private labs to GA and removing it from the private Labs admin UI.
- Released `commentsPinning` by moving it from private labs to GA and removing it from the private Labs admin UI.
- Updated the Admin Settings API header snapshot affected by the labs payload change.

## Why
These comment features are ready to go out to everyone in the next release.

ref https://linear.app/ghost/issue/BER-3685/ga-threading-and-pinned-comments

## Testing
- `pnpm --dir ghost/core exec eslint --cache -- core/shared/labs.js`
- `pnpm --dir apps/admin-x-settings exec eslint --cache -- src/components/settings/advanced/labs/private-features.tsx`
- `pnpm test:single test/e2e-api/admin/settings.test.js` (29 passing)
- `pnpm test:single test/unit/shared/labs.test.js` (9 passing)