### PR TITLE
Updated Renovate workflow cron offset and timeout

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,13 +7,15 @@ name: Renovate
 # schedule, and automergeSchedule.
 on:
   schedule:
-    # Hourly. The repo-level `schedule` / `automergeSchedule` blocks in
-    # renovate.json5 still gate when Renovate actually acts or merges, so
-    # extra wake-ups outside those windows are no-ops (~30s each). Hourly
-    # ticks during the 7h weeknight automerge window roughly match Ghost's
-    # CI duration, giving each merge a fresh rebase + green CI window
-    # before the next tick.
-    - cron: '0 * * * *'
+    # Hourly, offset to :17 past the hour. The repo-level `schedule` /
+    # `automergeSchedule` blocks in renovate.json5 still gate when Renovate
+    # actually acts or merges, so extra wake-ups outside those windows are
+    # no-ops (~30s each). Hourly ticks during the 7h weeknight automerge
+    # window roughly match Ghost's CI duration, giving each merge a fresh
+    # rebase + green CI window before the next tick.
+    # The :17 offset avoids top-of-hour GH Actions scheduler contention,
+    # which was dropping roughly every other tick on `0 * * * *`.
+    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       ignoreSchedule:
@@ -32,7 +34,7 @@ permissions:
 jobs:
   renovate:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Get GitHub App token


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-48

## Why

First day on `0 * * * *` surfaced two issues:

1. **GitHub Actions dropped every even-hour tick.** Since hourly landed, every UTC even hour (00, 02, 04, 06, 08, 10) failed to fire; only odd hours started runs. GH's docs flag the top of every hour as the worst scheduler-delivery window. `17 * * * *` puts us off the contended slot.
2. **30m timeout was firing on real work.** Most runs hit `timeout-minutes: 30` mid-rebase or mid-lockfile-maintenance across the current 29-PR backlog. Raising to 45 lets catch-up cycles finish; can drop back to 30 once the queue steadies.