### PR TITLE
🐛 Fixed staff invite error for existing users

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
@@ -13,7 +13,7 @@ import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 type RoleType = 'administrator' | 'editor' | 'author' | 'contributor' | 'super editor';
 
-const USER_ALREADY_REGISTERED_VALIDATION = 'User is already registered.';
+const USER_ALREADY_REGISTERED_CODE = 'USER_ALREADY_REGISTERED';
 const USER_ALREADY_EXISTS_ERROR = 'A user with that email address already exists.';
 
 const InviteUserModal = NiceModal.create(() => {
@@ -138,7 +138,7 @@ const InviteUserModal = NiceModal.create(() => {
         } catch (e) {
             const validationError = e instanceof ValidationError ? e.data?.errors[0] : undefined;
 
-            if (validationError && (validationError.context || validationError.message) === USER_ALREADY_REGISTERED_VALIDATION) {
+            if (validationError?.code === USER_ALREADY_REGISTERED_CODE) {
                 setSaveState('');
                 setErrors({
                     email: USER_ALREADY_EXISTS_ERROR

--- a/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
@@ -1,6 +1,6 @@
 import NiceModal from '@ebay/nice-modal-react';
 import validator from 'validator';
-import {APIError} from '@tryghost/admin-x-framework/errors';
+import {APIError, ValidationError} from '@tryghost/admin-x-framework/errors';
 import {HostLimitError, useLimiter} from '../../../hooks/use-limiter';
 import {Modal, Radio, TextField, showToast} from '@tryghost/admin-x-design-system';
 import {useAddInvite, useBrowseInvites} from '@tryghost/admin-x-framework/api/invites';
@@ -12,6 +12,9 @@ import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 type RoleType = 'administrator' | 'editor' | 'author' | 'contributor' | 'super editor';
+
+const USER_ALREADY_REGISTERED_VALIDATION = 'User is already registered.';
+const USER_ALREADY_EXISTS_ERROR = 'A user with that email address already exists.';
 
 const InviteUserModal = NiceModal.create(() => {
     const modal = NiceModal.useModal();
@@ -99,7 +102,7 @@ const InviteUserModal = NiceModal.create(() => {
 
         if (users?.some(({email: userEmail}) => userEmail === email)) {
             setErrors({
-                email: 'A user with that email address already exists.'
+                email: USER_ALREADY_EXISTS_ERROR
             });
             return;
         }
@@ -133,6 +136,16 @@ const InviteUserModal = NiceModal.create(() => {
             modal.remove();
             updateRoute('staff?tab=invited');
         } catch (e) {
+            const validationError = e instanceof ValidationError ? e.data?.errors[0] : undefined;
+
+            if (validationError && (validationError.context || validationError.message) === USER_ALREADY_REGISTERED_VALIDATION) {
+                setSaveState('');
+                setErrors({
+                    email: USER_ALREADY_EXISTS_ERROR
+                });
+                return;
+            }
+
             setSaveState('error');
             let title = 'Failed to send invitation';
             let message = (<span>If the problem persists, <a href="https://ghost.org/contact"><u>contact support</u>.</a>.</span>);

--- a/apps/admin-x-settings/test/acceptance/general/users/invite.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/invite.test.ts
@@ -128,9 +128,9 @@ test.describe('User invitations', async () => {
                         message: 'Validation error, cannot save invite.',
                         context: 'User is already registered.',
                         details: null,
-                        property: null,
+                        property: 'email',
                         help: null,
-                        code: null,
+                        code: 'USER_ALREADY_REGISTERED',
                         ghostErrorCode: null
                     }]
                 }

--- a/apps/admin-x-settings/test/acceptance/general/users/invite.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/invite.test.ts
@@ -93,6 +93,73 @@ test.describe('User invitations', async () => {
         });
     });
 
+    test('Shows an existing-user validation error when the user is not in the loaded page', async ({page}) => {
+        const firstPageUsers = {
+            ...responseFixtures.users,
+            meta: {
+                pagination: {
+                    page: 1,
+                    limit: 100,
+                    pages: 2,
+                    total: 101,
+                    next: 2,
+                    prev: null
+                }
+            }
+        };
+
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: firstPageUsers},
+            browseInvites: {method: 'GET', path: '/invites/?limit=100&include=roles', response: responseFixtures.invites},
+            browseRoles: {method: 'GET', path: '/roles/?limit=100', response: responseFixtures.roles},
+            browseAssignableRoles: {method: 'GET', path: '/roles/?limit=100&permissions=assign', response: responseFixtures.roles},
+            addInvite: {
+                method: 'POST',
+                path: '/invites/',
+                responseStatus: 422,
+                responseHeaders: {
+                    'content-type': 'application/json'
+                },
+                response: {
+                    errors: [{
+                        id: 'validation-error',
+                        type: 'ValidationError',
+                        message: 'Validation error, cannot save invite.',
+                        context: 'User is already registered.',
+                        details: null,
+                        property: null,
+                        help: null,
+                        code: null,
+                        ghostErrorCode: null
+                    }]
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('users');
+        await section.getByRole('button', {name: 'Invite people'}).click();
+
+        const modal = page.getByTestId('invite-user-modal');
+        await modal.getByLabel('Email address').fill('existing-user-page-2@test.com');
+        await modal.locator('button[value=author]').click();
+        await modal.getByRole('button', {name: 'Send invitation'}).click();
+
+        await expect.poll(() => lastApiRequests.addInvite?.body).toEqual({
+            invites: [{
+                email: 'existing-user-page-2@test.com',
+                expires: null,
+                role_id: '645453f3d254799990dd0e18',
+                status: null,
+                token: null
+            }]
+        });
+        await expect(modal).toContainText('A user with that email address already exists.');
+        await expect(page.getByTestId('toast-error')).not.toBeVisible();
+    });
+
     test('Supports resending invitations', async ({page}) => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/invites.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/invites.js
@@ -11,7 +11,9 @@ module.exports = {
         const user = await models.User.findOne({email: frame.data.invites[0].email}, frame.options);
         if (user) {
             throw new errors.ValidationError({
-                message: tpl(messages.userAlreadyRegistered)
+                message: tpl(messages.userAlreadyRegistered),
+                code: 'USER_ALREADY_REGISTERED',
+                property: 'email'
             });
         }
     }

--- a/ghost/core/test/e2e-api/admin/invites.test.js
+++ b/ghost/core/test/e2e-api/admin/invites.test.js
@@ -96,6 +96,31 @@ describe('Invites API', function () {
             assert.equal(new URL(res.headers.location).pathname, `/ghost/api/admin/invites/${res.body.invites[0].id}/`);
         });
 
+        it('Cannot invite an existing user', async function () {
+            await request
+                .post(localUtils.API.getApiQuery('invites/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    invites: [{
+                        email: testUtils.getExistingData().users[1].email,
+                        role_id: testUtils.getExistingData().roles[1].id
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(422)
+                .expect((res) => {
+                    const error = res.body.errors[0];
+
+                    assert.equal(error.message, 'Validation error, cannot save invite.');
+                    assert.equal(error.context, 'User is already registered.');
+                    assert.equal(error.code, 'USER_ALREADY_REGISTERED');
+                    assert.equal(error.property, 'email');
+                });
+
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
+        });
+
         it('Can destroy an existing invite', async function () {
             await request.del(localUtils.API.getApiQuery(`invites/${testUtils.DataGenerator.forKnex.invites[0].id}/`))
                 .set('Origin', config.get('url'))


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ONC-1778

## Summary
- Maps the invite API duplicate-user validation error back to the email field in the staff invite modal
- Keeps pagination behavior intact while avoiding the generic failure toast for existing staff users
- Adds an acceptance test for an existing user outside the loaded first users page

## Testing
- NODE_PATH=/Users/aileen/code/tryghost/Ghost/node_modules/.pnpm/node_modules pnpm --filter @tryghost/admin-x-settings test:acceptance test/acceptance/general/users/invite.test.ts --project=chromium
- NODE_PATH=/Users/aileen/code/tryghost/Ghost/node_modules/.pnpm/node_modules pnpm --filter @tryghost/admin-x-settings lint:js