### PR TITLE
Fixed offer Portal preview sticky CTA behavior

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.51",
+  "version": "2.68.52",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/frame.styles.js
+++ b/apps/portal/src/components/frame.styles.js
@@ -399,15 +399,14 @@ html[dir="rtl"] .gh-portal-btn-site-title-back span {
 .gh-portal-popup-container.preview.offer,
 .gh-portal-popup-container.preview.account-plan {
     max-width: 420px;
-    transform: scale(0.9);
-    margin: 3.2vw auto 0;
+    margin: 3.2vw auto 32px;
+    zoom: 0.9;
 }
 
 @media (max-width: 480px) {
     .gh-portal-popup-container.preview.offer,
     .gh-portal-popup-container.preview.account-plan {
-        transform-origin: top;
-        margin-top: 0;
+        margin: 0 auto 32px;
     }
 }
 
@@ -956,9 +955,9 @@ const MobileStyles = `
         max-width: 420px;
         width: auto;
         height: auto;
-        margin: 3.2vw auto 0;
+        margin: 3.2vw auto 32px;
         padding-bottom: 24px;
-        transform: scale(0.9);
+        zoom: 0.9;
     }
 }
 
@@ -1038,7 +1037,7 @@ const MobileStyles = `
         margin-bottom: 16px;
     }
 
-    .preview .gh-portal-btn-container.sticky {
+    .gh-portal-popup-wrapper.preview:not(.offer):not(.account-plan) .gh-portal-btn-container.sticky {
         margin-bottom: 32px;
         padding-bottom: 0;
     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1272/footer-scroll-bug-in-portal-settings-preview

Fixed the offer Portal preview so the sticky CTA stays pinned to the bottom while scrolling, while preserving the intended scaled preview size and bottom spacing.

This uses `zoom` instead of `transform: scale()` because `transform` only changes the visual rendering, while sticky positioning is still calculated from the unscaled layout box.