### PR TITLE
Updated indexnow/llms/theme-upload logs to event.name convention

### DIFF
--- a/ghost/core/core/frontend/services/llms/handler.js
+++ b/ghost/core/core/frontend/services/llms/handler.js
@@ -41,7 +41,8 @@ function createLlmsHandler({llmsService, config, settingsCache}) {
             const eventDetails = {route: req.path};
 
             logging.error({
-                system: {event: eventName, ...eventDetails},
+                event: {name: eventName},
+                url: {path: req.path},
                 err
             }, `${LLMS_LOG_KEY} ${err.message}`);
 

--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -91,12 +91,8 @@ async function ping(post) {
 
         if (!url || url.endsWith('/404/')) {
             logging.warn({
-                system: {
-                    event: 'indexnow.unresolved_url',
-                    post_id: post.id,
-                    post_slug: post.slug,
-                    url
-                }
+                event: {name: 'indexnow.unresolved_url'},
+                post: {id: post.id, slug: post.slug, url}
             }, `${INDEXNOW_LOG_KEY} Skipped ping - post has no resolvable URL`);
             return;
         }
@@ -105,11 +101,8 @@ async function ping(post) {
         const key = getApiKey();
         if (!key) {
             logging.warn({
-                system: {
-                    event: 'indexnow.api_key_missing',
-                    post_id: post.id,
-                    post_slug: post.slug
-                }
+                event: {name: 'indexnow.api_key_missing'},
+                post: {id: post.id, slug: post.slug}
             }, `${INDEXNOW_LOG_KEY} API key not available`);
             return;
         }
@@ -139,13 +132,9 @@ async function ping(post) {
         }
 
         logging.info({
-            system: {
-                event: 'indexnow.pinged',
-                post_id: post.id,
-                post_slug: post.slug,
-                url,
-                status_code: response.statusCode
-            }
+            event: {name: 'indexnow.pinged'},
+            post: {id: post.id, slug: post.slug, url},
+            http: {response: {status_code: response.statusCode}}
         }, `${INDEXNOW_LOG_KEY} Successfully pinged ${url}`);
     } catch (err) {
         // Log errors but don't throw - IndexNow failures shouldn't disrupt publishing
@@ -180,13 +169,9 @@ async function ping(post) {
         }
 
         logging.warn({
-            system: {
-                event: eventName,
-                post_id: post.id,
-                post_slug: post.slug,
-                url,
-                status_code: err.statusCode ?? null
-            },
+            event: {name: eventName},
+            post: {id: post.id, slug: post.slug, url},
+            http: {response: {status_code: err.statusCode ?? null}},
             err: error
         }, `${INDEXNOW_LOG_KEY} ${error.message}`);
     }

--- a/ghost/core/core/server/services/themes/upload-size-limit-reporter.js
+++ b/ghost/core/core/server/services/themes/upload-size-limit-reporter.js
@@ -20,7 +20,7 @@ const reportThemeUploadSizeLimitError = (err, {themeName = null, zip = null} = {
     const eventName = `theme_upload.${SIZE_LIMIT_EVENTS_BY_CODE[err.code]}`;
     const errorDetails = err.errorDetails || {};
     const eventDetails = {
-        theme_name: themeName,
+        name: themeName,
         entry_name: errorDetails.entryName ?? null,
         observed_bytes: errorDetails.observedBytes,
         limit_bytes: errorDetails.limitBytes,
@@ -28,7 +28,8 @@ const reportThemeUploadSizeLimitError = (err, {themeName = null, zip = null} = {
     };
 
     logging.error({
-        system: {event: eventName, ...eventDetails},
+        event: {name: eventName},
+        theme: eventDetails,
         err
     }, `${THEME_UPLOAD_LOG_KEY} ${err.message}`);
 

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -267,8 +267,8 @@ describe('IndexNow', function () {
             await ping(testPost);
 
             sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.pinged');
-            assert.equal(loggingStub.args[0][0].system.status_code, 200);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.pinged');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 200);
         });
 
         it('does not ping when the post has no resolvable URL (/404/)', async function () {
@@ -283,11 +283,11 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), false);
             sinon.assert.calledOnce(loggingStub);
-            const logged = loggingStub.args[0][0].system;
-            assert.equal(logged.event, 'indexnow.unresolved_url');
-            assert.equal(logged.url, 'https://example.com/404/');
-            assert.equal(logged.post_id, testPost.id);
-            assert.equal(logged.post_slug, testPost.slug);
+            const logged = loggingStub.args[0][0];
+            assert.equal(logged.event.name, 'indexnow.unresolved_url');
+            assert.equal(logged.post.url, 'https://example.com/404/');
+            assert.equal(logged.post.id, testPost.id);
+            assert.equal(logged.post.slug, testPost.slug);
         });
 
         it('with default post should not execute ping', async function () {
@@ -355,7 +355,7 @@ describe('IndexNow', function () {
             assert.equal(pingRequest.isDone(), false);
             // Should have logged a warning with a structured event
             sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.api_key_missing');
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.api_key_missing');
             assert(loggingStub.args[0][1].includes('API key not available'));
         });
 
@@ -370,8 +370,8 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.pinged');
-            assert.equal(loggingStub.args[0][0].system.status_code, 202);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.pinged');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 202);
         });
 
         it('captures && logs errors from 400 requests', async function () {
@@ -385,8 +385,8 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.ping_failed');
-            assert.equal(loggingStub.args[0][0].system.status_code, 400);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.ping_failed');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 400);
         });
 
         it('captures && logs validation errors from 422 requests', async function () {
@@ -400,8 +400,8 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.key_validation_failed');
-            assert.equal(loggingStub.args[0][0].system.status_code, 422);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.key_validation_failed');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 422);
         });
 
         it('should behave correctly when getting a 429', async function () {
@@ -415,8 +415,8 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.rate_limited');
-            assert.equal(loggingStub.args[0][0].system.status_code, 429);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.rate_limited');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 429);
         });
 
         it('logs the real status code for an unexpected 2xx response', async function () {
@@ -432,8 +432,8 @@ describe('IndexNow', function () {
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].system.event, 'indexnow.ping_failed');
-            assert.equal(loggingStub.args[0][0].system.status_code, 204);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.ping_failed');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 204);
         });
     });
 

--- a/ghost/core/test/unit/server/services/themes/upload-size-limit-reporter.test.js
+++ b/ghost/core/test/unit/server/services/themes/upload-size-limit-reporter.test.js
@@ -46,9 +46,9 @@ describe('Theme upload size limit reporter', function () {
 
         sinon.assert.calledOnce(loggingStub);
         sinon.assert.calledWith(loggingStub, {
-            system: {
-                event: 'theme_upload.entry_too_large',
-                theme_name: 'large-theme',
+            event: {name: 'theme_upload.entry_too_large'},
+            theme: {
+                name: 'large-theme',
                 entry_name: 'assets/big.jpg',
                 observed_bytes: 101,
                 limit_bytes: 100,
@@ -60,7 +60,7 @@ describe('Theme upload size limit reporter', function () {
         sinon.assert.calledOnceWithExactly(sentryStub, err, {
             tags: {source: 'theme_upload.entry_too_large'},
             extra: {
-                theme_name: 'large-theme',
+                name: 'large-theme',
                 entry_name: 'assets/big.jpg',
                 observed_bytes: 101,
                 limit_bytes: 100,


### PR DESCRIPTION
## Summary

Structured error logs are standardising on OpenTelemetry-style naming, where the event identifier is `event.name` rather than `system.event` (`system.*` is reserved for host/machine metrics).

Three reporters were still on the older `system: { event, ... }` shape. This moves them to `event.name` and re-homes their context fields off the reserved `system` namespace, grouping by **entity** rather than by feature so the indexed field set stays bounded as more features adopt the convention:

| Reporter | Event id | Context |
|---|---|---|
| indexnow | `event.name` | `post.{id,slug,url}`, `http.response.status_code` |
| llms | `event.name` | `url.path` |
| theme-upload | `event.name` | `theme.*` (size metrics) |

`http.response.status_code` and `url.path` are stable OpenTelemetry attributes; `post.*` and `theme.*` are domain attributes (OTel deliberately does not define business entities, so those are a Ghost convention).

No behavioural change — same log levels, messages and error handling; only the structured field shape changes. Sentry reporting for llms/theme-upload is unchanged.

## Test

- Updated the indexnow and theme-upload unit tests to assert the new field shape.
- `pnpm test:single` green for both suites; `eslint` clean on all five files.
