### PR TITLE
Added permissions block to migration-review workflow

### DIFF
--- a/.github/workflows/migration-review.yml
+++ b/.github/workflows/migration-review.yml
@@ -5,11 +5,16 @@ on:
     paths:
       - 'ghost/core/core/server/data/schema/**'
       - 'ghost/core/core/server/data/migrations/versions/**'
+permissions:
+  contents: read
 jobs:
   createComment:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'TryGhost'
     name: Add migration review requirements
+    permissions:
+      issues: write          # github-script addLabels uses the issues API
+      pull-requests: write   # peter-evans/create-or-update-comment on a PR
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:


### PR DESCRIPTION
## Summary

The Migration Review workflow uses `pull_request_target` to do two write operations on the PR:

1. `github.rest.issues.addLabels` (via `actions/github-script`) — adds the `migration` label
2. `peter-evans/create-or-update-comment` — posts the migration-review checklist

Both go through the issues / pull-requests API and need write access. The workflow has never had an explicit `permissions:` block and was previously relying on the broad default `GITHUB_TOKEN` permissions. Once we tightened those defaults to read-only, the workflow started failing at runtime when those calls hit 403.

This adds the minimum-viable permissions:

- Workflow-level default: `contents: read`
- `createComment` job: `issues: write` (for `addLabels`) and `pull-requests: write` (for `create-or-update-comment`)

Scoping the writes to the single job that needs them (rather than the workflow level) keeps the blast radius tight, which matters more than usual here because `pull_request_target` runs with access to the base repo even on fork PRs.

## Test plan

- [ ] Open a PR that touches `ghost/core/core/server/data/schema/**` or `ghost/core/core/server/data/migrations/versions/**` and confirm the `migration` label is applied and the checklist comment appears.