### PR TITLE
🐛 Fixed members-only 403 leaking when llms.txt is disabled

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/entry.js
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.js
@@ -59,18 +59,18 @@ module.exports = function entryController(req, res, next) {
 
             // CASE: .md URL — serve entry as markdown for LLM consumption
             if (res.routerOptions.isMarkdownRequest) {
-                if (entry.visibility !== 'public') {
-                    return res.status(403).type('text/markdown').send(
-                        '# Members-only content\n\nThis post requires a subscription and is not available for public access.\n'
-                    );
-                }
-
                 const llmsService = getLlmsService(req);
                 if (!llmsService || !llmsService.isEnabled()) {
                     return res.redirect(302, url.format({
                         pathname: url.parse(entry.url).pathname,
                         search: url.parse(req.originalUrl).search
                     }));
+                }
+
+                if (entry.visibility !== 'public') {
+                    return res.status(403).type('text/markdown').send(
+                        '# Members-only content\n\nThis post requires a subscription and is not available for public access.\n'
+                    );
                 }
 
                 return serveMarkdown(res, entry);

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -204,4 +204,89 @@ describe('Unit - services/routing/controllers/entry', function () {
             return promise;
         });
     });
+
+    describe('markdown requests (llms.txt)', function () {
+        let llmsService;
+
+        beforeEach(function () {
+            llmsService = {
+                isEnabled: sinon.stub()
+            };
+
+            req.app = {
+                get: sinon.stub()
+            };
+            req.app.get.withArgs('llmsService').returns(llmsService);
+
+            res.status = sinon.stub().returns(res);
+            res.type = sinon.stub().returns(res);
+            res.send = sinon.spy();
+            res.set = sinon.spy();
+            res.vary = sinon.spy();
+
+            res.routerOptions.isMarkdownRequest = true;
+            res.routerOptions.resourceType = 'posts';
+
+            post.url = '/does-exist/';
+            req.path = '/does-exist.md';
+            req.originalUrl = req.path;
+        });
+
+        it('does not return 403 for non-public posts when the llms feature is disabled', async function () {
+            post.visibility = 'paid';
+            llmsService.isEnabled.returns(false);
+
+            entryLookUpStub.withArgs(req.path, res.routerOptions)
+                .resolves({entry: post});
+
+            await controllers.entry(req, res, sinon.stub());
+
+            sinon.assert.notCalled(res.status);
+            sinon.assert.notCalled(res.send);
+            sinon.assert.calledWith(res.redirect, 302, '/does-exist/');
+        });
+
+        it('redirects public posts to the canonical URL when the llms feature is disabled', async function () {
+            post.visibility = 'public';
+            llmsService.isEnabled.returns(false);
+
+            entryLookUpStub.withArgs(req.path, res.routerOptions)
+                .resolves({entry: post});
+
+            await controllers.entry(req, res, sinon.stub());
+
+            sinon.assert.notCalled(res.send);
+            sinon.assert.calledWith(res.redirect, 302, '/does-exist/');
+        });
+
+        it('returns 403 for non-public posts when the llms feature is enabled', async function () {
+            post.visibility = 'members';
+            llmsService.isEnabled.returns(true);
+
+            entryLookUpStub.withArgs(req.path, res.routerOptions)
+                .resolves({entry: post});
+
+            await controllers.entry(req, res, sinon.stub());
+
+            sinon.assert.calledWith(res.status, 403);
+            sinon.assert.calledWith(res.type, 'text/markdown');
+            sinon.assert.calledOnce(res.send);
+            sinon.assert.notCalled(res.redirect);
+        });
+
+        it('serves markdown for public posts when the llms feature is enabled', async function () {
+            post.url = 'http://127.0.0.1:2369/does-exist/';
+            post.visibility = 'public';
+            llmsService.isEnabled.returns(true);
+
+            entryLookUpStub.withArgs(req.path, res.routerOptions)
+                .resolves({entry: post});
+
+            await controllers.entry(req, res, sinon.stub());
+
+            sinon.assert.calledWith(res.type, 'text/markdown');
+            sinon.assert.calledOnce(res.send);
+            sinon.assert.notCalled(res.redirect);
+        });
+    });
 });


### PR DESCRIPTION
## Ref

Follow-up to the `llms.txt` work (labs flag `llmsTxt`).

## Problem

The per-post `.md` markdown routes (`/:slug.md`) are registered **unconditionally** in the static-pages and collection routers, so the entry controller relies on a runtime check to gate the feature. That check ran in the wrong order — the members-only `403` for non-public posts was returned **before** the `llmsService.isEnabled()` check:

```js
if (res.routerOptions.isMarkdownRequest) {
    if (entry.visibility !== 'public') {
        return res.status(403)...; // fired BEFORE the flag check
    }
    const llmsService = getLlmsService(req);
    if (!llmsService || !llmsService.isEnabled()) {
        return res.redirect(302, canonical);
    }
    return serveMarkdown(res, entry);
}
```

So with the `llmsTxt` labs flag **off**, requesting a paid/members post's `.md` URL still returned a feature-specific `403 text/markdown` "Members-only content" body — leaking llms.txt behaviour (and revealing a post's existence/visibility) when the feature is supposed to be fully disabled.

This was found while verifying that nothing in the feature works with the flag off. Everything else gated correctly (`/llms.txt` → 302 redirect, `Accept: text/markdown` content negotiation → normal HTML, discovery headers absent); only non-public `.md` requests leaked.

| Request (flag OFF) | Before | After |
|---|---|---|
| Public post `.md` | 302 → canonical | 302 → canonical |
| **Paid post `.md`** | **403 members-only markdown** | **302 → canonical** |
| **Members post `.md`** | **403 members-only markdown** | **302 → canonical** |

## Fix

Move the `isEnabled()` check ahead of the visibility check, so a disabled feature always falls back to the canonical 302 redirect — the same graceful degradation already used for public `.md` requests — regardless of visibility. The members-only 403 is preserved when the feature is enabled.

## Tests

Added a `markdown requests (llms.txt)` block to the entry controller unit tests, including a regression test that fails on the old ordering:

- does **not** return 403 for non-public posts when the feature is disabled (regression)
- redirects public posts to canonical when disabled
- returns 403 for non-public posts when **enabled**
- serves markdown for public posts when **enabled**

Verified live against a dev instance with the flag off: all `.md` requests (public/paid/members) now 302-redirect to canonical, with no feature-specific 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
