### PR TITLE
Updated Renovate quiet-hours schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,9 +41,9 @@
     // Restrict Renovate runs to the automerge windows so branch updates
     // (rebasing, force-pushes) happen around the same times automerge
     // can actually complete, not during the working day when CI is busy.
-    // Each block starts one hour earlier than the matching automerge
-    // window so Renovate has time to rebase and open/refresh PRs before
-    // automerge is eligible to run.
+    // Weekday windows are intentionally narrow now that the self-hosted runner
+    // can tick hourly, leaving a larger shared quiet period across US and
+    // European core working hours.
     //
     // `schedule` alone only gates *new* PR creation — Renovate defaults to
     // `updateNotScheduled: true`, which lets existing branches keep getting
@@ -57,22 +57,18 @@
     "schedule": [
         // Run all weekend
         "* * * * 0,6",
-        // Run on Monday morning (Sun 23:00 is already covered by weekend)
-        "* 0-12 * * 1",
-        // Run on weekday evenings, starting 1 hour earlier than automerge
-        "* 21-23 * * 1-5",
+        // Run on weekday evenings
+        "* 23 * * 1-5",
         // Run on early weekday mornings (previous day 23:00 is already
-        // covered by the evening block above)
-        "* 0-4 * * 2-6"
+        // covered by the evening/weekend blocks above)
+        "* 0-4 * * 1-6"
     ],
     "automergeSchedule": [
         // Allow automerge all weekend
         "* * * * 0,6",
-        // Allow automerge on Monday morning
-        "* 0-12 * * 1",
-        // Allow automerge overnight on weekday evenings (10pm-4:59am UTC)
-        "* 22-23 * * 1-5",
-        "* 0-4 * * 2-6"
+        // Allow automerge overnight on weekday evenings (11pm-4:59am UTC)
+        "* 23 * * 1-5",
+        "* 0-4 * * 1-6"
     ],
     // Vulnerability alerts normally bypass Renovate's PR concurrency, hourly
     // PR, and schedule limits. Let them keep doing that so security fixes can

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,12 +23,10 @@ on:
     # duration, giving each merge a fresh rebase + green CI window.
     #
     # Times are UTC; matches renovate.json5's `schedule` block.
-    # Monday morning window (Mon 00:00-12:59 UTC)
-    - cron: '17 0-12 * * 1'
-    # Weekday early-morning window (Tue-Sat 00:00-04:59 UTC)
-    - cron: '17 0-4 * * 2-6'
-    # Weekday evening window (Mon-Fri 21:00-23:59 UTC)
-    - cron: '17 21-23 * * 1-5'
+    # Weekday early-morning window (Mon-Sat 00:00-04:59 UTC)
+    - cron: '17 0-4 * * 1-6'
+    # Weekday evening window (Mon-Fri 23:00-23:59 UTC)
+    - cron: '17 23 * * 1-5'
     # Weekend - every 2h is plenty; no automerge urgency, just batch creation
     - cron: '17 */2 * * 0,6'
     # Weekday daytime CVE pickup tick (Mon-Fri 14:17 UTC)


### PR DESCRIPTION
## Summary
- narrows the weekday Renovate schedule to 23:00-04:59 UTC
- aligns automerge and GitHub Actions wakeups with the same six-hour window
- removes the old Monday daytime UTC tail so Amsterdam core hours stay quieter

## Testing
- pnpm exec node -e "const fs=require('fs'); const jsonc=require('jsonc-parser'); const text=fs.readFileSync('.github/renovate.json5','utf8'); const errors=[]; jsonc.parse(text, errors, {allowTrailingComma:true, disallowComments:false}); if (errors.length) { console.error(errors); process.exit(1); } console.log('renovate.json5 parses');"