### PR TITLE
Guarded automation polling in non-development environments

### DIFF
--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -7,5 +7,13 @@ export const poll = async ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     enqueueAnotherPollAt
 }: Readonly<PollOptions>): Promise<void> => {
+    // TODO(NY-1311) Once we're using real tables, we should remove this conditional.
+    if (
+        process.env.NODE_ENV !== 'development'
+        && !process.env.NODE_ENV?.startsWith('test')
+    ) {
+        return;
+    }
+
     // TODO(NY-1286) Implement polling. For now, this function is a skeleton.
 };


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1286

We don't want to run automation polls outside development right now. This change should have no user impact (the function is still a skeleton), but this is a concrete piece we'll want.
