### PR TITLE
Include site title in members export filename

### DIFF
--- a/apps/posts/src/views/members/components/members-actions.tsx
+++ b/apps/posts/src/views/members/components/members-actions.tsx
@@ -16,11 +16,23 @@ interface MembersActionsProps {
     memberCount: number;
     nql?: string;
     search: string;
+    siteTitle?: string | null;
     canBulkDelete: boolean;
     onImportComplete?: (importResponse?: ImportResponse) => void;
 }
 
-async function exportMembers(filter?: string, search?: string): Promise<void> {
+export function getMembersExportFileName(siteTitle?: string | null): string {
+    const titleSlug = siteTitle
+        ?.toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+    const titlePrefix = titleSlug ? `${titleSlug}.` : '';
+    const datetime = new Date().toJSON().substring(0, 10);
+
+    return `${titlePrefix}ghost.members.${datetime}.csv`;
+}
+
+export async function exportMembers(filter?: string, search?: string, siteTitle?: string | null): Promise<void> {
     const params = new URLSearchParams({limit: 'all'});
     if (filter) {
         params.set('filter', filter);
@@ -28,8 +40,7 @@ async function exportMembers(filter?: string, search?: string): Promise<void> {
     if (search) {
         params.set('search', search);
     }
-    const datetime = new Date().toJSON().substring(0, 10);
-    await blobDownloadFromEndpoint(`/members/upload/?${params}`, `members.${datetime}.csv`);
+    await blobDownloadFromEndpoint(`/members/upload/?${params}`, getMembersExportFileName(siteTitle));
 }
 
 const MembersActions: React.FC<MembersActionsProps> = ({
@@ -37,6 +48,7 @@ const MembersActions: React.FC<MembersActionsProps> = ({
     memberCount,
     nql,
     search,
+    siteTitle,
     canBulkDelete,
     onImportComplete
 }) => {
@@ -62,14 +74,14 @@ const MembersActions: React.FC<MembersActionsProps> = ({
     const memberOperationParams = buildMemberOperationParams({nql, search});
     const handleExport = useCallback(async () => {
         try {
-            await exportMembers(nql, search);
+            await exportMembers(nql, search, siteTitle);
         } catch (e) {
             toast.error('Export failed', {
                 description: 'There was a problem downloading your member data. Please check your connection and try again.'
             });
             throw e;
         }
-    }, [nql, search]);
+    }, [nql, search, siteTitle]);
 
     const handleAddLabel = useCallback(async (labelIds: string[]) => {
         try {

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -24,7 +24,7 @@ import {useLocation, useSearchParams} from 'react-router';
 const SEARCH_DEBOUNCE_MS = 250;
 const MEMBERS_HELP_CARDS_LIMIT = 6;
 
-const MembersPage: React.FC<{timezone: string; membershipsEnabled: boolean}> = ({timezone, membershipsEnabled}) => {
+const MembersPage: React.FC<{timezone: string; membershipsEnabled: boolean; siteTitle?: string | null}> = ({timezone, membershipsEnabled, siteTitle}) => {
     const headerRef = useRef<HTMLDivElement | null>(null);
     const setHeaderContentRef = useCallback((node: HTMLDivElement | null) => {
         headerRef.current = node?.closest('[data-list-page="header"]') as HTMLDivElement | null;
@@ -155,6 +155,7 @@ const MembersPage: React.FC<{timezone: string; membershipsEnabled: boolean}> = (
                                         memberCount={totalMembers}
                                         nql={nql}
                                         search={search}
+                                        siteTitle={siteTitle}
                                         onImportComplete={() => {
                                             void refetch();
                                         }}
@@ -282,9 +283,10 @@ const Members: React.FC = () => {
 
     const timezone = getSiteTimezone(settingsData.settings);
     const membersSignupAccess = getSettingValue<string>(settingsData.settings, 'members_signup_access');
+    const siteTitle = getSettingValue<string>(settingsData.settings, 'title');
     const membershipsEnabled = membersSignupAccess !== 'none';
 
-    return <MembersPage membershipsEnabled={membershipsEnabled} timezone={timezone} />;
+    return <MembersPage membershipsEnabled={membershipsEnabled} siteTitle={siteTitle} timezone={timezone} />;
 };
 
 export default Members;

--- a/apps/posts/test/unit/views/members/members-actions.test.tsx
+++ b/apps/posts/test/unit/views/members/members-actions.test.tsx
@@ -1,10 +1,11 @@
-import MembersActions from '@src/views/members/components/members-actions';
+import MembersActions, {exportMembers, getMembersExportFileName} from '@src/views/members/components/members-actions';
 import React from 'react';
-import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 
 const importModalPropsRef: {current: Record<string, unknown> | null} = {current: null};
-const {mockUseLocation, mockUseNavigate} = vi.hoisted(() => ({
+const {mockBlobDownloadFromEndpoint, mockUseLocation, mockUseNavigate} = vi.hoisted(() => ({
+    mockBlobDownloadFromEndpoint: vi.fn(),
     mockUseLocation: vi.fn(),
     mockUseNavigate: vi.fn()
 }));
@@ -12,6 +13,10 @@ const {mockUseLocation, mockUseNavigate} = vi.hoisted(() => ({
 vi.mock('@tryghost/admin-x-framework', () => ({
     useLocation: mockUseLocation,
     useNavigate: mockUseNavigate
+}));
+
+vi.mock('@tryghost/admin-x-framework/helpers', () => ({
+    blobDownloadFromEndpoint: mockBlobDownloadFromEndpoint
 }));
 
 vi.mock('@src/views/members/components/bulk-action-modals', () => ({
@@ -64,10 +69,41 @@ const renderMembersActions = (props: Partial<React.ComponentProps<typeof Members
 };
 
 describe('MembersActions', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     beforeEach(() => {
         importModalPropsRef.current = null;
+        mockBlobDownloadFromEndpoint.mockReset();
         setLocation('/members');
         mockUseNavigate.mockReturnValue(vi.fn());
+    });
+
+    it('builds a members export filename with the slugified site title', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-02T12:00:00.000Z'));
+
+        expect(getMembersExportFileName('My Publication')).toBe('my-publication.ghost.members.2026-06-02.csv');
+    });
+
+    it('falls back to ghost when the members export site title is missing', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-02T12:00:00.000Z'));
+
+        expect(getMembersExportFileName(null)).toBe('ghost.members.2026-06-02.csv');
+    });
+
+    it('exports members with the site title in the CSV filename', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-02T12:00:00.000Z'));
+
+        await exportMembers(undefined, '', 'My Publication');
+
+        expect(mockBlobDownloadFromEndpoint).toHaveBeenCalledWith(
+            '/members/upload/?limit=all',
+            'my-publication.ghost.members.2026-06-02.csv'
+        );
     });
 
     it('opens the import modal on the import route', () => {

--- a/e2e/tests/admin/members/export.test.ts
+++ b/e2e/tests/admin/members/export.test.ts
@@ -101,8 +101,7 @@ test.describe('Ghost Admin - Members Export', () => {
 
         expect(contentIds).toHaveLength(MEMBERS_FIXTURE.length);
         expect(contentTimestamps).toHaveLength(MEMBERS_FIXTURE.length);
-        expect(suggestedFilename.startsWith('members')).toBe(true);
-        expect(suggestedFilename.endsWith('.csv')).toBe(true);
+        expect(suggestedFilename).toMatch(/ghost\.members\.\d{4}-\d{2}-\d{2}\.csv$/);
     });
 
     test('exports filtered members by label to CSV', async ({page}) => {
@@ -124,7 +123,6 @@ test.describe('Ghost Admin - Members Export', () => {
 
         expect(contentIds).toHaveLength(filteredMembers.length);
         expect(contentTimestamps).toHaveLength(filteredMembers.length);
-        expect(suggestedFilename.startsWith('members')).toBe(true);
-        expect(suggestedFilename.endsWith('.csv')).toBe(true);
+        expect(suggestedFilename).toMatch(/ghost\.members\.\d{4}-\d{2}-\d{2}\.csv$/);
     });
 });


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/28310

## Summary

- add a members export filename helper that prefixes CSV exports with the slugified site title
- pass the existing settings `title` value from the members page into the export action
- keep the current `ghost.members.YYYY-MM-DD.csv` fallback when the site title is unavailable

## Verification

- `pnpm vitest run test/unit/views/members/members-actions.test.tsx` from `apps/posts` (7 tests passed)
- `pnpm --dir apps/posts exec eslint src/views/members/components/members-actions.tsx test/unit/views/members/members-actions.test.tsx`
- commit hook ESLint also covered `apps/posts/src/views/members/members.tsx`
- `pnpm --dir apps/posts exec tsc --noEmit`
- `git diff --check`
- `pnpm --filter @tryghost/posts build` got through TypeScript and then failed in Vite/Rollup on virtual `\0react` with Node `v24.15.0`; this checkout warns the repo expects Node `^22.13.1`

AI-assisted: yes. I reviewed the generated changes and test output before opening this PR.
