### PR TITLE
Restored rich Slack notification for release failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1840,13 +1840,6 @@ jobs:
       - name: Publish to npm
         run: npm publish ghost-*.tgz --access public
 
-      - uses: tryghost/actions/actions/slack-build@128d496a57fb11e44e97d690f0d5381c58e52489 # main
-        if: failure()
-        with:
-          status: ${{ job.status }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
   # --------------------------------------------------------------------------- #
   # Create GitHub Release — runs after successful npm publish
   # --------------------------------------------------------------------------- #
@@ -1888,13 +1881,15 @@ jobs:
           cat /tmp/release-notes.md
 
       - name: Create GitHub Release
+        id: create_release
         run: |
           gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --notes-file /tmp/release-notes.md
 
+      # Gate on create_release, not notes, so a failed release can't announce success
       - name: Notify Slack
-        if: always() && steps.notes.outcome == 'success'
+        if: success() && steps.create_release.outcome == 'success'
         run: |
           VERSION="${GITHUB_REF_NAME}"
           RELEASE_URL="https://github.com/TryGhost/Ghost/releases/tag/${VERSION}"
@@ -1910,3 +1905,28 @@ jobs:
             -H 'Content-type: application/json' \
             --data "${PAYLOAD}" \
             "${{ secrets.RELEASE_NOTIFICATION_URL }}" || echo "Slack notification failed (non-fatal)"
+
+  # --------------------------------------------------------------------------- #
+  # Notify on any release-path failure — fires if the tag was created but the
+  # publish run (build, npm publish, or GitHub Release) failed at any point.
+  # A single terminal job catches jobs skipped by an upstream failure, which a
+  # per-job `if: failure()` step cannot.
+  # --------------------------------------------------------------------------- #
+  notify_release_failure:
+    name: Notify release failure
+    needs: [job_setup, job_build_artifacts, job_ghost-cli, publish_ghost, create_github_release]
+    if: failure() && startsWith(github.ref, 'refs/tags/v') && github.repository == 'TryGhost/Ghost'
+    runs-on: ubuntu-latest
+    permissions: {}  # only posts to Slack via curl; needs no GITHUB_TOKEN scopes
+    steps:
+      - name: Notify Slack
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_NOTIFICATION_URL: ${{ secrets.RELEASE_NOTIFICATION_URL }}
+        run: |
+          VALUE=$(printf '<!subteam^S07ATDH3CLB|on-call-product> — check the failed run: <%s|view run>' "$RUN_URL")
+          PAYLOAD=$(jq -n --arg value "$VALUE" \
+            '{username: "Ghost CI", attachments: [{color: "danger", fields: [{title: "🚨 Ghost release failed", value: $value}]}]}')
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" \
+            "$RELEASE_NOTIFICATION_URL" || echo "Slack notification failed (non-fatal)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CANARY_DOCKER_BUILD }}  # PAT for GitHub API (check polling)
 
-      - name: Notify on failure
+      - name: Notify Slack on release failure
         if: failure()
-        uses: tryghost/actions/actions/slack-build@128d496a57fb11e44e97d690f0d5381c58e52489 # main
-        with:
-          status: ${{ job.status }}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_NOTIFICATION_URL: ${{ secrets.RELEASE_NOTIFICATION_URL }}
+        run: |
+          VALUE=$(printf '<!subteam^S07ATDH3CLB|on-call-product> — check the failed run: <%s|view run>' "$RUN_URL")
+          PAYLOAD=$(jq -n --arg value "$VALUE" \
+            '{username: "Ghost CI", attachments: [{color: "danger", fields: [{title: "🚨 Ghost release failed", value: $value}]}]}')
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" \
+            "$RELEASE_NOTIFICATION_URL" || echo "Slack notification failed (non-fatal)"


### PR DESCRIPTION
## Why

When the release flow lived in **Ghost-Release**, a failed release sent an on-call-paging Slack alert via the `notify-release-failure` grunt task. After the flow moved into Ghost, `release.yml` and `ci.yml` fell back to the generic `slack-build` "Test failure" message — which doesn't page `@on-call-product`.

A release now spans two workflows: `release.yml` (prepare + push the tag) and the tag-triggered `ci.yml` run (build → npm publish → GitHub Release). **Every stage** should page on failure. This PR restores that, posting to the existing `RELEASE_NOTIFICATION_URL` secret (already used for the "is loose!" success message), so no new secret is needed.

## The message

Both stages send the **same** message — title, on-call page, and a link to the failed run so someone can check what broke:

> 🚨 Ghost release failed
> @on-call-product — check the failed run: view run

It deliberately doesn't try to describe *what* failed; the run link is the source of truth.

## What changed

**`release.yml`** — replaces the generic `slack-build` failure step with the message above, on a failed prepare/tag run.

**`ci.yml`** — adds a single **terminal `notify_release_failure` job** that `needs` the whole publish chain (`job_setup` → `job_build_artifacts` → `job_ghost-cli` → `publish_ghost` → `create_github_release`) and fires on `failure()` with the same message.

Why a terminal job rather than per-job `if: failure()` steps: a step only runs if its job runs. When an upstream job fails (e.g. `job_build_artifacts`, which builds the npm tarball), `publish_ghost` is **skipped**, so a per-job failure step there never fires — the release silently fails to publish with no alert. `failure()` on a job that `needs` the whole chain is true if **any** job in it fails, so it catches the skipped cases too. This also replaces (and de-duplicates) the per-job `slack-build` steps.

**`ci.yml` `create_github_release`** — gates the existing "is loose!" success announcement on the release step (`steps.create_release.outcome`) rather than the notes step, so a failed `gh release create` can no longer announce a false success.

## Failure coverage

| Stage | Workflow / job | Alert |
|---|---|---|
| Prepare + push tag | `release.yml` | 🚨 Ghost release failed + run link |
| Build artifacts / Ghost-CLI / npm publish / GitHub Release | `ci.yml` publish chain → `notify_release_failure` | 🚨 Ghost release failed + run link |

## Notes for reviewers

- **`username: "Ghost CI"`** — the original used `"Jenkins"` (a relic). Switched to `"Ghost CI"` to match the workflow's own git identity.
- **Defaults are Ghost.org-specific — by design, not a leak.** The `on-call-product` subteam mention is a hardcoded *default*, not a secret. The only privacy boundary is the webhook (`RELEASE_NOTIFICATION_URL`, already a secret): a fork points it at its own channel and gets its own alerts, while an unknown `<!subteam^…>` simply renders inert elsewhere.
- **Forks** — `notify_release_failure` is guarded to `github.repository == 'TryGhost/Ghost'`, and `RELEASE_NOTIFICATION_URL` isn't exposed to fork PRs, so the alerts only fire on real release runs in the canonical repo.
- The same message lives inline in both workflows. If a single source of truth is preferred, it could move to a small local composite action — happy to do that as a follow-up.

refs https://github.com/TryGhost/Ghost/pull/26760
