### PR TITLE
Improved CI execution planning

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,27 @@
+name: Setup pnpm workspace
+description: Setup pnpm, Node, and install workspace dependencies with one reusable CI step.
+
+inputs:
+  node-version:
+    description: Node.js version to install.
+    required: true
+  install-command:
+    description: pnpm install command to run after setup.
+    required: false
+    default: pnpm install --frozen-lockfile
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      env:
+        FORCE_COLOR: 0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: ${{ inputs.install-command }}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,12 +4,12 @@
     ],
     // Keep Renovate's own concurrency guardrails in place. The shared preset
     // extends :disableRateLimiting (prConcurrentLimit: 0, prHourlyLimit: 0),
-    // so these override that unlimited default. The true "no more than 10
-    // open Renovate PRs" cap is enforced in .github/workflows/renovate.yml
-    // because Renovate's vulnerability-alert path can bypass these limits and
-    // because we need the cap to be based on the live GitHub PR count.
-    "prConcurrentLimit": 10,
-    "branchConcurrentLimit": 10,
+    // so these override that unlimited default. Dependency automation should
+    // feed CI at a sustainable rate instead of opening a branch storm that
+    // turns every lockfile refresh into dozens of competing workflow runs.
+    "prConcurrentLimit": 3,
+    "branchConcurrentLimit": 3,
+    "prHourlyLimit": 1,
     // Keep manually-closed immortal/grouped PRs closed unless explicitly
     // reopened from the Dependency Dashboard.
     "recreateWhen": "never",

--- a/.github/scripts/ci-plan.js
+++ b/.github/scripts/ci-plan.js
@@ -1,0 +1,561 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {execFileSync} = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+const DEP_SECTIONS = [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies'
+];
+
+const RENOVATE_ONLY_FILES = new Set([
+    '.github/renovate.json5',
+    '.github/renovate-bot.cjs',
+    '.github/workflows/renovate.yml'
+]);
+
+const PUBLIC_APP_PACKAGES = [
+    {package_name: '@tryghost/activitypub', package_path: 'apps/activitypub'},
+    {package_name: '@tryghost/portal', package_path: 'apps/portal'},
+    {package_name: '@tryghost/sodo-search', package_path: 'apps/sodo-search'},
+    {package_name: '@tryghost/comments-ui', package_path: 'apps/comments-ui'},
+    {package_name: '@tryghost/signup-form', package_path: 'apps/signup-form'},
+    {package_name: '@tryghost/announcement-bar', package_path: 'apps/announcement-bar'}
+];
+
+const ALWAYS_CORE_RUNTIME_DEPS = new Set([
+    'bookshelf',
+    'express',
+    'knex',
+    'mysql',
+    'mysql2',
+    'sqlite3',
+    '@tryghost/api-framework',
+    '@tryghost/bookshelf-plugins',
+    '@tryghost/database-info',
+    '@tryghost/domain-events',
+    '@tryghost/errors',
+    '@tryghost/job-manager',
+    '@tryghost/mw-error-handler',
+    '@tryghost/mw-vhost',
+    '@tryghost/security',
+    '@tryghost/validator'
+]);
+
+const PLAYWRIGHT_DEPS = new Set([
+    '@playwright/test',
+    'playwright'
+]);
+
+const TOOLING_DEPS = new Set([
+    '@eslint/js',
+    '@types/node',
+    '@typescript-eslint/eslint-plugin',
+    '@typescript-eslint/parser',
+    'eslint',
+    'eslint-plugin-ghost',
+    'eslint-plugin-playwright',
+    'knip',
+    'nx',
+    'prettier',
+    'typescript',
+    'typescript-eslint',
+    'vite',
+    'vitest'
+]);
+
+const TEST_TOOLING_DEPS = new Set([
+    'nx',
+    'tsx',
+    'typescript',
+    'vitest'
+]);
+
+function run(command, args, options = {}) {
+    return execFileSync(command, args, {
+        cwd: ROOT,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', options.inheritStderr ? 'inherit' : 'pipe']
+    }).trim();
+}
+
+function splitLines(output) {
+    return output.split('\n').map(line => line.trim()).filter(Boolean);
+}
+
+function parseArgs(argv) {
+    const args = {};
+
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (!arg.startsWith('--')) {
+            continue;
+        }
+
+        const key = arg.slice(2);
+        const next = argv[i + 1];
+        if (!next || next.startsWith('--')) {
+            args[key] = true;
+        } else {
+            args[key] = next;
+            i += 1;
+        }
+    }
+
+    return args;
+}
+
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(path.join(ROOT, filePath), 'utf8'));
+}
+
+function readJsonAtRef(ref, filePath) {
+    try {
+        return JSON.parse(run('git', ['show', `${ref}:${filePath}`]));
+    } catch {
+        return null;
+    }
+}
+
+function getChangedFiles(base, head) {
+    if (!base || !head) {
+        return [];
+    }
+
+    return splitLines(run('git', ['diff', '--name-only', `${base}...${head}`]));
+}
+
+function listWorkspacePackages() {
+    const packages = [];
+    const patterns = ['apps', 'ghost'];
+
+    for (const pattern of patterns) {
+        const dir = path.join(ROOT, pattern);
+        if (!fs.existsSync(dir)) {
+            continue;
+        }
+
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+
+            const packagePath = `${pattern}/${entry.name}/package.json`;
+            const absolutePackagePath = path.join(ROOT, packagePath);
+            if (!fs.existsSync(absolutePackagePath)) {
+                continue;
+            }
+
+            const pkg = readJson(packagePath);
+            packages.push({
+                name: pkg.name || (pattern === 'ghost' && entry.name === 'core' ? 'ghost' : entry.name),
+                root: `${pattern}/${entry.name}`,
+                packagePath,
+                packageJson: pkg
+            });
+        }
+    }
+
+    if (fs.existsSync(path.join(ROOT, 'e2e/package.json'))) {
+        const pkg = readJson('e2e/package.json');
+        packages.push({
+            name: pkg.name || '@tryghost/e2e',
+            root: 'e2e',
+            packagePath: 'e2e/package.json',
+            packageJson: pkg
+        });
+    }
+
+    return packages;
+}
+
+function projectForPath(filePath, packages = listWorkspacePackages()) {
+    const match = packages
+        .filter(pkg => filePath === pkg.root || filePath.startsWith(`${pkg.root}/`))
+        .sort((a, b) => b.root.length - a.root.length)[0];
+
+    return match ? match.name : null;
+}
+
+function changedManifestDiffs(changedFiles, base, packages = listWorkspacePackages()) {
+    return changedFiles
+        .filter(file => file === 'package.json' || file.endsWith('/package.json'))
+        .map((file) => {
+            const before = base ? readJsonAtRef(base, file) : null;
+            const after = fs.existsSync(path.join(ROOT, file)) ? readJson(file) : null;
+
+            const changedDeps = [];
+            for (const section of DEP_SECTIONS) {
+                const beforeDeps = before?.[section] || {};
+                const afterDeps = after?.[section] || {};
+                const names = new Set([...Object.keys(beforeDeps), ...Object.keys(afterDeps)]);
+                for (const name of names) {
+                    if (beforeDeps[name] !== afterDeps[name]) {
+                        changedDeps.push({
+                            name,
+                            section,
+                            before: beforeDeps[name] || null,
+                            after: afterDeps[name] || null
+                        });
+                    }
+                }
+            }
+
+            return {
+                file,
+                project: projectForPath(file, packages),
+                changedDeps
+            };
+        });
+}
+
+function changedWorkspaceCatalogDiffs(changedFiles, base, head, packages = listWorkspacePackages()) {
+    if (!base || !head || !changedFiles.includes('pnpm-workspace.yaml')) {
+        return [];
+    }
+
+    let diff = '';
+    try {
+        diff = run('git', ['diff', '--unified=0', `${base}...${head}`, '--', 'pnpm-workspace.yaml']);
+    } catch {
+        return [];
+    }
+
+    const depNames = unique(splitLines(diff)
+        .filter(line => /^[+-]/.test(line) && !line.startsWith('+++') && !line.startsWith('---'))
+        .map(line => line.match(/^[+-]\s{2,}['"]?([^'":]+)['"]?:\s*/)?.[1])
+        .filter(Boolean));
+
+    const diffs = [];
+    for (const name of depNames) {
+        const consumers = packages.filter(pkg => DEP_SECTIONS.some((section) => {
+            const version = pkg.packageJson[section]?.[name];
+            return typeof version === 'string' && version.startsWith('catalog');
+        }));
+
+        if (consumers.length === 0) {
+            diffs.push({
+                file: 'pnpm-workspace.yaml',
+                project: null,
+                changedDeps: [{name, section: 'catalog', before: null, after: null}]
+            });
+            continue;
+        }
+
+        for (const consumer of consumers) {
+            diffs.push({
+                file: 'pnpm-workspace.yaml',
+                project: consumer.name,
+                changedDeps: [{name, section: 'catalog', before: null, after: null}]
+            });
+        }
+    }
+
+    return diffs;
+}
+
+function unique(values) {
+    return [...new Set(values.filter(Boolean))];
+}
+
+function compactCsv(values) {
+    return unique(values).join(',');
+}
+
+function bool(value) {
+    return value ? 'true' : 'false';
+}
+
+function isDocsFile(file) {
+    return file.endsWith('.md') || file.startsWith('docs/') || file.startsWith('adr/');
+}
+
+function isConfigOnlyFile(file) {
+    return file.startsWith('.vscode/') || file.startsWith('.devcontainer/');
+}
+
+function shardMatrix(project, total, extra = {}) {
+    return Array.from({length: total}, (_, index) => ({
+        project,
+        shardIndex: index + 1,
+        shardTotal: total,
+        ...extra
+    }));
+}
+
+function e2eMatrix({full = false, analytics = false} = {}) {
+    const mainTotal = full ? 12 : 6;
+    const matrix = Array.from({length: mainTotal}, (_, index) => ({
+        projectName: 'Main',
+        projects: 'main',
+        analytics: 'false',
+        shardIndex: index + 1,
+        shardTotal: mainTotal
+    }));
+
+    if (analytics) {
+        matrix.push(
+            {projectName: 'Analytics', projects: 'analytics', analytics: 'true', shardIndex: 1, shardTotal: 2},
+            {projectName: 'Analytics', projects: 'analytics', analytics: 'true', shardIndex: 2, shardTotal: 2}
+        );
+    }
+
+    return matrix;
+}
+
+function appAcceptanceMatrix(projects) {
+    const matrix = [];
+    for (const project of unique(projects)) {
+        if (project === '@tryghost/admin-x-settings') {
+            matrix.push(...shardMatrix(project, 4, {app: project}));
+        } else {
+            matrix.push({app: project, project, shardIndex: 1, shardTotal: 1});
+        }
+    }
+
+    return matrix;
+}
+
+function coreDbMatrix({full = false} = {}) {
+    const dbs = full ? [
+        {DB: 'mysql8', NODE_ENV: 'testing-mysql'},
+        {DB: 'sqlite3', NODE_ENV: 'testing'}
+    ] : [
+        {DB: 'mysql8', NODE_ENV: 'testing-mysql'}
+    ];
+    const suites = full ? ['api', 'integration', 'legacy'] : ['api', 'integration'];
+    const matrix = [];
+
+    for (const env of dbs) {
+        for (const suite of suites) {
+            matrix.push({suite, env});
+        }
+    }
+
+    return matrix;
+}
+
+function classifyDependencyChanges(manifestDiffs) {
+    const changedDeps = manifestDiffs.flatMap(diff => diff.changedDeps.map(dep => ({
+        ...dep,
+        project: diff.project,
+        file: diff.file
+    })));
+
+    const runtimeCore = changedDeps.some(dep => dep.project === 'ghost' || ALWAYS_CORE_RUNTIME_DEPS.has(dep.name));
+    const playwright = changedDeps.some(dep => PLAYWRIGHT_DEPS.has(dep.name));
+    const tooling = changedDeps.some(dep => (
+        TOOLING_DEPS.has(dep.name) ||
+        dep.section === 'devDependencies' ||
+        (dep.file === 'pnpm-workspace.yaml' && dep.project === null)
+    ));
+    const packageProjects = unique(manifestDiffs.map(diff => diff.project));
+
+    return {
+        changedDeps,
+        runtimeCore,
+        playwright,
+        tooling,
+        packageProjects
+    };
+}
+
+function buildPlan({
+    changedFiles,
+    base = '',
+    head = '',
+    eventName = 'pull_request',
+    isTag = false,
+    affectedProjects = [],
+    unitTestProjects = [],
+    playwrightProjects = [],
+    i18nProjects = [],
+    manifestDiffs: providedManifestDiffs = null
+}) {
+    const files = unique(changedFiles);
+    const packages = listWorkspacePackages();
+    const manifestDiffs = providedManifestDiffs || [
+        ...changedManifestDiffs(files, base, packages),
+        ...changedWorkspaceCatalogDiffs(files, base, head, packages)
+    ];
+    const dependencyChanges = classifyDependencyChanges(manifestDiffs);
+    const allProjectNames = packages.map(pkg => pkg.name);
+    const lintableProjectNames = packages.filter(pkg => hasTarget(pkg, 'lint')).map(pkg => pkg.name);
+
+    const hasFiles = files.length > 0;
+    const docsOnly = hasFiles && files.every(file => isDocsFile(file) || isConfigOnlyFile(file));
+    const renovateOnly = hasFiles && files.every(file => RENOVATE_ONLY_FILES.has(file));
+    const ciChanged = files.some(file => (
+        file.startsWith('.github/workflows/') ||
+        file.startsWith('.github/actions/') ||
+        file.startsWith('.github/scripts/')
+    ) && !RENOVATE_ONLY_FILES.has(file));
+    const full = Boolean(isTag || ciChanged || eventName === 'merge_group');
+    const anyCode = hasFiles && !docsOnly && !renovateOnly;
+    const tinybird = full || files.some(file => (
+        file === 'compose.dev.analytics.yaml' ||
+        file.startsWith('ghost/core/core/server/data/tinybird/')
+    ) && !file.endsWith('.md'));
+    const tinybirdDatafiles = files.some(file => (
+        file.startsWith('ghost/core/core/server/data/tinybird/') && !file.endsWith('.md')
+    ));
+
+    const directlyChangedProjects = unique(files.map(file => projectForPath(file, packages)));
+    const depOnly = anyCode && files.every(file => (
+        file === 'pnpm-lock.yaml' ||
+        file === 'pnpm-workspace.yaml' ||
+        file === 'package.json' ||
+        file.endsWith('/package.json')
+    ));
+
+    const changedCore = full || files.some(file => (
+        file.startsWith('ghost/core/') &&
+        !file.startsWith('ghost/core/test/unit/') &&
+        file !== 'ghost/core/vitest.config.ts' &&
+        !file.startsWith('ghost/core/core/server/data/tinybird/')
+    )) || dependencyChanges.runtimeCore;
+
+    const runBrowserE2E = full || files.some(file => (
+        file.startsWith('e2e/') ||
+        file.startsWith('apps/portal/') ||
+        file.startsWith('apps/comments-ui/') ||
+        file.startsWith('apps/sodo-search/') ||
+        file.startsWith('apps/signup-form/') ||
+        file.startsWith('apps/announcement-bar/') ||
+        file.startsWith('ghost/core/core/frontend/')
+    )) || dependencyChanges.playwright;
+
+    const i18nChanged = full || files.some(file => file.startsWith('ghost/i18n/') || file.includes('/locales/')) || i18nProjects.length > 0;
+
+    const allProjects = full ? allProjectNames : [];
+    const affected = full ? allProjects : unique([
+        ...affectedProjects,
+        ...directlyChangedProjects,
+        ...dependencyChanges.packageProjects
+    ]);
+
+    const rootToolingChange = dependencyChanges.tooling && dependencyChanges.packageProjects.length === 0;
+    const testToolingChange = dependencyChanges.changedDeps.some(dep => TEST_TOOLING_DEPS.has(dep.name));
+    const lintProjects = docsOnly || renovateOnly ? [] : (depOnly ? unique([
+        ...dependencyChanges.packageProjects,
+        ...(dependencyChanges.runtimeCore ? ['ghost'] : []),
+        ...(rootToolingChange ? lintableProjectNames : [])
+    ]).filter(project => lintableProjectNames.includes(project)) : affected.filter(project => lintableProjectNames.includes(project)));
+
+    const units = docsOnly || renovateOnly ? [] : (full ? unitTestProjects : unique([
+        ...unitTestProjects.filter(project => lintProjects.includes(project)),
+        ...dependencyChanges.packageProjects.filter(Boolean),
+        ...(changedCore ? ['ghost'] : []),
+        ...(testToolingChange ? unitTestProjects : [])
+    ]));
+
+    const appAcceptanceProjects = docsOnly || renovateOnly ? [] : (full ? playwrightProjects : (depOnly ? (
+        dependencyChanges.playwright ? playwrightProjects : []
+    ) : unique([
+        ...playwrightProjects.filter(project => lintProjects.includes(project)),
+        ...directlyChangedProjects.filter(project => project?.startsWith('@tryghost/') && project !== '@tryghost/e2e')
+    ])));
+
+    const publicAppBuildProjects = runBrowserE2E ? PUBLIC_APP_PACKAGES : PUBLIC_APP_PACKAGES.filter(project => lintProjects.includes(project.package_name));
+
+    const unitMatrix = units.flatMap(project => (
+        project === 'ghost' ? shardMatrix('ghost', 4) : [{project, shardIndex: 1, shardTotal: 1}]
+    ));
+    const appMatrix = appAcceptanceMatrix(appAcceptanceProjects);
+    const coreMatrix = changedCore ? coreDbMatrix({full}) : [];
+    const browserMatrix = runBrowserE2E ? e2eMatrix({full, analytics: full || tinybird}) : [];
+    const packageBuildMatrix = publicAppBuildProjects;
+
+    return {
+        metadata: {
+            base,
+            head,
+            eventName,
+            files,
+            dependencyChanges: dependencyChanges.changedDeps,
+            full,
+            depOnly
+        },
+        outputs: {
+            affected_projects: JSON.stringify(affected),
+            affected_projects_str: compactCsv(affected),
+            lint_projects_str: compactCsv(lintProjects),
+            unit_test_projects_str: compactCsv(units),
+            affected_playwright_projects: JSON.stringify(appAcceptanceProjects),
+            changed_i18n_apps: bool(i18nChanged),
+            changed_core: bool(changedCore),
+            changed_tinybird: bool(tinybird),
+            changed_tinybird_datafiles: bool(tinybirdDatafiles),
+            changed_any_code: bool(anyCode),
+            run_e2e: bool(runBrowserE2E),
+            run_coverage: bool(full || eventName === 'push'),
+            unit_test_matrix: JSON.stringify({include: unitMatrix}),
+            app_acceptance_matrix: JSON.stringify({include: appMatrix}),
+            core_db_matrix: JSON.stringify({include: coreMatrix}),
+            e2e_matrix: JSON.stringify({include: browserMatrix}),
+            package_build_matrix: JSON.stringify({include: packageBuildMatrix})
+        }
+    };
+}
+
+function hasTarget(pkg, target) {
+    return Boolean(pkg.packageJson.scripts?.[target] || pkg.packageJson.nx?.targets?.[target]);
+}
+
+function writeGithubOutputs(outputs, outputPath) {
+    const lines = [];
+    for (const [key, value] of Object.entries(outputs)) {
+        lines.push(`${key}=${value}`);
+    }
+    fs.appendFileSync(outputPath, `${lines.join('\n')}\n`);
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const base = args.base || process.env.NX_BASE || '';
+    const head = args.head || process.env.NX_HEAD || process.env.HEAD_COMMIT || 'HEAD';
+    const eventName = args.event || process.env.GITHUB_EVENT_NAME || 'pull_request';
+    const isTag = args['is-tag'] === 'true' || process.env.IS_TAG === 'true';
+
+    const packages = listWorkspacePackages();
+    const changedFiles = isTag ? splitLines(run('git', ['ls-files'])) : getChangedFiles(base, head);
+    const affectedProjects = unique(changedFiles.map(file => projectForPath(file, packages)));
+    const unitTestProjects = packages.filter(pkg => hasTarget(pkg, 'test:unit')).map(pkg => pkg.name);
+    const playwrightProjects = packages
+        .filter(pkg => pkg.root.startsWith('apps/') && hasTarget(pkg, 'test:acceptance'))
+        .map(pkg => pkg.name);
+
+    const plan = buildPlan({
+        changedFiles,
+        base,
+        head,
+        eventName,
+        isTag,
+        affectedProjects,
+        unitTestProjects,
+        playwrightProjects,
+        i18nProjects: []
+    });
+
+    console.log(JSON.stringify(plan, null, 2));
+
+    if (process.env.GITHUB_OUTPUT) {
+        writeGithubOutputs(plan.outputs, process.env.GITHUB_OUTPUT);
+    }
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    buildPlan,
+    classifyDependencyChanges,
+    projectForPath
+};

--- a/.github/scripts/ci-plan.test.js
+++ b/.github/scripts/ci-plan.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const {describe, it} = require('node:test');
+const assert = require('node:assert');
+const {buildPlan, projectForPath} = require('./ci-plan');
+
+function plan(input) {
+    return buildPlan({
+        base: 'base',
+        head: 'head',
+        eventName: 'pull_request',
+        affectedProjects: [],
+        unitTestProjects: [],
+        playwrightProjects: [
+            '@tryghost/activitypub',
+            '@tryghost/admin-x-settings',
+            '@tryghost/comments-ui'
+        ],
+        i18nProjects: [],
+        ...input
+    }).outputs;
+}
+
+function includeMatrix(output) {
+    return JSON.parse(output).include;
+}
+
+describe('ci-plan', () => {
+    it('maps files to workspace projects', () => {
+        assert.strictEqual(projectForPath('ghost/core/package.json'), 'ghost');
+        assert.strictEqual(projectForPath('apps/admin-x-settings/src/App.tsx'), '@tryghost/admin-x-settings');
+        assert.strictEqual(projectForPath('e2e/tests/public/homepage.test.ts'), '@tryghost/e2e');
+    });
+
+    it('skips expensive lanes for docs-only changes', () => {
+        const outputs = plan({
+            changedFiles: ['docs/README.md', 'adr/0001-aaa-test-structure.md']
+        });
+
+        assert.strictEqual(outputs.changed_any_code, 'false');
+        assert.strictEqual(outputs.changed_core, 'false');
+        assert.strictEqual(outputs.run_e2e, 'false');
+        assert.deepStrictEqual(includeMatrix(outputs.unit_test_matrix), []);
+        assert.deepStrictEqual(includeMatrix(outputs.app_acceptance_matrix), []);
+    });
+
+    it('does not turn lockfile-only Renovate changes into full-repo CI', () => {
+        const outputs = plan({
+            changedFiles: ['pnpm-lock.yaml', 'pnpm-workspace.yaml']
+        });
+
+        assert.strictEqual(outputs.changed_any_code, 'true');
+        assert.strictEqual(outputs.changed_core, 'false');
+        assert.strictEqual(outputs.run_e2e, 'false');
+        assert.strictEqual(outputs.lint_projects_str, '');
+        assert.deepStrictEqual(includeMatrix(outputs.core_db_matrix), []);
+    });
+
+    it('maps core runtime dependency updates to core lanes only', () => {
+        const outputs = plan({
+            changedFiles: ['ghost/core/package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml'],
+            manifestDiffs: [{
+                file: 'ghost/core/package.json',
+                project: 'ghost',
+                changedDeps: [{
+                    name: 'mysql2',
+                    section: 'dependencies',
+                    before: '3.18.1',
+                    after: '3.22.3'
+                }]
+            }]
+        });
+
+        assert.strictEqual(outputs.changed_core, 'true');
+        assert.strictEqual(outputs.run_e2e, 'false');
+        assert.strictEqual(outputs.lint_projects_str, 'ghost');
+        assert.strictEqual(outputs.unit_test_projects_str, 'ghost');
+        assert.strictEqual(includeMatrix(outputs.unit_test_matrix).length, 4);
+        assert.deepStrictEqual(includeMatrix(outputs.app_acceptance_matrix), []);
+        assert.deepStrictEqual(includeMatrix(outputs.e2e_matrix), []);
+    });
+
+    it('maps Playwright updates to browser/app acceptance lanes', () => {
+        const outputs = plan({
+            changedFiles: ['package.json', 'pnpm-lock.yaml'],
+            manifestDiffs: [{
+                file: 'package.json',
+                project: null,
+                changedDeps: [{
+                    name: '@playwright/test',
+                    section: 'devDependencies',
+                    before: '1.59.0',
+                    after: '1.60.0'
+                }]
+            }]
+        });
+
+        assert.strictEqual(outputs.run_e2e, 'true');
+        assert.ok(includeMatrix(outputs.app_acceptance_matrix).some(item => item.app === '@tryghost/admin-x-settings'));
+        assert.ok(includeMatrix(outputs.app_acceptance_matrix).some(item => item.app === '@tryghost/admin-x-settings' && item.shardTotal === 4));
+        assert.ok(includeMatrix(outputs.e2e_matrix).length > 0);
+    });
+
+    it('maps root tooling updates to tooling lanes instead of no-op CI', () => {
+        const outputs = plan({
+            changedFiles: ['package.json', 'pnpm-lock.yaml'],
+            affectedProjects: [],
+            unitTestProjects: ['ghost', '@tryghost/admin-x-settings'],
+            manifestDiffs: [{
+                file: 'package.json',
+                project: null,
+                changedDeps: [{
+                    name: 'knip',
+                    section: 'devDependencies',
+                    before: '6.12.0',
+                    after: '6.14.2'
+                }]
+            }]
+        });
+
+        assert.strictEqual(outputs.changed_core, 'false');
+        assert.strictEqual(outputs.run_e2e, 'false');
+        assert.notStrictEqual(outputs.lint_projects_str, '');
+        assert.deepStrictEqual(includeMatrix(outputs.core_db_matrix), []);
+        assert.deepStrictEqual(includeMatrix(outputs.app_acceptance_matrix), []);
+    });
+
+    it('runs full matrices for CI workflow changes', () => {
+        const outputs = plan({
+            changedFiles: ['.github/workflows/ci.yml'],
+            affectedProjects: ['ghost', '@tryghost/admin-x-settings'],
+            unitTestProjects: ['ghost'],
+            playwrightProjects: ['@tryghost/admin-x-settings']
+        });
+
+        assert.strictEqual(outputs.changed_core, 'true');
+        assert.strictEqual(outputs.run_e2e, 'true');
+        assert.strictEqual(outputs.run_coverage, 'true');
+        assert.ok(outputs.affected_projects_str.includes('ghost'));
+        assert.ok(outputs.affected_projects_str.includes('@tryghost/admin-x-settings'));
+        assert.ok(includeMatrix(outputs.core_db_matrix).some(item => item.suite === 'legacy'));
+    });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      # Required by dorny/paths-filter, which calls pulls.listFiles on
-      # pull_request events. Private forks of this repo don't grant this
-      # implicitly when an explicit permissions block is present, so it must
-      # be listed here for the Setup job to succeed on those forks.
+      # Required for PR metadata reads used by setup-time policy checks.
       pull-requests: read
     steps:
       - name: Checkout current commit
@@ -87,143 +84,44 @@ jobs:
             echo "is_member=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Determine changed packages
-        if: env.IS_TAG != 'true'
-        uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5.0.0
-        id: changed
-        with:
-          base: ${{ env.NX_BASE }}
-          filters: |
-            shared: &shared
-              - '.github/**'
-              # Renovate config / workflow files have no Ghost
-              # runtime/test impact. Anchored as &renovate_only and
-              # referenced from every filter below so a PR touching
-              # only these files skips all downstream jobs; the
-              # rollup gate passes on skipped deps.
-              - &renovate_only
-                - '!.github/renovate.json5'
-                - '!.github/renovate-bot.cjs'
-                - '!.github/workflows/renovate.yml'
-              - '.npmrc'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-            ci:
-              - '.github/workflows/**'
-              - *renovate_only
-              - '.github/actions/**'
-              - '.github/scripts/**'
-            core:
-              - *shared
-              - 'ghost/**'
-              - '!ghost/admin/**'
-              - '!ghost/core/core/server/data/tinybird/**'
-              # Unit tests + vitest config are exercised only by job_unit-tests;
-              # they never affect the acceptance / legacy / ghost-cli jobs.
-              - '!ghost/core/test/unit/**'
-              - '!ghost/core/vitest.config.ts'
-              - '!ghost/core/test/utils/vitest-setup.ts'
-            tinybird:
-              - '.github/workflows/ci.yml'
-              - 'compose.dev.analytics.yaml'
-              - 'ghost/core/core/server/data/tinybird/**'
-              - '!ghost/core/core/server/data/tinybird/**/*.md'
-            tinybird-datafiles:
-              - 'ghost/core/core/server/data/tinybird/**'
-              - '!ghost/core/core/server/data/tinybird/**/*.md'
-            unit-test-globals:
-              - 'vitest.config.mjs'
-            core-unit-test-globals:
-              - 'ghost/core/vitest.config.ts'
-              - 'ghost/core/test/utils/vitest-*.ts'
-            any-code:
-              - '!**/*.md'
-              - '!.devcontainer/**'
-              - '!.vscode/**'
-              - *renovate_only
-            # Drives the run_e2e output: matches any changed file that could
-            # affect a running Ghost instance. Test files, test config and
-            # docs are excluded — a change confined to them cannot alter
-            # product behaviour, so the build + E2E lane is skipped.
-            # ghost/core test paths are listed today; app test paths can be
-            # added here as their conventions are confirmed.
-            e2e:
-              - '!**/*.md'
-              - '!.devcontainer/**'
-              - '!.vscode/**'
-              - '!ghost/core/test/**'
-              - '!ghost/core/vitest.config.ts'
-              - *renovate_only
-
       - name: Define Node test matrix
         id: node_matrix
         run: |
-          echo 'matrix=["22.18.0"]' >> $GITHUB_OUTPUT
+          echo 'matrix=["22.18.0"]' >> "$GITHUB_OUTPUT"
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        env:
-          FORCE_COLOR: 0
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+          install-command: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Determine Affected Projects
-        id: affected
+      - name: Generate CI execution plan
+        id: plan
         run: |
-          # if the ci files have changed or we're in a tag, ensure we don't just look at affected
-          # projects and we run the necessary jobs on all projects
-          AFFECTED_ARG="--affected"
-          if [[ "${{ steps.changed.outputs.ci }}" == 'true' || "${{ env.IS_TAG }}" == 'true' ]]; then
-            AFFECTED_ARG=""
-          fi
-
-          AFFECTED_PROJECTS=$(pnpm -s nx show projects ${AFFECTED_ARG} --json)
-          echo "affected_projects=$AFFECTED_PROJECTS" >> "$GITHUB_OUTPUT"
-          # string list for use in run-many commands
-          AFFECTED_PROJECTS_STR=$(pnpm -s nx show projects ${AFFECTED_ARG} --sep=, | tr -d '\n')
-          echo "affected_projects_str=$AFFECTED_PROJECTS_STR" >> "$GITHUB_OUTPUT"
-
-          UNIT_TEST_AFFECTED_ARG="$AFFECTED_ARG"
-          if [[ "${{ steps.changed.outputs.unit-test-globals }}" == 'true' ]]; then
-            UNIT_TEST_AFFECTED_ARG=""
-          fi
-          UNIT_TEST_PROJECTS_STR=$(pnpm -s nx show projects ${UNIT_TEST_AFFECTED_ARG} --withTarget test:unit --sep=, | tr -d '\n')
-          if [[ "${{ steps.changed.outputs.core-unit-test-globals }}" == 'true' ]]; then
-            UNIT_TEST_PROJECTS_STR=$(printf '%s\n%s\n' "$UNIT_TEST_PROJECTS_STR" "ghost" | awk 'NF && !seen[$0]++' | paste -sd, -)
-          fi
-          echo "unit_test_projects_str=$UNIT_TEST_PROJECTS_STR" >> "$GITHUB_OUTPUT"
-
-          # "i18n" tag = packages whose source is scanned by @tryghost/i18n's
-          # translate:* scripts (not packages that merely import @tryghost/i18n).
-          I18N_PROJECTS=$(pnpm -s nx show projects ${AFFECTED_ARG} --projects 'tag:i18n' --sep=, | tr -d '\n')
-          echo "affected_i18n_projects=${I18N_PROJECTS}" >> "$GITHUB_OUTPUT"
-
-          PLAYWRIGHT_PROJECTS=$(pnpm -s nx show projects ${AFFECTED_ARG} \
-            --withTarget test:acceptance \
-            --projects 'apps/*' \
-            --json)
-          echo "affected_playwright_projects=$PLAYWRIGHT_PROJECTS" >> "$GITHUB_OUTPUT"
+          node .github/scripts/ci-plan.js \
+            --base "${NX_BASE:-}" \
+            --head "${NX_HEAD:-${HEAD_COMMIT}}" \
+            --event "${{ github.event_name }}" \
+            --is-tag "${{ env.IS_TAG }}"
 
     outputs:
-      affected_projects: ${{ steps.affected.outputs.affected_projects }}
-      affected_projects_str: ${{ steps.affected.outputs.affected_projects_str }}
-      unit_test_projects_str: ${{ steps.affected.outputs.unit_test_projects_str }}
-      affected_playwright_projects: ${{ steps.affected.outputs.affected_playwright_projects }}
-      changed_i18n_apps: ${{ steps.affected.outputs.affected_i18n_projects != '' }}
-      changed_core: ${{ steps.changed.outputs.core }}
-      changed_tinybird: ${{ steps.changed.outputs.tinybird }}
-      changed_tinybird_datafiles: ${{ steps.changed.outputs.tinybird-datafiles }}
-      changed_any_code: ${{ steps.changed.outputs.any-code }}
-      # Single gate for the build + browser-E2E lane. True for tags, or when a
-      # changed file could affect a running Ghost instance (see the `e2e` path
-      # filter above). A test-only / docs-only change keeps this false.
-      run_e2e: ${{ env.IS_TAG == 'true' || steps.changed.outputs.e2e == 'true' }}
+      affected_projects: ${{ steps.plan.outputs.affected_projects }}
+      affected_projects_str: ${{ steps.plan.outputs.affected_projects_str }}
+      lint_projects_str: ${{ steps.plan.outputs.lint_projects_str }}
+      unit_test_projects_str: ${{ steps.plan.outputs.unit_test_projects_str }}
+      affected_playwright_projects: ${{ steps.plan.outputs.affected_playwright_projects }}
+      changed_i18n_apps: ${{ steps.plan.outputs.changed_i18n_apps }}
+      changed_core: ${{ steps.plan.outputs.changed_core }}
+      changed_tinybird: ${{ steps.plan.outputs.changed_tinybird }}
+      changed_tinybird_datafiles: ${{ steps.plan.outputs.changed_tinybird_datafiles }}
+      changed_any_code: ${{ steps.plan.outputs.changed_any_code }}
+      run_e2e: ${{ steps.plan.outputs.run_e2e }}
+      run_coverage: ${{ steps.plan.outputs.run_coverage }}
+      unit_test_matrix: ${{ steps.plan.outputs.unit_test_matrix }}
+      app_acceptance_matrix: ${{ steps.plan.outputs.app_acceptance_matrix }}
+      core_db_matrix: ${{ steps.plan.outputs.core_db_matrix }}
+      e2e_matrix: ${{ steps.plan.outputs.e2e_matrix }}
+      package_build_matrix: ${{ steps.plan.outputs.package_build_matrix }}
       is_main: ${{ env.IS_MAIN }}
       is_tag: ${{ env.IS_TAG }}
       is_development: ${{ env.IS_DEVELOPMENT }}
@@ -279,22 +177,16 @@ jobs:
   job_lint:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.affected_projects_str != ''
+    if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.lint_projects_str != ''
     name: Lint
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        env:
-          FORCE_COLOR: 0
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
@@ -302,7 +194,7 @@ jobs:
           key: eslint-cache
 
       - name: Lint projects
-        run: pnpm nx run-many -t lint -p "${{ needs.job_setup.outputs.affected_projects_str }}"
+        run: pnpm nx run-many -t lint -p "${{ needs.job_setup.outputs.lint_projects_str }}"
         env:
           NX_BASE: ${{ needs.job_setup.outputs.nx_base }}
           NX_HEAD: ${{ env.HEAD_COMMIT }}
@@ -323,14 +215,11 @@ jobs:
       || needs.job_setup.outputs.changed_i18n_apps == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --filter @tryghost/i18n... --ignore-scripts
+          install-command: pnpm install --frozen-lockfile --filter @tryghost/i18n... --ignore-scripts
 
       - name: Run i18n tests
         run: pnpm --filter @tryghost/i18n test
@@ -346,17 +235,13 @@ jobs:
       MOZ_HEADLESS: 1
       JOBS: 1
       CI: true
-      COVERAGE: true
+      COVERAGE: ${{ needs.job_setup.outputs.run_coverage }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - run: pnpm nx run ghost-admin:test
         env:
@@ -364,9 +249,11 @@ jobs:
 
       # Merge coverage reports and upload
       - name: Merge Admin test coverage
+        if: needs.job_setup.outputs.run_coverage == 'true'
         run: pnpm ember coverage-merge
         working-directory: ghost/admin
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: needs.job_setup.outputs.run_coverage == 'true'
         with:
           name: admin-coverage
           path: ghost/*/coverage/cobertura-coverage.xml
@@ -383,27 +270,22 @@ jobs:
     needs: [job_setup]
     if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.unit_test_projects_str != ''
     strategy:
-      matrix:
-        node: ${{ fromJSON(needs.job_setup.outputs.node_test_matrix) }}
-    name: Unit tests (Node ${{ matrix.node }})
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.job_setup.outputs.unit_test_matrix) }}
+    name: Unit tests (${{ matrix.project }} ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        env:
-          FORCE_COLOR: 0
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
-          node-version: ${{ matrix.node }}
-          cache: pnpm
-
-      - name: Install dependencies
-        # sqlite3 is an optionalDependency. Without --force, pnpm may skip
-        # installing/linking it when restoring from a cached store. --force
-        # ensures all optional deps are installed regardless.
-        # (ghost core's test:unit job requires sqlite3)
-        run: pnpm install --frozen-lockfile --force
+          node-version: ${{ env.NODE_VERSION }}
+          # sqlite3 is an optionalDependency. Without --force, pnpm may skip
+          # installing/linking it when restoring from a cached store. --force
+          # ensures all optional deps are installed regardless.
+          # (ghost core's test:unit job requires sqlite3)
+          install-command: pnpm install --frozen-lockfile --force
 
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
@@ -420,8 +302,20 @@ jobs:
         # passed, so a retry only re-runs the crashed one. Interim stopgap
         # until the vitest worker/teardown issue is fixed.
         run: |
+          PROJECT="${{ matrix.project }}"
+          SHARD_INDEX="${{ matrix.shardIndex }}"
+          SHARD_TOTAL="${{ matrix.shardTotal }}"
+
+          if [ "$PROJECT" = "ghost" ]; then
+            pnpm nx run @tryghost/parse-email-address:build
+            pnpm nx run ghost:build:assets
+            TEST_CMD=(pnpm --dir ghost/core test:vitest -- --shard="${SHARD_INDEX}/${SHARD_TOTAL}")
+          else
+            TEST_CMD=(pnpm nx run "${PROJECT}:test:unit")
+          fi
+
           for attempt in 1 2 3; do
-            pnpm nx run-many -t test:unit -p "${{ needs.job_setup.outputs.unit_test_projects_str }}" && exit 0
+            "${TEST_CMD[@]}" && exit 0
             if [ "${attempt}" -lt 3 ]; then
               echo "::warning::Unit tests attempt ${attempt} failed — retrying"
             else
@@ -453,7 +347,7 @@ jobs:
   job_acceptance-tests:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.changed_core == 'true'
+    if: needs.job_setup.outputs.core_db_matrix != '{"include":[]}'
     services:
       mysql:
         image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
@@ -478,40 +372,26 @@ jobs:
           --health-timeout=5s
           --health-retries=12
     strategy:
-      matrix:
-        node: ${{ fromJSON(needs.job_setup.outputs.node_test_matrix) }}
-        env:
-          - DB: mysql8
-            NODE_ENV: testing-mysql
-        include:
-          - node: ${{ needs.job_setup.outputs.node_version }}
-            env:
-              DB: sqlite3
-              NODE_ENV: testing
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.job_setup.outputs.core_db_matrix) }}
     env:
       DB: ${{ matrix.env.DB }}
       NODE_ENV: ${{ matrix.env.NODE_ENV }}
-    name: Acceptance tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
+    name: Core ${{ matrix.suite }} tests (${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        env:
-          FORCE_COLOR: 0
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
-          node-version: ${{ matrix.node }}
-          cache: pnpm
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: ${{ matrix.env.DB == 'sqlite3' && 'pnpm install --frozen-lockfile --force' || 'pnpm install --frozen-lockfile' }}
 
-      - name: Install dependencies
-        # sqlite3 is an optionalDependency. Without --force, pnpm may skip
-        # installing/linking it when restoring from a cached store. --force
-        # ensures all optional deps are installed regardless.
-        run: |
-          if [ "${{ matrix.env.DB }}" = "sqlite3" ]; then
-            pnpm install --frozen-lockfile --force
-          else
-            pnpm install --frozen-lockfile
-          fi
+      - name: Checkout default themes
+        if: matrix.suite == 'legacy'
+        run: git submodule update --init --depth=1 ghost/core/content/themes/casper ghost/core/content/themes/source
+
+      - name: Build core test dependencies
+        run: pnpm nx run @tryghost/parse-email-address:build
 
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
@@ -520,19 +400,23 @@ jobs:
 
       - name: Set env vars (SQLite)
         if: contains(matrix.env.DB, 'sqlite')
-        run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
+        run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> "$GITHUB_ENV"
 
       - name: Set env vars (MySQL)
         if: contains(matrix.env.DB, 'mysql')
         run: |
-          echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
-          echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
-          echo "database__connection__password=root" >> $GITHUB_ENV
+          {
+            echo "database__connection__host=127.0.0.1"
+            echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}"
+            echo "database__connection__password=root"
+          } >> "$GITHUB_ENV"
 
       - name: E2E tests
-        run: pnpm nx run ghost:test:ci:e2e
+        if: matrix.suite == 'api'
+        run: pnpm --dir ghost/core test:e2e -b
 
       - name: Start MinIO for integration tests
+        if: matrix.suite == 'integration'
         run: |
           docker run -d --rm --name minio \
             -p 9000:9000 \
@@ -552,101 +436,12 @@ jobs:
           exit 1
 
       - name: Integration tests
-        run: pnpm nx run ghost:test:ci:integration
-
-      - name: Check for unexpected file changes
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "Tests generated unexpected file changes. Commit them before merging:"
-            git status
-            git diff
-            exit 1
-          fi
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: matrix.node == env.NODE_VERSION && contains(matrix.env.DB, 'mysql')
-        with:
-          name: e2e-coverage
-          path: |
-            ghost/*/coverage-e2e/cobertura-coverage.xml
-            ghost/*/coverage-integration/cobertura-coverage.xml
-
-      - uses: tryghost/actions/actions/slack-build@128d496a57fb11e44e97d690f0d5381c58e52489 # main
-        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        with:
-          status: ${{ job.status }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  job_legacy-tests:
-    runs-on: ubuntu-latest
-    needs: [job_setup]
-    if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.changed_core == 'true'
-    services:
-      mysql:
-        image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
-        env:
-          MYSQL_DATABASE: ghost_testing
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306
-        options: >-
-          --tmpfs /var/lib/mysql
-          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=12
-    strategy:
-      matrix:
-        include:
-          - node: ${{ needs.job_setup.outputs.node_version }}
-            env:
-              DB: mysql8
-              NODE_ENV: testing-mysql
-          - node: ${{ needs.job_setup.outputs.node_version }}
-            env:
-              DB: sqlite3
-              NODE_ENV: testing
-    env:
-      DB: ${{ matrix.env.DB }}
-      NODE_ENV: ${{ matrix.env.NODE_ENV }}
-    name: Legacy tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        env:
-          FORCE_COLOR: 0
-        with:
-          node-version: ${{ matrix.node }}
-          cache: pnpm
-
-      - name: Install dependencies
-        # sqlite3 is an optionalDependency. Without --force, pnpm may skip
-        # installing/linking it when restoring from a cached store. --force
-        # ensures all optional deps are installed regardless.
-        run: |
-          if [ "${{ matrix.env.DB }}" = "sqlite3" ]; then
-            pnpm install --frozen-lockfile --force
-          else
-            pnpm install --frozen-lockfile
-          fi
-
-      - name: Set env vars (SQLite)
-        if: contains(matrix.env.DB, 'sqlite')
-        run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
-
-      - name: Set env vars (MySQL)
-        if: contains(matrix.env.DB, 'mysql')
-        run: |
-          echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
-          echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
-          echo "database__connection__password=root" >> $GITHUB_ENV
+        if: matrix.suite == 'integration'
+        run: pnpm --dir ghost/core test:integration -b
 
       - name: Legacy tests
-        run: pnpm nx run ghost:test:ci:legacy
+        if: matrix.suite == 'legacy'
+        run: pnpm --dir ghost/core test:legacy -b
 
       - name: Check for unexpected file changes
         run: |
@@ -667,32 +462,25 @@ jobs:
   job_apps_acceptance-tests:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.affected_playwright_projects != '[]'
+    if: needs.job_setup.outputs.app_acceptance_matrix != '{"include":[]}'
     name: App Playwright Acceptance Tests
     strategy:
       fail-fast: false
-      matrix:
-        app: ${{ fromJSON(needs.job_setup.outputs.affected_playwright_projects) }}
+      matrix: ${{ fromJSON(needs.job_setup.outputs.app_acceptance_matrix) }}
     env:
       CI: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        env:
-          FORCE_COLOR: 0
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
 
       - name: Run Playwright tests
-        run: pnpm nx run ${{ matrix.app }}:test:acceptance
+        run: pnpm nx run ${{ matrix.app }}:test:acceptance -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Get App Name
         if: always()
@@ -700,13 +488,13 @@ jobs:
         # trim '@tryghost/' prefix for better readability in test report artifact names
         run: |
           APP_NAME="${{ matrix.app }}"
-          echo "name=${APP_NAME#@tryghost/}" >> $GITHUB_OUTPUT
+          echo "name=${APP_NAME#@tryghost/}" >> "$GITHUB_OUTPUT"
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ steps.app_name.outputs.name }}-playwright-report
+          name: ${{ steps.app_name.outputs.name }}-${{ matrix.shardIndex }}-playwright-report
           path: apps/${{ steps.app_name.outputs.name }}/playwright-report
           retention-days: 30
 
@@ -831,16 +619,10 @@ jobs:
         with:
           submodules: true
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        env:
-          FORCE_COLOR: 0
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build server and admin assets
         run: |
@@ -1095,17 +877,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        env:
-          FORCE_COLOR: 0
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build public apps for E2E
         run: pnpm --filter @tryghost/e2e build:apps
@@ -1247,68 +1022,7 @@ jobs:
     if: needs.job_build_e2e_image.result == 'success'
     strategy:
       fail-fast: true
-      matrix:
-        include:
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 1
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 2
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 3
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 4
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 5
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 6
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 7
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 8
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 9
-            shardTotal: 10
-          - projectName: Main
-            projects: main
-            analytics: 'false'
-            shardIndex: 10
-            shardTotal: 10
-          - projectName: Analytics
-            projects: analytics
-            analytics: 'true'
-            shardIndex: 1
-            shardTotal: 2
-          - projectName: Analytics
-            projects: analytics
-            analytics: 'true'
-            shardIndex: 2
-            shardTotal: 2
+      matrix: ${{ fromJSON(needs.job_setup.outputs.e2e_matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1340,14 +1054,10 @@ jobs:
           image-tags: ${{ needs.job_build_e2e_image.outputs.image-tags }}
           artifact-name: docker-image-e2e
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Prepare E2E CI job
         env:
@@ -1486,10 +1196,12 @@ jobs:
   job_coverage:
     name: Coverage
     needs: [
+      job_setup,
       job_admin-tests,
       job_acceptance-tests,
       job_unit-tests
     ]
+    if: needs.job_setup.outputs.run_coverage == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1506,60 +1218,10 @@ jobs:
           rsync -av --remove-source-files admin/* ghost/admin
 
       - name: Upload Admin test coverage
+        if: contains(needs.job_admin-tests.result, 'success')
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           flags: admin-tests
-
-      - name: Restore E2E coverage
-        if: contains(needs.job_acceptance-tests.result, 'success')
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: e2e-coverage
-
-      - name: Move coverage
-        if: contains(needs.job_acceptance-tests.result, 'success')
-        run: |
-          rsync -av --remove-source-files core/* ghost/core
-
-      - name: Upload E2E test coverage
-        if: contains(needs.job_acceptance-tests.result, 'success')
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
-        with:
-          flags: e2e-tests
-
-  job_required_tests:
-    name: All required tests passed or skipped
-    needs:
-      [
-        job_setup,
-        job_app_version_bump_check,
-        job_migration_integrity_check,
-        job_lint,
-        job_i18n,
-        job_build_artifacts,
-        job_ghost-cli,
-        job_admin-tests,
-        job_unit-tests,
-        job_acceptance-tests,
-        job_legacy-tests,
-        job_apps_acceptance-tests,
-        job_tinybird-tests,
-        job_build_e2e_public_apps,
-        job_build_e2e_image,
-        job_e2e_tests,
-        build_packages,
-        publish_packages
-      ]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Output needs
-        run: echo "${{ toJson(needs) }}"
-
-      - name: Check if any required jobs failed or been cancelled
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: |
-          echo "One of the dependent jobs have failed or been cancelled. You may need to re-run it." && exit 1
 
   # Build verification for @tryghost/* public apps.
   # Runs on PRs and pushes. Intentionally has no `id-token: write` — PR-controlled
@@ -1577,33 +1239,15 @@ jobs:
     permissions:
       contents: read
     strategy:
-      matrix:
-        include:
-          - package_name: '@tryghost/activitypub'
-            package_path: 'apps/activitypub'
-          - package_name: '@tryghost/portal'
-            package_path: 'apps/portal'
-          - package_name: '@tryghost/sodo-search'
-            package_path: 'apps/sodo-search'
-          - package_name: '@tryghost/comments-ui'
-            package_path: 'apps/comments-ui'
-          - package_name: '@tryghost/signup-form'
-            package_path: 'apps/signup-form'
-          - package_name: '@tryghost/announcement-bar'
-            package_path: 'apps/announcement-bar'
+      matrix: ${{ fromJSON(needs.job_setup.outputs.package_build_matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build the package
         run: pnpm nx build ${{ matrix.package_name }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,7 +6,7 @@ name: Renovate
 # .github/renovate.json5 is still the source of truth for package rules,
 # schedule, and automergeSchedule. This workflow adds the live GitHub open-PR
 # cap because Renovate's config-level limits are not enough to express "run
-# maintenance, but create no more PRs once 10 are open."
+# maintenance, but create no more PRs once the configured live cap is reached."
 on:
   schedule:
     # Wake the runner only inside the windows where Renovate is actually
@@ -84,15 +84,15 @@ jobs:
       - name: Configure Renovate PR cap
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_CAP: ${{ vars.RENOVATE_OPEN_PR_CAP || '10' }}
+          PR_CAP: ${{ vars.RENOVATE_OPEN_PR_CAP || '3' }}
           MAINTENANCE_ONLY: ${{ vars.RENOVATE_MAINTENANCE_ONLY || 'false' }}
           IGNORE_SCHEDULE: ${{ github.event_name == 'workflow_dispatch' && inputs.ignoreSchedule }}
         run: |
           set -euo pipefail
 
           if ! [[ "$PR_CAP" =~ ^[0-9]+$ ]]; then
-            echo "::warning::RENOVATE_OPEN_PR_CAP must be a non-negative integer; falling back to 10."
-            PR_CAP=10
+            echo "::warning::RENOVATE_OPEN_PR_CAP must be a non-negative integer; falling back to 3."
+            PR_CAP=3
           fi
 
           open_count=$(gh pr list \

--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,9 @@
         "sharedGlobals": [
             "{workspaceRoot}/.npmrc",
             "{workspaceRoot}/ghost/tsconfig.json",
-            "{workspaceRoot}/package.json",
+            "{workspaceRoot}/package.json"
+        ],
+        "dependencyGraph": [
             "{workspaceRoot}/pnpm-workspace.yaml",
             "{workspaceRoot}/pnpm-lock.yaml"
         ]


### PR DESCRIPTION
## What changed

This replaces the static CI fanout with a generated execution plan that maps changed files and dependency updates to the smallest relevant set of lanes.

Key changes:
- adds `.github/scripts/ci-plan.js` plus unit tests
- routes lint, unit, app acceptance, core DB, E2E, and package build matrices from planner outputs
- shards Ghost Vitest and `admin-x-settings` Playwright acceptance jobs
- removes coverage instrumentation from normal correctness lanes
- keeps lockfile/catalog changes out of Nx shared globals
- adds a reusable pnpm setup action
- tightens Renovate PR creation pressure without disabling Renovate

## Why

Recent dependency-only PRs were running broad, unrelated CI matrices because lockfile/catalog changes invalidated almost everything and the workflow used static fanout. That made routine dependency updates consume excessive runner time and wall-clock time.

The planner classifies dependency updates by consumer so runtime core changes, Playwright changes, tooling changes, docs-only changes, and Renovate-only changes get different CI plans.

## Validation

- `node --test .github/scripts/ci-plan.test.js`
- YAML parse for CI workflow, Renovate workflow, and setup action
- `actionlint` schema validation via Docker with shellcheck disabled
- `git diff --check`
- scenario checks for docs-only, `mysql2`, admin UI, and tooling dependency changes
