### PR TITLE
Updated donation checkout request handling

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -631,7 +631,7 @@ module.exports = class RouterController {
      * @returns
      */
     async _createDonationCheckoutSession(options) {
-        if (!this._paymentsService.stripeAPIService.configured) {
+        if (!this._settingsHelpers.areDonationsEnabled()) {
             throw new DisabledFeatureError({
                 message: tpl(messages.notConfigured)
             });

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -85,7 +85,8 @@ describe('RouterController', function () {
         };
         settingsHelpers = {
             getMembersSupportAddress: sinon.stub().returns('noreply@example.com'),
-            arePaidMembersEnabled: sinon.stub().returns(true)
+            arePaidMembersEnabled: sinon.stub().returns(true),
+            areDonationsEnabled: sinon.stub().returns(true)
         };
     });
 
@@ -695,6 +696,43 @@ describe('RouterController', function () {
                         test: 'hello'
                     }
                 }));
+            });
+
+            it('throws DisabledFeatureError when donations are not enabled', async function () {
+                const routerController = new RouterController({
+                    tiersService,
+                    paymentsService,
+                    offersAPI,
+                    stripeAPIService,
+                    labsService,
+                    settingsCache,
+                    settingsHelpers: {
+                        ...settingsHelpers,
+                        areDonationsEnabled: sinon.stub().returns(false)
+                    },
+                    urlUtils,
+                    memberAttributionService: {
+                        getAttribution: sinon.stub().resolves({})
+                    }
+                });
+
+                try {
+                    await routerController.createCheckoutSession({
+                        body: {
+                            type: 'donation',
+                            successUrl: 'https://example.com/?type=success',
+                            cancelUrl: 'https://example.com/?type=cancel',
+                            metadata: {}
+                        }
+                    }, {
+                        writeHead: () => {},
+                        end: () => {}
+                    });
+                    assert.fail('Should have thrown');
+                } catch (error) {
+                    assert(error instanceof errors.DisabledFeatureError);
+                    sinon.assert.notCalled(getDonationLinkSpy);
+                }
             });
         });
 


### PR DESCRIPTION
no ref 

Aligns donation checkout session creation with the site's donation settings so the API path enforces the same enabled/disabled state already reflected in public settings and Portal.

- routes donation checkout creation through the existing donations-enabled check
- adds unit coverage for the disabled-donations path