### PR TITLE
🐛 Fixed design preview showing raw markdown when llms.txt is enabled

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/announcement-bar/announcement-bar-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/announcement-bar/announcement-bar-preview.tsx
@@ -39,7 +39,7 @@ const AnnouncementBarPreview: React.FC<AnnouncementBarSettings> = ({announcement
                     announcementContent,
                     visibilityMemo
                 ),
-                Accept: 'text/plain'
+                Accept: 'text/html'
             },
             mode: 'cors',
             credentials: 'include'

--- a/apps/admin-x-settings/src/components/settings/site/design-and-branding/theme-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-branding/theme-preview.tsx
@@ -80,7 +80,7 @@ const ThemePreview: React.FC<ThemePreviewProps> = ({settings,url}) => {
             headers: {
                 'Content-Type': 'text/html;charset=utf-8',
                 'x-ghost-preview': previewData,
-                Accept: 'text/plain'
+                Accept: 'text/html'
             },
             mode: 'cors',
             credentials: 'include'

--- a/apps/admin-x-settings/test/acceptance/site/design.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/design.test.ts
@@ -138,6 +138,7 @@ test.describe('Design settings', async () => {
 
         const matchingHeader = previewHeaders.headers()['x-ghost-preview'];
         expect(matchingHeader).toContain('cd5786');
+        expect(previewHeaders.headers().accept).toBe('text/html');
         await expect(modal.getByTestId('toggle-unsplash-button')).toBeVisible();
         await modal.getByRole('button', {name: 'Save'}).click();
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/28265

- the design & branding and announcement bar previews fetch the page, read it as text, and re-parse it as HTML into the iframe. They have always sent `Accept: text/plain` purely as a "give me the raw body" signal, which the frontend ignored
- the llms.txt feature added Accept-based content negotiation that now treats `text/plain` as a request for the markdown variant, so with labs.llmsTxt enabled these previews received markdown and rendered it as garbled text
- the previews genuinely want HTML, so they now ask for `text/html` instead of accidentally opting into markdown content negotiation

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
