### PR TITLE
Added self-hosted Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,61 @@
+name: Renovate
+
+# Self-hosted Renovate runner. Replaces the Mend-hosted scheduler so we can tick
+# more frequently than ~4h and clear the dependency backlog within the existing
+# automerge windows. See PLA-48 for the throughput rationale;
+# .github/renovate.json5 is still the source of truth for package rules,
+# schedule, and automergeSchedule.
+on:
+  schedule:
+    # Every 2h. The repo-level `schedule` / `automergeSchedule` blocks in
+    # renovate.json5 still gate when Renovate actually acts or merges, so
+    # extra wake-ups outside those windows are no-ops. Start at 2h and
+    # tighten to 1h once we've watched a few cycles.
+    - cron: '0 */2 * * *'
+  workflow_dispatch:
+    inputs:
+      ignoreSchedule:
+        description: 'Ignore Renovate schedule for this manual run'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.TRYGHOST_RENOVATE_APP_ID }}
+          private-key: ${{ secrets.TRYGHOST_RENOVATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: Ghost
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Allow manual run outside schedule
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.ignoreSchedule }}
+        run: echo 'RENOVATE_FORCE={"schedule":null,"automergeSchedule":null}' >> "$GITHUB_ENV"
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_REPOSITORY_CACHE: enabled
+          RENOVATE_REPOSITORIES: TryGhost/Ghost
+          # Ghost is already onboarded via Mend; don't open an onboarding PR.
+          RENOVATE_ONBOARDING: 'false'


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-48

## Why

Mend's hosted Renovate ticks every ~4h. With `platformAutomerge: false` (intentional, so merges stay inside `automergeSchedule`) and `branchConcurrentLimit: 10`, each merge forces every other open Renovate branch to rebase, and the rebased CI doesn't finish before the next tick. Net throughput is ~1 PR per tick — capped at ~2 PRs per weeknight automerge window and ~5–6 per weekend day. Small backlogs take all weekend to drain, and the concurrent-branch cap saturates the queue.

Other levers (`platformAutomerge` for low-risk classes, merge queue, wider schedule) help around the edges but don't change the math. The tick frequency is the bottleneck.

## What this does

`.github/workflows/renovate.yml` — runs the official `renovatebot/github-action` on a 2h cron. The repo-level `schedule` / `automergeSchedule` in `renovate.json5` still gate when Renovate acts or merges, so out-of-window wake-ups are no-ops. Auths via the already-org-installed TryGhost Renovate GitHub App (no new install or permission grant), with the App token scoped to `repositories: Ghost`. Runner-level overrides (`RENOVATE_REPOSITORIES`, `RENOVATE_ONBOARDING: false`) are passed via env rather than a separate config file.

`workflow_dispatch` with an `ignoreSchedule` toggle injects `RENOVATE_FORCE` — manual "drain the backlog now" button.

Pattern lifted from TryGhost/Toast's working setup; third-party actions pinned by SHA matching Toast's set.

## Cutover

Both Mend and self-hosted Renovate use deterministic `renovate/*` branch names, so running them in parallel would race on rebases/pushes during merge windows. We're currently outside every block in the schedule, so neither bot is actively acting on PRs — safe to merge now, smoke-test with a manual run (leave `ignoreSchedule` off; expected outcome is "no work in schedule, exiting" confirming auth + config), then disable Mend in the Mend dashboard before the next merge window opens.

Rollback is "delete the workflow file" — Mend can be re-enabled.

## Acceptance signal

After one normal `automergeSchedule` window with a non-empty backlog: ≥3 PRs merged in a single window (vs. current ~1–2).