### PR TITLE
Fixed notification +N count badge alignment in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.29",
+  "version": "3.1.30",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/notifications/notifications.tsx
+++ b/apps/activitypub/src/views/notifications/notifications.tsx
@@ -332,7 +332,7 @@ const Notifications: React.FC = () => {
                                             }
                                             {group.actors.length > 1 && <NotificationItem.Avatars>
                                                 <div className='flex w-full flex-col'>
-                                                    <div className='relative flex items-center pl-2'>
+                                                    <div className='relative flex w-fit items-center pl-2'>
                                                         {!openStates[group.id || `${group.type}_${index}`] && group.actors.slice(0, maxAvatars).map((actor: ActorProperties) => (
                                                             <APAvatar
                                                                 key={actor.id}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1400/notification-more-count-15-etc-alignment-is-off-in-activitypub

- the avatar stack row stretched to full width, so the absolutely positioned +N badge anchored to the far right edge instead of the last avatar
- added w-fit so the row shrinks to its content, letting the existing right offset land the badge on the last avatar

