### PR TITLE
🐛 Fix JWKS key length to meet RS512 requirements

### DIFF
--- a/ghost/core/core/server/models/settings.js
+++ b/ghost/core/core/server/models/settings.js
@@ -26,7 +26,7 @@ const getMembersKey = doBlock(() => {
     let UNO_KEYPAIRINO;
     return function getKey(type) {
         if (!UNO_KEYPAIRINO) {
-            UNO_KEYPAIRINO = keypair({bits: 1024});
+            UNO_KEYPAIRINO = keypair({bits: 2048});
         }
         return UNO_KEYPAIRINO[type];
     };
@@ -36,7 +36,7 @@ const getGhostKey = doBlock(() => {
     let UNO_KEYPAIRINO;
     return function getKey(type) {
         if (!UNO_KEYPAIRINO) {
-            UNO_KEYPAIRINO = keypair({bits: 1024});
+            UNO_KEYPAIRINO = keypair({bits: 2048});
         }
         return UNO_KEYPAIRINO[type];
     };

--- a/ghost/core/core/server/services/members/members-config-provider.js
+++ b/ghost/core/core/server/services/members/members-config-provider.js
@@ -54,7 +54,7 @@ class MembersConfigProvider {
 
         if (!privateKey || !publicKey) {
             logging.warn('Could not find members_private_key, using dynamically generated keypair');
-            const keypair = createKeypair({bits: 1024});
+            const keypair = createKeypair({bits: 2048});
             privateKey = keypair.private;
             publicKey = keypair.public;
         }


### PR DESCRIPTION
The RS512 algorithm specification requires an RSA key modulus length of 2048 bits or larger. The member token service generates its JWTs using RS512 but the fallback auto-generated keys (used for token signing and exposed at `/members/.well-known/jwks.json`) were using a 1024-bit key length.

This updates the dynamically generated RSA keys for members to 2048 bits to comply with the standard and resolve validation errors when external libraries try to parse the member token keys.

Fixes #24831