### PR TITLE
Gated gift subscriptions on paid members enabled

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
@@ -22,14 +22,14 @@ export const searchKeywords = {
 
 const MembershipSettings: React.FC = () => {
     const {config, settings} = useGlobalData();
-    const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
+    const [hasTipsAndDonations, paidMembersEnabled] = getSettingValues(settings, ['donations_enabled', 'paid_members_enabled']) as [boolean, boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
     const hasAutomations = useFeatureFlag('automations');
     const visibleSearchKeywords = [
         searchKeywords.access,
         searchKeywords.tiers,
         searchKeywords.portal,
-        ...(hasStripeEnabled ? [searchKeywords.giftSubscriptions] : []),
+        ...(paidMembersEnabled ? [searchKeywords.giftSubscriptions] : []),
         ...(hasAutomations ? [] : [searchKeywords.memberEmails]),
         searchKeywords.tips
     ].flat();
@@ -40,7 +40,7 @@ const MembershipSettings: React.FC = () => {
             <SpamFilters keywords={searchKeywords.access} />
             <Tiers keywords={searchKeywords.tiers} />
             <Portal keywords={searchKeywords.portal} />
-            {hasStripeEnabled && <GiftSubscriptions keywords={searchKeywords.giftSubscriptions} />}
+            {paidMembersEnabled && <GiftSubscriptions keywords={searchKeywords.giftSubscriptions} />}
             {!hasAutomations && <MemberEmails keywords={searchKeywords.memberEmails} />}
             {hasTipsAndDonations && hasStripeEnabled && <TipsAndDonations keywords={searchKeywords.tips} />}
         </SearchableSection>

--- a/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
@@ -1,8 +1,8 @@
 import React, {useEffect, useId, useState} from 'react';
 import {Button, List, ListItem, ModalPage, Select, TextField} from '@tryghost/admin-x-design-system';
-import {checkStripeEnabled} from '@tryghost/admin-x-framework/api/settings';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../../providers/global-data-provider';
 
 interface PortalLinkPrefs {
@@ -36,10 +36,10 @@ const PortalLink: React.FC<PortalLinkPrefs> = ({name, value}) => {
 const PortalLinks: React.FC = () => {
     const [isDataAttributes, setIsDataAttributes] = useState(false);
     const [selectedTier, setSelectedTier] = useState('');
-    const {siteData, config, settings} = useGlobalData();
+    const {siteData, settings} = useGlobalData();
     const {data: {tiers: allTiers} = {}} = useBrowseTiers();
     const tiers = getPaidActiveTiers(allTiers || []);
-    const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
+    const [paidMembersEnabled] = getSettingValues(settings, ['paid_members_enabled']) as [boolean];
 
     const toggleIsDataAttributes = () => {
         setIsDataAttributes(!isDataAttributes);
@@ -68,7 +68,7 @@ const PortalLinks: React.FC = () => {
                 <PortalLink name='Default' value={isDataAttributes ? 'data-portal' : `${homePageURL}#/portal`} />
                 <PortalLink name='Sign in' value={isDataAttributes ? 'data-portal="signin"' : `${homePageURL}#/portal/signin`} />
                 <PortalLink name='Sign up' value={isDataAttributes ? 'data-portal="signup"' : `${homePageURL}#/portal/signup`} />
-                {hasStripeEnabled && <PortalLink name='Gift subscriptions' value={isDataAttributes ? 'data-portal="gift"' : `${homePageURL}#/portal/gift`} />}
+                {paidMembersEnabled && <PortalLink name='Gift subscriptions' value={isDataAttributes ? 'data-portal="gift"' : `${homePageURL}#/portal/gift`} />}
             </List>
 
             <List className='mt-14' title='Tiers' titleSize='lg'>

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -54,17 +54,17 @@ const Sidebar: React.FC = () => {
     const searchInputRef = useRef<HTMLInputElement | null>(null);
     const {isAnyTextFieldFocused} = useFocusContext();
     const {settings, config} = useGlobalData();
-    const [hasTipsAndDonations, isPrivate] = getSettingValues(settings, ['donations_enabled', 'is_private']) as [string, boolean];
+    const [hasTipsAndDonations, isPrivate, paidMembersEnabled] = getSettingValues(settings, ['donations_enabled', 'is_private', 'paid_members_enabled']) as [string, boolean, boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
     const hasAutomations = useFeatureFlag('automations');
     const visibleMembershipSearchKeywords = React.useMemo(() => [
         membershipSearchKeywords.access,
         membershipSearchKeywords.tiers,
         membershipSearchKeywords.portal,
-        ...(hasStripeEnabled ? [membershipSearchKeywords.giftSubscriptions] : []),
+        ...(paidMembersEnabled ? [membershipSearchKeywords.giftSubscriptions] : []),
         ...(hasAutomations ? [] : [membershipSearchKeywords.memberEmails]),
         membershipSearchKeywords.tips
-    ].flat(), [hasAutomations, hasStripeEnabled]);
+    ].flat(), [hasAutomations, paidMembersEnabled]);
 
     // Focus in on search field when pressing "/"
     useEffect(() => {
@@ -219,7 +219,7 @@ const Sidebar: React.FC = () => {
                     />
                     <NavItem icon='bills' keywords={membershipSearchKeywords.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
                     <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
-                    {hasStripeEnabled && <NavItem icon='gift' keywords={membershipSearchKeywords.giftSubscriptions} navid='gift-subscriptions' title="Gift subscriptions" onClick={handleSectionClick} />}
+                    {paidMembersEnabled && <NavItem icon='gift' keywords={membershipSearchKeywords.giftSubscriptions} navid='gift-subscriptions' title="Gift subscriptions" onClick={handleSectionClick} />}
                     {!hasAutomations && <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />}
                     {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
                     <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -664,7 +664,7 @@ module.exports = class RouterController {
      * @returns
      */
     async _createGiftCheckoutSession(options) {
-        if (!this._paymentsService.stripeAPIService.configured) {
+        if (!this._settingsHelpers.arePaidMembersEnabled()) {
             throw new DisabledFeatureError({
                 message: tpl(messages.notConfigured)
             });

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -84,7 +84,8 @@ describe('RouterController', function () {
             get: sinon.stub().withArgs('all_blocked_email_domains').returns(['spam.xyz'])
         };
         settingsHelpers = {
-            getMembersSupportAddress: sinon.stub().returns('noreply@example.com')
+            getMembersSupportAddress: sinon.stub().returns('noreply@example.com'),
+            arePaidMembersEnabled: sinon.stub().returns(true)
         };
     });
 
@@ -801,6 +802,26 @@ describe('RouterController', function () {
                 } catch (error) {
                     assert(error instanceof errors.BadRequestError);
                     assert.equal(error.context, 'Offers cannot be applied to gift subscriptions');
+                }
+            });
+
+            it('throws DisabledFeatureError when paid members are not enabled', async function () {
+                const controller = createGiftController({
+                    tiersService: paidTierService(),
+                    settingsHelpers: {
+                        ...settingsHelpers,
+                        arePaidMembersEnabled: sinon.stub().returns(false)
+                    }
+                });
+
+                try {
+                    await controller.createCheckoutSession({
+                        body: {type: 'gift', tierId: 'tier_123', cadence: 'month', metadata: {}}
+                    }, mockRes);
+                    assert.fail('Should have thrown');
+                } catch (error) {
+                    assert(error instanceof errors.DisabledFeatureError);
+                    sinon.assert.notCalled(getGiftLinkSpy);
                 }
             });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3693

- Gift subscriptions were available if Stripe is connected
- With this change, we also check whether memberships are enabled. Gating for gift subscriptions is now: Stripe connected + members enabled (signup access is not set to none)

