### PR TITLE
Fixed Mastodon social account field mangling input while typing

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/social-accounts.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/social-accounts.tsx
@@ -34,6 +34,7 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const [errors, setErrors] = useState<Partial<Record<SocialPlatformKey, string>>>({});
     const [urls, setUrls] = useState<Record<SocialPlatformKey, string>>(() => getSocialUrls(localSettings));
+    const [focusedKey, setFocusedKey] = useState<SocialPlatformKey | null>(null);
 
     const handles = getSettingValues<string | null>(localSettings, [...SOCIAL_PLATFORM_KEYS]);
     const backendSupportsNewPlatforms = NEW_PLATFORM_KEYS.some(key => localSettings?.some(s => s.key === key));
@@ -46,6 +47,9 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     // Depend on stored values, not the localSettings reference (which churns on every updateSetting).
     useEffect(() => {
+        if (focusedKey) {
+            return;
+        }
         setUrls(getSocialUrls(localSettings));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [handles.map(value => value ?? '').join('|')]);
@@ -67,6 +71,17 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
         } catch {
             setErrors(current => ({...current, [key]: getSocialValidationError(key, value)}));
         }
+    };
+
+    const handleSocialBlur = (key: SocialPlatformKey) => {
+        setFocusedKey(current => (current === key ? null : current));
+
+        if (getSocialValidationError(key, urls[key])) {
+            return;
+        }
+
+        const {displayValue} = normalizeSocialInput(key, urls[key]);
+        setUrls(current => ({...current, [key]: displayValue}));
     };
 
     const handleSaveClick = () => {
@@ -109,7 +124,9 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         placeholder={config.placeholder}
                         title={config.publicationTitle}
                         value={urls[config.key]}
+                        onBlur={() => handleSocialBlur(config.key)}
                         onChange={event => handleSocialChange(config.key, event.target.value)}
+                        onFocus={() => setFocusedKey(config.key)}
                     />
                 ))}
             </SettingGroupContent>

--- a/apps/admin-x-settings/test/acceptance/general/social-accounts.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/social-accounts.test.ts
@@ -294,10 +294,46 @@ test.describe('Social account settings', async () => {
         const instagramInput = page.getByTestId('social-accounts').getByLabel('Instagram');
 
         await instagramInput.fill('ghostteam');
+        await instagramInput.blur();
         await expect(instagramInput).toHaveValue('https://www.instagram.com/ghostteam');
 
         await instagramInput.fill('https://www.instagram.com/ghostteam.');
         await expect(instagramInput).toHaveValue('https://www.instagram.com/ghostteam.');
         await expect(instagramInput.locator('xpath=../..')).toContainText('Your Username is not a valid Instagram Username');
+    });
+
+    test('Does not rewrite the Mastodon field while typing a handle', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests
+        }});
+
+        await page.goto('/');
+
+        const mastodonInput = page.getByTestId('social-accounts').getByLabel('Mastodon');
+
+        await mastodonInput.focus();
+        await mastodonInput.pressSequentially('@ghost@example.com');
+        await expect(mastodonInput).toHaveValue('@ghost@example.com');
+
+        await mastodonInput.blur();
+        await expect(mastodonInput).toHaveValue('https://example.com/@ghost');
+    });
+
+    test('Allows entering a federated Mastodon URL', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests
+        }});
+
+        await page.goto('/');
+
+        const mastodonInput = page.getByTestId('social-accounts').getByLabel('Mastodon');
+
+        await mastodonInput.focus();
+        await mastodonInput.pressSequentially('https://mastodon.social/@ghost@example.com');
+        await expect(mastodonInput).toHaveValue('https://mastodon.social/@ghost@example.com');
+
+        await mastodonInput.blur();
+        await expect(mastodonInput).toHaveValue('https://mastodon.social/@ghost@example.com');
+        await expect(mastodonInput.locator('xpath=../..')).not.toContainText('The URL must be in a format');
     });
 });


### PR DESCRIPTION
Fixes #27785

## Problem

The Mastodon field in **Settings → Social Accounts** rewrites the input while you type, making it impossible to enter handles like `@username@instance.tld` (or federated URLs such as `https://fedi.pub/@murat@muratcorlu.com`).

Typing `@murat@muratcorlu.com` character-by-character gets reordered to `https://muratcorlu.com/@murat` **before you finish** — the moment you reach `@murat@muratcorlu.co`, `muratcorlu.co` already validates as an FQDN, so the field is canonicalized early, the `.com` is dropped and the cursor jumps.

## Root cause

It's not the regex — it's *when* normalization runs. Every keystroke calls `updateSetting`, which changes the stored handle and triggers the resync `useEffect` to overwrite the visible field with the canonical display value.

For prefix-append platforms (Instagram, etc.) the canonical form is `prefix + raw tail`, so the cursor stays at the end and typing keeps working. But the Mastodon handle form **reorders** tokens (`@user@instance` → `https://instance/@user`), which corrupts in-progress input.

## Fix

Keep the user's raw text while the field is **focused**, and canonicalize once on **blur** — and only when the value is valid, so invalid input is left as typed with its error rather than reverted.

This is the flow the existing `testUrlValidation` helper already exercises (`fill → blur → expect canonical`), so every platform keeps its canonicalized display value once editing finishes.

## Tests

- Added an acceptance test that types a Mastodon handle character-by-character and asserts the field is **not** rewritten mid-typing, then canonicalizes on blur. Confirmed it **fails on the unfixed code** (field becomes `https://muratcorlu.com/@murat`) and passes with the fix.
- Added a test that a federated Mastodon URL can be entered without error.
- Updated one existing Instagram test to blur before asserting the canonical value (it previously relied on canonicalize-while-focused).
- All 8 acceptance tests + 13 Mastodon unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
