### PR TITLE
🐛 Fixed production builds using unpinned dependencies

### DIFF
--- a/ghost/core/scripts/pack.js
+++ b/ghost/core/scripts/pack.js
@@ -69,12 +69,9 @@ for (const section of ['dependencies', 'devDependencies', 'optionalDependencies'
 //   - catalog + catalogs (lockfile records & validates these)
 //   - allowBuilds + strictDepBuilds (end-user installs need this to permit
 //     native module post-install scripts like sqlite3, sharp, re2)
+//   - overrides + packageExtensions (root dependency policy must apply to the
+//     standalone install as well as the source workspace)
 // We deliberately drop:
-//   - overrides + packageExtensions: pnpm deploy already applied them to
-//     the resolved package.json and the deploy lockfile does not record
-//     them. Shipping them in workspace.yaml causes pnpm 11's
-//     frozen-lockfile install (CI=true default for ghost-cli) to fail
-//     ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
 //   - packages: relative paths that don't exist in the deployed dir.
 //   - minimumReleaseAge, blockExoticSubdeps, catalogMode: source-repo
 //     supply-chain policies that aren't meaningful at end-user install.
@@ -85,7 +82,7 @@ const workspaceSrc = path.join(ROOT_DIR, 'pnpm-workspace.yaml');
 const workspaceDst = path.join(DEPLOY_DIR, 'pnpm-workspace.yaml');
 const rootWorkspace = yaml.load(fs.readFileSync(workspaceSrc, 'utf8'));
 const deployWorkspace = {};
-for (const key of ['catalog', 'catalogs', 'allowBuilds', 'strictDepBuilds']) {
+for (const key of ['catalog', 'catalogs', 'allowBuilds', 'strictDepBuilds', 'overrides', 'packageExtensions']) {
     if (rootWorkspace[key] !== undefined) {
         deployWorkspace[key] = rootWorkspace[key];
     }
@@ -98,7 +95,7 @@ for (const key of ['catalog', 'catalogs', 'allowBuilds', 'strictDepBuilds']) {
 deployWorkspace.minimumReleaseAge = 0;
 fs.writeFileSync(workspaceDst, yaml.dump(deployWorkspace));
 
-console.log('Wrote trimmed pnpm-workspace.yaml (catalogs + allowBuilds, age check off)');
+console.log('Wrote trimmed pnpm-workspace.yaml (catalogs + overrides + allowBuilds, age check off)');
 
 // Pack private workspace packages as component tarballs.
 // These are not on npm, so ghost-cli can't install them from the registry.
@@ -139,7 +136,7 @@ if (!rootPkg.packageManager) {
 pkg.packageManager = rootPkg.packageManager;
 console.log(`  Set packageManager: ${rootPkg.packageManager.split('+')[0]}`);
 
-// pnpm overrides live in the published pnpm-workspace.yaml (copied above).
+// pnpm overrides live in the published pnpm-workspace.yaml (written above).
 // pnpm 11 only reads overrides from workspace.yaml, not from a package's
 // `pnpm.overrides`. We deliberately do NOT also write pnpm.overrides here:
 // pnpm 11 still hashes that field into its lockfile-overrides-config check,
@@ -183,6 +180,9 @@ if (!packagedPkg.packageManager) {
 const packagedWorkspace = yaml.load(fs.readFileSync(workspaceDst, 'utf8'));
 if (!packagedWorkspace?.catalog || Object.keys(packagedWorkspace.catalog).length === 0) {
     throw new Error('Packaged pnpm-workspace.yaml is missing the default catalog');
+}
+if (!packagedWorkspace?.overrides || Object.keys(packagedWorkspace.overrides).length === 0) {
+    throw new Error('Packaged pnpm-workspace.yaml is missing root overrides');
 }
 
 // 4. Create tarball


### PR DESCRIPTION
## Summary

- preserved root `pnpm-workspace.yaml` `overrides` and `packageExtensions` in the Ghost deploy archive
- kept the pnpm 11 lockfile regeneration flow so frozen production installs remain valid
- added validation that packaged archives include root overrides

## Why

The pnpm 11 archive flow was writing a trimmed deploy workspace that dropped root overrides. That let production archives resolve a different dependency graph from the source workspace, including changed versions for packages such as `@tryghost/errors`, `moment-timezone`, `juice`, and other transitive dependencies.

## Testing

- `CI=true pnpm --filter ghost archive`
- extracted `ghost/core/ghost-6.42.1-rc.0.tgz` and confirmed `pnpm-workspace.yaml` contains `catalog`, `catalogs`, `overrides`, `packageExtensions`, and `minimumReleaseAge: 0`
- from the extracted package: `CI=true pnpm install --prod --frozen-lockfile --ignore-scripts`
- confirmed the install output resolves pinned packages including `@tryghost/errors 1.3.13`, `moment-timezone 0.5.45`, and `juice 9.1.0`
