### PR TITLE
🎨 Improved adapter-manager error for missing adapter dependencies

### DIFF
--- a/ghost/core/core/server/services/adapter-manager/adapter-manager.js
+++ b/ghost/core/core/server/services/adapter-manager/adapter-manager.js
@@ -18,6 +18,18 @@ const resolveAdapterExport = (moduleExport) => {
 };
 
 /**
+ * Extracts the unresolved module specifier from a Node MODULE_NOT_FOUND error,
+ * e.g. the message "Cannot find module 'superagent'" yields "superagent".
+ *
+ * @param {Error} err
+ * @returns {string|null} the specifier, or null if it can't be determined
+ */
+const getMissingModuleSpecifier = (err) => {
+    const match = /Cannot find module '([^']+)'/.exec(err.message || '');
+    return match ? match[1] : null;
+};
+
+/**
  * @typedef { function(new: Adapter, object) } AdapterConstructor
  */
 
@@ -135,10 +147,25 @@ module.exports = class AdapterManager {
                     throw new errors.IncorrectUsageError({err});
                 }
 
-                // Catch missing dependencies BUT NOT missing adapter
-                if (!err.message.includes(pathToAdapter)) {
+                // A MODULE_NOT_FOUND means one of two things:
+                //   1. the adapter itself doesn't exist at this path — try the next path
+                //   2. the adapter loaded but one of ITS own requires failed — a
+                //      genuine missing dependency we should surface clearly
+                // Discriminate on the actual unresolved specifier, NOT a substring
+                // match of the whole message: a missing dependency's error embeds the
+                // adapter's path in its require stack, so a naive includes(pathToAdapter)
+                // misclassifies case 2 as case 1 and hides the real cause (e.g. the
+                // SchedulingPro adapter requiring a missing `superagent` surfaced as the
+                // misleading "Unable to find scheduling adapter SchedulingPro").
+                const missingModule = getMissingModuleSpecifier(err);
+                const adapterItselfMissing = missingModule === null
+                    ? err.message.includes(pathToAdapter) // fallback to legacy heuristic
+                    : missingModule === pathToAdapter;
+
+                if (!adapterItselfMissing) {
+                    const missingDescription = missingModule ? `'${missingModule}'` : 'a dependency';
                     throw new errors.IncorrectUsageError({
-                        message: `You are missing dependencies in your adapter ${pathToAdapter}`,
+                        message: `The ${adapterType} adapter ${adapterClassName} is missing a dependency: ${missingDescription}. Install it where the adapter can resolve it (e.g. ghost/core).`,
                         err
                     });
                 }

--- a/ghost/core/test/unit/server/services/adapter-manager/adapter-manager.test.js
+++ b/ghost/core/test/unit/server/services/adapter-manager/adapter-manager.test.js
@@ -180,4 +180,77 @@ describe('AdapterManager', function () {
         const secondMailNewslettersAdapter = adapterManager.getAdapter('mail:newsletters', 'custom');
         assert.equal(mailNewslettersAdapter, secondMailNewslettersAdapter);
     });
+
+    // Builds a MODULE_NOT_FOUND error shaped like Node's, including the Require
+    // stack so we can assert the manager doesn't fall for the substring trap.
+    function moduleNotFoundError(specifier, requireStack = []) {
+        const stack = requireStack.map(p => `- ${p}`).join('\n');
+        const err = new Error(`Cannot find module '${specifier}'${stack ? `\nRequire stack:\n${stack}` : ''}`);
+        err.code = 'MODULE_NOT_FOUND';
+        if (requireStack.length) {
+            err.requireStack = requireStack;
+        }
+        return err;
+    }
+
+    it('surfaces the missing dependency when an adapter loads but one of its requires fails', function () {
+        // Regression: SchedulingPro requires `superagent`; when it's absent the
+        // MODULE_NOT_FOUND message embeds the adapter's own path in the require
+        // stack, which used to be misread as "adapter not found at this path".
+        const pathsToAdapters = ['/path'];
+
+        const loadAdapterFromPath = sinon.stub();
+        loadAdapterFromPath.withArgs('/path/scheduling/SchedulingPro')
+            .throws(moduleNotFoundError('superagent', ['/path/scheduling/SchedulingPro.js']));
+
+        const adapterManager = new AdapterManager({loadAdapterFromPath, pathsToAdapters});
+        adapterManager.registerAdapter('scheduling', BaseMailAdapter);
+
+        assert.throws(() => {
+            adapterManager.getAdapter('scheduling', 'SchedulingPro', {});
+        }, {
+            errorType: 'IncorrectUsageError',
+            message: `The scheduling adapter SchedulingPro is missing a dependency: 'superagent'. Install it where the adapter can resolve it (e.g. ghost/core).`
+        });
+    });
+
+    it('reports adapter-not-found (not missing dependency) when the adapter file itself is absent', function () {
+        const pathsToAdapters = ['/path'];
+
+        const loadAdapterFromPath = sinon.stub();
+        // The unresolved specifier IS the adapter path -> the file is genuinely missing.
+        loadAdapterFromPath.withArgs('/path/scheduling/SchedulingPro')
+            .throws(moduleNotFoundError('/path/scheduling/SchedulingPro'));
+
+        const adapterManager = new AdapterManager({loadAdapterFromPath, pathsToAdapters});
+        adapterManager.registerAdapter('scheduling', BaseMailAdapter);
+
+        assert.throws(() => {
+            adapterManager.getAdapter('scheduling', 'SchedulingPro', {});
+        }, {
+            errorType: 'IncorrectUsageError',
+            message: 'Unable to find scheduling adapter SchedulingPro in /path.'
+        });
+    });
+
+    it('falls back to reporting a missing dependency when the specifier cannot be parsed', function () {
+        const pathsToAdapters = ['/path'];
+
+        const loadAdapterFromPath = sinon.stub();
+        // An unusual MODULE_NOT_FOUND whose message has no parseable specifier
+        // and does not mention the adapter path -> treated as a missing dependency.
+        const err = new Error('module resolution failed for some transitive require');
+        err.code = 'MODULE_NOT_FOUND';
+        loadAdapterFromPath.withArgs('/path/scheduling/SchedulingPro').throws(err);
+
+        const adapterManager = new AdapterManager({loadAdapterFromPath, pathsToAdapters});
+        adapterManager.registerAdapter('scheduling', BaseMailAdapter);
+
+        assert.throws(() => {
+            adapterManager.getAdapter('scheduling', 'SchedulingPro', {});
+        }, {
+            errorType: 'IncorrectUsageError',
+            message: 'The scheduling adapter SchedulingPro is missing a dependency: a dependency. Install it where the adapter can resolve it (e.g. ghost/core).'
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-39

### Problem

When an adapter loads but one of its **own** `require()`s fails — e.g. the Ghost(Pro) `SchedulingPro` adapter requiring a missing `superagent` — Node's `MODULE_NOT_FOUND` error embeds the adapter's path in its **Require stack**. `AdapterManager` used `!err.message.includes(pathToAdapter)` to tell "adapter file missing" apart from "adapter's dependency missing", so the require-stack path made it misclassify the missing dependency as "adapter not found at this path". The error was swallowed, the path loop exhausted, and the user got the misleading:

> Unable to find scheduling adapter SchedulingPro

This sent debugging toward a missing *file* rather than a missing *dependency* (it contributed to a recent Ghost(Pro) boot outage).

### Fix

Discriminate on the **actual unresolved module specifier** parsed from the error (`Cannot find module 'X'`) instead of substring-matching the whole message:

- specifier **is** the adapter path → adapter genuinely absent at this path, try the next path (unchanged behaviour)
- specifier is **anything else** → the adapter loaded but a dependency is missing; throw an error that **names the missing module**, e.g. `The scheduling adapter SchedulingPro is missing a dependency: 'superagent'. Install it where the adapter can resolve it (e.g. ghost/core).`

Falls back to the legacy substring heuristic if the specifier can't be parsed, so unusual error shapes never crash the loader.

### Tests

Added three unit tests to `adapter-manager.test.js`:
- adapter loads but a `require()` fails (missing dep in require stack) → names the missing dependency (regression for this bug)
- adapter file itself absent → still reports "Unable to find … adapter" (no false "missing dependency")
- unparseable `MODULE_NOT_FOUND` message → falls back to a generic missing-dependency error

`yarn test:single test/unit/server/services/adapter-manager/adapter-manager.test.js` → 9 passing. Lint clean.

### Note

This improves the *diagnostic* only. The underlying footgun — OSS-declared deps consumed solely by externally-injected Pro adapters (tracked in PLA-39) — is a separate, larger pattern discussion.