### PR TITLE
Named the missing module in adapter dependency errors

### DIFF
--- a/ghost/core/core/server/services/adapter-manager/adapter-manager.js
+++ b/ghost/core/core/server/services/adapter-manager/adapter-manager.js
@@ -140,8 +140,12 @@ module.exports = class AdapterManager {
                 // that includes the adapter's own path, which would false-positive.
                 const firstLine = err.message.split('\n')[0];
                 if (!firstLine.includes(pathToAdapter)) {
+                    // Name the unresolved module so the error is actionable, e.g.
+                    // "Cannot find module 'superagent'" -> 'superagent'.
+                    const missingMatch = /Cannot find module '([^']+)'/.exec(firstLine);
+                    const missingModule = missingMatch ? ` '${missingMatch[1]}'` : '';
                     throw new errors.IncorrectUsageError({
-                        message: `You are missing dependencies in your adapter ${pathToAdapter}`,
+                        message: `You are missing a dependency${missingModule} in your adapter ${pathToAdapter}`,
                         err
                     });
                 }

--- a/ghost/core/test/unit/server/services/adapter-manager/adapter-manager.test.js
+++ b/ghost/core/test/unit/server/services/adapter-manager/adapter-manager.test.js
@@ -105,7 +105,8 @@ describe('AdapterManager', function () {
                 adapterManager.getAdapter('scheduling', 'BrokenAdapter', {});
             }, {
                 errorType: 'IncorrectUsageError',
-                message: /missing dependencies/
+                // The error names the unresolved module so it's actionable
+                message: /missing a dependency 'this-package-does-not-exist-at-all' in your adapter/
             });
         } finally {
             fs.rmSync(tmpDir, {recursive: true, force: true});


### PR DESCRIPTION
Follow-up to 44af74370c, which made the adapter "missing dependency" error reachable again. That error said dependencies were missing but not *which* one.

This parses the module name from the `MODULE_NOT_FOUND` first line and includes it. Falls back to the existing wording if no specifier can be parsed. Minor actionability improvement, no behavior change.

- `adapter-manager.js`: extract and include the unresolved module name
- `adapter-manager.test.js`: assert the name appears in the error
