### PR TITLE
Added abuse guards to the i18n review workflow

### DIFF
--- a/.github/scripts/i18n-review/src/analyzer.js
+++ b/.github/scripts/i18n-review/src/analyzer.js
@@ -11,6 +11,12 @@ const PROMPT_PATH = path.join(__dirname, '..', 'prompt.md');
 const I18N_PATH_PATTERN = /^ghost\/i18n\/locales\/(?!en\/)[^/]+\/[^/]+\.json$/;
 const DEFAULT_MODEL = 'claude-sonnet-4-6';
 const MAX_TOKENS = 4096;
+// Abuse / cost guards. A normal translation PR touches one locale and adds a
+// handful of strings; well past that is either a bulk regeneration that a
+// human should review, or someone trying to burn API budget. When exceeded we
+// skip the model call and post a short notice instead.
+const MAX_FILES = 15;
+const MAX_ADDED_LINES = 500;
 
 const REVIEW_TOOL = {
     name: 'post_translation_review',
@@ -104,6 +110,24 @@ export async function analyzePR(prNumber, {octokit, anthropic, owner, repo, mode
             validKeys.add(key);
             lineLookup.set(key, l.line);
         }
+    }
+
+    if (fileChanges.length > MAX_FILES || validKeys.size > MAX_ADDED_LINES) {
+        console.log(`PR exceeds review caps (files=${fileChanges.length}/${MAX_FILES}, lines=${validKeys.size}/${MAX_ADDED_LINES}). Skipping model call.`);
+        return {
+            prNumber: pr.number,
+            prTitle: pr.title,
+            headSha: pr.head.sha,
+            verdict: 'skipped',
+            overall: `This PR touches ${fileChanges.length} translation file${fileChanges.length === 1 ? '' : 's'} and ${validKeys.size} added line${validKeys.size === 1 ? '' : 's'}, which is beyond the automated reviewer's per-PR limit (max ${MAX_FILES} files / ${MAX_ADDED_LINES} lines). A maintainer should review the translations manually.`,
+            comments: [],
+            stats: {
+                filesReviewed: fileChanges.length,
+                linesReviewed: validKeys.size,
+                commentsRaised: 0
+            },
+            usage: null
+        };
     }
 
     const systemPrompt = await fs.readFile(PROMPT_PATH, 'utf8');

--- a/.github/scripts/i18n-review/src/analyzer.js
+++ b/.github/scripts/i18n-review/src/analyzer.js
@@ -82,9 +82,17 @@ export async function analyzePR(prNumber, {octokit, anthropic, owner, repo, mode
     }
     console.log(`Found ${i18nFiles.length} i18n file(s) to review.`);
 
-    const contextJson = await fetchFile(octokit, owner, repo, 'ghost/i18n/locales/context.json', 'main');
+    // Short-circuit on raw file count before any network call. Patch contents
+    // for the diff are already on the listFiles response, so we can also
+    // compute the added-line count without any further fetches.
+    if (i18nFiles.length > MAX_FILES) {
+        console.log(`PR exceeds file cap (files=${i18nFiles.length}/${MAX_FILES}). Skipping model call.`);
+        return buildSkippedReview({pr, filesCount: i18nFiles.length, linesCount: 0, reason: 'files'});
+    }
 
-    const fileChanges = [];
+    const eligibleFiles = [];
+    const lineLookup = new Map();
+    const validKeys = new Set();
     for (const file of i18nFiles) {
         if (file.status === 'removed') continue;
         if (!file.patch) {
@@ -93,41 +101,30 @@ export async function analyzePR(prNumber, {octokit, anthropic, owner, repo, mode
         }
         const addedLines = extractAddedLines(file.patch);
         if (addedLines.length === 0) continue;
-        const currentContent = await fetchFile(octokit, owner, repo, file.filename, pr.head.sha);
-        fileChanges.push({filename: file.filename, addedLines, currentContent});
+        for (const l of addedLines) {
+            const key = `${file.filename}:${l.position}`;
+            validKeys.add(key);
+            lineLookup.set(key, l.line);
+        }
+        eligibleFiles.push({file, addedLines});
     }
 
-    if (fileChanges.length === 0) {
+    if (eligibleFiles.length === 0) {
         console.log('No added translation lines found. Nothing to review.');
         return null;
     }
 
-    const lineLookup = new Map();
-    const validKeys = new Set();
-    for (const fc of fileChanges) {
-        for (const l of fc.addedLines) {
-            const key = `${fc.filename}:${l.position}`;
-            validKeys.add(key);
-            lineLookup.set(key, l.line);
-        }
+    if (validKeys.size > MAX_ADDED_LINES) {
+        console.log(`PR exceeds line cap (lines=${validKeys.size}/${MAX_ADDED_LINES}). Skipping model call.`);
+        return buildSkippedReview({pr, filesCount: eligibleFiles.length, linesCount: validKeys.size, reason: 'lines'});
     }
 
-    if (fileChanges.length > MAX_FILES || validKeys.size > MAX_ADDED_LINES) {
-        console.log(`PR exceeds review caps (files=${fileChanges.length}/${MAX_FILES}, lines=${validKeys.size}/${MAX_ADDED_LINES}). Skipping model call.`);
-        return {
-            prNumber: pr.number,
-            prTitle: pr.title,
-            headSha: pr.head.sha,
-            verdict: 'skipped',
-            overall: `This PR touches ${fileChanges.length} translation file${fileChanges.length === 1 ? '' : 's'} and ${validKeys.size} added line${validKeys.size === 1 ? '' : 's'}, which is beyond the automated reviewer's per-PR limit (max ${MAX_FILES} files / ${MAX_ADDED_LINES} lines). A maintainer should review the translations manually.`,
-            comments: [],
-            stats: {
-                filesReviewed: fileChanges.length,
-                linesReviewed: validKeys.size,
-                commentsRaised: 0
-            },
-            usage: null
-        };
+    // Both caps passed — now make the network calls we need for the review.
+    const contextJson = await fetchFile(octokit, owner, repo, 'ghost/i18n/locales/context.json', 'main');
+    const fileChanges = [];
+    for (const {file, addedLines} of eligibleFiles) {
+        const currentContent = await fetchFile(octokit, owner, repo, file.filename, pr.head.sha);
+        fileChanges.push({filename: file.filename, addedLines, currentContent});
     }
 
     const systemPrompt = await fs.readFile(PROMPT_PATH, 'utf8');
@@ -182,6 +179,26 @@ export async function analyzePR(prNumber, {octokit, anthropic, owner, repo, mode
             commentsRaised: validComments.length
         },
         usage: response.usage || null
+    };
+}
+
+function buildSkippedReview({pr, filesCount, linesCount, reason}) {
+    const overall = reason === 'files'
+        ? `This PR touches ${filesCount} translation file${filesCount === 1 ? '' : 's'}, which is beyond the automated reviewer's per-PR limit (max ${MAX_FILES} files / ${MAX_ADDED_LINES} lines). A maintainer should review the translations manually.`
+        : `This PR adds ${linesCount} translation line${linesCount === 1 ? '' : 's'}, which is beyond the automated reviewer's per-PR limit (max ${MAX_FILES} files / ${MAX_ADDED_LINES} lines). A maintainer should review the translations manually.`;
+    return {
+        prNumber: pr.number,
+        prTitle: pr.title,
+        headSha: pr.head.sha,
+        verdict: 'skipped',
+        overall,
+        comments: [],
+        stats: {
+            filesReviewed: filesCount,
+            linesReviewed: linesCount,
+            commentsRaised: 0
+        },
+        usage: null
     };
 }
 

--- a/.github/scripts/i18n-review/src/github.js
+++ b/.github/scripts/i18n-review/src/github.js
@@ -26,7 +26,9 @@ function formatReviewBody(review) {
     const {comments, stats, overall, verdict} = review;
     const verdictLine = verdict === 'ok'
         ? '✅ **Looks good** — no concerns flagged'
-        : `⚠️ **Has questions** — ${comments.length} inline comment${comments.length === 1 ? '' : 's'}`;
+        : verdict === 'skipped'
+            ? '⏭️ **Skipped** — PR is too large for automated review'
+            : `⚠️ **Has questions** — ${comments.length} inline comment${comments.length === 1 ? '' : 's'}`;
 
     const lines = [
         '### 🌐 Automated translation review',

--- a/.github/scripts/i18n-review/test/analyzer.test.js
+++ b/.github/scripts/i18n-review/test/analyzer.test.js
@@ -3,7 +3,8 @@ import test from 'node:test';
 import {analyzePR} from '../src/analyzer.js';
 
 function createOctokit({files, headSha = 'abc123'}) {
-    return {
+    const getContentCalls = [];
+    const octokit = {
         pulls: {
             get: async () => ({
                 data: {
@@ -20,13 +21,18 @@ function createOctokit({files, headSha = 'abc123'}) {
             return response.data;
         },
         repos: {
-            getContent: async ({path, ref}) => ({
-                data: {
-                    content: Buffer.from(JSON.stringify({path, ref}), 'utf8').toString('base64')
-                }
-            })
+            getContent: async ({path, ref}) => {
+                getContentCalls.push({path, ref});
+                return {
+                    data: {
+                        content: Buffer.from(JSON.stringify({path, ref}), 'utf8').toString('base64')
+                    }
+                };
+            }
         }
     };
+    octokit.getContentCalls = getContentCalls;
+    return octokit;
 }
 
 test('ignores English source locale files', async () => {
@@ -90,6 +96,40 @@ test('skips the model call when the PR exceeds the per-PR line cap', async () =>
     assert.equal(review.verdict, 'skipped');
     assert.equal(review.comments.length, 0);
     assert.ok(review.overall.includes('beyond the automated reviewer'));
+    // The model call AND the per-file currentContent fetch should be skipped.
+    assert.equal(octokit.getContentCalls.length, 0);
+});
+
+test('skips the model call when the PR exceeds the per-PR file cap without fetching per-file contents', async () => {
+    const files = [];
+    for (let i = 0; i < 20; i++) {
+        files.push({
+            filename: `ghost/i18n/locales/de/file${i}.json`,
+            status: 'modified',
+            patch: '@@ -1,1 +1,2 @@\n {\n+  "New": "Neu"\n }'
+        });
+    }
+    let anthropicCalled = false;
+    const octokit = createOctokit({files});
+    const anthropic = {
+        messages: {
+            create: async () => {
+                anthropicCalled = true;
+            }
+        }
+    };
+
+    const review = await analyzePR(123, {
+        octokit,
+        anthropic,
+        owner: 'TryGhost',
+        repo: 'Ghost'
+    });
+
+    assert.equal(anthropicCalled, false);
+    assert.equal(review.verdict, 'skipped');
+    // Neither context.json nor any per-file currentContent should have been fetched.
+    assert.equal(octokit.getContentCalls.length, 0);
 });
 
 test('downgrades verdict when all model comments are filtered out', async () => {

--- a/.github/scripts/i18n-review/test/analyzer.test.js
+++ b/.github/scripts/i18n-review/test/analyzer.test.js
@@ -57,6 +57,41 @@ test('ignores English source locale files', async () => {
     assert.equal(anthropicCalled, false);
 });
 
+test('skips the model call when the PR exceeds the per-PR line cap', async () => {
+    const lines = [];
+    for (let i = 0; i < 600; i++) {
+        lines.push(`+  "Key${i}": "Wert${i}"`);
+    }
+    const patch = `@@ -1,1 +1,${lines.length + 1} @@\n {\n${lines.join('\n')}\n }`;
+    let anthropicCalled = false;
+    const octokit = createOctokit({
+        files: [{
+            filename: 'ghost/i18n/locales/de/ghost.json',
+            status: 'modified',
+            patch
+        }]
+    });
+    const anthropic = {
+        messages: {
+            create: async () => {
+                anthropicCalled = true;
+            }
+        }
+    };
+
+    const review = await analyzePR(123, {
+        octokit,
+        anthropic,
+        owner: 'TryGhost',
+        repo: 'Ghost'
+    });
+
+    assert.equal(anthropicCalled, false);
+    assert.equal(review.verdict, 'skipped');
+    assert.equal(review.comments.length, 0);
+    assert.ok(review.overall.includes('beyond the automated reviewer'));
+});
+
 test('downgrades verdict when all model comments are filtered out', async () => {
     const octokit = createOctokit({
         files: [{

--- a/.github/workflows/translation-review.yml
+++ b/.github/workflows/translation-review.yml
@@ -44,6 +44,7 @@ jobs:
   review:
     name: Review translations
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: |
       github.repository_owner == 'TryGhost' && (
         github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
## Summary
- Caps automated review at 15 files / 500 added lines per PR; oversized PRs get a brief "skipped" notice instead of a model call
- Adds a 5-minute job timeout so a stuck Anthropic call can't eat runner minutes
- Together this puts a hard ceiling on per-PR API spend without changing the experience on normal translation PRs

The cap is deliberately scoped to translator-contributor PRs (typically 1–5 files). Developer PRs that introduce new keys and auto-propagate them across all ~62 locales (typically 50–90 files) will be skipped — those contain English placeholders rather than translations, so the bot has little to validate there.

## Test plan
- [x] `npm test` under `.github/scripts/i18n-review` (new test covers the skip path)
- [ ] On merge, re-run the workflow against a normal translation PR and confirm a regular review still posts