### PR TITLE
Added confirmation before deleting automation emails

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -113,7 +113,7 @@ const buildSendEmailAction = (): AutomationSendEmailAction => ({
     id: generateActionId(),
     type: 'send_email',
     data: {
-        email_subject: 'Untitled email',
+        email_subject: '',
         email_lexical: EMPTY_EMAIL_LEXICAL,
         email_sender_name: null,
         email_sender_email: null,

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -182,7 +182,7 @@ describe('automations api helpers', () => {
             expect(next.actions).toHaveLength(1);
             const newAction = next.actions[0];
             expectSendEmailAction(newAction);
-            expect(newAction.data.email_subject).toBe('Untitled email');
+            expect(newAction.data.email_subject).toBe('');
             expect(() => JSON.parse(newAction.data.email_lexical)).not.toThrow();
             expect(JSON.parse(newAction.data.email_lexical).root.children).toEqual([]);
             expect(newAction.data.email_design_setting_id).toBe('placeholder');

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -39,6 +39,7 @@ type StepNodeDisplayData = {
     label: string;
     isPlaceholderValue?: boolean;
     value?: string;
+    warningMessage?: string;
 };
 
 type StepNodeData = StepNodeDisplayData & {
@@ -75,10 +76,11 @@ const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: Ste
         aria-pressed={data.selected}
         className={cn(
             'flex w-64 items-center gap-3 rounded-lg border border-transparent bg-surface-elevated p-3 text-left text-sm text-foreground shadow-sm transition-all focus-visible:border-border-strong focus-visible:outline-none',
-            data.errorMessage && 'items-start',
+            (data.errorMessage || data.warningMessage) && 'items-start',
             !data.selected && 'hover:border-border-strong',
             data.selected && !data.errorMessage && 'border-gray-700 shadow-[inset_0_0_0_1px_var(--color-gray-700),0_1px_2px_0_rgb(0_0_0_/_0.05)]',
             data.errorMessage && 'border-destructive',
+            !data.errorMessage && data.warningMessage && 'border-yellow-600',
             className
         )}
         type='button'
@@ -90,15 +92,17 @@ const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: Ste
 
 const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
     const Icon = data.icon;
+    const statusMessage = data.errorMessage || data.warningMessage;
     return (
         <>
-            <div className={cn('flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary', data.errorMessage && 'mt-[3px]')}>
+            <div className={cn('flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary', statusMessage && 'mt-[3px]')}>
                 <Icon className='size-4' />
             </div>
             <div className='flex min-w-0 flex-col text-left'>
                 <span className='text-xs text-text-secondary'>{data.label}</span>
                 {data.value && <span className={cn('truncate font-medium', data.isPlaceholderValue && 'opacity-50')}>{data.value}</span>}
                 {data.errorMessage && <span className='mt-1 text-xs text-destructive'>{data.errorMessage}</span>}
+                {!data.errorMessage && data.warningMessage && <span className='mt-1 text-xs text-yellow-600'>{data.warningMessage}</span>}
             </div>
         </>
     );
@@ -195,6 +199,25 @@ export const formatWait = (hours: number): string => {
     return hours === 1 ? '1 hour' : `${hours} hours`;
 };
 
+const isEmptyEmailLexical = (lexical: string | null | undefined): boolean => {
+    if (!lexical) {
+        return true;
+    }
+
+    try {
+        const parsed = JSON.parse(lexical);
+        const children = parsed?.root?.children;
+
+        if (!children || children.length === 0) {
+            return true;
+        }
+
+        return children.length === 1 && children[0].type === 'paragraph' && (!children[0].children || children[0].children.length === 0);
+    } catch {
+        return true;
+    }
+};
+
 const buildActionData = (action: AutomationAction): StepNodeDisplayData => {
     switch (action.type) {
     case 'wait':
@@ -204,7 +227,8 @@ const buildActionData = (action: AutomationAction): StepNodeDisplayData => {
             icon: LucideIcon.Mail,
             isPlaceholderValue: !action.data.email_subject,
             label: 'Send email',
-            value: action.data.email_subject || 'Untitled'
+            value: action.data.email_subject || 'Untitled',
+            warningMessage: isEmptyEmailLexical(action.data.email_lexical) ? 'Empty email body' : undefined
         };
     default: {
         const _exhaustive: never = action;

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -34,8 +34,10 @@ const toApiAnchor = ({sourceId, targetId}: CanvasAnchor): InsertActionAnchor => 
 });
 
 type StepNodeDisplayData = {
+    errorMessage?: string;
     icon: React.ElementType;
     label: string;
+    isPlaceholderValue?: boolean;
     value?: string;
 };
 
@@ -68,12 +70,15 @@ const HiddenHandle: React.FC<{type: 'source' | 'target'; position: Position}> = 
 
 const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: StepNodeData}>> = ({children, className, data}) => (
     <button
+        aria-invalid={Boolean(data.errorMessage)}
         aria-label={data.value ? `${data.label}: ${data.value}` : data.label}
         aria-pressed={data.selected}
         className={cn(
             'flex w-64 items-center gap-3 rounded-lg border border-transparent bg-surface-elevated p-3 text-left text-sm text-foreground shadow-sm transition-all focus-visible:border-border-strong focus-visible:outline-none',
+            data.errorMessage && 'items-start',
             !data.selected && 'hover:border-border-strong',
-            data.selected && 'border-gray-700 shadow-[inset_0_0_0_1px_var(--color-gray-700),0_1px_2px_0_rgb(0_0_0_/_0.05)]',
+            data.selected && !data.errorMessage && 'border-gray-700 shadow-[inset_0_0_0_1px_var(--color-gray-700),0_1px_2px_0_rgb(0_0_0_/_0.05)]',
+            data.errorMessage && 'border-destructive',
             className
         )}
         type='button'
@@ -87,12 +92,13 @@ const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
     const Icon = data.icon;
     return (
         <>
-            <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary'>
+            <div className={cn('flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary', data.errorMessage && 'mt-[3px]')}>
                 <Icon className='size-4' />
             </div>
             <div className='flex min-w-0 flex-col text-left'>
                 <span className='text-xs text-text-secondary'>{data.label}</span>
-                {data.value && <span className='truncate font-medium'>{data.value}</span>}
+                {data.value && <span className={cn('truncate font-medium', data.isPlaceholderValue && 'opacity-50')}>{data.value}</span>}
+                {data.errorMessage && <span className='mt-1 text-xs text-destructive'>{data.errorMessage}</span>}
             </div>
         </>
     );
@@ -194,7 +200,12 @@ const buildActionData = (action: AutomationAction): StepNodeDisplayData => {
     case 'wait':
         return {icon: LucideIcon.Clock, label: 'Wait', value: formatWait(action.data.wait_hours)};
     case 'send_email':
-        return {icon: LucideIcon.Mail, label: 'Send email', value: action.data.email_subject};
+        return {
+            icon: LucideIcon.Mail,
+            isPlaceholderValue: !action.data.email_subject,
+            label: 'Send email',
+            value: action.data.email_subject || 'Untitled'
+        };
     default: {
         const _exhaustive: never = action;
         throw new Error(`Unknown automation action type: ${_exhaustive}`);
@@ -244,6 +255,7 @@ const getInitialActionOrder = (automation: AutomationDetail): AutomationAction[]
 };
 
 type BuildGraphParams = {
+    actionErrors: Record<string, string>;
     automation: AutomationDetail;
     disabled: boolean;
     onPick: (type: StepPickerType, anchor: CanvasAnchor) => void;
@@ -251,7 +263,7 @@ type BuildGraphParams = {
     selectedStepId: string | null;
 }
 
-const buildGraph = ({automation, disabled, onPick, onSelectStep, selectedStepId}: BuildGraphParams): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
+const buildGraph = ({actionErrors, automation, disabled, onPick, onSelectStep, selectedStepId}: BuildGraphParams): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
     const ordered = getInitialActionOrder(automation);
     const baseNodeProps = {
         draggable: false,
@@ -290,6 +302,7 @@ const buildGraph = ({automation, disabled, onPick, onSelectStep, selectedStepId}
             position: {x: NODE_X, y: NODE_GAP_Y * (index + 1)},
             data: {
                 ...buildActionData(action),
+                errorMessage: actionErrors[action.id],
                 selected: selectedStepId === action.id,
                 onSelect: () => onSelectStep(action.id)
             },
@@ -349,6 +362,7 @@ const getInitialViewport = (canvasWidth: number): {x: number; y: number; zoom: n
 
 type BaseStepSidebarDetail<Type extends string, LabelText extends string> = {
     icon: React.ElementType;
+    isPlaceholderTitle?: boolean;
     title: string;
     label: LabelText;
     type: Type;
@@ -429,7 +443,8 @@ const getStepSidebarDetail = ({automation, autoFocusSubject, stepId, onDelete, o
         return {
             icon: LucideIcon.Mail,
             label: 'Send email',
-            title: action.data.email_subject || 'No subject',
+            isPlaceholderTitle: !action.data.email_subject,
+            title: action.data.email_subject || 'Untitled',
             action,
             autoFocusSubject,
             onDelete: () => onDelete(action.id),
@@ -625,7 +640,7 @@ const StepSidebarContent: React.FC<{detail: StepSidebarDetail}> = ({detail}) => 
                     </div>
                     <div className='min-w-0'>
                         <span className='block text-xs text-text-secondary'>{detail.label}</span>
-                        <h2 className='truncate text-base leading-tight font-semibold text-foreground'>{detail.title}</h2>
+                        <h2 className={cn('truncate text-base leading-tight font-semibold text-foreground', detail.isPlaceholderTitle && 'opacity-50')}>{detail.title}</h2>
                     </div>
                 </div>
             </div>
@@ -673,6 +688,7 @@ const StepSidebar: React.FC<{detail: StepSidebarDetail | null; isEmailModalOpen:
 };
 
 type AutomationCanvasProps = {
+    actionErrors?: Record<string, string>;
     automation?: AutomationDetail;
     isLoading: boolean;
     isError: boolean;
@@ -690,7 +706,7 @@ const insertActionByType = {
     send_email: insertSendEmailAction
 };
 
-const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError, onChange}) => {
+const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, automation, isLoading, isError, onChange}) => {
     const [selectedStep, setSelectedStep] = useState<SelectedStep | null>(null);
     const [deleteConfirmationActionId, setDeleteConfirmationActionId] = useState<string | null>(null);
     const selectedStepId = selectedStep?.id ?? null;
@@ -783,13 +799,14 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             return null;
         }
         return buildGraph({
+            actionErrors,
             automation,
             disabled: automation.actions.length >= MAX_AUTOMATION_ACTIONS,
             onPick: handlePick,
             onSelectStep: id => setSelectedStep({id, isEditingEmail: false}),
             selectedStepId
         });
-    }, [automation, handlePick, selectedStepId]);
+    }, [actionErrors, automation, handlePick, selectedStepId]);
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -368,6 +368,7 @@ type WaitStepSidebarDetail = ActionStepSidebarDetail<AutomationWaitAction, 'Wait
 };
 
 type SendEmailStepSidebarDetail = ActionStepSidebarDetail<AutomationSendEmailAction, 'Send email'> & {
+    autoFocusSubject: boolean;
     onUpdateSubject: (subject: string) => void;
     onEditEmail: () => void;
 };
@@ -383,6 +384,7 @@ const automationSlugMemberTiers: Record<string, MemberTier[]> = {
 
 type StepSidebarDetailOptions = {
     automation: AutomationDetail;
+    autoFocusSubject: boolean;
     onDelete: (actionId: string) => void;
     onUpdateWait: (actionId: string, waitHours: number) => void;
     onUpdateSubject: (actionId: string, subject: string) => void;
@@ -390,7 +392,7 @@ type StepSidebarDetailOptions = {
     stepId: string | null;
 };
 
-const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
+const getStepSidebarDetail = ({automation, autoFocusSubject, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
     if (!stepId) {
         return null;
     }
@@ -429,6 +431,7 @@ const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpd
             label: 'Send email',
             title: action.data.email_subject || 'No subject',
             action,
+            autoFocusSubject,
             onDelete: () => onDelete(action.id),
             onUpdateSubject: (subject: string) => onUpdateSubject(action.id, subject),
             onEditEmail: () => onEditEmail(action.id),
@@ -556,32 +559,44 @@ const WaitSidebarBody: React.FC<{
 
 const SendEmailSidebarBody: React.FC<{
     action: AutomationSendEmailAction;
+    autoFocusSubject: boolean;
     onUpdateSubject: (subject: string) => void;
     onEditEmail: () => void;
     onDelete: () => void;
-}> = ({action, onUpdateSubject, onEditEmail, onDelete}) => (
-    <div className='flex flex-1 flex-col gap-5'>
-        <SidebarField label='Subject line'>
-            <Input
-                placeholder='Subject line'
-                value={action.data.email_subject}
-                onChange={e => onUpdateSubject(e.target.value)}
-            />
-        </SidebarField>
-        <Button
-            className='w-full'
-            type='button'
-            variant='outline'
-            onClick={onEditEmail}
-        >
-            <LucideIcon.Pencil className='size-4' />
-            Edit email
-        </Button>
-        <div className='mt-auto pt-6'>
-            <DeleteStepButton onClick={onDelete} />
+}> = ({action, autoFocusSubject, onUpdateSubject, onEditEmail, onDelete}) => {
+    const subjectInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (autoFocusSubject) {
+            subjectInputRef.current?.focus({preventScroll: true});
+        }
+    }, [action.id, autoFocusSubject]);
+
+    return (
+        <div className='flex flex-1 flex-col gap-5'>
+            <SidebarField label='Subject line'>
+                <Input
+                    ref={subjectInputRef}
+                    placeholder='Subject line'
+                    value={action.data.email_subject}
+                    onChange={e => onUpdateSubject(e.target.value)}
+                />
+            </SidebarField>
+            <Button
+                className='w-full'
+                type='button'
+                variant='outline'
+                onClick={onEditEmail}
+            >
+                <LucideIcon.Pencil className='size-4' />
+                Edit email
+            </Button>
+            <div className='mt-auto pt-6'>
+                <DeleteStepButton onClick={onDelete} />
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     switch (detail.type) {
@@ -590,7 +605,7 @@ const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     case 'wait':
         return <WaitSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onUpdate={detail.onUpdate} />;
     case 'send_email':
-        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
+        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} autoFocusSubject={detail.autoFocusSubject} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
     default: {
         const _exhaustive: never = detail;
         throw new Error(`Unknown sidebar type: ${_exhaustive}`);
@@ -667,6 +682,7 @@ type AutomationCanvasProps = {
 type SelectedStep = {
     id: string;
     isEditingEmail: boolean;
+    shouldFocusSubject?: boolean;
 };
 
 const insertActionByType = {
@@ -689,6 +705,20 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         const apiAnchor = toApiAnchor(anchor);
         const insertAction = insertActionByType[type];
         const next = insertAction({detail: automation, anchor: apiAnchor});
+        if (type === 'send_email') {
+            const existingActionIds = new Set(automation.actions.map(action => action.id));
+            const insertedEmailAction = next.actions.find((action): action is AutomationSendEmailAction => (
+                action.type === 'send_email' && !existingActionIds.has(action.id)
+            ));
+
+            if (insertedEmailAction) {
+                setSelectedStep({
+                    id: insertedEmailAction.id,
+                    isEditingEmail: false,
+                    shouldFocusSubject: true
+                });
+            }
+        }
         onChange(next);
     }, [automation, onChange]);
 
@@ -763,6 +793,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,
+        autoFocusSubject: Boolean(selectedStep?.shouldFocusSubject),
         onDelete: handleRequestDelete,
         onUpdateWait: handleUpdateWait,
         onUpdateSubject: handleUpdateSubject,

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -531,9 +531,11 @@ const WaitSidebarBody: React.FC<{
     }
     const initialDays = action.data.wait_hours / 24;
     const [daysText, setDaysText] = useState<string>(String(initialDays));
+    const [hasBlurredDaysInput, setHasBlurredDaysInput] = useState(false);
 
     const days = Number(daysText);
     const isValid = getValidWaitDays(daysText) !== null;
+    const showValidationError = hasBlurredDaysInput && !isValid;
     const unitLabel = days === 1 ? 'Day' : 'Days';
 
     const updateWaitDays = (nextDays: number) => {
@@ -559,15 +561,17 @@ const WaitSidebarBody: React.FC<{
             <SidebarField label='Wait for'>
                 <div className='grid grid-cols-[6rem_1fr] gap-2'>
                     <Input
-                        aria-invalid={!isValid}
+                        aria-invalid={showValidationError}
                         className='h-(--control-height)'
                         inputMode='numeric'
                         value={daysText}
+                        onBlur={() => setHasBlurredDaysInput(true)}
                         onChange={handleChange}
+                        onFocus={() => setHasBlurredDaysInput(false)}
                     />
                     <ReadOnlySelect value={unitLabel} />
                 </div>
-                {!isValid && (
+                {showValidationError && (
                     <span className='text-xs text-red'>
                         Enter a whole number between 1 and {formatNumber(MAX_WAIT_DAYS)} days.
                     </span>

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -573,7 +573,7 @@ const WaitSidebarBody: React.FC<{
                 </div>
                 {showValidationError && (
                     <span className='text-xs text-red'>
-                        Enter a whole number between 1 and {formatNumber(MAX_WAIT_DAYS)} days.
+                        Enter a delay between 1 and {formatNumber(MAX_WAIT_DAYS)} days
                     </span>
                 )}
             </SidebarField>

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -3,7 +3,7 @@ import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
 import EmailContentModal from './email-modal/email-content-modal';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
-import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Banner, Button, Checkbox, Input, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Banner, Button, Checkbox, Input, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger} from '@tryghost/shade/components';
 import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction, updateSendEmailAction, updateWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, BackgroundVariant, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
@@ -136,28 +136,15 @@ const TailNode: React.FC<NodeProps<TailFlowNode>> = ({data}) => {
     const triggerClassName = 'flex h-12 w-64 items-center justify-center rounded-lg border border-dashed border-border-default bg-surface-page transition-colors hover:border-border-strong focus-visible:border-border-strong focus-visible:outline-none';
 
     if (data.disabled) {
-        const content = (
+        return (
             <div
-                aria-disabled='true'
-                className={cn(triggerClassName, 'cursor-not-allowed opacity-60')}
-                data-testid='add-step-tail-button'
+                className='flex h-12 w-64 items-center justify-center rounded-lg border border-border-default bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_18px,var(--color-gray-100)_18px,var(--color-gray-100)_34px)] text-sm font-medium text-text-secondary'
+                data-testid='step-limit-tail-node'
             >
                 <HiddenHandle position={Position.Top} type='target' />
-                <LucideIcon.Plus className='size-5 text-text-secondary' strokeWidth={1.5} />
+                <LucideIcon.Milestone className='mr-2 size-4' strokeWidth={1.5} />
+                {data.disabledReason}
             </div>
-        );
-        if (!data.disabledReason) {
-            return content;
-        }
-        return (
-            <TooltipProvider delayDuration={150}>
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <span tabIndex={0}>{content}</span>
-                    </TooltipTrigger>
-                    <TooltipContent>{data.disabledReason}</TooltipContent>
-                </Tooltip>
-            </TooltipProvider>
         );
     }
 
@@ -622,7 +609,7 @@ const SendEmailSidebarBody: React.FC<{
                 onClick={onEditEmail}
             >
                 <LucideIcon.Pencil className='size-4' />
-                Edit email
+                Edit email content
             </Button>
             <div className='mt-auto pt-6'>
                 <DeleteStepButton onClick={onDelete} />

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -382,7 +382,6 @@ type WaitStepSidebarDetail = ActionStepSidebarDetail<AutomationWaitAction, 'Wait
 };
 
 type SendEmailStepSidebarDetail = ActionStepSidebarDetail<AutomationSendEmailAction, 'Send email'> & {
-    autoFocusSubject: boolean;
     onUpdateSubject: (subject: string) => void;
     onEditEmail: () => void;
 };
@@ -398,7 +397,6 @@ const automationSlugMemberTiers: Record<string, MemberTier[]> = {
 
 type StepSidebarDetailOptions = {
     automation: AutomationDetail;
-    autoFocusSubject: boolean;
     onDelete: (actionId: string) => void;
     onUpdateWait: (actionId: string, waitHours: number) => void;
     onUpdateSubject: (actionId: string, subject: string) => void;
@@ -406,7 +404,7 @@ type StepSidebarDetailOptions = {
     stepId: string | null;
 };
 
-const getStepSidebarDetail = ({automation, autoFocusSubject, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
+const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
     if (!stepId) {
         return null;
     }
@@ -446,7 +444,6 @@ const getStepSidebarDetail = ({automation, autoFocusSubject, stepId, onDelete, o
             isPlaceholderTitle: !action.data.email_subject,
             title: action.data.email_subject || 'Untitled',
             action,
-            autoFocusSubject,
             onDelete: () => onDelete(action.id),
             onUpdateSubject: (subject: string) => onUpdateSubject(action.id, subject),
             onEditEmail: () => onEditEmail(action.id),
@@ -574,18 +571,15 @@ const WaitSidebarBody: React.FC<{
 
 const SendEmailSidebarBody: React.FC<{
     action: AutomationSendEmailAction;
-    autoFocusSubject: boolean;
     onUpdateSubject: (subject: string) => void;
     onEditEmail: () => void;
     onDelete: () => void;
-}> = ({action, autoFocusSubject, onUpdateSubject, onEditEmail, onDelete}) => {
+}> = ({action, onUpdateSubject, onEditEmail, onDelete}) => {
     const subjectInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
-        if (autoFocusSubject) {
-            subjectInputRef.current?.focus({preventScroll: true});
-        }
-    }, [action.id, autoFocusSubject]);
+        subjectInputRef.current?.focus({preventScroll: true});
+    }, [action.id]);
 
     return (
         <div className='flex flex-1 flex-col gap-5'>
@@ -620,7 +614,7 @@ const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     case 'wait':
         return <WaitSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onUpdate={detail.onUpdate} />;
     case 'send_email':
-        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} autoFocusSubject={detail.autoFocusSubject} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
+        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
     default: {
         const _exhaustive: never = detail;
         throw new Error(`Unknown sidebar type: ${_exhaustive}`);
@@ -698,7 +692,6 @@ type AutomationCanvasProps = {
 type SelectedStep = {
     id: string;
     isEditingEmail: boolean;
-    shouldFocusSubject?: boolean;
 };
 
 const insertActionByType = {
@@ -730,8 +723,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
             if (insertedEmailAction) {
                 setSelectedStep({
                     id: insertedEmailAction.id,
-                    isEditingEmail: false,
-                    shouldFocusSubject: true
+                    isEditingEmail: false
                 });
             }
         }
@@ -810,7 +802,6 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,
-        autoFocusSubject: Boolean(selectedStep?.shouldFocusSubject),
         onDelete: handleRequestDelete,
         onUpdateWait: handleUpdateWait,
         onUpdateSubject: handleUpdateSubject,

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -16,7 +16,7 @@ const NODE_WIDTH = 256;
 const NODE_COLUMN_CENTER_X = NODE_X + (NODE_WIDTH / 2);
 const NODE_GAP_Y = 180;
 const INITIAL_VIEWPORT_Y = 40;
-const DISABLED_REASON = `Limit of ${formatNumber(MAX_AUTOMATION_ACTIONS)} steps reached`;
+const DISABLED_REASON = 'Maximum steps added';
 const DEFAULT_EDGE_STROKE = 'var(--xy-edge-stroke)';
 
 // React Flow node IDs for the trigger and tail nodes. The canvas builds the visual graph using
@@ -138,7 +138,7 @@ const TailNode: React.FC<NodeProps<TailFlowNode>> = ({data}) => {
     if (data.disabled) {
         return (
             <div
-                className='flex h-12 w-64 items-center justify-center rounded-lg border border-border-default bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_18px,var(--color-gray-100)_18px,var(--color-gray-100)_34px)] text-sm font-medium text-text-secondary'
+                className='flex h-12 w-64 items-center justify-center rounded-lg border border-border-default bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_12px,var(--color-gray-100)_12px,var(--color-gray-100)_24px)] text-sm font-medium text-text-secondary'
                 data-testid='step-limit-tail-node'
             >
                 <HiddenHandle position={Position.Top} type='target' />

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -3,9 +3,9 @@ import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
 import EmailContentModal from './email-modal/email-content-modal';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Banner, Button, Checkbox, Input, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction, updateSendEmailAction, updateWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, BackgroundVariant, Edge, Handle, Node, NodeProps, Position, ReactFlow} from '@xyflow/react';
-import {Banner, Button, Checkbox, Input, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 
 const MAX_WAIT_DAYS = 30;
@@ -676,6 +676,7 @@ const insertActionByType = {
 
 const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError, onChange}) => {
     const [selectedStep, setSelectedStep] = useState<SelectedStep | null>(null);
+    const [deleteConfirmationActionId, setDeleteConfirmationActionId] = useState<string | null>(null);
     const selectedStepId = selectedStep?.id ?? null;
 
     const handlePick = useCallback((type: StepPickerType, anchor: CanvasAnchor) => {
@@ -697,8 +698,23 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         }
         const next = removeAction({detail: automation, actionId});
         setSelectedStep(null);
+        setDeleteConfirmationActionId(null);
         onChange(next);
     }, [automation, onChange]);
+
+    const handleRequestDelete = useCallback((actionId: string) => {
+        if (!automation) {
+            return;
+        }
+
+        const action = automation.actions.find(item => item.id === actionId);
+        if (action?.type === 'send_email') {
+            setDeleteConfirmationActionId(action.id);
+            return;
+        }
+
+        handleDelete(actionId);
+    }, [automation, handleDelete]);
 
     const handleUpdateWait = useCallback((actionId: string, waitHours: number) => {
         if (!automation) {
@@ -726,6 +742,10 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         ? automation.actions.find((action): action is AutomationSendEmailAction => action.id === selectedStep.id && action.type === 'send_email')
         : undefined;
 
+    const deleteConfirmationAction = automation && deleteConfirmationActionId
+        ? automation.actions.find((action): action is AutomationSendEmailAction => action.id === deleteConfirmationActionId && action.type === 'send_email')
+        : undefined;
+
     const initialViewport = useRef(getInitialViewport(window.innerWidth));
 
     const graph = useMemo(() => {
@@ -743,7 +763,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,
-        onDelete: handleDelete,
+        onDelete: handleRequestDelete,
         onUpdateWait: handleUpdateWait,
         onUpdateSubject: handleUpdateSubject,
         onEditEmail: handleEditEmail,
@@ -809,7 +829,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             >
                 <Background variant={BackgroundVariant.Dots} />
             </ReactFlow>
-            <StepSidebar detail={sidebarDetail} isEmailModalOpen={Boolean(emailModalAction)} onClose={clearDetail} />
+            <StepSidebar detail={sidebarDetail} isEmailModalOpen={Boolean(emailModalAction) || Boolean(deleteConfirmationAction)} onClose={clearDetail} />
             {emailModalAction && automation && (
                 <EmailContentModal
                     initialLexical={emailModalAction.data.email_lexical}
@@ -821,6 +841,36 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
                     }}
                 />
             )}
+            <AlertDialog
+                open={Boolean(deleteConfirmationAction)}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setDeleteConfirmationActionId(null);
+                    }
+                }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete this email?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This email will be removed from the automation. Save or publish the automation to apply this change.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <Button
+                            variant='destructive'
+                            onClick={() => {
+                                if (deleteConfirmationAction) {
+                                    handleDelete(deleteConfirmationAction.id);
+                                }
+                            }}
+                        >
+                            Delete email
+                        </Button>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 };

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -10,6 +10,26 @@ import {useConfirmUnload, useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
 
 const SUBJECT_REQUIRED_MESSAGE = 'Add a subject line.';
+const EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE = 'One or more emails in this automation do not have a body. Are you sure you want to save and publish this automation?';
+
+const isEmptyEmailLexical = (lexical: string | null | undefined): boolean => {
+    if (!lexical) {
+        return true;
+    }
+
+    try {
+        const parsed = JSON.parse(lexical);
+        const children = parsed?.root?.children;
+
+        if (!children || children.length === 0) {
+            return true;
+        }
+
+        return children.length === 1 && children[0].type === 'paragraph' && (!children[0].children || children[0].children.length === 0);
+    } catch {
+        return true;
+    }
+};
 
 const editableSlice = (automation: AutomationDetail) => ({
     status: automation.status,
@@ -24,6 +44,7 @@ const isFailedEditState = (editState: AutomationEditState): boolean => {
     case 'failed to save':
     case 'failed to unpublish':
         return true;
+    case 'confirming empty-body publish':
     case 'confirming re-publish':
     case 'confirming unpublish':
     case 'idle':
@@ -50,6 +71,10 @@ const getActionErrors = (automation: AutomationDetail): Record<string, string> =
 
     return errors;
 };
+
+const hasEmptyEmailBodies = (automation: AutomationDetail): boolean => (
+    automation.actions.some(action => action.type === 'send_email' && isEmptyEmailLexical(action.data.email_lexical))
+);
 
 const AutomationEditor: React.FC = () => {
     const {id = ''} = useParams<{id: string}>();
@@ -98,6 +123,20 @@ const AutomationEditor: React.FC = () => {
         ));
     };
 
+    const validateActionErrors = (automationToValidate: AutomationDetail, errorState: AutomationEditState): boolean => {
+        const nextActionErrors = getActionErrors(automationToValidate);
+        if (Object.keys(nextActionErrors).length > 0) {
+            setActionErrors(nextActionErrors);
+            setEditState(errorState);
+            toast.error('Could not save automation', {
+                description: 'Fix the highlighted steps and try again.'
+            });
+            return false;
+        }
+
+        return true;
+    };
+
     const save = (statusToSave?: AutomationStatus) => {
         if (!draft) {
             throw new Error('Cannot edit an automation that has not loaded.');
@@ -132,17 +171,11 @@ const AutomationEditor: React.FC = () => {
         }
         }
 
-        setEditState(requestState);
-
-        const nextActionErrors = getActionErrors(draft);
-        if (Object.keys(nextActionErrors).length > 0) {
-            setActionErrors(nextActionErrors);
-            setEditState(errorState);
-            toast.error('Could not save automation', {
-                description: 'Fix the highlighted steps and try again.'
-            });
+        if (!validateActionErrors(draft, errorState)) {
             return;
         }
+
+        setEditState(requestState);
 
         editMutation.mutate(
             {
@@ -167,6 +200,8 @@ const AutomationEditor: React.FC = () => {
         );
     };
 
+    const hasEmptyEmailBodyWarnings = draft ? hasEmptyEmailBodies(draft) : false;
+    let isConfirmEmptyBodyPublishAlertOpen = false;
     let isConfirmUnpublishAlertOpen = false;
     let isConfirmRepublishAlertOpen = false;
     let isEditRequestActive = false;
@@ -236,6 +271,12 @@ const AutomationEditor: React.FC = () => {
             </>
         );
         break;
+    case 'confirming empty-body publish':
+        isConfirmEmptyBodyPublishAlertOpen = true;
+        isSaveButtonEnabled = false;
+        isPublishButtonEnabled = false;
+        isTurnOffButtonEnabled = false;
+        break;
     case 'confirming unpublish':
         isConfirmUnpublishAlertOpen = true;
         isSaveButtonEnabled = false;
@@ -272,6 +313,19 @@ const AutomationEditor: React.FC = () => {
         throw new Error(`Unhandled edit state: ${_exhaustive}`);
     }
     }
+
+    const onConfirmEmptyBodyPublishOpenChange = (open: boolean): void => {
+        setEditState((oldEditState) => {
+            switch (oldEditState) {
+            case 'confirming empty-body publish':
+                return open ? oldEditState : 'idle';
+            case 'idle':
+                return open ? 'confirming empty-body publish' : oldEditState;
+            default:
+                return oldEditState;
+            }
+        });
+    };
 
     const onConfirmUnpublishOpenChange = (open: boolean): void => {
         setEditState((oldEditState) => {
@@ -310,6 +364,13 @@ const AutomationEditor: React.FC = () => {
             setEditState('confirming re-publish');
             break;
         case 'inactive':
+            if (!validateActionErrors(draft, 'failed to publish')) {
+                return;
+            }
+            if (hasEmptyEmailBodies(draft)) {
+                setEditState('confirming empty-body publish');
+                return;
+            }
             save('active');
             break;
         default: {
@@ -379,6 +440,26 @@ const AutomationEditor: React.FC = () => {
             </AlertDialog>
 
             <AlertDialog
+                open={isConfirmEmptyBodyPublishAlertOpen}
+                onOpenChange={onConfirmEmptyBodyPublishOpenChange}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Publish automation with empty emails?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <Button onClick={() => save('active')}>
+                            Publish automation
+                        </Button>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog
                 open={isConfirmUnpublishAlertOpen}
                 onOpenChange={onConfirmUnpublishOpenChange}
             >
@@ -410,7 +491,7 @@ const AutomationEditor: React.FC = () => {
                     <AlertDialogHeader>
                         <AlertDialogTitle>Update automation?</AlertDialogTitle>
                         <AlertDialogDescription>
-                            This will update the automation for new runs of the automation, as well as any actively-running ones.
+                            {hasEmptyEmailBodyWarnings ? `${EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE} This will update the automation for new runs of the automation, as well as any actively-running ones.` : 'This will update the automation for new runs of the automation, as well as any actively-running ones.'}
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -128,7 +128,7 @@ const AutomationEditor: React.FC = () => {
         if (Object.keys(nextActionErrors).length > 0) {
             setActionErrors(nextActionErrors);
             setEditState(errorState);
-            toast.error('Could not save automation', {
+            toast.error('Automation couldn’t be saved', {
                 description: 'Fix the highlighted steps and try again.'
             });
             return false;
@@ -192,8 +192,8 @@ const AutomationEditor: React.FC = () => {
                 },
                 onError: () => {
                     setEditState(errorState);
-                    toast.error('Could not save automation', {
-                        description: 'Fix any highlighted steps and try again.'
+                    toast.error('Automation couldn’t be saved', {
+                        description: 'Fix the highlighted steps and try again.'
                     });
                 }
             }

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -4,9 +4,12 @@ import React from 'react';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, type ButtonProps, LoadingIndicator} from '@tryghost/shade/components';
 import {AutomationDetail, AutomationStatus, useEditAutomation, useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
 import {dequal} from 'dequal';
+import {toast} from 'sonner';
 import {useBlocker} from 'react-router';
 import {useConfirmUnload, useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
+
+const SUBJECT_REQUIRED_MESSAGE = 'Add a subject line.';
 
 const editableSlice = (automation: AutomationDetail) => ({
     status: automation.status,
@@ -36,6 +39,18 @@ const isFailedEditState = (editState: AutomationEditState): boolean => {
     }
 };
 
+const getActionErrors = (automation: AutomationDetail): Record<string, string> => {
+    const errors: Record<string, string> = {};
+
+    for (const action of automation.actions) {
+        if (action.type === 'send_email' && !action.data.email_subject.trim()) {
+            errors[action.id] = SUBJECT_REQUIRED_MESSAGE;
+        }
+    }
+
+    return errors;
+};
+
 const AutomationEditor: React.FC = () => {
     const {id = ''} = useParams<{id: string}>();
 
@@ -46,6 +61,7 @@ const AutomationEditor: React.FC = () => {
 
     const editMutation = useEditAutomation();
     const [editState, setEditState] = React.useState<AutomationEditState>('idle');
+    const [actionErrors, setActionErrors] = React.useState<Record<string, string>>({});
 
     // Draft is the user-facing, locally mutable copy. The React Query cache stays as server truth;
     // staged edits (adding steps, etc.) live here until the user publishes. Seeded once when the
@@ -67,6 +83,16 @@ const AutomationEditor: React.FC = () => {
 
     const onDraftChange = (next: AutomationDetail) => {
         setDraft(next);
+        setActionErrors((oldErrors) => {
+            if (Object.keys(oldErrors).length === 0) {
+                return oldErrors;
+            }
+
+            const nextErrors = getActionErrors(next);
+            return Object.fromEntries(
+                Object.entries(oldErrors).filter(([actionId]) => nextErrors[actionId])
+            );
+        });
         setEditState(prev => (
             isFailedEditState(prev) ? 'idle' : prev
         ));
@@ -108,6 +134,16 @@ const AutomationEditor: React.FC = () => {
 
         setEditState(requestState);
 
+        const nextActionErrors = getActionErrors(draft);
+        if (Object.keys(nextActionErrors).length > 0) {
+            setActionErrors(nextActionErrors);
+            setEditState(errorState);
+            toast.error('Could not save automation', {
+                description: 'Fix the highlighted steps and try again.'
+            });
+            return;
+        }
+
         editMutation.mutate(
             {
                 id: draft.id,
@@ -118,9 +154,15 @@ const AutomationEditor: React.FC = () => {
             {
                 onSuccess: (response) => {
                     setDraft(response.automations[0]);
+                    setActionErrors({});
                     setEditState('idle');
                 },
-                onError: () => setEditState(errorState)
+                onError: () => {
+                    setEditState(errorState);
+                    toast.error('Could not save automation', {
+                        description: 'Fix any highlighted steps and try again.'
+                    });
+                }
             }
         );
     };
@@ -306,6 +348,7 @@ const AutomationEditor: React.FC = () => {
             />
 
             <AutomationCanvas
+                actionErrors={actionErrors}
                 automation={draft}
                 isError={isError}
                 isLoading={isLoadingAutomation}

--- a/apps/posts/src/views/Automations/types.ts
+++ b/apps/posts/src/views/Automations/types.ts
@@ -4,6 +4,7 @@ export type AutomationEditState =
   | 'publishing'
   | 're-publishing'
   | 'unpublishing'
+  | 'confirming empty-body publish'
   | 'confirming unpublish'
   | 'confirming re-publish'
   | 'failed to save'

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -502,7 +502,13 @@ describe('AutomationEditor', () => {
         const waitInput = within(sidebar).getByDisplayValue('1');
 
         for (const value of ['2e1', '+2']) {
+            fireEvent.focus(waitInput);
             fireEvent.change(waitInput, {target: {value}});
+
+            expect(waitInput).toHaveAttribute('aria-invalid', 'false');
+            expect(within(sidebar).queryByText('Enter a whole number between 1 and 30 days.')).not.toBeInTheDocument();
+
+            fireEvent.blur(waitInput);
 
             expect(waitInput).toHaveAttribute('aria-invalid', 'true');
             expect(within(sidebar).getByText('Enter a whole number between 1 and 30 days.')).toBeInTheDocument();

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -506,12 +506,12 @@ describe('AutomationEditor', () => {
             fireEvent.change(waitInput, {target: {value}});
 
             expect(waitInput).toHaveAttribute('aria-invalid', 'false');
-            expect(within(sidebar).queryByText('Enter a whole number between 1 and 30 days.')).not.toBeInTheDocument();
+            expect(within(sidebar).queryByText('Enter a delay between 1 and 30 days')).not.toBeInTheDocument();
 
             fireEvent.blur(waitInput);
 
             expect(waitInput).toHaveAttribute('aria-invalid', 'true');
-            expect(within(sidebar).getByText('Enter a whole number between 1 and 30 days.')).toBeInTheDocument();
+            expect(within(sidebar).getByText('Enter a delay between 1 and 30 days')).toBeInTheDocument();
             expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
         }
     });
@@ -988,7 +988,7 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Save'}));
 
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
-        expect(mockToastError).toHaveBeenCalledWith('Could not save automation', {
+        expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
             description: 'Fix the highlighted steps and try again.'
         });
 

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -5,6 +5,16 @@ import {RouterProvider, createMemoryRouter} from 'react-router';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 
+const {mockToastError} = vi.hoisted(() => ({
+    mockToastError: vi.fn()
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        error: mockToastError
+    }
+}));
+
 // Stub the email content editor modal — its real internals (Koenig + email API
 // hooks) are out of scope here. The stub exposes the seed props and a save button
 // so we can assert the canvas wiring (open → seed → onSave → draft → publish).
@@ -162,6 +172,7 @@ describe('AutomationEditor', () => {
         mockEditMutation.mutate.mockReset();
         mockEditMutation.isLoading = false;
         mockEditMutation.variables = undefined;
+        mockToastError.mockReset();
     });
 
     it('renders the loading state while the automation is fetching', () => {
@@ -900,11 +911,91 @@ describe('AutomationEditor', () => {
         fireEvent.click(within(picker).getByText('Email'));
 
         // The new send_email step renders with the placeholder subject.
-        expect(screen.getByRole('button', {name: 'Send email: Untitled email'})).toBeInTheDocument();
+        const emailStep = screen.getByRole('button', {name: 'Send email: Untitled'});
+        expect(within(emailStep).getByText('Untitled')).toHaveClass('opacity-50');
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
-        expect(within(sidebar).getByRole('heading', {name: 'Untitled email'})).toBeInTheDocument();
-        expect(within(sidebar).getByDisplayValue('Untitled email')).toHaveFocus();
+        expect(within(sidebar).getByRole('heading', {name: 'Untitled'})).toHaveClass('opacity-50');
+        expect(within(sidebar).getByPlaceholderText('Subject line')).toHaveFocus();
+        expect(within(sidebar).getByPlaceholderText('Subject line')).toHaveValue('');
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+    });
+
+    it('shows a toast and highlights email cards with missing subjects when saving fails validation', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Email'));
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalledWith('Could not save automation', {
+            description: 'Fix the highlighted steps and try again.'
+        });
+
+        let emailStep = screen.getByRole('button', {name: 'Send email: Untitled'});
+        expect(emailStep).toHaveAttribute('aria-invalid', 'true');
+        expect(emailStep).toHaveClass('items-start');
+        expect(within(emailStep).getByText('Add a subject line.').closest('div')?.previousElementSibling).toHaveClass('mt-[3px]');
+        expect(within(emailStep).getByText('Add a subject line.')).toHaveClass('text-destructive');
+        expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        fireEvent.change(within(sidebar).getByPlaceholderText('Subject line'), {
+            target: {value: 'Welcome subject'}
+        });
+
+        emailStep = screen.getByRole('button', {name: 'Send email: Welcome subject'});
+        expect(emailStep).not.toHaveAttribute('aria-invalid', 'true');
+        expect(within(emailStep).queryByText('Add a subject line.')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                actions: expect.arrayContaining([
+                    expect.objectContaining({
+                        type: 'send_email',
+                        data: expect.objectContaining({email_subject: 'Welcome subject'})
+                    })
+                ])
+            }),
+            expect.any(Object)
+        );
+    });
+
+    it('does not show new missing-subject errors until the next save validation', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Email'));
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).getByText('Add a subject line.')).toBeInTheDocument();
+
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        const subjectInput = within(sidebar).getByPlaceholderText('Subject line');
+        fireEvent.change(subjectInput, {target: {value: 'Temporary subject'}});
+        expect(within(screen.getByRole('button', {name: 'Send email: Temporary subject'})).queryByText('Add a subject line.')).not.toBeInTheDocument();
+
+        fireEvent.change(subjectInput, {target: {value: ''}});
+        expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).queryByText('Add a subject line.')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).getByText('Add a subject line.')).toBeInTheDocument();
     });
 
     it('inserts a step between two existing actions via the in-edge + button', async () => {

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -912,7 +912,9 @@ describe('AutomationEditor', () => {
 
         // The new send_email step renders with the placeholder subject.
         const emailStep = screen.getByRole('button', {name: 'Send email: Untitled'});
+        expect(emailStep).toHaveClass('border-yellow-600');
         expect(within(emailStep).getByText('Untitled')).toHaveClass('opacity-50');
+        expect(within(emailStep).getByText('Empty email body')).toHaveClass('text-yellow-600');
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
         expect(within(sidebar).getByRole('heading', {name: 'Untitled'})).toHaveClass('opacity-50');
         expect(within(sidebar).getByPlaceholderText('Subject line')).toHaveFocus();
@@ -943,8 +945,11 @@ describe('AutomationEditor', () => {
         let emailStep = screen.getByRole('button', {name: 'Send email: Untitled'});
         expect(emailStep).toHaveAttribute('aria-invalid', 'true');
         expect(emailStep).toHaveClass('items-start');
+        expect(emailStep).toHaveClass('border-destructive');
+        expect(emailStep).not.toHaveClass('border-yellow-600');
         expect(within(emailStep).getByText('Add a subject line.').closest('div')?.previousElementSibling).toHaveClass('mt-[3px]');
         expect(within(emailStep).getByText('Add a subject line.')).toHaveClass('text-destructive');
+        expect(within(emailStep).queryByText('Empty email body')).not.toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
 
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
@@ -954,7 +959,9 @@ describe('AutomationEditor', () => {
 
         emailStep = screen.getByRole('button', {name: 'Send email: Welcome subject'});
         expect(emailStep).not.toHaveAttribute('aria-invalid', 'true');
+        expect(emailStep).toHaveClass('border-yellow-600');
         expect(within(emailStep).queryByText('Add a subject line.')).not.toBeInTheDocument();
+        expect(within(emailStep).getByText('Empty email body')).toHaveClass('text-yellow-600');
 
         fireEvent.click(screen.getByRole('button', {name: 'Save'}));
         expect(mockEditMutation.mutate).toHaveBeenCalledWith(

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -9,6 +9,9 @@ const {mockToastError} = vi.hoisted(() => ({
     mockToastError: vi.fn()
 }));
 
+const NON_EMPTY_EMAIL_LEXICAL = '{"root":{"children":[{"type":"paragraph","children":[{"type":"text","text":"Welcome email body"}]}]}}';
+const EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE = 'One or more emails in this automation do not have a body. Are you sure you want to save and publish this automation?';
+
 vi.mock('sonner', () => ({
     toast: {
         error: mockToastError
@@ -28,7 +31,7 @@ vi.mock('@src/views/Automations/components/email-modal/email-content-modal', () 
         <div data-testid='email-content-modal'>
             <span data-testid='modal-initial-subject'>{initialSubject}</span>
             <span data-testid='modal-initial-lexical'>{initialLexical}</span>
-            <button data-testid='modal-save' type='button' onClick={() => onSave({subject: 'Edited via modal', lexical: '{"root":{"children":[{"type":"paragraph"}]}}'})}>save</button>
+            <button data-testid='modal-save' type='button' onClick={() => onSave({subject: 'Edited via modal', lexical: NON_EMPTY_EMAIL_LEXICAL})}>save</button>
             <button data-testid='modal-close' type='button' onClick={onClose}>close</button>
         </div>
     )
@@ -135,7 +138,7 @@ const automationDetail: AutomationDetail = {
             type: 'send_email',
             data: {
                 email_subject: 'Welcome to The Blueprint',
-                email_lexical: '{"root":{"children":[]}}',
+                email_lexical: NON_EMPTY_EMAIL_LEXICAL,
                 email_sender_name: null,
                 email_sender_email: null,
                 email_sender_reply_to: null,
@@ -165,6 +168,21 @@ const renderEditor = () => {
         ...render(<RouterProvider router={router} />)
     };
 };
+
+const withEmptyEmailBodies = (fixture: AutomationDetail): AutomationDetail => ({
+    ...fixture,
+    actions: fixture.actions.map(action => (
+        action.type === 'send_email'
+            ? {
+                ...action,
+                data: {
+                    ...action.data,
+                    email_lexical: '{"root":{"children":[]}}'
+                }
+            }
+            : action
+    ))
+});
 
 describe('AutomationEditor', () => {
     beforeEach(() => {
@@ -363,7 +381,7 @@ describe('AutomationEditor', () => {
         // The modal opens, seeded from the step's current content.
         expect(screen.getByTestId('email-content-modal')).toBeInTheDocument();
         expect(screen.getByTestId('modal-initial-subject')).toHaveTextContent('Welcome to The Blueprint');
-        expect(screen.getByTestId('modal-initial-lexical')).toHaveTextContent('{"root":{"children":[]}}');
+        expect(screen.getByTestId('modal-initial-lexical')).toHaveTextContent(NON_EMPTY_EMAIL_LEXICAL);
 
         // Saving in the modal commits to the local draft only — no API call.
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
@@ -383,7 +401,7 @@ describe('AutomationEditor', () => {
                         id: 'action-email',
                         data: expect.objectContaining({
                             email_subject: 'Edited via modal',
-                            email_lexical: '{"root":{"children":[{"type":"paragraph"}]}}'
+                            email_lexical: NON_EMPTY_EMAIL_LEXICAL
                         })
                     })
                 ])
@@ -573,6 +591,32 @@ describe('AutomationEditor', () => {
                 actions: automationDetail.actions,
                 edges: automationDetail.edges
             },
+            expect.any(Object)
+        );
+    });
+
+    it('confirms before publishing an inactive automation with empty email bodies', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [withEmptyEmailBodies({...automationDetail, status: 'inactive'})]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Publish automation with empty emails?'});
+        expect(within(dialog).getByText(EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE)).toBeInTheDocument();
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish automation'}));
+
+        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 'automation-id-1',
+                status: 'active'
+            }),
             expect.any(Object)
         );
     });
@@ -1358,6 +1402,35 @@ describe('AutomationEditor', () => {
         const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
         expect(within(dialog).getByText(/new runs of the automation/)).toBeInTheDocument();
         expect(within(dialog).getByText(/actively-running ones/)).toBeInTheDocument();
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));
+
+        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
+            {
+                id: 'automation-id-1',
+                status: 'active',
+                actions: expect.any(Array),
+                edges: expect.any(Array)
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('warns before publishing changes to an active automation with empty email bodies', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [withEmptyEmailBodies(automationDetail)]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        await stageLocalEdit();
+        fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
+        expect(within(dialog).getByText(new RegExp(EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE.replace(/[.?]/g, '\\$&')))).toBeInTheDocument();
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
 
         fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -969,7 +969,7 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
     });
 
-    it('deletes a send email step and keeps the wait step in place', () => {
+    it('asks for confirmation before deleting a send email step', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [automationDetail]},
             isLoading: false,
@@ -981,6 +981,31 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
         fireEvent.click(within(sidebar).getByRole('button', {name: 'Delete step'}));
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Delete this email?'});
+        expect(within(dialog).getByText('This email will be removed from the automation. Save or publish the automation to apply this change.')).toBeInTheDocument();
+
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Cancel'}));
+
+        expect(screen.queryByRole('alertdialog', {name: 'Delete this email?'})).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'})).toBeInTheDocument();
+        expect(screen.getByRole('complementary', {name: 'Step details'})).toBeInTheDocument();
+    });
+
+    it('deletes a send email step after confirmation and keeps the wait step in place', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Delete step'}));
+        const dialog = screen.getByRole('alertdialog', {name: 'Delete this email?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Delete email'}));
 
         expect(screen.queryByRole('button', {name: 'Send email: Welcome to The Blueprint'})).not.toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Wait: 1 day'})).toBeInTheDocument();

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1295,9 +1295,9 @@ describe('AutomationEditor', () => {
         expect(screen.queryByTestId('add-step-tail-button')).not.toBeInTheDocument();
         const limitNode = screen.getByTestId('step-limit-tail-node');
         expect(limitNode).toHaveClass('border-border-default');
-        expect(limitNode).toHaveClass('bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_18px,var(--color-gray-100)_18px,var(--color-gray-100)_34px)]');
+        expect(limitNode).toHaveClass('bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_12px,var(--color-gray-100)_12px,var(--color-gray-100)_24px)]');
         expect(limitNode.querySelector('svg')).toBeInTheDocument();
-        expect(limitNode).toHaveTextContent(`Limit of ${MAX_AUTOMATION_ACTIONS} steps reached`);
+        expect(limitNode).toHaveTextContent('Maximum steps added');
         // The edge + uses a real <button> element.
         expect(screen.getByTestId('add-step-button-wait-0-wait-1')).toBeDisabled();
     });

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -322,7 +322,7 @@ describe('AutomationEditor', () => {
         expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toHaveFocus();
         expect(within(sidebar).queryByText('Sender')).not.toBeInTheDocument();
         expect(within(sidebar).queryByText('Reply-to')).not.toBeInTheDocument();
-        expect(within(sidebar).getByRole('button', {name: 'Edit email'})).toBeEnabled();
+        expect(within(sidebar).getByRole('button', {name: 'Edit email content'})).toBeEnabled();
         expect(within(sidebar).getByRole('button', {name: 'Delete step'})).toBeEnabled();
     });
 
@@ -376,7 +376,7 @@ describe('AutomationEditor', () => {
 
         fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
-        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email content'}));
 
         // The modal opens, seeded from the step's current content.
         expect(screen.getByTestId('email-content-modal')).toBeInTheDocument();
@@ -423,7 +423,7 @@ describe('AutomationEditor', () => {
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
         expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toBeInTheDocument();
 
-        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email content'}));
         fireEvent.click(screen.getByTestId('modal-save'));
 
         expect(within(sidebar).getByDisplayValue('Edited via modal')).toBeInTheDocument();
@@ -1264,7 +1264,7 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
     });
 
-    it('disables both + affordances when the action limit is reached', () => {
+    it('replaces the tail + affordance with limit text when the action limit is reached', () => {
         const filled: AutomationDetail = {
             ...automationDetail,
             actions: Array.from({length: MAX_AUTOMATION_ACTIONS}, (_, index) => ({
@@ -1286,8 +1286,12 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        // The tail is a div with role=button; check aria-disabled instead of the disabled attribute.
-        expect(screen.getByTestId('add-step-tail-button')).toHaveAttribute('aria-disabled', 'true');
+        expect(screen.queryByTestId('add-step-tail-button')).not.toBeInTheDocument();
+        const limitNode = screen.getByTestId('step-limit-tail-node');
+        expect(limitNode).toHaveClass('border-border-default');
+        expect(limitNode).toHaveClass('bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_18px,var(--color-gray-100)_18px,var(--color-gray-100)_34px)]');
+        expect(limitNode.querySelector('svg')).toBeInTheDocument();
+        expect(limitNode).toHaveTextContent(`Limit of ${MAX_AUTOMATION_ACTIONS} steps reached`);
         // The edge + uses a real <button> element.
         expect(screen.getByTestId('add-step-button-wait-0-wait-1')).toBeDisabled();
     });

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -301,7 +301,7 @@ describe('AutomationEditor', () => {
         expect(waitStep).toHaveAttribute('aria-pressed', 'false');
         expect(emailStep).toHaveAttribute('aria-pressed', 'true');
         expect(within(sidebar).getByRole('heading', {name: 'Welcome to The Blueprint'})).toBeInTheDocument();
-        expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toBeInTheDocument();
+        expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toHaveFocus();
         expect(within(sidebar).queryByText('Sender')).not.toBeInTheDocument();
         expect(within(sidebar).queryByText('Reply-to')).not.toBeInTheDocument();
         expect(within(sidebar).getByRole('button', {name: 'Edit email'})).toBeEnabled();

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -900,7 +900,10 @@ describe('AutomationEditor', () => {
         fireEvent.click(within(picker).getByText('Email'));
 
         // The new send_email step renders with the placeholder subject.
-        expect(screen.getByText('Untitled email')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Send email: Untitled email'})).toBeInTheDocument();
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).getByRole('heading', {name: 'Untitled email'})).toBeInTheDocument();
+        expect(within(sidebar).getByDisplayValue('Untitled email')).toHaveFocus();
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
     });
 


### PR DESCRIPTION
## What changed

- Added a confirmation dialog before deleting send email steps from the Automations canvas.
- Kept the existing immediate deletion behavior for non-email steps.
- Added unit coverage for cancelling and confirming email deletion.

## Why

Deleting an email step was immediate, which made accidental removals too easy while editing an automation draft. The confirmation keeps the draft-save/publish flow intact while adding a safer interaction for email cards.

## Validation

- `pnpm --filter @tryghost/posts test -- automations/automation-editor.test.tsx`
- Pre-commit lint-staged ESLint check passed for the staged files.
