### PR TITLE
Added Renovate grouping for pnpm catalog updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -225,6 +225,37 @@
             ]
         },
 
+        // Group each pinned-version pnpm catalog into a single PR per catalog.
+        //
+        // The named catalogs in pnpm-workspace.yaml (react17, eslint9,
+        // tailwind3) each hold a version lane we deliberately keep separate
+        // from the main `catalog:` — e.g. eslint 9 lives in `eslint9` while the
+        // default catalog stays on eslint 8. Renovate tags every catalog dep
+        // with a depType of `pnpm.catalog.<name>`, so matching the depType
+        // groups the whole catalog without restating its package list and stays
+        // correct as entries are added or removed in pnpm-workspace.yaml.
+        //
+        // These also override the shared preset's `group:monorepos` rules,
+        // which would otherwise group e.g. eslint + @eslint/js *by name* and
+        // mix the default-catalog (v8) and eslint9-catalog (v9) bumps into one
+        // PR. Matching by depType keeps each lane in its own reviewable PR.
+        //
+        // The main `catalog:` is intentionally left ungrouped: its entries are
+        // independent, so grouping them would only couple unrelated bumps and
+        // let one risky update block the rest.
+        {
+            "groupName": "react17 catalog",
+            "matchDepTypes": ["pnpm.catalog.react17"]
+        },
+        {
+            "groupName": "eslint9 catalog",
+            "matchDepTypes": ["pnpm.catalog.eslint9"]
+        },
+        {
+            "groupName": "tailwind3 catalog",
+            "matchDepTypes": ["pnpm.catalog.tailwind3"]
+        },
+
         // Always automerge these packages:
         {
             "matchPackageNames": [


### PR DESCRIPTION
Without grouping rules, each catalogued dependency still opens its own Renovate PR — so a single named-catalog bump can fan out into several PRs, which is the churn the catalog was meant to collapse. This adds the missing half of the catalog strategy: one reviewable PR per named catalog.

Renovate tags every pnpm catalog dependency with a `pnpm.catalog.<name>` depType, so the rules match on depType rather than restating each catalog's package list. They stay correct as entries are added to or removed from `pnpm-workspace.yaml`:

- `react17 catalog` — `react`, `react-dom`, `@testing-library/react`
- `eslint9 catalog` — `eslint`, `@eslint/js`
- `tailwind3 catalog` — `tailwindcss`, `eslint-plugin-tailwindcss`

These also override the shared preset's `group:monorepos` behaviour. That preset groups e.g. `eslint` + `@eslint/js` and `react` + `react-dom` *by name* across the whole repo, which would otherwise merge the default-catalog version lane (eslint 8, React 18) and the named-catalog lane (eslint 9, React 17) into a single PR. Matching by depType keeps each lane in its own PR — the separation the named catalogs exist to enforce.

The main `catalog:` is intentionally left ungrouped. Its entries are independent of one another, so grouping them would only couple unrelated bumps and let one risky update block the rest of the group from merging. Per-catalog grouping is applied only where the catalog represents a genuine lockstep version lane.

Composes with the existing rules: the named-catalog deps don't overlap the vulnerability-alert carve-out, the Ember/CSS freeze rules, or the `@tryghost/*` groups, so current behaviour is unchanged. The off-hours schedule is untouched. The `react17` group only takes effect once the React catalog split lands.

ref https://linear.app/ghost/issue/PLA-58