### PR TITLE
🐛 Fixed cut-off dropdowns in Membership settings during pre-launch mode

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/access.tsx
@@ -168,15 +168,17 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const form = (
         <SettingGroupContent className='gap-y-4' columns={1}>
             {isTrialMode && (
-                <Banner className='mb-2 flex w-full cursor-default flex-col gap-4 border-0 p-6 pt-5 transition-none hover:translate-y-0 hover:scale-100 hover:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_28%),7px_6px_42px_8px_rgb(202_103_255_/_32%)] md:flex-row md:items-center md:justify-between dark:hover:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_36%),7px_6px_42px_8px_rgb(202_103_255_/_38%)]' size='lg' variant='gradient'>
-                    <div>
-                        <div className='text-base font-semibold'>Pre-launch mode</div>
-                        <div className='mt-2 text-gray-700'>
-                            During your free trial, a private access code is required to browse your site. When you&apos;re ready to launch, pick a plan to upgrade your account and make everything public.
+                <div className='-m-5 overflow-hidden p-5'>
+                    <Banner className='mb-2 flex w-full cursor-default flex-col gap-4 border-0 p-6 pt-5 transition-none hover:translate-y-0 hover:scale-100 hover:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_28%),7px_6px_42px_8px_rgb(202_103_255_/_32%)] md:flex-row md:items-center md:justify-between dark:hover:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_36%),7px_6px_42px_8px_rgb(202_103_255_/_38%)]' size='lg' variant='gradient'>
+                        <div>
+                            <div className='text-base font-semibold'>Pre-launch mode</div>
+                            <div className='mt-2 text-gray-700'>
+                                During your free trial, a private access code is required to browse your site. When you&apos;re ready to launch, pick a plan to upgrade your account and make everything public.
+                            </div>
                         </div>
-                    </div>
-                    <ShadeButton className='shrink-0 self-start md:self-center' asChild><a href="#/pro/billing/plans">Upgrade now</a></ShadeButton>
-                </Banner>
+                        <ShadeButton className='shrink-0 self-start md:self-center' asChild><a href="#/pro/billing/plans">Upgrade now</a></ShadeButton>
+                    </Banner>
+                </div>
             )}
             <div className="flex flex-col content-center items-center gap-4 md:flex-row">
                 <div className="w-full max-w-none min-w-[160px] md:w-2/3 md:max-w-[320px]">Who should be able to browse your site?</div>
@@ -310,7 +312,6 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             keywords={keywords}
             navid='members'
             saveState={saveState}
-            styles={isTrialMode ? 'overflow-hidden' : undefined}
             testId='access'
             title='Access'
             hideEditButton

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -154,7 +154,7 @@ test.describe('Access settings', async () => {
         await expect(accessCode).toHaveValue('fake-456');
     });
 
-    test('Does not clip the Access card in pre-launch mode so dropdowns are not cut off', async ({page}) => {
+    test('Does not clip dropdown options off the Access card in pre-launch mode', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             browseConfig: createConfigWithLimits({
@@ -171,9 +171,20 @@ test.describe('Access settings', async () => {
 
         await expect(section.getByText('Pre-launch mode')).toBeVisible();
 
-        const overflowY = await section.evaluate(el => getComputedStyle(el).overflowY);
-        expect(overflowY).not.toBe('hidden');
-        expect(overflowY).not.toBe('clip');
+        await section.getByTestId('commenting-select').click();
+
+        const lastOption = page.locator('[data-testid="select-option"]', {hasText: 'Nobody'});
+        await expect(lastOption).toBeVisible();
+
+        const box = await lastOption.boundingBox();
+        expect(box).not.toBeNull();
+
+        const optionIsActuallyPainted = await page.evaluate(({x, y, width, height}) => {
+            const el = document.elementFromPoint(x + width / 2, y + height / 2);
+            return Boolean(el?.closest('[data-testid="select-option"]'));
+        }, box!);
+
+        expect(optionIsActuallyPainted).toBe(true);
     });
 
     test('Disables other sections when signup is disabled', async ({page}) => {

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -154,6 +154,28 @@ test.describe('Access settings', async () => {
         await expect(accessCode).toHaveValue('fake-456');
     });
 
+    test('Does not clip the Access card in pre-launch mode so dropdowns are not cut off', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: createConfigWithLimits({
+                publicSiteAccess: {
+                    disabled: true,
+                    error: 'This plan does not include public site access'
+                }
+            })
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('access');
+
+        await expect(section.getByText('Pre-launch mode')).toBeVisible();
+
+        const overflowY = await section.evaluate(el => getComputedStyle(el).overflowY);
+        expect(overflowY).not.toBe('hidden');
+        expect(overflowY).not.toBe('clip');
+    });
+
     test('Disables other sections when signup is disabled', async ({page}) => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,


### PR DESCRIPTION
## Summary

- Fixes the access dropdowns in **Settings → Membership** being clipped when a site is in pre-launch mode (free trial), so options below the fold are no longer cut off.
- Root cause: in pre-launch mode the Access card was given `overflow-hidden` to contain the gradient "Pre-launch mode" banner's glow shadow. That clip is geometric, so it also truncated any `Select` dropdown that opened past the card's edge.
- Fix: drop the card-level `overflow-hidden` and instead contain the glow on a small `overflow-hidden` wrapper around the gradient banner — so the card no longer clips anything and the dropdowns render normally.

## Screenshots

<img width="1280" height="1000" alt="before-1280" src="https://github.com/user-attachments/assets/213c21b9-0943-4050-b71f-75b198fe886a" />

**Before:** the "access to new posts" dropdown is cut off at the card edge — only the first option and a half are visible.

<img width="1280" height="1000" alt="after-new" src="https://github.com/user-attachments/assets/efb3fe1b-5b18-4f7e-b91f-f91e1dd9620e" />

**After:** all options render fully, overflowing the card as expected.


## Context

When `publicSiteAccess` is limited (free-trial / pre-launch mode), `access.tsx` applied `overflow-hidden` to the Access `TopLevelGroup` to keep the banner's large coloured glow inside the card. Because that clip applies to the whole card, it also cropped the visibility dropdowns ("who can subscribe / access new posts / comment") whenever a menu extended below the card. Outside pre-launch mode there was no `overflow-hidden`, so the issue only appeared for trial sites.

## Implementation notes

- Removed `overflow-hidden` from the Access card, so dropdown menus are no longer clipped.
- Wrapped the gradient banner in an `overflow-hidden` container with matching padding and negative margin (`-m-5 ... p-5`), which keeps the banner's glow contained within the card (cross-browser, no reliance on `overflow-clip-margin`) and is layout-neutral, so sibling elements (the dropdowns) are unaffected.
- The banner — and therefore its wrapper — only renders in pre-launch mode, so nothing changes for non-trial sites.

## Testing

- [x] `pnpm --filter @tryghost/admin-x-settings exec tsc --noEmit`
- [x] `pnpm nx run @tryghost/admin-x-settings:lint` (0 errors)
- [x] Manual: ran the app via `pnpm dev`, enabled pre-launch mode — confirmed the dropdowns are no longer clipped and the banner glow stays contained within the card.
- [x] Added an acceptance test asserting the Access card does not clip its overflow in pre-launch mode (verified it fails on the pre-fix code and passes with the fix).

