### PR TITLE
Bump comments-ui default asset version to 1.5

### DIFF
--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -267,7 +267,7 @@
     },
     "comments": {
         "url": "https://cdn.jsdelivr.net/ghost/comments-ui@~{version}/umd/comments-ui.min.js",
-        "version": "1.4"
+        "version": "1.5"
     },
     "signupForm": {
         "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",


### PR DESCRIPTION
Bumped Ghost's default comments-ui CDN minor from 1.4 to 1.5. Staging was receiving the comments dislikes capability from the API, but Ghost still injected the 1.4 comments-ui bundle, so the frontend rendered the old UI.

