### PR TITLE
Fixed CI build artifact publishing for non TryGhost/Ghost repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -880,11 +880,11 @@ jobs:
       - name: Determine push strategy
         id: strategy
         run: |
-          # Same-org repos (e.g. TryGhost/Ghost, TryGhost/Ghost-Security) push to GHCR.
-          # External forks and cross-repo PRs use artifact-based image transfer instead.
+          # Only the canonical repo publishes to GHCR by default.
+          # Direct clones, external forks, and cross-repo PRs use artifact-based image transfer instead.
           USE_ARTIFACT="false"
-          if [ "${{ github.repository_owner }}" != "TryGhost" ]; then
-            # External fork — no GHCR push
+          if [ "${{ github.repository }}" != "TryGhost/Ghost" ]; then
+            # Non-canonical repo - no GHCR push
             USE_ARTIFACT="true"
           elif [ "${{ github.event_name }}" = "pull_request" ] && \
                [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
@@ -905,9 +905,9 @@ jobs:
             IMAGE_FULL_NAME="ghcr.io/${OWNER}/${REPO_NAME}"
           fi
 
-          # Force push on tag pushes (release images must always be published)
+          # Force push on canonical tag pushes (release images must always be published)
           IS_TAG="${{ startsWith(github.ref, 'refs/tags/v') }}"
-          if [ "$IS_TAG" = "true" ]; then
+          if [ "$IS_TAG" = "true" ] && [ "${{ github.repository }}" = "TryGhost/Ghost" ]; then
             USE_ARTIFACT="false"
           fi
 


### PR DESCRIPTION
## Summary
- restrict default GHCR publishing in CI to the canonical TryGhost/Ghost repository
- make direct clones use artifact mode so docker-image-production is uploaded
- keep release tag GHCR publishing canonical-only and leave Trigger Pro CD restricted to TryGhost/Ghost