### PR TITLE
Enabled invoice creation for gift subscription checkout

### DIFF
--- a/ghost/core/core/server/services/stripe/services/webhook/charge-refunded-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/charge-refunded-event-service.js
@@ -36,8 +36,7 @@ module.exports = class ChargeRefundedEventService {
 
         // Gifts are identified by a payment_intent_id match in the gift
         // repository; non-matching charges (subscription renewals, donations,
-        // unrelated one-time payments) are no-ops. We can't filter by
-        // `charge.invoice` here — gift Checkout sessions create invoices too.
+        // unrelated one-time payments) are no-ops.
         await this.handleGiftRefundEvent(paymentIntentId);
     }
 

--- a/ghost/core/core/server/services/stripe/services/webhook/charge-refunded-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/charge-refunded-event-service.js
@@ -34,10 +34,11 @@ module.exports = class ChargeRefundedEventService {
             return;
         }
 
-        // One-time payments (gifts, donations) have no invoice
-        if (charge.invoice === null) {
-            await this.handleGiftRefundEvent(paymentIntentId);
-        }
+        // Gifts are identified by a payment_intent_id match in the gift
+        // repository; non-matching charges (subscription renewals, donations,
+        // unrelated one-time payments) are no-ops. We can't filter by
+        // `charge.invoice` here — gift Checkout sessions create invoices too.
+        await this.handleGiftRefundEvent(paymentIntentId);
     }
 
     /**

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -719,10 +719,7 @@ module.exports = class StripeAPI {
             customer_email: !customer && customerEmail ? customerEmail : undefined,
             submit_type: 'pay',
             invoice_creation: {
-                enabled: true,
-                invoice_data: {
-                    metadata
-                }
+                enabled: true
             },
             line_items: [{
                 price_data: {

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -718,6 +718,12 @@ module.exports = class StripeAPI {
             customer: customer ? customer.id : undefined,
             customer_email: !customer && customerEmail ? customerEmail : undefined,
             submit_type: 'pay',
+            invoice_creation: {
+                enabled: true,
+                invoice_data: {
+                    metadata
+                }
+            },
             line_items: [{
                 price_data: {
                     currency,

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/charge-refunded-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/charge-refunded-event-service.test.js
@@ -56,11 +56,16 @@ describe('ChargeRefundedEventService', function () {
         sinon.assert.notCalled(giftService.refund);
     });
 
-    it('skips processing when the charge has an invoice (subscription refund)', async function () {
-        const service = new ChargeRefundedEventService({giftService});
+    it('attempts the gift lookup even when the charge has an invoice', async function () {
+        // Gift Checkout sessions now create invoices, so `charge.invoice` is
+        // not a reliable signal that a charge is non-gift. The giftService
+        // lookup is the real classifier — it returns falsy for non-gifts.
+        giftService.refund.resolves(false);
 
+        const service = new ChargeRefundedEventService({giftService});
         await service.handleEvent({payment_intent: 'pi_123', invoice: 'in_123'});
 
-        sinon.assert.notCalled(giftService.refund);
+        sinon.assert.calledOnce(giftService.refund);
+        sinon.assert.calledWith(giftService.refund, 'pi_123');
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/charge-refunded-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/charge-refunded-event-service.test.js
@@ -55,17 +55,4 @@ describe('ChargeRefundedEventService', function () {
 
         sinon.assert.notCalled(giftService.refund);
     });
-
-    it('attempts the gift lookup even when the charge has an invoice', async function () {
-        // Gift Checkout sessions now create invoices, so `charge.invoice` is
-        // not a reliable signal that a charge is non-gift. The giftService
-        // lookup is the real classifier — it returns falsy for non-gifts.
-        giftService.refund.resolves(false);
-
-        const service = new ChargeRefundedEventService({giftService});
-        await service.handleEvent({payment_intent: 'pi_123', invoice: 'in_123'});
-
-        sinon.assert.calledOnce(giftService.refund);
-        sinon.assert.calledWith(giftService.refund, 'pi_123');
-    });
 });

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -858,8 +858,6 @@ describe('StripeAPI', function () {
         });
 
         it('enables invoice_creation and does not include custom_fields', async function () {
-            const metadata = {ghost_gift: 'true', gift_token: 'token-1'};
-
             await api.createGiftCheckoutSession({
                 amount: 5000,
                 currency: 'usd',
@@ -868,15 +866,12 @@ describe('StripeAPI', function () {
                 duration: 1,
                 successUrl: '/gift-success',
                 cancelUrl: '/gift-cancel',
-                metadata
+                metadata: {}
             });
 
             const args = mockStripe.checkout.sessions.create.firstCall.firstArg;
 
-            assert.deepEqual(args.invoice_creation, {
-                enabled: true,
-                invoice_data: {metadata}
-            });
+            assert.deepEqual(args.invoice_creation, {enabled: true});
             assert.equal(args.custom_fields, undefined);
         });
 

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -857,7 +857,9 @@ describe('StripeAPI', function () {
             assert.equal(args.customer_email, undefined);
         });
 
-        it('does not include invoice_creation or custom_fields', async function () {
+        it('enables invoice_creation and does not include custom_fields', async function () {
+            const metadata = {ghost_gift: 'true', gift_token: 'token-1'};
+
             await api.createGiftCheckoutSession({
                 amount: 5000,
                 currency: 'usd',
@@ -866,12 +868,15 @@ describe('StripeAPI', function () {
                 duration: 1,
                 successUrl: '/gift-success',
                 cancelUrl: '/gift-cancel',
-                metadata: {}
+                metadata
             });
 
             const args = mockStripe.checkout.sessions.create.firstCall.firstArg;
 
-            assert.equal(args.invoice_creation, undefined);
+            assert.deepEqual(args.invoice_creation, {
+                enabled: true,
+                invoice_data: {metadata}
+            });
             assert.equal(args.custom_fields, undefined);
         });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/FEA-630

- Gift subscription Stripe Checkout sessions did not automatically generate Stripe invoices, they now do.
- This change matches **Tips & Donations** behaviour: we generate invoices for tips/donations' one-time payments
- Paid subscriptions are unaffected: Stripe auto-generates invoices for those as part of subscription billing