### PR TITLE
♻️ Added shared notification email primitive

### DIFF
--- a/ghost/core/core/server/services/mail/templates/notification.html
+++ b/ghost/core/core/server/services/mail/templates/notification.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Ghost notification</title>
+<style>
+@media only screen and (max-width: 620px) {
+    table[class=body] h1 {
+    font-size: 28px !important;
+    margin-bottom: 10px !important;
+    }
+    table[class=body] p,
+        table[class=body] ul,
+        table[class=body] ol,
+        table[class=body] td,
+        table[class=body] span,
+        table[class=body] a {
+    font-size: 16px !important;
+    }
+    table[class=body] .wrapper,
+        table[class=body] .article {
+    padding: 10px !important;
+    }
+    table[class=body] .content {
+    padding: 0 !important;
+    }
+    table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+    }
+    table[class=body] .main {
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+    }
+    table[class=body] .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+    }
+    table[class=body] p[class=small],
+    table[class=body] a[class=small] {
+    font-size: 12px !important;
+    }
+}
+@media all {
+    .ExternalClass {
+    width: 100%;
+    }
+    .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+    line-height: 100%;
+    }
+    .recipient-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+    }
+    #MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    }
+}
+.message {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    font-size: 16px;
+    color: #3A464C;
+    line-height: 25px;
+}
+.message p {
+    margin: 0 0 20px 0;
+}
+.message a {
+    color: #15212A;
+    word-break: break-all;
+}
+.message hr {
+    border: 0;
+    border-top: 1px solid #EEF5F8;
+    margin: 28px 0;
+}
+.message ul,
+.message ol {
+    margin: 0 0 20px 0;
+    padding-left: 20px;
+}
+.message blockquote {
+    margin: 0 0 20px 0;
+    padding-left: 16px;
+    border-left: 3px solid #EEF5F8;
+    color: #738A94;
+}
+.message code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    background: #F2F6F8;
+    padding: 1px 4px;
+    border-radius: 3px;
+}
+a {
+    color: #3A464C;
+}
+</style>
+</head>
+<body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+
+<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+    <tr>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+
+            <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
+
+                <tr>
+                <td class="wrapper" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 8px 8px 0;">
+                    <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                        <tr>
+                            <td align="center" style="padding-top: 20px; padding-bottom: 12px;"><img src="https://static.ghost.org/v4.0.0/images/ghost-orb-2.png" width="60" height="60" style="width: 60px; height: 60px;" alt="Ghost" /></td>
+                        </tr>
+                        <tr>
+                            <td class="message" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; line-height: 25px; vertical-align: top; padding-top: 24px; padding-bottom: 10px;">
+                                {{message}}
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; padding-top: 80px; padding-bottom: 10px;">
+                    <div class="footer">
+                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; color: #738A94; font-weight: normal; margin: 0; line-height: 18px; margin-bottom: 0px; font-size: 11px;">This email was sent from <a href="{{siteUrl}}" style="color: #738A94;">{{siteUrl}}</a> to <a href="mailto:{{recipientEmail}}" style="color: #738A94;">{{recipientEmail}}</a></p>
+                    </div>
+                </td>
+            </tr>
+
+            </table>
+
+            </div>
+        </td>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/ghost/core/core/server/services/notifications/notification-email.ts
+++ b/ghost/core/core/server/services/notifications/notification-email.ts
@@ -1,0 +1,66 @@
+import {sanitizeEmailHtml} from './sanitize-email-html';
+
+interface Mailer {
+    send(options: {to: string; subject: string; html: string; text?: string}): Promise<unknown>;
+}
+
+interface GenerateEmailContent {
+    (options: {template: string; data: Record<string, unknown>}): Promise<{html: string; text?: string}>;
+}
+
+export interface NotificationEmailDeps {
+    mailer: Mailer;
+    generateEmailContent: GenerateEmailContent;
+    getSiteUrl: () => string;
+}
+
+export interface NotificationEmailMessage {
+    /**
+     * Resolved recipient addresses. The service does not decide who receives
+     * the email; callers compose recipients via a separate audience helper.
+     */
+    to: string[];
+    subject: string;
+    /**
+     * Untrusted HTML content. Sanitised before being rendered into the shell,
+     * so the email cannot ship scripts, event handlers or unsafe links even
+     * if the upstream source is compromised.
+     */
+    content: string;
+}
+
+/**
+ * Renders a notification email in the shared shell and sends it to each
+ * recipient. Recipient resolution is a separate concern handled by the caller.
+ */
+export class NotificationEmailService {
+    private readonly mailer: Mailer;
+    private readonly generateEmailContent: GenerateEmailContent;
+    private readonly getSiteUrl: () => string;
+
+    constructor(deps: NotificationEmailDeps) {
+        this.mailer = deps.mailer;
+        this.generateEmailContent = deps.generateEmailContent;
+        this.getSiteUrl = deps.getSiteUrl;
+    }
+
+    async send({to, subject, content}: NotificationEmailMessage): Promise<void> {
+        if (!to.length) {
+            return;
+        }
+        const message = sanitizeEmailHtml(content);
+        const siteUrl = this.getSiteUrl();
+        for (const recipient of to) {
+            const {html, text} = await this.generateEmailContent({
+                template: 'notification',
+                data: {message, siteUrl, recipientEmail: recipient}
+            });
+            await this.mailer.send({
+                to: recipient,
+                subject,
+                html,
+                ...(text ? {text} : {})
+            });
+        }
+    }
+}

--- a/ghost/core/core/server/services/notifications/sanitize-email-html.ts
+++ b/ghost/core/core/server/services/notifications/sanitize-email-html.ts
@@ -1,0 +1,35 @@
+import sanitizeHtml from 'sanitize-html';
+
+// Even though the upstream feed is operated by Ghost org, the resulting HTML
+// is rendered into admin inboxes on the receiving install. A compromised or
+// malformed feed entry must not be able to ship scripts, event handlers, or
+// non-http(s) URLs to recipients via this path.
+const ALLOWED_TAGS = [
+    'p', 'br', 'hr',
+    'strong', 'b', 'em', 'i', 'u', 'code',
+    'a',
+    'ul', 'ol', 'li',
+    'blockquote',
+    'h1', 'h2', 'h3', 'h4'
+];
+
+const ALLOWED_SCHEMES = ['http', 'https', 'mailto'];
+
+const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+    allowedTags: ALLOWED_TAGS,
+    allowedAttributes: {
+        a: ['href', 'title', 'target', 'rel']
+    },
+    allowedSchemes: ALLOWED_SCHEMES,
+    allowProtocolRelative: false,
+    transformTags: {
+        a: sanitizeHtml.simpleTransform('a', {
+            target: '_blank',
+            rel: 'noopener noreferrer'
+        })
+    }
+};
+
+export function sanitizeEmailHtml(html: string): string {
+    return sanitizeHtml(html, SANITIZE_OPTIONS);
+}

--- a/ghost/core/core/server/services/update-check/index.js
+++ b/ghost/core/core/server/services/update-check/index.js
@@ -11,6 +11,7 @@ const databaseInfo = require('../../data/db/info');
 const request = require('@tryghost/request');
 const ghostVersion = require('@tryghost/version');
 const UpdateCheckService = require('./update-check-service');
+const {NotificationEmailService} = require('../notifications/notification-email');
 
 /**
  * Initializes and triggers update check
@@ -34,8 +35,14 @@ module.exports = async ({
         }
     }
 
-    const {GhostMailer} = require('../mail');
-    const ghostMailer = new GhostMailer();
+    const mailService = require('../mail');
+    const ghostMailer = new mailService.GhostMailer();
+
+    const notificationEmailService = new NotificationEmailService({
+        mailer: ghostMailer,
+        generateEmailContent: mailService.utils.generateContent,
+        getSiteUrl: () => urlUtils.urlFor('home', true)
+    });
 
     const updateChecker = new UpdateCheckService({
         api: {
@@ -66,7 +73,7 @@ module.exports = async ({
             rethrowErrors
         },
         request,
-        sendEmail: ghostMailer.send.bind(ghostMailer)
+        notificationEmailService
     });
 
     await updateChecker.check();

--- a/ghost/core/core/server/services/update-check/update-check-service.js
+++ b/ghost/core/core/server/services/update-check/update-check-service.js
@@ -50,14 +50,14 @@ class UpdateCheckService {
      * @param {boolean} [options.config.forceUpdate]
      * @param {string} options.config.ghostVersion - Ghost instance version
      * @param {Function} options.request - a HTTP request proxy function
-     * @param {Function} options.sendEmail - function handling sending an email
+     * @param {Object} options.notificationEmailService - service that sends a sanitised, shell-rendered notification email to a recipient list
     */
-    constructor({api, config, request, sendEmail}) {
+    constructor({api, config, request, notificationEmailService}) {
         this.api = api;
         this.config = config;
         this.logging = logging;
         this.request = request;
-        this.sendEmail = sendEmail;
+        this.notificationEmailService = notificationEmailService;
     }
 
     nextCheckTimestamp() {
@@ -315,15 +315,6 @@ class UpdateCheckService {
         }
 
         debug(`creating custom notifications for ${notification.messages.length} notifications`);
-        const {users} = await this.api.users.browse(Object.assign({
-            limit: 'all',
-            include: ['roles'],
-            filter: 'status:active'
-        }, internal));
-
-        const adminEmails = users
-            .filter(user => ['Owner', 'Administrator'].includes(user.roles[0].name))
-            .map(user => user.email);
 
         const siteUrl = this.config.siteUrl;
 
@@ -340,19 +331,21 @@ class UpdateCheckService {
             };
 
             if (toAdd.type === 'alert') {
-                for (const email of adminEmails) {
-                    try {
-                        this.sendEmail({
-                            to: email,
-                            subject: `Action required: Critical alert from Ghost instance ${siteUrl}`,
-                            html: toAdd.message,
-                            forceTextContent: true
-                        });
-                    } catch (err) {
-                        this.logging.error(err);
-                        if (this.config.rethrowErrors) {
-                            throw err;
-                        }
+                try {
+                    const {users} = await this.api.users.browse({
+                        filter: 'status:active+roles.name:[Owner,Administrator]',
+                        ...internal
+                    });
+                    const to = users.map(user => user.email);
+                    await this.notificationEmailService.send({
+                        to,
+                        subject: `Action required: Critical alert from Ghost instance ${siteUrl}`,
+                        content: toAdd.message
+                    });
+                } catch (err) {
+                    this.logging.error(err);
+                    if (this.config.rethrowErrors) {
+                        throw err;
                     }
                 }
             }

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -270,6 +270,7 @@
     "@types/nodemailer": "6.4.23",
     "@types/on-headers": "1.0.4",
     "@types/papaparse": "5.5.2",
+    "@types/sanitize-html": "catalog:",
     "@types/sinon": "17.0.4",
     "@types/supertest": "6.0.3",
     "@typescript-eslint/parser": "catalog:",

--- a/ghost/core/test/unit/server/services/notifications/__snapshots__/sanitize-email-html.test.ts.snap
+++ b/ghost/core/test/unit/server/services/notifications/__snapshots__/sanitize-email-html.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`sanitizeEmailHtml preserves safe formatting and neutralises dangerous content 1 1`] = `
+Object {
+  "output": "
+    <h2>Ghost 6.50.0 is now available</h2>
+    <p>This release includes a <strong>critical</strong> fix for an authentication issue. Please update <em>as soon as possible</em>.</p>
+    <ul>
+        <li><a href=\\"https://github.com/TryGhost/Ghost/releases/tag/v6.50.0\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Release notes</a></li>
+        <li><a href=\\"https://ghost.org/docs/update/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Upgrade guide</a></li>
+    </ul>
+    <p><a href=\\"mailto:security@ghost.org\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Contact security</a> if you have questions.</p>
+    
+    <p><a target=\\"_blank\\" rel=\\"noopener noreferrer\\">do not click</a></p>
+",
+}
+`;

--- a/ghost/core/test/unit/server/services/notifications/notification-email.test.ts
+++ b/ghost/core/test/unit/server/services/notifications/notification-email.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import {NotificationEmailService} from '../../../../../core/server/services/notifications/notification-email';
+
+function fakeMailer() {
+    return {send: sinon.stub().resolves()};
+}
+
+describe('NotificationEmailService', function () {
+    it('sends one email per recipient, shell-rendered with that recipient interpolated', async function () {
+        const mailer = fakeMailer();
+        const generateEmailContent = sinon.stub().callsFake(async (opts: {data: Record<string, unknown>}) => ({
+            html: `<html>shell:${opts.data.recipientEmail}:${opts.data.message}</html>`,
+            text: 'plain'
+        }));
+        const service = new NotificationEmailService({
+            mailer,
+            generateEmailContent,
+            getSiteUrl: () => 'https://example.com'
+        });
+
+        await service.send({
+            to: ['owner@example.com', 'admin@example.com'],
+            subject: 'Security update',
+            content: '<p>Update now</p>'
+        });
+
+        sinon.assert.calledTwice(mailer.send);
+        assert.equal(mailer.send.args[0][0].to, 'owner@example.com');
+        assert.equal(mailer.send.args[1][0].to, 'admin@example.com');
+        assert.equal(mailer.send.args[0][0].subject, 'Security update');
+        assert.match(mailer.send.args[0][0].html, /shell:owner@example.com:/);
+        assert.match(mailer.send.args[1][0].html, /shell:admin@example.com:/);
+    });
+
+    it('sanitises the content before passing it to the shell', async function () {
+        const mailer = fakeMailer();
+        const generateEmailContent = sinon.stub().resolves({html: '<html></html>'});
+        const service = new NotificationEmailService({
+            mailer,
+            generateEmailContent,
+            getSiteUrl: () => 'https://example.com'
+        });
+
+        await service.send({
+            to: ['owner@example.com'],
+            subject: 'x',
+            content: '<p>hi</p><script>alert(1)</script>'
+        });
+
+        const renderedMessage = generateEmailContent.args[0][0].data.message;
+        assert.equal(renderedMessage.includes('<script>'), false);
+        assert.ok(renderedMessage.includes('<p>hi</p>'));
+    });
+
+    it('does nothing when there are no recipients', async function () {
+        const mailer = fakeMailer();
+        const generateEmailContent = sinon.stub();
+        const service = new NotificationEmailService({
+            mailer,
+            generateEmailContent,
+            getSiteUrl: () => 'https://example.com'
+        });
+
+        await service.send({to: [], subject: 'x', content: '<p>hi</p>'});
+
+        sinon.assert.notCalled(generateEmailContent);
+        sinon.assert.notCalled(mailer.send);
+    });
+});

--- a/ghost/core/test/unit/server/services/notifications/sanitize-email-html.test.ts
+++ b/ghost/core/test/unit/server/services/notifications/sanitize-email-html.test.ts
@@ -1,0 +1,22 @@
+const {assertMatchSnapshot} = require('../../../../utils/assertions');
+const {sanitizeEmailHtml} = require('../../../../../core/server/services/notifications/sanitize-email-html');
+
+// The script tag, on* handler, and javascript: URL are deliberate negative
+// cases — the snapshot must show them stripped.
+const FIXTURE_MESSAGE_HTML = `
+    <h2>Ghost 6.50.0 is now available</h2>
+    <p>This release includes a <strong>critical</strong> fix for an authentication issue. Please update <em>as soon as possible</em>.</p>
+    <ul>
+        <li><a href="https://github.com/TryGhost/Ghost/releases/tag/v6.50.0">Release notes</a></li>
+        <li><a href="https://ghost.org/docs/update/">Upgrade guide</a></li>
+    </ul>
+    <p><a href="mailto:security@ghost.org">Contact security</a> if you have questions.</p>
+    <script>alert('phish')</script>
+    <p><a href="javascript:alert(1)" onclick="alert(1)">do not click</a></p>
+`;
+
+describe('sanitizeEmailHtml', function () {
+    it('preserves safe formatting and neutralises dangerous content', function () {
+        assertMatchSnapshot({output: sanitizeEmailHtml(FIXTURE_MESSAGE_HTML)});
+    });
+});

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -290,17 +290,10 @@ describe('Update Check', function () {
             assert.equal(targetNotification.type, 'info');
             assert.equal(targetNotification.message, notification.messages[0].content);
 
-            sinon.assert.calledTwice(usersBrowseStub);
-
-            // Second (non statistical) call should be looking for admin users with an 'active' status only
-            assert.deepEqual(usersBrowseStub.args[1][0], {
-                limit: 'all',
-                include: ['roles'],
-                filter: 'status:active',
-                context: {
-                    internal: true
-                }
-            });
+            // users.browse is called once here, for stats reporting: this
+            // notification is non-alert, so the admin-lookup query in the
+            // alert branch never runs.
+            sinon.assert.calledOnce(usersBrowseStub);
         });
 
         it('preserves custom flag value from update check response', async function () {
@@ -364,7 +357,15 @@ describe('Update Check', function () {
                 });
 
             const notificationsAPIAddStub = sinon.stub().resolves();
-            const sendEmailStub = sinon.stub().resolves();
+            const emailSendStub = sinon.stub().resolves();
+            const usersBrowseStub = sinon.stub().resolves({
+                users: [{
+                    email: 'jbloggs@example.com',
+                    roles: [{
+                        name: 'Owner'
+                    }]
+                }]
+            });
 
             const updateCheckService = new UpdateCheckService({
                 api: {
@@ -373,14 +374,7 @@ describe('Update Check', function () {
                         edit: settingsStub
                     },
                     users: {
-                        browse: sinon.stub().resolves({
-                            users: [{
-                                email: 'jbloggs@example.com',
-                                roles: [{
-                                    name: 'Owner'
-                                }]
-                            }]
-                        })
+                        browse: usersBrowseStub
                     },
                     posts: {
                         browse: sinon.stub().resolves()
@@ -396,16 +390,24 @@ describe('Update Check', function () {
                     ghostVersion: '0.8.0'
                 },
                 request: request,
-                sendEmail: sendEmailStub
+                notificationEmailService: {send: emailSendStub}
             });
 
             await updateCheckService.check();
 
-            sinon.assert.called(sendEmailStub);
-            assert.equal(sendEmailStub.args[0][0].to, 'jbloggs@example.com');
-            assert.equal(sendEmailStub.args[0][0].subject, 'Action required: Critical alert from Ghost instance http://127.0.0.1:2369');
-            assert.equal(sendEmailStub.args[0][0].html, '<p>Critical message. Upgrade your site!</p>');
-            assert.equal(sendEmailStub.args[0][0].forceTextContent, true);
+            sinon.assert.calledOnce(emailSendStub);
+            assert.deepEqual(emailSendStub.args[0][0].to, ['jbloggs@example.com']);
+            assert.equal(emailSendStub.args[0][0].subject, 'Action required: Critical alert from Ghost instance http://127.0.0.1:2369');
+            assert.equal(emailSendStub.args[0][0].content, '<p>Critical message. Upgrade your site!</p>');
+
+            // users.browse is called twice: once for stats reporting, once for
+            // the admin lookup. The second call pushes the role filter into
+            // NQL so the DB returns only Owner/Administrator users.
+            sinon.assert.calledTwice(usersBrowseStub);
+            assert.deepEqual(usersBrowseStub.args[1][0], {
+                filter: 'status:active+roles.name:[Owner,Administrator]',
+                context: {internal: true}
+            });
 
             sinon.assert.calledOnce(notificationsAPIAddStub);
             assert.equal(notificationsAPIAddStub.args[0][0].notifications.length, 1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ catalogs:
     '@types/react-dom':
       specifier: 18.3.7
       version: 18.3.7
+    '@types/sanitize-html':
+      specifier: 2.16.1
+      version: 2.16.1
     '@types/validator':
       specifier: 13.15.10
       version: 13.15.10
@@ -2738,6 +2741,9 @@ importers:
       '@types/papaparse':
         specifier: 5.5.2
         version: 5.5.2
+      '@types/sanitize-html':
+        specifier: 'catalog:'
+        version: 2.16.1
       '@types/sinon':
         specifier: 17.0.4
         version: 17.0.4
@@ -9109,6 +9115,9 @@ packages:
   '@types/rimraf@2.0.5':
     resolution: {integrity: sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
@@ -14546,7 +14555,7 @@ packages:
       csstype: ^3.0.10
 
   google-caja-bower@https://codeload.github.com/acburdine/google-caja-bower/tar.gz/275cb75249f038492094a499756a73719ae071fd:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/acburdine/google-caja-bower/tar.gz/275cb75249f038492094a499756a73719ae071fd}
+    resolution: {gitHosted: true, integrity: sha512-mmCXdxGKGKDznjgkNzVqzTslaldslk5KMb/A7l8rxWnqyxzwsdPhuBJ6oT1Kh/Y3k4jN54ISee/2AgjFyCBxYw==, tarball: https://codeload.github.com/acburdine/google-caja-bower/tar.gz/275cb75249f038492094a499756a73719ae071fd}
     version: 6011.0.0
 
   gopd@1.2.0:
@@ -15972,7 +15981,7 @@ packages:
     engines: {node: '>= 0.6'}
 
   keymaster@https://codeload.github.com/madrobby/keymaster/tar.gz/f8f43ddafad663b505dc0908e72853bcf8daea49:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/madrobby/keymaster/tar.gz/f8f43ddafad663b505dc0908e72853bcf8daea49}
+    resolution: {gitHosted: true, integrity: sha512-/WVovQslVEqPGNoD97TbqNHuCDPYu2v4/ggrZj0a+9PVPw3Rud4Ut2K7fOi0kMqzoJINkgP68e9m09Al/wFZ8g==, tarball: https://codeload.github.com/madrobby/keymaster/tar.gz/f8f43ddafad663b505dc0908e72853bcf8daea49}
     version: 1.6.3
 
   keypair@1.0.4:
@@ -29535,6 +29544,10 @@ snapshots:
       '@types/glob': 9.0.0
       '@types/node': 25.9.1
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
@@ -30055,7 +30068,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   '@types/node': 22.19.19
   '@types/react': 18.3.29
   '@types/react-dom': 18.3.7
+  '@types/sanitize-html': 2.16.1
   '@types/validator': 13.15.10
   '@typescript-eslint/parser': 8.49.0
   '@vitejs/plugin-react': 4.7.0


### PR DESCRIPTION
## Problem

Sending a notification email lived inline inside the update-check service, so any other source (security advisories, ad-hoc operational notifications) could not send one without duplicating that code. The message also had to carry its own styling, which bloats limited payloads and produces inconsistent emails.

## Solution

Introduce a shared notification email primitive. It takes a resolved recipient list, sanitises the content, renders it inside a styled shell per recipient, and sends. The shell holds the chrome so notifications stay short and semantic. The sanitiser strips scripts, inline handlers and unsafe links so an untrusted upstream source cannot ship a phishing or injection payload through this path.

The primitive is intentionally recipient-agnostic: who receives a notification is a notification concern that each caller decides for itself. update-check is the first consumer; it composes the primitive with an inline admin lookup against the users API, pushing the role filter into NQL so the database returns only Owner and Administrator rows. Behaviour is identical for existing alert emails.

This is the first of a short stack: this PR adds the primitive; a follow-up moves notification storage behind a repository; and further work adds an automatic security-advisory source that composes the primitive with its own templated content.

<img width="700" height="1050" alt="image" src="https://github.com/user-attachments/assets/0da421f6-ba5c-411b-9509-42c755baa0d7" />
