### PR TITLE
Added structured logging to IndexNow service

### DIFF
--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -121,7 +121,8 @@ async function ping(post) {
 
         if (response.statusCode !== 200 && response.statusCode !== 202) {
             throw new errors.InternalServerError({
-                message: `IndexNow returned unexpected status: ${response.statusCode}`
+                message: `IndexNow returned unexpected status: ${response.statusCode}`,
+                statusCode: response.statusCode
             });
         }
 
@@ -130,7 +131,8 @@ async function ping(post) {
                 event: 'indexnow.pinged',
                 post_id: post.id,
                 post_slug: post.slug,
-                url
+                url,
+                status_code: response.statusCode
             }
         }, `${INDEXNOW_LOG_KEY} Successfully pinged ${url}`);
     } catch (err) {

--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -35,6 +35,8 @@ const messages = {
     requestFailedHelp: 'If you get this error repeatedly, please seek help on {url}.'
 };
 
+const INDEXNOW_LOG_KEY = '[indexnow]';
+
 const defaultPostSlugs = [
     'welcome',
     'the-editor',
@@ -83,13 +85,20 @@ async function ping(post) {
         return;
     }
 
+    let url = null;
     try {
-        const url = urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
+        url = urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
 
         // Get the API key (auto-generated on boot by settings service)
         const key = getApiKey();
         if (!key) {
-            logging.warn('IndexNow: API key not available');
+            logging.warn({
+                system: {
+                    event: 'indexnow.api_key_missing',
+                    post_id: post.id,
+                    post_slug: post.slug
+                }
+            }, `${INDEXNOW_LOG_KEY} API key not available`);
             return;
         }
 
@@ -116,11 +125,21 @@ async function ping(post) {
             });
         }
 
-        logging.info(`IndexNow: Successfully pinged ${url}`);
+        logging.info({
+            system: {
+                event: 'indexnow.pinged',
+                post_id: post.id,
+                post_slug: post.slug,
+                url
+            }
+        }, `${INDEXNOW_LOG_KEY} Successfully pinged ${url}`);
     } catch (err) {
         // Log errors but don't throw - IndexNow failures shouldn't disrupt publishing
+        let eventName;
         let error;
         if (err.statusCode === 429) {
+            // Rate limited by IndexNow - we have no retry/backoff, so the ping is dropped
+            eventName = 'indexnow.rate_limited';
             error = new errors.TooManyRequestsError({
                 err,
                 message: err.message,
@@ -129,6 +148,7 @@ async function ping(post) {
             });
         } else if (err.statusCode === 422) {
             // 422 means the URL is invalid or key doesn't match
+            eventName = 'indexnow.key_validation_failed';
             error = new errors.ValidationError({
                 err,
                 message: 'IndexNow key validation failed',
@@ -136,6 +156,7 @@ async function ping(post) {
                 help: 'Ensure your IndexNow API key file is accessible at the correct URL'
             });
         } else {
+            eventName = 'indexnow.ping_failed';
             error = new errors.InternalServerError({
                 err: err,
                 message: err.message,
@@ -143,7 +164,17 @@ async function ping(post) {
                 help: tpl(messages.requestFailedHelp, {url: 'https://ghost.org/docs/'})
             });
         }
-        logging.warn(error);
+
+        logging.warn({
+            system: {
+                event: eventName,
+                post_id: post.id,
+                post_slug: post.slug,
+                url,
+                status_code: err.statusCode ?? null
+            },
+            err: error
+        }, `${INDEXNOW_LOG_KEY} ${error.message}`);
     }
 }
 

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -262,6 +262,7 @@ describe('IndexNow', function () {
             await ping(testPost);
 
             sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.pinged');
         });
 
         it('with default post should not execute ping', async function () {
@@ -327,9 +328,10 @@ describe('IndexNow', function () {
 
             // Should NOT have made the ping request
             assert.equal(pingRequest.isDone(), false);
-            // Should have logged a warning
+            // Should have logged a warning with a structured event
             sinon.assert.calledOnce(loggingStub);
-            assert(loggingStub.args[0][0].includes('API key not available'));
+            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.api_key_missing');
+            assert(loggingStub.args[0][1].includes('API key not available'));
         });
 
         it('should handle 202 response as success', async function () {
@@ -343,6 +345,7 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.pinged');
         });
 
         it('captures && logs errors from 400 requests', async function () {
@@ -356,6 +359,8 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.ping_failed');
+            assert.equal(loggingStub.args[0][0].system.status_code, 400);
         });
 
         it('captures && logs validation errors from 422 requests', async function () {
@@ -369,7 +374,8 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
-            assert(loggingStub.args[0][0].message.includes('key validation failed'));
+            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.key_validation_failed');
+            assert.equal(loggingStub.args[0][0].system.status_code, 422);
         });
 
         it('should behave correctly when getting a 429', async function () {
@@ -383,6 +389,8 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.rate_limited');
+            assert.equal(loggingStub.args[0][0].system.status_code, 429);
         });
     });
 

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -263,6 +263,7 @@ describe('IndexNow', function () {
 
             sinon.assert.calledOnce(loggingStub);
             assert.equal(loggingStub.args[0][0].system.event, 'indexnow.pinged');
+            assert.equal(loggingStub.args[0][0].system.status_code, 200);
         });
 
         it('with default post should not execute ping', async function () {
@@ -346,6 +347,7 @@ describe('IndexNow', function () {
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
             assert.equal(loggingStub.args[0][0].system.event, 'indexnow.pinged');
+            assert.equal(loggingStub.args[0][0].system.status_code, 202);
         });
 
         it('captures && logs errors from 400 requests', async function () {
@@ -391,6 +393,23 @@ describe('IndexNow', function () {
             sinon.assert.calledOnce(loggingStub);
             assert.equal(loggingStub.args[0][0].system.event, 'indexnow.rate_limited');
             assert.equal(loggingStub.args[0][0].system.status_code, 429);
+        });
+
+        it('logs the real status code for an unexpected 2xx response', async function () {
+            loggingStub = sinon.stub(logging, 'warn');
+            // 204 is a 2xx that request() does not throw on, so it hits the
+            // manual unexpected-status check rather than an HTTP error
+            const pingRequest = nock('https://api.indexnow.org')
+                .get(/\/indexnow/)
+                .reply(204);
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+
+            await ping(testPost);
+
+            assert.equal(pingRequest.isDone(), true);
+            sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.ping_failed');
+            assert.equal(loggingStub.args[0][0].system.status_code, 204);
         });
     });
 


### PR DESCRIPTION
## ref https://github.com/TryGhost/Ghost/pull/25773

### What & why

The IndexNow service (behind the `indexnow` labs flag) pings `api.indexnow.org` when a post is published or edited. Failures are deliberately caught and swallowed so they never disrupt publishing — but the log lines carried **no machine-readable event field**, so it wasn't possible to tell from logs whether pings were succeeding, being **rate limited (429)**, or **rejected (422)**. With no retry/backoff and no batching, rate-limiting during a bulk publish is a real possibility worth being able to observe.

### What changed — additive only

This is intentionally an **additive** change. **Nothing in the existing error handling was removed:**

- The typed `GhostError`s (`TooManyRequestsError` / `ValidationError` / `InternalServerError`) and their `tpl` `context`/`help` are **retained**.
- The catch-and-swallow behaviour (failures never throw, never disrupt publishing) is **unchanged**.
- The existing **log levels are unchanged** — success/api-key stay `info`/`warn`, failures stay `warn`.

It only **adds** a structured `system.event` field — same shape as `llms/handler.js` and `upload-size-limit-reporter.js` — with one event per outcome:

| Event | Level | When |
|---|---|---|
| `indexnow.pinged` | info | successful ping (200/202) |
| `indexnow.api_key_missing` | warn | no API key configured |
| `indexnow.rate_limited` | warn | 429 from IndexNow |
| `indexnow.key_validation_failed` | warn | 422 from IndexNow |
| `indexnow.ping_failed` | warn | any other failure |

Each record carries `post_id`, `post_slug`, `url`, and (for failures) `status_code`, prefixed `[indexnow]`. The event name lives in `system.event` only; the message keeps the `${KEY} ${err.message}` convention.

### Testing

`indexnow.test.js` asserts the `system.event` + `status_code` per outcome. 20/20 unit tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
