### PR TITLE
🎨 Changed offer links so they always open Portal's offer page

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,9 @@
+# Context Map
+
+## Contexts
+
+### Portal
+
+Path: `apps/portal/CONTEXT.md`
+
+Portal is the visitor-facing membership widget embedded on a Ghost site — the modal that handles member signup, sign-in, paid subscription checkout, offers, and account management.

--- a/apps/portal/CONTEXT.md
+++ b/apps/portal/CONTEXT.md
@@ -1,0 +1,23 @@
+# Context
+
+## Glossary
+
+### Portal button
+
+The ambient on-site control that lets a visitor open Portal without following a specific Portal link. It does not control whether a specific Portal link opens Portal.
+
+### Offer link
+
+A Portal link for viewing and accepting a membership offer. Offer links always open the offer page — even when the Portal button is hidden — and only for visitors eligible to accept the offer. Portal offer triggers are offer links.
+
+For ineligible visitors — existing paid members (excluding complimentary members), or expired, archived, or retention offers — the link is silently ignored and Portal does not open.
+
+### Checkout button
+
+A site control that starts checkout for a membership plan, sending visitors directly to checkout instead of opening an offer page.
+
+### Checkout attempt
+
+An attempt to start checkout for a membership plan. Checkout attempts are protected by request limits across checkout traffic and repeated attempts against one email address.
+
+When a checkout attempt indicates that the submitted email should sign in instead, Portal continues with the sign-in email flow rather than asking the visitor to retry checkout.

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.60",
+  "version": "2.69.0",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.68.59",
+  "version": "2.68.60",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -4,6 +4,8 @@ import {getGiftRedemptionErrorMessage, getGiftRedemptionSuccessMessage} from './
 import {createNotification, createPopupNotification, getMemberEmail, getMemberName, getProductCadenceFromPrice, removePortalLinkFromUrl, getRefDomain} from './utils/helpers';
 import {t} from './utils/i18n';
 
+const CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION = 'CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION';
+
 function switchPage({data, state}) {
     return {
         page: data.page,
@@ -186,12 +188,13 @@ async function signup({data, state, api}) {
             const integrityToken = await api.member.getIntegrityToken();
             ({inboxLinks} = await api.member.sendMagicLink({emailType: 'signup', integrityToken, ...data, name}));
         } else {
-            if (tierId && cadence) {
-                await api.member.checkoutPlan({plan, tierId, cadence, email, name, newsletters, offerId});
-            } else {
+            // An existing (logged-in) member starting a paid checkout is upgrading, not signing up,
+            // so flag it as an upgrade to suppress the signup email.
+            const metadata = state.member ? {checkoutType: 'upgrade'} : undefined;
+            if (!tierId || !cadence) {
                 ({tierId, cadence} = getProductCadenceFromPrice({site: state?.site, priceId: plan}));
-                await api.member.checkoutPlan({plan, tierId, cadence, email, name, newsletters, offerId});
             }
+            await api.member.checkoutPlan({plan, tierId, cadence, email, name, newsletters, offerId, metadata});
             return {
                 page: 'loading'
             };
@@ -206,6 +209,18 @@ async function signup({data, state, api}) {
             }
         };
     } catch (e) {
+        if (e.code === CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION) {
+            return {
+                page: 'magiclink',
+                lastPage: 'signin',
+                pageData: {
+                    ...(state.pageData || {}),
+                    email: (data?.email || '').trim()
+                },
+                popupNotification: null
+            };
+        }
+
         const message = chooseBestErrorMessage(e, t('Failed to sign up, please try again'));
         return {
             action: 'signup:failed',

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -949,7 +949,6 @@ export default class App extends React.Component {
 
     /** Handle Portal offer urls */
     async handleOfferQuery({site, offerId, member = this.state.member}) {
-        const {portal_button: portalButton} = site;
         removePortalLinkFromUrl();
 
         if (!isPaidMember({member}) || isComplimentaryMember({member})) {
@@ -970,25 +969,10 @@ export default class App extends React.Component {
                     return;
                 }
 
-                if (!portalButton) {
-                    const product = getProductFromId({site, productId: offer.tier.id});
-                    const price = offer.cadence === 'month' ? product.monthlyPrice : product.yearlyPrice;
-                    this.dispatchAction('openPopup', {
-                        page: 'loading'
-                    });
-                    if (member) {
-                        const {tierId, cadence} = getProductCadenceFromPrice({site, priceId: price.id});
-                        this.dispatchAction('checkoutPlan', {plan: price.id, offerId, tierId, cadence});
-                    } else {
-                        const {tierId, cadence} = getProductCadenceFromPrice({site, priceId: price.id});
-                        this.dispatchAction('signup', {plan: price.id, offerId, tierId, cadence});
-                    }
-                } else {
-                    this.dispatchAction('openPopup', {
-                        page: 'offer',
-                        pageData: offerData?.offers[0]
-                    });
-                }
+                this.dispatchAction('openPopup', {
+                    page: 'offer',
+                    pageData: offer
+                });
             } catch (e) {
                 // ignore invalid portal url
             }

--- a/apps/portal/src/components/pages/offer-page.js
+++ b/apps/portal/src/components/pages/offer-page.js
@@ -276,7 +276,7 @@ export default class OfferPage extends React.Component {
 
     handleSignup(e) {
         e.preventDefault();
-        const {pageData: offer, site} = this.context;
+        const {pageData: offer, site, member} = this.context;
         if (!offer || !offer.tier) {
             return null;
         }
@@ -298,7 +298,9 @@ export default class OfferPage extends React.Component {
                     offerId: offer?.id,
                     phonenumber
                 };
-                if (hasMultipleNewsletters({site})) {
+                // Logged-in members are upgrading and already have newsletter preferences,
+                // so they skip the newsletter selection step that new signups see.
+                if (hasMultipleNewsletters({site}) && !member) {
                     this.setState({
                         showNewsletterSelection: true,
                         pageData: signupData,

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -535,8 +535,11 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             }).then(async function (res) {
                 if (!res.ok) {
                     const errData = await res.json();
-                    const errMssg = errData?.errors?.[0]?.message || 'Failed to signup, please try again.';
-                    throw new Error(errMssg);
+                    const err = errData?.errors?.[0] || {};
+                    const errMssg = err.message || 'Failed to signup, please try again.';
+                    const error = new Error(errMssg);
+                    error.code = err.code;
+                    throw error;
                 }
                 return res.json();
             }).then(function (responseBody) {

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -44,6 +44,48 @@ describe('signup action', () => {
             expect.objectContaining({name: 'John Doe'})
         );
     });
+
+    test('continues to signin magic link page when checkout finds an existing subscription', async () => {
+        const checkoutError = new Error('A subscription exists for this Member.') as Error & {code: string};
+        checkoutError.code = 'CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION';
+
+        const mockApi = {
+            member: {
+                checkoutPlan: vi.fn(() => Promise.reject(checkoutError))
+            }
+        };
+        const state = {
+            site: {},
+            pageData: {
+                offerId: 'offer_123'
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'signup',
+            data: {
+                plan: 'price_123',
+                tierId: 'tier_123',
+                cadence: 'month',
+                email: 'jamie@example.com',
+                name: 'Jamie'
+            },
+            state,
+            api: mockApi
+        });
+
+        expect(mockApi.member.checkoutPlan).toHaveBeenCalled();
+        expect(result).toMatchObject({
+            page: 'magiclink',
+            lastPage: 'signin',
+            pageData: {
+                offerId: 'offer_123',
+                email: 'jamie@example.com'
+            },
+            popupNotification: null
+        });
+        expect(result).not.toHaveProperty('action', 'signup:failed');
+    });
 });
 
 describe('redeemGift action', () => {

--- a/apps/portal/test/api.test.js
+++ b/apps/portal/test/api.test.js
@@ -176,3 +176,54 @@ describe('Portal API gift checkout', () => {
         expect(window.location.assign).toHaveBeenCalledWith('https://checkout.stripe.com/gift-session');
     });
 });
+
+describe('Portal API member checkout', () => {
+    let originalLocation;
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        originalLocation = window.location;
+        delete window.location;
+        window.location = {
+            href: 'https://example.com/#/portal/offers/offer_123',
+            assign: vi.fn()
+        };
+    });
+
+    afterEach(() => {
+        window.location = originalLocation;
+    });
+
+    test('preserves checkout session error code', async () => {
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+
+        vi.spyOn(window, 'fetch').mockImplementation((url) => {
+            if (url.includes('/members/api/session/')) {
+                return Promise.resolve(new Response('identity-token', {status: 200}));
+            }
+
+            return Promise.resolve(new Response(JSON.stringify({
+                errors: [{
+                    message: 'A subscription exists for this Member.',
+                    code: 'CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION'
+                }]
+            }), {
+                status: 403,
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }));
+        });
+
+        await expect(ghostApi.member.checkoutPlan({
+            plan: 'price_123',
+            tierId: 'tier_123',
+            cadence: 'month',
+            email: 'jamie@example.com',
+            offerId: 'offer_123'
+        })).rejects.toMatchObject({
+            message: 'A subscription exists for this Member.',
+            code: 'CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION'
+        });
+    });
+});

--- a/apps/portal/test/data-attributes.test.js
+++ b/apps/portal/test/data-attributes.test.js
@@ -1,5 +1,5 @@
 import App from '../src/app';
-import {site as FixturesSite, member as FixtureMember} from './utils/test-fixtures';
+import {offer as FixtureOffer, site as FixturesSite, member as FixtureMember} from './utils/test-fixtures';
 import {fireEvent, appRender, within, waitFor} from './utils/test-utils';
 import setupGhostApi from '../src/utils/api';
 import * as helpers from '../src/utils/helpers';
@@ -727,7 +727,7 @@ describe('Member Data attributes:', () => {
     });
 });
 
-const setup = async ({site, member = null, showPopup = true}) => {
+const setup = async ({site, member = null, showPopup = true, waitForTrigger = true, offer = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
     ghostApi.init = vi.fn(() => {
         return Promise.resolve({
@@ -744,11 +744,17 @@ const setup = async ({site, member = null, showPopup = true}) => {
         return Promise.resolve();
     });
 
+    ghostApi.site.offer = vi.fn(() => {
+        return Promise.resolve({
+            offers: [offer]
+        });
+    });
+
     const utils = appRender(
         <App api={ghostApi} showPopup={showPopup} />
     );
 
-    const triggerButtonFrame = await utils.findByTitle(/portal-trigger/i);
+    const triggerButtonFrame = waitForTrigger ? await utils.findByTitle(/portal-trigger/i) : utils.queryByTitle(/portal-trigger/i);
     const popupFrame = utils.queryByTitle(/portal-popup/i);
     return {
         ghostApi,
@@ -897,6 +903,43 @@ describe('Portal Data attributes:', () => {
             fireEvent.click(portalElement);
             popupFrame = await utils.findByTitle(/portal-popup/i);
             expect(popupFrame).toBeInTheDocument();
+        });
+    });
+
+    describe('data-portal=offers/:offerid', () => {
+        test('opens Portal offer page when the Portal button is disabled', async () => {
+            const siteData = {
+                ...FixturesSite.singleTier.basic,
+                portal_button: false
+            };
+
+            document.body.innerHTML = `
+                <div data-portal="offers/${FixtureOffer.id}"> </div>
+            `;
+            let {
+                ghostApi, popupFrame, triggerButtonFrame, ...utils
+            } = await setup({
+                site: siteData,
+                showPopup: false,
+                waitForTrigger: false,
+                offer: FixtureOffer
+            });
+            expect(popupFrame).not.toBeInTheDocument();
+            expect(triggerButtonFrame).not.toBeInTheDocument();
+
+            const portalElement = document.querySelector('[data-portal]');
+            await waitFor(() => {
+                expect(portalElement).toHaveClass('gh-portal-close');
+            });
+            fireEvent.click(portalElement);
+
+            popupFrame = await utils.findByTitle(/portal-popup/i);
+            expect(popupFrame).toBeInTheDocument();
+            // The offer page renders only after the async site.offer() request resolves.
+            await waitFor(() => {
+                expect(within(popupFrame.contentDocument).queryByText(FixtureOffer.display_title)).toBeInTheDocument();
+            });
+            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
         });
     });
 

--- a/apps/portal/test/signup-flow.test.js
+++ b/apps/portal/test/signup-flow.test.js
@@ -580,39 +580,30 @@ describe('Signup', () => {
         });
 
         test('to an offer via link', async () => {
-            window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
+            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
             const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
+                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton, offerDescription
             } = await offerSetup({
                 site: FixtureSite.singleTier.basic,
                 offer: FixtureOffer
             });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let tier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
+            const tier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+
             expect(popupFrame).toBeInTheDocument();
             expect(triggerButtonFrame).toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
             expect(offerDescription).toBeInTheDocument();
+            expect(signinButton).toBeInTheDocument();
+            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
 
             fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});
             fireEvent.change(nameInput, {target: {value: 'Jamie Larsen'}});
-
-            expect(emailInput).toHaveValue('jamie@example.com');
             fireEvent.click(submitButton);
 
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 name: 'Jamie Larsen',
-                offerId,
-                plan: planId,
+                offerId: FixtureOffer.id,
+                plan: tier.monthlyPrice.id,
                 tierId: tier.id,
                 cadence: 'month'
             });
@@ -621,30 +612,18 @@ describe('Signup', () => {
         });
 
         test('to an offer via link with portal disabled', async () => {
-            let site = {
-                ...FixtureSite.singleTier.basic,
-                portal_button: false
-            };
             window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
             const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
+                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, submitButton, offerDescription
             } = await offerSetup({
-                site,
+                site: {...FixtureSite.singleTier.basic, portal_button: false},
                 offer: FixtureOffer
             });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let tier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
+            const tier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+
+            // the offer page opens instead of redirecting straight to checkout
             expect(popupFrame).toBeInTheDocument();
             expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
             expect(offerDescription).toBeInTheDocument();
             expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
 
@@ -655,8 +634,8 @@ describe('Signup', () => {
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 name: 'Jamie Larsen',
-                offerId,
-                plan: planId,
+                offerId: FixtureOffer.id,
+                plan: tier.monthlyPrice.id,
                 tierId: tier.id,
                 cadence: 'month'
             });
@@ -843,84 +822,28 @@ describe('Signup', () => {
         });
 
         test('to an offer via link', async () => {
-            window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
+            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
             const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
+                ghostApi, popupFrame, emailInput, nameInput, submitButton, offerDescription
             } = await offerSetup({
                 site: FixtureSite.multipleTiers.basic,
                 offer: FixtureOffer
             });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let tier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
+            const tier = FixtureSite.multipleTiers.basic.products.find(p => p.type === 'paid');
+
             expect(popupFrame).toBeInTheDocument();
-            expect(triggerButtonFrame).toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
             expect(offerDescription).toBeInTheDocument();
 
             fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});
             fireEvent.change(nameInput, {target: {value: 'Jamie Larsen'}});
-
-            expect(emailInput).toHaveValue('jamie@example.com');
             fireEvent.click(submitButton);
 
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 name: 'Jamie Larsen',
-                offerId,
-                plan: planId,
+                offerId: FixtureOffer.id,
+                plan: tier.monthlyPrice.id,
                 tierId: tier.id,
-                cadence: 'month'
-            });
-
-            window.location.hash = '';
-        });
-
-        test('to an offer via link with portal disabled', async () => {
-            let site = {
-                ...FixtureSite.multipleTiers.basic,
-                portal_button: false
-            };
-            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
-            const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
-            } = await offerSetup({
-                site,
-                offer: FixtureOffer
-            });
-            const singleTier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let offerId = FixtureOffer.id;
-            expect(popupFrame).toBeInTheDocument();
-            expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
-            expect(offerDescription).toBeInTheDocument();
-            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
-
-            fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});
-            fireEvent.change(nameInput, {target: {value: 'Jamie Larsen'}});
-            fireEvent.click(submitButton);
-
-            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com',
-                name: 'Jamie Larsen',
-                offerId,
-                plan: planId,
-                tierId: singleTier.id,
                 cadence: 'month'
             });
 

--- a/apps/portal/test/signup-flow.test.js
+++ b/apps/portal/test/signup-flow.test.js
@@ -44,6 +44,11 @@ const offerSetup = async ({site, member = null, offer}) => {
     let emailInput, nameInput, continueButton, chooseBtns, signinButton, siteTitle, offerName, offerDescription, freePlanTitle, monthlyPlanTitle, yearlyPlanTitle, fullAccessTitle;
 
     if (popupIframeDocument) {
+        // The offer page renders only after the async site.offer() request resolves, so wait for
+        // its content before capturing queries to avoid snapshotting the loading/empty popup.
+        await waitFor(() => {
+            expect(within(popupIframeDocument).queryByText(offer.display_title)).toBeInTheDocument();
+        });
         emailInput = within(popupIframeDocument).queryByLabelText(/email/i);
         nameInput = within(popupIframeDocument).queryByLabelText(/name/i);
         continueButton = within(popupIframeDocument).queryByRole('button', {name: 'Continue'});
@@ -634,18 +639,23 @@ describe('Signup', () => {
             let offerId = FixtureOffer.id;
             expect(popupFrame).toBeInTheDocument();
             expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).not.toBeInTheDocument();
-            expect(emailInput).not.toBeInTheDocument();
-            expect(nameInput).not.toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).not.toBeInTheDocument();
-            expect(offerName).not.toBeInTheDocument();
-            expect(offerDescription).not.toBeInTheDocument();
+            expect(siteTitle).toBeInTheDocument();
+            expect(emailInput).toBeInTheDocument();
+            expect(nameInput).toBeInTheDocument();
+            expect(signinButton).toBeInTheDocument();
+            expect(submitButton).toBeInTheDocument();
+            expect(offerName).toBeInTheDocument();
+            expect(offerDescription).toBeInTheDocument();
+            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
+
+            fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});
+            fireEvent.change(nameInput, {target: {value: 'Jamie Larsen'}});
+            fireEvent.click(submitButton);
 
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                email: undefined,
-                name: undefined,
-                offerId: offerId,
+                email: 'jamie@example.com',
+                name: 'Jamie Larsen',
+                offerId,
                 plan: planId,
                 tierId: tier.id,
                 cadence: 'month'
@@ -892,18 +902,23 @@ describe('Signup', () => {
             let offerId = FixtureOffer.id;
             expect(popupFrame).toBeInTheDocument();
             expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).not.toBeInTheDocument();
-            expect(emailInput).not.toBeInTheDocument();
-            expect(nameInput).not.toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).not.toBeInTheDocument();
-            expect(offerName).not.toBeInTheDocument();
-            expect(offerDescription).not.toBeInTheDocument();
+            expect(siteTitle).toBeInTheDocument();
+            expect(emailInput).toBeInTheDocument();
+            expect(nameInput).toBeInTheDocument();
+            expect(signinButton).toBeInTheDocument();
+            expect(submitButton).toBeInTheDocument();
+            expect(offerName).toBeInTheDocument();
+            expect(offerDescription).toBeInTheDocument();
+            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
+
+            fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});
+            fireEvent.change(nameInput, {target: {value: 'Jamie Larsen'}});
+            fireEvent.click(submitButton);
 
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                email: undefined,
-                name: undefined,
-                offerId: offerId,
+                email: 'jamie@example.com',
+                name: 'Jamie Larsen',
+                offerId,
                 plan: planId,
                 tierId: singleTier.id,
                 cadence: 'month'

--- a/apps/portal/test/upgrade-flow.test.js
+++ b/apps/portal/test/upgrade-flow.test.js
@@ -268,29 +268,22 @@ describe('Logged-in free member', () => {
         });
 
         test('to an offer via link', async () => {
-            window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
+            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
             const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
+                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton, offerDescription
             } = await offerSetup({
                 site: FixtureSite.singleTier.basic,
                 member: FixtureMember.altFree,
                 offer: FixtureOffer
             });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
+            const tier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+
             expect(popupFrame).toBeInTheDocument();
             expect(triggerButtonFrame).toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
             expect(offerDescription).toBeInTheDocument();
+            expect(signinButton).not.toBeInTheDocument();
 
+            // member details are pre-filled for logged-in members
             expect(emailInput).toHaveValue('jimmie@example.com');
             expect(nameInput).toHaveValue('Jimmie Larson');
             fireEvent.click(submitButton);
@@ -298,9 +291,9 @@ describe('Logged-in free member', () => {
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
                 email: 'jimmie@example.com',
                 name: 'Jimmie Larson',
-                offerId,
-                plan: planId,
-                tierId: singleTierProduct.id,
+                offerId: FixtureOffer.id,
+                plan: tier.monthlyPrice.id,
+                tierId: tier.id,
                 cadence: 'month',
                 metadata: {checkoutType: 'upgrade'}
             });
@@ -309,45 +302,30 @@ describe('Logged-in free member', () => {
         });
 
         test('to an offer via link with portal disabled', async () => {
-            let site = {
-                ...FixtureSite.singleTier.basic,
-                portal_button: false
-            };
-
             window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
             const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
+                ghostApi, popupFrame, triggerButtonFrame, submitButton, offerDescription
             } = await offerSetup({
-                site: site,
+                site: {...FixtureSite.singleTier.basic, portal_button: false},
                 member: FixtureMember.altFree,
                 offer: FixtureOffer
             });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
+            const tier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+
+            // the offer page opens instead of redirecting straight to checkout
             expect(popupFrame).toBeInTheDocument();
             expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
             expect(offerDescription).toBeInTheDocument();
             expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
 
-            expect(emailInput).toHaveValue('jimmie@example.com');
-            expect(nameInput).toHaveValue('Jimmie Larson');
             fireEvent.click(submitButton);
 
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
                 email: 'jimmie@example.com',
                 name: 'Jimmie Larson',
-                offerId,
-                plan: planId,
-                tierId: singleTierProduct.id,
+                offerId: FixtureOffer.id,
+                plan: tier.monthlyPrice.id,
+                tierId: tier.id,
                 cadence: 'month',
                 metadata: {checkoutType: 'upgrade'}
             });
@@ -396,29 +374,20 @@ describe('Logged-in free member', () => {
         });
 
         test('to an offer via link', async () => {
-            window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
+            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
             const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
+                ghostApi, popupFrame, emailInput, nameInput, submitButton, offerDescription
             } = await offerSetup({
                 site: FixtureSite.multipleTiers.basic,
                 member: FixtureMember.altFree,
                 offer: FixtureOffer
             });
-            let planId = FixtureSite.multipleTiers.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let singleTierProduct = FixtureSite.multipleTiers.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
+            const tier = FixtureSite.multipleTiers.basic.products.find(p => p.type === 'paid');
+
             expect(popupFrame).toBeInTheDocument();
-            expect(triggerButtonFrame).toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
             expect(offerDescription).toBeInTheDocument();
 
+            // member details are pre-filled for logged-in members
             expect(emailInput).toHaveValue('jimmie@example.com');
             expect(nameInput).toHaveValue('Jimmie Larson');
             fireEvent.click(submitButton);
@@ -426,9 +395,9 @@ describe('Logged-in free member', () => {
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
                 email: 'jimmie@example.com',
                 name: 'Jimmie Larson',
-                offerId,
-                plan: planId,
-                tierId: singleTierProduct.id,
+                offerId: FixtureOffer.id,
+                plan: tier.monthlyPrice.id,
+                tierId: tier.id,
                 cadence: 'month',
                 metadata: {checkoutType: 'upgrade'}
             });
@@ -565,29 +534,20 @@ describe('Logged-in complimentary member', () => {
         });
 
         test('to an offer via link', async () => {
-            window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
+            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
             const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
+                ghostApi, popupFrame, emailInput, nameInput, submitButton, offerDescription
             } = await offerSetup({
                 site: FixtureSite.singleTier.basic,
                 member: FixtureMember.altComplimentary,
                 offer: FixtureOffer
             });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
+            const tier = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+
             expect(popupFrame).toBeInTheDocument();
-            expect(triggerButtonFrame).toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
             expect(offerDescription).toBeInTheDocument();
 
+            // member details are pre-filled for logged-in members
             expect(emailInput).toHaveValue('jimmie@example.com');
             expect(nameInput).toHaveValue('Jimmie Larson');
             fireEvent.click(submitButton);
@@ -595,56 +555,9 @@ describe('Logged-in complimentary member', () => {
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
                 email: 'jimmie@example.com',
                 name: 'Jimmie Larson',
-                offerId,
-                plan: planId,
-                tierId: singleTierProduct.id,
-                cadence: 'month',
-                metadata: {checkoutType: 'upgrade'}
-            });
-
-            window.location.hash = '';
-        });
-
-        test('to an offer via link with portal disabled', async () => {
-            let site = {
-                ...FixtureSite.singleTier.basic,
-                portal_button: false
-            };
-
-            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
-            const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
-            } = await offerSetup({
-                site: site,
-                member: FixtureMember.altComplimentary,
-                offer: FixtureOffer
-            });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
-            expect(popupFrame).toBeInTheDocument();
-            expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
-            expect(offerDescription).toBeInTheDocument();
-            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
-
-            expect(emailInput).toHaveValue('jimmie@example.com');
-            expect(nameInput).toHaveValue('Jimmie Larson');
-            fireEvent.click(submitButton);
-
-            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                email: 'jimmie@example.com',
-                name: 'Jimmie Larson',
-                offerId,
-                plan: planId,
-                tierId: singleTierProduct.id,
+                offerId: FixtureOffer.id,
+                plan: tier.monthlyPrice.id,
+                tierId: tier.id,
                 cadence: 'month',
                 metadata: {checkoutType: 'upgrade'}
             });
@@ -734,47 +647,6 @@ describe('Logged-in complimentary member', () => {
                 tierId: singleTierProduct.id,
                 cadence: 'year'
             });
-        });
-
-        test('to an offer via link', async () => {
-            window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
-            const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
-            } = await offerSetup({
-                site: FixtureSite.multipleTiers.basic,
-                member: FixtureMember.altComplimentary,
-                offer: FixtureOffer
-            });
-            let planId = FixtureSite.multipleTiers.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let singleTierProduct = FixtureSite.multipleTiers.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
-            expect(popupFrame).toBeInTheDocument();
-            expect(triggerButtonFrame).toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
-            expect(offerDescription).toBeInTheDocument();
-
-            expect(emailInput).toHaveValue('jimmie@example.com');
-            expect(nameInput).toHaveValue('Jimmie Larson');
-            fireEvent.click(submitButton);
-
-            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                email: 'jimmie@example.com',
-                name: 'Jimmie Larson',
-                offerId,
-                plan: planId,
-                tierId: singleTierProduct.id,
-                cadence: 'month',
-                metadata: {checkoutType: 'upgrade'}
-            });
-
-            window.location.hash = '';
         });
     });
 });

--- a/apps/portal/test/upgrade-flow.test.js
+++ b/apps/portal/test/upgrade-flow.test.js
@@ -1,5 +1,5 @@
 import App from '../src/app.js';
-import {fireEvent, appRender, within} from './utils/test-utils';
+import {fireEvent, appRender, within, waitFor} from './utils/test-utils';
 import {offer as FixtureOffer, site as FixtureSite, member as FixtureMember} from './utils/test-fixtures';
 import setupGhostApi from '../src/utils/api.js';
 
@@ -33,6 +33,12 @@ const offerSetup = async ({site, member = null, offer}) => {
     const popupFrame = await utils.findByTitle(/portal-popup/i);
     const triggerButtonFrame = utils.queryByTitle(/portal-trigger/i);
     const popupIframeDocument = popupFrame.contentDocument;
+
+    // The offer page renders only after the async site.offer() request resolves, so wait for
+    // its content before capturing queries to avoid snapshotting the loading/empty popup.
+    await waitFor(() => {
+        expect(within(popupIframeDocument).queryByText(offer.display_title)).toBeInTheDocument();
+    });
 
     const emailInput = within(popupIframeDocument).queryByLabelText(/email/i);
     const nameInput = within(popupIframeDocument).queryByLabelText(/name/i);
@@ -295,7 +301,8 @@ describe('Logged-in free member', () => {
                 offerId,
                 plan: planId,
                 tierId: singleTierProduct.id,
-                cadence: 'month'
+                cadence: 'month',
+                metadata: {checkoutType: 'upgrade'}
             });
 
             window.location.hash = '';
@@ -322,22 +329,27 @@ describe('Logged-in free member', () => {
             let offerId = FixtureOffer.id;
             expect(popupFrame).toBeInTheDocument();
             expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).not.toBeInTheDocument();
-            expect(emailInput).not.toBeInTheDocument();
-            expect(nameInput).not.toBeInTheDocument();
+            expect(siteTitle).toBeInTheDocument();
+            expect(emailInput).toBeInTheDocument();
+            expect(nameInput).toBeInTheDocument();
             expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).not.toBeInTheDocument();
-            expect(offerName).not.toBeInTheDocument();
-            expect(offerDescription).not.toBeInTheDocument();
+            expect(submitButton).toBeInTheDocument();
+            expect(offerName).toBeInTheDocument();
+            expect(offerDescription).toBeInTheDocument();
+            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
+
+            expect(emailInput).toHaveValue('jimmie@example.com');
+            expect(nameInput).toHaveValue('Jimmie Larson');
+            fireEvent.click(submitButton);
 
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                metadata: {
-                    checkoutType: 'upgrade'
-                },
-                offerId: offerId,
+                email: 'jimmie@example.com',
+                name: 'Jimmie Larson',
+                offerId,
                 plan: planId,
                 tierId: singleTierProduct.id,
-                cadence: 'month'
+                cadence: 'month',
+                metadata: {checkoutType: 'upgrade'}
             });
 
             window.location.hash = '';
@@ -417,7 +429,8 @@ describe('Logged-in free member', () => {
                 offerId,
                 plan: planId,
                 tierId: singleTierProduct.id,
-                cadence: 'month'
+                cadence: 'month',
+                metadata: {checkoutType: 'upgrade'}
             });
 
             window.location.hash = '';
@@ -585,7 +598,8 @@ describe('Logged-in complimentary member', () => {
                 offerId,
                 plan: planId,
                 tierId: singleTierProduct.id,
-                cadence: 'month'
+                cadence: 'month',
+                metadata: {checkoutType: 'upgrade'}
             });
 
             window.location.hash = '';
@@ -612,22 +626,27 @@ describe('Logged-in complimentary member', () => {
             let offerId = FixtureOffer.id;
             expect(popupFrame).toBeInTheDocument();
             expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).not.toBeInTheDocument();
-            expect(emailInput).not.toBeInTheDocument();
-            expect(nameInput).not.toBeInTheDocument();
+            expect(siteTitle).toBeInTheDocument();
+            expect(emailInput).toBeInTheDocument();
+            expect(nameInput).toBeInTheDocument();
             expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).not.toBeInTheDocument();
-            expect(offerName).not.toBeInTheDocument();
-            expect(offerDescription).not.toBeInTheDocument();
+            expect(submitButton).toBeInTheDocument();
+            expect(offerName).toBeInTheDocument();
+            expect(offerDescription).toBeInTheDocument();
+            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
+
+            expect(emailInput).toHaveValue('jimmie@example.com');
+            expect(nameInput).toHaveValue('Jimmie Larson');
+            fireEvent.click(submitButton);
 
             expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                metadata: {
-                    checkoutType: 'upgrade'
-                },
-                offerId: offerId,
+                email: 'jimmie@example.com',
+                name: 'Jimmie Larson',
+                offerId,
                 plan: planId,
                 tierId: singleTierProduct.id,
-                cadence: 'month'
+                cadence: 'month',
+                metadata: {checkoutType: 'upgrade'}
             });
 
             window.location.hash = '';
@@ -751,11 +770,11 @@ describe('Logged-in complimentary member', () => {
                 offerId,
                 plan: planId,
                 tierId: singleTierProduct.id,
-                cadence: 'month'
+                cadence: 'month',
+                metadata: {checkoutType: 'upgrade'}
             });
 
             window.location.hash = '';
         });
     });
 });
-

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -262,7 +262,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.68"
+        "version": "2.69"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3695/

When the Portal button is configured to be hidden, offer links would redirect to Stripe immediately rather than show Portal's offer details page.

This change modifies the behaviour so Portal's offer details modal is always shown. Fixes customer confusion and removes an avenue allowing members to accidentally sign up for a second paid subscription.

- The immediate redirect to Stripe behaviour of offer links is removed so the Portal offer screen is always displayed
- Fixed logged-in members upgrading via an offer link not being flagged as upgrades, so they no longer receive a confusing signup email, and they skip the newsletter selection step
- Fixed incorrect handling of `CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION` in Portal so already-signed-up members are switched to the magic-link confirmation page instead of being shown an unhelpful 'Failed to sign up' error
- Added initial Portal shared-language context docs and a root context map
