### PR TITLE
Added job_build_artifacts to required-tests gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1536,6 +1536,7 @@ jobs:
         job_migration_integrity_check,
         job_lint,
         job_i18n,
+        job_build_artifacts,
         job_ghost-cli,
         job_admin-tests,
         job_unit-tests,


### PR DESCRIPTION
`job_build_artifacts` is missing from `job_required_tests.needs`, so when it fails the gate doesn't see it. Its downstream jobs (`job_ghost-cli`, `job_build_e2e_image`, `job_e2e_tests`) cascade into "skipped" via their own `needs:` / `if:` checks, and the gate's `contains(needs.*.result, 'failure')` check sees only success/skipped — green merge despite a real release-pipeline failure.

Surfaced concretely in #28197: pack.js broke under pnpm 11, `Build & Publish Artifacts` went red, the three downstream jobs skipped, gate passed, the .npmrc-deletion regression landed on main (devcontainer + production Docker + next release would all have failed).

Adding the job to the gate's `needs` list closes the gap. Zero CI cost — the job already runs.