### PR TITLE
Moved get helper deduplication behind a labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -67,6 +67,10 @@ const features: Feature[] = [{
     title: 'LLMs.txt',
     description: 'Serve llms.txt, per-entry markdown exports, and Accept: text/markdown content negotiation for AI and LLM tooling',
     flag: 'llmsTxt'
+}, {
+    title: 'Get helper deduplication',
+    description: 'Deduplicate identical {{#get}} helper queries within a single request to avoid redundant database calls',
+    flag: 'getHelperDeduplication'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
+++ b/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
@@ -3,7 +3,7 @@ const hbs = require('../engine');
 const urlUtils = require('../../../../shared/url-utils');
 const customThemeSettingsCache = require('../../../../shared/custom-theme-settings-cache');
 const preview = require('../preview');
-const config = require('../../../../shared/config');
+const labs = require('../../../../shared/labs');
 
 function updateLocalTemplateOptions(req, res, next) {
     const localTemplateOptions = hbs.getLocalTemplateOptions(res.locals);
@@ -39,7 +39,7 @@ function updateLocalTemplateOptions(req, res, next) {
         status: req.member.status
     } : null;
 
-    const enableDeduplication = config.get('optimization:getHelper:deduplication');
+    const enableDeduplication = labs.isSet('getHelperDeduplication');
 
     hbs.updateLocalTemplateOptions(res.locals, _.merge({}, localTemplateOptions, {
         data: {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -54,7 +54,8 @@ const PRIVATE_FEATURES = [
     'indexnow',
     'pictureImageFormats',
     'smarterCounts',
-    'llmsTxt'
+    'llmsTxt',
+    'getHelperDeduplication'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -22,6 +22,7 @@ Object {
       "emailUniqueid": true,
       "explore": true,
       "featurebaseFeedback": true,
+      "getHelperDeduplication": true,
       "giftSubscriptions": true,
       "importMemberTier": true,
       "indexnow": true,

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -617,7 +617,6 @@ describe('{{#get}} helper', function () {
         });
 
         it('should deduplicate identical queries when enabled', async function () {
-            configUtils.set('optimization:getHelper:deduplication', true);
             locals = {root: {_locals: {}}, _queryCache: new Map()};
 
             // First call
@@ -641,7 +640,6 @@ describe('{{#get}} helper', function () {
         });
 
         it('should make separate API calls for different queries when enabled', async function () {
-            configUtils.set('optimization:getHelper:deduplication', true);
             locals = {root: {_locals: {}}, _queryCache: new Map()};
 
             // First call
@@ -663,8 +661,6 @@ describe('{{#get}} helper', function () {
         });
 
         it('should include member uuid in cache key', async function () {
-            configUtils.set('optimization:getHelper:deduplication', true);
-
             // Call with member A
             const localsA = {root: {_locals: {}}, _queryCache: new Map(), member: {uuid: 'member-a'}};
             await get.call(
@@ -686,7 +682,6 @@ describe('{{#get}} helper', function () {
         });
 
         it('should not cache failed API requests', async function () {
-            configUtils.set('optimization:getHelper:deduplication', true);
             locals = {root: {_locals: {}}, _queryCache: new Map()};
 
             // Set up stub to fail first, then succeed
@@ -712,7 +707,6 @@ describe('{{#get}} helper', function () {
         });
 
         it('should work without _queryCache in data', async function () {
-            configUtils.set('optimization:getHelper:deduplication', true);
             // No _queryCache in locals
             locals = {root: {_locals: {}}};
 
@@ -728,7 +722,6 @@ describe('{{#get}} helper', function () {
         });
 
         it('should deduplicate queries with same parameters in different order', async function () {
-            configUtils.set('optimization:getHelper:deduplication', true);
             locals = {root: {_locals: {}}, _queryCache: new Map()};
 
             // First call
@@ -750,7 +743,6 @@ describe('{{#get}} helper', function () {
         });
 
         it('should handle concurrent identical requests', async function () {
-            configUtils.set('optimization:getHelper:deduplication', true);
             locals = {root: {_locals: {}}, _queryCache: new Map()};
 
             let resolveBrowse;
@@ -788,7 +780,6 @@ describe('{{#get}} helper', function () {
         });
 
         it('should not reuse the same response object instance across renders', async function () {
-            configUtils.set('optimization:getHelper:deduplication', true);
             locals = {root: {_locals: {}}, _queryCache: new Map()};
 
             await get.call(

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -212,6 +212,33 @@ describe('Themes middleware', function () {
                 `admin_url should end with /ghost/ but got: ${data.site.admin_url}`);
             assert.equal(data.site.admin_url, 'https://admin.example.com/ghost/');
         });
+
+        it('does not add a _queryCache when the getHelperDeduplication flag is disabled', async function () {
+            // fakeLabsData does not include getHelperDeduplication, so the flag is off
+            await request(app)
+                .get('/')
+                .expect(200);
+
+            sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
+            const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
+            const data = templateOptions.data;
+
+            assert.ok(!('_queryCache' in data), '_queryCache should not be set when the flag is disabled');
+        });
+
+        it('adds a _queryCache Map when the getHelperDeduplication flag is enabled', async function () {
+            fakeLabsData.getHelperDeduplication = true;
+
+            await request(app)
+                .get('/')
+                .expect(200);
+
+            sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
+            const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
+            const data = templateOptions.data;
+
+            assert.ok(data._queryCache instanceof Map, '_queryCache should be a Map when the flag is enabled');
+        });
     });
 
     describe('Preview Mode', function () {


### PR DESCRIPTION
ref [HKG-1961](https://linear.app/ghost/issue/HKG-1961)

Per-request `{{#get}}` helper deduplication (shipped in TryGhost/Ghost#26487) was gated by the `optimization:getHelper:deduplication` config setting. This moves the gate to a labs flag so it can be toggled per-site through labs config instead of needing a separate config setting — which is what we need to roll it out to sites individually.

It's registered as a private/experimental (alpha) flag since it's still under evaluation.

## Changes

* Added `getHelperDeduplication` to the private (developer experiments) labs features.
* The theme-engine middleware that seeds the per-request query cache now reads `labs.isSet('getHelperDeduplication')` instead of the config setting.
* Added the toggle to the admin Labs "Private features" tab.
* `get.js` is unchanged in contract — it still keys off the presence of the per-request cache; the flag only controls whether that cache is created.

## Tests

* Updated `get.test.js` (removed the now-defunct config setup; dedup is driven by the cache's presence).
* Added middleware coverage asserting the flag controls whether the per-request cache is created (enabled → `Map`, disabled → absent).
* Updated the admin config API snapshot (single new flag).