### PR TITLE
Made member token scope authoritative

### DIFF
--- a/ghost/core/core/server/services/members/members-api/services/token-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/token-service.js
@@ -2,6 +2,11 @@ const jose = require('node-jose');
 const jwt = require('jsonwebtoken');
 const crypto = require('crypto');
 
+// A token's `scope` declares its purpose. Only identity tokens may act as a
+// member; entitlement tokens are read-only and handed to integrations.
+const IDENTITY_TOKEN_SCOPE = 'members:identity';
+const ENTITLEMENT_TOKEN_SCOPE = 'members:entitlements:read';
+
 module.exports = class TokenService {
     constructor({
         privateKey,
@@ -19,7 +24,8 @@ module.exports = class TokenService {
         const jwk = await this._keyStoreReady;
         return jwt.sign({
             sub,
-            kid: jwk.kid
+            kid: jwk.kid,
+            scope: IDENTITY_TOKEN_SCOPE
         }, this._privateKey, {
             keyid: jwk.kid,
             algorithm: 'RS512',
@@ -40,7 +46,7 @@ module.exports = class TokenService {
         return jwt.sign({
             sub,
             kid: jwk.kid,
-            scope: 'members:entitlements:read',
+            scope: ENTITLEMENT_TOKEN_SCOPE,
             member_uuid: memberUuid,
             paid,
             active_tier_ids: activeTierIds,
@@ -55,6 +61,15 @@ module.exports = class TokenService {
     }
 
     /**
+     * Decode and verify a member *identity* token.
+     *
+     * Identity and entitlement tokens are signed with the same key and share the
+     * same issuer/audience, so a signature check alone cannot tell them apart.
+     * They are distinguished by `scope`: only tokens scoped `members:identity`
+     * may act as the member. Read-only entitlement tokens
+     * (`members:entitlements:read`) are handed to integrations and must never be
+     * accepted on state-changing endpoints.
+     *
      * @param {string} token
      * @returns {Promise<jwt.JwtPayload>}
      */
@@ -68,6 +83,10 @@ module.exports = class TokenService {
 
         if (typeof result === 'string') {
             return {sub: result};
+        }
+
+        if (result.scope !== IDENTITY_TOKEN_SCOPE) {
+            throw new jwt.JsonWebTokenError('Only identity tokens can act as a member');
         }
 
         return result;

--- a/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
@@ -5,12 +5,11 @@ const TokenService = require('../../../../../../../core/server/services/members/
 
 describe('TokenService', function () {
     let tokenService;
+    const privateKey = '-----BEGIN RSA PRIVATE KEY-----\nMIICWwIBAAKBgQCea7oriNoFgxnY/JgFDpNRlxLMVIapfoMQTCJMWkH9pDYoAq/8GF6q0yTd\nn5+AS7TGasCjgNGW6miEbBDBaQy8hS8hWqhaRKY6Sy8/11KyAC8y5cs+QW4dFY2JvnXO6UpE\nFaTtHR7oAtTSZJ9D9i/FN+2wAoO/4193Leoqqw1dJwIDAQABAoGAeqejo5M4Yi4n9AVV2gx3\n6SLTrhn/jPljllmr8HutPilGuOGjycZAfXguwdyVjKqQ01LRxYW2QGdK9sQIkQa5kXjzTtLa\ndtHYcplk0rTTsdjbvZ31AKNTNYn5s+PhGGb0Gc9n8co18K75ol8VPG8lpXjUUCWsb2xcV7wA\nQuHkOukCQQD7TluL8I4tHXzREIW3OZeLTyRlPEIn5cDdPPEIHrAIu4WJ50zAbkMH7W4HBmWf\ntafxSgWcRsdMIZn//wZV3goLAkEAoWE6/LgKgowSouIjbRdekw7QPZMvN2LUV0a0GZHpSA2K\nzzyvOsW1dU9EO+WhCpdfoikuxWiPtN+byAe2sbBG1QJALuKgm8wmim488jhV6ig5iMkcLjL+\n2Li5sc0D3xLynr51nJPlsuUfZmQ6qd7cqN5YVeEMiOp/lkmSlLs8sFp7nwJAKEkFWKD4vq4I\n2PBqt4jl6v//q99aIhFhwIe93cQ23+3BgQo9FAbWzXoEJo+kK+itzuVI766ycQyA7uY+DQ1c\nIQJAER3D4lsY5wnE+01eqk8NfF7TO+u4ezWs/rmNyn3hapskgV0xqn+FanXeVJ5K7B3AzabR\na4/tLo88gWEfcow6WQ==\n-----END RSA PRIVATE KEY-----\n';
+    const publicKey = '-----BEGIN RSA PUBLIC KEY-----\nMIGJAoGBAJ5ruiuI2gWDGdj8mAUOk1GXEsxUhql+gxBMIkxaQf2kNigCr/wYXqrTJN2fn4BL\ntMZqwKOA0ZbqaIRsEMFpDLyFLyFaqFpEpjpLLz/XUrIALzLlyz5Bbh0VjYm+dc7pSkQVpO0d\nHugC1NJkn0P2L8U37bACg7/jX3ct6iqrDV0nAgMBAAE=\n-----END RSA PUBLIC KEY-----\n';
+    const issuer = 'http://127.0.0.1:2369/members/api';
 
     beforeAll(function () {
-        const privateKey = '-----BEGIN RSA PRIVATE KEY-----\nMIICWwIBAAKBgQCea7oriNoFgxnY/JgFDpNRlxLMVIapfoMQTCJMWkH9pDYoAq/8GF6q0yTd\nn5+AS7TGasCjgNGW6miEbBDBaQy8hS8hWqhaRKY6Sy8/11KyAC8y5cs+QW4dFY2JvnXO6UpE\nFaTtHR7oAtTSZJ9D9i/FN+2wAoO/4193Leoqqw1dJwIDAQABAoGAeqejo5M4Yi4n9AVV2gx3\n6SLTrhn/jPljllmr8HutPilGuOGjycZAfXguwdyVjKqQ01LRxYW2QGdK9sQIkQa5kXjzTtLa\ndtHYcplk0rTTsdjbvZ31AKNTNYn5s+PhGGb0Gc9n8co18K75ol8VPG8lpXjUUCWsb2xcV7wA\nQuHkOukCQQD7TluL8I4tHXzREIW3OZeLTyRlPEIn5cDdPPEIHrAIu4WJ50zAbkMH7W4HBmWf\ntafxSgWcRsdMIZn//wZV3goLAkEAoWE6/LgKgowSouIjbRdekw7QPZMvN2LUV0a0GZHpSA2K\nzzyvOsW1dU9EO+WhCpdfoikuxWiPtN+byAe2sbBG1QJALuKgm8wmim488jhV6ig5iMkcLjL+\n2Li5sc0D3xLynr51nJPlsuUfZmQ6qd7cqN5YVeEMiOp/lkmSlLs8sFp7nwJAKEkFWKD4vq4I\n2PBqt4jl6v//q99aIhFhwIe93cQ23+3BgQo9FAbWzXoEJo+kK+itzuVI766ycQyA7uY+DQ1c\nIQJAER3D4lsY5wnE+01eqk8NfF7TO+u4ezWs/rmNyn3hapskgV0xqn+FanXeVJ5K7B3AzabR\na4/tLo88gWEfcow6WQ==\n-----END RSA PRIVATE KEY-----\n';
-        const publicKey = '-----BEGIN RSA PUBLIC KEY-----\nMIGJAoGBAJ5ruiuI2gWDGdj8mAUOk1GXEsxUhql+gxBMIkxaQf2kNigCr/wYXqrTJN2fn4BL\ntMZqwKOA0ZbqaIRsEMFpDLyFLyFaqFpEpjpLLz/XUrIALzLlyz5Bbh0VjYm+dc7pSkQVpO0d\nHugC1NJkn0P2L8U37bACg7/jX3ct6iqrDV0nAgMBAAE=\n-----END RSA PUBLIC KEY-----\n';
-        const issuer = 'http://127.0.0.1:2369/members/api';
-
         tokenService = new TokenService({
             privateKey,
             publicKey,
@@ -23,22 +22,31 @@ describe('TokenService', function () {
             const token = await tokenService.encodeIdentityToken({sub: 'member@example.com'});
             const decodedToken = await tokenService.decodeToken(token);
 
-            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'iat', 'exp', 'aud', 'iss']);
+            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'iat', 'exp', 'aud', 'iss']);
             assert.equal(decodedToken.aud, 'http://127.0.0.1:2369/members/api');
             assert.equal(decodedToken.iss, 'http://127.0.0.1:2369/members/api');
             assert.equal(decodedToken.sub, 'member@example.com');
+            assert.equal(decodedToken.scope, 'members:identity');
         });
     });
 
     describe('encodeEntitlementToken', function () {
-        it('can encode an entitlement token and decode it afterwards', async function () {
+        it('can encode an entitlement token and verify it afterwards', async function () {
             const token = await tokenService.encodeEntitlementToken({
                 sub: 'member@example.com',
                 memberUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
                 paid: true,
                 activeTierIds: ['tier_1', 'tier_2']
             });
-            const decodedToken = await tokenService.decodeToken(token);
+
+            // Entitlement tokens are consumed by external integrations that verify
+            // against the published public keys, not via decodeToken (see below).
+            const jwks = await tokenService.getPublicKeys();
+            const entitlementPublicKey = jwkToPem(jwks.keys[0]);
+            const decodedToken = jwt.verify(token, entitlementPublicKey, {
+                algorithms: ['RS512'],
+                issuer: 'http://127.0.0.1:2369/members/api'
+            });
 
             assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'member_uuid', 'paid', 'active_tier_ids', 'jti', 'iat', 'exp', 'aud', 'iss']);
             assert.equal(decodedToken.aud, 'http://127.0.0.1:2369/members/api');
@@ -53,17 +61,56 @@ describe('TokenService', function () {
         });
     });
 
+    describe('decodeToken', function () {
+        it('accepts an identity token', async function () {
+            const token = await tokenService.encodeIdentityToken({sub: 'member@example.com'});
+            const decodedToken = await tokenService.decodeToken(token);
+
+            assert.equal(decodedToken.sub, 'member@example.com');
+            assert.equal(decodedToken.scope, 'members:identity');
+        });
+
+        it('rejects an entitlement token used as a member identity', async function () {
+            const token = await tokenService.encodeEntitlementToken({
+                sub: 'member@example.com',
+                memberUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                paid: true,
+                activeTierIds: ['tier_1', 'tier_2']
+            });
+
+            await assert.rejects(
+                tokenService.decodeToken(token),
+                /Only identity tokens can act as a member/
+            );
+        });
+
+        it('rejects a token without the identity scope', async function () {
+            // Any token not scoped `members:identity` - including a scopeless
+            // token signed with the same key - must not act as a member.
+            const token = jwt.sign(
+                {sub: 'member@example.com'},
+                privateKey,
+                {algorithm: 'RS512', audience: issuer, issuer}
+            );
+
+            await assert.rejects(
+                tokenService.decodeToken(token),
+                /Only identity tokens can act as a member/
+            );
+        });
+    });
+
     describe('getPublicKeys', function () {
         it('can verify the token using public keys', async function () {
             const token = await tokenService.encodeIdentityToken({sub: 'member@example.com'});
             const jwks = await tokenService.getPublicKeys();
-            const publicKey = jwkToPem(jwks.keys[0]);
+            const verificationKey = jwkToPem(jwks.keys[0]);
 
-            const decodedToken = jwt.verify(token, publicKey, {
+            const decodedToken = jwt.verify(token, verificationKey, {
                 algorithms: ['RS512']
             });
 
-            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'iat', 'exp', 'aud', 'iss']);
+            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'iat', 'exp', 'aud', 'iss']);
             assert.equal(decodedToken.aud, 'http://127.0.0.1:2369/members/api');
             assert.equal(decodedToken.iss, 'http://127.0.0.1:2369/members/api');
             assert.equal(decodedToken.sub, 'member@example.com');


### PR DESCRIPTION
## Summary

Member identity and entitlement tokens are issued by the same service with the same signature, issuer, and audience, and were only differentiated by a descriptive `scope` claim that nothing enforced.

This makes `scope` the source of truth for a token's purpose:

- identity tokens now declare `scope: members:identity`
- the identity decode path (`decodeToken`) requires that scope and rejects anything else

The change is additive to the entitlement token payload, so anything verifying it via the JWKS is unaffected. This feels like a more correct pattern than assuming tokens can act as members, which was the prior behavior.

## Tests

Updated the `token-service` unit tests to cover the identity/entitlement scopes and the decode-path enforcement.
