### PR TITLE
Updated Renovate self-host throughput config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,10 +2,14 @@
     "extends": [
         "github>tryghost/renovate-config"
     ],
-    // Limit concurrent branches to keep Renovate runs within the 30-minute
-    // Mend timeout and avoid overwhelming CI with dozens of queued jobs.
-    // The shared preset disables rate limiting, but Ghost's monorepo is
-    // large enough that unlimited branches cause timeouts during rebasing.
+    // Cap total open Renovate PRs at 10. The shared preset extends
+    // :disableRateLimiting (prConcurrentLimit: 0, prHourlyLimit: 0), so
+    // branchConcurrentLimit alone leaks — it exempts grouped, automerge-
+    // eligible, and vulnerability PRs, and is enforced per-run rather than
+    // as a true total. Setting prConcurrentLimit overrides the preset and
+    // gives us a hard ceiling regardless of update type. branchConcurrentLimit
+    // stays as a secondary guardrail.
+    "prConcurrentLimit": 10,
     "branchConcurrentLimit": 10,
     // Keep manually-closed immortal/grouped PRs closed unless explicitly
     // reopened from the Dependency Dashboard.

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,11 +7,13 @@ name: Renovate
 # schedule, and automergeSchedule.
 on:
   schedule:
-    # Every 2h. The repo-level `schedule` / `automergeSchedule` blocks in
+    # Hourly. The repo-level `schedule` / `automergeSchedule` blocks in
     # renovate.json5 still gate when Renovate actually acts or merges, so
-    # extra wake-ups outside those windows are no-ops. Start at 2h and
-    # tighten to 1h once we've watched a few cycles.
-    - cron: '0 */2 * * *'
+    # extra wake-ups outside those windows are no-ops (~30s each). Hourly
+    # ticks during the 7h weeknight automerge window roughly match Ghost's
+    # CI duration, giving each merge a fresh rebase + green CI window
+    # before the next tick.
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       ignoreSchedule:


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-48

## Why

Two tuning fixes from the first self-hosted Renovate cycle:

**(1) The PR cap was leaky.** `branchConcurrentLimit: 10` was already set, but on the first successful self-hosted run it opened **17 PRs in 15 minutes**. The cap doesn't enforce a hard total — it exempts grouped, automerge-eligible, and vulnerability PRs, and is enforced per-run rather than as a true total across runs. On Mend's 4h tick that didn't matter because the tick frequency was the real throttle; on the self-hosted 2h cron, nothing else was gating volume. The shared preset (`tryghost/renovate-config:quiet.json5`) also extends `:disableRateLimiting`, which sets `prConcurrentLimit: 0` and `prHourlyLimit: 0` (both unlimited).

**(2) The 2h cron under-uses the merge window.** The weeknight `automergeSchedule` is 22:00–04:59 UTC = 7 hours. At a 2h cron that's ~4 merge-eligible ticks per night. Ghost's CI runs ~25 min, so the bot has plenty of time between ticks to merge one PR, rebase the next in line, and let CI finish before the following tick. Hourly cron lifts the ceiling to ~7 merges/night without changing CI cost meaningfully — `rebaseWhen: "automerging"` (from the preset) means each merge triggers exactly one rebase (the next PR in line), not a fan-out across all open branches.

## What this changes

- `.github/renovate.json5`: add `prConcurrentLimit: 10`. Strict total cap on open Renovate PRs, overrides the `:disableRateLimiting` preset, no per-update-type exemptions. `branchConcurrentLimit: 10` stays as a secondary guardrail. No `prHourlyLimit` — the new 1h cron and `prConcurrentLimit` together pace opens; we don't need a third gate.
- `.github/workflows/renovate.yml`: cron `0 */2 * * *` → `0 * * * *`. Out-of-window ticks no-op in ~30s (~24 min/day extra Actions runtime, negligible).

## Rollout

Workflow runs are currently cancelled to prevent further over-opens. Once this lands, the next hourly tick respects both new settings. The 17 PRs already open from the first run will need to either drain naturally during tonight's automerge window or be triaged manually; either way no new opens until the count drops below 10.