### PR TITLE
Converged faker onto v9 for e2e and stats

### DIFF
--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -37,7 +37,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@faker-js/faker": "9.9.0",
+        "@faker-js/faker": "catalog:",
         "@testing-library/jest-dom": "catalog:",
         "@testing-library/react": "catalog:",
         "@types/jest": "catalog:",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -29,7 +29,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "catalog:",
-    "@faker-js/faker": "8.4.1",
+    "@faker-js/faker": "catalog:",
     "@playwright/test": "catalog:",
     "@tryghost/debug": "catalog:",
     "@tryghost/logging": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@eslint/js':
       specifier: 8.57.1
       version: 8.57.1
+    '@faker-js/faker':
+      specifier: 9.9.0
+      version: 9.9.0
     '@playwright/test':
       specifier: 1.60.0
       version: 1.60.0
@@ -1781,7 +1784,7 @@ importers:
         version: 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@faker-js/faker':
-        specifier: 9.9.0
+        specifier: 'catalog:'
         version: 9.9.0
       '@testing-library/jest-dom':
         specifier: 'catalog:'
@@ -1841,8 +1844,8 @@ importers:
         specifier: 'catalog:'
         version: 8.57.1
       '@faker-js/faker':
-        specifier: 8.4.1
-        version: 8.4.1
+        specifier: 'catalog:'
+        version: 9.9.0
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -4863,10 +4866,6 @@ packages:
   '@faker-js/faker@7.6.0':
     resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
     engines: {node: '>=14.0.0', npm: '>=6.0.0'}
-
-  '@faker-js/faker@8.4.1':
-    resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
 
   '@faker-js/faker@9.9.0':
     resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
@@ -24355,8 +24354,6 @@ snapshots:
       - encoding
 
   '@faker-js/faker@7.6.0': {}
-
-  '@faker-js/faker@8.4.1': {}
 
   '@faker-js/faker@9.9.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ allowBuilds:
 catalog:
   '@ebay/nice-modal-react': 1.2.13
   '@eslint/js': 8.57.1
+  '@faker-js/faker': 9.9.0
   '@playwright/test': 1.60.0
   '@radix-ui/react-avatar': 1.1.11
   '@radix-ui/react-checkbox': 1.3.3


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-59

`@faker-js/faker` was declared at two versions across the workspace — `8.4.1` in `e2e` and `9.9.0` in `apps/stats`. This catalogues a single `9.9.0` entry and points both consumers at it, collapsing the split so a future bump is one decision.

`e2e` moves from `8.4.1` to `9.9.0`. Its faker call sites already use the modern (v8+) API — `faker.string.uuid()`, `faker.person.*`, `faker.datatype.boolean()`, `faker.internet.email({firstName, lastName})`, `faker.commerce.*`, `faker.lorem.*` — so the bump is code-clean: `tsc --noEmit` and `pnpm lint` both pass with no source changes. `apps/stats` is unchanged in resolved version (already `9.9.0`); it just switches to the `catalog:` reference. The lockfile diff is minimal — `8.4.1` drops out entirely.

No version bumps required: the app-version-bump check only monitors the six public apps and skips dependency-only `package.json` changes, and neither `e2e` nor `stats` is in that set.

`ghost/core` and `ghost/admin` stay on `7.x`. That lane is a real codemod (datatype/name/address renames, a couple of `date.between` signature changes, and a removed `helpers.slugify`), confined to `ghost/core`'s seed-data generator, and is tracked separately.