### PR TITLE
Added llms.txt settings toggle behind labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/general-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/general-settings.tsx
@@ -14,7 +14,7 @@ export const searchKeywords = {
     timeZone: ['general', 'time', 'date', 'site timezone', 'time zone'],
     publicationLanguage: ['general', 'publication language', 'locale'],
     users: ['general', 'users and permissions', 'roles', 'staff', 'invite people', 'contributors', 'editors', 'authors', 'administrators'],
-    metadata: ['general', 'metadata', 'title', 'description', 'search', 'engine', 'google', 'meta data', 'twitter card', 'structured data', 'rich cards', 'x card', 'social', 'facebook card'],
+    metadata: ['general', 'metadata', 'title', 'description', 'search', 'engine', 'google', 'meta data', 'twitter card', 'structured data', 'rich cards', 'x card', 'social', 'facebook card', 'llms', 'ai', 'ai search engines', 'llm'],
     socialAccounts: ['general', 'social accounts', 'facebook', 'twitter', 'threads', 'bluesky', 'mastodon', 'tiktok', 'youtube', 'instagram', 'linkedin', 'structured data', 'rich cards'],
     analytics: ['membership', 'analytics', 'tracking', 'privacy', 'membership']
 };

--- a/apps/admin-x-settings/src/components/settings/general/seo-meta.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/seo-meta.tsx
@@ -1,9 +1,10 @@
 import React, {useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
+import useFeatureFlag from '../../../hooks/use-feature-flag';
 import usePinturaEditor from '../../../hooks/use-pintura-editor';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {FacebookLogo, GoogleLogo, Icon, ImageUpload, SettingGroupContent, TabView, TextField, XLogo, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {FacebookLogo, GoogleLogo, Icon, ImageUpload, SettingGroupContent, TabView, TextField, Toggle, XLogo, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -76,6 +77,7 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const handleError = useHandleError();
     const {mutateAsync: uploadImage} = useUploadImage();
     const editor = usePinturaEditor();
+    const hasLlmsTxt = useFeatureFlag('llmsTxt');
 
     // Get all settings needed for all tabs
     const [
@@ -101,6 +103,9 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
         'twitter_description',
         'twitter_image'
     ]).map(value => value || '') as string[];
+
+    const [llmsEnabledValue] = getSettingValues(localSettings, ['llms_enabled']);
+    const llmsEnabled = llmsEnabledValue !== false;
 
     // Tab management
     const [selectedTab, setSelectedTab] = useState('metadata');
@@ -136,6 +141,12 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
     };
 
     // Meta data handlers
+    const handleLlmsToggleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        updateSetting('llms_enabled', e.target.checked);
+        if (!isEditing) {
+            handleEditingChange(true);
+        }
+    };
     const handleMetaTitleChange = createSettingHandler('meta_title');
     const handleMetaDescriptionChange = createSettingHandler('meta_description');
 
@@ -155,6 +166,14 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const metadataTabContent = (
         <>
             <SettingGroupContent className="my-6 gap-3">
+                {hasLlmsTxt && (
+                    <Toggle
+                        checked={llmsEnabled}
+                        direction='rtl'
+                        label='Enable structured data for LLMs and AI search engines'
+                        onChange={handleLlmsToggleChange}
+                    />
+                )}
                 <TextField
                     hint="Recommended: 70 characters"
                     inputRef={focusRef}

--- a/apps/admin-x-settings/test/acceptance/general/seometa.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/seometa.test.ts
@@ -1,7 +1,58 @@
 import {expect, test} from '@playwright/test';
 import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
 
+const configWithLlmsTxt = {
+    ...responseFixtures.config,
+    config: {
+        ...responseFixtures.config.config,
+        labs: {
+            ...responseFixtures.config.config.labs,
+            llmsTxt: true
+        }
+    }
+};
+
 test.describe('SEO Meta settings', async () => {
+    test('Supports toggling LLM structured data in Search tab when the llmsTxt labs flag is on', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: {...globalDataRequests.browseConfig, response: configWithLlmsTxt},
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'llms_enabled', value: false}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('seometa');
+        const toggle = section.getByLabel('Enable structured data for LLMs and AI search engines');
+
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toBeChecked();
+
+        await toggle.uncheck();
+        await section.getByRole('button', {name: 'Save'}).click();
+
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [
+                {key: 'llms_enabled', value: false}
+            ]
+        });
+    });
+
+    test('Hides LLM structured data toggle when the llmsTxt labs flag is off', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('seometa');
+
+        await expect(section.getByLabel('Meta title')).toBeVisible();
+        await expect(section.getByLabel('Enable structured data for LLMs and AI search engines')).toHaveCount(0);
+    });
+
     test('Supports editing metadata in Search tab', async ({page}) => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,


### PR DESCRIPTION
## Summary
- Re-adds the llms.txt settings UI from the closed PR #27400, now **gated behind the `llmsTxt` labs flag**
- Adds an "Enable structured data for LLMs and AI search engines" toggle to the **Search tab** of Meta data settings
- Adds `llms` / `ai` search keywords so the section is discoverable in settings search

## Context
The llms.txt feature shipped on `main` behind the private (developer experiments) `llmsTxt` labs flag, but the settings UI from the original PR was never re-added. The `llms_enabled` boolean site setting already exists on `main` (default `true`); this PR only adds the front-end toggle that writes it.

Unlike the original PR (where the toggle was always shown), the toggle here only renders when the `llmsTxt` labs flag is enabled, via `useFeatureFlag('llmsTxt')`.

## Changes
- `seo-meta.tsx` — read `llms_enabled`, add the gated `Toggle`, and a change handler that writes the setting and enters edit mode
- `general-settings.tsx` — add `llms`, `ai`, `ai search engines`, `llm` to the `metadata` search keywords
- `seometa.test.ts` — acceptance tests covering the toggle visible/saving when the flag is **on**, and absent when the flag is **off**

## Testing
- `pnpm lint` — passes (changed files clean)
- `tsc --noEmit` — passes
- seometa Playwright acceptance suite — **7 passed** (including both new tests)

Ref #27400

🤖 Generated with [Claude Code](https://claude.com/claude-code)