### PR TITLE
Converged @testing-library/jest-dom onto a single catalog version

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -74,7 +74,7 @@
     ],
     "devDependencies": {
         "@playwright/test": "catalog:",
-        "@testing-library/jest-dom": "5.17.0",
+        "@testing-library/jest-dom": "catalog:",
         "@testing-library/react": "14.3.1",
         "@tryghost/koenig-lexical": "catalog:",
         "@types/react": "catalog:",

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@playwright/test": "catalog:",
-    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "14.3.1",
     "@tryghost/admin-x-design-system": "workspace:*",
     "@tryghost/admin-x-framework": "workspace:*",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -30,7 +30,7 @@
     "@eslint/js": "catalog:eslint9",
     "@tailwindcss/vite": "catalog:",
     "@tanstack/react-query": "catalog:",
-    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "14.3.1",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@playwright/test": "catalog:",
-    "@testing-library/jest-dom": "5.17.0",
+    "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "12.1.5",
     "@tryghost/i18n": "workspace:*",
     "@tryghost/nql": "catalog:",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -111,7 +111,7 @@
   "devDependencies": {
     "@doist/react-interpolate": "2.2.2",
     "@sentry/react": "catalog:",
-    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.6.1",
     "@tryghost/i18n": "workspace:*",

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -40,7 +40,7 @@
         "@playwright/test": "catalog:",
         "@tanstack/react-query": "catalog:",
         "@tanstack/react-virtual": "3.13.25",
-        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/jest-dom": "catalog:",
         "@testing-library/react": "14.3.1",
         "@types/jest": "catalog:",
         "@types/papaparse": "5.5.2",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/sodo-search",
-  "version": "1.8.21",
+  "version": "1.8.22",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -93,7 +93,7 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "5.17.0",
+    "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "12.1.5",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/apps/sodo-search/test/setup-tests.js
+++ b/apps/sodo-search/test/setup-tests.js
@@ -1,5 +1,5 @@
-import matchers from '@testing-library/jest-dom/matchers';
-import {afterEach, expect} from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import {afterEach} from 'vitest';
 import {cleanup} from '@testing-library/react';
 import {fetch} from 'cross-fetch';
 
@@ -13,8 +13,6 @@ globalThis.fetch = fetch;
 // Add the cleanup function for React testing library
 afterEach(cleanup);
 
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
+// jest-dom (imported above as /vitest) registers custom matchers for asserting
+// on DOM nodes, e.g. expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-expect.extend(matchers);

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -38,7 +38,7 @@
     },
     "devDependencies": {
         "@faker-js/faker": "9.9.0",
-        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/jest-dom": "catalog:",
         "@testing-library/react": "14.3.1",
         "@types/jest": "catalog:",
         "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     '@tanstack/react-query':
       specifier: 4.44.0
       version: 4.44.0
+    '@testing-library/jest-dom':
+      specifier: 6.9.1
+      version: 6.9.1
     '@tryghost/api-framework':
       specifier: 3.2.3
       version: 3.2.3
@@ -469,7 +472,7 @@ importers:
         specifier: 'catalog:'
         version: 4.44.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/jest-dom':
-        specifier: 6.9.1
+        specifier: 'catalog:'
         version: 6.9.1
       '@testing-library/react':
         specifier: 14.3.1
@@ -769,8 +772,8 @@ importers:
         specifier: 'catalog:'
         version: 1.60.0
       '@testing-library/jest-dom':
-        specifier: 5.17.0
-        version: 5.17.0
+        specifier: 'catalog:'
+        version: 6.9.1
       '@testing-library/react':
         specifier: 14.3.1
         version: 14.3.1(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -929,7 +932,7 @@ importers:
         specifier: 'catalog:'
         version: 1.60.0
       '@testing-library/jest-dom':
-        specifier: 6.9.1
+        specifier: 'catalog:'
         version: 6.9.1
       '@testing-library/react':
         specifier: 14.3.1
@@ -1078,8 +1081,8 @@ importers:
         specifier: 'catalog:'
         version: 1.60.0
       '@testing-library/jest-dom':
-        specifier: 5.17.0
-        version: 5.17.0
+        specifier: 'catalog:'
+        version: 6.9.1
       '@testing-library/react':
         specifier: 12.1.5
         version: 12.1.5(@types/react@18.3.29)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -1154,7 +1157,7 @@ importers:
         specifier: 'catalog:'
         version: 7.120.4(react@17.0.2)
       '@testing-library/jest-dom':
-        specifier: 6.9.1
+        specifier: 'catalog:'
         version: 6.9.1
       '@testing-library/react':
         specifier: 12.1.5
@@ -1287,7 +1290,7 @@ importers:
         specifier: 3.13.25
         version: 3.13.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/jest-dom':
-        specifier: 6.9.1
+        specifier: 'catalog:'
         version: 6.9.1
       '@testing-library/react':
         specifier: 14.3.1
@@ -1644,8 +1647,8 @@ importers:
         version: 17.0.2(react@17.0.2)
     devDependencies:
       '@testing-library/jest-dom':
-        specifier: 5.17.0
-        version: 5.17.0
+        specifier: 'catalog:'
+        version: 6.9.1
       '@testing-library/react':
         specifier: 12.1.5
         version: 12.1.5(@types/react@18.3.29)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -1717,7 +1720,7 @@ importers:
         specifier: 9.9.0
         version: 9.9.0
       '@testing-library/jest-dom':
-        specifier: 6.9.1
+        specifier: 'catalog:'
         version: 6.9.1
       '@testing-library/react':
         specifier: 14.3.1
@@ -5238,10 +5241,6 @@ packages:
     resolution: {integrity: sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/expect-utils@30.4.1':
-    resolution: {integrity: sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/expect@29.7.0':
     resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5264,10 +5263,6 @@ packages:
 
   '@jest/pattern@30.0.1':
     resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/pattern@30.4.0':
-    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/reporters@29.7.0':
@@ -5321,10 +5316,6 @@ packages:
 
   '@jest/types@30.3.0':
     resolution: {integrity: sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/types@30.4.1':
-    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
@@ -8322,10 +8313,6 @@ packages:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
 
-  '@testing-library/jest-dom@5.17.0':
-    resolution: {integrity: sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==}
-    engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
-
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
@@ -8979,9 +8966,6 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
-  '@types/jest@30.0.0':
-    resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
-
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
@@ -9171,9 +9155,6 @@ packages:
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
-
-  '@types/testing-library__jest-dom@5.14.9':
-    resolution: {integrity: sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -11075,10 +11056,6 @@ packages:
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
-
-  chalk@3.0.0:
-    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
-    engines: {node: '>=8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -13804,10 +13781,6 @@ packages:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  expect@30.4.1:
-    resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
@@ -15648,10 +15621,6 @@ packages:
     resolution: {integrity: sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.4.1:
-    resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-message-util@29.7.0:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -15660,20 +15629,12 @@ packages:
     resolution: {integrity: sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.4.1:
-    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-mock@30.3.0:
     resolution: {integrity: sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-mock@30.4.1:
-    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-pnp-resolver@1.2.3:
@@ -15691,10 +15652,6 @@ packages:
 
   jest-regex-util@30.0.1:
     resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-regex-util@30.4.0:
-    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-resolve-dependencies@29.7.0:
@@ -15727,10 +15684,6 @@ packages:
 
   jest-util@30.3.0:
     resolution: {integrity: sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-util@30.4.1:
-    resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-validate@29.7.0:
@@ -24837,10 +24790,6 @@ snapshots:
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect-utils@30.4.1':
-    dependencies:
-      '@jest/get-type': 30.1.0
-
   '@jest/expect@29.7.0':
     dependencies:
       expect: 29.7.0
@@ -24879,11 +24828,6 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
       jest-regex-util: 30.0.1
-
-  '@jest/pattern@30.4.0':
-    dependencies:
-      '@types/node': 25.9.1
-      jest-regex-util: 30.4.0
 
   '@jest/reporters@29.7.0(node-notifier@10.0.1)':
     dependencies:
@@ -25007,16 +24951,6 @@ snapshots:
     dependencies:
       '@jest/pattern': 30.0.1
       '@jest/schemas': 30.0.5
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.1
-      '@types/yargs': 17.0.35
-      chalk: 4.1.2
-
-  '@jest/types@30.4.1':
-    dependencies:
-      '@jest/pattern': 30.4.0
-      '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 25.9.1
@@ -28204,18 +28138,6 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@5.17.0':
-    dependencies:
-      '@adobe/css-tools': 4.5.0
-      '@babel/runtime': 7.29.7
-      '@types/testing-library__jest-dom': 5.14.9
-      aria-query: 5.3.2
-      chalk: 3.0.0
-      css.escape: 1.5.1
-      dom-accessibility-api: 0.5.16
-      lodash: 4.18.1
-      redent: 3.0.0
-
   '@testing-library/jest-dom@6.9.1':
     dependencies:
       '@adobe/css-tools': 4.5.0
@@ -29372,11 +29294,6 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
-  '@types/jest@30.0.0':
-    dependencies:
-      expect: 30.4.1
-      pretty-format: 30.4.1
-
   '@types/js-yaml@4.0.9': {}
 
   '@types/jsdom@28.0.3':
@@ -29589,10 +29506,6 @@ snapshots:
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 25.9.1
-
-  '@types/testing-library__jest-dom@5.14.9':
-    dependencies:
-      '@types/jest': 30.0.0
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -32615,11 +32528,6 @@ snapshots:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-
-  chalk@3.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
 
   chalk@4.1.2:
     dependencies:
@@ -36410,15 +36318,6 @@ snapshots:
       jest-mock: 30.3.0
       jest-util: 30.3.0
 
-  expect@30.4.1:
-    dependencies:
-      '@jest/expect-utils': 30.4.1
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.4.1
-      jest-message-util: 30.4.1
-      jest-mock: 30.4.1
-      jest-util: 30.4.1
-
   exponential-backoff@3.1.3: {}
 
   express-brute@1.0.1(express@4.22.2):
@@ -38799,13 +38698,6 @@ snapshots:
       jest-diff: 30.3.0
       pretty-format: 30.3.0
 
-  jest-matcher-utils@30.4.1:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.4.1
-      pretty-format: 30.4.1
-
   jest-message-util@29.7.0:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -38830,19 +38722,6 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-message-util@30.4.1:
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@jest/types': 30.4.1
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      jest-util: 30.4.1
-      picomatch: 4.0.4
-      pretty-format: 30.4.1
-      slash: 3.0.0
-      stack-utils: 2.0.6
-
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -38855,12 +38734,6 @@ snapshots:
       '@types/node': 25.9.1
       jest-util: 30.3.0
 
-  jest-mock@30.4.1:
-    dependencies:
-      '@jest/types': 30.4.1
-      '@types/node': 25.9.1
-      jest-util: 30.4.1
-
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
     optionalDependencies:
       jest-resolve: 29.7.0
@@ -38868,8 +38741,6 @@ snapshots:
   jest-regex-util@29.6.3: {}
 
   jest-regex-util@30.0.1: {}
-
-  jest-regex-util@30.4.0: {}
 
   jest-resolve-dependencies@29.7.0:
     dependencies:
@@ -39006,15 +38877,6 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.9.1
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      graceful-fs: 4.2.11
-      picomatch: 4.0.4
-
-  jest-util@30.4.1:
-    dependencies:
-      '@jest/types': 30.4.1
       '@types/node': 25.9.1
       chalk: 4.1.2
       ci-info: 4.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ catalog:
   '@tailwindcss/postcss': 4.2.2
   '@tailwindcss/vite': 4.2.2
   '@tanstack/react-query': 4.44.0
+  '@testing-library/jest-dom': 6.9.1
   '@tryghost/api-framework': 3.2.3
   '@tryghost/color-utils': 0.2.18
   '@tryghost/custom-fonts': 1.0.10


### PR DESCRIPTION
`@testing-library/jest-dom` was split between 6.9.1 (5 apps) and 5.17.0 (admin-x-framework, comments-ui, sodo-search), with nothing holding them together.

Adds it to the catalog at 6.9.1 and points every consumer at `catalog:`, bumping the three laggards and preventing future drift. sodo-search's test setup used the v5 `import matchers … expect.extend(matchers)` pattern that v6 removed, so it's switched to the `@testing-library/jest-dom/vitest` import already used by posts/admin-x-settings.

Unit suites for the three bumped packages pass: comments-ui (259), admin-x-framework (388), sodo-search (8).