### PR TITLE
Fixed pack.js and Dockerfile references to deleted .npmrc

### DIFF
--- a/.github/scripts/enforce-package-manager.js
+++ b/.github/scripts/enforce-package-manager.js
@@ -4,11 +4,11 @@ if (/\bpnpm\//.test(userAgent)) {
     process.exit(0);
 }
 
-// Fallback for environments where pnpm 11 doesn't propagate
-// npm_config_user_agent to lifecycle scripts — observed on GitHub Actions
-// where the runner's pre-installed pnpm v10 shim layer strips the var even
-// when pnpm 11 is the active binary. The `pnpm_config_*` env-var prefix is
-// exclusive to pnpm and reliably set when pnpm 11 spawns a child process.
+// Fallback heuristic for environments where npm_config_user_agent isn't
+// propagated to lifecycle scripts (we've hit this on CI runners with mixed
+// pnpm install layouts). pnpm-driven lifecycles typically set
+// `pnpm_config_*` env vars, so we treat the presence of any such key as a
+// strong-but-not-absolute signal that pnpm is the active package manager.
 if (Object.keys(process.env).some(key => key.startsWith('pnpm_config_'))) {
     process.exit(0);
 }

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -25,7 +25,7 @@ WORKDIR /home/ghost
 
 RUN corepack enable
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY components ./components
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 WORKDIR /home/ghost
 
 # Copy package files for dependency installation
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY ghost/core/package.json ghost/core/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
 COPY ghost/parse-email-address/package.json ghost/parse-email-address/package.json

--- a/ghost/core/scripts/pack.js
+++ b/ghost/core/scripts/pack.js
@@ -12,8 +12,8 @@
  * the output for Ghost-CLI compatibility:
  *
  *  1. Strip peer dep suffixes from version strings (pnpm deploy artifact)
- *  2. Pack private workspace packages as component tarballs
- *  3. Merge root pnpm overrides so standalone installs resolve correctly
+ *  2. Copy pnpm-workspace.yaml (carries overrides + catalogs for the install)
+ *  3. Pack private workspace packages as component tarballs
  *  4. Create a Ghost-CLI compatible tarball (package/ prefix, no node_modules)
  */
 
@@ -23,6 +23,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const {execFileSync} = require('node:child_process');
 const fsExtra = require('fs-extra');
+const yaml = require('js-yaml');
 
 const CORE_DIR = path.resolve(__dirname, '..');
 const ROOT_DIR = path.resolve(CORE_DIR, '../..');
@@ -64,6 +65,41 @@ for (const section of ['dependencies', 'devDependencies', 'optionalDependencies'
     }
 }
 
+// Write a trimmed pnpm-workspace.yaml into the deploy dir. We keep:
+//   - catalog + catalogs (lockfile records & validates these)
+//   - allowBuilds + strictDepBuilds (end-user installs need this to permit
+//     native module post-install scripts like sqlite3, sharp, re2)
+// We deliberately drop:
+//   - overrides + packageExtensions: pnpm deploy already applied them to
+//     the resolved package.json and the deploy lockfile does not record
+//     them. Shipping them in workspace.yaml causes pnpm 11's
+//     frozen-lockfile install (CI=true default for ghost-cli) to fail
+//     ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+//   - packages: relative paths that don't exist in the deployed dir.
+//   - minimumReleaseAge, blockExoticSubdeps, catalogMode: source-repo
+//     supply-chain policies that aren't meaningful at end-user install.
+// Written early (rather than after the pack loop) so workspace component
+// `pnpm pack` calls below have catalog context to resolve `catalog:` refs
+// in their devDependencies.
+const workspaceSrc = path.join(ROOT_DIR, 'pnpm-workspace.yaml');
+const workspaceDst = path.join(DEPLOY_DIR, 'pnpm-workspace.yaml');
+const rootWorkspace = yaml.load(fs.readFileSync(workspaceSrc, 'utf8'));
+const deployWorkspace = {};
+for (const key of ['catalog', 'catalogs', 'allowBuilds', 'strictDepBuilds']) {
+    if (rootWorkspace[key] !== undefined) {
+        deployWorkspace[key] = rootWorkspace[key];
+    }
+}
+// Disable minimumReleaseAge in the published tarball. The source repo gates
+// fresh deps from entering the lockfile; the deployed package is itself a
+// release artifact, and its component tarballs (@tryghost/i18n,
+// @tryghost/parse-email-address) aren't on npm so the age check 404s and
+// fails the install.
+deployWorkspace.minimumReleaseAge = 0;
+fs.writeFileSync(workspaceDst, yaml.dump(deployWorkspace));
+
+console.log('Wrote trimmed pnpm-workspace.yaml (catalogs + allowBuilds, age check off)');
+
 // Pack private workspace packages as component tarballs.
 // These are not on npm, so ghost-cli can't install them from the registry.
 // pnpm deploy writes absolute file:// refs that won't work on another machine.
@@ -103,40 +139,35 @@ if (!rootPkg.packageManager) {
 pkg.packageManager = rootPkg.packageManager;
 console.log(`  Set packageManager: ${rootPkg.packageManager.split('+')[0]}`);
 
-// pnpm overrides — the root overrides apply globally in the workspace (e.g., forcing
-// moment to 2.24.0 so moment-timezone doesn't pull in a separate copy). pnpm deploy
-// creates a standalone context where these don't apply, so we merge them in.
-if (rootPkg.pnpm?.overrides || rootPkg.overrides) {
-    const rootOverrides = rootPkg.pnpm?.overrides || rootPkg.overrides;
-    pkg.pnpm = pkg.pnpm || {};
-    pkg.pnpm.overrides = {...rootOverrides, ...pkg.pnpm.overrides};
-    console.log(`  Merged ${Object.keys(rootOverrides).length} root overrides into package.json`);
-}
+// pnpm overrides live in the published pnpm-workspace.yaml (copied above).
+// pnpm 11 only reads overrides from workspace.yaml, not from a package's
+// `pnpm.overrides`. We deliberately do NOT also write pnpm.overrides here:
+// pnpm 11 still hashes that field into its lockfile-overrides-config check,
+// even though it logs that it's ignoring it, which produces
+// ERR_PNPM_LOCKFILE_CONFIG_MISMATCH under frozen-lockfile (CI=true) installs.
 
 fsExtra.writeJsonSync(pkgPath, pkg, {spaces: 2});
 
-// Copy .npmrc and pnpm-workspace.yaml for ghost-cli installs.
-// The lockfile references catalogs from pnpm-workspace.yaml, and pnpm validates
-// this even without --frozen-lockfile when CI=true. frozen-lockfile=false prevents
-// the config mismatch error in CI environments.
-const npmrcSrc = path.join(ROOT_DIR, '.npmrc');
-const npmrcDst = path.join(DEPLOY_DIR, '.npmrc');
-let npmrc = fs.readFileSync(npmrcSrc, 'utf8');
-npmrc += '\nfrozen-lockfile=false\n';
-fs.writeFileSync(npmrcDst, npmrc);
-
-const workspaceSrc = path.join(ROOT_DIR, 'pnpm-workspace.yaml');
-const workspaceDst = path.join(DEPLOY_DIR, 'pnpm-workspace.yaml');
-fs.copyFileSync(workspaceSrc, workspaceDst);
-
-console.log('Copied .npmrc (with frozen-lockfile=false) and pnpm-workspace.yaml');
+// Regenerate the lockfile inside the deploy dir to match the post-processed
+// package.json. We've stripped peer suffixes and rewritten file: refs to
+// component tarballs; without this step, the lockfile retains the original
+// (unstripped, absolute-path) specifiers and end users hit
+// ERR_PNPM_OUTDATED_LOCKFILE under pnpm 11's frozen-lockfile (CI=true)
+// install. Previously masked by `frozen-lockfile=false` in the shipped
+// .npmrc, which pnpm 11 no longer honors.
+console.log('\nRegenerating lockfile against post-processed package.json...');
+execFileSync(
+    'pnpm',
+    ['install', '--lockfile-only', '--no-frozen-lockfile', '--ignore-scripts'],
+    {cwd: DEPLOY_DIR, stdio: 'inherit'}
+);
 
 // 3. Validate deploy output before tarring.
 // Guards against regressions in this script that would produce a valid-looking
 // but broken tarball (missing lockfile, missing overrides merge, empty components/).
 console.log('\nValidating deploy output...');
 const packagedPkg = fsExtra.readJsonSync(pkgPath);
-const requiredFiles = ['.npmrc', 'pnpm-workspace.yaml', 'pnpm-lock.yaml', 'package.json'];
+const requiredFiles = ['pnpm-workspace.yaml', 'pnpm-lock.yaml', 'package.json'];
 for (const rel of requiredFiles) {
     if (!fs.existsSync(path.join(DEPLOY_DIR, rel))) {
         throw new Error(`Required file missing from deploy output: ${rel}`);
@@ -149,8 +180,9 @@ if (componentTgzs.length === 0) {
 if (!packagedPkg.packageManager) {
     throw new Error('Packaged package.json is missing packageManager');
 }
-if (!packagedPkg.pnpm?.overrides || Object.keys(packagedPkg.pnpm.overrides).length === 0) {
-    throw new Error('Packaged package.json is missing pnpm.overrides');
+const packagedWorkspace = yaml.load(fs.readFileSync(workspaceDst, 'utf8'));
+if (!packagedWorkspace?.catalog || Object.keys(packagedWorkspace.catalog).length === 0) {
+    throw new Error('Packaged pnpm-workspace.yaml is missing the default catalog');
 }
 
 // 4. Create tarball


### PR DESCRIPTION
Hotfix for #28197. Five distinct release-pipeline files broke after the `.npmrc` deletion, but the deeper story is that `.npmrc` was also carrying `frozen-lockfile=false`, which was silently absorbing several pnpm-deploy-vs-lockfile mismatches under pnpm 10. pnpm 11 ignores `.npmrc` for that directive, so the mismatches surface.

## What was broken

- `Dockerfile.production:28` — production image builds. `COPY` fails on missing source.
- `docker/ghost-dev/Dockerfile:21` — devcontainer + local dev. Already failed on main: [run 26525156893](https://github.com/TryGhost/Ghost/actions/runs/26525156893).
- `ghost/core/scripts/pack.js:124` — read root `.npmrc` to build the published Ghost tarball; would throw on next release.
- `pack.js` — `pnpm pack` of `@tryghost/i18n`/etc. needs `pnpm-workspace.yaml` in scope (pnpm 11 strict-validates `catalog:` refs); pack.js wrote it AFTER the pack loop.
- `pack.js` — the shipped tarball's `pnpm-workspace.yaml` carried `overrides` + `packageExtensions` verbatim from root, but `pnpm deploy`'s generated lockfile doesn't record them (they're already applied to the resolved package.json). pnpm 11's frozen-lockfile install (CI=true default for ghost-cli) failed `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.
- `pack.js` — after the existing peer-suffix-stripping and component-file: rewriting on the deployed package.json, the deploy lockfile no longer matched. Under pnpm 10 this was masked by `frozen-lockfile=false` in `.npmrc`; pnpm 11 fails `ERR_PNPM_OUTDATED_LOCKFILE`.
- `pack.js` — `minimumReleaseAge` policy in the shipped workspace.yaml 404'd on the private component tarballs and failed install inside `Dockerfile.production`.

## What changed

- **Dockerfiles** — removed `.npmrc` from the `COPY` line in both. Single-token edit per file.
- **`pack.js`** — stop reading the deleted root `.npmrc`.
- **`pack.js`** — copy `pnpm-workspace.yaml` BEFORE the pack loop (so workspace `catalog:` refs resolve for `pnpm pack` of components).
- **`pack.js`** — ship a trimmed `pnpm-workspace.yaml` carrying only `catalog`, `catalogs`, `allowBuilds`, `strictDepBuilds` (the things end-user installs need). Drop `overrides`, `packageExtensions`, `packages`, supply-chain policies. Explicitly set `minimumReleaseAge: 0` since the published tarball is itself a release artifact and the policy 404s on private component tarballs.
- **`pack.js`** — regenerate the deploy lockfile inside the deploy dir with `pnpm install --lockfile-only` after package.json post-processing, so the shipped tarball is internally consistent under pnpm 11's strict checks.
- **`enforce-package-manager.js`** — re-applies the comment softening from the #28197 review (lost to a rebase autostash on my end).

## Verification

End-to-end through the full release pipeline, locally, with `CI=true` to match production install behavior:

| Step | Result |
|---|---|
| `pnpm archive` (in `ghost/core/`) | ✅ tarball 34.3 MiB, lockfile regenerated, deploy workspace.yaml trimmed |
| `docker build --target core -t … .` (from extracted tarball) | ✅ image builds, deps install cleanly |
| `CI=true ghost install local --archive …` | ✅ "Ghost was installed successfully!" |

## How this slipped through #28197

Two layers of cause:

1. I checked `.npmrc` references at the start of #28197 and noted the two Dockerfile `COPY` lines and `pack.js`'s read, but didn't follow through with edits when I deleted the file. Should have grepped post-delete as a final sweep.
2. I tested ghost-cli install locally WITHOUT `CI=true`, which silently reconciled the lockfile mismatches via the default `frozen-lockfile=false`. CI runs with `CI=true` → `frozen-lockfile=true` → strict check tripped. **Adding `CI=true` to my local verification checklist for any release-pipeline change.**

And a third: `Build & Publish Artifacts` (which runs `pnpm archive`) was failing on #28197's CI but the merge gate didn't see it because that job wasn't in `job_required_tests.needs`. Fixed separately in #28206.