### PR TITLE
Improved checkout session request limits

### DIFF
--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -101,9 +101,15 @@ module.exports = function setupMembersApp() {
             return membersService.api.middleware.verifyOTC(req, res, next);
         }
     );
-    membersApp.post('/api/create-stripe-checkout-session', function lazyCreateCheckoutSessionMw(req, res, next) {
-        return membersService.api.middleware.createCheckoutSession(req, res, next);
-    });
+    membersApp.post(
+        '/api/create-stripe-checkout-session',
+        bodyParser.json(),
+        shared.middleware.brute.checkoutSessionGlobal,
+        shared.middleware.brute.checkoutSessionEmail,
+        function lazyCreateCheckoutSessionMw(req, res, next) {
+            return membersService.api.middleware.createCheckoutSession(req, res, next);
+        }
+    );
     membersApp.post('/api/create-stripe-update-session', function lazyCreateCheckoutSetupSessionMw(req, res, next) {
         return membersService.api.middleware.createCheckoutSetupSession(req, res, next);
     });

--- a/ghost/core/core/server/web/shared/middleware/api/spam-prevention.js
+++ b/ghost/core/core/server/web/shared/middleware/api/spam-prevention.js
@@ -21,6 +21,9 @@ const messages = {
         context: 'Too many login attempts.'
     },
     tooManyAttempts: 'Too many attempts.',
+    tooManyCheckoutAttempts: {
+        context: 'Too many checkout attempts.'
+    },
     tooManyOTCVerificationAttempts: {
         error: 'Too many attempts for this verification code.',
         context: 'Too many verification code attempts.'
@@ -36,6 +39,8 @@ let spamUserLogin = spam.user_login || {};
 let spamSendVerificationCode = spam.send_verification_code || {};
 let spamUserVerification = spam.user_verification || {};
 let spamMemberLogin = spam.member_login || {};
+let spamCheckoutSessionGlobal = spam.checkout_session_global || {};
+let spamCheckoutSessionEmail = spam.checkout_session_email || {};
 let spamContentApiKey = spam.content_api_key || {};
 let spamWebmentionsBlock = spam.webmentions_block || {};
 let spamEmailPreviewBlock = spam.email_preview_block || {};
@@ -51,6 +56,8 @@ let webmentionsBlockInstance;
 let userLoginInstance;
 let membersAuthInstance;
 let membersAuthEnumerationInstance;
+let checkoutSessionGlobalInstance;
+let checkoutSessionEmailInstance;
 let userResetInstance;
 let sendVerificationCodeInstance;
 let userVerificationInstance;
@@ -254,6 +261,66 @@ const membersAuthEnumeration = () => {
     }
 
     return membersAuthEnumerationInstance;
+};
+
+const checkoutSessionGlobal = () => {
+    const ExpressBrute = require('express-brute');
+    const BruteKnex = require('brute-knex');
+    const db = require('../../../../data/db');
+
+    store = store || new BruteKnex({
+        tablename: 'brute',
+        createTable: false,
+        knex: db.knex
+    });
+
+    if (!checkoutSessionGlobalInstance) {
+        checkoutSessionGlobalInstance = new ExpressBrute(store,
+            extend({
+                attachResetToRequest: true,
+                failCallback(req, res, next, nextValidRequestDate) {
+                    return next(new errors.TooManyRequestsError({
+                        message: `Too many checkout attempts, try again in ${moment(nextValidRequestDate).fromNow(true)}`,
+                        context: tpl(messages.tooManyCheckoutAttempts.context),
+                        help: tpl(messages.tooManyCheckoutAttempts.context)
+                    }));
+                },
+                handleStoreError: handleStoreError
+            }, pick(spamCheckoutSessionGlobal, spamConfigKeys))
+        );
+    }
+
+    return checkoutSessionGlobalInstance;
+};
+
+const checkoutSessionEmail = () => {
+    const ExpressBrute = require('express-brute');
+    const BruteKnex = require('brute-knex');
+    const db = require('../../../../data/db');
+
+    store = store || new BruteKnex({
+        tablename: 'brute',
+        createTable: false,
+        knex: db.knex
+    });
+
+    if (!checkoutSessionEmailInstance) {
+        checkoutSessionEmailInstance = new ExpressBrute(store,
+            extend({
+                attachResetToRequest: true,
+                failCallback(req, res, next, nextValidRequestDate) {
+                    return next(new errors.TooManyRequestsError({
+                        message: `Too many checkout attempts for this email, try again in ${moment(nextValidRequestDate).fromNow(true)}`,
+                        context: tpl(messages.tooManyCheckoutAttempts.context),
+                        help: tpl(messages.tooManyCheckoutAttempts.context)
+                    }));
+                },
+                handleStoreError: handleStoreError
+            }, pick(spamCheckoutSessionEmail, spamConfigKeys))
+        );
+    }
+
+    return checkoutSessionEmailInstance;
 };
 
 const otcVerificationEnumeration = () => {
@@ -502,6 +569,8 @@ module.exports = {
     userVerification: userVerification,
     membersAuth: membersAuth,
     membersAuthEnumeration: membersAuthEnumeration,
+    checkoutSessionGlobal: checkoutSessionGlobal,
+    checkoutSessionEmail: checkoutSessionEmail,
     otcVerification: otcVerification,
     otcVerificationEnumeration: otcVerificationEnumeration,
     userReset: userReset,
@@ -518,6 +587,8 @@ module.exports = {
         userLoginInstance = undefined;
         membersAuthInstance = undefined;
         membersAuthEnumerationInstance = undefined;
+        checkoutSessionGlobalInstance = undefined;
+        checkoutSessionEmailInstance = undefined;
         userResetInstance = undefined;
         sendVerificationCodeInstance = undefined;
         userVerificationInstance = undefined;
@@ -534,6 +605,8 @@ module.exports = {
         spamSendVerificationCode = spam.send_verification_code || {};
         spamUserVerification = spam.user_verification || {};
         spamMemberLogin = spam.member_login || {};
+        spamCheckoutSessionGlobal = spam.checkout_session_global || {};
+        spamCheckoutSessionEmail = spam.checkout_session_email || {};
         spamContentApiKey = spam.content_api_key || {};
         spamOtcVerificationEnumeration = spam.otc_verification_enumeration || {};
         spamOtcVerification = spam.otc_verification || {};

--- a/ghost/core/core/server/web/shared/middleware/brute.js
+++ b/ghost/core/core/server/web/shared/middleware/brute.js
@@ -128,6 +128,24 @@ module.exports = {
         return spamPrevention.membersAuthEnumeration().prevent(req, res, next);
     },
 
+    checkoutSessionGlobal(req, res, next) {
+        return spamPrevention.checkoutSessionGlobal().prevent(req, res, next);
+    },
+
+    checkoutSessionEmail(req, res, next) {
+        if (!req.body?.customerEmail) {
+            return next();
+        }
+
+        return spamPrevention.checkoutSessionEmail().getMiddleware({
+            // ignoring IP blocks rotating-IP attacks against a single email address
+            ignoreIP: true,
+            key(_req, _res, _next) {
+                return _next(`${String(_req.body.customerEmail).trim().toLowerCase()}checkout`);
+            }
+        })(req, res, next);
+    },
+
     /**
      * Block too many OTC verification attempts from same IP (blocks user enumeration)
      */

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -130,6 +130,18 @@
             "lifetime": 43200,
             "freeRetries": 8
         },
+        "checkout_session_global": {
+            "minWait": 3600000,
+            "maxWait": 3600000,
+            "lifetime": 3600,
+            "freeRetries": 99
+        },
+        "checkout_session_email": {
+            "minWait": 600000,
+            "maxWait": 43200000,
+            "lifetime": 43200,
+            "freeRetries": 8
+        },
         "webmentions_block": {
             "minWait": 10,
             "maxWait": 100,

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -82,6 +82,18 @@
             "lifetime": 3600,
             "freeRetries": 10
         },
+        "checkout_session_global": {
+            "minWait": 3600000,
+            "maxWait": 3600000,
+            "lifetime": 3600,
+            "freeRetries": 99
+        },
+        "checkout_session_email": {
+            "minWait": 600000,
+            "maxWait": 43200000,
+            "lifetime": 43200,
+            "freeRetries": 8
+        },
         "otc_verification_enumeration": {
             "minWait": 600000,
             "maxWait": 43200000,

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -78,6 +78,18 @@
             "lifetime": 3600,
             "freeRetries": 10
         },
+        "checkout_session_global": {
+            "minWait": 3600000,
+            "maxWait": 3600000,
+            "lifetime": 3600,
+            "freeRetries": 99
+        },
+        "checkout_session_email": {
+            "minWait": 600000,
+            "maxWait": 43200000,
+            "lifetime": 43200,
+            "freeRetries": 8
+        },
         "otc_verification_enumeration": {
             "minWait": 600000,
             "maxWait": 43200000,

--- a/ghost/core/test/unit/server/web/shared/middleware/brute.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/brute.test.js
@@ -3,12 +3,17 @@ const sinon = require('sinon');
 const brute = require('../../../../../../core/server/web/shared/middleware/brute');
 
 describe('brute middleware', function () {
-    afterAll(function () {
+    afterEach(function () {
         sinon.restore();
     });
 
     it('exports a contentApiKey method', function () {
         assert.equal(typeof brute.contentApiKey, 'function');
+    });
+
+    it('exports checkout session methods', function () {
+        assert.equal(typeof brute.checkoutSessionGlobal, 'function');
+        assert.equal(typeof brute.checkoutSessionEmail, 'function');
     });
 
     describe('contentApiKey', function () {
@@ -24,6 +29,36 @@ describe('brute middleware', function () {
                 // I don't care
             } finally {
                 sinon.assert.called(contentApiKeyStub);
+            }
+        });
+    });
+
+    describe('checkoutSessionGlobal', function () {
+        it('calls the checkoutSessionGlobal method of spam prevention', function () {
+            const spamPrevention = require('../../../../../../core/server/web/shared/middleware/api/spam-prevention');
+            const checkoutSessionGlobalStub = sinon.stub(spamPrevention, 'checkoutSessionGlobal');
+
+            try {
+                brute.checkoutSessionGlobal();
+            } catch (err) {
+                // We only care that the spam prevention method is called.
+            } finally {
+                sinon.assert.called(checkoutSessionGlobalStub);
+            }
+        });
+    });
+
+    describe('checkoutSessionEmail', function () {
+        it('calls the checkoutSessionEmail method of spam prevention', function () {
+            const spamPrevention = require('../../../../../../core/server/web/shared/middleware/api/spam-prevention');
+            const checkoutSessionEmailStub = sinon.stub(spamPrevention, 'checkoutSessionEmail');
+
+            try {
+                brute.checkoutSessionEmail({body: {customerEmail: 'test@example.com'}});
+            } catch (err) {
+                // We only care that the spam prevention method is called.
+            } finally {
+                sinon.assert.called(checkoutSessionEmailStub);
             }
         });
     });

--- a/ghost/core/test/utils/fixtures/config/defaults.json
+++ b/ghost/core/test/utils/fixtures/config/defaults.json
@@ -60,6 +60,18 @@
             "lifetime": 43200,
             "freeRetries": 8
         },
+        "checkout_session_global": {
+            "minWait": 3600000,
+            "maxWait": 3600000,
+            "lifetime": 3600,
+            "freeRetries": 99
+        },
+        "checkout_session_email": {
+            "minWait": 600000,
+            "maxWait": 43200000,
+            "lifetime": 43200,
+            "freeRetries": 8
+        },
         "webmentions_block": {
             "minWait": 3600000,
             "maxWait": 3600000,


### PR DESCRIPTION
no issue

Checkout session creation had no dedicated request limits, so abusive traffic (e.g. card testing) against `/members/api/create-stripe-checkout-session` couldn't be blocked or tuned independently from sign-in traffic. The endpoint now has two dedicated limiters:

- a global IP-based limiter with generous limits (matching `global_block`) so communities behind a shared IP aren't blocked by a single user
- an email-keyed limiter that ignores IP, so rotating-IP attacks against a single email address share one counter (matching the OTC verification limiter)

Both limiters have explicit tuned defaults in config so they don't fall back to express-brute's very strict built-in limits.
