### PR TITLE
Updated ghost/core seed-data generator to faker v9

### DIFF
--- a/ghost/core/core/server/data/seeders/data-generator.js
+++ b/ghost/core/core/server/data/seeders/data-generator.js
@@ -246,7 +246,7 @@ class DataGenerator {
             crypto.randomBytes = (size) => {
                 const buffer = Buffer.alloc(size);
                 for (let i = 0; i < size; i++) {
-                    buffer[i] = Math.floor(faker.datatype.number({min: 0, max: 255}));
+                    buffer[i] = Math.floor(faker.number.int({min: 0, max: 255}));
                 }
                 return buffer;
             };

--- a/ghost/core/core/server/data/seeders/importers/benefits-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/benefits-importer.js
@@ -19,8 +19,8 @@ class BenefitsImporter extends TableImporter {
         return {
             id: this.fastFakeObjectId(),
             name: name,
-            slug: `${slugify(name)}-${faker.random.numeric(3)}`,
-            created_at: faker.date.between(blogStartDate, sixMonthsLater)
+            slug: `${slugify(name)}-${faker.string.numeric(3)}`,
+            created_at: faker.date.between({from: blogStartDate, to: sixMonthsLater})
         };
     }
 }

--- a/ghost/core/core/server/data/seeders/importers/comment-reports-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/comment-reports-importer.js
@@ -51,7 +51,7 @@ class CommentReportsImporter extends TableImporter {
 
         const reportTime = dateToDatabaseString.randomBetween(this.model.created_at, new Date());
 
-        const reporter = this.possibleReporters[faker.datatype.number(this.possibleReporters.length - 1)];
+        const reporter = this.possibleReporters[faker.number.int(this.possibleReporters.length - 1)];
 
         return {
             id: this.fastFakeObjectId(),

--- a/ghost/core/core/server/data/seeders/importers/comments-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/comments-importer.js
@@ -32,7 +32,7 @@ class CommentsImporter extends TableImporter {
             shape: 'ease-out',
             trend: 'negative',
             // Use commentsPerPost as a baseline with some variance (+/- 20%)
-            total: Math.round(this.commentsPerPost * faker.datatype.float({min: 0.8, max: 1.2})),
+            total: Math.round(this.commentsPerPost * faker.number.float({min: 0.8, max: 1.2})),
             startTime: publishedAt,
             endTime: new Date()
         }).sort((a, b) => a.getTime() - b.getTime()); // Sort chronologically so replies always come after their targets
@@ -68,11 +68,11 @@ class CommentsImporter extends TableImporter {
                 let replyTarget;
                 if (preferReplyToReply) {
                     // Pick from existing replies to create a reply-to-reply
-                    const replyToIndex = faker.datatype.number(existingReplies.length - 1);
+                    const replyToIndex = faker.number.int(existingReplies.length - 1);
                     replyTarget = existingReplies[replyToIndex];
                 } else {
                     // Pick any random eligible comment
-                    const replyToIndex = faker.datatype.number(eligibleComments.length - 1);
+                    const replyToIndex = faker.number.int(eligibleComments.length - 1);
                     replyTarget = eligibleComments[replyToIndex];
                 }
                 const [replyToId, replyToParentId] = replyTarget;
@@ -93,7 +93,7 @@ class CommentsImporter extends TableImporter {
         const event = {
             id: this.fastFakeObjectId(),
             post_id: this.model.id,
-            member_id: this.possibleMembers[faker.datatype.number(this.possibleMembers.length - 1)].id,
+            member_id: this.possibleMembers[faker.number.int(this.possibleMembers.length - 1)].id,
             parent_id: parentId,
             in_reply_to_id: inReplyToId,
             status: 'published',

--- a/ghost/core/core/server/data/seeders/importers/email-batches-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/email-batches-importer.js
@@ -27,7 +27,7 @@ class EmailBatchesImporter extends TableImporter {
         return {
             id: this.fastFakeObjectId(),
             email_id: this.model.id,
-            provider_id: `${new Date().toISOString().split('.')[0].replace(/[^0-9]/g, '')}.${faker.datatype.hexadecimal({length: 16, prefix: '', case: 'lower'})}@m.example.com`,
+            provider_id: `${new Date().toISOString().split('.')[0].replace(/[^0-9]/g, '')}.${faker.string.hexadecimal({length: 16, prefix: '', casing: 'lower'})}@m.example.com`,
             status: 'submitted', // TODO: introduce failures
             created_at: this.model.created_at,
             updated_at: dateToDatabaseString(dateToDatabaseString.randomBetween(emailSentDate, latestUpdatedDate))

--- a/ghost/core/core/server/data/seeders/importers/email-recipient-failures-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/email-recipient-failures-importer.js
@@ -57,7 +57,7 @@ class EmailRecipientFailuresImporter extends TableImporter {
             email_id: this.model.email_id,
             member_id: this.model.member_id,
             email_recipient_id: this.model.id,
-            event_id: faker.random.alphaNumeric(20),
+            event_id: faker.string.alphanumeric(20),
             ...error,
             failed_at: this.model.failed_at
         };

--- a/ghost/core/core/server/data/seeders/importers/emails-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/emails-importer.js
@@ -56,25 +56,25 @@ class EmailsImporter extends TableImporter {
         const recipientCount = this.membersSubscribeEvents
             .filter(entry => entry.newsletter_id === newsletter.id)
             .filter(entry => dateToDatabaseString.parse(entry.created_at) < timestamp).length;
-        const deliveredCount = Math.ceil(recipientCount * faker.datatype.float({
+        const deliveredCount = Math.ceil(recipientCount * faker.number.float({
             max: 1,
             min: 0.9,
-            precision: 0.001
+            multipleOf: 0.001
         }));
-        const openedCount = Math.ceil(deliveredCount * faker.datatype.float({
+        const openedCount = Math.ceil(deliveredCount * faker.number.float({
             max: 0.95,
             min: 0.6,
-            precision: 0.001
+            multipleOf: 0.001
         }));
-        const failedCount = Math.floor((recipientCount - deliveredCount) * faker.datatype.float({
+        const failedCount = Math.floor((recipientCount - deliveredCount) * faker.number.float({
             max: 0.05,
             min: 0,
-            precision: 0.001
+            multipleOf: 0.001
         }));
 
         return {
             id,
-            uuid: faker.datatype.uuid(),
+            uuid: faker.string.uuid(),
             post_id: this.model.id,
             status: 'submitted',
             recipient_filter: '', // TODO: Add recipient filter?

--- a/ghost/core/core/server/data/seeders/importers/labels-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/labels-importer.js
@@ -17,7 +17,7 @@ class LabelsImporter extends TableImporter {
     generateName() {
         let name;
         do {
-            name = `${faker.color.human()} ${faker.name.jobType()}`;
+            name = `${faker.color.human()} ${faker.person.jobType()}`;
             name = `${name[0].toUpperCase()}${name.slice(1)}`;
         } while (this.generatedNames.has(name));
         this.generatedNames.add(name);

--- a/ghost/core/core/server/data/seeders/importers/members-click-events-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/members-click-events-importer.js
@@ -36,7 +36,7 @@ class MembersClickEventsImporter extends TableImporter {
 
     setReferencedModel(model) {
         this.model = model;
-        this.amount = model.opened_at === null ? 0 : luck(40) ? faker.datatype.number({
+        this.amount = model.opened_at === null ? 0 : luck(40) ? faker.number.int({
             min: 0,
             max: this.quantity
         }) : 0;
@@ -52,12 +52,12 @@ class MembersClickEventsImporter extends TableImporter {
 
         const openedAt = dateToDatabaseString.parse(this.model.opened_at);
         const laterOn = new Date(openedAt.getTime() + 1000 * 60 * 15);
-        const clickTime = faker.date.between(openedAt.getTime(), laterOn.getTime()); //added getTime here because it threw random errors
+        const clickTime = faker.date.between({from: openedAt.getTime(), to: laterOn.getTime()}); //added getTime here because it threw random errors
 
         return {
             id: this.fastFakeObjectId(),
             member_id: this.model.member_id,
-            redirect_id: this.redirectList[this.redirectList.length === 1 ? 0 : (faker.datatype.number({
+            redirect_id: this.redirectList[this.redirectList.length === 1 ? 0 : (faker.number.int({
                 min: 0,
                 max: this.redirectList.length - 1
             }))].id,

--- a/ghost/core/core/server/data/seeders/importers/members-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/members-importer.js
@@ -10,7 +10,7 @@ const debug = require('@tryghost/debug')('MembersImporter');
 class MembersImporter extends TableImporter {
     static table = 'members';
     static dependencies = [];
-    defaultQuantity = faker.datatype.number({
+    defaultQuantity = faker.number.int({
         min: 7000,
         max: 8000
     });
@@ -68,27 +68,27 @@ class MembersImporter extends TableImporter {
     generate() {
         const id = this.fastFakeObjectId();
         // Use name from American locale to reflect an English-speaking audience
-        const name = `${americanFaker.name.firstName()} ${americanFaker.name.lastName()}`;
+        const name = `${americanFaker.person.firstName()} ${americanFaker.person.lastName()}`;
         const timestamp = this.timestamps.pop();
 
         return {
             id,
-            uuid: faker.datatype.uuid(),
-            transient_id: faker.datatype.uuid(),
-            email: `${name.replace(' ', '.').replace(/[^a-zA-Z0-9]/g, '').toLowerCase()}${faker.datatype.number({min: 0, max: 999999})}@example.com`,
+            uuid: faker.string.uuid(),
+            transient_id: faker.string.uuid(),
+            email: `${name.replace(' ', '.').replace(/[^a-zA-Z0-9]/g, '').toLowerCase()}${faker.number.int({min: 0, max: 999999})}@example.com`,
             status: luck(5) ? 'comped' : luck(15) ? 'paid' : 'free',
             name: name,
-            expertise: luck(30) ? faker.name.jobTitle() : undefined,
+            expertise: luck(30) ? faker.person.jobTitle() : undefined,
             geolocation: JSON.stringify({
-                country: faker.address.country(),
-                country_code: faker.address.countryCode('alpha-2'),
-                region: faker.address.state()
+                country: faker.location.country(),
+                country_code: faker.location.countryCode('alpha-2'),
+                region: faker.location.state()
             }),
             email_count: 0, // Depends on number of emails sent since created_at, the newsletter they're a part of and subscription status
             email_opened_count: 0,
             email_open_rate: null,
             // 40% of users logged in within a week, 60% sometime since registering
-            last_seen_at: luck(40) ? dateToDatabaseString(faker.date.recent(7)) : dateToDatabaseString(faker.date.between(timestamp, new Date())),
+            last_seen_at: luck(40) ? dateToDatabaseString(faker.date.recent({days: 7})) : dateToDatabaseString(faker.date.between({from: timestamp, to: new Date()})),
             created_at: dateToDatabaseString(timestamp),
             updated_at: dateToDatabaseString(timestamp)
         };

--- a/ghost/core/core/server/data/seeders/importers/members-labels-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/members-labels-importer.js
@@ -27,7 +27,7 @@ class MembersLabelsImporter extends TableImporter {
         return {
             id: this.fastFakeObjectId(),
             member_id: this.model.id,
-            label_id: this.labels[faker.datatype.number({
+            label_id: this.labels[faker.number.int({
                 min: 0,
                 max: this.labels.length - 1
             })].id,

--- a/ghost/core/core/server/data/seeders/importers/members-stripe-customers-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/members-stripe-customers-importer.js
@@ -37,7 +37,7 @@ class MembersStripeCustomersImporter extends TableImporter {
             // The number should increase the older the member is
 
             const daysSinceMemberCreated = Math.floor((new Date() - dateToDatabaseString.parse(this.model.created_at)) / (1000 * 60 * 60 * 24));
-            const shouldHaveStripeCustomer = faker.datatype.number({min: 0, max: 100}) < Math.max(Math.min(daysSinceMemberCreated / 60, 15), 2);
+            const shouldHaveStripeCustomer = faker.number.int({min: 0, max: 100}) < Math.max(Math.min(daysSinceMemberCreated / 60, 15), 2);
 
             if (!shouldHaveStripeCustomer) {
                 return;
@@ -47,7 +47,8 @@ class MembersStripeCustomersImporter extends TableImporter {
         return {
             id: this.fastFakeObjectId(),
             member_id: this.model.id,
-            customer_id: `cus_${faker.random.alphaNumeric(14, {
+            customer_id: `cus_${faker.string.alphanumeric({
+                length: 14,
                 casing: 'mixed'
             })}`,
             name: this.model.name,

--- a/ghost/core/core/server/data/seeders/importers/members-stripe-customers-subscriptions-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/members-stripe-customers-subscriptions-importer.js
@@ -148,7 +148,7 @@ class MembersStripeCustomersSubscriptionsImporter extends TableImporter {
                     return;
                 }
 
-                const randomMonthDiff = faker.datatype.number({min: 1, max: monthDiff});
+                const randomMonthDiff = faker.number.int({min: 1, max: monthDiff});
                 endDate.setMonth(startDate.getMonth() + randomMonthDiff);
             } else {
                 // What is the year difference between startDate and now? Pick a random number in between
@@ -158,7 +158,7 @@ class MembersStripeCustomersSubscriptionsImporter extends TableImporter {
                     // Not possible to create an invalid subscription here
                     return;
                 }
-                const randomYearDiff = faker.datatype.number({min: 1, max: yearDiff});
+                const randomYearDiff = faker.number.int({min: 1, max: yearDiff});
 
                 endDate.setFullYear(startDate.getFullYear() + randomYearDiff);
             }
@@ -235,7 +235,7 @@ class MembersStripeCustomersSubscriptionsImporter extends TableImporter {
         return {
             id: this.fastFakeObjectId(),
             customer_id: customer.customer_id,
-            subscription_id: `sub_${faker.random.alphaNumeric(14)}`,
+            subscription_id: `sub_${faker.string.alphanumeric(14)}`,
             stripe_price_id: stripePrice.stripe_price_id,
             start_date: dateToDatabaseString(startDate),
             created_at: dateToDatabaseString(startDate),

--- a/ghost/core/core/server/data/seeders/importers/newsletters-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/newsletters-importer.js
@@ -25,14 +25,14 @@ class NewslettersImporter extends TableImporter {
 
         return {
             id: this.fastFakeObjectId(),
-            uuid: faker.datatype.uuid(),
+            uuid: faker.string.uuid(),
             name: name,
-            slug: `${slugify(name)}-${faker.random.numeric(3)}`,
+            slug: `${slugify(name)}-${faker.string.numeric(3)}`,
             sender_reply_to: 'newsletter',
             status: 'active',
             subscribe_on_signup: faker.datatype.boolean(),
             sort_order: sortOrder,
-            created_at: faker.date.between(blogStartDate, weekAfter)
+            created_at: faker.date.between({from: blogStartDate, to: weekAfter})
         };
     }
 }

--- a/ghost/core/core/server/data/seeders/importers/offer-redemptions-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/offer-redemptions-importer.js
@@ -94,7 +94,7 @@ class OfferRedemptionsImporter extends TableImporter {
             subscriptionState.redemptionEndAt.valueOf()
         ));
         const latest = subscriptionState.redemptionEndAt > earliest ? subscriptionState.redemptionEndAt : earliest;
-        const createdAt = latest.valueOf() === earliest.valueOf() ? earliest : faker.date.between(earliest, latest);
+        const createdAt = latest.valueOf() === earliest.valueOf() ? earliest : faker.date.between({from: earliest, to: latest});
 
         subscriptionState.lastRedeemedAt = createdAt;
 
@@ -102,12 +102,12 @@ class OfferRedemptionsImporter extends TableImporter {
     }
 
     generate() {
-        const subscriptionIndex = faker.datatype.number({
+        const subscriptionIndex = faker.number.int({
             min: 0,
             max: this.subscriptionPool.length - 1
         });
         const subscriptionState = this.subscriptionPool[subscriptionIndex];
-        const offerIndex = faker.datatype.number({
+        const offerIndex = faker.number.int({
             min: 0,
             max: subscriptionState.availableOffers.length - 1
         });

--- a/ghost/core/core/server/data/seeders/importers/posts-authors-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/posts-authors-importer.js
@@ -23,7 +23,7 @@ class PostsAuthorsImporter extends TableImporter {
         return {
             id: this.fastFakeObjectId(),
             post_id: this.model.id,
-            author_id: this.users[faker.datatype.number(this.users.length - 1)].id,
+            author_id: this.users[faker.number.int(this.users.length - 1)].id,
             sort_order: sortOrder
         };
     }

--- a/ghost/core/core/server/data/seeders/importers/posts-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/posts-importer.js
@@ -7,7 +7,7 @@ const dateToDatabaseString = require('../utils/database-date');
 class PostsImporter extends TableImporter {
     static table = 'posts';
     static dependencies = ['newsletters'];
-    defaultQuantity = faker.datatype.number({
+    defaultQuantity = faker.number.int({
         min: 80,
         max: 120
     });
@@ -26,7 +26,7 @@ class PostsImporter extends TableImporter {
 
     generate() {
         const title = faker.lorem.sentence();
-        const content = faker.lorem.paragraphs(faker.datatype.number({
+        const content = faker.lorem.paragraphs(faker.number.int({
             min: 3,
             max: 10
         })).split('\n');
@@ -34,7 +34,7 @@ class PostsImporter extends TableImporter {
         twoYearsAgo.setFullYear(twoYearsAgo.getFullYear() - 2);
         const twoWeeksFromNow = new Date();
         twoWeeksFromNow.setDate(twoWeeksFromNow.getDate() + 14);
-        const timestamp = faker.date.between(twoYearsAgo, twoWeeksFromNow);
+        const timestamp = faker.date.between({from: twoYearsAgo, to: twoWeeksFromNow});
         const currentTime = new Date();
 
         let status = 'published';
@@ -55,12 +55,12 @@ class PostsImporter extends TableImporter {
             id,
             created_at: dateToDatabaseString(timestamp),
             updated_at: dateToDatabaseString(timestamp),
-            published_at: status === 'published' ? dateToDatabaseString(timestamp) : status === 'scheduled' ? dateToDatabaseString(faker.date.soon(5, timestamp)) : null,
-            uuid: faker.datatype.uuid(),
+            published_at: status === 'published' ? dateToDatabaseString(timestamp) : status === 'scheduled' ? dateToDatabaseString(faker.date.soon({days: 5, refDate: timestamp})) : null,
+            uuid: faker.string.uuid(),
             comment_id: this.type === 'post' ? id : null,
             title: title,
             type: this.type,
-            slug: `${slugify(title)}-${faker.random.numeric(3)}`,
+            slug: `${slugify(title)}-${faker.string.numeric(3)}`,
             status,
             visibility,
             lexical: JSON.stringify({

--- a/ghost/core/core/server/data/seeders/importers/posts-tags-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/posts-tags-importer.js
@@ -14,7 +14,7 @@ class PostsTagsImporter extends TableImporter {
         const posts = await this.transaction.select('id').from('posts').where('type', 'post');
         this.tags = await this.transaction.select('id').from('tags');
 
-        await this.importForEach(posts, quantity ? quantity / posts.length : () => faker.datatype.number({
+        await this.importForEach(posts, quantity ? quantity / posts.length : () => faker.number.int({
             min: 0,
             max: 3
         }));
@@ -30,7 +30,7 @@ class PostsTagsImporter extends TableImporter {
         this.sortOrder = this.sortOrder + 1;
         let tagIndex = 0;
         do {
-            tagIndex = faker.datatype.number(this.tags.length - 1);
+            tagIndex = faker.number.int(this.tags.length - 1);
         } while (this.notIndex.includes(tagIndex));
         this.notIndex.push(tagIndex);
 

--- a/ghost/core/core/server/data/seeders/importers/products-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/products-importer.js
@@ -80,9 +80,9 @@ class ProductsImporter extends TableImporter {
         return Object.assign({}, {
             id: this.fastFakeObjectId(),
             name: name,
-            slug: `${slugify(name)}-${faker.random.numeric(3)}`,
+            slug: `${slugify(name)}-${faker.string.numeric(3)}`,
             visibility: 'public',
-            created_at: faker.date.between(blogStartDate, sixMonthsLater)
+            created_at: faker.date.between({from: blogStartDate, to: sixMonthsLater})
         }, tierInfo);
     }
 }

--- a/ghost/core/core/server/data/seeders/importers/recommendation-click-events-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/recommendation-click-events-importer.js
@@ -14,7 +14,7 @@ class RecommendationClickEventsImporter extends TableImporter {
         const recommendations = await this.transaction.select('id', 'created_at').from('recommendations');
         this.members = await this.transaction.select('id').from('members').limit(500);
 
-        await this.importForEach(recommendations, quantity ? quantity / recommendations.length : () => faker.datatype.number({min: 0, max: 30}));
+        await this.importForEach(recommendations, quantity ? quantity / recommendations.length : () => faker.number.int({min: 0, max: 30}));
     }
 
     generate() {

--- a/ghost/core/core/server/data/seeders/importers/recommendation-subscribe-events-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/recommendation-subscribe-events-importer.js
@@ -14,7 +14,7 @@ class RecommendationSubscribeEventsImporter extends TableImporter {
         const recommendations = await this.transaction.select('id', 'created_at').from('recommendations').where('one_click_subscribe', true);
         this.members = await this.transaction.select('id').from('members').limit(500);
 
-        await this.importForEach(recommendations, quantity ? quantity / recommendations.length : () => faker.datatype.number({min: 0, max: 50}));
+        await this.importForEach(recommendations, quantity ? quantity / recommendations.length : () => faker.number.int({min: 0, max: 50}));
     }
 
     generate() {

--- a/ghost/core/core/server/data/seeders/importers/redirects-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/redirects-importer.js
@@ -1,5 +1,6 @@
 const TableImporter = require('./table-importer');
 const {faker} = require('@faker-js/faker');
+const {slugify} = require('@tryghost/string');
 
 class RedirectsImporter extends TableImporter {
     static table = 'redirects';
@@ -24,7 +25,7 @@ class RedirectsImporter extends TableImporter {
         this.model = model;
 
         // Reset the amount for each model
-        this.amount = faker.datatype.number({
+        this.amount = faker.number.int({
             min: 0,
             max: this.quantity
         });
@@ -37,8 +38,8 @@ class RedirectsImporter extends TableImporter {
         this.amount -= 1;
         return {
             id: this.fastFakeObjectId(),
-            from: `/r/${faker.datatype.hexadecimal({length: 8, prefix: '', case: 'lower'})}`,
-            to: `${faker.internet.url()}/${faker.helpers.slugify(`${faker.word.adjective()} ${faker.word.noun()}`).toLowerCase()}`,
+            from: `/r/${faker.string.hexadecimal({length: 8, prefix: '', casing: 'lower'})}`,
+            to: `${faker.internet.url()}/${slugify(`${faker.word.adjective()} ${faker.word.noun()}`).toLowerCase()}`,
             post_id: this.model.id,
             created_at: this.model.published_at,
             updated_at: this.model.published_at

--- a/ghost/core/core/server/data/seeders/importers/roles-users-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/roles-users-importer.js
@@ -27,7 +27,7 @@ class RolesUsersImporter extends TableImporter {
 
     generate() {
         const userRoles = ['Editor', 'Contributor', 'Author'];
-        const userRole = userRoles[faker.datatype.number({
+        const userRole = userRoles[faker.number.int({
             min: 0,
             max: userRoles.length - 1
         })];

--- a/ghost/core/core/server/data/seeders/importers/stripe-prices-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/stripe-prices-importer.js
@@ -55,13 +55,13 @@ class StripePricesImporter extends TableImporter {
 
         return Object.assign({}, {
             id: this.fastFakeObjectId(),
-            stripe_price_id: faker.datatype.hexadecimal({
+            stripe_price_id: faker.string.hexadecimal({
                 length: 64,
                 prefix: ''
             }),
             stripe_product_id: this.model.stripe_product_id,
             active: true,
-            created_at: faker.date.between(blogStartDate, sixWeeksLater)
+            created_at: faker.date.between({from: blogStartDate, to: sixWeeksLater})
         }, billingCycle);
     }
 }

--- a/ghost/core/core/server/data/seeders/importers/stripe-products-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/stripe-products-importer.js
@@ -22,11 +22,11 @@ class StripeProductsImporter extends TableImporter {
         return {
             id: this.fastFakeObjectId(),
             product_id: this.model.id,
-            stripe_product_id: faker.datatype.hexadecimal({
+            stripe_product_id: faker.string.hexadecimal({
                 length: 64,
                 prefix: ''
             }),
-            created_at: faker.date.between(blogStartDate, sixWeeksLater)
+            created_at: faker.date.between({from: blogStartDate, to: sixWeeksLater})
         };
     }
 }

--- a/ghost/core/core/server/data/seeders/importers/tags-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/tags-importer.js
@@ -6,7 +6,7 @@ const dateToDatabaseString = require('../utils/database-date');
 class TagsImporter extends TableImporter {
     static table = 'tags';
     static dependencies = ['users'];
-    defaultQuantity = faker.datatype.number({
+    defaultQuantity = faker.number.int({
         min: 16,
         max: 24
     });
@@ -21,7 +21,7 @@ class TagsImporter extends TableImporter {
     }
 
     generate() {
-        let name = `${faker.color.human()} ${faker.name.jobType()} ${faker.random.numeric(10)}`;
+        let name = `${faker.color.human()} ${faker.person.jobType()} ${faker.string.numeric(10)}`;
         name = `${name[0].toUpperCase()}${name.slice(1)}`;
         const threeYearsAgo = new Date();
         threeYearsAgo.setFullYear(threeYearsAgo.getFullYear() - 3);
@@ -32,7 +32,7 @@ class TagsImporter extends TableImporter {
             name: name,
             slug: slugify(name),
             description: faker.lorem.sentence(),
-            created_at: dateToDatabaseString(faker.date.between(threeYearsAgo, twoYearsAgo))
+            created_at: dateToDatabaseString(faker.date.between({from: threeYearsAgo, to: twoYearsAgo}))
         };
     }
 }

--- a/ghost/core/core/server/data/seeders/importers/users-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/users-importer.js
@@ -14,15 +14,17 @@ class UsersImporter extends TableImporter {
     }
 
     async generate() {
-        const name = `${faker.name.firstName()} ${faker.name.lastName()}`;
+        const firstName = faker.person.firstName();
+        const lastName = faker.person.lastName();
+        const name = `${firstName} ${lastName}`;
         return {
             id: this.fastFakeObjectId(),
             name: name,
             slug: slugify(name),
             password: await security.password.hash(faker.color.human()),
-            email: faker.internet.email(name),
-            profile_image: faker.internet.avatar(),
-            created_at: dateToDatabaseString(faker.date.between(new Date(2016, 0), new Date()))
+            email: faker.internet.email({firstName, lastName}),
+            profile_image: faker.image.avatar(),
+            created_at: dateToDatabaseString(faker.date.between({from: new Date(2016, 0), to: new Date()}))
         };
     }
 }

--- a/ghost/core/core/server/data/seeders/importers/web-mentions-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/web-mentions-importer.js
@@ -16,7 +16,7 @@ class WebMentionsImporter extends TableImporter {
     generate() {
         const id = this.fastFakeObjectId();
 
-        const author = `${faker.name.fullName()}`;
+        const author = `${faker.person.fullName()}`;
 
         // Generating only incoming recommendations for now, since we don't use webmentions for other things atm
         return {

--- a/ghost/core/core/server/data/seeders/utils/database-date.js
+++ b/ghost/core/core/server/data/seeders/utils/database-date.js
@@ -26,7 +26,7 @@ dateToDatabaseString.randomBetween = function randomBetween(start, end) {
     const earliest = dateToDatabaseString.parse(start);
     const latest = dateToDatabaseString.parse(end);
 
-    return latest > earliest ? faker.date.between(earliest, latest) : earliest;
+    return latest > earliest ? faker.date.between({from: earliest, to: latest}) : earliest;
 };
 
 module.exports = dateToDatabaseString;

--- a/ghost/core/core/server/data/seeders/utils/random.js
+++ b/ghost/core/core/server/data/seeders/utils/random.js
@@ -5,7 +5,7 @@ const {faker} = require('@faker-js/faker');
  * @param {number} lowerThan Only this % of people will achieve this luck
  * @returns {boolean} Whether this person is lucky enough for the condition
  */
-const luck = lowerThan => faker.datatype.number({
+const luck = lowerThan => faker.number.int({
     min: 1,
     max: 100
 }) <= lowerThan;

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.1053.0",
     "@extractus/oembed-extractor": "3.2.1",
-    "@faker-js/faker": "7.6.0",
+    "@faker-js/faker": "catalog:",
     "@isaacs/ttlcache": "1.4.1",
     "@sentry/node": "7.120.4",
     "@tryghost/adapter-base-cache": "0.1.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2283,8 +2283,8 @@ importers:
         specifier: 3.2.1
         version: 3.2.1(encoding@0.1.13)
       '@faker-js/faker':
-        specifier: 7.6.0
-        version: 7.6.0
+        specifier: 'catalog:'
+        version: 9.9.0
       '@isaacs/ttlcache':
         specifier: 1.4.1
         version: 1.4.1


### PR DESCRIPTION
`ghost/core` was the last maintained workspace on `@faker-js/faker` 7.x. This points it at the catalogued `9.9.0` (e2e and stats converged in #28327) and migrates the seeder call sites off the APIs faker removed in v8/v9. faker is reachable only through the demo/dev data generator (`reset:data`) — there are no faker call sites in `test/`, and nothing asserts on generated output, so resolved values shifting between majors is cosmetic.

**Mechanical renames:** `datatype.number`/`datatype.float` → `number.int`/`number.float`; `datatype.uuid`/`datatype.hexadecimal` and `random.numeric`/`random.alphaNumeric` → `string.*`; `name.*` → `person.*`; `address.*` → `location.*`; `internet.avatar` → `image.avatar`.

**Signature changes:** `date.between`/`soon`/`recent` now take an options object (`{from, to}` / `{days, refDate}`); `number.float` uses `multipleOf` instead of `precision`; `string.hexadecimal` uses `casing` instead of `case`; `string.alphanumeric` takes a `length` option.

**Genuine replacements:** `internet.email(name)` (the removed positional form) now passes `{firstName, lastName}`, captured from the names the importer already builds; `helpers.slugify` (removed in v8) is replaced with `@tryghost/string`'s `slugify` in `redirects-importer`. The `en_US`-locale `americanFaker` instance in `members-importer` was migrated too — easy to miss since it's aliased, not the default `faker`.

**Out of scope:** `ghost/admin` stays on 7.x. Its faker usage is four Mirage factories on the frozen Ember stack; bumping it under broccoli/babel is unverified risk for near-zero value on a client being retired.

**Validation:**
- The `data-generator` unit test passes (10/10).
- A full generator run against an in-memory sqlite DB (members + posts, default dataset) completes with **zero** faker deprecation warnings.
- A smoke test exercising all 29 distinct API/argument shapes the seeders use passes under 9.9.0.
- `eslint` clean on the seeders.

No version bump on `ghost/core` (release-managed) and no app-version-bump check applies (it monitors only the six public apps).

ref https://linear.app/ghost/issue/PLA-61