### PR TITLE
Fixed api_kpis erroring when date_to is omitted

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
@@ -5,7 +5,7 @@ NODE timeseries
 SQL >
 
     %
-        {% set _single_day = defined(date_from) and day_diff(date_from, date_to) == 0 %}
+        {% set _single_day = defined(date_from) and defined(date_to) and day_diff(date_from, date_to) == 0 %}
         with
             {% if defined(date_from) %}
                 toStartOfDay(
@@ -65,7 +65,7 @@ SQL >
     %
         select
             site_uuid,
-            {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+            {% if defined(date_from) and defined(date_to) and day_diff(date_from, date_to) == 0 %}
                 toStartOfHour(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
             {% else %}
                 toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
@@ -107,7 +107,7 @@ SQL >
 
     %
             select
-                {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                {% if defined(date_from) and defined(date_to) and day_diff(date_from, date_to) == 0 %}
                     toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
                 {% else %}
                     toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
@@ -115,7 +115,7 @@ SQL >
                 count() pageviews
             from timeseries a
             inner join _mv_hits h on
-                {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                {% if defined(date_from) and defined(date_to) and day_diff(date_from, date_to) == 0 %}
                     a.date = toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
                 {% else %}
                     a.date = toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))

--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis_v2.pipe
@@ -5,7 +5,7 @@ NODE timeseries
 SQL >
 
     %
-        {% set _single_day = defined(date_from) and day_diff(date_from, date_to) == 0 %}
+        {% set _single_day = defined(date_from) and defined(date_to) and day_diff(date_from, date_to) == 0 %}
         with
             {% if defined(date_from) %}
                 toStartOfDay(
@@ -81,7 +81,7 @@ SQL >
     %
         select
             site_uuid,
-            {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+            {% if defined(date_from) and defined(date_to) and day_diff(date_from, date_to) == 0 %}
                 toStartOfHour(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
             {% else %}
                 toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
@@ -121,7 +121,7 @@ SQL >
 
     %
             select
-                {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                {% if defined(date_from) and defined(date_to) and day_diff(date_from, date_to) == 0 %}
                     toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
                 {% else %}
                     toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
@@ -129,7 +129,7 @@ SQL >
                 count() pageviews
             from timeseries a
             inner join _mv_hits h on
-                {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                {% if defined(date_from) and defined(date_to) and day_diff(date_from, date_to) == 0 %}
                     a.date = toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
                 {% else %}
                     a.date = toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))

--- a/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
@@ -265,3 +265,8 @@
     {"date":"2100-01-05","visits":2,"pageviews":5,"bounce_rate":0,"avg_session_sec":308}
     {"date":"2100-01-06","visits":2,"pageviews":2,"bounce_rate":1,"avg_session_sec":0}
     {"date":"2100-01-07","visits":3,"pageviews":3,"bounce_rate":1,"avg_session_sec":0}
+
+- name: Missing date_to
+  description: Missing date_to defaults to today (no rows as fixtures are future-dated)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&timezone=Etc/UTC
+  expected_result: ''

--- a/ghost/core/core/server/data/tinybird/tests/api_kpis_v2.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_kpis_v2.yaml
@@ -265,3 +265,8 @@
     {"date":"2100-01-05","visits":2,"pageviews":5,"bounce_rate":0,"avg_session_sec":308}
     {"date":"2100-01-06","visits":2,"pageviews":2,"bounce_rate":1,"avg_session_sec":0}
     {"date":"2100-01-07","visits":3,"pageviews":3,"bounce_rate":1,"avg_session_sec":0}
+
+- name: Missing date_to
+  description: Missing date_to defaults to today (no rows as fixtures are future-dated)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&timezone=Etc/UTC
+  expected_result: ''


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1316
  - `day_diff(date_from, date_to)` ran whenever `date_from` was defined, so a request with `date_from` but no `date_to` threw a 400 error. These errors don't come from the Ghost frontend - we always send `date_to` to this endpoint - but requests directly to this endpoint were hitting the error
  - every other stats endpoint (via `filtered_sessions`) already defaults a missing `date_to` to today; api_kpis intended to as well but the day_diff guard broke that
  - added `defined(date_to)` to the `day_diff` checks so a missing `date_to` falls through to the existing `today()` default instead of erroring