### PR TITLE
Fixed Renovate rebasing all open PRs during workday

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,6 +44,16 @@
     // Each block starts one hour earlier than the matching automerge
     // window so Renovate has time to rebase and open/refresh PRs before
     // automerge is eligible to run.
+    //
+    // `schedule` alone only gates *new* PR creation — Renovate defaults to
+    // `updateNotScheduled: true`, which lets existing branches keep getting
+    // rebased and force-pushed any time the runner ticks. With the hourly
+    // self-hosted workflow that means a CI-storm of force-pushes across all
+    // open Renovate PRs during the workday. Setting `updateNotScheduled:
+    // false` keeps existing branch maintenance inside the same windows.
+    // `vulnerabilityAlerts.schedule: "at any time"` overrides this for
+    // CVE-driven PRs so security work still flows intraday.
+    "updateNotScheduled": false,
     "schedule": [
         // Run all weekend
         "* * * * 0,6",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,15 +7,30 @@ name: Renovate
 # schedule, and automergeSchedule.
 on:
   schedule:
-    # Hourly, offset to :17 past the hour. The repo-level `schedule` /
-    # `automergeSchedule` blocks in renovate.json5 still gate when Renovate
-    # actually acts or merges, so extra wake-ups outside those windows are
-    # no-ops (~30s each). Hourly ticks during the 7h weeknight automerge
-    # window roughly match Ghost's CI duration, giving each merge a fresh
-    # rebase + green CI window before the next tick.
-    # The :17 offset avoids top-of-hour GH Actions scheduler contention,
-    # which was dropping roughly every other tick on `0 * * * *`.
-    - cron: '17 * * * *'
+    # Wake the runner only inside the windows where Renovate is actually
+    # allowed to open or maintain PRs (see `schedule` in renovate.json5),
+    # plus a single weekday daytime tick to service `vulnerabilityAlerts.
+    # schedule: "at any time"` for CVE-driven PRs. Ticks outside those
+    # windows aren't no-ops in practice — each one is a 20-30min full
+    # extract — so the previous `17 * * * *` was burning ~17h/day of
+    # Actions compute for no merge benefit.
+    #
+    # :17-past-the-hour offset avoids top-of-hour GH Actions scheduler
+    # contention, which was dropping roughly every other tick on `0 * * * *`.
+    # Hourly cadence inside active windows roughly matches Ghost's CI
+    # duration, giving each merge a fresh rebase + green CI window.
+    #
+    # Times are UTC; matches renovate.json5's `schedule` block.
+    # Monday morning window (Mon 00:00-12:59 UTC)
+    - cron: '17 0-12 * * 1'
+    # Weekday early-morning window (Tue-Sat 00:00-04:59 UTC)
+    - cron: '17 0-4 * * 2-6'
+    # Weekday evening window (Mon-Fri 21:00-23:59 UTC)
+    - cron: '17 21-23 * * 1-5'
+    # Weekend - every 2h is plenty; no automerge urgency, just batch creation
+    - cron: '17 */2 * * 0,6'
+    # Weekday daytime CVE pickup tick (Mon-Fri 14:17 UTC)
+    - cron: '17 14 * * 1-5'
   workflow_dispatch:
     inputs:
       ignoreSchedule:


### PR DESCRIPTION
The hourly self-hosted Renovate workflow was force-pushing every open Renovate PR on each tick, firing a fresh CI run on each — including during the workday, despite the off-hours `schedule` block in `renovate.json5`.

Renovate's `schedule` only gates *new PR creation*. Its `updateNotScheduled` option defaults to `true`, which keeps existing branches getting rebased and force-pushed any time the runner ticks. Combined with the `'17 * * * *'` cron, that was ~30 min of Actions compute every daytime hour plus a CI storm across all open Renovate PRs.

Changes:
- `renovate.json5`: `updateNotScheduled: false` so branch maintenance also obeys the windows. `vulnerabilityAlerts.schedule: "at any time"` overrides this per-block, so CVE-driven PRs continue to flow intraday.
- `renovate.yml`: replaced the hourly wildcard cron with 5 windowed entries matching the `schedule` windows, plus one weekday 14:17 UTC tick so the CVE path still has a runner. Roughly halves the weekly tick count and removes ~17h/day of daytime no-op runner time.