### PR TITLE
Fixed release workflow running on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository == 'TryGhost/Ghost'
     runs-on: ubuntu-latest
     name: Prepare & Push Release
     steps:


### PR DESCRIPTION
## Summary
- restricted the scheduled release job to the canonical TryGhost/Ghost repository
- prevents forked repositories from executing the Friday release workflow job