### PR TITLE
Mounted apps/ into ghost-dev container for pnpm 11

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -61,6 +61,12 @@ services:
     command: ["pnpm", "dev"]
     volumes:
       - ./ghost:/home/ghost/ghost
+      # ghost/admin has workspace:* deps on apps/* (e.g. @tryghost/admin-x-framework).
+      # The dev Dockerfile only stages ghost/{core,i18n,parse-email-address}
+      # package.jsons at build time; mounting apps/ here makes the workspace
+      # graph complete at runtime. pnpm 10 tolerated the missing packages;
+      # pnpm 11 strict-validates and fails without this mount.
+      - ./apps:/home/ghost/apps
       # Mount specific content subdirectories to preserve themes/adapters from source
       - ghost-dev-data:/home/ghost/ghost/core/content/data
       - ghost-dev-images:/home/ghost/ghost/core/content/images


### PR DESCRIPTION
Follow-up to #28197 / #28205. 

`pnpm dev` / `ghost-dev` failing to spin up after the pnpm 11 bump.

## Why

The dev Dockerfile (`docker/ghost-dev/Dockerfile`) only stages `ghost/{core,i18n,parse-email-address}` `package.json`s at build time. Compose then mounts `./ghost` into the container at runtime, which exposes `ghost/admin`'s `workspace:*` deps (e.g. `@tryghost/admin-x-framework` → lives in `apps/admin-x-framework/`). pnpm 10 was lenient about the missing workspace packages; pnpm 11 strict-validates the workspace graph and `pnpm dev` fails instead of being tolerated.

## What changed

Added `./apps:/home/ghost/apps` to the `ghost-dev` service's volume mounts in `compose.dev.yaml`. Same pattern as the existing `./ghost` mount.

This makes only the `package.json`s visible to the in-container workspace resolver. Host-side frontend dev servers (portal, comments-ui, admin-x-settings, …) continue running on the host under `pnpm dev` as before — this doesn't touch that path.

## Longer-term

The cleaner fix is in the Dockerfile, not compose — stage all workspace `package.json`s, or install with `pnpm install --filter ghost...`. The mount approach here is a fine immediate unblocker and consistent with the existing dev-mount pattern. A follow-up Linear can capture the Dockerfile cleanup separately.