### PR TITLE
Removed the unused date-fns dependency from shade

### DIFF
--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -140,7 +140,6 @@
         "clsx": "catalog:",
         "cmdk": "1.1.1",
         "color": "5.0.3",
-        "date-fns": "4.1.0",
         "lucide-react": "catalog:",
         "moment-timezone": "^0.5.48",
         "react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1488,9 +1488,6 @@ importers:
       color:
         specifier: 5.0.3
         version: 5.0.3
-      date-fns:
-        specifier: 4.1.0
-        version: 4.1.0
       lucide-react:
         specifier: 'catalog:'
         version: 1.17.0(react@18.3.1)


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-60

`apps/shade` declared `date-fns@4.1.0` as a direct dependency but **never imports it** — there's no `date-fns` reference anywhere in the package's source. The calendar component pulls in `react-day-picker@9.14.0`, which depends on date-fns 4.x itself, so shade's direct declaration was redundant.