### PR TITLE
🐛 Fixed paid members on other tiers receiving gated newsletter content

### DIFF
--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -206,7 +206,8 @@ class BatchSendingService {
             return await email.getLazyRelation('newsletter', {require: true});
         }, {...this.#getBeforeRetryConfig(email), description: `getLazyRelation newsletter for email ${email.id}`});
 
-        const postRelations = [...new Set(['posts_meta', 'authors', ...this.#getRequiredUrlRelations()])];
+        // 'tiers' is required by the email tier-gating logic (renderer/segmenter), not for URL generation
+        const postRelations = [...new Set(['posts_meta', 'authors', 'tiers', ...this.#getRequiredUrlRelations()])];
         const post = await this.retryDb(async () => {
             return await email.getLazyRelation('post', {require: true, withRelated: postRelations});
         }, {...this.#getBeforeRetryConfig(email), description: `getLazyRelation post for email ${email.id}`});

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -17,6 +17,7 @@ const EmailAddressParser = require('../email-address/email-address-parser');
 const {getEmailDesign} = require('../email-rendering/email-design');
 const {registerHelpers} = require('./helpers/register-helpers');
 const crypto = require('crypto');
+const {getPostAccessFilter} = require('../members/content-gating');
 /** @import {TemplateDelegate} from 'handlebars' */
 
 const DEFAULT_LOCALE = 'en-gb';
@@ -71,6 +72,82 @@ function isValidLocale(locale) {
     } catch (e) {
         return false; // RangeError means invalid locale
     }
+}
+
+/**
+ * Builds a plain {visibility, tiers} shape from a Post model, for the shared
+ * content-gating helpers (which operate on serialized post attributes).
+ * @param {Post} post
+ * @returns {{visibility: string, tiers: object[]|undefined}}
+ */
+function getPostGatingShape(post) {
+    const tiersRelation = post.related && post.related('tiers');
+    const tiers = tiersRelation && typeof tiersRelation.toJSON === 'function'
+        ? tiersRelation.toJSON()
+        : undefined;
+    return {
+        visibility: post.get('visibility'),
+        tiers
+    };
+}
+
+/**
+ * The NQL member filter selecting members WITHOUT access to a tier-restricted
+ * post: members who hold none of the post's tiers. This is the exact complement
+ * of the post's tier access filter (De Morgan over the OR of tiers). Free
+ * members (no products) match this naturally.
+ * @param {Post} post
+ * @returns {string|null}
+ */
+function getNegatedTierFilter(post) {
+    const tiers = getPostGatingShape(post).tiers || [];
+    if (tiers.length === 0) {
+        return null;
+    }
+    return tiers.map(tier => `product:-'${tier.slug}'`).join('+');
+}
+
+/**
+ * Returns 'status:free' / 'status:-free' identifying which free/paid audience a
+ * segment renders for. Used ONLY for data-gh-segment card stripping, which is a
+ * free/paid-only axis independent of tier access. Returns null for segments that
+ * target a mixed/everyone audience (where no free/paid cards are present anyway).
+ * @param {Segment} segment
+ * @returns {string|null}
+ */
+function getSegmentStatus(segment) {
+    if (!segment) {
+        return null;
+    }
+    if (segment.includes('status:-free')) {
+        return 'status:-free';
+    }
+    if (segment.includes('status:free')) {
+        return 'status:free';
+    }
+    return null;
+}
+
+/**
+ * Whether the members matched by a segment can read the post's gated content.
+ * Derived from the post's visibility (not just free/paid): for paid posts the
+ * access segment is the paid one; for tier-restricted posts it's the segment
+ * carrying the post's positive tier filter.
+ * @param {Post} post
+ * @param {Segment} segment
+ * @returns {boolean}
+ */
+function segmentHasPostAccess(post, segment) {
+    const visibility = post.get('visibility');
+    if (visibility !== 'paid' && visibility !== 'tiers') {
+        return true;
+    }
+    const accessFilter = getPostAccessFilter(getPostGatingShape(post));
+    if (!accessFilter) {
+        // misconfigured tiers post (no tiers) -> nobody has access
+        return false;
+    }
+    return !!segment && segment.includes(accessFilter);
 }
 
 /**
@@ -343,24 +420,40 @@ class EmailRenderer {
         const allowedSegments = ['status:free', 'status:-free'];
         const html = await this.renderPostBaseHtml(post);
 
-        /**
-         * Always add free and paid segments if email has paywall card
-         */
-        if (html.indexOf('<!--members-only-->') !== -1) {
-            // We have different content between free and paid members
-            return allowedSegments;
-        }
+        const hasPaywall = html.indexOf('<!--members-only-->') !== -1;
 
         const $ = cheerioLoad(html);
+        const cardSegments = [...new Set(
+            $('[data-gh-segment]').get().map(el => el.attribs['data-gh-segment'])
+        )].filter(segment => allowedSegments.includes(segment));
+        const hasCards = cardSegments.length > 0;
 
-        let allSegments = $('[data-gh-segment]')
-            .get()
-            .map(el => el.attribs['data-gh-segment']);
-
-        const segments = [...new Set(allSegments)].filter(segment => allowedSegments.includes(segment));
-        if (segments.length === 0) {
-            // No difference in email content between free and paid
+        if (!hasPaywall && !hasCards) {
+            // No difference in email content between members
             return [null];
+        }
+
+        // Tier-restricted posts split recipients by tier access (not just
+        // free/paid) so members on a tier that can't read this post get the
+        // public preview + paywall, exactly as they do on the web.
+        if (post.get('visibility') === 'tiers' && hasPaywall) {
+            const accessFilter = getPostAccessFilter(getPostGatingShape(post));
+            const noAccessFilter = getNegatedTierFilter(post);
+
+            if (accessFilter && noAccessFilter) {
+                if (hasCards) {
+                    // free/paid cards in the preview need free vs paid rendering
+                    // within the no-access audience -> three render variants
+                    return [
+                        'status:free',
+                        `status:-free+(${accessFilter})`,
+                        `status:-free+(${noAccessFilter})`
+                    ];
+                }
+                // free members hold no products, so they fall into no-access
+                return [accessFilter, noAccessFilter];
+            }
+            // misconfigured tiers post (no tiers) -> fall through to free/paid
         }
 
         // We have different content between free and paid members
@@ -406,14 +499,16 @@ class EmailRenderer {
         const hasMembersOnlyContent = membersOnlyIndex !== -1;
         let addPaywall = false;
 
-        if (isPaidPost && hasMembersOnlyContent) {
-            if (segment === 'status:free') {
-                // Add paywall
-                addPaywall = true;
+        // Members without access to the gated content (free members, or members
+        // on a tier that can't read this post) get the public preview + paywall,
+        // exactly as on the web. Access is derived from the post's visibility,
+        // not just free/paid.
+        if (isPaidPost && hasMembersOnlyContent && !segmentHasPostAccess(post, segment)) {
+            // Add paywall
+            addPaywall = true;
 
-                // Remove the members-only content
-                html = html.slice(0, membersOnlyIndex);
-            }
+            // Remove the members-only content
+            html = html.slice(0, membersOnlyIndex);
         }
 
         let $ = cheerioLoad(html);
@@ -422,9 +517,13 @@ class EmailRenderer {
         // before rendering the template as the preheader for the email may be generated
         // using the HTML and we don't want to include content that should not be
         // visible depending on the segment
+        // data-gh-segment cards are a free/paid-only axis, independent of tier
+        // access. Match them against this segment's free/paid status rather than
+        // the raw segment filter (which may carry a tier expression).
+        const segmentStatus = getSegmentStatus(segment);
         $('[data-gh-segment]').get().forEach((node) => {
             // TODO: replace with NQL interpretation
-            if (node.attribs['data-gh-segment'] !== segment) {
+            if (node.attribs['data-gh-segment'] !== segmentStatus) {
                 $(node).remove();
             } else {
                 // Getting rid of the attribute for a cleaner html output

--- a/ghost/core/core/server/services/members/content-gating.js
+++ b/ghost/core/core/server/services/members/content-gating.js
@@ -26,6 +26,37 @@ const rejectUnknownKeys = input => nql.utils.mapQuery(input, function (value, ke
 });
 
 /**
+ * Builds the NQL member filter describing which members have access to a post's
+ * gated content, based purely on its `visibility`. This is the single source of
+ * truth for "who can read this post" — shared between the web content gating
+ * (checkPostAccess) and the email sending pipeline (segmentation), so the two
+ * can never drift apart.
+ *
+ * Note: `public` and `members` are handled by the callers (they don't reduce to
+ * a member-status filter); this only produces the filter for the gated cases.
+ *
+ * @param {object} post - A post object
+ * @returns {string|null} An NQL member filter, or null when the post's tiers are
+ *   misconfigured so that no member should have access.
+ */
+function getPostAccessFilter(post) {
+    if (post.visibility === 'paid') {
+        return 'status:-free';
+    }
+
+    if (post.visibility === 'tiers') {
+        if (!post.tiers) {
+            return null;
+        }
+        return post.tiers.map((product) => {
+            return `product:'${product.slug}'`;
+        }).join(',') || null;
+    }
+
+    return post.visibility;
+}
+
+/**
  * @param {object} post - A post object to check access to
  * @param {object} member - The member whos access should be checked
  *
@@ -44,15 +75,7 @@ function checkPostAccess(post, member) {
         return PERMIT_ACCESS;
     }
 
-    let visibility = post.visibility === 'paid' ? 'status:-free' : post.visibility;
-    if (visibility === 'tiers') {
-        if (!post.tiers) {
-            return BLOCK_ACCESS;
-        }
-        visibility = post.tiers.map((product) => {
-            return `product:'${product.slug}'`;
-        }).join(',');
-    }
+    const visibility = getPostAccessFilter(post);
 
     if (visibility && member.status && nql(visibility, {expansions: MEMBER_NQL_EXPANSIONS, transformer: rejectUnknownKeys}).queryJSON(member)) {
         return PERMIT_ACCESS;
@@ -88,6 +111,7 @@ function checkGatedBlockAccess(gatedBlockParams, member) {
 }
 
 module.exports = {
+    getPostAccessFilter,
     checkPostAccess,
     checkGatedBlockAccess,
     PERMIT_ACCESS,

--- a/ghost/core/test/integration/services/email-service/tier-segmentation.test.js
+++ b/ghost/core/test/integration/services/email-service/tier-segmentation.test.js
@@ -1,0 +1,139 @@
+const {agentProvider, fixtureManager} = require('../../../utils/e2e-framework');
+const assert = require('node:assert/strict');
+const ObjectID = require('bson-objectid').default;
+
+/**
+ * Risk 1 coverage for tier-based email visibility.
+ *
+ * The email pipeline splits recipients of a tier-restricted post into two
+ * segments: members who hold one of the post's tiers (full content) and members
+ * who hold none of them (public preview + paywall). The no-access segment is the
+ * NQL complement of the access filter — a negation over the to-many `products`
+ * relation (`product:-'a'`). This test proves, against a real database and
+ * mongo-knex, that the two segments partition the recipients exactly: no member
+ * is dropped and no member appears in both — including a member holding multiple
+ * tiers.
+ *
+ * The segments are resolved through the same Member.getFilteredCollectionQuery
+ * path that batch-sending-service uses to select recipients, so this exercises
+ * the real query engine (not the in-memory NQL queryJSON the web path uses).
+ */
+describe('Email tier segmentation (recipient partition)', function () {
+    let models;
+    let goldProduct;
+    let silverProduct;
+
+    // Unique label so we only ever query the members this test seeds, never
+    // any members created by shared fixtures.
+    const LABEL = 'tier-segmentation-test';
+
+    const members = {};
+
+    beforeAll(async function () {
+        await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('newsletters');
+
+        // Reference models only after Ghost has booted
+        models = require('../../../../core/server/models');
+
+        goldProduct = await models.Product.add({
+            name: 'Gold Tier (seg test)',
+            slug: 'gold-tier-seg',
+            type: 'paid',
+            active: true
+        });
+        silverProduct = await models.Product.add({
+            name: 'Silver Tier (seg test)',
+            slug: 'silver-tier-seg',
+            type: 'paid',
+            active: true
+        });
+
+        const seed = {
+            labels: [{name: LABEL}],
+            email_disabled: false
+        };
+
+        members.gold = await models.Member.add({
+            ...seed,
+            email: `gold-${ObjectID().toHexString()}@example.com`,
+            status: 'paid',
+            products: [{id: goldProduct.id}]
+        });
+        members.silver = await models.Member.add({
+            ...seed,
+            email: `silver-${ObjectID().toHexString()}@example.com`,
+            status: 'paid',
+            products: [{id: silverProduct.id}]
+        });
+        members.both = await models.Member.add({
+            ...seed,
+            email: `both-${ObjectID().toHexString()}@example.com`,
+            status: 'paid',
+            products: [{id: goldProduct.id}, {id: silverProduct.id}]
+        });
+        members.free = await models.Member.add({
+            ...seed,
+            email: `free-${ObjectID().toHexString()}@example.com`,
+            status: 'free'
+        });
+    });
+
+    afterAll(async function () {
+        for (const member of Object.values(members)) {
+            if (member) {
+                await models.Member.destroy({id: member.id});
+            }
+        }
+        if (goldProduct) {
+            await models.Product.destroy({id: goldProduct.id});
+        }
+        if (silverProduct) {
+            await models.Product.destroy({id: silverProduct.id});
+        }
+    });
+
+    /**
+     * Resolve a segment's member filter to the set of seeded members it selects,
+     * mirroring how batch-sending-service selects recipients (the segment is
+     * AND-ed into the member query). Scoped to this test's label so shared
+     * fixtures never leak in.
+     */
+    async function membersForSegment(segment) {
+        const rows = await models.Member
+            .getFilteredCollectionQuery({filter: `label:${LABEL}+(${segment})`})
+            .select('members.email');
+        return new Set(rows.map(row => row.email));
+    }
+
+    it('partitions recipients of a tier-restricted post into access and no-access segments', async function () {
+        const goldSlug = goldProduct.get('slug');
+
+        // The exact segment strings email-renderer's getSegments() emits for a
+        // post restricted to the Gold tier (pinned by the email-renderer unit tests).
+        const accessSegment = `product:'${goldSlug}'`;
+        const noAccessSegment = `product:-'${goldSlug}'`;
+
+        const accessMembers = await membersForSegment(accessSegment);
+        const noAccessMembers = await membersForSegment(noAccessSegment);
+
+        // Access = members holding the Gold tier (gold-only and the multi-tier member)
+        assert.deepEqual(accessMembers, new Set([
+            members.gold.get('email'),
+            members.both.get('email')
+        ]), 'access segment should be exactly the members on the Gold tier');
+
+        // No-access = the Silver-only member and the free member
+        assert.deepEqual(noAccessMembers, new Set([
+            members.silver.get('email'),
+            members.free.get('email')
+        ]), 'no-access segment should be exactly the members NOT on the Gold tier');
+
+        // The partition must be exact: no overlap, and the union covers everyone.
+        const overlap = [...accessMembers].filter(email => noAccessMembers.has(email));
+        assert.deepEqual(overlap, [], 'no member may appear in both segments (no double-send)');
+
+        const union = new Set([...accessMembers, ...noAccessMembers]);
+        assert.equal(union.size, 4, 'every seeded recipient must land in exactly one segment (no drops)');
+    });
+});

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1248,6 +1248,85 @@ describe('Email renderer', function () {
             let response = await emailRenderer.getSegments(post);
             assert.deepEqual(response, ['status:free', 'status:-free']);
         });
+
+        it('returns tier access and no-access segments for a tiers post with a paywall', async function () {
+            emailRenderer = new EmailRenderer({
+                renderers: {
+                    lexical: {
+                        render: () => {
+                            return '<p>preview</p><!--members-only--><p>members</p>';
+                        }
+                    }
+                },
+                getPostUrl: () => {
+                    return 'http://example.com/post-id';
+                },
+                labs: {
+                    isSet: () => false
+                }
+            });
+
+            const post = {
+                get: (key) => {
+                    if (key === 'lexical') {
+                        return '{}';
+                    }
+                    if (key === 'visibility') {
+                        return 'tiers';
+                    }
+                },
+                related: (key) => {
+                    if (key === 'tiers') {
+                        return {toJSON: () => [{slug: 'gold'}, {slug: 'silver'}]};
+                    }
+                }
+            };
+            const response = await emailRenderer.getSegments(post);
+            assert.deepEqual(response, [
+                'product:\'gold\',product:\'silver\'',
+                'product:-\'gold\'+product:-\'silver\''
+            ]);
+        });
+
+        it('splits no-access into free/paid when a tiers post also has preview cards', async function () {
+            emailRenderer = new EmailRenderer({
+                renderers: {
+                    lexical: {
+                        render: () => {
+                            return '<div data-gh-segment="status:free">upsell</div><!--members-only--><p>members</p>';
+                        }
+                    }
+                },
+                getPostUrl: () => {
+                    return 'http://example.com/post-id';
+                },
+                labs: {
+                    isSet: () => false
+                }
+            });
+
+            const post = {
+                get: (key) => {
+                    if (key === 'lexical') {
+                        return '{}';
+                    }
+                    if (key === 'visibility') {
+                        return 'tiers';
+                    }
+                },
+                related: (key) => {
+                    if (key === 'tiers') {
+                        return {toJSON: () => [{slug: 'gold'}]};
+                    }
+                }
+            };
+            const response = await emailRenderer.getSegments(post);
+            assert.deepEqual(response, [
+                'status:free',
+                'status:-free+(product:\'gold\')',
+                'status:-free+(product:-\'gold\')'
+            ]);
+        });
     });
 
     describe('renderBody', function () {
@@ -2191,6 +2270,54 @@ describe('Email renderer', function () {
             assert(responsePaid.html.includes('some text for both'));
             assert(responsePaid.html.includes('finishing part only for members'));
             assert(!responsePaid.html.includes('Become a paid member of Test Blog to get access to all'));
+        });
+
+        it('paywalls a tiers post for the no-access segment and not for the access segment', async function () {
+            renderedPost = '<div> Lexical Test </div> some text for both <!--members-only--> finishing part only for members';
+            const post = {
+                related: (key) => {
+                    if (key === 'tiers') {
+                        return {toJSON: () => [{slug: 'gold'}]};
+                    }
+                    return null;
+                },
+                get: (key) => {
+                    if (key === 'lexical') {
+                        return '{}';
+                    }
+                    if (key === 'visibility') {
+                        return 'tiers';
+                    }
+                    if (key === 'title') {
+                        return 'Test Post';
+                    }
+                },
+                getLazyRelation: () => {
+                    return {models: [{get: k => (k === 'name' ? 'Test Author' : undefined)}]};
+                }
+            };
+            const newsletter = {
+                get: (key) => {
+                    if (key === 'show_post_title_section') {
+                        return true;
+                    }
+                    if (key === 'feedback_enabled') {
+                        return true;
+                    }
+                    return false;
+                }
+            };
+
+            // Member NOT on the post's tier -> public preview + paywall
+            const noAccess = await emailRenderer.renderBody(post, newsletter, 'product:-\'gold\'', {});
+            assert(noAccess.html.includes('some text for both'));
+            assert(!noAccess.html.includes('finishing part only for members'));
+            assert(noAccess.html.includes('Become a paid member of Test Blog to get access to all'));
+
+            // Member ON the post's tier -> full content, no paywall
+            const access = await emailRenderer.renderBody(post, newsletter, 'product:\'gold\'', {});
+            assert(access.html.includes('finishing part only for members'));
+            assert(!access.html.includes('Become a paid member of Test Blog to get access to all'));
         });
 
         it('should output valid HTML and escape HTML characters in mobiledoc', async function () {

--- a/ghost/core/test/unit/server/services/members/content-gating.test.js
+++ b/ghost/core/test/unit/server/services/members/content-gating.test.js
@@ -1,7 +1,39 @@
 const assert = require('node:assert/strict');
-const {checkPostAccess, checkGatedBlockAccess} = require('../../../../../core/server/services/members/content-gating');
+const {getPostAccessFilter, checkPostAccess, checkGatedBlockAccess} = require('../../../../../core/server/services/members/content-gating');
 
 describe('Members Service - Content gating', function () {
+    describe('getPostAccessFilter', function () {
+        it('returns status:-free for paid posts', function () {
+            assert.equal(getPostAccessFilter({visibility: 'paid'}), 'status:-free');
+        });
+
+        it('returns a product OR filter for tiers posts', function () {
+            const filter = getPostAccessFilter({visibility: 'tiers', tiers: [{slug: 'gold'}, {slug: 'silver'}]});
+            assert.equal(filter, 'product:\'gold\',product:\'silver\'');
+        });
+
+        it('returns null for a tiers post with no tiers relation', function () {
+            assert.equal(getPostAccessFilter({visibility: 'tiers'}), null);
+        });
+
+        it('returns null for a tiers post with an empty tiers list', function () {
+            assert.equal(getPostAccessFilter({visibility: 'tiers', tiers: []}), null);
+        });
+
+        it('passes through other visibility values', function () {
+            assert.equal(getPostAccessFilter({visibility: 'members'}), 'members');
+            assert.equal(getPostAccessFilter({visibility: 'public'}), 'public');
+        });
+
+        it('agrees with checkPostAccess for tiers posts', function () {
+            const post = {visibility: 'tiers', tiers: [{slug: 'gold'}]};
+            const onTier = {id: 'a', status: 'paid', products: [{slug: 'gold'}]};
+            const offTier = {id: 'b', status: 'paid', products: [{slug: 'silver'}]};
+            assert.equal(checkPostAccess(post, onTier), true);
+            assert.equal(checkPostAccess(post, offTier), false);
+        });
+    });
+
     describe('checkPostAccess', function () {
         let post;
         let member;


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/27893
Fixes https://linear.app/ghost/issue/ONC-1725
Related: https://github.com/TryGhost/Ghost/issues/25046 · [Forum: paid tier without post access still has access](https://forum.ghost.org/t/paid-tier-without-post-access-still-has-access/62848)


### Problem

When a post's visibility is restricted to specific tiers, the website correctly gates the content — a paying member on a tier *not* included in the post sees the public preview and paywall. Email newsletters did not honor this: the sending pipeline only understood a free/paid split, so **any** paying member received the full members-only content in their inbox, regardless of which tier they were on.

This contradicts the [documented behavior](https://ghost.org/help/public-previews/) that post access settings determine how members see content "on your site, or in their inbox as an email newsletter."

### Cause

The email pipeline reasoned only about `status:free` vs `status:-free`:

- `getSegments()` returned a hardcoded free/paid pair and never produced tier-based segments.
- `renderBody()` applied the paywall only to the `status:free` segment — so every paying member, on any tier, got the full body.
- The post's `tiers` relation wasn't even loaded during batch sending.

### Change

- **Single source of truth for access** — extracted `getPostAccessFilter(post)` in `content-gating.js`; `checkPostAccess` (web) now delegates to it, so web and email derive "who can read this post" the same way.
- **Tier-aware segmentation** — `getSegments()` now splits a tier-restricted post into an access segment (members on an allowed tier → full content) and its complement (everyone else → preview + paywall). Reduces to the existing behavior for `paid`/`members` posts.
- **Access-driven paywall** — `renderBody()` paywalls any segment lacking post access, instead of keying off `status:free`. Per-block `data-gh-segment` (free/paid) card visibility remains keyed on free/paid status, independent of tier access.
- **Load the relation** — batch sending now loads the post's `tiers`.

### Behavior

Post restricted to Tier A, sent to all members:

| Recipient | Receives |
|---|---|
| Member on Tier A | Full content |
| Paying member on Tier B | Public preview + paywall |
| Free member | Public preview + paywall |

`paid` and `members` posts are unchanged.

### Tests

- Unit: `getPostAccessFilter` across visibilities; `getSegments` tier (2-cell and 3-cell) cases; `renderBody` paywalls the no-access tier segment, not the access one.
- Integration: seeds members across tiers (including a multi-tier member) and asserts the access/no-access segments partition recipients exactly against a real DB — no double-sends, no drops.
- Verified manually end-to-end via a real newsletter send.

### Known follow-up (not in this PR)

The email preheader/excerpt still regenerates from gated HTML only for the `status:free` segment, so a wrong-tier paid member sees members-only text in the *preview text* (the body is correctly gated). Same free/paid-vs-tier assumption, in `#getEmailPreheader()`; tracked for a separate change.
