### PR TITLE
Added a workflow-level cap on open Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,15 +2,36 @@
     "extends": [
         "github>tryghost/renovate-config"
     ],
-    // Cap total open Renovate PRs at 10. The shared preset extends
-    // :disableRateLimiting (prConcurrentLimit: 0, prHourlyLimit: 0), so
-    // branchConcurrentLimit alone leaks — it exempts grouped, automerge-
-    // eligible, and vulnerability PRs, and is enforced per-run rather than
-    // as a true total. Setting prConcurrentLimit overrides the preset and
-    // gives us a hard ceiling regardless of update type. branchConcurrentLimit
-    // stays as a secondary guardrail.
+    // PR/branch throughput caps. All three live at the top level — these
+    // options aren't valid inside packageRules (no `parents: ['packageRules']`
+    // in renovate `lib/config/options/index.ts`).
+    //
+    // Important Renovate semantics (verified against
+    // `lib/workers/repository/process/limits.ts`):
+    //
+    //   - `prConcurrentLimit` and `branchConcurrentLimit` are **per-run**:
+    //     `getConcurrentPrsCount` iterates only the branches Renovate is
+    //     processing in the current run and counts how many already have
+    //     open PRs. PRs for deps not in the current run's update list
+    //     do NOT count. So this caps "new opens within a single run,"
+    //     not "total open across the repo." See
+    //     https://github.com/renovatebot/renovate/discussions/19585.
+    //
+    //   - `prHourlyLimit` is the only true global throttle: it scans
+    //     `platform.getPrList()` for every PR whose `sourceBranch`
+    //     starts with `branchPrefix` and was created this hour. With
+    //     our hourly-windowed cron it caps cross-run PR creation rate.
+    //
+    //   - Vulnerability alerts bypass all three (hardcoded in
+    //     `lib/workers/repository/update/branch/index.ts`, no config
+    //     toggle). CVE waves can overshoot — intentional.
+    //
+    // The shared preset extends `:disableRateLimiting` which sets all
+    // three to 0; these top-level values override that via the standard
+    // repo-wins config merge (`merge.ts` line 326).
     "prConcurrentLimit": 10,
     "branchConcurrentLimit": 10,
+    "prHourlyLimit": 2,
     // Keep manually-closed immortal/grouped PRs closed unless explicitly
     // reopened from the Dependency Dashboard.
     "recreateWhen": "never",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -48,6 +48,12 @@ permissions:
 
 jobs:
   renovate:
+    # Pause without merging a PR: set repo variable RENOVATE_PAUSED=true
+    # (Settings → Secrets and variables → Actions → Variables). Manual
+    # workflow_dispatch runs are exempt so you can still force a run while
+    # paused. The "Disable workflow" toggle in the Actions UI also works as
+    # a faster emergency stop.
+    if: ${{ vars.RENOVATE_PAUSED != 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -70,11 +70,48 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # True global cap on open Renovate PRs. Renovate's own
+      # `prConcurrentLimit` is per-run scoped (counts only branches in the
+      # current run's update list), so a global cap has to live outside
+      # Renovate. Count open PRs authored by the Renovate App; if at or
+      # above the cap, skip this tick. The next scheduled tick will run
+      # once automerge/review has drained the queue below the cap.
+      #
+      # Exemptions (always run regardless of backlog):
+      #   - workflow_dispatch — manual force-runs always proceed.
+      #   - The 14:17 UTC weekday CVE-pickup tick — exists specifically to
+      #     service `vulnerabilityAlerts.schedule: "at any time"`, and
+      #     vulnerability alerts bypass Renovate's own concurrent limits
+      #     by design. We don't want a stale backlog to block CVE flow.
+      #
+      # Tune via repo variable `RENOVATE_OPEN_PR_CAP` (default 10).
+      - name: Check open Renovate PR count
+        id: pr-cap
+        if: ${{ github.event_name == 'schedule' && github.event.schedule != '17 14 * * 1-5' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_CAP: ${{ vars.RENOVATE_OPEN_PR_CAP || '10' }}
+        run: |
+          set -euo pipefail
+          open_count=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --author "app/tryghost-renovate" \
+            --state open \
+            --json number --jq 'length')
+          echo "Renovate has $open_count open PRs (cap: $PR_CAP)"
+          if [ "$open_count" -ge "$PR_CAP" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Renovate run — $open_count open PRs at or above cap of $PR_CAP. Drain the queue or raise RENOVATE_OPEN_PR_CAP."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Allow manual run outside schedule
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.ignoreSchedule }}
         run: echo 'RENOVATE_FORCE={"schedule":null,"automergeSchedule":null}' >> "$GITHUB_ENV"
 
       - name: Self-hosted Renovate
+        if: ${{ steps.pr-cap.outputs.skip != 'true' }}
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
no ref

## Why

Renovate's `prConcurrentLimit` is per-run scoped, not global. From `lib/workers/repository/process/limits.ts`:

```ts
export async function getConcurrentPrsCount(config, branches) {
  let openPrCount = 0;
  for (const { branchName } of branches) {
    const pr = await platform.getBranchPr(branchName, config.baseBranch);
    if (pr && pr.state === 'open') openPrCount++;
  }
  return openPrCount;
}
```

It only counts open PRs **for branches in the current run's update list** — i.e. deps Renovate is actively trying to update right now. PRs for deps not in this run's update list don't count. Each hourly tick sees a different slice of in-scope branches, finds room under the per-run cap, and opens more. Steady-state: total open grows unbounded.

Mend masked this with a 4h tick; self-hosted hourly compounds the leak. The repo currently has 34 open Renovate PRs, all opened in the last 24h.

There's no Renovate config option that gives a true global cap on open PRs. `prConcurrentLimit`/`branchConcurrentLimit` are per-run. `prHourlyLimit` is a creation rate, not a backlog cap. `dependencyDashboardApproval` is per-PR manual gating.

So the global cap has to live outside Renovate, in the workflow that invokes it.

## What changed

**`.github/workflows/renovate.yml`**

- New step `Check open Renovate PR count` runs before the Renovate action. It counts open PRs authored by the `tryghost-renovate` App and skips the Renovate step if at or above the cap. The next scheduled tick runs once automerge/review drains the queue.
- Cap is configurable via repo variable `RENOVATE_OPEN_PR_CAP` (default `10`). Settings → Secrets and variables → Actions → Variables.
- Exemptions: `workflow_dispatch` always runs (manual force-runs), and the `17 14 * * 1-5` UTC tick is exempt (it exists specifically for CVE pickup; vulnerability alerts already hardcode-bypass Renovate's own limits).
- Added a `RENOVATE_PAUSED` repo-variable gate on the whole job for emergency stops without merging a PR.

**`.github/renovate.json5`**

- Added `prHourlyLimit: 2` as a secondary throttle. With the workflow cap as the hard ceiling, this just smooths each individual tick so a single run doesn't burst open many PRs in the moment the backlog clears.
- Rewrote the throughput-cap comment to accurately describe Renovate semantics (per-run vs global, vulnerability bypass, source-file references) so future readers don't repeat the wrong investigation.
- Kept `prConcurrentLimit: 10` / `branchConcurrentLimit: 10` as per-run safety nets.

## What to expect

- New scheduled ticks won't open PRs while ≥ 10 Renovate PRs are open. The existing 34-PR backlog has to drain through automerge / manual review before new ones can open.
- Hourly cap (`prHourlyLimit: 2`) provides smoothing within each individual run.
- CVEs continue to flow intraday via the exempt 14:17 UTC tick and Renovate's own vulnerability-alert bypass.
- To temporarily allow more, set `RENOVATE_OPEN_PR_CAP` to a higher number in repo variables (no merge needed).
- To pause entirely, set `RENOVATE_PAUSED=true` or disable the workflow in the Actions UI.

## Caveats

- Vulnerability alerts hardcode-bypass Renovate's three internal limits in `lib/workers/repository/update/branch/index.ts`. They will still open even if the workflow-level cap would otherwise skip — because the CVE-pickup tick is exempt, and other scheduled ticks that run (i.e. when below cap) will also open CVE PRs.
- `gh pr list --author "app/tryghost-renovate"` depends on the App's bot account name. If we ever rename the GitHub App, this query needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
