### PR TITLE
🐛 Fixed hyphen-separated permalink params

### DIFF
--- a/ghost/core/core/frontend/services/data/entry-lookup.js
+++ b/ghost/core/core/frontend/services/data/entry-lookup.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const url = require('url');
 const debug = require('@tryghost/debug')('services:data:entry-lookup');
-const routeMatch = require('path-match')();
+const matchPermalinkParams = require('./match-permalink-params');
 
 /**
  * Query API for a single entry/resource.
@@ -15,16 +15,14 @@ function entryLookup(postUrl, routerOptions, locals) {
 
     const api = require('../proxy').api;
     const targetPath = url.parse(postUrl).path;
-    const permalinks = routerOptions.permalinks;
     let isEditURL = false;
 
     // CASE: e.g. /:slug/ -> { slug: 'value' }
-    const matchFunc = routeMatch(permalinks);
-    const params = matchFunc(targetPath);
+    const params = matchPermalinkParams(routerOptions.permalinks, targetPath);
 
     debug(targetPath);
     debug(params);
-    debug(permalinks);
+    debug(routerOptions.permalinks);
 
     // CASE 1: no matches, resolve
     // CASE 2: params can be empty e.g. permalink is /featured/:options(edit)?/ and path is /featured/

--- a/ghost/core/core/frontend/services/data/match-permalink-params.js
+++ b/ghost/core/core/frontend/services/data/match-permalink-params.js
@@ -1,0 +1,33 @@
+const routeMatch = require('path-match')();
+
+const PARAM = /:([A-Za-z_]\w*)(?:\([^)]*\))?[+*?]?/g;
+const BARE_PARAM = /:([A-Za-z_]\w*)(?![\w(])/g;
+
+function constrainHyphenatedPermalinkParams(permalinks) {
+    // Hyphen-separated params need explicit bounds so earlier params do not
+    // consume hyphenated values that belong to later params.
+    return permalinks.split('/').map((segment) => {
+        if (!segment.includes('-')) {
+            return segment;
+        }
+
+        const params = [...segment.matchAll(PARAM)];
+
+        if (params.length < 2) {
+            return segment;
+        }
+
+        return segment.replace(BARE_PARAM, (match, ...args) => {
+            const offset = args[args.length - 2];
+            const index = params.findIndex(param => param.index === offset);
+            const isLastParamInSegment = index === params.length - 1;
+
+            return `${match}${isLastParamInSegment ? '([^/]+)' : '([^-/]+)'}`;
+        });
+    }).join('/');
+}
+
+module.exports = function matchPermalinkParams(permalinks, targetPath) {
+    const matchFunc = routeMatch(constrainHyphenatedPermalinkParams(permalinks));
+    return matchFunc(targetPath);
+};

--- a/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
+++ b/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 
 const api = require('../../../../../core/frontend/services/proxy').api;
 const data = require('../../../../../core/frontend/services/data');
+const matchPermalinkParams = require('../../../../../core/frontend/services/data/match-permalink-params');
 const testUtils = require('../../../../utils');
 
 describe('Unit - frontend/data/entry-lookup', function () {
@@ -123,6 +124,105 @@ describe('Unit - frontend/data/entry-lookup', function () {
                 assertExists(lookup.entry);
                 assert.equal(lookup.entry.url, posts[0].url);
                 assert.equal(lookup.isEditURL, true);
+            });
+        });
+
+        it('matches hyphen-separated date permalinks with hyphenated slugs', function () {
+            const datedRouterOptions = {
+                permalinks: '/articles/:year-:month-:day-:slug/:options(edit)?/',
+                query: {controller: 'posts', resource: 'posts'}
+            };
+
+            postsReadStub.resolves({
+                posts: [
+                    testUtils.DataGenerator.forKnex.createPost({
+                        url: '/articles/2026-05-22-sample-hyphenated-post-title/',
+                        slug: 'sample-hyphenated-post-title'
+                    })
+                ]
+            });
+
+            return data.entryLookup('http://127.0.0.1:2369/articles/2026-05-22-sample-hyphenated-post-title/', datedRouterOptions, locals).then(function (lookup) {
+                sinon.assert.calledOnce(postsReadStub);
+                assert.equal(postsReadStub.firstCall.args[0].slug, 'sample-hyphenated-post-title');
+                assertExists(lookup.entry);
+                assert.equal(lookup.isEditURL, false);
+            });
+        });
+
+        it('matches edit URLs for hyphen-separated date permalinks with hyphenated slugs', function () {
+            const datedRouterOptions = {
+                permalinks: '/articles/:year-:month-:day-:slug/:options(edit)?/',
+                query: {controller: 'posts', resource: 'posts'}
+            };
+
+            postsReadStub.resolves({
+                posts: [
+                    testUtils.DataGenerator.forKnex.createPost({
+                        url: '/articles/2026-05-22-sample-hyphenated-post-title/',
+                        slug: 'sample-hyphenated-post-title'
+                    })
+                ]
+            });
+
+            return data.entryLookup('http://127.0.0.1:2369/articles/2026-05-22-sample-hyphenated-post-title/edit/', datedRouterOptions, locals).then(function (lookup) {
+                sinon.assert.calledOnce(postsReadStub);
+                assert.equal(postsReadStub.firstCall.args[0].slug, 'sample-hyphenated-post-title');
+                assertExists(lookup.entry);
+                assert.equal(lookup.isEditURL, true);
+                assert.equal(lookup.isUnknownOption, false);
+            });
+        });
+
+        it('matches generic hyphen-separated params with hyphenated slugs', function () {
+            const sectionRouterOptions = {
+                permalinks: '/articles/:section-:slug/:options(edit)?/',
+                query: {controller: 'posts', resource: 'posts'}
+            };
+
+            postsReadStub.resolves({
+                posts: [
+                    testUtils.DataGenerator.forKnex.createPost({
+                        url: '/articles/news-sample-hyphenated-post-title/',
+                        slug: 'sample-hyphenated-post-title'
+                    })
+                ]
+            });
+
+            return data.entryLookup('http://127.0.0.1:2369/articles/news-sample-hyphenated-post-title/', sectionRouterOptions, locals).then(function (lookup) {
+                sinon.assert.calledOnce(postsReadStub);
+                assert.equal(postsReadStub.firstCall.args[0].slug, 'sample-hyphenated-post-title');
+                assertExists(lookup.entry);
+                assert.equal(lookup.isEditURL, false);
+            });
+        });
+    });
+
+    describe('permalink param matching', function () {
+        it('extracts date params and full slug from hyphen-separated date permalinks', function () {
+            const params = matchPermalinkParams(
+                '/articles/:year-:month-:day-:slug/:options(edit)?/',
+                '/articles/2026-05-22-sample-hyphenated-post-title/'
+            );
+
+            assert.deepEqual(params, {
+                year: '2026',
+                month: '05',
+                day: '22',
+                slug: 'sample-hyphenated-post-title'
+            });
+        });
+
+        it('extracts generic params and full slug from hyphen-separated permalinks', function () {
+            const params = matchPermalinkParams(
+                '/articles/:section-:slug/:options(edit)?/',
+                '/articles/news-sample-hyphenated-post-title/edit/'
+            );
+
+            assert.deepEqual(params, {
+                section: 'news',
+                slug: 'sample-hyphenated-post-title',
+                options: 'edit'
             });
         });
     });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/28076

## Summary
- constrained generic hyphen-separated permalink params so earlier params stop at the hyphen and the final param can keep a hyphenated slug
- kept dated permalink regression coverage and added a non-date `:section-:slug` case using fabricated URLs

## Why this approach
`path-match` depends on `path-to-regexp` via a broad `^1.0.0` range, and the package is archived. Pinning the transitive dependency would restore the old behavior for now, but it keeps Ghost coupled to an unmaintained parser detail. This keeps the fix in Ghost by normalizing ambiguous hyphen-separated param segments before entry lookup.

## Testing
- `pnpm --dir ghost/core test:single test/unit/frontend/services/data/entry-lookup.test.js`