### PR TITLE
fix: include site name in members CSV export filename (#28310)

### DIFF
--- a/ghost/core/core/server/api/endpoints/members.js
+++ b/ghost/core/core/server/api/endpoints/members.js
@@ -9,6 +9,7 @@ const membersService = require('../../services/members');
 const settingsCache = require('../../../shared/settings-cache');
 const tpl = require('@tryghost/tpl');
 const _ = require('lodash');
+const {slugify} = require('@tryghost/string');
 
 const messages = {
     memberNotFound: 'Member not found.',
@@ -378,7 +379,9 @@ const controller = {
                 type: 'csv',
                 value() {
                     const datetime = (new Date()).toJSON().substring(0, 10);
-                    return `members.${datetime}.csv`;
+                    const title = settingsCache.get('title');
+                    const titlePrefix = title ? `${slugify(title)}.` : '';
+                    return `${titlePrefix}ghost.members.${datetime}.csv`;
                 }
             },
             contentType: 'text/csv',


### PR DESCRIPTION
## Why are you making it?
The members CSV export filename did not include the site name, unlike the JSON export and the already-fixed analytics CSV export (#28227). This inconsistency makes it harder to identify which site the data comes from when managing multiple Ghost instances.

## What does it do?
Updates the members CSV export filename to follow the same convention:
`<site-name>.ghost.members.YYYY-MM-DD.csv`

Falls back to `ghost.members.YYYY-MM-DD.csv` if no site title is set.

## Why is this something Ghost users need?
Consistency across all exports and easier file management when handling multiple Ghost sites.

---

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works