### PR TITLE
Removed the no-op lodash.template override pin

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -119,7 +119,17 @@
         "ember-cli-code-coverage",
         // https://github.com/TryGhost/Ghost/commit/1382e34e42a513c201cb957b7f843369a2ce1b63
         // ember-cli-terser@4.0.2 has a regression that breaks our sourcemaps
-        "ember-cli-terser"
+        "ember-cli-terser",
+
+        // https://linear.app/ghost/issue/PLA-56
+        // Deprecated (per-method lodash packages are EOL); last real release is
+        // 4.5.0 (2019). The flagged "4.18.0 [SECURITY]" bump does not exist, so
+        // Renovate can't remediate it. It's transitive-only — we never call
+        // `_.template` ourselves — and only reachable via frozen Ember build
+        // tooling (broccoli-templater, sourcemap-validator) plus old @tryghost/*
+        // packages, so it can't be removed from the tree here. Ignore it to stop
+        // the unactionable dashboard noise.
+        "lodash.template"
     ],
     "ignorePaths": [
         "test",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -242,9 +242,6 @@
     "xml": "1.0.1",
     "zod": "catalog:"
   },
-  "overrides": {
-    "lodash.template": "4.5.0"
-  },
   "optionalDependencies": {
     "@tryghost/html-to-mobiledoc": "3.3.2",
     "sqlite3": "5.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,7 +310,6 @@ overrides:
   eslint-plugin-ghost>@typescript-eslint/utils: 8.49.0
   ember-svg-jar>cheerio: 1.2.0
   juice>cheerio: 0.22.0
-  lodash.template: 4.5.0
   '@babel/runtime@<7.26.10': ^7.26.10
   '@tootallnate/once@<3.0.1': ^3.0.1
   ansi-html@<0.0.8: ^0.0.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -142,7 +142,6 @@ overrides:
   'eslint-plugin-ghost>@typescript-eslint/utils': 8.49.0
   'ember-svg-jar>cheerio': 1.2.0
   'juice>cheerio': 0.22.0
-  lodash.template: 4.5.0
   '@babel/runtime@<7.26.10': ^7.26.10
   '@tootallnate/once@<3.0.1': ^3.0.1
   'ansi-html@<0.0.8': ^0.0.9


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-56

`lodash.template` is deprecated and flagged in the Renovate dashboard, but Renovate can't remediate it: its only published release is `4.5.0` (2019) and the advisory's "4.18.0 [SECURITY]" fixed version doesn't exist.

It's also **transitive-only** — Ghost never calls `_.template`. It reaches the tree solely via frozen Ember build tooling (`broccoli-templater`, `sourcemap-validator`) and old `@tryghost/*` packages, so it can't be removed from the lockfile here.

The override pinning it to `4.5.0` was therefore a **no-op** (4.5.0 is the only version). This PR:

- Drops the `lodash.template` override from `pnpm-workspace.yaml` and the redundant `overrides` block in `ghost/core/package.json`
- Regenerates the lockfile (one line removed; `lodash.template@4.5.0` still resolves transitively, as expected)
- Adds `lodash.template` to Renovate `ignoreDeps` so the unactionable dashboard entry stops resurfacing