### PR TITLE
Add archived tiers to tier filter

### DIFF
--- a/apps/posts/src/hooks/filter-sources/use-tier-value-source.ts
+++ b/apps/posts/src/hooks/filter-sources/use-tier-value-source.ts
@@ -1,66 +1,54 @@
 import {createLocalValueSource} from './create-local-value-source';
-import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
-import {useEffect, useMemo} from 'react';
+import {getActiveTiers, getArchivedTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {useMemo} from 'react';
 import type {FilterOption, ValueSource} from '@tryghost/shade/patterns';
 import type {Tier} from '@tryghost/admin-x-framework/api/tiers';
 
-const TIER_FILTER_PAGE_LIMIT = '100';
-const TIER_FILTER_TYPE = 'type:paid';
-const ARCHIVED_TIER_LABEL_SUFFIX = ' (archived)';
-const EMPTY_TIERS: Tier[] = [];
-
-type TierValueSource = ValueSource<string> & {
+interface TierValueSource {
+    valueSource: ValueSource<string>;
+    // True once more than one paid tier (active or archived) exists, i.e. when
+    // filtering members by tier is meaningful. Stays false until tiers load.
     hasMultipleTiers: boolean;
-};
+}
 
 function toTierFilterOption(tier: Tier): FilterOption<string> {
     return {
         value: tier.id,
-        label: tier.active ? tier.name : `${tier.name}${ARCHIVED_TIER_LABEL_SUFFIX}`,
+        label: tier.active ? tier.name : `${tier.name} (archived)`,
         detail: tier.slug
     };
 }
 
-function buildTierFilterOptions(tiers: Tier[] = []): FilterOption<string>[] {
-    const activeTiers = tiers.filter(tier => tier.active);
-    const archivedTiers = tiers.filter(tier => !tier.active);
-
+// Active tiers first, then archived; each group keeps the order returned by the API.
+function buildTierFilterOptions(tiers: Tier[]): FilterOption<string>[] {
     return [
-        ...activeTiers.map(toTierFilterOption),
-        ...archivedTiers.map(toTierFilterOption)
+        ...getActiveTiers(tiers).map(toTierFilterOption),
+        ...getArchivedTiers(tiers).map(toTierFilterOption)
     ];
 }
 
 export function useTierValueSource(): TierValueSource {
-    const {
-        data: tiersData,
-        fetchNextPage,
-        isFetchingNextPage,
-        isLoading
-    } = useBrowseTiers({searchParams: {filter: TIER_FILTER_TYPE, limit: TIER_FILTER_PAGE_LIMIT}});
+    // The tiers endpoint returns every match in a single response, so no paging or
+    // limit is needed; `type:paid` keeps free/complimentary tiers out of the filter.
+    const {data: tiersData, isLoading} = useBrowseTiers({
+        searchParams: {filter: 'type:paid'}
+    });
 
-    useEffect(() => {
-        if (tiersData?.isEnd === false && !isFetchingNextPage) {
-            void fetchNextPage();
-        }
-    }, [fetchNextPage, isFetchingNextPage, tiersData?.isEnd]);
-
-    const tiers = tiersData?.tiers ?? EMPTY_TIERS;
-    const isLoadingTierOptions = isLoading || isFetchingNextPage || tiersData?.isEnd === false;
+    const tiers = useMemo(() => tiersData?.tiers ?? [], [tiersData?.tiers]);
     const options = useMemo(() => buildTierFilterOptions(tiers), [tiers]);
-    const hasMultipleTiers = tiers.length > 1 || tiersData?.isEnd === false;
+    const hasMultipleTiers = tiers.length > 1;
 
     const useLocalTierValueSource = createLocalValueSource<FilterOption<string>, string>({
         id: 'posts.tiers.local',
         useItems: () => ({
-            data: isLoadingTierOptions ? undefined : options,
-            isLoading: isLoadingTierOptions
+            data: options,
+            isLoading
         }),
         toOption: option => option
     });
 
     return {
-        ...useLocalTierValueSource(),
+        valueSource: useLocalTierValueSource(),
         hasMultipleTiers
     };
 }

--- a/apps/posts/src/hooks/filter-sources/use-tier-value-source.ts
+++ b/apps/posts/src/hooks/filter-sources/use-tier-value-source.ts
@@ -1,15 +1,66 @@
-import {FilterOption, ValueSource} from '@tryghost/shade/patterns';
 import {createLocalValueSource} from './create-local-value-source';
+import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {useEffect, useMemo} from 'react';
+import type {FilterOption, ValueSource} from '@tryghost/shade/patterns';
+import type {Tier} from '@tryghost/admin-x-framework/api/tiers';
 
-export function useTierValueSource(options: FilterOption<string>[] = []): ValueSource<string> {
+const TIER_FILTER_PAGE_LIMIT = '100';
+const TIER_FILTER_TYPE = 'type:paid';
+const ARCHIVED_TIER_LABEL_SUFFIX = ' (archived)';
+const EMPTY_TIERS: Tier[] = [];
+
+type TierValueSource = ValueSource<string> & {
+    hasMultipleTiers: boolean;
+};
+
+function toTierFilterOption(tier: Tier): FilterOption<string> {
+    return {
+        value: tier.id,
+        label: tier.active ? tier.name : `${tier.name}${ARCHIVED_TIER_LABEL_SUFFIX}`,
+        detail: tier.slug
+    };
+}
+
+function buildTierFilterOptions(tiers: Tier[] = []): FilterOption<string>[] {
+    const activeTiers = tiers.filter(tier => tier.active);
+    const archivedTiers = tiers.filter(tier => !tier.active);
+
+    return [
+        ...activeTiers.map(toTierFilterOption),
+        ...archivedTiers.map(toTierFilterOption)
+    ];
+}
+
+export function useTierValueSource(): TierValueSource {
+    const {
+        data: tiersData,
+        fetchNextPage,
+        isFetchingNextPage,
+        isLoading
+    } = useBrowseTiers({searchParams: {filter: TIER_FILTER_TYPE, limit: TIER_FILTER_PAGE_LIMIT}});
+
+    useEffect(() => {
+        if (tiersData?.isEnd === false && !isFetchingNextPage) {
+            void fetchNextPage();
+        }
+    }, [fetchNextPage, isFetchingNextPage, tiersData?.isEnd]);
+
+    const tiers = tiersData?.tiers ?? EMPTY_TIERS;
+    const isLoadingTierOptions = isLoading || isFetchingNextPage || tiersData?.isEnd === false;
+    const options = useMemo(() => buildTierFilterOptions(tiers), [tiers]);
+    const hasMultipleTiers = tiers.length > 1 || tiersData?.isEnd === false;
+
     const useLocalTierValueSource = createLocalValueSource<FilterOption<string>, string>({
         id: 'posts.tiers.local',
         useItems: () => ({
-            data: options,
-            isLoading: false
+            data: isLoadingTierOptions ? undefined : options,
+            isLoading: isLoadingTierOptions
         }),
         toOption: option => option
     });
 
-    return useLocalTierValueSource();
+    return {
+        ...useLocalTierValueSource(),
+        hasMultipleTiers
+    };
 }

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -13,7 +13,6 @@ import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/ap
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
-import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useEmailPostValueSource} from '@src/hooks/filter-sources/use-email-post-value-source';
 import {useLabelValueSource} from '@src/hooks/filter-sources/use-label-value-source';
 import {usePostResourceValueSource} from '@src/hooks/filter-sources/use-post-resource-value-source';
@@ -55,7 +54,6 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     activeView,
     iconOnly = false
 }) => {
-    const {data: tiersData} = useBrowseTiers({searchParams: {limit: '100'}});
     const {data: offersData} = useBrowseOffers({});
     const {data: newslettersData} = useBrowseNewsletters({searchParams: {limit: '100'}});
     const {data: settingsData} = useBrowseSettings({});
@@ -68,11 +66,8 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const emailTrackClicks = getSettingValue<boolean>(settings, 'email_track_clicks') === true;
     const siteTimezone = getSiteTimezone(settings);
 
-    const tiers = tiersData?.tiers || [];
     const newsletters = newslettersData?.newsletters || [];
     const offers = useMemo(() => offersData?.offers ?? EMPTY_OFFERS, [offersData?.offers]);
-    const activePaidTiers = tiers.filter(tier => tier.type === 'paid' && tier.active);
-    const hasMultipleTiers = activePaidTiers.length > 1;
 
     const offersOptions = useMemo(() => {
         return buildOfferOptions(offers);
@@ -98,7 +93,8 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const postValueSource = usePostResourceValueSource();
     const emailValueSource = useEmailPostValueSource();
     const labelValueSource = useLabelValueSource();
-    const tierValueSource = useTierValueSource(activePaidTiers.map(tier => ({value: tier.id, label: tier.name, detail: tier.slug})));
+    const tierValueSource = useTierValueSource();
+    const hasMultipleTiers = tierValueSource.hasMultipleTiers;
 
     const filterFields = useMemberFilterFields({
         newsletters,

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -93,8 +93,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const postValueSource = usePostResourceValueSource();
     const emailValueSource = useEmailPostValueSource();
     const labelValueSource = useLabelValueSource();
-    const tierValueSource = useTierValueSource();
-    const hasMultipleTiers = tierValueSource.hasMultipleTiers;
+    const {valueSource: tierValueSource, hasMultipleTiers} = useTierValueSource();
 
     const filterFields = useMemberFilterFields({
         newsletters,

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -171,6 +171,23 @@ describe('useMemberFilterFields', () => {
         expect(statusField?.options?.map(o => o.value)).toEqual(['paid', 'free', 'comped', 'gift']);
     });
 
+    it('includes the membership tier filter when multiple paid tiers are available', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            paidMembersEnabled: true,
+            hasMultipleTiers: true,
+            tierValueSource,
+            siteTimezone: 'UTC'
+        }));
+
+        const subscriptionFields = result.current.find(group => group.group === 'Subscription')?.fields ?? [];
+        const tierField = subscriptionFields.find(field => field.key === 'tier_id');
+
+        expect(subscriptionFields.map(field => field.key)).toContain('tier_id');
+        expect(tierField).toMatchObject({
+            valueSource: tierValueSource
+        });
+    });
+
     it('hydrates grouped retention offers on the offer field', () => {
         const {result} = renderHook(() => useMemberFilterFields({
             paidMembersEnabled: true,

--- a/apps/posts/test/unit/hooks/use-tier-value-source.test.tsx
+++ b/apps/posts/test/unit/hooks/use-tier-value-source.test.tsx
@@ -7,9 +7,13 @@ const {mockUseBrowseTiers} = vi.hoisted(() => ({
     mockUseBrowseTiers: vi.fn()
 }));
 
-vi.mock('@tryghost/admin-x-framework/api/tiers', () => ({
-    useBrowseTiers: mockUseBrowseTiers
-}));
+vi.mock('@tryghost/admin-x-framework/api/tiers', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@tryghost/admin-x-framework/api/tiers')>();
+    return {
+        ...actual,
+        useBrowseTiers: mockUseBrowseTiers
+    };
+});
 
 function tier(overrides: Partial<Tier>): Tier {
     return {
@@ -31,24 +35,13 @@ function tier(overrides: Partial<Tier>): Tier {
 
 function mockTiersResponse({
     tiers = [],
-    isEnd = true,
-    isFetchingNextPage = false,
-    isLoading = false,
-    fetchNextPage = vi.fn()
+    isLoading = false
 }: {
     tiers?: Tier[];
-    isEnd?: boolean;
-    isFetchingNextPage?: boolean;
     isLoading?: boolean;
-    fetchNextPage?: ReturnType<typeof vi.fn>;
 } = {}) {
     mockUseBrowseTiers.mockReturnValue({
-        data: {
-            tiers,
-            isEnd
-        },
-        fetchNextPage,
-        isFetchingNextPage,
+        data: {tiers},
         isLoading
     });
 }
@@ -58,7 +51,31 @@ describe('useTierValueSource', () => {
         vi.clearAllMocks();
     });
 
-    it('exposes active and archived tier options in display order', () => {
+    it('fetches every paid tier in a single request', () => {
+        mockTiersResponse();
+
+        renderHook(() => useTierValueSource());
+
+        expect(mockUseBrowseTiers).toHaveBeenCalledWith({searchParams: {filter: 'type:paid'}});
+    });
+
+    it('handles the first render before any tiers data has loaded', () => {
+        mockUseBrowseTiers.mockReturnValue({data: undefined, isLoading: true});
+
+        const {result} = renderHook(() => {
+            const source = useTierValueSource();
+            return {
+                hasMultipleTiers: source.hasMultipleTiers,
+                state: source.valueSource.useOptions({query: '', selectedValues: []})
+            };
+        });
+
+        expect(result.current.hasMultipleTiers).toBe(false);
+        expect(result.current.state.options).toEqual([]);
+        expect(result.current.state.isInitialLoad).toBe(true);
+    });
+
+    it('exposes active tiers before archived tiers, labelling archived ones', () => {
         mockTiersResponse({
             tiers: [
                 tier({id: 'archived', name: 'Archived Gold', slug: 'archived-gold', active: false}),
@@ -67,8 +84,8 @@ describe('useTierValueSource', () => {
         });
 
         const {result} = renderHook(() => {
-            const source = useTierValueSource();
-            return source.useOptions({query: '', selectedValues: []});
+            const {valueSource} = useTierValueSource();
+            return valueSource.useOptions({query: '', selectedValues: []});
         });
 
         expect(result.current.options).toEqual([
@@ -85,26 +102,18 @@ describe('useTierValueSource', () => {
         ]);
     });
 
-    it('counts fetched paid tiers when deciding if the tier filter is available', () => {
+    it('counts paid tiers when deciding if the tier filter is available', () => {
         const cases = [
             {
-                tiers: [
-                    tier({id: 'active', active: true}),
-                    tier({id: 'archived', active: false})
-                ],
+                tiers: [tier({id: 'active', active: true}), tier({id: 'archived', active: false})],
                 expected: true
             },
             {
-                tiers: [
-                    tier({id: 'archived-1', active: false}),
-                    tier({id: 'archived-2', active: false})
-                ],
+                tiers: [tier({id: 'archived-1', active: false}), tier({id: 'archived-2', active: false})],
                 expected: true
             },
             {
-                tiers: [
-                    tier({id: 'archived', active: false})
-                ],
+                tiers: [tier({id: 'archived', active: false})],
                 expected: false
             },
             {
@@ -122,51 +131,6 @@ describe('useTierValueSource', () => {
         }
     });
 
-    it('treats an incomplete tiers response as multiple tiers', () => {
-        mockTiersResponse({
-            tiers: [
-                tier({id: 'active', active: true})
-            ],
-            isEnd: false
-        });
-
-        const {result} = renderHook(() => useTierValueSource());
-
-        expect(result.current.hasMultipleTiers).toBe(true);
-    });
-
-    it('fetches paid tiers with a numeric page limit and exposes tier options', () => {
-        mockTiersResponse({
-            tiers: [
-                tier({id: 'active-tier', name: 'Active Gold', slug: 'active-gold', active: true}),
-                tier({id: 'archived-tier', name: 'Archived Gold', slug: 'archived-gold', active: false})
-            ]
-        });
-
-        const {result} = renderHook(() => {
-            const source = useTierValueSource();
-            return {
-                hasMultipleTiers: source.hasMultipleTiers,
-                state: source.useOptions({query: '', selectedValues: []})
-            };
-        });
-
-        expect(mockUseBrowseTiers).toHaveBeenCalledWith({searchParams: {filter: 'type:paid', limit: '100'}});
-        expect(result.current.hasMultipleTiers).toBe(true);
-        expect(result.current.state.options).toEqual([
-            {
-                value: 'active-tier',
-                label: 'Active Gold',
-                detail: 'active-gold'
-            },
-            {
-                value: 'archived-tier',
-                label: 'Archived Gold (archived)',
-                detail: 'archived-gold'
-            }
-        ]);
-    });
-
     it('searches local tier options by archived label text', () => {
         mockTiersResponse({
             tiers: [
@@ -176,8 +140,8 @@ describe('useTierValueSource', () => {
         });
 
         const {result} = renderHook(() => {
-            const source = useTierValueSource();
-            return source.useOptions({query: 'archived', selectedValues: []});
+            const {valueSource} = useTierValueSource();
+            return valueSource.useOptions({query: 'archived', selectedValues: []});
         });
 
         expect(result.current.options).toEqual([
@@ -189,48 +153,19 @@ describe('useTierValueSource', () => {
         ]);
     });
 
-    it('keeps options in the initial load state while additional tier pages are loading', () => {
-        mockTiersResponse({
-            tiers: [
-                tier({id: 'active-tier', name: 'Active Gold', slug: 'active-gold', active: true})
-            ],
-            isEnd: false,
-            isFetchingNextPage: true
-        });
+    it('reports the initial load state while tiers are loading', () => {
+        mockTiersResponse({tiers: [], isLoading: true});
 
         const {result} = renderHook(() => {
             const source = useTierValueSource();
-            return source.useOptions({query: '', selectedValues: []});
+            return {
+                hasMultipleTiers: source.hasMultipleTiers,
+                state: source.valueSource.useOptions({query: '', selectedValues: []})
+            };
         });
 
-        expect(result.current.options).toEqual([]);
-        expect(result.current.isInitialLoad).toBe(true);
-    });
-
-    it('loads the next page until the tiers response is complete', () => {
-        const fetchNextPage = vi.fn();
-        mockTiersResponse({
-            tiers: [tier({id: 'active-tier'})],
-            isEnd: false,
-            fetchNextPage
-        });
-
-        renderHook(() => useTierValueSource());
-
-        expect(fetchNextPage).toHaveBeenCalledOnce();
-    });
-
-    it('does not load another page while a tiers page is already loading', () => {
-        const fetchNextPage = vi.fn();
-        mockTiersResponse({
-            tiers: [tier({id: 'active-tier'})],
-            isEnd: false,
-            isFetchingNextPage: true,
-            fetchNextPage
-        });
-
-        renderHook(() => useTierValueSource());
-
-        expect(fetchNextPage).not.toHaveBeenCalled();
+        expect(result.current.hasMultipleTiers).toBe(false);
+        expect(result.current.state.options).toEqual([]);
+        expect(result.current.state.isInitialLoad).toBe(true);
     });
 });

--- a/apps/posts/test/unit/hooks/use-tier-value-source.test.tsx
+++ b/apps/posts/test/unit/hooks/use-tier-value-source.test.tsx
@@ -1,0 +1,236 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@testing-library/react';
+import {useTierValueSource} from '@src/hooks/filter-sources/use-tier-value-source';
+import type {Tier} from '@tryghost/admin-x-framework/api/tiers';
+
+const {mockUseBrowseTiers} = vi.hoisted(() => ({
+    mockUseBrowseTiers: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/tiers', () => ({
+    useBrowseTiers: mockUseBrowseTiers
+}));
+
+function tier(overrides: Partial<Tier>): Tier {
+    return {
+        id: 'tier-id',
+        name: 'Tier',
+        description: null,
+        slug: 'tier',
+        active: true,
+        type: 'paid',
+        welcome_page_url: null,
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z',
+        visibility: 'public',
+        benefits: [],
+        trial_days: 0,
+        ...overrides
+    };
+}
+
+function mockTiersResponse({
+    tiers = [],
+    isEnd = true,
+    isFetchingNextPage = false,
+    isLoading = false,
+    fetchNextPage = vi.fn()
+}: {
+    tiers?: Tier[];
+    isEnd?: boolean;
+    isFetchingNextPage?: boolean;
+    isLoading?: boolean;
+    fetchNextPage?: ReturnType<typeof vi.fn>;
+} = {}) {
+    mockUseBrowseTiers.mockReturnValue({
+        data: {
+            tiers,
+            isEnd
+        },
+        fetchNextPage,
+        isFetchingNextPage,
+        isLoading
+    });
+}
+
+describe('useTierValueSource', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('exposes active and archived tier options in display order', () => {
+        mockTiersResponse({
+            tiers: [
+                tier({id: 'archived', name: 'Archived Gold', slug: 'archived-gold', active: false}),
+                tier({id: 'active', name: 'Active Gold', slug: 'active-gold', active: true})
+            ]
+        });
+
+        const {result} = renderHook(() => {
+            const source = useTierValueSource();
+            return source.useOptions({query: '', selectedValues: []});
+        });
+
+        expect(result.current.options).toEqual([
+            {
+                value: 'active',
+                label: 'Active Gold',
+                detail: 'active-gold'
+            },
+            {
+                value: 'archived',
+                label: 'Archived Gold (archived)',
+                detail: 'archived-gold'
+            }
+        ]);
+    });
+
+    it('counts fetched paid tiers when deciding if the tier filter is available', () => {
+        const cases = [
+            {
+                tiers: [
+                    tier({id: 'active', active: true}),
+                    tier({id: 'archived', active: false})
+                ],
+                expected: true
+            },
+            {
+                tiers: [
+                    tier({id: 'archived-1', active: false}),
+                    tier({id: 'archived-2', active: false})
+                ],
+                expected: true
+            },
+            {
+                tiers: [
+                    tier({id: 'archived', active: false})
+                ],
+                expected: false
+            },
+            {
+                tiers: [],
+                expected: false
+            }
+        ];
+
+        for (const testCase of cases) {
+            mockTiersResponse({tiers: testCase.tiers});
+
+            const {result} = renderHook(() => useTierValueSource());
+
+            expect(result.current.hasMultipleTiers).toBe(testCase.expected);
+        }
+    });
+
+    it('treats an incomplete tiers response as multiple tiers', () => {
+        mockTiersResponse({
+            tiers: [
+                tier({id: 'active', active: true})
+            ],
+            isEnd: false
+        });
+
+        const {result} = renderHook(() => useTierValueSource());
+
+        expect(result.current.hasMultipleTiers).toBe(true);
+    });
+
+    it('fetches paid tiers with a numeric page limit and exposes tier options', () => {
+        mockTiersResponse({
+            tiers: [
+                tier({id: 'active-tier', name: 'Active Gold', slug: 'active-gold', active: true}),
+                tier({id: 'archived-tier', name: 'Archived Gold', slug: 'archived-gold', active: false})
+            ]
+        });
+
+        const {result} = renderHook(() => {
+            const source = useTierValueSource();
+            return {
+                hasMultipleTiers: source.hasMultipleTiers,
+                state: source.useOptions({query: '', selectedValues: []})
+            };
+        });
+
+        expect(mockUseBrowseTiers).toHaveBeenCalledWith({searchParams: {filter: 'type:paid', limit: '100'}});
+        expect(result.current.hasMultipleTiers).toBe(true);
+        expect(result.current.state.options).toEqual([
+            {
+                value: 'active-tier',
+                label: 'Active Gold',
+                detail: 'active-gold'
+            },
+            {
+                value: 'archived-tier',
+                label: 'Archived Gold (archived)',
+                detail: 'archived-gold'
+            }
+        ]);
+    });
+
+    it('searches local tier options by archived label text', () => {
+        mockTiersResponse({
+            tiers: [
+                tier({id: 'active-tier', name: 'Active Gold', slug: 'active-gold', active: true}),
+                tier({id: 'archived-tier', name: 'Archived Gold', slug: 'archived-gold', active: false})
+            ]
+        });
+
+        const {result} = renderHook(() => {
+            const source = useTierValueSource();
+            return source.useOptions({query: 'archived', selectedValues: []});
+        });
+
+        expect(result.current.options).toEqual([
+            {
+                value: 'archived-tier',
+                label: 'Archived Gold (archived)',
+                detail: 'archived-gold'
+            }
+        ]);
+    });
+
+    it('keeps options in the initial load state while additional tier pages are loading', () => {
+        mockTiersResponse({
+            tiers: [
+                tier({id: 'active-tier', name: 'Active Gold', slug: 'active-gold', active: true})
+            ],
+            isEnd: false,
+            isFetchingNextPage: true
+        });
+
+        const {result} = renderHook(() => {
+            const source = useTierValueSource();
+            return source.useOptions({query: '', selectedValues: []});
+        });
+
+        expect(result.current.options).toEqual([]);
+        expect(result.current.isInitialLoad).toBe(true);
+    });
+
+    it('loads the next page until the tiers response is complete', () => {
+        const fetchNextPage = vi.fn();
+        mockTiersResponse({
+            tiers: [tier({id: 'active-tier'})],
+            isEnd: false,
+            fetchNextPage
+        });
+
+        renderHook(() => useTierValueSource());
+
+        expect(fetchNextPage).toHaveBeenCalledOnce();
+    });
+
+    it('does not load another page while a tiers page is already loading', () => {
+        const fetchNextPage = vi.fn();
+        mockTiersResponse({
+            tiers: [tier({id: 'active-tier'})],
+            isEnd: false,
+            isFetchingNextPage: true,
+            fetchNextPage
+        });
+
+        renderHook(() => useTierValueSource());
+
+        expect(fetchNextPage).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- Added grouped Shade filter option support for multiselect lists, including group-heading search behavior.
- Wrapped member tier fetching, paging, option mapping, and tier-count visibility inside `useTierValueSource`, matching the other member filter value sources.
- Updated the members tier filter to include paid active and archived tiers grouped as Active tiers and Archived tiers, without using deprecated `limit=all`.
- Replaced the members component-level unit test with business-logic and hook unit coverage, plus e2e coverage for the user interaction.

## Why
Members can retain archived paid tiers, but the members filter only exposed active paid tiers. That made archived-tier member segments impossible to select from the tier filter.

## Impact
The Membership tier filter now shows active and archived paid tiers in separate sections. Member table values continue to display the actual tier name, including archived tier names.

## Validation
- `pnpm --filter @tryghost/shade exec vitest run test/unit/components/patterns/filters.test.tsx`
- `pnpm --filter @tryghost/posts exec vitest run test/unit/hooks/use-tier-value-source.test.tsx test/unit/views/members/member-query-params.test.ts src/views/members/use-member-filter-fields.test.ts`
- `pnpm --filter @tryghost/posts lint:code`
- `pnpm --filter @tryghost/posts lint:test`
- `pnpm --filter @tryghost/e2e lint`
- `pnpm --filter @tryghost/e2e test:types`
- `git diff --check origin/main..HEAD`

Notes:
- Posts lint passes with the existing unrelated warning in `apps/posts/src/hooks/use-post-success-modal.ts`.
- E2E lint passes with existing unrelated warnings.
- The focused e2e run was attempted with `pnpm --filter @tryghost/e2e test tests/admin/members/tier-filter-search.test.ts`, but this temp worktree's dev-mode Ghost container failed before tests ran because `ghost/core` has no local `node_modules` (`nodemon: not found`).

ref https://linear.app/ghost/issue/BER-3588/add-archived-tiers-to-tiers-filter
