### PR TITLE
Improved analytics CSV exports to include the site name

### DIFF
--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -54,6 +54,7 @@
     "@tanstack/react-query": "catalog:",
     "@tryghost/color-utils": "catalog:",
     "@tryghost/i18n": "workspace:*",
+    "@tryghost/string": "catalog:",
     "@tryghost/kg-unsplash-selector": "0.4.1",
     "@tryghost/limit-service": "catalog:",
     "@tryghost/nql": "catalog:",

--- a/apps/admin-x-settings/src/components/settings/advanced/migration-tools/migration-tools-export.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migration-tools/migration-tools-export.tsx
@@ -1,11 +1,23 @@
 import React from 'react';
 import {Button} from '@tryghost/admin-x-design-system';
 import {downloadAllContent} from '@tryghost/admin-x-framework/api/db';
+import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {slugify} from '@tryghost/string';
+import {useGlobalData} from '../../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {usePostsExports} from '@tryghost/admin-x-framework/api/posts';
 
+export const getPostAnalyticsExportFileName = (siteTitle?: string | null) => {
+    const titlePrefix = siteTitle ? `${slugify(siteTitle)}.` : '';
+    const today = new Date().toISOString().split('T')[0];
+
+    return `${titlePrefix}ghost.analytics.${today}.csv`;
+};
+
 const MigrationToolsExport: React.FC = () => {
     const [isExportingPosts, setIsExportingPosts] = React.useState(false);
+    const {settings} = useGlobalData();
+    const [siteTitle] = getSettingValues<string>(settings, ['title']);
     const {refetch: postsData} = usePostsExports({
         searchParams: {
             limit: '1000'
@@ -29,7 +41,7 @@ const MigrationToolsExport: React.FC = () => {
                 const a = document.createElement('a');
                 a.setAttribute('hidden', '');
                 a.setAttribute('href', url);
-                a.setAttribute('download', `post-analytics.${new Date().toISOString().split('T')[0]}.csv`);
+                a.setAttribute('download', getPostAnalyticsExportFileName(siteTitle));
                 document.body.appendChild(a);
                 a.click();
                 document.body.removeChild(a);

--- a/apps/admin-x-settings/src/typings.d.ts
+++ b/apps/admin-x-settings/src/typings.d.ts
@@ -1,5 +1,8 @@
 declare module '@tryghost/limit-service'
 declare module '@tryghost/nql'
+declare module '@tryghost/string' {
+    export function slugify(string: string, options?: {requiredChangesOnly?: boolean}): string;
+}
 
 declare module '*.svg' {
     // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/apps/admin-x-settings/test/unit/utils/post-analytics-export-filename.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/post-analytics-export-filename.test.ts
@@ -1,0 +1,22 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {getPostAnalyticsExportFileName} from '@src/components/settings/advanced/migration-tools/migration-tools-export';
+
+describe('getPostAnalyticsExportFileName', function () {
+    afterEach(function () {
+        vi.useRealTimers();
+    });
+
+    it('includes the slugified site title', function () {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-02T12:00:00.000Z'));
+
+        expect(getPostAnalyticsExportFileName('My Publication')).toBe('my-publication.ghost.analytics.2026-06-02.csv');
+    });
+
+    it('falls back to ghost when the site title is missing', function () {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-02T12:00:00.000Z'));
+
+        expect(getPostAnalyticsExportFileName(null)).toBe('ghost.analytics.2026-06-02.csv');
+    });
+});

--- a/apps/admin/src/vite-env.d.ts
+++ b/apps/admin/src/vite-env.d.ts
@@ -2,4 +2,7 @@
 
 declare module '@tryghost/limit-service'
 declare module '@tryghost/nql'
+declare module '@tryghost/string' {
+    export function slugify(string: string, options?: {requiredChangesOnly?: boolean}): string;
+}
 declare module '@tryghost/koenig-lexical'

--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -1,5 +1,7 @@
 const urlUtils = require('../../../shared/url-utils');
 const models = require('../../models');
+const settingsCache = require('../../../shared/settings-cache');
+const {slugify} = require('@tryghost/string');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const allowedIncludes = [
     'tags',
@@ -21,6 +23,14 @@ const allowedIncludes = [
 const unsafeAttrs = ['status', 'authors', 'visibility'];
 
 const postsService = getPostServiceInstance();
+
+function getPostAnalyticsExportFileName() {
+    const datetime = (new Date()).toJSON().substring(0, 10);
+    const title = settingsCache.get('title');
+    const titlePrefix = title ? `${slugify(title)}.` : '';
+
+    return `${titlePrefix}ghost.analytics.${datetime}.csv`;
+}
 
 /**
  * @param {string} event
@@ -91,8 +101,7 @@ const controller = {
             disposition: {
                 type: 'csv',
                 value() {
-                    const datetime = (new Date()).toJSON().substring(0, 10);
-                    return `post-analytics.${datetime}.csv`;
+                    return getPostAnalyticsExportFileName();
                 }
             },
             cacheInvalidate: false
@@ -107,7 +116,8 @@ const controller = {
         validation: {},
         async query(frame) {
             return {
-                data: await postsService.export(frame)
+                data: await postsService.export(frame),
+                filename: getPostAnalyticsExportFileName()
             };
         }
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
@@ -58,9 +58,8 @@ module.exports = {
         frame.response = function streamResponse(req, res, next) {
             const csvTransform = createCSVTransform();
 
-            const todayIsoDate = (new Date()).toJSON().substring(0, 10);
             res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-            res.setHeader('Content-Disposition', `Attachment; filename="post-analytics.${todayIsoDate}.csv"`);
+            res.setHeader('Content-Disposition', `Attachment; filename="${models.filename}"`);
             const cacheControl = res.getHeader('Cache-Control');
             const cacheControlDirectives = cacheControl ? String(cacheControl).split(',').map(value => value.trim().toLowerCase()) : [];
             if (!cacheControlDirectives.includes('no-transform')) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
@@ -3,6 +3,7 @@ const mappers = require('./mappers');
 const tiersService = require('../../../../../services/tiers');
 const {pipeline} = require('stream');
 const {createCSVTransform} = require('./posts-csv-transform');
+const {InternalServerError} = require('@tryghost/errors');
 
 module.exports = {
     async all(models, apiConfig, frame) {
@@ -56,6 +57,12 @@ module.exports = {
 
     exportCSV(models, apiConfig, frame) {
         frame.response = function streamResponse(req, res, next) {
+            if (!models.filename) {
+                return next(new InternalServerError({
+                    message: 'Missing CSV export filename'
+                }));
+            }
+
             const csvTransform = createCSVTransform();
 
             res.setHeader('Content-Type', 'text/csv; charset=utf-8');

--- a/ghost/core/test/e2e-api/admin/__snapshots__/post-analytics-export.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/post-analytics-export.test.js.snap
@@ -4,7 +4,7 @@ exports[`Post Analytics Export Default settings (all features enabled) Exports C
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -37,7 +37,7 @@ exports[`Post Analytics Export Settings variations Hides clicks column when emai
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -70,7 +70,7 @@ exports[`Post Analytics Export Settings variations Hides email columns when memb
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -103,7 +103,7 @@ exports[`Post Analytics Export Settings variations Hides feedback columns when n
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -136,7 +136,7 @@ exports[`Post Analytics Export Settings variations Hides opens column when email
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -169,7 +169,7 @@ exports[`Post Analytics Export Settings variations Hides paid_conversions when p
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -202,7 +202,7 @@ exports[`Post Analytics Export Settings variations Hides signups and paid_conver
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/post-analytics-export.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/post-analytics-export.test.js.snap
@@ -4,7 +4,7 @@ exports[`Post Analytics Export Default settings (all features enabled) Exports C
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -37,7 +37,7 @@ exports[`Post Analytics Export Settings variations Hides clicks column when emai
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -70,7 +70,7 @@ exports[`Post Analytics Export Settings variations Hides email columns when memb
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -103,7 +103,7 @@ exports[`Post Analytics Export Settings variations Hides feedback columns when n
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -136,7 +136,7 @@ exports[`Post Analytics Export Settings variations Hides opens column when email
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -169,7 +169,7 @@ exports[`Post Analytics Export Settings variations Hides paid_conversions when p
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -202,7 +202,7 @@ exports[`Post Analytics Export Settings variations Hides signups and paid_conver
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -1834,7 +1834,7 @@ exports[`Posts API Export Can export 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -1865,7 +1865,7 @@ exports[`Posts API Export Can export with filter 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -1885,7 +1885,7 @@ exports[`Posts API Export Can export with limit 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -1904,7 +1904,7 @@ exports[`Posts API Export Can export with order 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\(\\?:\\[a-z0-9-\\]\\+\\\\\\.\\)\\?ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -1834,7 +1834,7 @@ exports[`Posts API Export Can export 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -1865,7 +1865,7 @@ exports[`Posts API Export Can export with filter 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -1885,7 +1885,7 @@ exports[`Posts API Export Can export with limit 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",
@@ -1904,7 +1904,7 @@ exports[`Posts API Export Can export with order 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, no-transform",
-  "content-disposition": StringMatching /\\^Attachment; filename="post-analytics\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\.csv"\\$/,
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[a-z0-9-\\]\\+\\\\\\.ghost\\\\\\.analytics\\\\\\.\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}\\\\\\.csv"\\$/,
   "content-type": "text/csv; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin",

--- a/ghost/core/test/e2e-api/admin/post-analytics-export.test.js
+++ b/ghost/core/test/e2e-api/admin/post-analytics-export.test.js
@@ -29,7 +29,7 @@ const csvReplacements = [
 
 const matchExportHeaders = {
     'content-version': anyContentVersion,
-    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
+    'content-disposition': stringMatching(/^Attachment; filename="(?:[a-z0-9-]+\.)?ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
 };
 
 describe('Post Analytics Export', function () {

--- a/ghost/core/test/e2e-api/admin/post-analytics-export.test.js
+++ b/ghost/core/test/e2e-api/admin/post-analytics-export.test.js
@@ -29,7 +29,7 @@ const csvReplacements = [
 
 const matchExportHeaders = {
     'content-version': anyContentVersion,
-    'content-disposition': stringMatching(/^Attachment; filename="post-analytics.\d{4}-\d{2}-\d{2}.csv"$/)
+    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
 };
 
 describe('Post Analytics Export', function () {

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -141,7 +141,7 @@ describe('Posts API', function () {
                 .expectStatus(200)
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    'content-disposition': stringMatching(/^Attachment; filename="post-analytics.\d{4}-\d{2}-\d{2}.csv"$/)
+                    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
                 });
 
             // body snapshot doesn't work with text/csv
@@ -158,7 +158,7 @@ describe('Posts API', function () {
                 .expectStatus(200)
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    'content-disposition': stringMatching(/^Attachment; filename="post-analytics.\d{4}-\d{2}-\d{2}.csv"$/)
+                    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
                 });
 
             // body snapshot doesn't work with text/csv
@@ -175,7 +175,7 @@ describe('Posts API', function () {
                 .expectStatus(200)
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    'content-disposition': stringMatching(/^Attachment; filename="post-analytics.\d{4}-\d{2}-\d{2}.csv"$/)
+                    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
                 });
 
             // body snapshot doesn't work with text/csv
@@ -192,7 +192,7 @@ describe('Posts API', function () {
                 .expectStatus(200)
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    'content-disposition': stringMatching(/^Attachment; filename="post-analytics.\d{4}-\d{2}-\d{2}.csv"$/)
+                    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
                 });
 
             // body snapshot doesn't work with text/csv

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -141,7 +141,7 @@ describe('Posts API', function () {
                 .expectStatus(200)
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
+                    'content-disposition': stringMatching(/^Attachment; filename="(?:[a-z0-9-]+\.)?ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
                 });
 
             // body snapshot doesn't work with text/csv
@@ -158,7 +158,7 @@ describe('Posts API', function () {
                 .expectStatus(200)
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
+                    'content-disposition': stringMatching(/^Attachment; filename="(?:[a-z0-9-]+\.)?ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
                 });
 
             // body snapshot doesn't work with text/csv
@@ -175,7 +175,7 @@ describe('Posts API', function () {
                 .expectStatus(200)
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
+                    'content-disposition': stringMatching(/^Attachment; filename="(?:[a-z0-9-]+\.)?ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
                 });
 
             // body snapshot doesn't work with text/csv
@@ -192,7 +192,7 @@ describe('Posts API', function () {
                 .expectStatus(200)
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    'content-disposition': stringMatching(/^Attachment; filename="[a-z0-9-]+\.ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
+                    'content-disposition': stringMatching(/^Attachment; filename="(?:[a-z0-9-]+\.)?ghost\.analytics\.\d{4}-\d{2}-\d{2}\.csv"$/)
                 });
 
             // body snapshot doesn't work with text/csv

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/posts-export-csv.test.ts
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/posts-export-csv.test.ts
@@ -13,7 +13,7 @@ describe('Unit: posts CSV export serializer', function () {
         const chunks: Buffer[] = [];
         const nextCalls: unknown[] = [];
 
-        postsSerializer.exportCSV({data: source}, null, frame);
+        postsSerializer.exportCSV({data: source, filename: 'test-blog.ghost.analytics.2026-06-02.csv'}, null, frame);
 
         const response: any = new Writable({
             write(chunk: Buffer, _encoding: string, callback: Function) {
@@ -39,7 +39,7 @@ describe('Unit: posts CSV export serializer', function () {
 
         assert.equal(Buffer.concat(chunks).toString(), expected);
         assert.equal(headers['Content-Type'], 'text/csv; charset=utf-8');
-        assert.match(headers['Content-Disposition'], /^Attachment; filename="post-analytics\.\d{4}-\d{2}-\d{2}\.csv"$/);
+        assert.equal(headers['Content-Disposition'], 'Attachment; filename="test-blog.ghost.analytics.2026-06-02.csv"');
         assert.equal(headers['Cache-Control'], 'no-transform');
         assert.deepEqual(nextCalls, []);
     });
@@ -49,7 +49,7 @@ describe('Unit: posts CSV export serializer', function () {
         const frame: {response?: Function} = {};
         const headers: Record<string, string> = {};
 
-        postsSerializer.exportCSV({data: source}, null, frame);
+        postsSerializer.exportCSV({data: source, filename: 'test-blog.ghost.analytics.2026-06-02.csv'}, null, frame);
 
         const response: any = new Writable({
             write(_chunk: Buffer, _encoding: string, callback: Function) {
@@ -75,7 +75,7 @@ describe('Unit: posts CSV export serializer', function () {
         const frame: {response?: Function} = {};
         const headers: Record<string, string> = {};
 
-        postsSerializer.exportCSV({data: source}, null, frame);
+        postsSerializer.exportCSV({data: source, filename: 'test-blog.ghost.analytics.2026-06-02.csv'}, null, frame);
 
         const response: any = new Writable({
             write(_chunk: Buffer, _encoding: string, callback: Function) {

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/posts-export-csv.test.ts
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/posts-export-csv.test.ts
@@ -101,7 +101,7 @@ describe('Unit: posts CSV export serializer', function () {
         const source = Readable.from([{id: '1', title: 'Post'}], {objectMode: true});
         const frame: {response?: Function} = {};
 
-        postsSerializer.exportCSV({data: source}, null, frame);
+        postsSerializer.exportCSV({data: source, filename: 'test-blog.ghost.analytics.2026-06-02.csv'}, null, frame);
 
         const response: any = new Writable({
             write(_chunk: unknown, _encoding: string, callback: Function) {
@@ -117,5 +117,29 @@ describe('Unit: posts CSV export serializer', function () {
         });
 
         assert.equal(err, sourceError);
+    });
+
+    it('Passes missing filenames to next', async function () {
+        const source = Readable.from([{id: '1', title: 'Post'}], {objectMode: true});
+        const frame: {response?: Function} = {};
+        const response: any = new Writable({
+            write(_chunk: unknown, _encoding: string, callback: Function) {
+                callback();
+            }
+        });
+        const headers: Record<string, string> = {};
+        response.setHeader = (key: string, value: string) => {
+            headers[key] = value;
+        };
+        response.getHeader = () => undefined;
+
+        postsSerializer.exportCSV({data: source}, null, frame);
+
+        const err = await new Promise((resolve) => {
+            frame.response!(null, response, resolve);
+        });
+
+        assert.equal((err as Error).message, 'Missing CSV export filename');
+        assert.deepEqual(headers, {});
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,9 @@ importers:
       '@tryghost/i18n':
         specifier: workspace:*
         version: link:../../ghost/i18n
+      '@tryghost/string':
+        specifier: 'catalog:'
+        version: 0.3.4
       '@tryghost/kg-unsplash-selector':
         specifier: 0.4.1
         version: 0.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
closes [ONC-1782](https://linear.app/ghost/issue/ONC-1782/oss-issue-analytics-csv-export-should-include-site-name-in-filename)
Closes #28227

## Why

Post analytics CSV exports were downloaded with a generic `post-analytics.YYYY-MM-DD.csv` filename. That made exports from multiple Ghost sites harder to identify and was inconsistent with content exports, which already include the site name in the filename.

## How

This updates the Admin settings export flow to build the analytics CSV filename from the current site title, using Ghost's existing `@tryghost/string.slugify` helper so the title formatting matches Ghost's established safe filename behavior. The direct Admin API `/posts/export/` response now uses the same `site-name.ghost.analytics.YYYY-MM-DD.csv` filename in `Content-Disposition`, so browser-triggered and direct downloads stay consistent.

## Impact

Users managing exports across multiple publications can tell which site an analytics CSV came from without manually renaming files, and repeated exports are less likely to collide in downloads folders.

## Testing

- Added unit coverage for analytics export filename generation with and without a site title.
- Updated core serializer and E2E header expectations for the new filename format.
- Pre-commit lint-staged checks passed for the staged JS/TS/TSX files.
- `git diff --check` passed before committing.
- Focused test execution in this local shell was blocked by native module code-signature errors for Rollup/sqlite3.