### PR TITLE
Updated update-check service URL to check.ghost.org

### DIFF
--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -10,7 +10,7 @@
         "redirects": true
     },
     "updateCheck": {
-        "url": "https://updates.ghost.org",
+        "url": "https://check.ghost.org",
         "forceUpdate": false
     },
     "privacy": false,


### PR DESCRIPTION
## Problem

Ghost's update-check service runs on `updates.ghost.org` (a DigitalOcean droplet). It is being replaced by a Cloudflare Worker at `check.ghost.org`.

## Solution

Point the default `updateCheck.url` at `check.ghost.org`. The new Worker is a backwards-compatible drop-in — identical request and response contract — so this is purely a default-endpoint change. `updates.ghost.org` stays up to drain existing installs, which keep their current config until they upgrade.