### PR TITLE
Added lazy routing

### DIFF
--- a/ghost/core/core/server/services/url/lazy-find-resource.ts
+++ b/ghost/core/core/server/services/url/lazy-find-resource.ts
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const _ = require('lodash');
+const resourcesConfig = require('./config');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+export type FindResource = (
+    routerType: string,
+    params: Record<string, string>
+) => Promise<Record<string, unknown> | null>;
+
+interface BookshelfModel {
+    findOne(query: Record<string, unknown>, options?: Record<string, unknown>): Promise<{toJSON(): Record<string, unknown>} | null>;
+}
+
+interface Models {
+    Post: BookshelfModel;
+    TagPublic: BookshelfModel;
+    Author: BookshelfModel;
+}
+
+const POST_SCOPE = {type: 'post', status: 'published'};
+const PAGE_SCOPE = {type: 'page', status: 'published'};
+const POST_RELATIONS = ['tags', 'authors'];
+const RELATION_KEYS = ['tags', 'authors', 'primary_tag', 'primary_author'];
+// Permalink segments that are real, unique lookup columns. Derived segments
+// (year/month/day) and relation segments (primary_tag/author) are not columns,
+// so passing them to findOne would build invalid SQL and 500 a simple URL miss.
+const QUERYABLE_PARAMS = ['id', 'uuid', 'slug'];
+
+// Drop the same fields the eager resourceConfig excludes so the resolved record
+// has the same shape the eager service exposes (no post body, no extra
+// author/tag fields). posts_meta is an auto-loaded relation eager never keeps.
+function excludeFor(type: string): string[] {
+    const cfg = resourcesConfig.find((c: {type: string}) => c.type === type);
+    const exclude = (cfg && cfg.modelOptions.exclude) || [];
+    return [...exclude, 'posts_meta'];
+}
+
+// Eager trims relations to {id, slug} via withRelatedFields; match that.
+function trimRelation(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(item => _.pick(item, ['id', 'slug']));
+    }
+    if (value && typeof value === 'object') {
+        return _.pick(value, ['id', 'slug']);
+    }
+    return value;
+}
+
+function pruneToEagerShape(record: Record<string, unknown>, type: string): Record<string, unknown> {
+    const pruned = _.omit(record, excludeFor(type));
+
+    if (type === 'pages') {
+        // Eager always exposes primary_tag/primary_author as null on pages (they
+        // are virtual Post fields) but never carries the tags/authors arrays.
+        pruned.primary_tag = null;
+        pruned.primary_author = null;
+        return pruned;
+    }
+
+    for (const key of RELATION_KEYS) {
+        if (pruned[key] !== undefined) {
+            pruned[key] = trimRelation(pruned[key]);
+        }
+    }
+    return pruned;
+}
+
+/**
+ * Builds the per-request DB lookup hook injected into LazyUrlService.resolveUrl.
+ * Visibility rules mirror the eager service so a guessed slug can't surface
+ * anything the eager path hid; unknown types resolve to null.
+ */
+export function createFindResource(models: Models): FindResource {
+    const loadOne = async (
+        Model: BookshelfModel,
+        query: Record<string, unknown>,
+        type: string,
+        options: Record<string, unknown> = {}
+    ): Promise<Record<string, unknown> | null> => {
+        const result = await Model.findOne(query, {...options, require: false});
+        if (!result) {
+            return null;
+        }
+        const record = result.toJSON();
+        // Post.toJSON computes primary_tag but not primary_author.
+        if (Array.isArray(record.authors)) {
+            record.primary_author = record.authors[0] ?? null;
+        }
+        return pruneToEagerShape(record, type);
+    };
+
+    return (type: string, params: Record<string, string>): Promise<Record<string, unknown> | null> => {
+        const query = _.pick(params, QUERYABLE_PARAMS);
+        if (_.isEmpty(query)) {
+            return Promise.resolve(null);
+        }
+        switch (type) {
+        case 'posts':
+            return loadOne(models.Post, {...query, ...POST_SCOPE}, type, {withRelated: POST_RELATIONS});
+        case 'pages':
+            return loadOne(models.Post, {...query, ...PAGE_SCOPE}, type);
+        case 'tags':
+            return loadOne(models.TagPublic, {...query, visibility: 'public'}, type);
+        case 'authors':
+            return loadOne(models.Author, {...query, visibility: 'public'}, type);
+        default:
+            return Promise.resolve(null);
+        }
+    };
+}
+
+module.exports = {createFindResource};
+module.exports.createFindResource = createFindResource;

--- a/ghost/core/core/server/services/url/lazy-find-resource.ts
+++ b/ghost/core/core/server/services/url/lazy-find-resource.ts
@@ -3,15 +3,7 @@ const _ = require('lodash');
 const resourcesConfig = require('./config');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
-// A resource is looked up by exactly one real, unique column. Multi-segment
-// permalinks capture more (year/month, primary_tag, ...), but those segments
-// are validated by the canonical re-check in the service, never queried here.
-export type ResourceLookupParams = {id: string} | {slug: string};
-
-export type FindResource = (
-    routerType: string,
-    params: ResourceLookupParams
-) => Promise<Record<string, unknown> | null>;
+import type {ResourceLookupParams, FindResource} from './lazy-url-service';
 
 interface BookshelfModel {
     findOne(query: Record<string, unknown>, options?: Record<string, unknown>): Promise<{toJSON(): Record<string, unknown>} | null>;

--- a/ghost/core/core/server/services/url/lazy-find-resource.ts
+++ b/ghost/core/core/server/services/url/lazy-find-resource.ts
@@ -3,9 +3,14 @@ const _ = require('lodash');
 const resourcesConfig = require('./config');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
+// A resource is looked up by exactly one real, unique column. Multi-segment
+// permalinks capture more (year/month, primary_tag, ...), but those segments
+// are validated by the canonical re-check in the service, never queried here.
+export type ResourceLookupParams = {id: string} | {uuid: string} | {slug: string};
+
 export type FindResource = (
     routerType: string,
-    params: Record<string, string>
+    params: ResourceLookupParams
 ) => Promise<Record<string, unknown> | null>;
 
 interface BookshelfModel {
@@ -22,10 +27,6 @@ const POST_SCOPE = {type: 'post', status: 'published'};
 const PAGE_SCOPE = {type: 'page', status: 'published'};
 const POST_RELATIONS = ['tags', 'authors'];
 const RELATION_KEYS = ['tags', 'authors', 'primary_tag', 'primary_author'];
-// Permalink segments that are real, unique lookup columns. Derived segments
-// (year/month/day) and relation segments (primary_tag/author) are not columns,
-// so passing them to findOne would build invalid SQL and 500 a simple URL miss.
-const QUERYABLE_PARAMS = ['id', 'uuid', 'slug'];
 
 // Drop the same fields the eager resourceConfig excludes so the resolved record
 // has the same shape the eager service exposes (no post body, no extra
@@ -90,20 +91,16 @@ export function createFindResource(models: Models): FindResource {
         return pruneToEagerShape(record, type);
     };
 
-    return (type: string, params: Record<string, string>): Promise<Record<string, unknown> | null> => {
-        const query = _.pick(params, QUERYABLE_PARAMS);
-        if (_.isEmpty(query)) {
-            return Promise.resolve(null);
-        }
+    return (type: string, params: ResourceLookupParams): Promise<Record<string, unknown> | null> => {
         switch (type) {
         case 'posts':
-            return loadOne(models.Post, {...query, ...POST_SCOPE}, type, {withRelated: POST_RELATIONS});
+            return loadOne(models.Post, {...params, ...POST_SCOPE}, type, {withRelated: POST_RELATIONS});
         case 'pages':
-            return loadOne(models.Post, {...query, ...PAGE_SCOPE}, type);
+            return loadOne(models.Post, {...params, ...PAGE_SCOPE}, type);
         case 'tags':
-            return loadOne(models.TagPublic, {...query, visibility: 'public'}, type);
+            return loadOne(models.TagPublic, {...params, visibility: 'public'}, type);
         case 'authors':
-            return loadOne(models.Author, {...query, visibility: 'public'}, type);
+            return loadOne(models.Author, {...params, visibility: 'public'}, type);
         default:
             return Promise.resolve(null);
         }

--- a/ghost/core/core/server/services/url/lazy-find-resource.ts
+++ b/ghost/core/core/server/services/url/lazy-find-resource.ts
@@ -6,7 +6,7 @@ const resourcesConfig = require('./config');
 // A resource is looked up by exactly one real, unique column. Multi-segment
 // permalinks capture more (year/month, primary_tag, ...), but those segments
 // are validated by the canonical re-check in the service, never queried here.
-export type ResourceLookupParams = {id: string} | {uuid: string} | {slug: string};
+export type ResourceLookupParams = {id: string} | {slug: string};
 
 export type FindResource = (
     routerType: string,

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -1,0 +1,225 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const debug = require('@tryghost/debug')('services:url:lazy');
+const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
+const localUtils = require('../../../shared/url-utils');
+const {matchPermalink} = require('./permalink-matcher');
+const {buildFilter, filterMatches, routerTypeOf} = require('./router-filter');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+import type {Resource, UrlOptions, LazyUrlServiceBackend} from './url-service-facade';
+import type {FindResource} from './lazy-find-resource';
+import type {CompiledFilter} from './router-filter';
+
+interface RouterConfig {
+    identifier: string;
+    filter: string | null;
+    resourceType: string;
+    permalink: string;
+    compiledFilter: CompiledFilter | null;
+}
+
+interface LazyUrlServiceDeps {
+    urlUtils?: typeof localUtils;
+    findResource?: FindResource | null;
+}
+
+const ROUTER_TYPE_TO_DB_TYPE: Record<string, string> = {posts: 'post', pages: 'page'};
+
+/**
+ * On-demand replacement for the eager UrlService: computes URLs and ownership
+ * per call from the registered router configs instead of precomputing a full
+ * map at boot. Forward lookups are pure; resolveUrl is the only DB-touching
+ * path, and only through the injected findResource hook.
+ */
+export class LazyUrlService implements LazyUrlServiceBackend {
+    private urlUtils: typeof localUtils;
+    private findResource: FindResource | null;
+    // Router configs in registration order, which is also their priority.
+    private routerConfigs: RouterConfig[];
+
+    constructor({urlUtils = localUtils, findResource = null}: LazyUrlServiceDeps = {}) {
+        this.urlUtils = urlUtils;
+        this.findResource = findResource;
+        this.routerConfigs = [];
+    }
+
+    onRouterAddedType(identifier: string, filter: string | null, resourceType: string, permalink: string): void {
+        debug('onRouterAddedType', identifier, resourceType, permalink, filter);
+        this.routerConfigs.push({
+            identifier,
+            filter,
+            resourceType,
+            permalink,
+            compiledFilter: buildFilter(filter)
+        });
+    }
+
+    onRouterUpdated(): void {
+        // No precomputed state to regenerate.
+    }
+
+    reset(): void {
+        this.routerConfigs = [];
+    }
+
+    hasFinished(): boolean {
+        return true;
+    }
+
+    getUrlForResource(resource: Resource, options: UrlOptions = {}): string {
+        const routerType = routerTypeOf(resource);
+        if (!routerType) {
+            return this._formatNotFound(options);
+        }
+
+        const record = this._recordForFilter(resource);
+        for (const config of this.routerConfigs) {
+            if (config.resourceType !== routerType) {
+                continue;
+            }
+            this._warnIfThin(config, resource, routerType);
+            if (filterMatches(config.compiledFilter, record)) {
+                const path = this.urlUtils.replacePermalink(config.permalink, resource);
+                return this._formatPath(path, options);
+            }
+        }
+        return this._formatNotFound(options);
+    }
+
+    ownsResource(routerIdentifier: string, resource: Resource | null): boolean {
+        if (!resource) {
+            return false;
+        }
+        const routerType = routerTypeOf(resource);
+        if (!routerType) {
+            return false;
+        }
+        // Ownership is exclusive: only the first matching router of the type
+        // owns the resource, matching eager's reservation.
+        const record = this._recordForFilter(resource);
+        const owner = this.routerConfigs.find(
+            c => c.resourceType === routerType && filterMatches(c.compiledFilter, record)
+        );
+        return !!owner && owner.identifier === routerIdentifier;
+    }
+
+    async resolveUrl(urlPath: string): Promise<Resource | null> {
+        if (!this.findResource) {
+            return null;
+        }
+        // Memoize per call so routers sharing a resourceType+permalink shape (or
+        // fallthrough across filters) don't repeat the same DB lookup.
+        const lookupCache = new Map<string, Record<string, unknown> | null>();
+        for (const config of this.routerConfigs) {
+            const params = matchPermalink(config.permalink, urlPath);
+            if (!params) {
+                continue;
+            }
+            const cacheKey = `${config.resourceType}:${JSON.stringify(params)}`;
+            let resource: Record<string, unknown> | null;
+            if (lookupCache.has(cacheKey)) {
+                resource = lookupCache.get(cacheKey) ?? null;
+            } else {
+                resource = await this.findResource(config.resourceType, params);
+                lookupCache.set(cacheKey, resource);
+            }
+            if (!resource) {
+                continue;
+            }
+            // Normalize the same way the forward paths do so page: filters are
+            // evaluated against an identical shape regardless of findResource.
+            const record = this._recordForFilter(resource as Resource);
+            if (!filterMatches(config.compiledFilter, record)) {
+                continue;
+            }
+            if (!this._matchesCanonicalUrl(config, params, resource)) {
+                continue;
+            }
+            return Object.assign({}, resource, {type: config.resourceType}) as Resource;
+        }
+        return null;
+    }
+
+    // Eager only resolves a URL that equals a resource's generated (canonical)
+    // URL, so we regenerate the record's URL for this permalink and confirm the
+    // captured params match it. Without this, derived/relation segments the
+    // query can't filter on (year/month, primary_tag) would resolve any slug,
+    // 200-ing a URL the eager service 404s.
+    private _matchesCanonicalUrl(config: RouterConfig, params: Record<string, string>, resource: Record<string, unknown>): boolean {
+        const canonicalPath = this.urlUtils.replacePermalink(config.permalink, resource);
+        const canonicalParams = matchPermalink(config.permalink, canonicalPath);
+        if (!canonicalParams) {
+            return false;
+        }
+        return Object.keys(params).every(key => canonicalParams[key] === params[key]);
+    }
+
+    // Normalizes the plural router type to the singular DB value for filter
+    // evaluation only, so page: filters match as in the eager generator.
+    private _recordForFilter(resource: Resource): Record<string, unknown> {
+        const record = resource as Record<string, unknown>;
+        const dbType = ROUTER_TYPE_TO_DB_TYPE[record.type as string];
+        return dbType ? {...record, type: dbType} : record;
+    }
+
+    private _formatPath(path: string, options: UrlOptions): string {
+        if (options.absolute) {
+            return this.urlUtils.createUrl(path, options.absolute);
+        }
+        if (options.withSubdirectory) {
+            return this.urlUtils.createUrl(path, false, true);
+        }
+        return path;
+    }
+
+    // Mirrors the eager miss path: the /404/ fallback carries no subdirectory.
+    private _formatNotFound(options: UrlOptions): string {
+        if (options.absolute) {
+            return this.urlUtils.createUrl('/404/', options.absolute);
+        }
+        if (options.withSubdirectory) {
+            return this.urlUtils.createUrl('/404/', false);
+        }
+        return '/404/';
+    }
+
+    // Warns when a filtered router can't see a relation the caller didn't load:
+    // lazy would 404 here while eager (full data in memory) returns a URL.
+    private _warnIfThin(config: RouterConfig, resource: Resource, routerType: string): void {
+        if (!config.filter) {
+            return;
+        }
+        const r = resource as Record<string, unknown>;
+        const missing: string[] = [];
+        if (/\btags?\b/.test(config.filter) && !Array.isArray(r.tags)) {
+            missing.push('tags');
+        }
+        if (/\bauthors?\b/.test(config.filter) && !Array.isArray(r.authors)) {
+            missing.push('authors');
+        }
+        if (/\bprimary_tag\b/.test(config.filter) && r.primary_tag === undefined) {
+            missing.push('primary_tag');
+        }
+        if (/\bprimary_author\b/.test(config.filter) && r.primary_author === undefined) {
+            missing.push('primary_author');
+        }
+        if (missing.length === 0) {
+            return;
+        }
+        logging.error(new errors.InternalServerError({
+            message: 'Thin resource passed to LazyUrlService.getUrlForResource',
+            code: 'LAZY_URL_THIN_RESOURCE',
+            errorDetails: {
+                resourceType: routerType,
+                resourceId: resource.id,
+                routerIdentifier: config.identifier,
+                filter: config.filter,
+                missing
+            }
+        }));
+    }
+}
+
+module.exports = LazyUrlService;
+module.exports.LazyUrlService = LazyUrlService;

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const debug = require('@tryghost/debug')('services:url:lazy');
-const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const localUtils = require('../../../shared/url-utils');
 const {matchPermalink} = require('./permalink-matcher');
@@ -8,7 +7,7 @@ const {buildFilter, filterMatches, routerTypeOf} = require('./router-filter');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 import type {Resource, UrlOptions, LazyUrlServiceBackend} from './url-service-facade';
-import type {FindResource} from './lazy-find-resource';
+import type {FindResource, ResourceLookupParams} from './lazy-find-resource';
 import type {CompiledFilter} from './router-filter';
 
 interface RouterConfig {
@@ -25,6 +24,24 @@ interface LazyUrlServiceDeps {
 }
 
 const ROUTER_TYPE_TO_DB_TYPE: Record<string, string> = {posts: 'post', pages: 'page'};
+
+// Real, unique lookup columns, in priority order. A multi-segment permalink
+// also captures derived (year/month) and relation (primary_tag) segments, but
+// only one of these columns is ever queried — the others are checked by the
+// canonical re-check below.
+const QUERYABLE_PARAMS = ['id', 'uuid', 'slug'] as const;
+
+// Narrow the full captured params down to the single column we query by, or
+// null when the permalink captured no queryable column to look up at all.
+function toLookupParams(params: Record<string, string>): ResourceLookupParams | null {
+    for (const key of QUERYABLE_PARAMS) {
+        const value = params[key];
+        if (value !== undefined) {
+            return {[key]: value} as ResourceLookupParams;
+        }
+    }
+    return null;
+}
 
 /**
  * On-demand replacement for the eager UrlService: computes URLs and ownership
@@ -78,7 +95,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             if (config.resourceType !== routerType) {
                 continue;
             }
-            this._warnIfThin(config, resource, routerType);
+            this._assertNotThin(config, resource, routerType);
             if (filterMatches(config.compiledFilter, record)) {
                 const path = this.urlUtils.replacePermalink(config.permalink, resource);
                 return this._formatPath(path, options);
@@ -116,12 +133,16 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             if (!params) {
                 continue;
             }
-            const cacheKey = `${config.resourceType}:${JSON.stringify(params)}`;
+            const lookupParams = toLookupParams(params);
+            if (!lookupParams) {
+                continue;
+            }
+            const cacheKey = `${config.resourceType}:${JSON.stringify(lookupParams)}`;
             let resource: Record<string, unknown> | null;
             if (lookupCache.has(cacheKey)) {
                 resource = lookupCache.get(cacheKey) ?? null;
             } else {
-                resource = await this.findResource(config.resourceType, params);
+                resource = await this.findResource(config.resourceType, lookupParams);
                 lookupCache.set(cacheKey, resource);
             }
             if (!resource) {
@@ -184,9 +205,12 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         return '/404/';
     }
 
-    // Warns when a filtered router can't see a relation the caller didn't load:
-    // lazy would 404 here while eager (full data in memory) returns a URL.
-    private _warnIfThin(config: RouterConfig, resource: Resource, routerType: string): void {
+    // A filtered router that references a relation the resource doesn't carry
+    // can't be evaluated: lazy would 404 here while eager (full data in memory)
+    // returns a URL. Callers must hand the service fully-inflated resources, so
+    // a thin one is a programmer error we refuse loudly rather than mask as a
+    // silent /404/.
+    private _assertNotThin(config: RouterConfig, resource: Resource, routerType: string): void {
         if (!config.filter) {
             return;
         }
@@ -207,7 +231,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         if (missing.length === 0) {
             return;
         }
-        logging.error(new errors.InternalServerError({
+        throw new errors.InternalServerError({
             message: 'Thin resource passed to LazyUrlService.getUrlForResource',
             code: 'LAZY_URL_THIN_RESOURCE',
             errorDetails: {
@@ -217,7 +241,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
                 filter: config.filter,
                 missing
             }
-        }));
+        });
     }
 }
 

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -29,10 +29,28 @@ const ROUTER_TYPE_TO_DB_TYPE: Record<string, string> = {posts: 'post', pages: 'p
 // also captures derived (year/month) and relation (primary_tag) segments, but
 // only one of these columns is ever queried — the others are checked by the
 // canonical re-check below.
-const QUERYABLE_PARAMS = ['id', 'uuid', 'slug'] as const;
+const QUERYABLE_PARAMS = ['id', 'slug'] as const;
 
-// Narrow the full captured params down to the single column we query by, or
-// null when the permalink captured no queryable column to look up at all.
+// Permalink fields with a fixed, knowable format.
+const FIELD_VALIDATORS: Record<string, RegExp> = {
+    id: /^[0-9a-f]{24}$/i,
+    year: /^\d{4}$/,
+    month: /^\d{2}$/,
+    day: /^\d{2}$/
+};
+
+function capturedValuesAreValid(params: Record<string, string>): boolean {
+    for (const [field, value] of Object.entries(params)) {
+        const pattern = FIELD_VALIDATORS[field];
+        if (pattern && !pattern.test(value)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Narrow the full captured params down to the single column we query the DB by,
+// or null when the permalink captured no queryable column at all.
 function toLookupParams(params: Record<string, string>): ResourceLookupParams | null {
     for (const key of QUERYABLE_PARAMS) {
         const value = params[key];
@@ -131,6 +149,9 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         for (const config of this.routerConfigs) {
             const params = matchPermalink(config.permalink, urlPath);
             if (!params) {
+                continue;
+            }
+            if (!capturedValuesAreValid(params)) {
                 continue;
             }
             const lookupParams = toLookupParams(params);

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -7,8 +7,15 @@ const {buildFilter, filterMatches, routerTypeOf} = require('./router-filter');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 import type {Resource, UrlOptions, LazyUrlServiceBackend} from './url-service-facade';
-import type {FindResource} from './lazy-find-resource';
 import type {CompiledFilter} from './router-filter';
+import type {PermalinkParams} from './permalink-matcher';
+
+export type ResourceLookupParams = {id: string} | {slug: string};
+
+export type FindResource = (
+    routerType: string,
+    params: ResourceLookupParams
+) => Promise<Record<string, unknown> | null>;
 
 interface RouterConfig {
     identifier: string;
@@ -117,20 +124,9 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             if (!params) {
                 continue;
             }
+            // matchPermalink only matches permalinks that capture a queryable
+            // column, so this always yields a usable lookup.
             const lookupParams = toLookupParams(params);
-            if (!lookupParams) {
-                // A resource permalink always carries a slug or id, so matching
-                // one without a queryable column means the router was registered
-                // with an invalid permalink — a config bug.
-                throw new errors.InternalServerError({
-                    message: 'LazyUrlService matched a permalink with no queryable lookup column',
-                    code: 'LAZY_URL_NO_LOOKUP_PARAM',
-                    errorDetails: {
-                        routerIdentifier: config.identifier,
-                        permalink: config.permalink
-                    }
-                });
-            }
             const cacheKey = `${config.resourceType}:${JSON.stringify(lookupParams)}`;
             let resource: Record<string, unknown> | null;
             if (lookupCache.has(cacheKey)) {
@@ -161,13 +157,15 @@ export class LazyUrlService implements LazyUrlServiceBackend {
     // captured params match it. Without this, derived/relation segments the
     // query can't filter on (year/month, primary_tag) would resolve any slug,
     // 200-ing a URL the eager service 404s.
-    private _matchesCanonicalUrl(config: RouterConfig, params: Record<string, string>, resource: Record<string, unknown>): boolean {
+    private _matchesCanonicalUrl(config: RouterConfig, params: PermalinkParams, resource: Record<string, unknown>): boolean {
         const canonicalPath = this.urlUtils.replacePermalink(config.permalink, resource);
         const canonicalParams = matchPermalink(config.permalink, canonicalPath);
         if (!canonicalParams) {
             return false;
         }
-        return Object.keys(params).every(key => canonicalParams[key] === params[key]);
+        const captured = params as Record<string, string>;
+        const canonical = canonicalParams as Record<string, string>;
+        return Object.keys(captured).every(key => canonical[key] === captured[key]);
     }
 
     // Normalizes the plural router type to the singular DB value for filter

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -2,12 +2,12 @@
 const debug = require('@tryghost/debug')('services:url:lazy');
 const errors = require('@tryghost/errors');
 const localUtils = require('../../../shared/url-utils');
-const {matchPermalink} = require('./permalink-matcher');
+const {matchPermalink, toLookupParams} = require('./permalink-matcher');
 const {buildFilter, filterMatches, routerTypeOf} = require('./router-filter');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 import type {Resource, UrlOptions, LazyUrlServiceBackend} from './url-service-facade';
-import type {FindResource, ResourceLookupParams} from './lazy-find-resource';
+import type {FindResource} from './lazy-find-resource';
 import type {CompiledFilter} from './router-filter';
 
 interface RouterConfig {
@@ -20,46 +20,10 @@ interface RouterConfig {
 
 interface LazyUrlServiceDeps {
     urlUtils?: typeof localUtils;
-    findResource?: FindResource | null;
+    findResource: FindResource;
 }
 
 const ROUTER_TYPE_TO_DB_TYPE: Record<string, string> = {posts: 'post', pages: 'page'};
-
-// Real, unique lookup columns, in priority order. A multi-segment permalink
-// also captures derived (year/month) and relation (primary_tag) segments, but
-// only one of these columns is ever queried — the others are checked by the
-// canonical re-check below.
-const QUERYABLE_PARAMS = ['id', 'slug'] as const;
-
-// Permalink fields with a fixed, knowable format.
-const FIELD_VALIDATORS: Record<string, RegExp> = {
-    id: /^[0-9a-f]{24}$/i,
-    year: /^\d{4}$/,
-    month: /^\d{2}$/,
-    day: /^\d{2}$/
-};
-
-function capturedValuesAreValid(params: Record<string, string>): boolean {
-    for (const [field, value] of Object.entries(params)) {
-        const pattern = FIELD_VALIDATORS[field];
-        if (pattern && !pattern.test(value)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-// Narrow the full captured params down to the single column we query the DB by,
-// or null when the permalink captured no queryable column at all.
-function toLookupParams(params: Record<string, string>): ResourceLookupParams | null {
-    for (const key of QUERYABLE_PARAMS) {
-        const value = params[key];
-        if (value !== undefined) {
-            return {[key]: value} as ResourceLookupParams;
-        }
-    }
-    return null;
-}
 
 /**
  * On-demand replacement for the eager UrlService: computes URLs and ownership
@@ -69,11 +33,16 @@ function toLookupParams(params: Record<string, string>): ResourceLookupParams | 
  */
 export class LazyUrlService implements LazyUrlServiceBackend {
     private urlUtils: typeof localUtils;
-    private findResource: FindResource | null;
+    private findResource: FindResource;
     // Router configs in registration order, which is also their priority.
     private routerConfigs: RouterConfig[];
 
-    constructor({urlUtils = localUtils, findResource = null}: LazyUrlServiceDeps = {}) {
+    constructor({urlUtils = localUtils, findResource}: LazyUrlServiceDeps) {
+        if (typeof findResource !== 'function') {
+            throw new errors.IncorrectUsageError({
+                message: 'LazyUrlService requires a findResource function'
+            });
+        }
         this.urlUtils = urlUtils;
         this.findResource = findResource;
         this.routerConfigs = [];
@@ -140,9 +109,6 @@ export class LazyUrlService implements LazyUrlServiceBackend {
     }
 
     async resolveUrl(urlPath: string): Promise<Resource | null> {
-        if (!this.findResource) {
-            return null;
-        }
         // Memoize per call so routers sharing a resourceType+permalink shape (or
         // fallthrough across filters) don't repeat the same DB lookup.
         const lookupCache = new Map<string, Record<string, unknown> | null>();
@@ -151,12 +117,19 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             if (!params) {
                 continue;
             }
-            if (!capturedValuesAreValid(params)) {
-                continue;
-            }
             const lookupParams = toLookupParams(params);
             if (!lookupParams) {
-                continue;
+                // A resource permalink always carries a slug or id, so matching
+                // one without a queryable column means the router was registered
+                // with an invalid permalink — a config bug.
+                throw new errors.InternalServerError({
+                    message: 'LazyUrlService matched a permalink with no queryable lookup column',
+                    code: 'LAZY_URL_NO_LOOKUP_PARAM',
+                    errorDetails: {
+                        routerIdentifier: config.identifier,
+                        permalink: config.permalink
+                    }
+                });
             }
             const cacheKey = `${config.resourceType}:${JSON.stringify(lookupParams)}`;
             let resource: Record<string, unknown> | null;

--- a/ghost/core/core/server/services/url/permalink-matcher.ts
+++ b/ghost/core/core/server/services/url/permalink-matcher.ts
@@ -1,0 +1,67 @@
+// Placeholder names are word chars only (\w === [A-Za-z0-9_]); a literal scan
+// keeps the matcher regex-free, so no regex ever runs on a request path.
+function isWordChars(value: string): boolean {
+    if (value.length === 0) {
+        return false;
+    }
+    for (let i = 0; i < value.length; i += 1) {
+        const code = value.charCodeAt(i);
+        const isDigit = code >= 48 && code <= 57;
+        const isUpper = code >= 65 && code <= 90;
+        const isLower = code >= 97 && code <= 122;
+        const isUnderscore = code === 95;
+        if (!isDigit && !isUpper && !isLower && !isUnderscore) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Matches a permalink template (e.g. `/:slug/`) against a URL path and extracts
+ * the `:field` placeholders, or returns `null` when the path doesn't match.
+ */
+export function matchPermalink(template: string, urlPath: string): Record<string, string> | null {
+    if (typeof template !== 'string' || typeof urlPath !== 'string') {
+        return null;
+    }
+
+    const templateSegments = template.split('/');
+    const pathSegments = urlPath.split('/');
+
+    if (templateSegments.length !== pathSegments.length) {
+        return null;
+    }
+
+    // Null-prototype map so a placeholder named after an Object.prototype member
+    // (e.g. `/:__proto__/`) is captured as an own key instead of being swallowed.
+    const params: Record<string, string> = Object.create(null);
+
+    for (let i = 0; i < templateSegments.length; i += 1) {
+        const templateSegment = templateSegments[i];
+        const pathSegment = pathSegments[i];
+
+        if (!templateSegment.startsWith(':')) {
+            if (templateSegment !== pathSegment) {
+                return null;
+            }
+            continue;
+        }
+
+        const fieldName = templateSegment.slice(1);
+        if (!isWordChars(fieldName) || pathSegment.length === 0) {
+            return null;
+        }
+
+        try {
+            params[fieldName] = decodeURIComponent(pathSegment);
+        } catch {
+            return null;
+        }
+    }
+
+    return params;
+}
+
+module.exports = {matchPermalink};
+module.exports.matchPermalink = matchPermalink;

--- a/ghost/core/core/server/services/url/permalink-matcher.ts
+++ b/ghost/core/core/server/services/url/permalink-matcher.ts
@@ -2,7 +2,15 @@
 const routeMatch = require('path-match')();
 /* eslint-enable @typescript-eslint/no-require-imports */
 
-import type {ResourceLookupParams} from './lazy-find-resource';
+import type {ResourceLookupParams} from './lazy-url-service';
+
+export type PermalinkParams = ResourceLookupParams & {
+    year?: string;
+    month?: string;
+    day?: string;
+    primary_tag?: string;
+    primary_author?: string;
+};
 
 const SUPPORTED_TOKENS = new Set([
     'id',
@@ -13,8 +21,6 @@ const SUPPORTED_TOKENS = new Set([
     'primary_tag',
     'primary_author'
 ]);
-
-const QUERYABLE_PARAMS = ['id', 'slug'] as const;
 
 const FIELD_VALIDATORS: Record<string, RegExp> = {
     id: /^[0-9a-f]{24}$/i,
@@ -68,7 +74,7 @@ function valuesFitTheirFormat(params: Record<string, string>): boolean {
     return true;
 }
 
-export function matchPermalink(template: string, urlPath: string): Record<string, string> | null {
+export function matchPermalink(template: string, urlPath: string): PermalinkParams | null {
     if (!hasOnlySupportedTokens(template)) {
         return null;
     }
@@ -91,22 +97,23 @@ export function matchPermalink(template: string, urlPath: string): Record<string
         return null;
     }
 
-    return params;
+    if (params.id === undefined && params.slug === undefined) {
+        return null;
+    }
+
+    return params as PermalinkParams;
 }
 
 /**
- * Narrows the captured params down to the single column the DB is queried by,
- * or null when no queryable column is present — which, for a real resource
- * permalink, can't happen and signals an invalid permalink to the caller.
+ * Narrows a matched permalink down to the single unique column the DB is
+ * queried by. matchPermalink guarantees a queryable column is present, so this
+ * is total — there is no "no lookup column" case to handle.
  */
-export function toLookupParams(params: Record<string, string>): ResourceLookupParams | null {
-    for (const key of QUERYABLE_PARAMS) {
-        const value = params[key];
-        if (value !== undefined) {
-            return {[key]: value} as ResourceLookupParams;
-        }
+export function toLookupParams(params: PermalinkParams): ResourceLookupParams {
+    if ('id' in params) {
+        return {id: params.id};
     }
-    return null;
+    return {slug: params.slug};
 }
 
 module.exports = {matchPermalink, toLookupParams};

--- a/ghost/core/core/server/services/url/permalink-matcher.ts
+++ b/ghost/core/core/server/services/url/permalink-matcher.ts
@@ -1,63 +1,114 @@
-// Placeholder names are word chars only (\w === [A-Za-z0-9_]); a literal scan
-// keeps the matcher regex-free, so no regex ever runs on a request path.
-function isWordChars(value: string): boolean {
-    if (value.length === 0) {
-        return false;
-    }
-    for (let i = 0; i < value.length; i += 1) {
-        const code = value.charCodeAt(i);
-        const isDigit = code >= 48 && code <= 57;
-        const isUpper = code >= 65 && code <= 90;
-        const isLower = code >= 97 && code <= 122;
-        const isUnderscore = code === 95;
-        if (!isDigit && !isUpper && !isLower && !isUnderscore) {
+/* eslint-disable @typescript-eslint/no-require-imports */
+const routeMatch = require('path-match')();
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+import type {ResourceLookupParams} from './lazy-find-resource';
+
+const SUPPORTED_TOKENS = new Set([
+    'id',
+    'slug',
+    'year',
+    'month',
+    'day',
+    'primary_tag',
+    'primary_author'
+]);
+
+const QUERYABLE_PARAMS = ['id', 'slug'] as const;
+
+const FIELD_VALIDATORS: Record<string, RegExp> = {
+    id: /^[0-9a-f]{24}$/i,
+    year: /^\d{4}$/,
+    month: /^\d{2}$/,
+    day: /^\d{2}$/
+};
+
+const TOKEN = /:([A-Za-z_]\w*)/g;
+const PARAM = /:([A-Za-z_]\w*)(?:\([^)]*\))?[+*?]?/g;
+const BARE_PARAM = /:([A-Za-z_]\w*)(?![\w(])/g;
+
+function constrainHyphenatedPermalinkParams(permalink: string): string {
+    return permalink.split('/').map((segment) => {
+        if (!segment.includes('-')) {
+            return segment;
+        }
+
+        const params = [...segment.matchAll(PARAM)];
+
+        if (params.length < 2) {
+            return segment;
+        }
+
+        return segment.replace(BARE_PARAM, (match, ...args) => {
+            const offset = args[args.length - 2];
+            const index = params.findIndex(param => param.index === offset);
+            const isLastParamInSegment = index === params.length - 1;
+
+            return `${match}${isLastParamInSegment ? '([^/]+)' : '([^-/]+)'}`;
+        });
+    }).join('/');
+}
+
+function hasOnlySupportedTokens(template: string): boolean {
+    for (const [, token] of template.matchAll(TOKEN)) {
+        if (!SUPPORTED_TOKENS.has(token)) {
             return false;
         }
     }
     return true;
 }
 
-/**
- * Matches a permalink template (e.g. `/:slug/`) against a URL path and extracts
- * the `:field` placeholders, or returns `null` when the path doesn't match.
- */
-export function matchPermalink(template: string, urlPath: string): Record<string, string> | null {
-    const templateSegments = template.split('/');
-    const pathSegments = urlPath.split('/');
+function valuesFitTheirFormat(params: Record<string, string>): boolean {
+    for (const [field, value] of Object.entries(params)) {
+        const pattern = FIELD_VALIDATORS[field];
+        if (pattern && !pattern.test(value)) {
+            return false;
+        }
+    }
+    return true;
+}
 
-    if (templateSegments.length !== pathSegments.length) {
+export function matchPermalink(template: string, urlPath: string): Record<string, string> | null {
+    if (!hasOnlySupportedTokens(template)) {
         return null;
     }
 
-    // Null-prototype map so a placeholder named after an Object.prototype member
-    // (e.g. `/:__proto__/`) is captured as an own key instead of being swallowed.
-    const params: Record<string, string> = Object.create(null);
+    const match = routeMatch(constrainHyphenatedPermalinkParams(template));
 
-    for (let i = 0; i < templateSegments.length; i += 1) {
-        const templateSegment = templateSegments[i];
-        const pathSegment = pathSegments[i];
+    let params: Record<string, string> | false;
+    try {
+        params = match(urlPath);
+    } catch {
+        // path-match throws a 400 on an undecodable %-escape; treat as no match.
+        return null;
+    }
 
-        if (!templateSegment.startsWith(':')) {
-            if (templateSegment !== pathSegment) {
-                return null;
-            }
-            continue;
-        }
+    if (params === false) {
+        return null;
+    }
 
-        const fieldName = templateSegment.slice(1);
-        if (!isWordChars(fieldName) || pathSegment.length === 0) {
-            return null;
-        }
-
-        try {
-            params[fieldName] = decodeURIComponent(pathSegment);
-        } catch {
-            return null;
-        }
+    if (!valuesFitTheirFormat(params)) {
+        return null;
     }
 
     return params;
 }
 
-module.exports = {matchPermalink};
+/**
+ * Narrows the captured params down to the single column the DB is queried by,
+ * or null when no queryable column is present — which, for a real resource
+ * permalink, can't happen and signals an invalid permalink to the caller.
+ */
+export function toLookupParams(params: Record<string, string>): ResourceLookupParams | null {
+    for (const key of QUERYABLE_PARAMS) {
+        const value = params[key];
+        if (value !== undefined) {
+            return {[key]: value} as ResourceLookupParams;
+        }
+    }
+    return null;
+}
+
+module.exports = {matchPermalink, toLookupParams};
 module.exports.matchPermalink = matchPermalink;
+module.exports.toLookupParams = toLookupParams;

--- a/ghost/core/core/server/services/url/permalink-matcher.ts
+++ b/ghost/core/core/server/services/url/permalink-matcher.ts
@@ -22,10 +22,6 @@ function isWordChars(value: string): boolean {
  * the `:field` placeholders, or returns `null` when the path doesn't match.
  */
 export function matchPermalink(template: string, urlPath: string): Record<string, string> | null {
-    if (typeof template !== 'string' || typeof urlPath !== 'string') {
-        return null;
-    }
-
     const templateSegments = template.split('/');
     const pathSegments = urlPath.split('/');
 

--- a/ghost/core/core/server/services/url/router-filter.ts
+++ b/ghost/core/core/server/services/url/router-filter.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const nql = require('@tryghost/nql');
+const debug = require('@tryghost/debug')('services:url:router-filter');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+// A deliberate copy of the eager UrlGenerator's NQL semantics: while both
+// services run side by side, eager is the parity oracle and must stay separate.
+export const EXPANSIONS = [
+    {key: 'author', replacement: 'authors.slug'},
+    {key: 'tags', replacement: 'tags.slug'},
+    {key: 'tag', replacement: 'tags.slug'},
+    {key: 'authors', replacement: 'authors.slug'},
+    {key: 'primary_tag', replacement: 'primary_tag.slug'},
+    {key: 'primary_author', replacement: 'primary_author.slug'}
+];
+
+const PAGE_TRANSFORMER = nql.utils.mapKeyValues({
+    key: {from: 'page', to: 'type'},
+    values: [
+        {from: false, to: 'post'},
+        {from: true, to: 'page'}
+    ]
+});
+
+// Accepts both singular DB types ('post') and plural router keys ('posts').
+const TYPE_TO_ROUTER_TYPE: Record<string, string> = {
+    post: 'posts',
+    posts: 'posts',
+    page: 'pages',
+    pages: 'pages',
+    tag: 'tags',
+    tags: 'tags',
+    author: 'authors',
+    authors: 'authors'
+};
+
+export interface CompiledFilter {
+    queryJSON(record: Record<string, unknown>): unknown;
+}
+
+export function routerTypeOf(resource: {type?: string} | null | undefined): string | null {
+    if (!resource || !resource.type) {
+        return null;
+    }
+    return TYPE_TO_ROUTER_TYPE[resource.type] || null;
+}
+
+export function buildFilter(filter: string | null | undefined): CompiledFilter | null {
+    if (!filter) {
+        return null;
+    }
+    return nql(filter, {expansions: EXPANSIONS, transformer: PAGE_TRANSFORMER});
+}
+
+// A null filter always matches; a filter that throws is a non-match, not an
+// error, mirroring the eager generator's try/catch.
+export function filterMatches(compiledFilter: CompiledFilter | null, record: Record<string, unknown>): boolean {
+    if (!compiledFilter) {
+        return true;
+    }
+    try {
+        return !!compiledFilter.queryJSON(record);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        debug('NQL match failed', message);
+        return false;
+    }
+}
+
+module.exports = {EXPANSIONS, routerTypeOf, buildFilter, filterMatches};
+module.exports.EXPANSIONS = EXPANSIONS;
+module.exports.routerTypeOf = routerTypeOf;
+module.exports.buildFilter = buildFilter;
+module.exports.filterMatches = filterMatches;

--- a/ghost/core/core/server/services/url/router-filter.ts
+++ b/ghost/core/core/server/services/url/router-filter.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const nql = require('@tryghost/nql');
-const debug = require('@tryghost/debug')('services:url:router-filter');
+const logging = require('@tryghost/logging');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 // A deliberate copy of the eager UrlGenerator's NQL semantics: while both
@@ -62,7 +62,7 @@ export function filterMatches(compiledFilter: CompiledFilter | null, record: Rec
         return !!compiledFilter.queryJSON(record);
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        debug('NQL match failed', message);
+        logging.warn('NQL match failed', message);
         return false;
     }
 }

--- a/ghost/core/test/integration/url-service-parity.test.js
+++ b/ghost/core/test/integration/url-service-parity.test.js
@@ -1,0 +1,269 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const testUtils = require('../utils');
+const models = require('../../core/server/models');
+const db = require('../../core/server/data/db');
+const UrlService = require('../../core/server/services/url/url-service');
+const LazyUrlService = require('../../core/server/services/url/lazy-url-service');
+const {createFindResource} = require('../../core/server/services/url/lazy-find-resource');
+
+const RESOURCE_TYPES = ['posts', 'pages', 'tags', 'authors'];
+
+// Routing sets registered identically on both services. Slug-backed permalinks
+// only, since that is Ghost's default shape and the one resolveUrl queries by.
+const SCENARIOS = [
+    {
+        name: 'default routing set',
+        routes: [
+            {identifier: 'posts-router', filter: 'featured:false', resourceType: 'posts', permalink: '/:slug/'},
+            {identifier: 'authors-router', filter: null, resourceType: 'authors', permalink: '/author/:slug/'},
+            {identifier: 'tags-router', filter: null, resourceType: 'tags', permalink: '/tag/:slug/'},
+            {identifier: 'pages-router', filter: null, resourceType: 'pages', permalink: '/:slug/'}
+        ]
+    },
+    {
+        name: 'featured collection with priority fallthrough',
+        routes: [
+            {identifier: 'featured-router', filter: 'featured:true', resourceType: 'posts', permalink: '/featured/:slug/'},
+            {identifier: 'posts-router', filter: null, resourceType: 'posts', permalink: '/:slug/'},
+            {identifier: 'tags-router', filter: null, resourceType: 'tags', permalink: '/tag/:slug/'},
+            {identifier: 'authors-router', filter: null, resourceType: 'authors', permalink: '/author/:slug/'}
+        ]
+    },
+    {
+        name: 'date-based post permalinks',
+        routes: [
+            {identifier: 'posts-router', filter: null, resourceType: 'posts', permalink: '/:year/:month/:slug/'},
+            {identifier: 'tags-router', filter: null, resourceType: 'tags', permalink: '/tag/:slug/'},
+            {identifier: 'authors-router', filter: null, resourceType: 'authors', permalink: '/author/:slug/'}
+        ]
+    }
+];
+
+function waitUntilFinished(urlService, timeout = 5000) {
+    return new Promise((resolve, reject) => {
+        const start = Date.now();
+        (function retry() {
+            if (urlService.hasFinished()) {
+                return resolve();
+            }
+            if (Date.now() - start > timeout) {
+                return reject(new Error('Eager UrlService did not finish in time'));
+            }
+            setTimeout(retry, 50);
+        })();
+    });
+}
+
+describe('Integration: eager/lazy URL service parity', function () {
+    let zeroPostTag;
+
+    before(testUtils.teardownDb);
+    before(testUtils.setup('users:roles', 'posts'));
+    before(async function () {
+        // An explicit public tag with no posts, so the zero-post gating case is
+        // deterministic instead of depending on fixture composition.
+        zeroPostTag = await models.Tag.add(
+            {name: 'Parity Orphan Tag', slug: 'parity-orphan-tag'},
+            {context: {internal: true}}
+        );
+    });
+    after(testUtils.teardownDb);
+
+    after(function () {
+        sinon.restore();
+    });
+
+    SCENARIOS.forEach(function (scenario) {
+        describe(scenario.name, function () {
+            let eager;
+            let lazy;
+
+            before(async function () {
+                eager = new UrlService();
+                scenario.routes.forEach(r => eager.onRouterAddedType(r.identifier, r.filter, r.resourceType, r.permalink));
+                eager.init();
+                await waitUntilFinished(eager);
+
+                lazy = new LazyUrlService({findResource: createFindResource(models)});
+                scenario.routes.forEach(r => lazy.onRouterAddedType(r.identifier, r.filter, r.resourceType, r.permalink));
+            });
+
+            after(function () {
+                eager.reset();
+            });
+
+            function cachedResourcesByType() {
+                return RESOURCE_TYPES.map(type => ({
+                    type,
+                    resources: eager.resources.getAllByType(type) || []
+                }));
+            }
+
+            function allGeneratedUrls() {
+                const urls = [];
+                eager.urlGenerators.forEach((generator) => {
+                    generator.getUrls().forEach((entry) => {
+                        urls.push({url: entry.url, id: entry.resource.data.id});
+                    });
+                });
+                return urls;
+            }
+
+            it('loaded a non-trivial fixture set so the comparison is not vacuous', function () {
+                const total = cachedResourcesByType().reduce((sum, group) => sum + group.resources.length, 0);
+                assert.ok(total > 0, 'expected the eager service to cache at least one resource');
+                assert.ok(allGeneratedUrls().length > 0, 'expected the eager service to generate at least one url');
+            });
+
+            it('forward lookup returns the same relative URL for every cached resource', function () {
+                for (const {type, resources} of cachedResourcesByType()) {
+                    for (const resource of resources) {
+                        const id = resource.data.id;
+                        const lazyResource = Object.assign({}, resource.data, {type});
+
+                        assert.equal(
+                            lazy.getUrlForResource(lazyResource),
+                            eager.getUrlByResourceId(id),
+                            `relative URL mismatch for ${type} ${id}`
+                        );
+                    }
+                }
+            });
+
+            it('forward lookup returns the same absolute URL for every cached resource', function () {
+                for (const {type, resources} of cachedResourcesByType()) {
+                    for (const resource of resources) {
+                        const id = resource.data.id;
+                        const lazyResource = Object.assign({}, resource.data, {type});
+
+                        assert.equal(
+                            lazy.getUrlForResource(lazyResource, {absolute: true}),
+                            eager.getUrlByResourceId(id, {absolute: true}),
+                            `absolute URL mismatch for ${type} ${id}`
+                        );
+                    }
+                }
+            });
+
+            it('agrees with the eager service on which router owns each resource', function () {
+                for (const {type, resources} of cachedResourcesByType()) {
+                    for (const resource of resources) {
+                        const id = resource.data.id;
+                        const lazyResource = Object.assign({}, resource.data, {type});
+
+                        for (const route of scenario.routes) {
+                            assert.equal(
+                                lazy.ownsResource(route.identifier, lazyResource),
+                                eager.owns(route.identifier, id),
+                                `ownership mismatch for router ${route.identifier} and ${type} ${id}`
+                            );
+                        }
+                    }
+                }
+            });
+
+            it('reverse lookup resolves every eager-generated URL to the same resource', async function () {
+                for (const {url, id} of allGeneratedUrls()) {
+                    const eagerEnvelope = eager.getResource(url);
+                    const resolved = await lazy.resolveUrl(url);
+
+                    assert.ok(resolved, `lazy resolveUrl returned null for ${url}`);
+                    assert.equal(resolved.id, id, `resolved id mismatch for ${url}`);
+                    assert.equal(resolved.type, eagerEnvelope.config.type, `resolved type mismatch for ${url}`);
+                }
+            });
+
+            it('reverse lookup returns the same record shape as the eager service', async function () {
+                for (const {url} of allGeneratedUrls()) {
+                    const eagerEnvelope = eager.getResource(url);
+                    const eagerFlat = Object.assign({}, eagerEnvelope.data, {type: eagerEnvelope.config.type});
+                    const resolved = await lazy.resolveUrl(url);
+
+                    // Exact field-set parity guards against lazy leaking fields the
+                    // eager backend strips (e.g. title/html/mobiledoc on posts,
+                    // email on authors), which would change downstream behaviour.
+                    assert.deepEqual(
+                        Object.keys(resolved).sort(),
+                        Object.keys(eagerFlat).sort(),
+                        `field-set mismatch for ${url}`
+                    );
+
+                    assert.equal(resolved.slug, eagerFlat.slug, `slug mismatch for ${url}`);
+                    if ('name' in eagerFlat) {
+                        assert.equal(resolved.name, eagerFlat.name, `name mismatch for ${url}`);
+                    }
+                    assert.ok(!('title' in resolved), `lazy leaked title for ${url}`);
+
+                    // Relations stay trimmed to {id, slug} like eager's withRelatedFields.
+                    for (const key of ['tags', 'authors']) {
+                        if (Array.isArray(resolved[key])) {
+                            resolved[key].forEach((relation) => {
+                                assert.deepEqual(
+                                    Object.keys(relation).sort(),
+                                    ['id', 'slug'],
+                                    `${key} relation not trimmed for ${url}`
+                                );
+                            });
+                        }
+                    }
+                }
+            });
+
+            it('reverse lookup returns null for an unknown URL, like the eager service', async function () {
+                assert.equal(eager.getResource('/this-does-not-exist/'), null);
+                assert.equal(await lazy.resolveUrl('/this-does-not-exist/'), null);
+            });
+
+            it('does not resolve public tags/authors with no posts, like the eager service', async function () {
+                // Eager only caches tags/authors that pass shouldHavePosts; a
+                // public resource with no posts is therefore never cached and 404s.
+                // Lazy must hide it too or it exposes non-public URLs.
+                const tagsRouter = scenario.routes.find(r => r.resourceType === 'tags');
+
+                // Deterministic case: our explicitly-created public, zero-post tag.
+                const postCount = await db.knex('posts_tags').where('tag_id', zeroPostTag.id).count({c: '*'});
+                assert.equal(zeroPostTag.get('visibility'), 'public');
+                assert.equal(Number(postCount[0].c), 0, 'expected the orphan tag to have no posts');
+
+                const tagUrl = tagsRouter.permalink.replace(':slug', zeroPostTag.get('slug'));
+                assert.equal(eager.getResource(tagUrl), null, `eager resolved zero-post tag ${tagUrl}`);
+                assert.equal(await lazy.resolveUrl(tagUrl), null, `lazy resolved zero-post tag ${tagUrl}`);
+
+                // Best-effort: any fixture author with no posts must also 404 in both.
+                const authorsRouter = scenario.routes.find(r => r.resourceType === 'authors');
+                if (authorsRouter) {
+                    const cachedIds = new Set((eager.resources.getAllByType('authors') || []).map(r => r.data.id));
+                    const publicUsers = await db.knex('users').where('visibility', 'public').select('id', 'slug');
+                    const orphan = publicUsers.find(row => !cachedIds.has(row.id));
+                    if (orphan) {
+                        const url = authorsRouter.permalink.replace(':slug', orphan.slug);
+                        assert.equal(eager.getResource(url), null, `eager resolved zero-post author ${url}`);
+                        assert.equal(await lazy.resolveUrl(url), null, `lazy resolved zero-post author ${url}`);
+                    }
+                }
+            });
+
+            if (scenario.routes.some(r => r.permalink.includes(':year'))) {
+                it('agrees with the eager service that a non-canonical (wrong-date) URL 404s', async function () {
+                    let checked = 0;
+                    for (const {url} of allGeneratedUrls()) {
+                        const yearMatch = url.match(/^\/(\d{4})\//);
+                        if (!yearMatch) {
+                            continue;
+                        }
+                        // Swap the year for one the post wasn't published in: a
+                        // valid permalink shape that is not this post's canonical
+                        // URL, so both services must reject it.
+                        const variant = url.replace(/^\/\d{4}\//, `/${Number(yearMatch[1]) - 1}/`);
+
+                        assert.equal(eager.getResource(variant), null, `eager resolved non-canonical ${variant}`);
+                        assert.equal(await lazy.resolveUrl(variant), null, `lazy resolved non-canonical ${variant}`);
+                        checked += 1;
+                    }
+                    assert.ok(checked > 0, 'expected at least one date-based URL to mutate');
+                });
+            }
+        });
+    });
+});

--- a/ghost/core/test/integration/url-service-parity.test.js
+++ b/ghost/core/test/integration/url-service-parity.test.js
@@ -37,6 +37,14 @@ const SCENARIOS = [
             {identifier: 'tags-router', filter: null, resourceType: 'tags', permalink: '/tag/:slug/'},
             {identifier: 'authors-router', filter: null, resourceType: 'authors', permalink: '/author/:slug/'}
         ]
+    },
+    {
+        name: 'hyphen-separated date post permalinks',
+        routes: [
+            {identifier: 'posts-router', filter: null, resourceType: 'posts', permalink: '/:year-:month-:day-:slug/'},
+            {identifier: 'tags-router', filter: null, resourceType: 'tags', permalink: '/tag/:slug/'},
+            {identifier: 'authors-router', filter: null, resourceType: 'authors', permalink: '/author/:slug/'}
+        ]
     }
 ];
 
@@ -248,14 +256,20 @@ describe('Integration: eager/lazy URL service parity', function () {
                 it('agrees with the eager service that a non-canonical (wrong-date) URL 404s', async function () {
                     let checked = 0;
                     for (const {url} of allGeneratedUrls()) {
-                        const yearMatch = url.match(/^\/(\d{4})\//);
+                        // Swap the year for one the post wasn't published in, in
+                        // either the slash (/YYYY/...) or hyphen (/YYYY-MM-DD-...)
+                        // date shape: a valid permalink that isn't this post's
+                        // canonical URL, so both services must reject it.
+                        const slashMatch = url.match(/^\/(\d{4})\//);
+                        const hyphenMatch = url.match(/^\/(\d{4})-/);
+                        const yearMatch = slashMatch || hyphenMatch;
                         if (!yearMatch) {
                             continue;
                         }
-                        // Swap the year for one the post wasn't published in: a
-                        // valid permalink shape that is not this post's canonical
-                        // URL, so both services must reject it.
-                        const variant = url.replace(/^\/\d{4}\//, `/${Number(yearMatch[1]) - 1}/`);
+                        const wrongYear = Number(yearMatch[1]) - 1;
+                        const variant = slashMatch
+                            ? url.replace(/^\/\d{4}\//, `/${wrongYear}/`)
+                            : url.replace(/^\/\d{4}-/, `/${wrongYear}-`);
 
                         assert.equal(eager.getResource(variant), null, `eager resolved non-canonical ${variant}`);
                         assert.equal(await lazy.resolveUrl(variant), null, `lazy resolved non-canonical ${variant}`);

--- a/ghost/core/test/unit/server/services/url/lazy-find-resource.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-find-resource.test.js
@@ -1,13 +1,6 @@
-// Preserved as a parity spec for the LazyFindResource re-implementation (HKG-1817).
-// The implementation module was removed in the experimental revert (HKG-1816);
-// the suite is kept skipped (not deleted) so the behaviour contract stays visible
-// in-tree. `createFindResource` is stubbed to null because the module no longer
-// exists. To revive: restore the require, drop the eslint-disable, and switch
-// describe.skip back to describe.
-/* eslint-disable ghost/mocha/no-skipped-tests */
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const createFindResource = null; // ({createFindResource} = require('../../../../../core/server/services/url/lazy-find-resource'));
+const {createFindResource} = require('../../../../../core/server/services/url/lazy-find-resource');
 
 function fakeModel() {
     return {findOne: sinon.stub()};
@@ -17,7 +10,7 @@ function record(attrs) {
     return {toJSON: () => attrs};
 }
 
-describe.skip('createFindResource', function () {
+describe('createFindResource', function () {
     let models;
     let findResource;
 
@@ -26,97 +19,260 @@ describe.skip('createFindResource', function () {
         findResource = createFindResource(models);
     });
 
-    it('queries Post with type:post and status:published for posts', async function () {
-        models.Post.findOne.resolves(record({id: 'p1', slug: 'hello'}));
+    describe('posts', function () {
+        it('queries Post scoped to type:post and status:published', async function () {
+            models.Post.findOne.resolves(record({id: 'p1', slug: 'hello'}));
 
-        await findResource('posts', {slug: 'hello'});
+            await findResource('posts', {slug: 'hello'});
 
-        sinon.assert.calledWith(
-            models.Post.findOne,
-            sinon.match({slug: 'hello', type: 'post', status: 'published'}),
-            sinon.match.has('require', false)
-        );
+            sinon.assert.calledWith(
+                models.Post.findOne,
+                sinon.match({slug: 'hello', type: 'post', status: 'published'}),
+                sinon.match.has('require', false)
+            );
+        });
+
+        it('loads the tags and authors relations', async function () {
+            models.Post.findOne.resolves(record({id: 'p1'}));
+
+            await findResource('posts', {slug: 'hello'});
+
+            sinon.assert.calledWith(
+                models.Post.findOne,
+                sinon.match.any,
+                sinon.match({withRelated: ['tags', 'authors']})
+            );
+        });
+
+        it('derives primary_author from the first author', async function () {
+            models.Post.findOne.resolves(record({
+                id: 'p1',
+                slug: 'hello',
+                authors: [{slug: 'jane'}, {slug: 'bob'}]
+            }));
+
+            const result = await findResource('posts', {slug: 'hello'});
+
+            assert.deepEqual(result.primary_author, {slug: 'jane'});
+        });
+
+        it('strips fields the eager service excludes (body, status, posts_meta)', async function () {
+            models.Post.findOne.resolves(record({
+                id: 'p1',
+                slug: 'hello',
+                title: 'Hello',
+                html: '<p>x</p>',
+                mobiledoc: '{}',
+                lexical: '{}',
+                plaintext: 'x',
+                status: 'published',
+                comment_id: 'c1',
+                posts_meta: {meta_title: 'm'},
+                featured: false,
+                visibility: 'public'
+            }));
+
+            const result = await findResource('posts', {slug: 'hello'});
+
+            for (const key of ['title', 'html', 'mobiledoc', 'lexical', 'plaintext', 'status', 'comment_id', 'posts_meta']) {
+                assert.equal(key in result, false, `${key} should be stripped`);
+            }
+            assert.equal(result.featured, false);
+            assert.equal(result.visibility, 'public');
+        });
+
+        it('trims tags and authors relations to {id, slug}', async function () {
+            models.Post.findOne.resolves(record({
+                id: 'p1',
+                slug: 'hello',
+                tags: [{id: 't1', slug: 'news', name: 'News', description: 'd'}],
+                authors: [{id: 'a1', slug: 'jane', name: 'Jane', email: 'jane@x.com'}]
+            }));
+
+            const result = await findResource('posts', {slug: 'hello'});
+
+            assert.deepEqual(result.tags, [{id: 't1', slug: 'news'}]);
+            assert.deepEqual(result.authors, [{id: 'a1', slug: 'jane'}]);
+        });
+
+        it('trims the derived primary_author and primary_tag to {id, slug}', async function () {
+            models.Post.findOne.resolves(record({
+                id: 'p1',
+                slug: 'hello',
+                authors: [{id: 'a1', slug: 'jane', name: 'Jane', email: 'jane@x.com'}, {id: 'a2', slug: 'bob'}],
+                primary_tag: {id: 't1', slug: 'news', name: 'News', description: 'd'}
+            }));
+
+            const result = await findResource('posts', {slug: 'hello'});
+
+            assert.deepEqual(result.primary_author, {id: 'a1', slug: 'jane'});
+            assert.deepEqual(result.primary_tag, {id: 't1', slug: 'news'});
+        });
+
+        it('sets primary_author to null when the authors relation is empty', async function () {
+            models.Post.findOne.resolves(record({id: 'p1', slug: 'hello', authors: []}));
+
+            const result = await findResource('posts', {slug: 'hello'});
+
+            assert.equal(result.primary_author, null);
+        });
+
+        it('leaves primary_author untouched when authors are not loaded', async function () {
+            models.Post.findOne.resolves(record({id: 'p1', slug: 'hello'}));
+
+            const result = await findResource('posts', {slug: 'hello'});
+
+            assert.equal('primary_author' in result, false);
+        });
     });
 
-    it('queries Post with type:page and status:published for pages', async function () {
-        models.Post.findOne.resolves(record({id: 'pg1', slug: 'about'}));
+    describe('pages', function () {
+        it('queries Post scoped to type:page and status:published', async function () {
+            models.Post.findOne.resolves(record({id: 'pg1', slug: 'about'}));
 
-        await findResource('pages', {slug: 'about'});
+            await findResource('pages', {slug: 'about'});
 
-        sinon.assert.calledWith(
-            models.Post.findOne,
-            sinon.match({slug: 'about', type: 'page', status: 'published'}),
-            sinon.match.has('require', false)
-        );
+            sinon.assert.calledWith(
+                models.Post.findOne,
+                sinon.match({slug: 'about', type: 'page', status: 'published'}),
+                sinon.match.has('require', false)
+            );
+        });
+
+        it('does not load relations for pages', async function () {
+            models.Post.findOne.resolves(record({id: 'pg1'}));
+
+            await findResource('pages', {slug: 'about'});
+
+            const options = models.Post.findOne.firstCall.args[1];
+            assert.equal(options.withRelated, undefined);
+        });
+
+        it('exposes primary_tag/primary_author as null and strips relations and body', async function () {
+            models.Post.findOne.resolves(record({
+                id: 'pg1',
+                slug: 'about',
+                title: 'About',
+                html: '<p>x</p>',
+                tags: [{id: 't1', slug: 'news'}],
+                authors: [{id: 'a1', slug: 'jane'}]
+            }));
+
+            const result = await findResource('pages', {slug: 'about'});
+
+            assert.equal(result.primary_tag, null);
+            assert.equal(result.primary_author, null);
+            assert.equal('tags' in result, false);
+            assert.equal('authors' in result, false);
+            assert.equal('title' in result, false);
+            assert.equal('html' in result, false);
+        });
     });
 
-    it('asks Post.findOne to load the tags and authors relations on posts', async function () {
-        // Locks the contract that exposed HKG-1738: tag/author NQL filters
-        // (e.g. routes.yaml `filter: tag:news`) evaluate against
-        // `tags.slug` / `authors.slug` on the loaded record. Without
-        // withRelated the record has no `.tags` / `.authors`, every
-        // tag-filtered route silently 404s.
-        models.Post.findOne.resolves(record({id: 'p1'}));
+    describe('tags and authors', function () {
+        it('queries TagPublic with visibility:public for tags', async function () {
+            models.TagPublic.findOne.resolves(record({id: 't1', slug: 'news'}));
 
-        await findResource('posts', {slug: 'hello'});
+            await findResource('tags', {slug: 'news'});
 
-        sinon.assert.calledWith(
-            models.Post.findOne,
-            sinon.match.any,
-            sinon.match({withRelated: sinon.match.array.contains(['tags', 'authors'])})
-        );
+            sinon.assert.calledWith(
+                models.TagPublic.findOne,
+                sinon.match({slug: 'news', visibility: 'public'}),
+                sinon.match.has('require', false)
+            );
+        });
+
+        it('strips description and meta fields from a tag', async function () {
+            models.TagPublic.findOne.resolves(record({
+                id: 't1',
+                slug: 'news',
+                name: 'News',
+                description: 'd',
+                meta_title: 'm',
+                meta_description: 'md'
+            }));
+
+            const result = await findResource('tags', {slug: 'news'});
+
+            assert.equal('description' in result, false);
+            assert.equal('meta_title' in result, false);
+            assert.equal('meta_description' in result, false);
+            assert.equal(result.name, 'News');
+            assert.equal(result.slug, 'news');
+        });
+
+        it('queries Author with visibility:public for authors', async function () {
+            models.Author.findOne.resolves(record({id: 'a1', slug: 'jane'}));
+
+            await findResource('authors', {slug: 'jane'});
+
+            sinon.assert.calledWith(
+                models.Author.findOne,
+                sinon.match({slug: 'jane', visibility: 'public'}),
+                sinon.match.has('require', false)
+            );
+        });
+
+        it('strips bio and contact fields from an author', async function () {
+            models.Author.findOne.resolves(record({
+                id: 'a1',
+                slug: 'jane',
+                name: 'Jane',
+                bio: 'b',
+                website: 'w',
+                twitter: 't',
+                last_seen: 'x'
+            }));
+
+            const result = await findResource('authors', {slug: 'jane'});
+
+            assert.equal('bio' in result, false);
+            assert.equal('website' in result, false);
+            assert.equal('twitter' in result, false);
+            assert.equal('last_seen' in result, false);
+            assert.equal(result.name, 'Jane');
+        });
     });
 
-    it('asks Post.findOne to load tags and authors on pages too', async function () {
-        models.Post.findOne.resolves(record({id: 'pg1'}));
+    describe('misses and unknown types', function () {
+        it('returns the pruned record on a hit and null on a miss', async function () {
+            models.Post.findOne.onFirstCall().resolves(record({id: 'p1', slug: 'hello'}));
+            models.Post.findOne.onSecondCall().resolves(null);
 
-        await findResource('pages', {slug: 'about'});
+            assert.deepEqual(await findResource('posts', {slug: 'hello'}), {id: 'p1', slug: 'hello'});
+            assert.equal(await findResource('posts', {slug: 'missing'}), null);
+        });
 
-        sinon.assert.calledWith(
-            models.Post.findOne,
-            sinon.match.any,
-            sinon.match({withRelated: sinon.match.array.contains(['tags', 'authors'])})
-        );
-    });
+        it('returns null for an unknown router type without touching any model', async function () {
+            const result = await findResource('widgets', {slug: 'anything'});
 
-    it('queries TagPublic with visibility:public for tags', async function () {
-        models.TagPublic.findOne.resolves(record({id: 't1', slug: 'news'}));
+            assert.equal(result, null);
+            sinon.assert.notCalled(models.Post.findOne);
+            sinon.assert.notCalled(models.TagPublic.findOne);
+            sinon.assert.notCalled(models.Author.findOne);
+        });
 
-        await findResource('tags', {slug: 'news'});
+        it('queries only by column params, dropping derived/relation permalink segments', async function () {
+            models.Post.findOne.resolves(record({id: 'p1', slug: 'hello'}));
 
-        sinon.assert.calledWith(
-            models.TagPublic.findOne,
-            sinon.match({slug: 'news', visibility: 'public'}),
-            sinon.match.any
-        );
-    });
+            await findResource('posts', {year: '2026', month: '04', primary_tag: 'podcast', slug: 'hello'});
 
-    it('queries Author with visibility:public for authors', async function () {
-        models.Author.findOne.resolves(record({id: 'a1', slug: 'jane'}));
+            sinon.assert.calledWith(
+                models.Post.findOne,
+                sinon.match({slug: 'hello', type: 'post', status: 'published'}),
+                sinon.match.any
+            );
+            const query = models.Post.findOne.firstCall.args[0];
+            assert.equal('year' in query, false);
+            assert.equal('month' in query, false);
+            assert.equal('primary_tag' in query, false);
+        });
 
-        await findResource('authors', {slug: 'jane'});
+        it('returns null without querying when no column param was captured', async function () {
+            const result = await findResource('posts', {year: '2026', month: '04'});
 
-        sinon.assert.calledWith(
-            models.Author.findOne,
-            sinon.match({slug: 'jane', visibility: 'public'}),
-            sinon.match.any
-        );
-    });
-
-    it('returns the toJSON result on hit, null on miss', async function () {
-        models.Post.findOne.onFirstCall().resolves(record({id: 'p1', slug: 'hello'}));
-        models.Post.findOne.onSecondCall().resolves(null);
-
-        assert.deepEqual(await findResource('posts', {slug: 'hello'}), {id: 'p1', slug: 'hello'});
-        assert.equal(await findResource('posts', {slug: 'missing'}), null);
-    });
-
-    it('returns null for unknown router types without touching any model', async function () {
-        const result = await findResource('unknown', {slug: 'anything'});
-
-        assert.equal(result, null);
-        sinon.assert.notCalled(models.Post.findOne);
-        sinon.assert.notCalled(models.TagPublic.findOne);
-        sinon.assert.notCalled(models.Author.findOne);
+            assert.equal(result, null);
+            sinon.assert.notCalled(models.Post.findOne);
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/url/lazy-find-resource.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-find-resource.test.js
@@ -251,28 +251,5 @@ describe('createFindResource', function () {
             sinon.assert.notCalled(models.TagPublic.findOne);
             sinon.assert.notCalled(models.Author.findOne);
         });
-
-        it('queries only by column params, dropping derived/relation permalink segments', async function () {
-            models.Post.findOne.resolves(record({id: 'p1', slug: 'hello'}));
-
-            await findResource('posts', {year: '2026', month: '04', primary_tag: 'podcast', slug: 'hello'});
-
-            sinon.assert.calledWith(
-                models.Post.findOne,
-                sinon.match({slug: 'hello', type: 'post', status: 'published'}),
-                sinon.match.any
-            );
-            const query = models.Post.findOne.firstCall.args[0];
-            assert.equal('year' in query, false);
-            assert.equal('month' in query, false);
-            assert.equal('primary_tag' in query, false);
-        });
-
-        it('returns null without querying when no column param was captured', async function () {
-            const result = await findResource('posts', {year: '2026', month: '04'});
-
-            assert.equal(result, null);
-            sinon.assert.notCalled(models.Post.findOne);
-        });
     });
 });

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -1,13 +1,6 @@
-// Preserved as a parity spec for the LazyUrlService re-implementation (HKG-1817).
-// The implementation module was removed in the experimental revert (HKG-1816);
-// the suite is kept skipped (not deleted) so the behaviour contract stays visible
-// in-tree. `LazyUrlService` is stubbed to null because the module no longer
-// exists. To revive: restore the require, drop the eslint-disable, and switch
-// describe.skip back to describe.
-/* eslint-disable ghost/mocha/no-skipped-tests */
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const LazyUrlService = null; // require('../../../../../core/server/services/url/lazy-url-service');
+const LazyUrlService = require('../../../../../core/server/services/url/lazy-url-service');
 
 function makeUrlUtils() {
     // Just enough of url-utils to satisfy the service. createUrl returns the
@@ -40,7 +33,7 @@ function makeUrlUtils() {
     };
 }
 
-describe.skip('LazyUrlService', function () {
+describe('LazyUrlService', function () {
     let urlUtils;
 
     beforeEach(function () {
@@ -188,6 +181,22 @@ describe.skip('LazyUrlService', function () {
             assert.equal(service.ownsResource('featured', {type: 'posts', id: 'a', featured: true}), true);
             assert.equal(service.ownsResource('featured', {type: 'posts', id: 'b', featured: false}), false);
         });
+
+        it('grants exclusive ownership to the first matching router', function () {
+            // A featured collection ahead of a catch-all: the catch-all must
+            // not claim a featured post the higher-priority router owns.
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            const featured = {type: 'posts', id: 'f', slug: 'hot', featured: true};
+            assert.equal(service.ownsResource('featured', featured), true);
+            assert.equal(service.ownsResource('default', featured), false);
+
+            const ordinary = {type: 'posts', id: 'p', slug: 'meh', featured: false};
+            assert.equal(service.ownsResource('featured', ordinary), false);
+            assert.equal(service.ownsResource('default', ordinary), true);
+        });
     });
 
     describe('hasFinished', function () {
@@ -259,6 +268,37 @@ describe.skip('LazyUrlService', function () {
             assert.equal(hot.id, 'p3');
         });
 
+        it('evaluates a page:false router against the normalized record shape', async function () {
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello', type: 'post'});
+            findResource.withArgs('posts', {slug: 'a-page'}).resolves({id: 'pg1', slug: 'a-page', type: 'page'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('posts-only', 'page:false', 'posts', '/:slug/');
+
+            // page:false compiles to type:post, so a post resolves but a record
+            // the DB returns as a page is filtered out, matching the forward path.
+            const post = await service.resolveUrl('/hello/');
+            assert.equal(post.id, 'p1');
+            assert.equal(await service.resolveUrl('/a-page/'), null);
+        });
+
+        it('does not repeat an identical findResource lookup within one resolveUrl call', async function () {
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello', featured: false});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            // Two same-type routers share the /:slug/ shape: the higher-priority
+            // one filters the record out, so resolution falls through to the next.
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/:slug/');
+            service.onRouterAddedType('posts', 'featured:false', 'posts', '/:slug/');
+
+            const result = await service.resolveUrl('/hello/');
+
+            assert.equal(result.id, 'p1');
+            sinon.assert.calledOnce(findResource);
+        });
+
         // The next two tests pin the contract for findResource: tag/author
         // filters expand to `tags.slug` / `authors.slug` lookups via
         // EXPANSIONS, and NQL evaluates them against the loaded record. If
@@ -316,7 +356,7 @@ describe.skip('LazyUrlService', function () {
             // pass `primary_tag`) fails on the resolve, not just on the spy.
             findResource
                 .withArgs('posts', {primary_tag: 'podcast', slug: 'hello'})
-                .resolves({id: 'p1', slug: 'hello'});
+                .resolves({id: 'p1', slug: 'hello', primary_tag: {slug: 'podcast'}});
 
             const service = new LazyUrlService({urlUtils, findResource});
             service.onRouterAddedType('default', null, 'posts', '/:primary_tag/:slug/');
@@ -326,17 +366,45 @@ describe.skip('LazyUrlService', function () {
             assert.equal(result.type, 'posts');
         });
 
-        it('matches date-based permalinks', async function () {
+        it('returns null when the primary_tag segment is not the record canonical tag', async function () {
+            const findResource = sinon.stub();
+            findResource
+                .withArgs('posts', {primary_tag: 'news', slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello', primary_tag: {slug: 'podcast'}});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:primary_tag/:slug/');
+
+            // The post's canonical URL is /podcast/hello/, so /news/hello/ must
+            // 404 exactly as the eager service does.
+            assert.equal(await service.resolveUrl('/news/hello/'), null);
+        });
+
+        it('matches date-based permalinks when the date is canonical', async function () {
             const findResource = sinon.stub();
             findResource
                 .withArgs('posts', {year: '2026', month: '04', slug: 'hello'})
-                .resolves({id: 'p1', slug: 'hello'});
+                .resolves({id: 'p1', slug: 'hello', published_at: '2026-04-15T00:00:00.000Z'});
 
             const service = new LazyUrlService({urlUtils, findResource});
             service.onRouterAddedType('default', null, 'posts', '/:year/:month/:slug/');
 
             const result = await service.resolveUrl('/2026/04/hello/');
             assert.equal(result.id, 'p1');
+        });
+
+        it('returns null when the date segments do not match the record published date', async function () {
+            const findResource = sinon.stub();
+            findResource
+                .withArgs('posts', {year: '2026', month: '05', slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello', published_at: '2026-04-15T00:00:00.000Z'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:year/:month/:slug/');
+
+            // Post is published in 2026-04, so a 2026-05 URL is not its canonical
+            // URL and must 404, matching the eager service.
+            assert.equal(await service.resolveUrl('/2026/05/hello/'), null);
         });
 
         it('does not throw on malformed %-escapes; returns null instead', async function () {

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -83,6 +83,30 @@ describe('LazyUrlService', function () {
             assert.equal(url, '/404/');
         });
 
+        it('throws when a relation-filtered router is given a thin resource', function () {
+            const service = new LazyUrlService({urlUtils});
+            // tag:news needs the tags relation; a resource with no tags array
+            // can't be evaluated, which would otherwise silently 404.
+            service.onRouterAddedType('news', 'tag:news', 'posts', '/:slug/');
+
+            assert.throws(
+                () => service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello'}),
+                /Thin resource passed to LazyUrlService/
+            );
+        });
+
+        it('does not throw when the relation a filter references is present', function () {
+            const service = new LazyUrlService({urlUtils});
+            service.onRouterAddedType('news', 'tag:news', 'posts', '/:slug/');
+
+            // An empty tags array is still a loaded relation, so the resource is
+            // evaluated normally and falls through to /404/ on no match.
+            assert.equal(
+                service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello', tags: []}),
+                '/404/'
+            );
+        });
+
         it('expands shorthand tag/author filters via the EXPANSIONS table', function () {
             const service = new LazyUrlService({urlUtils});
             service.onRouterAddedType('podcast', 'tag:podcast', 'posts', '/podcast/:slug/');
@@ -351,11 +375,11 @@ describe('LazyUrlService', function () {
 
         it('matches multi-segment permalinks (e.g. /:primary_tag/:slug/)', async function () {
             const findResource = sinon.stub();
-            // withArgs binds the resolve to the exact param shape, so a
-            // regression that drops one of the captures (e.g. forgets to
-            // pass `primary_tag`) fails on the resolve, not just on the spy.
+            // Only the queryable slug column is passed to findResource; the
+            // primary_tag segment is validated by the canonical re-check, not
+            // the DB query.
             findResource
-                .withArgs('posts', {primary_tag: 'podcast', slug: 'hello'})
+                .withArgs('posts', {slug: 'hello'})
                 .resolves({id: 'p1', slug: 'hello', primary_tag: {slug: 'podcast'}});
 
             const service = new LazyUrlService({urlUtils, findResource});
@@ -364,12 +388,13 @@ describe('LazyUrlService', function () {
             const result = await service.resolveUrl('/podcast/hello/');
             assert.equal(result.id, 'p1');
             assert.equal(result.type, 'posts');
+            sinon.assert.calledWith(findResource, 'posts', {slug: 'hello'});
         });
 
         it('returns null when the primary_tag segment is not the record canonical tag', async function () {
             const findResource = sinon.stub();
             findResource
-                .withArgs('posts', {primary_tag: 'news', slug: 'hello'})
+                .withArgs('posts', {slug: 'hello'})
                 .resolves({id: 'p1', slug: 'hello', primary_tag: {slug: 'podcast'}});
 
             const service = new LazyUrlService({urlUtils, findResource});
@@ -383,7 +408,7 @@ describe('LazyUrlService', function () {
         it('matches date-based permalinks when the date is canonical', async function () {
             const findResource = sinon.stub();
             findResource
-                .withArgs('posts', {year: '2026', month: '04', slug: 'hello'})
+                .withArgs('posts', {slug: 'hello'})
                 .resolves({id: 'p1', slug: 'hello', published_at: '2026-04-15T00:00:00.000Z'});
 
             const service = new LazyUrlService({urlUtils, findResource});
@@ -396,7 +421,7 @@ describe('LazyUrlService', function () {
         it('returns null when the date segments do not match the record published date', async function () {
             const findResource = sinon.stub();
             findResource
-                .withArgs('posts', {year: '2026', month: '05', slug: 'hello'})
+                .withArgs('posts', {slug: 'hello'})
                 .resolves({id: 'p1', slug: 'hello', published_at: '2026-04-15T00:00:00.000Z'});
 
             const service = new LazyUrlService({urlUtils, findResource});
@@ -425,6 +450,17 @@ describe('LazyUrlService', function () {
             service.onRouterAddedType('default', null, 'posts', '/blog-:slug/');
 
             assert.equal(await service.resolveUrl('/blog-hello/'), null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('does not query findResource when the permalink captures no queryable column', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            // An archive-style permalink captures only derived date segments,
+            // so there's no id/uuid/slug column to look a resource up by.
+            service.onRouterAddedType('archive', null, 'posts', '/:year/:month/');
+
+            assert.equal(await service.resolveUrl('/2026/04/'), null);
             sinon.assert.notCalled(findResource);
         });
 

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -33,6 +33,8 @@ function makeUrlUtils() {
     };
 }
 
+const noopFindResource = () => Promise.resolve(null);
+
 describe('LazyUrlService', function () {
     let urlUtils;
 
@@ -42,19 +44,19 @@ describe('LazyUrlService', function () {
 
     describe('getUrlForResource', function () {
         it('returns /404/ when no router has been registered', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             const url = service.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
             assert.equal(url, '/404/');
         });
 
         it('returns /404/ when called without a resource type', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             assert.equal(service.getUrlForResource(null), '/404/');
             assert.equal(service.getUrlForResource({}), '/404/');
         });
 
         it('uses the unfiltered collection router for any post', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
             const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello'});
@@ -62,7 +64,7 @@ describe('LazyUrlService', function () {
         });
 
         it('respects router priority for filtered collections', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             // Featured posts go to /featured/, everything else to /:slug/.
             service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
@@ -75,7 +77,7 @@ describe('LazyUrlService', function () {
         });
 
         it('falls back to /404/ when a post matches no collection filter', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             // Only featured posts are routed.
             service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
 
@@ -84,7 +86,7 @@ describe('LazyUrlService', function () {
         });
 
         it('throws when a relation-filtered router is given a thin resource', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             // tag:news needs the tags relation; a resource with no tags array
             // can't be evaluated, which would otherwise silently 404.
             service.onRouterAddedType('news', 'tag:news', 'posts', '/:slug/');
@@ -96,7 +98,7 @@ describe('LazyUrlService', function () {
         });
 
         it('does not throw when the relation a filter references is present', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('news', 'tag:news', 'posts', '/:slug/');
 
             // An empty tags array is still a loaded relation, so the resource is
@@ -108,7 +110,7 @@ describe('LazyUrlService', function () {
         });
 
         it('expands shorthand tag/author filters via the EXPANSIONS table', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('podcast', 'tag:podcast', 'posts', '/podcast/:slug/');
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
@@ -130,7 +132,7 @@ describe('LazyUrlService', function () {
             // type:'page' resource is routed to the pages collection rather
             // than reaching this posts router's filter at all. That's why
             // only the positive match is asserted here.
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('posts-only', 'page:false', 'posts', '/:slug/');
 
             const post = service.getUrlForResource({type: 'post', id: 'p', slug: 'hello'});
@@ -138,7 +140,7 @@ describe('LazyUrlService', function () {
         });
 
         it('handles deterministic ownership for tags/authors/pages', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('tagsRouter', null, 'tags', '/tag/:slug/');
             service.onRouterAddedType('authorsRouter', null, 'authors', '/author/:slug/');
             service.onRouterAddedType('staticPages', null, 'pages', '/:slug/');
@@ -158,7 +160,7 @@ describe('LazyUrlService', function () {
         });
 
         it('substitutes date-based permalink fields', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('dated', null, 'posts', '/:year/:month/:slug/');
 
             const url = service.getUrlForResource({
@@ -171,7 +173,7 @@ describe('LazyUrlService', function () {
         });
 
         it('honours the absolute and withSubdirectory options', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
             const post = {type: 'posts', id: 'p', slug: 'hello'};
@@ -182,24 +184,24 @@ describe('LazyUrlService', function () {
 
     describe('ownsResource', function () {
         it('returns false for an unknown router identifier', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             assert.equal(service.ownsResource('unknown', {type: 'posts', id: 'p'}), false);
         });
 
         it('returns true for an unfiltered router that matches the resource type', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
             assert.equal(service.ownsResource('default', {type: 'posts', id: 'p', slug: 'x'}), true);
         });
 
         it('returns false when the resource type does not match the router', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
             assert.equal(service.ownsResource('default', {type: 'pages', id: 'p', slug: 'x'}), false);
         });
 
         it('evaluates NQL filters against the resource', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
 
             assert.equal(service.ownsResource('featured', {type: 'posts', id: 'a', featured: true}), true);
@@ -209,7 +211,7 @@ describe('LazyUrlService', function () {
         it('grants exclusive ownership to the first matching router', function () {
             // A featured collection ahead of a catch-all: the catch-all must
             // not claim a featured post the higher-priority router owns.
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
@@ -225,13 +227,13 @@ describe('LazyUrlService', function () {
 
     describe('hasFinished', function () {
         it('always returns true', function () {
-            assert.equal(new LazyUrlService({urlUtils}).hasFinished(), true);
+            assert.equal(new LazyUrlService({urlUtils, findResource: noopFindResource}).hasFinished(), true);
         });
     });
 
     describe('reset', function () {
         it('drops all registered router configs', function () {
-            const service = new LazyUrlService({urlUtils});
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
             assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p'}), '/hello/');
 
@@ -240,13 +242,13 @@ describe('LazyUrlService', function () {
         });
     });
 
-    describe('resolveUrl', function () {
-        it('returns null when no findResource hook is configured', async function () {
-            const service = new LazyUrlService({urlUtils});
-            service.onRouterAddedType('default', null, 'posts', '/:slug/');
-            assert.equal(await service.resolveUrl('/hello/'), null);
+    describe('constructor', function () {
+        it('throws when constructed without a findResource hook', function () {
+            assert.throws(() => new LazyUrlService({urlUtils}), /findResource/);
         });
+    });
 
+    describe('resolveUrl', function () {
         it('extracts slug params and queries the DB by router type', async function () {
             const findResource = sinon.stub();
             findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello', title: 'Hello'});
@@ -442,25 +444,40 @@ describe('LazyUrlService', function () {
             sinon.assert.notCalled(findResource);
         });
 
-        it('rejects mixed-literal-and-placeholder segments (no ReDoS surface)', async function () {
+        it('matches literal-prefixed placeholder segments', async function () {
             const findResource = sinon.stub();
+            findResource.withArgs('posts', {slug: 'hello'}).resolves({id: 'p1', slug: 'hello'});
+
             const service = new LazyUrlService({urlUtils, findResource});
-            // Mixed segments like `/blog-:slug/` are not a documented Ghost
-            // permalink shape; we deliberately don't try to match them.
             service.onRouterAddedType('default', null, 'posts', '/blog-:slug/');
 
-            assert.equal(await service.resolveUrl('/blog-hello/'), null);
-            sinon.assert.notCalled(findResource);
+            const result = await service.resolveUrl('/blog-hello/');
+            assert.equal(result.id, 'p1');
+            sinon.assert.calledWith(findResource, 'posts', {slug: 'hello'});
         });
 
-        it('does not query findResource when the permalink captures no queryable column', async function () {
+        it('matches hyphen-separated multi-token segments (#28076)', async function () {
+            const findResource = sinon.stub();
+            findResource
+                .withArgs('posts', {slug: 'hello'})
+                .resolves({id: 'p1', slug: 'hello', published_at: '2026-04-15T00:00:00.000Z'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:year-:month-:day-:slug/');
+
+            const result = await service.resolveUrl('/2026-04-15-hello/');
+            assert.equal(result.id, 'p1');
+            sinon.assert.calledWith(findResource, 'posts', {slug: 'hello'});
+        });
+
+        it('throws when a matched permalink has no queryable lookup column', async function () {
             const findResource = sinon.stub();
             const service = new LazyUrlService({urlUtils, findResource});
-            // An archive-style permalink captures only derived date segments,
-            // so there's no id/slug column to look a resource up by.
+            // A permalink with neither slug nor id is invalid config; matching
+            // one is a programmer error we refuse loudly rather than mask.
             service.onRouterAddedType('archive', null, 'posts', '/:year/:month/');
 
-            assert.equal(await service.resolveUrl('/2026/04/'), null);
+            await assert.rejects(() => service.resolveUrl('/2026/04/'), /no queryable lookup column/);
             sinon.assert.notCalled(findResource);
         });
 

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -457,11 +457,48 @@ describe('LazyUrlService', function () {
             const findResource = sinon.stub();
             const service = new LazyUrlService({urlUtils, findResource});
             // An archive-style permalink captures only derived date segments,
-            // so there's no id/uuid/slug column to look a resource up by.
+            // so there's no id/slug column to look a resource up by.
             service.onRouterAddedType('archive', null, 'posts', '/:year/:month/');
 
             assert.equal(await service.resolveUrl('/2026/04/'), null);
             sinon.assert.notCalled(findResource);
+        });
+
+        it('does not query findResource when a captured id cannot fit the ObjectId format', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            // `:id` is a real permalink token, but a Ghost id is a 24-char hex
+            // ObjectId. A path segment that can't be one is a guaranteed miss,
+            // so we skip the lookup eager would also never have a URL for.
+            service.onRouterAddedType('default', null, 'posts', '/:id/');
+
+            assert.equal(await service.resolveUrl('/blahblah/'), null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('does not query findResource when a derived date segment cannot fit its format', async function () {
+            const findResource = sinon.stub();
+            const service = new LazyUrlService({urlUtils, findResource});
+            // The slug is queryable here, but a non-numeric year can never be a
+            // canonical date segment, so the path is a guaranteed miss — skip
+            // the lookup instead of finding the post and failing the re-check.
+            service.onRouterAddedType('dated', null, 'posts', '/:year/:month/:slug/');
+
+            assert.equal(await service.resolveUrl('/notayear/04/hello/'), null);
+            sinon.assert.notCalled(findResource);
+        });
+
+        it('still queries findResource when the captured id is a valid ObjectId', async function () {
+            const findResource = sinon.stub();
+            findResource.withArgs('posts', {id: '0123456789abcdef01234567'})
+                .resolves({id: '0123456789abcdef01234567', slug: 'hello', type: 'post'});
+
+            const service = new LazyUrlService({urlUtils, findResource});
+            service.onRouterAddedType('default', null, 'posts', '/:id/');
+
+            const result = await service.resolveUrl('/0123456789abcdef01234567/');
+            assert.equal(result.id, '0123456789abcdef01234567');
+            sinon.assert.calledOnce(findResource);
         });
 
         it('uses the singular DB type field to find posts collections', async function () {

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -470,14 +470,14 @@ describe('LazyUrlService', function () {
             sinon.assert.calledWith(findResource, 'posts', {slug: 'hello'});
         });
 
-        it('throws when a matched permalink has no queryable lookup column', async function () {
+        it('does not resolve a permalink that captures no queryable column', async function () {
             const findResource = sinon.stub();
             const service = new LazyUrlService({urlUtils, findResource});
-            // A permalink with neither slug nor id is invalid config; matching
-            // one is a programmer error we refuse loudly rather than mask.
+            // A permalink with neither slug nor id can't identify a resource, so
+            // the matcher treats it as no match and the DB is never touched.
             service.onRouterAddedType('archive', null, 'posts', '/:year/:month/');
 
-            await assert.rejects(() => service.resolveUrl('/2026/04/'), /no queryable lookup column/);
+            assert.equal(await service.resolveUrl('/2026/04/'), null);
             sinon.assert.notCalled(findResource);
         });
 

--- a/ghost/core/test/unit/server/services/url/permalink-matcher.test.js
+++ b/ghost/core/test/unit/server/services/url/permalink-matcher.test.js
@@ -1,0 +1,96 @@
+const assert = require('node:assert/strict');
+const {matchPermalink} = require('../../../../../core/server/services/url/permalink-matcher');
+
+function captured(template, urlPath) {
+    const result = matchPermalink(template, urlPath);
+    return result === null ? null : {...result};
+}
+
+describe('permalink-matcher', function () {
+    describe('single-segment templates', function () {
+        it('captures a :slug placeholder', function () {
+            assert.deepEqual(captured('/:slug/', '/hello/'), {slug: 'hello'});
+        });
+
+        it('returns an empty params object for a fully literal template', function () {
+            assert.deepEqual(captured('/about/', '/about/'), {});
+        });
+
+        it('returns null when a literal segment differs', function () {
+            assert.equal(matchPermalink('/about/', '/hello/'), null);
+        });
+
+        it('returns null for an empty placeholder segment', function () {
+            assert.equal(matchPermalink('/:slug/', '//'), null);
+        });
+    });
+
+    describe('multi-segment templates', function () {
+        it('captures multiple placeholders', function () {
+            assert.deepEqual(
+                captured('/:primary_tag/:slug/', '/podcast/hello/'),
+                {primary_tag: 'podcast', slug: 'hello'}
+            );
+        });
+
+        it('captures date-based placeholders', function () {
+            assert.deepEqual(
+                captured('/:year/:month/:slug/', '/2026/04/hello/'),
+                {year: '2026', month: '04', slug: 'hello'}
+            );
+        });
+
+        it('mixes literals and placeholders across segments', function () {
+            assert.deepEqual(
+                captured('/blog/:slug/', '/blog/hello/'),
+                {slug: 'hello'}
+            );
+        });
+
+        it('returns null when segment counts differ', function () {
+            assert.equal(matchPermalink('/:slug/', '/a/b/'), null);
+            assert.equal(matchPermalink('/:year/:slug/', '/2026/'), null);
+        });
+    });
+
+    describe('decoding', function () {
+        it('percent-decodes captured segments', function () {
+            assert.deepEqual(captured('/:slug/', '/hello%20world/'), {slug: 'hello world'});
+        });
+
+        it('returns null (does not throw) on malformed %-escapes', function () {
+            assert.equal(matchPermalink('/:slug/', '/foo%ZZ/'), null);
+        });
+    });
+
+    describe('unsupported shapes', function () {
+        it('rejects mixed literal-and-placeholder segments', function () {
+            assert.equal(matchPermalink('/blog-:slug/', '/blog-hello/'), null);
+        });
+
+        it('rejects placeholders with non-word characters', function () {
+            assert.equal(matchPermalink('/:sl-ug/', '/hello/'), null);
+        });
+    });
+
+    describe('reserved placeholder names', function () {
+        // A plain object would route `params.__proto__ = ...` through the
+        // Object.prototype setter and drop the capture; the null-prototype map
+        // stores it as an own key so the downstream lookup/cache key sees it.
+        it('captures a placeholder named __proto__ as an own key', function () {
+            const result = matchPermalink('/:__proto__/', '/hello/');
+
+            assert.deepEqual(Object.keys(result), ['__proto__']);
+            assert.equal(result.__proto__, 'hello');
+            assert.equal(JSON.stringify(result), '{"__proto__":"hello"}');
+        });
+    });
+
+    describe('guards', function () {
+        it('returns null when either argument is not a string', function () {
+            assert.equal(matchPermalink(null, '/hello/'), null);
+            assert.equal(matchPermalink('/:slug/', null), null);
+            assert.equal(matchPermalink(undefined, undefined), null);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/url/permalink-matcher.test.js
+++ b/ghost/core/test/unit/server/services/url/permalink-matcher.test.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert/strict');
-const {matchPermalink} = require('../../../../../core/server/services/url/permalink-matcher');
+const {matchPermalink, toLookupParams} = require('../../../../../core/server/services/url/permalink-matcher');
 
 function captured(template, urlPath) {
     const result = matchPermalink(template, urlPath);
@@ -53,6 +53,28 @@ describe('permalink-matcher', function () {
         });
     });
 
+    describe('multi-token segments (#28076)', function () {
+        it('captures hyphen-separated params within one segment', function () {
+            assert.deepEqual(
+                captured('/:year-:month-:day-:slug/', '/2026-04-15-hello/'),
+                {year: '2026', month: '04', day: '15', slug: 'hello'}
+            );
+        });
+
+        it('does not let an earlier param consume a later one across hyphens', function () {
+            // Without explicit bounds, :year would greedily swallow the whole
+            // segment. Each hyphenated param must stop at its own boundary.
+            assert.deepEqual(
+                captured('/:slug-:primary_tag/', '/hello-podcast/'),
+                {slug: 'hello', primary_tag: 'podcast'}
+            );
+        });
+
+        it('captures a literal-prefixed placeholder segment', function () {
+            assert.deepEqual(captured('/blog-:slug/', '/blog-hello/'), {slug: 'hello'});
+        });
+    });
+
     describe('decoding', function () {
         it('percent-decodes captured segments', function () {
             assert.deepEqual(captured('/:slug/', '/hello%20world/'), {slug: 'hello world'});
@@ -63,26 +85,54 @@ describe('permalink-matcher', function () {
         });
     });
 
-    describe('unsupported shapes', function () {
-        it('rejects mixed literal-and-placeholder segments', function () {
-            assert.equal(matchPermalink('/blog-:slug/', '/blog-hello/'), null);
+    describe('supported tokens only', function () {
+        // The matcher only recognises Ghost's documented permalink tokens, so an
+        // unknown :token (including reserved names like __proto__) never matches
+        // and can never reach the lookup or a cache key.
+        it('returns null for an unsupported token', function () {
+            assert.equal(matchPermalink('/:foo/', '/hello/'), null);
         });
 
-        it('rejects placeholders with non-word characters', function () {
-            assert.equal(matchPermalink('/:sl-ug/', '/hello/'), null);
+        it('returns null for a placeholder named __proto__', function () {
+            assert.equal(matchPermalink('/:__proto__/', '/hello/'), null);
         });
     });
 
-    describe('reserved placeholder names', function () {
-        // A plain object would route `params.__proto__ = ...` through the
-        // Object.prototype setter and drop the capture; the null-prototype map
-        // stores it as an own key so the downstream lookup/cache key sees it.
-        it('captures a placeholder named __proto__ as an own key', function () {
-            const result = matchPermalink('/:__proto__/', '/hello/');
+    describe('value-format pre-filter', function () {
+        // A captured value that can't fit its token's fixed format is a
+        // guaranteed miss, so the matcher rejects it up front (parity-safe: the
+        // patterns are strict supersets of every value eager emits).
+        it('returns null when an :id segment is not a 24-char ObjectId', function () {
+            assert.equal(matchPermalink('/:id/', '/blahblah/'), null);
+        });
 
-            assert.deepEqual(Object.keys(result), ['__proto__']);
-            assert.equal(result.__proto__, 'hello');
-            assert.equal(JSON.stringify(result), '{"__proto__":"hello"}');
+        it('matches when an :id segment is a valid ObjectId', function () {
+            assert.deepEqual(
+                captured('/:id/', '/0123456789abcdef01234567/'),
+                {id: '0123456789abcdef01234567'}
+            );
+        });
+
+        it('returns null when a date segment is not numeric', function () {
+            assert.equal(matchPermalink('/:year/:month/:slug/', '/notayear/04/hello/'), null);
+        });
+    });
+
+    describe('toLookupParams', function () {
+        it('narrows to slug when present', function () {
+            assert.deepEqual(toLookupParams({slug: 'hello', primary_tag: 'podcast'}), {slug: 'hello'});
+        });
+
+        it('narrows to id when present', function () {
+            assert.deepEqual(toLookupParams({id: '0123456789abcdef01234567'}), {id: '0123456789abcdef01234567'});
+        });
+
+        it('prefers id over slug', function () {
+            assert.deepEqual(toLookupParams({id: '0123456789abcdef01234567', slug: 'hello'}), {id: '0123456789abcdef01234567'});
+        });
+
+        it('returns null when no queryable column is present', function () {
+            assert.equal(toLookupParams({year: '2026', month: '04'}), null);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/permalink-matcher.test.js
+++ b/ghost/core/test/unit/server/services/url/permalink-matcher.test.js
@@ -12,10 +12,6 @@ describe('permalink-matcher', function () {
             assert.deepEqual(captured('/:slug/', '/hello/'), {slug: 'hello'});
         });
 
-        it('returns an empty params object for a fully literal template', function () {
-            assert.deepEqual(captured('/about/', '/about/'), {});
-        });
-
         it('returns null when a literal segment differs', function () {
             assert.equal(matchPermalink('/about/', '/hello/'), null);
         });
@@ -50,6 +46,16 @@ describe('permalink-matcher', function () {
         it('returns null when segment counts differ', function () {
             assert.equal(matchPermalink('/:slug/', '/a/b/'), null);
             assert.equal(matchPermalink('/:year/:slug/', '/2026/'), null);
+        });
+    });
+
+    describe('queryable column required', function () {
+        it('returns null for a fully literal template', function () {
+            assert.equal(matchPermalink('/about/', '/about/'), null);
+        });
+
+        it('returns null for a template that captures only derived segments', function () {
+            assert.equal(matchPermalink('/:year/:month/', '/2026/04/'), null);
         });
     });
 
@@ -129,10 +135,6 @@ describe('permalink-matcher', function () {
 
         it('prefers id over slug', function () {
             assert.deepEqual(toLookupParams({id: '0123456789abcdef01234567', slug: 'hello'}), {id: '0123456789abcdef01234567'});
-        });
-
-        it('returns null when no queryable column is present', function () {
-            assert.equal(toLookupParams({year: '2026', month: '04'}), null);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/permalink-matcher.test.js
+++ b/ghost/core/test/unit/server/services/url/permalink-matcher.test.js
@@ -85,12 +85,4 @@ describe('permalink-matcher', function () {
             assert.equal(JSON.stringify(result), '{"__proto__":"hello"}');
         });
     });
-
-    describe('guards', function () {
-        it('returns null when either argument is not a string', function () {
-            assert.equal(matchPermalink(null, '/hello/'), null);
-            assert.equal(matchPermalink('/:slug/', null), null);
-            assert.equal(matchPermalink(undefined, undefined), null);
-        });
-    });
 });

--- a/ghost/core/test/unit/server/services/url/router-filter.test.js
+++ b/ghost/core/test/unit/server/services/url/router-filter.test.js
@@ -1,0 +1,102 @@
+const assert = require('node:assert/strict');
+const {
+    EXPANSIONS,
+    routerTypeOf,
+    buildFilter,
+    filterMatches
+} = require('../../../../../core/server/services/url/router-filter');
+
+describe('router-filter', function () {
+    describe('routerTypeOf', function () {
+        it('maps singular DB types to plural router types', function () {
+            assert.equal(routerTypeOf({type: 'post'}), 'posts');
+            assert.equal(routerTypeOf({type: 'page'}), 'pages');
+            assert.equal(routerTypeOf({type: 'tag'}), 'tags');
+            assert.equal(routerTypeOf({type: 'author'}), 'authors');
+        });
+
+        it('passes plural router types through unchanged', function () {
+            assert.equal(routerTypeOf({type: 'posts'}), 'posts');
+            assert.equal(routerTypeOf({type: 'pages'}), 'pages');
+            assert.equal(routerTypeOf({type: 'tags'}), 'tags');
+            assert.equal(routerTypeOf({type: 'authors'}), 'authors');
+        });
+
+        it('returns null for unknown or missing types', function () {
+            assert.equal(routerTypeOf({type: 'widgets'}), null);
+            assert.equal(routerTypeOf({}), null);
+            assert.equal(routerTypeOf(null), null);
+            assert.equal(routerTypeOf(undefined), null);
+        });
+    });
+
+    describe('buildFilter', function () {
+        it('returns null for an empty filter', function () {
+            assert.equal(buildFilter(null), null);
+            assert.equal(buildFilter(undefined), null);
+            assert.equal(buildFilter(''), null);
+        });
+
+        it('returns a compiled matcher for a non-empty filter', function () {
+            const compiled = buildFilter('featured:true');
+            assert.equal(typeof compiled.queryJSON, 'function');
+        });
+    });
+
+    describe('filterMatches', function () {
+        it('always matches when there is no compiled filter', function () {
+            assert.equal(filterMatches(null, {anything: true}), true);
+        });
+
+        it('evaluates a simple boolean filter', function () {
+            const compiled = buildFilter('featured:true');
+            assert.equal(filterMatches(compiled, {featured: true}), true);
+            assert.equal(filterMatches(compiled, {featured: false}), false);
+        });
+
+        it('expands tag shorthand to tags.slug', function () {
+            const compiled = buildFilter('tag:news');
+            assert.equal(filterMatches(compiled, {tags: [{slug: 'news'}]}), true);
+            assert.equal(filterMatches(compiled, {tags: [{slug: 'sport'}]}), false);
+        });
+
+        it('expands author shorthand to authors.slug', function () {
+            const compiled = buildFilter('author:jane');
+            assert.equal(filterMatches(compiled, {authors: [{slug: 'jane'}]}), true);
+            assert.equal(filterMatches(compiled, {authors: [{slug: 'bob'}]}), false);
+        });
+
+        it('expands primary_tag shorthand', function () {
+            const compiled = buildFilter('primary_tag:news');
+            assert.equal(filterMatches(compiled, {primary_tag: {slug: 'news'}}), true);
+            assert.equal(filterMatches(compiled, {primary_tag: {slug: 'other'}}), false);
+        });
+
+        it('transforms page:false to type:post', function () {
+            const compiled = buildFilter('page:false');
+            assert.equal(filterMatches(compiled, {type: 'post'}), true);
+            assert.equal(filterMatches(compiled, {type: 'page'}), false);
+        });
+
+        it('transforms page:true to type:page', function () {
+            const compiled = buildFilter('page:true');
+            assert.equal(filterMatches(compiled, {type: 'page'}), true);
+            assert.equal(filterMatches(compiled, {type: 'post'}), false);
+        });
+
+        it('returns false (does not throw) when the record lacks a referenced relation', function () {
+            const compiled = buildFilter('tag:news');
+            assert.equal(filterMatches(compiled, {id: 'p1'}), false);
+        });
+    });
+
+    describe('EXPANSIONS', function () {
+        it('exposes the shorthand keys the eager generator supports', function () {
+            const keys = EXPANSIONS.map(e => e.key);
+            assert.deepEqual(
+                keys,
+                ['author', 'tags', 'tag', 'authors', 'primary_tag', 'primary_author']
+            );
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1817

### Why

The eager `UrlService` precomputes a full resource → URL map at boot and holds every published resource in memory. We want to replace it with an on-demand service that computes each answer per call. The earlier experiment (#28336, behind `config.lazyRouting`) was reverted (HKG-1816); this rebuilds it as production-ready code with cleaner, smaller, individually-testable pieces.

This PR **only adds the new service and its tests** — nothing is wired into the request path yet. The `UrlServiceFacade` already has the seams, but no instance selects the lazy backend. Wiring and the eager-removal cutover are separate milestone issues.

The overriding goal is parity: the lazy service must return the **same answer as the eager service** for the same inputs, because downstream issues will shadow-compare the two before we switch over.

### What

Built as four small modules so each piece is testable in isolation, plus a real-DB parity suite:

- **`permalink-matcher.ts`** — pure, regex-free function that matches a request path against a permalink template (`/:slug/`, `/:year/:month/:slug/`) and extracts the params. No ReDoS surface; malformed/unsupported shapes are non-matches.
- **`router-filter.ts`** — the NQL routing semantics (expansions, the `page:` transformer, `routerTypeOf`, `buildFilter`, `filterMatches`). A deliberate copy of the eager generator's rules, not a shared module, so a shared bug can't hide identical wrong output on both sides while eager is the comparison oracle.
- **`lazy-find-resource.ts`** — the single DB-touching seam, injected into `resolveUrl`. Mirrors the eager `resourceConfig` visibility rules (published-only posts/pages, public `TagPublic`/`Author` that gate on having posts) so a guessed slug can't surface anything the eager path hid. Queries only by real column params (`id`/`uuid`/`slug`) and prunes the loaded record to the exact shape the eager service exposes — dropping the post body and other excluded fields, and trimming `tags`/`authors`/`primary_tag`/`primary_author` to `{id, slug}` — so the resolved record never leaks fields eager strips.
- **`lazy-url-service.ts`** — composes the helpers. Forward lookups are pure; all DB access is confined to `resolveUrl`. Ownership is exclusive (first matching router of the type wins), matching eager's reservation. The `/404/` fallback matches eager's miss path exactly, including subdirectory handling. Logs a thin-resource error when a filtered router can't see a relation the caller didn't load — that's exactly the case where lazy would `/404/` while eager returns a URL.

**Notable design choice:** `resolveUrl` re-validates the resolved record against its canonical URL. The slug-only DB lookup can't filter on derived or relation permalink segments (`:year`/`:month`, `:primary_tag`), so it regenerates the record's URL with the same `replacePermalink` the eager generator uses and confirms the captured params match. This makes the reverse path agree with eager by construction: the eager service only resolves a URL that equals a resource's generated (canonical) URL, so a wrong-date (`/2026/05/<slug>/`) or wrong-tag URL 404s in both backends rather than resolving the post by slug alone.

### Testing

- Restored the preserved `lazy-url-service` contract spec from skipped to running (HKG-1817's acceptance criterion).
- Added unit tests for every module: matcher (13), router-filter (14), find-resource (19), service (33, incl. ownership exclusivity and the canonical re-check).
- Added an **eager/lazy parity integration test** that drives both services from identical routing sets and feeds lazy the exact records eager cached, comparing all directions a caller depends on — forward (relative + absolute, including `/404/`), ownership (every router × every resource), and reverse (every eager-generated URL resolves back to the same resource, with full record-shape parity). A featured-collection scenario exercises priority fallthrough (this caught and fixed an ownership-exclusivity bug during development), and a date-based scenario asserts both services 404 a non-canonical (wrong-date) URL.
- `tsc --noEmit`, `eslint`, all unit suites, and the parity integration suite pass.

### Known follow-ups (deferred to the wiring/comparison issue)

- `resolveUrl` queries `findResource` only by real column params (`id`/`uuid`/`slug`) and validates derived/relation segments via the canonical re-check, so custom permalinks (`/:year/:month/:slug/`, `/:primary_tag/:slug/`) resolve and 404 in parity with eager. Permalinks that key off a field the pruned record doesn't carry remain a wiring-phase follow-up.
- The thin-resource warning covers filter-referenced relations, not permalink-referenced fields.
