### PR TITLE
Fixed future filter date selection

### DIFF
--- a/apps/shade/src/components/patterns/filters.tsx
+++ b/apps/shade/src/components/patterns/filters.tsx
@@ -852,7 +852,7 @@ export function FilterDatePicker<T = unknown>({
                 </PopoverTrigger>
                 <PopoverContent align="center" className="w-auto overflow-hidden p-0" sideOffset={4}>
                     <Calendar
-                        captionLayout="dropdown"
+                        captionLayout="dropdown-months"
                         mode="single"
                         month={month}
                         selected={parsed}


### PR DESCRIPTION
## What changed
- Changed the Shade filter date picker calendar caption layout from `dropdown` to `dropdown-months`.

## Why
- `react-day-picker` caps year dropdown navigation at the current year by default when using `captionLayout="dropdown"`.
- This prevented member report date filters, including next billing date filters, from selecting dates beyond 2026 through the calendar UI.

## Validation
- `pnpm --filter @tryghost/shade test -- filters.test.tsx`
- `pnpm --filter @tryghost/shade build`