### PR TITLE
Cleaned up ghost/core's zod dependency to use the catalog

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -239,7 +239,7 @@
     "type-fest": "catalog:",
     "ua-parser-js": "1.0.41",
     "xml": "1.0.1",
-    "zod": "4.1.12"
+    "zod": "catalog:"
   },
   "overrides": {
     "lodash.template": "4.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2678,7 +2678,7 @@ importers:
         specifier: 1.0.1
         version: 1.0.1
       zod:
-        specifier: 4.1.12
+        specifier: 'catalog:'
         version: 4.1.12
     devDependencies:
       '@actions/core':


### PR DESCRIPTION
ghost/core pinned `zod` inline at 4.1.12, which is exactly the catalog value. With `catalogMode: strict`, every other zod consumer already references the catalog; pointing ghost/core at `catalog:` keeps the version single-sourced.

Pure no-op: only the lockfile specifier changes, resolution is unchanged.