### PR TITLE
Added admin-toolbar to CI publish pipeline and release tooling

### DIFF
--- a/.devcontainer/compose.devcontainer.yaml
+++ b/.devcontainer/compose.devcontainer.yaml
@@ -48,4 +48,5 @@ services:
       SIGNUP_DEV_SERVER: ghost-dev:6174
       SEARCH_DEV_SERVER: ghost-dev:4178
       ANNOUNCEMENT_DEV_SERVER: ghost-dev:4177
+      ADMIN_TOOLBAR_DEV_SERVER: ghost-dev:4176
       LEXICAL_DEV_SERVER: ghost-dev:4173

--- a/.github/scripts/check-app-version-bump.js
+++ b/.github/scripts/check-app-version-bump.js
@@ -22,6 +22,10 @@ const MONITORED_APPS = {
     signupForm: {
         packageName: '@tryghost/signup-form',
         path: 'apps/signup-form'
+    },
+    adminToolbar: {
+        packageName: '@tryghost/admin-toolbar',
+        path: 'apps/admin-toolbar'
     }
 };
 

--- a/.github/scripts/release-apps.js
+++ b/.github/scripts/release-apps.js
@@ -11,7 +11,8 @@ const CONFIG_KEYS = {
     '@tryghost/sodo-search': 'sodoSearch',
     '@tryghost/comments-ui': 'comments',
     '@tryghost/announcement-bar': 'announcementBar',
-    '@tryghost/signup-form': 'signupForm'
+    '@tryghost/signup-form': 'signupForm',
+    '@tryghost/admin-toolbar': 'adminToolbar'
 };
 
 const CURRENT_DIR = process.cwd();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1117,7 +1117,8 @@ jobs:
             apps/comments-ui/umd \
             apps/sodo-search/umd \
             apps/signup-form/umd \
-            apps/announcement-bar/umd
+            apps/announcement-bar/umd \
+            apps/admin-toolbar/umd
           ls -lh e2e-public-apps.tar.gz
 
       - name: Upload public app artifacts
@@ -1591,6 +1592,8 @@ jobs:
             package_path: 'apps/signup-form'
           - package_name: '@tryghost/announcement-bar'
             package_path: 'apps/announcement-bar'
+          - package_name: '@tryghost/admin-toolbar'
+            package_path: 'apps/admin-toolbar'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1653,6 +1656,9 @@ jobs:
           - package_name: '@tryghost/announcement-bar'
             package_path: 'apps/announcement-bar'
             cdn_paths: 'https://cdn.jsdelivr.net/ghost/announcement-bar@~CURRENT_MINOR/umd/announcement-bar.min.js'
+          - package_name: '@tryghost/admin-toolbar'
+            package_path: 'apps/admin-toolbar'
+            cdn_paths: 'https://cdn.jsdelivr.net/ghost/admin-toolbar@~CURRENT_MINOR/umd/admin-toolbar.min.js'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -5,7 +5,6 @@
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "files": [
-    "src/",
     "umd/",
     "LICENSE",
     "README.md"
@@ -22,7 +21,10 @@
     "build:watch": "pnpm exec vite build --watch",
     "dev": "concurrently --kill-others --names preview,build \"pnpm exec vite preview -l silent\" \"pnpm build:watch\"",
     "lint": "pnpm exec eslint src --ext .js --cache",
-    "test": "pnpm run build && pnpm exec mocha --exit --trace-warnings --timeout=60000 \"test/**/*.test.js\""
+    "test": "pnpm run build && pnpm exec mocha --exit --trace-warnings --timeout=60000 \"test/**/*.test.js\"",
+    "preship": "pnpm lint",
+    "ship": "node ../../.github/scripts/release-apps.js",
+    "prepublishOnly": "pnpm build"
   },
   "devDependencies": {
     "concurrently": "catalog:",


### PR DESCRIPTION
## Summary
- The `@tryghost/admin-toolbar` package was never published to npm, so the jsDelivr CDN URL returns 404 in production — the toolbar only worked in dev mode where Docker overrides the URL to a local Vite server.
- Added admin-toolbar to the CI `build_packages` and `publish_packages` matrices, the E2E artifact archive, version bump checks, release scripts, and devcontainer config — matching the setup of every other public app (portal, comments-ui, sodo-search, signup-form, announcement-bar).

## Changes
- `.github/workflows/ci.yml` — added to `build_packages` matrix, `publish_packages` matrix, and E2E tar archive
- `.github/scripts/release-apps.js` — added to `CONFIG_KEYS` so `pnpm ship` works
- `.github/scripts/check-app-version-bump.js` — added to `MONITORED_APPS` so version bumps are enforced on PRs
- `apps/admin-toolbar/package.json` — added `ship`/`preship`/`prepublishOnly` scripts, removed `src/` from published files
- `.devcontainer/compose.devcontainer.yaml` — added `ADMIN_TOOLBAR_DEV_SERVER` env var

## Test plan
- [ ] CI passes (no runtime changes, only CI/release config)
- [ ] After merge, verify `@tryghost/admin-toolbar` appears on npm
- [ ] After npm publish, verify jsDelivr serves `https://cdn.jsdelivr.net/ghost/admin-toolbar@~0.1/umd/admin-toolbar.min.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)