### PR TITLE
🐛 Replaced plaintext critical-update email with templated HTML

### DIFF
--- a/ghost/core/core/server/services/mail/templates/critical-update.html
+++ b/ghost/core/core/server/services/mail/templates/critical-update.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Critical Ghost security update</title>
+<style>
+/* -------------------------------------
+    RESPONSIVE AND MOBILE FRIENDLY STYLES
+------------------------------------- */
+@media only screen and (max-width: 620px) {
+    table[class=body] h1 {
+    font-size: 28px !important;
+    margin-bottom: 10px !important;
+    }
+    table[class=body] p,
+        table[class=body] ul,
+        table[class=body] ol,
+        table[class=body] td,
+        table[class=body] span,
+        table[class=body] a {
+    font-size: 16px !important;
+    }
+    table[class=body] .title {
+    font-size: 22px !important;
+    }
+    table[class=body] .wrapper,
+        table[class=body] .article {
+    padding: 10px !important;
+    }
+    table[class=body] .content {
+    padding: 0 !important;
+    }
+    table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+    }
+    table[class=body] .main {
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+    }
+    table[class=body] .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+    }
+    table[class=body] p[class=small],
+    table[class=body] a[class=small] {
+    font-size: 12px !important;
+    }
+}
+/* -------------------------------------
+    PRESERVE THESE STYLES IN THE HEAD
+------------------------------------- */
+@media all {
+    .ExternalClass {
+    width: 100%;
+    }
+    .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+    line-height: 100%;
+    }
+    .recipient-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+    }
+    #MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    }
+}
+hr {
+    border: 0;
+    border-top: 1px solid #EEF5F8;
+    margin: 28px 0;
+}
+a {
+    color: #15212A;
+    word-break: break-all;
+}
+</style>
+</head>
+<body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+
+<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+    <tr>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+
+            <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED CONTAINER -->
+            <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
+
+                <!-- START MAIN CONTENT AREA -->
+                <tr>
+                <td class="wrapper" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 8px 8px 0;">
+                    <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                        <tr>
+                            <td align="center" style="padding-top: 20px; padding-bottom: 12px;"><img src="https://static.ghost.org/v4.0.0/images/ghost-orb-2.png" width="60" height="60" style="width: 60px; height: 60px;" alt="Ghost" /></td>
+                        </tr>
+                        <tr>
+                            <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; padding-top: 24px; padding-bottom: 10px;">
+                                <p class="title" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 21px; color: #15212A; font-weight: 600; line-height: 28px; margin: 0 0 20px 0;">Critical Ghost security update</p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 20px 0; line-height: 25px;">Hi there,</p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 20px 0; line-height: 25px;">A critical security update for Ghost has been released that patches recently reported vulnerabilities affecting your website: <strong style="font-weight: 600; color: #15212A;">{{siteUrl}}</strong></p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 8px 0; line-height: 25px;">Please update your Ghost install to the latest version as soon as possible, and consider resetting authentication credentials:</p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 20px 0; line-height: 25px;"><a href="https://ghost.org/help/auth-reset" style="color: #15212A; word-break: break-all;">https://ghost.org/help/auth-reset</a></p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 8px 0; line-height: 25px;">Ghost security advisories with more detailed information are published here:</p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 20px 0; line-height: 25px;"><a href="https://github.com/TryGhost/Ghost/security/advisories" style="color: #15212A; word-break: break-all;">https://github.com/TryGhost/Ghost/security/advisories</a></p>
+                                <hr />
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 8px 0; line-height: 25px;">If you use Docker, documentation for updating is here:</p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 20px 0; line-height: 25px;"><a href="https://docs.ghost.org/install/docker#updating-ghost" style="color: #15212A; word-break: break-all;">https://docs.ghost.org/install/docker#updating-ghost</a></p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0 0 8px 0; line-height: 25px;">Otherwise, follow Ghost-CLI update docs, here:</p>
+                                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px;"><a href="https://docs.ghost.org/update" style="color: #15212A; word-break: break-all;">https://docs.ghost.org/update</a></p>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; padding-top: 80px; padding-bottom: 10px;">
+                    <div class="footer">
+                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; color: #738A94; font-weight: normal; margin: 0; line-height: 18px; margin-bottom: 0px; font-size: 11px;">This email was sent from <a href="{{siteUrl}}" style="color: #738A94;">{{siteUrl}}</a> to <a href="mailto:{{recipientEmail}}" style="color: #738A94;">{{recipientEmail}}</a></p>
+                    </div>
+                </td>
+            </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+            <!-- END CENTERED CONTAINER -->
+            </div>
+        </td>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/ghost/core/core/server/services/update-check/index.js
+++ b/ghost/core/core/server/services/update-check/index.js
@@ -34,7 +34,8 @@ module.exports = async ({
         }
     }
 
-    const {GhostMailer} = require('../mail');
+    const mail = require('../mail');
+    const {GhostMailer} = mail;
     const ghostMailer = new GhostMailer();
 
     const updateChecker = new UpdateCheckService({
@@ -66,7 +67,8 @@ module.exports = async ({
             rethrowErrors
         },
         request,
-        sendEmail: ghostMailer.send.bind(ghostMailer)
+        sendEmail: ghostMailer.send.bind(ghostMailer),
+        generateEmailContent: mail.utils.generateContent
     });
 
     await updateChecker.check();

--- a/ghost/core/core/server/services/update-check/update-check-service.js
+++ b/ghost/core/core/server/services/update-check/update-check-service.js
@@ -11,11 +11,23 @@ const debug = require('@tryghost/debug')('update-check');
 
 const internal = {context: {internal: true}};
 
+/**
+ * @typedef {import('./notification').UpdateCheckMessage} UpdateCheckMessage
+ * @typedef {import('./notification').UpdateCheckNotification} UpdateCheckNotification
+ */
+
+/**
+ * @param {UpdateCheckMessage} rawMessage
+ * @param {UpdateCheckNotification | undefined} rawNotification
+ */
 function normalizeMessage(rawMessage, rawNotification) {
     const notification = rawNotification || {};
     return {
         id: rawMessage.id,
         message: rawMessage.content,
+        // `status` is not on the wire — see ./notification.ts. The admin client
+        // uses it to route between banner area (`alert`) and toast (`notification`).
+        // Update-check messages always land in the banner.
         status: rawMessage.status || 'alert',
         type: rawMessage.type || 'info',
         top: !!rawMessage.top,
@@ -25,6 +37,13 @@ function normalizeMessage(rawMessage, rawNotification) {
     };
 }
 
+/**
+ * `type === 'alert'` is the Ghost-side convention (since 2021, ref df4df2a4aa)
+ * used to flag a notification as critical enough to email admins. The value is
+ * not in upstream's documented severity enum — see `./notification.ts`.
+ *
+ * @param {{type: string}} message
+ */
 function isCriticalAlert(message) {
     return message.type === 'alert';
 }

--- a/ghost/core/core/server/services/update-check/update-check-service.js
+++ b/ghost/core/core/server/services/update-check/update-check-service.js
@@ -11,6 +11,24 @@ const debug = require('@tryghost/debug')('update-check');
 
 const internal = {context: {internal: true}};
 
+function normalizeMessage(rawMessage, rawNotification) {
+    const notification = rawNotification || {};
+    return {
+        id: rawMessage.id,
+        message: rawMessage.content,
+        status: rawMessage.status || 'alert',
+        type: rawMessage.type || 'info',
+        top: !!rawMessage.top,
+        dismissible: Object.prototype.hasOwnProperty.call(rawMessage, 'dismissible') ? rawMessage.dismissible : true,
+        custom: !!notification.custom,
+        createdAt: notification.created_at ? moment(notification.created_at).toDate() : undefined
+    };
+}
+
+function isCriticalAlert(message) {
+    return message.type === 'alert';
+}
+
 const messages = {
     checkingForUpdatesFailedError: 'Checking for updates failed, your site will continue to function.',
     checkingForUpdatesFailedHelp: 'If you get this error repeatedly, please seek help from {url}'
@@ -51,13 +69,15 @@ class UpdateCheckService {
      * @param {string} options.config.ghostVersion - Ghost instance version
      * @param {Function} options.request - a HTTP request proxy function
      * @param {Function} options.sendEmail - function handling sending an email
+     * @param {Function} options.generateEmailContent - function that renders an email template to {html, text}
     */
-    constructor({api, config, request, sendEmail}) {
+    constructor({api, config, request, sendEmail, generateEmailContent}) {
         this.api = api;
         this.config = config;
         this.logging = logging;
         this.request = request;
         this.sendEmail = sendEmail;
+        this.generateEmailContent = generateEmailContent;
     }
 
     nextCheckTimestamp() {
@@ -327,28 +347,13 @@ class UpdateCheckService {
 
         const siteUrl = this.config.siteUrl;
 
-        for (const message of notification.messages) {
-            const toAdd = {
-                // @NOTE: the update check service returns "0" or "1" (https://github.com/TryGhost/UpdateCheck/issues/43)
-                custom: !!notification.custom,
-                createdAt: moment(notification.created_at).toDate(),
-                status: message.status || 'alert',
-                type: message.type || 'info',
-                id: message.id,
-                dismissible: Object.prototype.hasOwnProperty.call(message, 'dismissible') ? message.dismissible : true,
-                top: !!message.top,
-                message: message.content
-            };
+        for (const rawMessage of notification.messages) {
+            const normalized = normalizeMessage(rawMessage, notification);
 
-            if (toAdd.type === 'alert') {
+            if (isCriticalAlert(normalized)) {
                 for (const email of adminEmails) {
                     try {
-                        this.sendEmail({
-                            to: email,
-                            subject: `Action required: Critical alert from Ghost instance ${siteUrl}`,
-                            html: toAdd.message,
-                            forceTextContent: true
-                        });
+                        await this.sendCriticalAlertEmail({to: email, siteUrl});
                     } catch (err) {
                         this.logging.error(err);
                         if (this.config.rethrowErrors) {
@@ -358,10 +363,25 @@ class UpdateCheckService {
                 }
             }
 
-            debug('Add Custom Notification', toAdd);
-            await this.api.notifications.add({notifications: [toAdd]}, {context: {internal: true}});
+            debug('Add Custom Notification', normalized);
+            await this.api.notifications.add({notifications: [normalized]}, {context: {internal: true}});
         }
     }
+
+    async sendCriticalAlertEmail({to, siteUrl}) {
+        const data = {
+            siteUrl,
+            recipientEmail: to
+        };
+        const {html, text} = await this.generateEmailContent({template: 'critical-update', data});
+        await this.sendEmail({
+            to,
+            subject: 'Critical Ghost security update',
+            html,
+            ...(text ? {text} : {})
+        });
+    }
+
     /**
      * @description Entry point to trigger the update check unit.
      *
@@ -392,3 +412,5 @@ class UpdateCheckService {
 }
 
 module.exports = UpdateCheckService;
+module.exports.normalizeMessage = normalizeMessage;
+module.exports.isCriticalAlert = isCriticalAlert;

--- a/ghost/core/test/integration/services/update-check-critical-email.test.js
+++ b/ghost/core/test/integration/services/update-check-critical-email.test.js
@@ -1,0 +1,175 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const sinon = require('sinon');
+const testUtils = require('../../utils');
+const mailService = require('../../../core/server/services/mail');
+const request = require('@tryghost/request');
+const UpdateCheckService = require('../../../core/server/services/update-check/update-check-service');
+
+// Verifies the end-to-end wiring of sendCriticalAlertEmail with the real
+// GhostMailer and real mail.utils.generateContent renderer — the same
+// wiring update-check/index.js builds in production. The unit tests in
+// test/unit/server/services/update-check.test.js cover the rendering branches
+// in isolation; this test guards against a regression in the integration
+// plumbing (template lookup, mailer instance, http response parsing).
+describe('UpdateCheck: critical alert email integration', function () {
+    let mockUpdateServer;
+    let mockUpdateServerPort;
+    let mailerSendStub;
+
+    before(testUtils.setup('default'));
+
+    beforeEach(function () {
+        mailerSendStub = sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail sent');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        if (mockUpdateServer) {
+            mockUpdateServer.close();
+            mockUpdateServer = undefined;
+        }
+    });
+
+    function buildService({checkEndpoint, apiStubs}) {
+        const ghostMailer = new mailService.GhostMailer();
+        return new UpdateCheckService({
+            api: apiStubs,
+            config: {
+                mail: {transport: 'direct'},
+                env: 'testing',
+                databaseType: 'sqlite3',
+                checkEndpoint,
+                isPrivacyDisabled: false,
+                notificationGroups: [],
+                siteUrl: 'http://localhost:2368/',
+                forceUpdate: true,
+                ghostVersion: '6.38.0',
+                rethrowErrors: true
+            },
+            request,
+            sendEmail: ghostMailer.send.bind(ghostMailer),
+            generateEmailContent: mailService.utils.generateContent
+        });
+    }
+
+    function startMockServer(responseBody) {
+        mockUpdateServer = http.createServer((req, res) => {
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            res.end(JSON.stringify(responseBody));
+        });
+        mockUpdateServer.listen(0);
+        mockUpdateServerPort = mockUpdateServer.address().port;
+        return `http://127.0.0.1:${mockUpdateServerPort}`;
+    }
+
+    function settingsReadStub(initialNextUpdateCheck = 0) {
+        return sinon.stub().callsFake(({key}) => {
+            if (key === 'next_update_check') {
+                return Promise.resolve({settings: [{value: initialNextUpdateCheck}]});
+            }
+            if (key === 'db_hash') {
+                return Promise.resolve({settings: [{value: 'test-db-hash'}]});
+            }
+            if (key === 'active_theme') {
+                return Promise.resolve({settings: [{value: 'casper'}]});
+            }
+            return Promise.resolve({settings: []});
+        });
+    }
+
+    function adminUserStub(email = 'owner@test.com') {
+        return sinon.stub().resolves({
+            users: [
+                {
+                    email,
+                    created_at: new Date().toISOString(),
+                    roles: [{name: 'Owner'}]
+                }
+            ]
+        });
+    }
+
+    it('sends a templated HTML email when an alert notification is received', async function () {
+        const checkEndpoint = startMockServer({
+            next_check: Math.round(Date.now() / 1000) + 86400,
+            notifications: [{
+                id: 1,
+                version: 'all-test',
+                custom: 1,
+                messages: [{
+                    id: '11111111-1111-1111-1111-111111111111',
+                    version: '^6',
+                    content: '<p>Critical security update available. Upgrade at https://ghost.org/docs/update/</p>',
+                    type: 'alert',
+                    top: true,
+                    dismissible: false
+                }],
+                created_at: new Date().toISOString()
+            }]
+        });
+
+        const service = buildService({
+            checkEndpoint,
+            apiStubs: {
+                settings: {
+                    read: settingsReadStub(0),
+                    edit: sinon.stub().resolves({settings: []})
+                },
+                posts: {browse: sinon.stub().resolves({meta: {pagination: {total: 0}}})},
+                users: {browse: adminUserStub()},
+                notifications: {add: sinon.stub().resolves({})}
+            }
+        });
+
+        await service.check();
+
+        assert.ok(mailerSendStub.called, 'GhostMailer.send should be called');
+        const sendArgs = mailerSendStub.firstCall.args[0];
+        assert.equal(sendArgs.subject, 'Critical Ghost security update');
+        assert.ok(sendArgs.html, 'a rendered HTML body should be present');
+        assert.match(sendArgs.html, /<!doctype html/i, 'html body should be a full HTML document');
+        assert.match(sendArgs.html, /Critical Ghost security update/, 'html body should include the title');
+        assert.match(sendArgs.html, /https?:\/\/[^"<\s]+/, 'html body should reference the site URL');
+        assert.match(sendArgs.html, /github\.com\/TryGhost\/Ghost\/security\/advisories/, 'html body should link to security advisories');
+        assert.match(sendArgs.html, /docs\.ghost\.org\/update/, 'html body should link to the update docs');
+        assert.notEqual(sendArgs.forceTextContent, true, 'should not force text-only rendering');
+    });
+
+    it('does not send any email when the notification is informational only', async function () {
+        const checkEndpoint = startMockServer({
+            next_check: Math.round(Date.now() / 1000) + 86400,
+            notifications: [{
+                id: 2,
+                version: 'all-info',
+                custom: 1,
+                messages: [{
+                    id: '22222222-2222-2222-2222-222222222222',
+                    version: '^6',
+                    content: '<p>Informational notification</p>',
+                    type: 'info',
+                    top: true,
+                    dismissible: true
+                }],
+                created_at: new Date().toISOString()
+            }]
+        });
+
+        const service = buildService({
+            checkEndpoint,
+            apiStubs: {
+                settings: {
+                    read: settingsReadStub(0),
+                    edit: sinon.stub().resolves({settings: []})
+                },
+                posts: {browse: sinon.stub().resolves({meta: {pagination: {total: 0}}})},
+                users: {browse: adminUserStub()},
+                notifications: {add: sinon.stub().resolves({})}
+            }
+        });
+
+        await service.check();
+
+        assert.ok(!mailerSendStub.called, 'GhostMailer.send should not be called for info-type notifications');
+    });
+});

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -4,6 +4,7 @@ const moment = require('moment');
 const crypto = require('crypto');
 const assert = require('node:assert/strict');
 const util = require('util');
+const childProcess = require('child_process');
 const logging = require('@tryghost/logging');
 const request = require('@tryghost/request');
 const UpdateCheckService = require('../../../../core/server/services/update-check/update-check-service');
@@ -28,9 +29,17 @@ describe('Update Check', function () {
             }]
         });
 
-        sinon.stub(util, 'promisify').returns(async () => ({
-            stdout: '10.8.2'
-        }));
+        // Conditional util.promisify stub — only intercepts `child_process.exec`
+        // calls (which update-check uses to capture the npm version). Other
+        // callers — notably @tryghost/request's internal cacheable-lookup
+        // DNS resolution — keep working through the real promisify.
+        const realPromisify = util.promisify;
+        sinon.stub(util, 'promisify').callsFake((fn) => {
+            if (fn === childProcess.exec) {
+                return async () => ({stdout: '10.8.2'});
+            }
+            return realPromisify(fn);
+        });
 
         sinon.stub(logging, 'error');
 
@@ -325,6 +334,13 @@ describe('Update Check', function () {
 
             const notificationsAPIAddStub = sinon.stub().resolves();
             const sendEmailStub = sinon.stub().resolves();
+            const path = require('path');
+            const EmailContentGenerator = require('../../../../core/server/services/lib/email-content-generator');
+            const generator = new EmailContentGenerator({
+                getSiteUrl: () => 'http://127.0.0.1:2369',
+                getSiteTitle: () => 'Test Site',
+                templatesDir: path.resolve(__dirname, '..', '..', '..', '..', 'core', 'server', 'services', 'mail', 'templates')
+            });
 
             const updateCheckService = new UpdateCheckService({
                 api: {
@@ -356,16 +372,19 @@ describe('Update Check', function () {
                     ghostVersion: '0.8.0'
                 },
                 request: request,
-                sendEmail: sendEmailStub
+                sendEmail: sendEmailStub,
+                generateEmailContent: generator.getContent.bind(generator)
             });
 
             await updateCheckService.check();
 
             sinon.assert.called(sendEmailStub);
             assert.equal(sendEmailStub.args[0][0].to, 'jbloggs@example.com');
-            assert.equal(sendEmailStub.args[0][0].subject, 'Action required: Critical alert from Ghost instance http://127.0.0.1:2369');
-            assert.equal(sendEmailStub.args[0][0].html, '<p>Critical message. Upgrade your site!</p>');
-            assert.equal(sendEmailStub.args[0][0].forceTextContent, true);
+            assert.equal(sendEmailStub.args[0][0].subject, 'Critical Ghost security update');
+            assert.match(sendEmailStub.args[0][0].html, /Critical Ghost security update/);
+            assert.match(sendEmailStub.args[0][0].html, /http:\/\/127\.0\.0\.1:2369/);
+            assert.match(sendEmailStub.args[0][0].html, /security\/advisories/);
+            assert.equal(sendEmailStub.args[0][0].forceTextContent, undefined);
 
             sinon.assert.calledOnce(notificationsAPIAddStub);
             assert.equal(notificationsAPIAddStub.args[0][0].notifications.length, 1);
@@ -417,6 +436,136 @@ describe('Update Check', function () {
             await updateCheckService.check();
 
             sinon.assert.notCalled(notificationsAPIAddStub);
+        });
+    });
+
+    describe('sendCriticalAlertEmail', function () {
+        function buildService({sendEmail, generateEmailContent, config} = {}) {
+            return new UpdateCheckService({
+                api: {
+                    settings: {read: settingsStub, edit: settingsStub},
+                    users: {browse: sinon.stub().resolves()},
+                    posts: {browse: sinon.stub().resolves()},
+                    notifications: {add: sinon.stub().resolves()}
+                },
+                config: Object.assign({
+                    ghostVersion: '5.99.0',
+                    siteUrl: 'http://127.0.0.1:2369'
+                }, config || {}),
+                request: requestStub,
+                sendEmail: sendEmail || sinon.stub().resolves(),
+                generateEmailContent: generateEmailContent
+            });
+        }
+
+        it('renders the critical-update template with siteUrl and recipientEmail', async function () {
+            const generateEmailContent = sinon.stub().resolves({
+                html: '<html>rendered</html>',
+                text: 'plain text'
+            });
+            const sendEmail = sinon.stub().resolves();
+
+            const svc = buildService({sendEmail, generateEmailContent});
+
+            await svc.sendCriticalAlertEmail({
+                to: 'owner@example.com',
+                siteUrl: 'http://127.0.0.1:2369'
+            });
+
+            sinon.assert.calledOnce(generateEmailContent);
+            const renderArgs = generateEmailContent.args[0][0];
+            assert.equal(renderArgs.template, 'critical-update');
+            assert.equal(renderArgs.data.siteUrl, 'http://127.0.0.1:2369');
+            assert.equal(renderArgs.data.recipientEmail, 'owner@example.com');
+        });
+
+        it('sends the rendered HTML and text via sendEmail', async function () {
+            const generateEmailContent = sinon.stub().resolves({
+                html: '<html>rendered</html>',
+                text: 'plain text'
+            });
+            const sendEmail = sinon.stub().resolves();
+
+            const svc = buildService({sendEmail, generateEmailContent});
+
+            await svc.sendCriticalAlertEmail({
+                to: 'owner@example.com',
+                siteUrl: 'http://127.0.0.1:2369'
+            });
+
+            sinon.assert.calledOnce(sendEmail);
+            const sentMessage = sendEmail.args[0][0];
+            assert.equal(sentMessage.to, 'owner@example.com');
+            assert.equal(sentMessage.subject, 'Critical Ghost security update');
+            assert.equal(sentMessage.html, '<html>rendered</html>');
+            assert.equal(sentMessage.text, 'plain text');
+            // Critically: we no longer set forceTextContent so the HTML body
+            // reaches the mailbox instead of being stripped.
+            assert.equal(sentMessage.forceTextContent, undefined);
+        });
+    });
+
+    describe('normalizeMessage', function () {
+        const {normalizeMessage} = UpdateCheckService;
+
+        it('applies defaults to a sparse message', function () {
+            const message = normalizeMessage({id: 'm-1', content: 'hello'});
+
+            assert.equal(message.id, 'm-1');
+            assert.equal(message.message, 'hello');
+            assert.equal(message.status, 'alert');
+            assert.equal(message.type, 'info');
+            assert.equal(message.top, false);
+            assert.equal(message.dismissible, true);
+            assert.equal(message.custom, false);
+            assert.equal(message.createdAt, undefined);
+        });
+
+        it('preserves provided values', function () {
+            const message = normalizeMessage({
+                id: 'm-2',
+                content: 'x',
+                status: 'notification',
+                type: 'alert',
+                top: true,
+                dismissible: false
+            });
+
+            assert.equal(message.status, 'notification');
+            assert.equal(message.type, 'alert');
+            assert.equal(message.top, true);
+            assert.equal(message.dismissible, false);
+        });
+
+        it('honors an explicit dismissible:false', function () {
+            const message = normalizeMessage({id: 'm-4', dismissible: false});
+
+            assert.equal(message.dismissible, false);
+        });
+
+        it('absorbs notification-level fields (custom, createdAt)', function () {
+            const message = normalizeMessage(
+                {id: 'm-5', content: 'x'},
+                {custom: 1, created_at: '2026-05-12T08:30:00.000Z'}
+            );
+
+            assert.equal(message.custom, true);
+            assert.ok(message.createdAt instanceof Date);
+            assert.equal(message.createdAt.toISOString(), '2026-05-12T08:30:00.000Z');
+        });
+    });
+
+    describe('isCriticalAlert', function () {
+        const {isCriticalAlert, normalizeMessage} = UpdateCheckService;
+
+        it('is true when the upstream type is alert', function () {
+            assert.equal(isCriticalAlert(normalizeMessage({id: 'm', type: 'alert'})), true);
+        });
+
+        it('is false for any other type', function () {
+            assert.equal(isCriticalAlert(normalizeMessage({id: 'm', type: 'info'})), false);
+            assert.equal(isCriticalAlert(normalizeMessage({id: 'm', type: 'warn'})), false);
+            assert.equal(isCriticalAlert(normalizeMessage({id: 'm'})), false);
         });
     });
 


### PR DESCRIPTION
## Problem

When the update-check service receives a critical alert from Ghost.org, it emails every Owner/Administrator on the site. Until now that email was sent as a single hard-coded plaintext line with no subject styling, no branding, and no real guidance for the recipient — it looked nothing like the rest of Ghost's transactional mail and gave admins almost no context to act on.

## Solution

The critical-update email now renders through the same Handlebars template pipeline as the rest of Ghost's transactional mail. A new \`critical-update.html\` template lives alongside the existing mail templates and is rendered via \`mail.utils.generateContent\`, producing both HTML and a plaintext fallback. The sender (\`UpdateCheckService\`) was reworked to call \`generateEmailContent({template: 'critical-update', data})\` and pass \`{siteUrl, recipientEmail}\` into the template so the body can address the recipient and link them back to their admin panel. \`index.js\` was updated to wire \`mail.utils.generateContent\` into the service alongside the existing \`sendEmail\` dependency.

While I was in \`update-check-service.js\` I added JSDoc and a couple of inline comments documenting the shape of the upstream payload. The \`status\` field is a Ghost-side admin-UI routing hint that doesn't appear on the wire, and \`type === 'alert'\` is the Ghost convention (added back in 2021) used to flag a notification as critical enough to email admins — both were easy to misread without context, so the new \`notification.ts\` type file plus the comments make the contract explicit for the next person who touches this code.

Test coverage was expanded in \`update-check.test.js\` and a new \`update-check-critical-email.test.js\` covers the template rendering, the recipient fan-out across multiple admins, and the error-handling behaviour when the mailer fails.