### PR TITLE
Fix post analytics member filter back navigation

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/growth.tsx
@@ -24,7 +24,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     const {stats: postReferrers, totals, isLoading, currencySymbol} = usePostReferrers(postId || '');
     const {appSettings} = useAppContext();
     const navigate = useNavigate();
-    const navigateToMembers = (filter: string) => navigate(buildMembersUrl({filter}), {crossApp: true});
+    const navigateToMembers = (filter: string) => navigate(buildMembersUrl({filter}));
 
     // Get site URL and icon from global data
     const siteUrl = globalData?.url as string | undefined;


### PR DESCRIPTION
## Summary

- Removed the `crossApp` navigation flag from the Growth analytics member drilldown links.
- Kept the existing members filter URL builder, but lets the admin router handle this as a normal in-app navigation.

## Context

The post analytics Growth view and members list are both handled by the admin router. Marking the drilldown as `crossApp` caused the members URL to be normalized into an extra browser history entry, so the first Back press only changed the filter encoding and the second Back press returned to post analytics.

fixes https://linear.app/ghost/issue/BER-3534/issue-when-navigating-back-to-post-analytics-from-filtered-member-view

## Testing

- Pre-commit hook ran `pnpm --dir 'apps/posts' exec eslint --cache -- 'src/views/PostAnalytics/Growth/growth.tsx'`.
- Seeded local member attribution data and verified the Growth -> filtered members -> Back flow locally.
- Attempted `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm --filter @tryghost/posts lint`; current local `node_modules` could not resolve `@typescript-eslint/eslint-plugin`.