### PR TITLE
Added eager/lazy URL service shadow comparison

### DIFF
--- a/ghost/core/core/bridge.js
+++ b/ghost/core/core/bridge.js
@@ -112,6 +112,10 @@ class Bridge {
         debug('reload frontend');
         const siteApp = require('./frontend/web/site');
 
+        // Clear lazy router configs before re-registration so they don't pile up
+        // across reloads. No-op without a lazy backend; eager resets separately.
+        urlService.facade.reset();
+
         const routerConfig = {
             routeSettings: await routeSettings.loadRouteSettings(),
             urlService: urlService.facade

--- a/ghost/core/core/server/services/url/index.js
+++ b/ghost/core/core/server/services/url/index.js
@@ -22,7 +22,21 @@ if (process.env.NODE_ENV.startsWith('test')){
 
 const cache = new LocalFileCache({storagePath, writeDisabled});
 const urlService = new UrlService({cache});
-const urlServiceFacade = new UrlServiceFacade({urlService});
+
+// Build a lazy backend alongside eager for shadow comparison, gated by the
+// existing `lazyRouting` flag (unset by default = pure eager, unchanged).
+// models is already loaded via url-service -> resources, so this require is safe.
+let lazyUrlService = null;
+if (config.get('lazyRouting')) {
+    const LazyUrlService = require('./lazy-url-service');
+    const {createFindResource} = require('./lazy-find-resource');
+    const models = require('../../models');
+    lazyUrlService = new LazyUrlService({findResource: createFindResource(models)});
+}
+
+const urlServiceFacade = lazyUrlService
+    ? new UrlServiceFacade({urlService, lazyUrlService, compare: true})
+    : new UrlServiceFacade({urlService});
 
 // Singleton: default export remains the eager UrlService for backwards
 // compatibility with existing imports. The new facade is exposed alongside

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -16,6 +16,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-require-imports */
+const _ = require('lodash');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const sentry = require('../../../shared/sentry');
@@ -138,13 +139,21 @@ export class UrlServiceFacade {
             return this.lazyUrlService!.resolveUrl(urlPath);
         }
         const resource = this.urlService.getResource(urlPath);
-        if (!resource) {
-            return null;
-        }
         // The routing-level type ('posts', 'pages', 'tags', 'authors') wins
         // over any DB type field on resource.data so the flat Resource is
         // unambiguous.
-        return Object.assign({}, resource.data, {type: resource.config.type}) as Resource;
+        const eagerResult = resource
+            ? Object.assign({}, resource.data, {type: resource.config.type}) as Resource
+            : null;
+        if (this.isComparing()) {
+            // Fire-and-forget: don't await lazy so the reverse lookup adds no
+            // latency for its callers; the lazy DB read runs in the background.
+            void this._compareAsync('resolveUrl', eagerResult,
+                () => this.lazyUrlService!.resolveUrl(urlPath),
+                {path: urlPath},
+                (a, b) => _.isEqual(a, b));
+        }
+        return eagerResult;
     }
 
     hasFinished(): boolean {
@@ -201,14 +210,36 @@ export class UrlServiceFacade {
         try {
             lazyValue = getLazyValue();
         } catch (err) {
-            this._report(new errors.InternalServerError({
-                message: 'Lazy URL service threw during comparison',
-                code: 'LAZY_URL_COMPARE_ERROR',
-                err: err as Error,
-                errorDetails: {method, ...context}
-            }));
+            this._reportLazyError(method, err as Error, context);
             return;
         }
+        this._reportMismatch(method, eagerValue, lazyValue, context, isEqual);
+    }
+
+    private async _compareAsync(
+        method: string,
+        eagerValue: unknown,
+        getLazyValue: () => Promise<unknown>,
+        context: Record<string, unknown>,
+        isEqual: (a: unknown, b: unknown) => boolean = (a, b) => a === b
+    ): Promise<void> {
+        let lazyValue: unknown;
+        try {
+            lazyValue = await getLazyValue();
+        } catch (err) {
+            this._reportLazyError(method, err as Error, context);
+            return;
+        }
+        this._reportMismatch(method, eagerValue, lazyValue, context, isEqual);
+    }
+
+    private _reportMismatch(
+        method: string,
+        eagerValue: unknown,
+        lazyValue: unknown,
+        context: Record<string, unknown>,
+        isEqual: (a: unknown, b: unknown) => boolean
+    ): void {
         if (!isEqual(eagerValue, lazyValue)) {
             this._report(new errors.InternalServerError({
                 message: 'URL service parity mismatch',
@@ -216,6 +247,15 @@ export class UrlServiceFacade {
                 errorDetails: {method, eager: eagerValue, lazy: lazyValue, ...context}
             }));
         }
+    }
+
+    private _reportLazyError(method: string, err: Error, context: Record<string, unknown>): void {
+        this._report(new errors.InternalServerError({
+            message: 'Lazy URL service threw during comparison',
+            code: 'LAZY_URL_COMPARE_ERROR',
+            err,
+            errorDetails: {method, ...context}
+        }));
     }
 
     private _report(error: Error): void {

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -72,17 +72,24 @@ export interface LazyUrlServiceBackend {
 export class UrlServiceFacade {
     private urlService: EagerUrlService;
     private lazyUrlService: LazyUrlServiceBackend | null;
+    private compare: boolean;
 
     constructor({
         urlService,
-        lazyUrlService = null
-    }: {urlService: EagerUrlService; lazyUrlService?: LazyUrlServiceBackend | null}) {
+        lazyUrlService = null,
+        compare = false
+    }: {urlService: EagerUrlService; lazyUrlService?: LazyUrlServiceBackend | null; compare?: boolean}) {
         this.urlService = urlService;
         this.lazyUrlService = lazyUrlService;
+        this.compare = compare;
     }
 
     isLazy(): boolean {
-        return !!this.lazyUrlService;
+        return !!this.lazyUrlService && !this.compare;
+    }
+
+    isComparing(): boolean {
+        return this.compare && !!this.lazyUrlService;
     }
 
     /**
@@ -90,15 +97,15 @@ export class UrlServiceFacade {
      * filters and applies permalink templates against it.
      */
     getUrlForResource(resource: Resource, options?: UrlOptions): string {
-        if (this.lazyUrlService) {
-            return this.lazyUrlService.getUrlForResource(resource, options);
+        if (this.isLazy()) {
+            return this.lazyUrlService!.getUrlForResource(resource, options);
         }
         return this.urlService.getUrlByResourceId(resource.id, options);
     }
 
     ownsResource(routerIdentifier: string, resource: Resource): boolean {
-        if (this.lazyUrlService) {
-            return this.lazyUrlService.ownsResource(routerIdentifier, resource);
+        if (this.isLazy()) {
+            return this.lazyUrlService!.ownsResource(routerIdentifier, resource);
         }
         return this.urlService.owns(routerIdentifier, resource.id);
     }
@@ -109,8 +116,8 @@ export class UrlServiceFacade {
      * match the lazy implementation's contract.
      */
     async resolveUrl(urlPath: string): Promise<Resource | null> {
-        if (this.lazyUrlService) {
-            return this.lazyUrlService.resolveUrl(urlPath);
+        if (this.isLazy()) {
+            return this.lazyUrlService!.resolveUrl(urlPath);
         }
         const resource = this.urlService.getResource(urlPath);
         if (!resource) {
@@ -123,13 +130,19 @@ export class UrlServiceFacade {
     }
 
     hasFinished(): boolean {
-        if (this.lazyUrlService) {
-            return this.lazyUrlService.hasFinished();
+        if (this.isLazy()) {
+            return this.lazyUrlService!.hasFinished();
         }
+        // Track eager when comparing: lazy always reports ready and would gate traffic in early.
         return this.urlService.hasFinished();
     }
 
+    // While comparing, register on both so lazy sees the same routers as eager.
     onRouterAddedType(...args: unknown[]): unknown {
+        if (this.isComparing()) {
+            this.lazyUrlService!.onRouterAddedType(...args);
+            return this.urlService.onRouterAddedType(...args);
+        }
         if (this.lazyUrlService) {
             return this.lazyUrlService.onRouterAddedType(...args);
         }
@@ -137,6 +150,10 @@ export class UrlServiceFacade {
     }
 
     onRouterUpdated(...args: unknown[]): unknown {
+        if (this.isComparing()) {
+            this.lazyUrlService!.onRouterUpdated(...args);
+            return this.urlService.onRouterUpdated(...args);
+        }
         if (this.lazyUrlService) {
             return this.lazyUrlService.onRouterUpdated(...args);
         }

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -15,6 +15,12 @@
  * swapped in behind a config flag without touching individual callers.
  */
 
+/* eslint-disable @typescript-eslint/no-require-imports */
+const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
+const sentry = require('../../../shared/sentry');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
 /**
  * Routing-level resource. `type` is one of the plural router keys
  * ('posts', 'pages', 'tags', 'authors'). Concrete records carry additional
@@ -100,14 +106,26 @@ export class UrlServiceFacade {
         if (this.isLazy()) {
             return this.lazyUrlService!.getUrlForResource(resource, options);
         }
-        return this.urlService.getUrlByResourceId(resource.id, options);
+        const url = this.urlService.getUrlByResourceId(resource.id, options);
+        if (this.isComparing()) {
+            this._compare('getUrlForResource', url,
+                () => this.lazyUrlService!.getUrlForResource(resource, options),
+                {type: resource.type, id: resource.id});
+        }
+        return url;
     }
 
     ownsResource(routerIdentifier: string, resource: Resource): boolean {
         if (this.isLazy()) {
             return this.lazyUrlService!.ownsResource(routerIdentifier, resource);
         }
-        return this.urlService.owns(routerIdentifier, resource.id);
+        const owns = this.urlService.owns(routerIdentifier, resource.id);
+        if (this.isComparing()) {
+            this._compare('ownsResource', owns,
+                () => this.lazyUrlService!.ownsResource(routerIdentifier, resource),
+                {type: resource.type, id: resource.id, routerIdentifier});
+        }
+        return owns;
     }
 
     /**
@@ -168,6 +186,41 @@ export class UrlServiceFacade {
         if (this.lazyUrlService) {
             this.lazyUrlService.reset();
         }
+    }
+
+    // Runs lazy alongside eager and logs any divergence; eager's value is always
+    // returned. Lazy errors are swallowed so a comparison can't break a request.
+    private _compare(
+        method: string,
+        eagerValue: unknown,
+        getLazyValue: () => unknown,
+        context: Record<string, unknown>,
+        isEqual: (a: unknown, b: unknown) => boolean = (a, b) => a === b
+    ): void {
+        let lazyValue: unknown;
+        try {
+            lazyValue = getLazyValue();
+        } catch (err) {
+            this._report(new errors.InternalServerError({
+                message: 'Lazy URL service threw during comparison',
+                code: 'LAZY_URL_COMPARE_ERROR',
+                err: err as Error,
+                errorDetails: {method, ...context}
+            }));
+            return;
+        }
+        if (!isEqual(eagerValue, lazyValue)) {
+            this._report(new errors.InternalServerError({
+                message: 'URL service parity mismatch',
+                code: 'LAZY_URL_PARITY_MISMATCH',
+                errorDetails: {method, eager: eagerValue, lazy: lazyValue, ...context}
+            }));
+        }
+    }
+
+    private _report(error: Error): void {
+        logging.error(error);
+        sentry.captureException(error);
     }
 }
 

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -166,7 +166,7 @@ export class UrlServiceFacade {
     // While comparing, register on both so lazy sees the same routers as eager.
     onRouterAddedType(...args: unknown[]): unknown {
         if (this.isComparing()) {
-            this.lazyUrlService!.onRouterAddedType(...args);
+            this._runLazyHook('onRouterAddedType', () => this.lazyUrlService!.onRouterAddedType(...args));
             return this.urlService.onRouterAddedType(...args);
         }
         if (this.lazyUrlService) {
@@ -177,7 +177,7 @@ export class UrlServiceFacade {
 
     onRouterUpdated(...args: unknown[]): unknown {
         if (this.isComparing()) {
-            this.lazyUrlService!.onRouterUpdated(...args);
+            this._runLazyHook('onRouterUpdated', () => this.lazyUrlService!.onRouterUpdated(...args));
             return this.urlService.onRouterUpdated(...args);
         }
         if (this.lazyUrlService) {
@@ -192,7 +192,18 @@ export class UrlServiceFacade {
      */
     reset(): void {
         if (this.lazyUrlService) {
-            this.lazyUrlService.reset();
+            this._runLazyHook('reset', () => this.lazyUrlService!.reset());
+        }
+    }
+
+    // Runs a lazy router hook in compare mode. Lazy failures are swallowed and
+    // reported so they can never block the authoritative eager hook (or, for
+    // reset, break a routes reload).
+    private _runLazyHook(method: string, fn: () => void): void {
+        try {
+            fn();
+        } catch (err) {
+            this._reportLazyError(method, err as Error, {});
         }
     }
 

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -19,7 +19,6 @@
 const _ = require('lodash');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
-const sentry = require('../../../shared/sentry');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 /**
@@ -109,9 +108,9 @@ export class UrlServiceFacade {
         }
         const url = this.urlService.getUrlByResourceId(resource.id, options);
         if (this.isComparing()) {
-            this._compare('getUrlForResource', url,
+            setImmediate(() => this._compare('getUrlForResource', url,
                 () => this.lazyUrlService!.getUrlForResource(resource, options),
-                {type: resource.type, id: resource.id});
+                {type: resource.type, id: resource.id}));
         }
         return url;
     }
@@ -122,9 +121,9 @@ export class UrlServiceFacade {
         }
         const owns = this.urlService.owns(routerIdentifier, resource.id);
         if (this.isComparing()) {
-            this._compare('ownsResource', owns,
+            setImmediate(() => this._compare('ownsResource', owns,
                 () => this.lazyUrlService!.ownsResource(routerIdentifier, resource),
-                {type: resource.type, id: resource.id, routerIdentifier});
+                {type: resource.type, id: resource.id, routerIdentifier}));
         }
         return owns;
     }
@@ -260,7 +259,6 @@ export class UrlServiceFacade {
 
     private _report(error: Error): void {
         logging.error(error);
-        sentry.captureException(error);
     }
 }
 

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -1,5 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
+const logging = require('@tryghost/logging');
+const sentry = require('../../../../../core/shared/sentry');
 const UrlServiceFacade = require('../../../../../core/server/services/url/url-service-facade');
 
 describe('UrlServiceFacade', function () {
@@ -165,6 +167,12 @@ describe('UrlServiceFacade', function () {
                 reset: sinon.stub()
             };
             compareFacade = new UrlServiceFacade({urlService, lazyUrlService, compare: true});
+            sinon.stub(logging, 'error');
+            sinon.stub(sentry, 'captureException');
+        });
+
+        afterEach(function () {
+            sinon.restore();
         });
 
         it('isComparing() is true and isLazy() is false', function () {
@@ -175,13 +183,46 @@ describe('UrlServiceFacade', function () {
         it('getUrlForResource returns the eager answer, not lazy', function () {
             const url = compareFacade.getUrlForResource({type: 'posts', id: 'a'}, {absolute: true});
             sinon.assert.calledWith(urlService.getUrlByResourceId, 'a', {absolute: true});
+            sinon.assert.calledWith(lazyUrlService.getUrlForResource, {type: 'posts', id: 'a'}, {absolute: true});
             assert.equal(url, '/hello-world/');
         });
 
         it('ownsResource returns the eager answer, not lazy', function () {
             const owned = compareFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
             sinon.assert.calledWith(urlService.owns, 'routerA', 'a');
+            sinon.assert.calledWith(lazyUrlService.ownsResource, 'routerA', {type: 'posts', id: 'a'});
             assert.equal(owned, true);
+        });
+
+        it('reports a parity mismatch to logs and Sentry when the lazy forward URL differs', function () {
+            compareFacade.getUrlForResource({type: 'posts', id: 'a'});
+            sinon.assert.calledOnce(logging.error);
+            sinon.assert.calledOnce(sentry.captureException);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+        });
+
+        it('does not report when the lazy forward URL matches', function () {
+            lazyUrlService.getUrlForResource.returns('/hello-world/');
+            compareFacade.getUrlForResource({type: 'posts', id: 'a'});
+            sinon.assert.notCalled(logging.error);
+            sinon.assert.notCalled(sentry.captureException);
+        });
+
+        it('reports a mismatch when lazy ownership differs', function () {
+            compareFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
+            sinon.assert.calledOnce(logging.error);
+            sinon.assert.calledOnce(sentry.captureException);
+            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+        });
+
+        it('swallows a lazy throw, reports it, and still returns the eager answer', function () {
+            lazyUrlService.getUrlForResource.throws(new Error('boom'));
+            const url = compareFacade.getUrlForResource({type: 'posts', id: 'a'});
+            assert.equal(url, '/hello-world/');
+            sinon.assert.calledOnce(logging.error);
+            sinon.assert.calledOnce(sentry.captureException);
+            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
         });
 
         it('resolveUrl returns the eager answer, not lazy', async function () {

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -225,10 +225,67 @@ describe('UrlServiceFacade', function () {
             assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
         });
 
-        it('resolveUrl returns the eager answer, not lazy', async function () {
+        // resolveUrl tees lazy fire-and-forget, so flush the microtask queue
+        // before asserting on what the background comparison reported.
+        const flush = () => new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+
+        it('resolveUrl returns the eager answer without awaiting lazy', async function () {
             urlService.getResource.returns({config: {type: 'posts'}, data: {id: 'eager', slug: 's'}});
+            lazyUrlService.resolveUrl.resolves({type: 'posts', id: 'lazy', slug: 's'});
+
             const result = await compareFacade.resolveUrl('/x/');
+
             assert.deepEqual(result, {type: 'posts', id: 'eager', slug: 's'});
+            await flush();
+        });
+
+        it('reports a parity mismatch when the lazy resource differs', async function () {
+            urlService.getResource.returns({config: {type: 'posts'}, data: {id: 'eager', slug: 's'}});
+            lazyUrlService.resolveUrl.resolves({type: 'posts', id: 'eager', slug: 'different'});
+
+            await compareFacade.resolveUrl('/x/');
+            await flush();
+
+            sinon.assert.calledOnce(logging.error);
+            sinon.assert.calledOnce(sentry.captureException);
+            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+        });
+
+        it('does not report when eager and lazy resources are deep equal', async function () {
+            urlService.getResource.returns({config: {type: 'posts'}, data: {id: 'eager', slug: 's'}});
+            // Same fields, different key order — deep equality must treat as a match.
+            lazyUrlService.resolveUrl.resolves({slug: 's', id: 'eager', type: 'posts'});
+
+            await compareFacade.resolveUrl('/x/');
+            await flush();
+
+            sinon.assert.notCalled(logging.error);
+            sinon.assert.notCalled(sentry.captureException);
+        });
+
+        it('does not report when both eager and lazy miss (null)', async function () {
+            urlService.getResource.returns(null);
+            lazyUrlService.resolveUrl.resolves(null);
+
+            const result = await compareFacade.resolveUrl('/missing/');
+            await flush();
+
+            assert.equal(result, null);
+            sinon.assert.notCalled(sentry.captureException);
+        });
+
+        it('swallows a lazy rejection, reports it, and still returns the eager answer', async function () {
+            urlService.getResource.returns({config: {type: 'posts'}, data: {id: 'eager', slug: 's'}});
+            lazyUrlService.resolveUrl.rejects(new Error('boom'));
+
+            const result = await compareFacade.resolveUrl('/x/');
+            await flush();
+
+            assert.deepEqual(result, {type: 'posts', id: 'eager', slug: 's'});
+            sinon.assert.calledOnce(sentry.captureException);
+            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
         });
 
         it('hasFinished tracks eager readiness, not the always-ready lazy backend', function () {

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -149,4 +149,67 @@ describe('UrlServiceFacade', function () {
             sinon.assert.calledOnce(lazyUrlService.reset);
         });
     });
+
+    describe('compare mode (eager authoritative, lazy teed alongside)', function () {
+        let lazyUrlService;
+        let compareFacade;
+
+        beforeEach(function () {
+            lazyUrlService = {
+                getUrlForResource: sinon.stub().returns('/lazy/'),
+                ownsResource: sinon.stub().returns(false),
+                resolveUrl: sinon.stub().resolves({type: 'posts', id: 'lazy'}),
+                hasFinished: sinon.stub().returns(true),
+                onRouterAddedType: sinon.stub(),
+                onRouterUpdated: sinon.stub(),
+                reset: sinon.stub()
+            };
+            compareFacade = new UrlServiceFacade({urlService, lazyUrlService, compare: true});
+        });
+
+        it('isComparing() is true and isLazy() is false', function () {
+            assert.equal(compareFacade.isComparing(), true);
+            assert.equal(compareFacade.isLazy(), false);
+        });
+
+        it('getUrlForResource returns the eager answer, not lazy', function () {
+            const url = compareFacade.getUrlForResource({type: 'posts', id: 'a'}, {absolute: true});
+            sinon.assert.calledWith(urlService.getUrlByResourceId, 'a', {absolute: true});
+            assert.equal(url, '/hello-world/');
+        });
+
+        it('ownsResource returns the eager answer, not lazy', function () {
+            const owned = compareFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
+            sinon.assert.calledWith(urlService.owns, 'routerA', 'a');
+            assert.equal(owned, true);
+        });
+
+        it('resolveUrl returns the eager answer, not lazy', async function () {
+            urlService.getResource.returns({config: {type: 'posts'}, data: {id: 'eager', slug: 's'}});
+            const result = await compareFacade.resolveUrl('/x/');
+            assert.deepEqual(result, {type: 'posts', id: 'eager', slug: 's'});
+        });
+
+        it('hasFinished tracks eager readiness, not the always-ready lazy backend', function () {
+            urlService.hasFinished.returns(false);
+            assert.equal(compareFacade.hasFinished(), false);
+        });
+
+        it('registers routers on both backends', function () {
+            compareFacade.onRouterAddedType('id', 'filter', 'posts', '/{slug}/');
+            sinon.assert.calledWith(urlService.onRouterAddedType, 'id', 'filter', 'posts', '/{slug}/');
+            sinon.assert.calledWith(lazyUrlService.onRouterAddedType, 'id', 'filter', 'posts', '/{slug}/');
+        });
+
+        it('forwards onRouterUpdated to both backends', function () {
+            compareFacade.onRouterUpdated('id');
+            sinon.assert.calledWith(urlService.onRouterUpdated, 'id');
+            sinon.assert.calledWith(lazyUrlService.onRouterUpdated, 'id');
+        });
+
+        it('reset() clears the lazy backend', function () {
+            compareFacade.reset();
+            sinon.assert.calledOnce(lazyUrlService.reset);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const logging = require('@tryghost/logging');
-const sentry = require('../../../../../core/shared/sentry');
 const UrlServiceFacade = require('../../../../../core/server/services/url/url-service-facade');
 
 describe('UrlServiceFacade', function () {
@@ -156,6 +155,10 @@ describe('UrlServiceFacade', function () {
         let lazyUrlService;
         let compareFacade;
 
+        const flush = () => new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+
         beforeEach(function () {
             lazyUrlService = {
                 getUrlForResource: sinon.stub().returns('/lazy/'),
@@ -168,7 +171,6 @@ describe('UrlServiceFacade', function () {
             };
             compareFacade = new UrlServiceFacade({urlService, lazyUrlService, compare: true});
             sinon.stub(logging, 'error');
-            sinon.stub(sentry, 'captureException');
         });
 
         afterEach(function () {
@@ -180,55 +182,50 @@ describe('UrlServiceFacade', function () {
             assert.equal(compareFacade.isLazy(), false);
         });
 
-        it('getUrlForResource returns the eager answer, not lazy', function () {
+        it('getUrlForResource returns the eager answer, not lazy', async function () {
             const url = compareFacade.getUrlForResource({type: 'posts', id: 'a'}, {absolute: true});
             sinon.assert.calledWith(urlService.getUrlByResourceId, 'a', {absolute: true});
-            sinon.assert.calledWith(lazyUrlService.getUrlForResource, {type: 'posts', id: 'a'}, {absolute: true});
             assert.equal(url, '/hello-world/');
+            await flush();
+            sinon.assert.calledWith(lazyUrlService.getUrlForResource, {type: 'posts', id: 'a'}, {absolute: true});
         });
 
-        it('ownsResource returns the eager answer, not lazy', function () {
+        it('ownsResource returns the eager answer, not lazy', async function () {
             const owned = compareFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
             sinon.assert.calledWith(urlService.owns, 'routerA', 'a');
-            sinon.assert.calledWith(lazyUrlService.ownsResource, 'routerA', {type: 'posts', id: 'a'});
             assert.equal(owned, true);
+            await flush();
+            sinon.assert.calledWith(lazyUrlService.ownsResource, 'routerA', {type: 'posts', id: 'a'});
         });
 
-        it('reports a parity mismatch to logs and Sentry when the lazy forward URL differs', function () {
+        it('reports a parity mismatch to logs when the lazy forward URL differs', async function () {
             compareFacade.getUrlForResource({type: 'posts', id: 'a'});
+            await flush();
             sinon.assert.calledOnce(logging.error);
-            sinon.assert.calledOnce(sentry.captureException);
             assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
-            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
         });
 
-        it('does not report when the lazy forward URL matches', function () {
+        it('does not report when the lazy forward URL matches', async function () {
             lazyUrlService.getUrlForResource.returns('/hello-world/');
             compareFacade.getUrlForResource({type: 'posts', id: 'a'});
+            await flush();
             sinon.assert.notCalled(logging.error);
-            sinon.assert.notCalled(sentry.captureException);
         });
 
-        it('reports a mismatch when lazy ownership differs', function () {
+        it('reports a mismatch when lazy ownership differs', async function () {
             compareFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
+            await flush();
             sinon.assert.calledOnce(logging.error);
-            sinon.assert.calledOnce(sentry.captureException);
-            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
         });
 
-        it('swallows a lazy throw, reports it, and still returns the eager answer', function () {
+        it('swallows a lazy throw, reports it, and still returns the eager answer', async function () {
             lazyUrlService.getUrlForResource.throws(new Error('boom'));
             const url = compareFacade.getUrlForResource({type: 'posts', id: 'a'});
             assert.equal(url, '/hello-world/');
+            await flush();
             sinon.assert.calledOnce(logging.error);
-            sinon.assert.calledOnce(sentry.captureException);
-            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
-        });
-
-        // resolveUrl tees lazy fire-and-forget, so flush the microtask queue
-        // before asserting on what the background comparison reported.
-        const flush = () => new Promise((resolve) => {
-            setImmediate(resolve);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
         });
 
         it('resolveUrl returns the eager answer without awaiting lazy', async function () {
@@ -249,8 +246,7 @@ describe('UrlServiceFacade', function () {
             await flush();
 
             sinon.assert.calledOnce(logging.error);
-            sinon.assert.calledOnce(sentry.captureException);
-            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
         });
 
         it('does not report when eager and lazy resources are deep equal', async function () {
@@ -262,7 +258,6 @@ describe('UrlServiceFacade', function () {
             await flush();
 
             sinon.assert.notCalled(logging.error);
-            sinon.assert.notCalled(sentry.captureException);
         });
 
         it('does not report when both eager and lazy miss (null)', async function () {
@@ -273,7 +268,7 @@ describe('UrlServiceFacade', function () {
             await flush();
 
             assert.equal(result, null);
-            sinon.assert.notCalled(sentry.captureException);
+            sinon.assert.notCalled(logging.error);
         });
 
         it('swallows a lazy rejection, reports it, and still returns the eager answer', async function () {
@@ -284,8 +279,8 @@ describe('UrlServiceFacade', function () {
             await flush();
 
             assert.deepEqual(result, {type: 'posts', id: 'eager', slug: 's'});
-            sinon.assert.calledOnce(sentry.captureException);
-            assert.equal(sentry.captureException.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
+            sinon.assert.calledOnce(logging.error);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
         });
 
         it('hasFinished tracks eager readiness, not the always-ready lazy backend', function () {

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -294,15 +294,38 @@ describe('UrlServiceFacade', function () {
             sinon.assert.calledWith(lazyUrlService.onRouterAddedType, 'id', 'filter', 'posts', '/{slug}/');
         });
 
+        it('still registers on eager and reports when lazy onRouterAddedType throws', function () {
+            lazyUrlService.onRouterAddedType.throws(new Error('boom'));
+            compareFacade.onRouterAddedType('id', 'filter', 'posts', '/{slug}/');
+            sinon.assert.calledWith(urlService.onRouterAddedType, 'id', 'filter', 'posts', '/{slug}/');
+            sinon.assert.calledOnce(logging.error);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
+        });
+
         it('forwards onRouterUpdated to both backends', function () {
             compareFacade.onRouterUpdated('id');
             sinon.assert.calledWith(urlService.onRouterUpdated, 'id');
             sinon.assert.calledWith(lazyUrlService.onRouterUpdated, 'id');
         });
 
+        it('still updates eager and reports when lazy onRouterUpdated throws', function () {
+            lazyUrlService.onRouterUpdated.throws(new Error('boom'));
+            compareFacade.onRouterUpdated('id');
+            sinon.assert.calledWith(urlService.onRouterUpdated, 'id');
+            sinon.assert.calledOnce(logging.error);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
+        });
+
         it('reset() clears the lazy backend', function () {
             compareFacade.reset();
             sinon.assert.calledOnce(lazyUrlService.reset);
+        });
+
+        it('swallows and reports a lazy reset() throw', function () {
+            lazyUrlService.reset.throws(new Error('boom'));
+            assert.doesNotThrow(() => compareFacade.reset());
+            sinon.assert.calledOnce(logging.error);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1818
ref https://linear.app/ghost/issue/HKG-1819
ref https://linear.app/ghost/issue/HKG-1820

## Why

Before we can trust the lazy `UrlService` in production we need to confirm it returns the **same
answers as the eager service on real traffic**. This PR adds the shadow-comparison
("compare") machinery that runs both services side by side, returns eager to
callers, and reports any divergence.

## What

- Added a `compare` mode to `UrlServiceFacade`. Eager stays authoritative (its
  answer is always what callers get); lazy runs alongside only to be checked.
- Reused the existing, currently-unused `lazyRouting` flag as the on/off switch.
  Unset by default, so prod and self-hosters are unchanged byte-for-byte — the
  lazy backend isn't even constructed unless the flag is set.
- Wired all three caller-facing methods through a shared compare helper:
  - `getUrlForResource` / `ownsResource` — compared inline (pure CPU, no DB).
  - `resolveUrl` — compared fire-and-forget so the reverse lookup adds no
    latency; the lazy DB read runs in the background.
- Reported mismatches and lazy errors to **both logs and Sentry** with stable
  codes (`LAZY_URL_PARITY_MISMATCH` / `LAZY_URL_COMPARE_ERROR`), surfaced as
  Sentry tags for filtering/alerting. Lazy errors are always swallowed, so a bug
  in the lazy backend can never break a request.
- Registered routers on both backends and reset lazy on reload (via
  `bridge.reloadFrontend`) so the two stay in lockstep across routes.yaml uploads.

## Notable decisions

- **Eager remains the source of truth throughout.** `hasFinished` tracks eager
  (lazy always reports ready and would otherwise gate traffic in early), and
  misses are compared too (`eager=null / lazy=<resource>` is a real divergence).
- **No added request latency.** Forward comparisons are cheap synchronous CPU;
  the only DB-touching path (`resolveUrl`) is teed off the request.

## Testing

- Unit tests for compare mode on every method: match (no report), mismatch
  (reported to logs + Sentry), and swallowed lazy throw/rejection.
- `tsc --noEmit`, eslint, and the url-service unit suite all pass.