### PR TITLE
Convert frontend routing config to TypeScript

### DIFF
--- a/ghost/core/core/frontend/services/routing/config.ts
+++ b/ghost/core/core/frontend/services/routing/config.ts
@@ -1,4 +1,4 @@
-module.exports.QUERY = {
+export const QUERY = {
     tag: {
         controller: 'tagsPublic',
         type: 'read',
@@ -43,9 +43,9 @@ module.exports.QUERY = {
             slug: '%s'
         }
     }
-};
+} as const;
 
-module.exports.TAXONOMIES = {
+export const TAXONOMIES = {
     tag: {
         filter: 'tags:\'%s\'+tags.visibility:public',
         editRedirect: '#/tags/:slug/',
@@ -56,4 +56,4 @@ module.exports.TAXONOMIES = {
         editRedirect: '#/settings/staff/:slug/',
         resource: 'authors'
     }
-};
+} as const;

--- a/ghost/core/core/server/services/route-settings/validate.js
+++ b/ghost/core/core/server/services/route-settings/validate.js
@@ -429,7 +429,8 @@ module.exports = function validate(object) {
     }
 
     // TODO: extract this config outta here! the config should be passed into this module
-    RESOURCE_CONFIG = require('../../../frontend/services/routing/config');
+    const {QUERY, TAXONOMIES} = require('../../../frontend/services/routing/config');
+    RESOURCE_CONFIG = {QUERY, TAXONOMIES};
 
     object.routes = _private.validateRoutes(object.routes);
     object.collections = _private.validateCollections(object.collections);

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -5,7 +5,8 @@ const settingsCache = require('../../../../../core/shared/settings-cache');
 const controllers = require('../../../../../core/frontend/services/routing/controllers');
 const TaxonomyRouter = require('../../../../../core/frontend/services/routing/taxonomy-router');
 
-const RESOURCE_CONFIG = require('../../../../../core/frontend/services/routing/config');
+const {QUERY, TAXONOMIES} = require('../../../../../core/frontend/services/routing/config');
+const RESOURCE_CONFIG = {QUERY, TAXONOMIES};
 
 describe('UNIT - services/routing/TaxonomyRouter', function () {
     let req;


### PR DESCRIPTION
no ref

This change should have no user impact.
