### PR TITLE
Improved member repository subscription argument type

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -11,6 +11,7 @@ const crypto = require('crypto');
 const hasActiveOffer = require('../utils/has-active-offer');
 const StartAutomationsPollEvent = require('../../../automations/events/start-automations-poll-event');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../member-welcome-emails/constants');
+/** @import {Knex} from 'knex' */
 /** @import * as automationsApi from '../../../automations/automations-api' */
 
 const messages = {
@@ -1059,7 +1060,8 @@ module.exports = class MemberRepository {
      * @param {Object} data.subscription
      * @param {string | null} [data.offerId]
      * @param {import('../../../member-attribution/attribution-builder').AttributionResource} [data.attribution]
-     * @param {*} options
+     * @param {object} [options]
+     * @param {Knex.Transaction} [options.transacting]
      * @returns
      */
     async linkSubscription(data, options = {}) {


### PR DESCRIPTION
no ref

Before this change, an argument to `linkSubscription` was `any`. Now it's a "proper" type.
