### PR TITLE
Fixed type for member repository subscription link

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1019,7 +1019,7 @@ module.exports = class MemberRepository {
      * @param {Object} data
      * @param {string} data.id - member ID
      * @param {Object} data.subscription
-     * @param {string} data.offerId
+     * @param {string | null} [data.offerId]
      * @param {import('../../../member-attribution/attribution-builder').AttributionResource} [data.attribution]
      * @param {*} options
      * @returns


### PR DESCRIPTION
no ref

This is a types-only change.

`MemberRepository.prototype.linkSubscription` takes an optional `offerId` option. The types incorrectly marked it required. This fixes that and makes it optional.
