### PR TITLE
Added live cap for Renovate PR creation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,13 +2,12 @@
     "extends": [
         "github>tryghost/renovate-config"
     ],
-    // Cap total open Renovate PRs at 10. The shared preset extends
-    // :disableRateLimiting (prConcurrentLimit: 0, prHourlyLimit: 0), so
-    // branchConcurrentLimit alone leaks — it exempts grouped, automerge-
-    // eligible, and vulnerability PRs, and is enforced per-run rather than
-    // as a true total. Setting prConcurrentLimit overrides the preset and
-    // gives us a hard ceiling regardless of update type. branchConcurrentLimit
-    // stays as a secondary guardrail.
+    // Keep Renovate's own concurrency guardrails in place. The shared preset
+    // extends :disableRateLimiting (prConcurrentLimit: 0, prHourlyLimit: 0),
+    // so these override that unlimited default. The true "no more than 10
+    // open Renovate PRs" cap is enforced in .github/workflows/renovate.yml
+    // because Renovate's vulnerability-alert path can bypass these limits and
+    // because we need the cap to be based on the live GitHub PR count.
     "prConcurrentLimit": 10,
     "branchConcurrentLimit": 10,
     // Keep manually-closed immortal/grouped PRs closed unless explicitly
@@ -35,7 +34,8 @@
     // Soak every dependency update for 72 hours before opening a PR. This guards
     // against compromised publishes (malicious version yanked within a few hours)
     // and against unstable releases that get hotfixed shortly after publish.
-    // Applies to vulnerability alerts too — see the comment on vulnerabilityAlerts.
+    // Vulnerability-alert PRs require dashboard approval below so they do not
+    // bypass the live open-PR cap enforced by the workflow.
     "minimumReleaseAge": "3 days",
     "timezone": "Etc/UTC",
     // Restrict Renovate runs to the automerge windows so branch updates
@@ -51,8 +51,8 @@
     // self-hosted workflow that means a CI-storm of force-pushes across all
     // open Renovate PRs during the workday. Setting `updateNotScheduled:
     // false` keeps existing branch maintenance inside the same windows.
-    // `vulnerabilityAlerts.schedule: "at any time"` overrides this for
-    // CVE-driven PRs so security work still flows intraday.
+    // Existing branches can still be maintained outside the normal creation
+    // schedule when the workflow switches Renovate into cap-reached mode.
     "updateNotScheduled": false,
     "schedule": [
         // Run all weekend
@@ -74,12 +74,9 @@
         "* 22-23 * * 1-5",
         "* 0-4 * * 2-6"
     ],
-    // CVE-driven updates skip the weekend schedule and the dashboard-
-    // approval gate, and stay rebased against main so conflicts don't
-    // strand them. The 72h release-age soak from the top-level
-    // minimumReleaseAge still applies here so a malicious "fix" publish
-    // can't fast-track into main. Automerge is configured per update-type
-    // in packageRules below so security majors still wait for human review.
+    // Vulnerability alerts normally bypass Renovate's PR concurrency, hourly
+    // PR, and schedule limits. Let them keep doing that so security fixes can
+    // still create PRs even when normal dependency updates are capped.
     "vulnerabilityAlerts": {
         "schedule": ["at any time"],
         "rebaseWhen": "behind-base-branch",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,16 +4,18 @@ name: Renovate
 # more frequently than ~4h and clear the dependency backlog within the existing
 # automerge windows. See PLA-48 for the throughput rationale;
 # .github/renovate.json5 is still the source of truth for package rules,
-# schedule, and automergeSchedule.
+# schedule, and automergeSchedule. This workflow adds the live GitHub open-PR
+# cap because Renovate's config-level limits are not enough to express "run
+# maintenance, but create no more PRs once 10 are open."
 on:
   schedule:
     # Wake the runner only inside the windows where Renovate is actually
     # allowed to open or maintain PRs (see `schedule` in renovate.json5),
-    # plus a single weekday daytime tick to service `vulnerabilityAlerts.
-    # schedule: "at any time"` for CVE-driven PRs. Ticks outside those
-    # windows aren't no-ops in practice — each one is a 20-30min full
-    # extract — so the previous `17 * * * *` was burning ~17h/day of
-    # Actions compute for no merge benefit.
+    # plus a single weekday daytime tick to keep vulnerability-alert state
+    # fresh in the Dependency Dashboard. Ticks outside those windows aren't
+    # no-ops in practice — each one is a 20-30min full extract — so the
+    # previous `17 * * * *` was burning ~17h/day of Actions compute for no
+    # merge benefit.
     #
     # :17-past-the-hour offset avoids top-of-hour GH Actions scheduler
     # contention, which was dropping roughly every other tick on `0 * * * *`.
@@ -64,9 +66,61 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Allow manual run outside schedule
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.ignoreSchedule }}
-        run: echo 'RENOVATE_FORCE={"schedule":null,"automergeSchedule":null}' >> "$GITHUB_ENV"
+      # Enforce a live cap on open Renovate PRs while still letting Renovate
+      # maintain and automerge the PRs that already exist.
+      #
+      # Why this lives outside renovate.json5:
+      # - prConcurrentLimit/branchConcurrentLimit are useful guardrails, but
+      #   Renovate computes them from the branches in the current run rather
+      #   than by asking GitHub for every open Renovate PR.
+      # - vulnerability-alert PRs can bypass Renovate's normal branch, PR,
+      #   hourly, and schedule limits.
+      #
+      # Below the cap, restrict PR creation to the number of slots left. At or
+      # above the cap, or when RENOVATE_MAINTENANCE_ONLY=true, force dashboard
+      # approval for new branches/PRs while allowing existing PR branches to
+      # keep updating outside the creation schedule. That gives us "rebase and
+      # merge the 10, but create no more."
+      - name: Configure Renovate PR cap
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_CAP: ${{ vars.RENOVATE_OPEN_PR_CAP || '10' }}
+          MAINTENANCE_ONLY: ${{ vars.RENOVATE_MAINTENANCE_ONLY || 'false' }}
+          IGNORE_SCHEDULE: ${{ github.event_name == 'workflow_dispatch' && inputs.ignoreSchedule }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "$PR_CAP" =~ ^[0-9]+$ ]]; then
+            echo "::warning::RENOVATE_OPEN_PR_CAP must be a non-negative integer; falling back to 10."
+            PR_CAP=10
+          fi
+
+          open_count=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --author "app/tryghost-renovate" \
+            --state open \
+            --json number --jq 'length')
+
+          echo "Renovate has $open_count open PRs (cap: $PR_CAP)"
+
+          if [ "$MAINTENANCE_ONLY" = "true" ]; then
+            force='{"dependencyDashboardApproval":true,"prCreation":"approval","updateNotScheduled":true,"vulnerabilityAlerts":{"dependencyDashboardApproval":false}}'
+            echo "::notice::RENOVATE_MAINTENANCE_ONLY=true. Running in maintenance-only mode: existing PRs may update/automerge, new PRs require dashboard approval."
+          elif [ "$open_count" -ge "$PR_CAP" ]; then
+            force='{"dependencyDashboardApproval":true,"prCreation":"approval","updateNotScheduled":true,"vulnerabilityAlerts":{"dependencyDashboardApproval":false}}'
+            echo "::notice::Renovate is at or above the open PR cap. Running in maintenance-only mode: existing PRs may update/automerge, new PRs require dashboard approval."
+          else
+            remaining=$((PR_CAP - open_count))
+            force="{\"prHourlyLimit\":$remaining}"
+
+            if [ "$IGNORE_SCHEDULE" = "true" ]; then
+              force="{\"schedule\":null,\"automergeSchedule\":null,\"prHourlyLimit\":$remaining}"
+            fi
+
+            echo "Renovate may create up to $remaining PR(s) in this run."
+          fi
+
+          echo "RENOVATE_FORCE=$force" >> "$GITHUB_ENV"
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14


### PR DESCRIPTION
Replaces #28217.

## Why

Renovate currently has far more than 10 open PRs, but only a small number are security updates. The overrun is mostly normal dependency throughput: Renovate's config-level `prConcurrentLimit` / `branchConcurrentLimit` are useful guardrails, but they are not a live GitHub-wide open PR cap.

We want scheduled Renovate runs to work down the existing backlog by rebasing/updating/automerging open PRs, while preventing new normal dependency PR creation once the live Renovate PR count is at or above 10. Security alert PRs are allowed to continue creating above the cap.

## What changed

- Added a workflow preflight that counts open PRs authored by `app/tryghost-renovate`.
- Below the cap, sets `prHourlyLimit` to the remaining slots so one run cannot create normal dependency PRs past the cap.
- At or above the cap, runs Renovate in maintenance-only mode by requiring Dependency Dashboard approval for new normal dependency PR/branch creation while allowing existing branches to keep updating.
- Added `RENOVATE_MAINTENANCE_ONLY=true` as an operator override for the same maintenance-only behavior without pausing the whole Renovate job.
- Leaves vulnerability alerts on `dependencyDashboardApproval: false`, so security fixes can still create PRs above the normal cap.
- Validates `RENOVATE_OPEN_PR_CAP` before using it in shell arithmetic, falling back to 10 if misconfigured.

## Validation

- `pnpm dlx --package renovate renovate-config-validator .github/renovate.json5`
- YAML parse of `.github/workflows/renovate.yml`
- `bash -n` on the workflow shell step
- `git diff --check`