### PR TITLE
Improve llms relation loading

### DIFF
--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -199,8 +199,7 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
             limit: 'all',
             order: type === 'post' ? 'published_at desc' : 'id asc',
             filter: `status:published+visibility:public+type:${type}`,
-            columns: ['id', 'title', 'slug', 'custom_excerpt', 'plaintext', 'published_at', 'type'],
-            withRelated: ['tags', 'authors']
+            columns: ['id', 'title', 'slug', 'custom_excerpt', 'plaintext', 'published_at', 'type']
         });
 
         const entries = page.data.map((model) => {
@@ -222,8 +221,7 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
             page: pageNum,
             order: type === 'post' ? 'published_at desc' : 'id asc',
             filter: `status:published+visibility:public+type:${type}`,
-            columns: ['id', 'title', 'slug', 'html', 'plaintext', 'custom_excerpt', 'updated_at', 'published_at', 'created_at', 'type'],
-            withRelated: ['tags', 'authors']
+            columns: ['id', 'title', 'slug', 'html', 'plaintext', 'custom_excerpt', 'updated_at', 'published_at', 'created_at', 'type']
         });
 
         const entries = result.data.map((model) => {

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -230,6 +230,46 @@ describe('Unit: frontend/services/llms/service', function () {
         assert.ok(callCount >= 4, `Expected at least 4 DB calls (2 per getLlmsTxt), got ${callCount}`);
     });
 
+    it('does not load post relations for llms.txt index entries', async function () {
+        const calls = [];
+        const models = {
+            Post: {
+                findPage: async function (options) {
+                    calls.push(options);
+                    return {data: []};
+                }
+            }
+        };
+
+        const service = createService({models, urlMap: {}});
+
+        await service.getLlmsTxt();
+
+        assert.equal(calls.length, 2);
+        assert.equal(calls[0].withRelated, undefined);
+        assert.equal(calls[1].withRelated, undefined);
+    });
+
+    it('does not load post relations for llms-full.txt entries', async function () {
+        const calls = [];
+        const models = {
+            Post: {
+                findPage: async function (options) {
+                    calls.push(options);
+                    return {data: []};
+                }
+            }
+        };
+
+        const service = createService({models, urlMap: {}});
+
+        await service.getLlmsFullTxt();
+
+        assert.equal(calls.length, 2);
+        assert.equal(calls[0].withRelated, undefined);
+        assert.equal(calls[1].withRelated, undefined);
+    });
+
     describe('fetchPublicEntry', function () {
         it('calls the correct controller for pages vs posts', async function () {
             const calls = [];


### PR DESCRIPTION
## Summary

- Makes a short-term relation-loading change for `/llms.txt` and `/llms-full.txt` so we can verify whether it improves llms latency in the wild.
- Removes `tags`/`authors` relation loading from the llms entry fetches.
- Leaves the generated output unchanged.

## Follow-up

- If this proves to improve latency in the wild, we can follow up with broader refactors to consolidate the llms entry-fetching path.

## Testing

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm test:single test/unit/frontend/services/llms/service.test.js` — 12 passing
- [x] `pnpm test:single test/unit/server/services/url/lazy-url-service.test.js`
- [x] `pnpm test:single test/unit/server/services/url/lazy-find-resource.test.js`
- [x] `pnpm lint` — completed with 2 existing warnings and no errors
- [x] `git diff --check`
