### PR TITLE
Converted redaction code to TypeScript

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -42,11 +42,11 @@ export class GhostStats {
         config.host = currentScript.getAttribute('data-host');
         config.token = currentScript.getAttribute('data-token') || null;
         config.domain = currentScript.getAttribute('data-domain');
-        
+
         // Get optional parameters
         config.datasource = currentScript.getAttribute('data-datasource') || config.datasource;
         config.stringifyPayload = currentScript.getAttribute('data-stringify-payload') !== 'false';
-        
+
         // Get global attributes
         for (const attr of currentScript.attributes) {
             if (attr.name.startsWith('tb_')) {
@@ -115,11 +115,11 @@ export class GhostStats {
             });
 
             this.browser.clearTimeout(timeoutId);
-            
+
             if (!response.ok) {
                 throw new Error(`HTTP error! Status: ${response.status}`);
             }
-            
+
             return response;
         } catch (error) {
             // Silently fail for tracking errors
@@ -141,9 +141,9 @@ export class GhostStats {
             // Get locale, falling back gracefully
             const navigator = this.browser.getNavigator();
             const locale = navigator?.languages?.[0] || navigator?.language || 'en';
-            return { 
+            return {
                 country: countryData ? countryData.id : null,  // Returns country code
-                locale 
+                locale
             };
         } catch (error) {
             return { country: null, locale: 'en' };
@@ -234,7 +234,7 @@ export class GhostStats {
 
         // Expose global API
         if (this.browser.window) {
-            this.browser.window.Tinybird = { 
+            this.browser.window.Tinybird = {
                 trackEvent: (name, payload) => this.trackEvent(name, payload),
                 _trackPageHit: () => this.trackPageHit()
             };
@@ -259,4 +259,4 @@ export const setupEventListeners = ghostStats.setupEventListeners.bind(ghostStat
 export const init = ghostStats.init.bind(ghostStats);
 
 // Also export the instance for testing
-export const ghostStatsInstance = ghostStats; 
+export const ghostStatsInstance = ghostStats;

--- a/ghost/core/core/frontend/src/utils/privacy.ts
+++ b/ghost/core/core/frontend/src/utils/privacy.ts
@@ -1,3 +1,5 @@
+import type {JsonValue} from 'type-fest';
+
 /**
  * Utility functions for data privacy and PII protection
  */
@@ -6,58 +8,52 @@
  * Default attributes that should be masked for privacy
  */
 export const SENSITIVE_ATTRIBUTES = [
-    'username', 
-    'user', 
-    'user_id', 
+    'username',
+    'user',
+    'user_id',
     'userid',
-    'password', 
-    'pass', 
-    'pin', 
+    'password',
+    'pass',
+    'pin',
     'passcode',
-    'token', 
-    'api_token', 
-    'email', 
+    'token',
+    'api_token',
+    'email',
     'address',
-    'phone', 
-    'sex', 
+    'phone',
+    'sex',
     'gender',
-    'order', 
-    'order_id', 
+    'order',
+    'order_id',
     'orderid',
-    'payment', 
+    'payment',
     'credit_card'
 ];
 
 /**
  * Mask sensitive attributes in a payload
- * 
- * @param {Object} payload - The payload to mask
- * @param {string[]} [attributesToMask] - Custom list of attributes to mask
- * @returns {string} JSON string with masked values
  */
-export function maskSensitiveData(payload, attributesToMask = SENSITIVE_ATTRIBUTES) {
+export function maskSensitiveData(payload: unknown, attributesToMask: ReadonlyArray<string> = SENSITIVE_ATTRIBUTES): string {
     // Deep copy
     let payloadStr = JSON.stringify(payload);
-    
-    attributesToMask.forEach(attr => {
+
+    attributesToMask.forEach((attr) => {
         payloadStr = payloadStr.replace(
             new RegExp(`("${attr}"):(".+?"|\\d+)`, 'mgi'),
             '$1:"********"'
         );
     });
-    
+
     return payloadStr;
 }
 
 /**
  * Process a payload with sensitive data masked
- * 
- * @param {Object} payload - The original payload 
- * @param {Object} globalAttributes - Additional attributes to add
- * @param {boolean} stringify - Whether to return a string or object
- * @returns {string|Object} Processed payload
  */
-export function processPayload(payload, globalAttributes = {}, stringify = true) {
+export function processPayload(payload: unknown, globalAttributes?: Record<string, unknown>, stringify?: true): string;
+export function processPayload(payload: unknown, globalAttributes: Record<string, unknown>, stringify: false): JsonValue;
+export function processPayload(payload: unknown, globalAttributes?: Record<string, unknown>, stringify?: boolean): string | JsonValue;
+export function processPayload(payload: unknown, globalAttributes = {}, stringify = true): string | JsonValue {
     if (stringify) {
         const maskedStr = maskSensitiveData(payload);
         const processed = Object.assign({}, JSON.parse(maskedStr), globalAttributes);
@@ -67,4 +63,4 @@ export function processPayload(payload, globalAttributes = {}, stringify = true)
         const maskedStr = maskSensitiveData(processed);
         return JSON.parse(maskedStr);
     }
-} 
+}

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -235,6 +235,7 @@
     "superagent-throttle": "1.0.1",
     "terser": "5.46.1",
     "tiny-glob": "0.2.9",
+    "type-fest": "catalog:",
     "ua-parser-js": "1.0.41",
     "xml": "1.0.1",
     "zod": "4.1.12"

--- a/ghost/core/test/unit/frontend/src/privacy.test.ts
+++ b/ghost/core/test/unit/frontend/src/privacy.test.ts
@@ -1,10 +1,8 @@
-const assert = require('node:assert/strict');
-
-// Use path relative to test file
-const {
+import assert from 'node:assert/strict';
+import {
     processPayload,
     maskSensitiveData
-} = require('../../../../core/frontend/src/utils/privacy');
+} from '../../../../core/frontend/src/utils/privacy';
 
 describe('Privacy Utils', function () {
     describe('maskSensitiveData', function () {
@@ -15,30 +13,30 @@ describe('Privacy Utils', function () {
                 email: 'john@example.com',
                 normal: 'data'
             };
-            
+
             const result = maskSensitiveData(payload);
             const parsed = JSON.parse(result);
-            
+
             assert.equal(parsed.user, '********');
             assert.equal(parsed.user_id, '********');
             assert.equal(parsed.email, '********');
             assert.equal(parsed.normal, 'data');
         });
-        
+
         it('should mask custom sensitive attributes', function () {
             const payload = {
                 custom_field: 'sensitive',
                 normal: 'data'
             };
-            
+
             const customAttributes = ['custom_field'];
             const result = maskSensitiveData(payload, customAttributes);
             const parsed = JSON.parse(result);
-            
+
             assert.equal(parsed.custom_field, '********');
             assert.equal(parsed.normal, 'data');
         });
-        
+
         it('should handle nested objects', function () {
             const payload = {
                 data: {
@@ -49,21 +47,21 @@ describe('Privacy Utils', function () {
                 },
                 normal: 'data'
             };
-            
+
             const result = maskSensitiveData(payload);
             const parsed = JSON.parse(result);
-            
+
             assert.equal(parsed.data.user, '********');
             assert.equal(parsed.data.details.email, '********');
             assert.equal(parsed.normal, 'data');
         });
-        
+
         it('should handle empty payloads', function () {
             const payload = {};
-            
+
             const result = maskSensitiveData(payload);
             const parsed = JSON.parse(result);
-            
+
             assert.deepEqual(parsed, {});
         });
     });
@@ -74,67 +72,70 @@ describe('Privacy Utils', function () {
                 email: 'john@example.com',
                 normal: 'data'
             };
-            
+
             const result = processPayload(payload);
-            
+
             assert.equal(typeof result, 'string');
             const parsed = JSON.parse(result);
             assert.equal(parsed.email, '********');
             assert.equal(parsed.normal, 'data');
         });
-        
+
         it('should add global attributes to payload', function () {
             const payload = {
                 data: 'value'
             };
-            
+
             const globalAttributes = {
                 global: 'attribute'
             };
-            
+
             const result = processPayload(payload, globalAttributes);
             const parsed = JSON.parse(result);
-            
+
             assert.equal(parsed.data, 'value');
             assert.equal(parsed.global, 'attribute');
         });
-        
+
         it('should return object when stringify is false', function () {
             const payload = {
                 email: 'john@example.com',
                 normal: 'data'
             };
-            
+
             const result = processPayload(payload, {}, false);
-            
-            assert.equal(typeof result, 'object');
-            assert.equal(result.email, '********');
-            assert.equal(result.normal, 'data');
+
+            assert.deepEqual(result, {
+                email: '********',
+                normal: 'data'
+            });
         });
-        
+
         it('should mask sensitive data in global attributes', function () {
             const payload = {
                 normal: 'data'
             };
-            
+
             const globalAttributes = {
                 email: 'john@example.com'
             };
-            
+
             const result = processPayload(payload, globalAttributes, false);
-            
-            assert.equal(result.email, '********');
-            assert.equal(result.normal, 'data');
+
+            assert.deepEqual(result, {
+                email: '********',
+                normal: 'data'
+            });
         });
-        
+
         it('should handle empty payload and attributes', function () {
             const payload = {};
             const globalAttributes = {};
-            
+
             const result = processPayload(payload, globalAttributes);
             const parsed = JSON.parse(result);
-            
+
             assert.deepEqual(parsed, {});
         });
     });
-}); 
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2628,6 +2628,9 @@ importers:
       tiny-glob:
         specifier: 0.2.9
         version: 0.2.9
+      type-fest:
+        specifier: 'catalog:'
+        version: 4.41.0
       ua-parser-js:
         specifier: 1.0.41
         version: 1.0.41


### PR DESCRIPTION
no ref

This change should have no user impact.

I recommend reviewing this with whitespace changes disabled. (My editor automatically removed a bunch of trailing whitespace which I didn't restore.)
