### PR TITLE
Added CI path-filter exemption for Renovate config edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,22 @@ jobs:
           filters: |
             shared: &shared
               - '.github/**'
+              # Renovate config / workflow files have no Ghost
+              # runtime/test impact. Anchored as &renovate_only and
+              # referenced from every filter below so a PR touching
+              # only these files skips all downstream jobs; the
+              # rollup gate passes on skipped deps.
+              - &renovate_only
+                - '!.github/renovate.json5'
+                - '!.github/renovate-bot.cjs'
+                - '!.github/workflows/renovate.yml'
               - '.npmrc'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
             ci:
               - '.github/workflows/**'
+              - *renovate_only
               - '.github/actions/**'
               - '.github/scripts/**'
             core:
@@ -131,6 +141,7 @@ jobs:
               - '!**/*.md'
               - '!.devcontainer/**'
               - '!.vscode/**'
+              - *renovate_only
             # Drives the run_e2e output: matches any changed file that could
             # affect a running Ghost instance. Test files, test config and
             # docs are excluded — a change confined to them cannot alter
@@ -143,6 +154,7 @@ jobs:
               - '!.vscode/**'
               - '!ghost/core/test/**'
               - '!ghost/core/vitest.config.ts'
+              - *renovate_only
 
       - name: Define Node test matrix
         id: node_matrix


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-48

## Why

Edits to `.github/renovate.json5` or `.github/workflows/renovate.yml` can't affect Ghost runtime or tests, but they currently match the `.github/**` entry in the `shared` path-filter and pull in the full Ghost CI matrix. That's wasted CI capacity every time we touch Renovate config.

## What this does

Anchored a `&renovate_only` negation list inside the `shared` filter:

```yaml
shared: &shared
  - '.github/**'
  - &renovate_only
    - '!.github/renovate.json5'
    - '!.github/renovate-bot.cjs'
    - '!.github/workflows/renovate.yml'
  - '.npmrc'
  - ...
```

Then referenced it via `*renovate_only` from the three other filters that would otherwise match Renovate config paths (`ci`, `any-code`, `e2e`). A PR whose entire diff is in those three files now matches **none** of the filters, every downstream job skips, and the `All required tests passed or skipped` rollup gate passes on skipped deps (it only fails on `failure` or `cancelled`).

PRs that touch a Renovate file plus anything else still run CI normally — the negation only excludes when those are the *only* changed files.

Single source of truth for the exclusion list — same anchor pattern that `core: [- *shared, ...]` already uses today.

## Caveat

This PR itself will run full Ghost CI one last time, since its base on `main` doesn't have the exemption yet. After it lands, future Renovate config tweaks should skip everything and pass the rollup in under a minute.