### PR TITLE
🎨 Cleaned up theme editor limit gate and fixed orphan in LimitModal

### DIFF
--- a/apps/admin-x-design-system/src/global/modal/limit-modal.tsx
+++ b/apps/admin-x-design-system/src/global/modal/limit-modal.tsx
@@ -30,7 +30,7 @@ export const LimitModalContent: React.FC<LimitModalProps> = ({
             width={540}
             onOk={onOk}
         >
-            <div className='py-4 leading-9'>
+            <div className='py-4 leading-9 text-pretty'>
                 {typeof prompt === 'string' && prompt.includes('<') ? (
                     <div dangerouslySetInnerHTML={{__html: prompt}} />
                 ) : (

--- a/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
@@ -47,15 +47,6 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
             return;
         }
 
-        // The editor saves through POST /themes/upload/, where the server
-        // calls errorIfWouldGoOverLimit('customThemes', {value: '.'}) — a
-        // sentinel that's never in the allowlist, so every save by a limited
-        // customer is blocked regardless of which theme they're editing.
-        // Mirror that sentinel here so the launch gate is consistent with
-        // what happens at save time. Passing the theme name instead lets a
-        // limited customer enter the editor whenever the theme they're
-        // already on is in the allowlist, then surface a generic upload
-        // failure when they hit Save.
         const limitError = await checkThemeLimitError('.');
 
         if (limitError) {

--- a/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
@@ -138,11 +138,6 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
 
             setIsCheckingEditorLimit(true);
 
-            // The editor's save uploads through POST /themes/upload/, which
-            // runs the limit check with a '.' sentinel — so any save by a
-            // limited customer is blocked regardless of allowlist. Use the
-            // same sentinel here so deep-linking to /theme/edit/:name blocks
-            // at launch rather than at first save.
             const error = await checkThemeLimitError('.');
 
             if (isCancelled) {

--- a/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
@@ -127,9 +127,6 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     };
 
     const handleEditCode = async () => {
-        // See change-theme.tsx for why this passes '.' rather than the
-        // theme name: every save in the editor uploads via POST /themes/upload/,
-        // and the server's upload-side limit check uses the same '.' sentinel.
         const limitError = await checkThemeLimitError('.');
 
         if (limitError) {

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -803,12 +803,6 @@ test.describe('Theme settings', async () => {
     });
 
     test('Prevents direct access to theme editor route even for an allowlisted theme', async ({page}) => {
-        // Regression cover for the launch gate: the editor saves via POST
-        // /themes/upload/, which the server enforces with a '.' sentinel —
-        // so any save by a limited customer is blocked regardless of
-        // allowlist. The launch gate must mirror that, otherwise editing
-        // an allowlisted theme opens the editor only to fail on save with
-        // a generic "something went wrong" toast.
         await mockApi({page, requests: {
             ...globalDataRequests,
             ...limitRequests,


### PR DESCRIPTION
## Summary
- Removed verbose inline comments from the theme editor limit gate added in #27970 — the test name and git history capture the intent
- Added `text-pretty` to `LimitModal` body text to prevent orphaned words at line breaks

## Test plan
- [x] `admin-x-settings` tests pass (169/169)
- [ ] Visually confirm LimitModal no longer has a dangling word on the last line


🤖 Generated with [Claude Code](https://claude.com/claude-code)