### PR TITLE
Fixed IndexNow pinging /404/ for posts with no web URL

### DIFF
--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -89,6 +89,18 @@ async function ping(post) {
     try {
         url = urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
 
+        if (!url || url.endsWith('/404/')) {
+            logging.warn({
+                system: {
+                    event: 'indexnow.unresolved_url',
+                    post_id: post.id,
+                    post_slug: post.slug,
+                    url
+                }
+            }, `${INDEXNOW_LOG_KEY} Skipped ping - post has no resolvable URL`);
+            return;
+        }
+
         // Get the API key (auto-generated on boot by settings service)
         const key = getApiKey();
         if (!key) {

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -251,6 +251,11 @@ describe('IndexNow', function () {
 
     describe('ping()', function () {
         const ping = indexnow.__get__('ping');
+        let urlStub;
+
+        beforeEach(function () {
+            urlStub = sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/my-post/');
+        });
 
         it('with a post should execute ping', async function () {
             loggingStub = sinon.stub(logging, 'info');
@@ -264,6 +269,25 @@ describe('IndexNow', function () {
             sinon.assert.calledOnce(loggingStub);
             assert.equal(loggingStub.args[0][0].system.event, 'indexnow.pinged');
             assert.equal(loggingStub.args[0][0].system.status_code, 200);
+        });
+
+        it('does not ping when the post has no resolvable URL (/404/)', async function () {
+            urlStub.returns('https://example.com/404/');
+            loggingStub = sinon.stub(logging, 'warn');
+            const pingRequest = nock('https://api.indexnow.org')
+                .get(/\/indexnow/)
+                .reply(200);
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+
+            await ping(testPost);
+
+            assert.equal(pingRequest.isDone(), false);
+            sinon.assert.calledOnce(loggingStub);
+            const logged = loggingStub.args[0][0].system;
+            assert.equal(logged.event, 'indexnow.unresolved_url');
+            assert.equal(logged.url, 'https://example.com/404/');
+            assert.equal(logged.post_id, testPost.id);
+            assert.equal(logged.post_slug, testPost.slug);
         });
 
         it('with default post should not execute ping', async function () {


### PR DESCRIPTION
### What

IndexNow (behind the `indexnow` labs flag) pings `api.indexnow.org` when a post is published or edited, resolving the post URL via `urlService.facade.getUrlForResource(...)`.

That returns a `/404/` URL when a published post is not owned by any route — e.g. an imported or members post that falls outside the site's collections, or a routing config with no catch-all. In that case the ping submitted `https://<site>/404/` instead of a post URL. This was seen in production on a site whose unrouted posts produced most of its IndexNow pings.

### Change

After resolving the URL, if it's empty or ends in `/404/`, skip the ping and log an `indexnow.unresolved_url` event instead. Other behaviour is unchanged.

### Notes

- A published post with no web URL is usually a site routing/content issue; the `indexnow.unresolved_url` event makes it observable.
- `getUrlForResource` returns `/404/` as its not-found sentinel (see `url-service.js`), so matching it identifies an unrouted resource.

### Testing

Added a unit test asserting no ping and an `indexnow.unresolved_url` event (with `post_id`/`post_slug`/`url`) when the URL resolves to `/404/`; existing ping tests stub a resolved URL. 22 unit tests pass; lint clean.
