### PR TITLE
🐛 Fixed post analytics missing first-day traffic on later days

### DIFF
--- a/apps/shade/src/lib/app-utils.ts
+++ b/apps/shade/src/lib/app-utils.ts
@@ -242,10 +242,10 @@ export const calculateYAxisWidth = (ticks: number[], formatter: (value: number) 
 
 // Get range for date
 export const getRangeForStartDate = (startDate: string) => {
-    const publishedDate = new Date(startDate);
-    const today = new Date();
-    const diffInTime = today.getTime() - publishedDate.getTime();
-    const diffInDays = Math.ceil(diffInTime / (1000 * 3600 * 24));
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const publishedDate = moment(startDate).tz(timezone).startOf('day');
+    const today = moment().tz(timezone).startOf('day');
+    const diffInDays = today.diff(publishedDate, 'days') + 1;
 
     // Ensure minimum of 1 day to avoid issues with same-day publications
     return Math.max(diffInDays, 1);

--- a/apps/shade/test/unit/utils/utils.test.ts
+++ b/apps/shade/test/unit/utils/utils.test.ts
@@ -6,6 +6,8 @@ import {
     formatQueryDate,
     formatDisplayDate,
     formatDisplayTime,
+    getRangeDates,
+    getRangeForStartDate,
     formatNumber,
     formatDuration,
     formatPercentage,
@@ -122,6 +124,41 @@ describe('utils', function () {
             const date = moment('2023-04-15');
             const formattedDate = formatQueryDate(date);
             assert.equal(formattedDate, '2023-04-15');
+        });
+    });
+
+    describe('getRangeForStartDate function', function () {
+        const currentTime = new Date('2026-05-28T09:00:00-04:00');
+        const publishedAt = '2026-05-26T12:00:00-04:00';
+
+        afterEach(function () {
+            vi.useRealTimers();
+        });
+
+        it('counts calendar days inclusively before the publish time-of-day has passed', function () {
+            vi.useFakeTimers();
+            vi.setSystemTime(currentTime);
+
+            const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            const expectedRange = moment(currentTime).tz(timezone).startOf('day')
+                .diff(moment(publishedAt).tz(timezone).startOf('day'), 'days') + 1;
+
+            const range = getRangeForStartDate(publishedAt);
+
+            assert.equal(range, expectedRange);
+        });
+
+        it('produces a date range that includes the publish calendar day', function () {
+            vi.useFakeTimers();
+            vi.setSystemTime(currentTime);
+
+            const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            const expectedStartDate = moment(publishedAt).tz(timezone).startOf('day');
+
+            const range = getRangeForStartDate(publishedAt);
+            const {startDate} = getRangeDates(range);
+
+            assert.equal(formatQueryDate(startDate), formatQueryDate(expectedStartDate));
         });
     });
 


### PR DESCRIPTION
ref [ONC-1771](https://linear.app/ghost/issue/ONC-1771/post-audience-wrong-data-after-days-of-publish)

Post analytics was calculating the publish-date range from elapsed hours, while the chart query dates are calendar-day based. This meant posts could lose their publication-day traffic whenever the current time was earlier than the original publish time.

So if you published on Monday at 11am, you'd have the following:
- Monday: you'd see stats all day
- Tuesday before 11am: you'd only see Tuesday stats
- Tuesday after 11am: you'd correctly see Tuesday and Monday
and so on

This PR updates the range calculation to count inclusive calendar days in the same timezone used by the chart date query, so the publish day is always included.

<h3>Before</h3>

  <table>
    <tr>
      <th>Analytics overview</th>
      <th>Post analytics</th>
    </tr>
    <tr>
      <td>Shows <strong>115 views</strong> for the post.</td>
      <td>Shows only <strong>15 unique visitors</strong>: 10 on 5/27 and 5 on 5/28. The <strong>100 visitors from publish day, 5/26, are missing</strong>.</td>
    </tr>
    <tr>
      <td>
        <img width="1270" height="936" alt="Screenshot 2026-05-28 at 12 28 16 PM" src="https://github.com/user-attachments/assets/af7ff895-62d5-4818-bf8c-cd7d0744f12c" />       </td>
      <td>
        <img width="1280" height="682" alt="Screenshot 2026-05-28 at 12 28 05 PM" src="https://github.com/user-attachments/assets/a0848cad-a630-475f-9071-4d2f0c5ae373" />       </td>
    </tr>
  </table>

<table>
 <tr>
<td>The control renders properly, however. See analytics overview above: we expect 90, we get 90 on post analytics</td>
</tr>
  <tr>
    <td>
<img width="1280" height="682" alt="Screenshot 2026-05-28 at 12 28 05 PM" src="https://github.com/user-attachments/assets/a6273b72-8752-4380-b208-366a150d1fb2" /> </td>
  </tr>
<table>

  <h3>After</h3>

  <table>
    <tr>
      <th>Post analytics</th>
    </tr>
    <tr>
      <td>Correctly shows data for all 3 days, including publish day.</td>
    </tr>
    <tr>
      <td>
        <img width="1292" height="812" alt="Screenshot 2026-05-28 at 12 32 02 PM" src="https://github.com/user-attachments/assets/896e0070-e35a-4265-bca6-657901d8d0c7" />       </td>
    </tr>
  </table>