### PR TITLE
Updated donation checkout metadata handling

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -64,6 +64,26 @@ function extractGiftToken(input) {
     return input.trim();
 }
 
+const RESERVED_CHECKOUT_METADATA_KEYS = new Set([
+    'ghost_donation',
+    'ghost_gift',
+    'ghostSignupContext',
+    'gift_token',
+    'tier_id',
+    'cadence',
+    'duration'
+]);
+
+function removeReservedCheckoutMetadata(metadata) {
+    if (!metadata || typeof metadata !== 'object') {
+        return;
+    }
+
+    for (const key of RESERVED_CHECKOUT_METADATA_KEYS) {
+        delete metadata[key];
+    }
+}
+
 /**
  * Validate that a candidate return URL (e.g. Stripe Checkout success/cancel URL) points back
  * to the configured Ghost site. Returns `undefined` when the candidate is missing, malformed,
@@ -733,6 +753,8 @@ module.exports = class RouterController {
         if (metadata.newsletters) {
             metadata.newsletters = JSON.stringify(await this._validateNewsletters(JSON.parse(metadata.newsletters)));
         }
+
+        removeReservedCheckoutMetadata(metadata);
 
         const siteUrl = this._urlUtils.getSiteUrl();
         const successUrl = sanitizeReturnUrl(req.body.successUrl, siteUrl);

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -6,6 +6,18 @@ const {
 } = require('../../../lib/member-signup-contexts');
 /** @typedef {import('../../../lib/member-signup-contexts').SignupContext} SignupContext */
 
+function isStripeMetadataTrue(value) {
+    return value === true || value === 'true';
+}
+
+function hasStripeMetadataKey(metadata, key) {
+    return Object.prototype.hasOwnProperty.call(metadata || {}, key);
+}
+
+function hasConflictingCheckoutFlowMetadata(metadata) {
+    return hasStripeMetadataKey(metadata, 'ghost_donation') && hasStripeMetadataKey(metadata, 'ghost_gift');
+}
+
 /**
  * Handles `checkout.session.completed` webhook events
  *
@@ -51,10 +63,17 @@ module.exports = class CheckoutSessionEventService {
             await this.handleSubscriptionEvent(session);
         }
 
-        if (session.mode === 'payment' && session.metadata?.ghost_donation) {
-            await this.handleDonationEvent(session);
-        } else if (session.mode === 'payment' && session.metadata?.ghost_gift) {
-            await this.handleGiftEvent(session);
+        if (session.mode === 'payment') {
+            if (hasConflictingCheckoutFlowMetadata(session.metadata)) {
+                logging.warn('Ignoring checkout session with conflicting payment flow metadata');
+                return;
+            }
+
+            if (isStripeMetadataTrue(session.metadata?.ghost_donation)) {
+                await this.handleDonationEvent(session);
+            } else if (isStripeMetadataTrue(session.metadata?.ghost_gift)) {
+                await this.handleGiftEvent(session);
+            }
         }
     }
 

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -629,11 +629,9 @@ module.exports = class StripeAPI {
          * @type {Stripe.Checkout.SessionCreateParams}
          */
 
-        // TODO - add it higher up the stack to the metadata object.
-        // add ghost_donation key to metadata object
         metadata = {
-            ghost_donation: true,
-            ...metadata
+            ...metadata,
+            ghost_donation: true
         };
 
         const stripeSessionOptions = {
@@ -650,11 +648,8 @@ module.exports = class StripeAPI {
             invoice_creation: {
                 enabled: true,
                 invoice_data: {
-                    // Make sure we pass the data through to the invoice
-                    metadata: {
-                        ghost_donation: true,
-                        ...metadata
-                    }
+                    // Stripe does not inherit Checkout Session metadata for invoice records
+                    metadata
                 }
             },
             line_items: [{

--- a/ghost/core/test/e2e-api/members/donation-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/donation-checkout-session.test.js
@@ -114,6 +114,86 @@ describe('Create Stripe Checkout Session for Donations', function () {
         assert.equal(lastDonation.get('attribution_url'), url);
     });
 
+    it('Strips reserved gift metadata from donation checkout sessions', async function () {
+        const post = await getPost(fixtureManager.get('posts', 0).id);
+        const url = urlService.getUrlByResourceId(post.id, {absolute: false});
+        const paidTier = await models.Product.findOne({type: 'paid'}, {require: true});
+        const attackerToken = 'poc-reserved-donation-metadata';
+        const email = 'reserved-metadata-donation@example.com';
+
+        await membersAgent.post('/api/create-stripe-checkout-session/')
+            .body({
+                customerEmail: email,
+                type: 'donation',
+                successUrl: 'https://example.com/?type=success',
+                cancelUrl: 'https://example.com/?type=cancel',
+                metadata: {
+                    ghost_donation: '',
+                    ghost_gift: 'true',
+                    ghostSignupContext: 'needs_magic_link',
+                    gift_token: attackerToken,
+                    tier_id: paidTier.id,
+                    cadence: 'year',
+                    duration: '10',
+                    urlHistory: [
+                        {
+                            path: url,
+                            time: Date.now(),
+                            referrerMedium: null,
+                            referrerSource: 'ghost-explore',
+                            referrerUrl: 'https://example.com/blog/'
+                        }
+                    ]
+                }
+            })
+            .expectStatus(200);
+
+        const checkoutSession = stripeMocker.checkoutSessions[stripeMocker.checkoutSessions.length - 1];
+
+        assert.equal(checkoutSession.metadata.ghost_donation, true);
+        assert.equal(checkoutSession.metadata.ghost_gift, undefined);
+        assert.equal(checkoutSession.metadata.ghostSignupContext, undefined);
+        assert.equal(checkoutSession.metadata.gift_token, undefined);
+        assert.equal(checkoutSession.metadata.tier_id, undefined);
+        assert.equal(checkoutSession.metadata.cadence, undefined);
+        assert.equal(checkoutSession.metadata.duration, undefined);
+
+        await stripeMocker.sendWebhook({
+            type: 'checkout.session.completed',
+            data: {
+                object: {
+                    id: checkoutSession.id,
+                    mode: 'payment',
+                    amount_total: 100,
+                    currency: 'usd',
+                    customer: checkoutSession.customer,
+                    customer_details: {
+                        name: 'Reserved Metadata Donor',
+                        email
+                    },
+                    metadata: checkoutSession.metadata,
+                    payment_intent: 'pi_reserved_donation_metadata',
+                    custom_fields: [{
+                        key: 'donation_message',
+                        text: {
+                            value: 'Reserved metadata should not create a gift'
+                        }
+                    }]
+                }
+            }
+        });
+
+        const donation = await models.DonationPaymentEvent.findOne({
+            email
+        }, {require: true});
+        const gift = await models.Gift.findOne({token: attackerToken});
+
+        assert.equal(donation.get('amount'), 100);
+        assert.equal(donation.get('currency'), 'usd');
+        assert.equal(donation.get('donation_message'), 'Reserved metadata should not create a gift');
+        assert.equal(gift, null);
+    });
+
     it('Can create a member checkout session for a donation', async function () {
         // Fake a visit to a post
         const post = await getPost(fixtureManager.get('posts', 0).id);

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -87,6 +87,26 @@ describe('CheckoutSessionEventService', function () {
             sinon.assert.calledWith(handleDonationEventStub, session);
         });
 
+        it('should call handleDonationEvent if session mode is payment and session metadata ghost_donation is string true', async function () {
+            const service = createService();
+            const session = {mode: 'payment', metadata: {ghost_donation: 'true'}};
+            const handleDonationEventStub = sinon.stub(service, 'handleDonationEvent');
+
+            await service.handleEvent(session);
+
+            sinon.assert.calledWith(handleDonationEventStub, session);
+        });
+
+        it('should ignore false donation metadata flags', async function () {
+            const service = createService();
+            const session = {mode: 'payment', metadata: {ghost_donation: 'false'}};
+            const handleDonationEventStub = sinon.stub(service, 'handleDonationEvent');
+
+            await service.handleEvent(session);
+
+            sinon.assert.notCalled(handleDonationEventStub);
+        });
+
         it('should call handleGiftEvent if session mode is payment and session metadata ghost_gift is present', async function () {
             const service = createService();
             const session = {mode: 'payment', metadata: {ghost_gift: 'true'}};
@@ -95,6 +115,40 @@ describe('CheckoutSessionEventService', function () {
             await service.handleEvent(session);
 
             sinon.assert.calledWith(handleGiftEventStub, session);
+        });
+
+        it('should ignore false gift metadata flags', async function () {
+            const service = createService();
+            const session = {mode: 'payment', metadata: {ghost_gift: 'false'}};
+            const handleGiftEventStub = sinon.stub(service, 'handleGiftEvent');
+
+            await service.handleEvent(session);
+
+            sinon.assert.notCalled(handleGiftEventStub);
+        });
+
+        it('should ignore payment sessions with conflicting donation and gift markers', async function () {
+            const service = createService();
+            const session = {mode: 'payment', metadata: {ghost_donation: '', ghost_gift: 'true'}};
+            const handleDonationEventStub = sinon.stub(service, 'handleDonationEvent');
+            const handleGiftEventStub = sinon.stub(service, 'handleGiftEvent');
+
+            await service.handleEvent(session);
+
+            sinon.assert.notCalled(handleDonationEventStub);
+            sinon.assert.notCalled(handleGiftEventStub);
+        });
+
+        it('should ignore payment sessions when both donation and gift markers are true', async function () {
+            const service = createService();
+            const session = {mode: 'payment', metadata: {ghost_donation: true, ghost_gift: 'true'}};
+            const handleDonationEventStub = sinon.stub(service, 'handleDonationEvent');
+            const handleGiftEventStub = sinon.stub(service, 'handleGiftEvent');
+
+            await service.handleEvent(session);
+
+            sinon.assert.notCalled(handleDonationEventStub);
+            sinon.assert.notCalled(handleGiftEventStub);
         });
 
         it('should do nothing if session mode is unsupported', async function () {


### PR DESCRIPTION
no ref

Tightens how donation checkout metadata is assembled so Ghost-owned metadata stays authoritative and webhook routing keys off trusted values.

- normalizes caller-supplied checkout metadata before it's used
- keeps Ghost's own donation metadata as the source of truth
- adds unit coverage for the metadata handling and webhook routing paths