### PR TITLE
Updated warnings and errors for automations email steps

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -113,7 +113,7 @@ const buildSendEmailAction = (): AutomationSendEmailAction => ({
     id: generateActionId(),
     type: 'send_email',
     data: {
-        email_subject: 'Untitled email',
+        email_subject: '',
         email_lexical: EMPTY_EMAIL_LEXICAL,
         email_sender_name: null,
         email_sender_email: null,

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -182,7 +182,7 @@ describe('automations api helpers', () => {
             expect(next.actions).toHaveLength(1);
             const newAction = next.actions[0];
             expectSendEmailAction(newAction);
-            expect(newAction.data.email_subject).toBe('Untitled email');
+            expect(newAction.data.email_subject).toBe('');
             expect(() => JSON.parse(newAction.data.email_lexical)).not.toThrow();
             expect(JSON.parse(newAction.data.email_lexical).root.children).toEqual([]);
             expect(newAction.data.email_design_setting_id).toBe('placeholder');

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -3,9 +3,9 @@ import AddStepEdge, {type AddStepEdgeData} from './add-step-edge';
 import EmailContentModal from './email-modal/email-content-modal';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Banner, Button, Checkbox, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger} from '@tryghost/shade/components';
 import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction, updateSendEmailAction, updateWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, BackgroundVariant, Controls, Edge, Handle, Node, NodeProps, Position, ReactFlow, useReactFlow, useViewport} from '@xyflow/react';
-import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Banner, Button, Checkbox, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import type {EmailModalMode} from './types';
 
@@ -1032,7 +1032,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
         }
 
         const action = automation.actions.find(item => item.id === actionId);
-        if (action?.type === 'send_email') {
+        if (action?.type === 'send_email' && !isEmptyEmailLexical(action.data.email_lexical)) {
             setDeleteConfirmationActionId(action.id);
             return;
         }
@@ -1091,7 +1091,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
             actionErrors,
             automation,
             disabled: automation.actions.length >= MAX_AUTOMATION_ACTIONS,
-            onDelete: handleDelete,
+            onDelete: handleRequestDelete,
             onEditEmailBody: handleContextMenuEditEmail,
             onPick: handlePick,
             onPreviewEmail: handleContextMenuPreviewEmail,
@@ -1099,7 +1099,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
             newStepId,
             selectedStepId
         });
-    }, [actionErrors, automation, handleContextMenuEditEmail, handleContextMenuPreviewEmail, handleDelete, handlePick, newStepId, selectedStepId]);
+    }, [actionErrors, automation, handleContextMenuEditEmail, handleContextMenuPreviewEmail, handlePick, handleRequestDelete, newStepId, selectedStepId]);
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -597,6 +597,7 @@ type WaitStepSidebarDetail = ActionStepSidebarDetail<AutomationWaitAction, 'Wait
 };
 
 type SendEmailStepSidebarDetail = ActionStepSidebarDetail<AutomationSendEmailAction, 'Send email'> & {
+    autoFocusSubject: boolean;
     onUpdateSubject: (subject: string) => void;
     onEditEmail: () => void;
 };
@@ -612,6 +613,7 @@ const automationSlugMemberTiers: Record<string, MemberTier[]> = {
 
 type StepSidebarDetailOptions = {
     automation: AutomationDetail;
+    autoFocusSubject: boolean;
     onDelete: (actionId: string) => void;
     onUpdateWait: (actionId: string, waitHours: number) => void;
     onUpdateSubject: (actionId: string, subject: string) => void;
@@ -619,7 +621,7 @@ type StepSidebarDetailOptions = {
     stepId: string | null;
 };
 
-const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
+const getStepSidebarDetail = ({automation, autoFocusSubject, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
     if (!stepId) {
         return null;
     }
@@ -658,6 +660,7 @@ const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpd
             label: 'Send email',
             title: action.data.email_subject || 'No subject',
             action,
+            autoFocusSubject,
             onDelete: () => onDelete(action.id),
             onUpdateSubject: (subject: string) => onUpdateSubject(action.id, subject),
             onEditEmail: () => onEditEmail(action.id),
@@ -822,33 +825,44 @@ const WaitSidebarBody: React.FC<{
 
 const SendEmailSidebarBody: React.FC<{
     action: AutomationSendEmailAction;
+    autoFocusSubject: boolean;
     onUpdateSubject: (subject: string) => void;
     onEditEmail: () => void;
     onDelete: () => void;
-}> = ({action, onUpdateSubject, onEditEmail, onDelete}) => (
-    <div className='flex flex-1 flex-col gap-5'>
-        <SidebarField htmlFor='automation-email-subject' label='Subject line'>
-            <Input
-                id='automation-email-subject'
-                placeholder='Subject line'
-                value={action.data.email_subject}
-                onChange={e => onUpdateSubject(e.target.value)}
-            />
-        </SidebarField>
-        <Button
-            className='w-full'
-            type='button'
-            variant='outline'
-            onClick={onEditEmail}
-        >
-            <LucideIcon.Pencil className='size-4' />
-            Edit email
-        </Button>
-        <div className='mt-auto pt-6'>
-            <DeleteStepButton onClick={onDelete} />
+}> = ({action, autoFocusSubject, onUpdateSubject, onEditEmail, onDelete}) => {
+    const subjectInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (autoFocusSubject) {
+            subjectInputRef.current?.focus({preventScroll: true});
+        }
+    }, [action.id, autoFocusSubject]);
+
+    return (
+        <div className='flex flex-1 flex-col gap-5'>
+            <SidebarField label='Subject line'>
+                <Input
+                    ref={subjectInputRef}
+                    placeholder='Subject line'
+                    value={action.data.email_subject}
+                    onChange={e => onUpdateSubject(e.target.value)}
+                />
+            </SidebarField>
+            <Button
+                className='w-full'
+                type='button'
+                variant='outline'
+                onClick={onEditEmail}
+            >
+                <LucideIcon.Pencil className='size-4' />
+                Edit email
+            </Button>
+            <div className='mt-auto pt-6'>
+                <DeleteStepButton onClick={onDelete} />
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     switch (detail.type) {
@@ -857,7 +871,7 @@ const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     case 'wait':
         return <WaitSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onUpdate={detail.onUpdate} />;
     case 'send_email':
-        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
+        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} autoFocusSubject={detail.autoFocusSubject} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
     default: {
         const _exhaustive: never = detail;
         throw new Error(`Unknown sidebar type: ${_exhaustive}`);
@@ -933,6 +947,7 @@ type AutomationCanvasProps = {
 
 type SelectedStep = {
     id: string;
+    shouldFocusSubject?: boolean;
 };
 
 const insertActionByType = {
@@ -961,7 +976,10 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         const insertedAction = next.actions.find(action => !automation.actions.some(existingAction => existingAction.id === action.id));
         setNewStepId(insertedAction?.id ?? null);
         if (insertedAction) {
-            setSelectedStep({id: insertedAction.id});
+            setSelectedStep({
+                id: insertedAction.id,
+                shouldFocusSubject: insertedAction.type === 'send_email' ? true : undefined
+            });
         }
         onChange(next);
     }, [automation, onChange]);
@@ -1063,6 +1081,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,
+        autoFocusSubject: Boolean(selectedStep?.shouldFocusSubject),
         onDelete: handleRequestDelete,
         onUpdateWait: handleUpdateWait,
         onUpdateSubject: handleUpdateSubject,

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -762,9 +762,11 @@ const WaitSidebarBody: React.FC<{
     }
     const initialDays = action.data.wait_hours / 24;
     const [daysText, setDaysText] = useState<string>(String(initialDays));
+    const [hasBlurredDaysInput, setHasBlurredDaysInput] = useState(false);
 
     const days = Number(daysText);
     const isValid = getValidWaitDays(daysText) !== null;
+    const showValidationError = hasBlurredDaysInput && !isValid;
     const updateWaitDays = (nextDays: number) => {
         const nextHours = nextDays * 24;
         if (nextHours !== action.data.wait_hours) {
@@ -800,16 +802,18 @@ const WaitSidebarBody: React.FC<{
                 <InputGroup
                     aria-label='Wait duration in days'
                     className='h-(--control-height)'
-                    data-disabled={!isValid ? 'true' : undefined}
+                    data-disabled={showValidationError ? 'true' : undefined}
                 >
                     <InputGroupInput
-                        aria-describedby={!isValid ? 'automation-wait-days-error' : undefined}
-                        aria-invalid={!isValid}
+                        aria-describedby={showValidationError ? 'automation-wait-days-error' : undefined}
+                        aria-invalid={showValidationError}
                         className='w-10 min-w-10 flex-none pr-1 font-mono tabular-nums'
                         id='automation-wait-days'
                         inputMode='numeric'
                         value={daysText}
+                        onBlur={() => setHasBlurredDaysInput(true)}
                         onChange={handleChange}
+                        onFocus={() => setHasBlurredDaysInput(false)}
                     />
                     <InputGroupText className='mr-auto'>{days === 1 ? 'day' : 'days'}</InputGroupText>
                     <InputGroupAddon align='inline-end' className='gap-0.5 pr-2'>
@@ -833,7 +837,7 @@ const WaitSidebarBody: React.FC<{
                         </InputGroupButton>
                     </InputGroupAddon>
                 </InputGroup>
-                {!isValid && (
+                {showValidationError && (
                     <FieldError className='text-xs' id='automation-wait-days-error'>
                         Enter a whole number between 1 and {formatNumber(MAX_WAIT_DAYS)} days.
                     </FieldError>

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -38,8 +38,10 @@ const toApiAnchor = ({sourceId, targetId}: CanvasAnchor): InsertActionAnchor => 
 });
 
 type StepNodeDisplayData = {
+    errorMessage?: string;
     icon: React.ElementType;
     label: string;
+    isPlaceholderValue?: boolean;
     value?: string;
 };
 
@@ -102,12 +104,15 @@ const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: Ste
         }}>
             <ContextMenuTrigger asChild>
                 <button
+                    aria-invalid={Boolean(data.errorMessage)}
                     aria-label={data.value ? `${data.label}: ${data.value}` : data.label}
                     aria-pressed={data.selected}
                     className={cn(
                         'flex w-64 items-center gap-3 rounded-lg border border-transparent bg-surface-elevated p-3 text-left text-sm text-foreground shadow-sm transition-all focus-visible:border-border-strong focus-visible:outline-none',
+                        data.errorMessage && 'items-start',
                         !data.selected && 'hover:border-border-strong',
-                        data.selected && 'border-gray-700 shadow-[inset_0_0_0_1px_var(--color-gray-700),0_1px_2px_0_rgb(0_0_0_/_0.05)]',
+                        data.selected && !data.errorMessage && 'border-gray-700 shadow-[inset_0_0_0_1px_var(--color-gray-700),0_1px_2px_0_rgb(0_0_0_/_0.05)]',
+                        data.errorMessage && 'border-destructive',
                         data.isNew && 'animate-in fade-in-0 zoom-in-90 duration-250 ease-out motion-reduce:animate-none',
                         className
                     )}
@@ -159,12 +164,13 @@ const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
     const Icon = data.icon;
     return (
         <>
-            <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary'>
+            <div className={cn('flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary', data.errorMessage && 'mt-[3px]')}>
                 <Icon className='size-4' />
             </div>
             <div className='flex min-w-0 flex-col text-left'>
                 <span className='text-xs text-text-secondary'>{data.label}</span>
-                {data.value && <span className='truncate font-medium'>{data.value}</span>}
+                {data.value && <span className={cn('truncate font-medium', data.isPlaceholderValue && 'opacity-50')}>{data.value}</span>}
+                {data.errorMessage && <span className='mt-1 text-xs text-destructive'>{data.errorMessage}</span>}
             </div>
         </>
     );
@@ -350,7 +356,12 @@ const buildActionData = (action: AutomationAction): StepNodeDisplayData => {
     case 'wait':
         return {icon: LucideIcon.Clock, label: 'Wait', value: formatWait(action.data.wait_hours)};
     case 'send_email':
-        return {icon: LucideIcon.Mail, label: 'Send email', value: action.data.email_subject};
+        return {
+            icon: LucideIcon.Mail,
+            isPlaceholderValue: !action.data.email_subject,
+            label: 'Send email',
+            value: action.data.email_subject || 'Untitled'
+        };
     default: {
         const _exhaustive: never = action;
         throw new Error(`Unknown automation action type: ${_exhaustive}`);
@@ -454,6 +465,7 @@ const getInitialActionOrder = (automation: AutomationDetail): AutomationAction[]
 };
 
 type BuildGraphParams = {
+    actionErrors: Record<string, string>;
     automation: AutomationDetail;
     disabled: boolean;
     onDelete: (stepId: string) => void;
@@ -465,7 +477,7 @@ type BuildGraphParams = {
     selectedStepId: string | null;
 }
 
-const buildGraph = ({automation, disabled, onDelete, onEditEmailBody, onPick, onPreviewEmail, onSelectStep, newStepId, selectedStepId}: BuildGraphParams): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
+const buildGraph = ({actionErrors, automation, disabled, onDelete, onEditEmailBody, onPick, onPreviewEmail, onSelectStep, newStepId, selectedStepId}: BuildGraphParams): {nodes: AutomationFlowNode[]; edges: Edge[]} => {
     const ordered = getInitialActionOrder(automation);
     const baseNodeProps = {
         draggable: false,
@@ -518,6 +530,7 @@ const buildGraph = ({automation, disabled, onDelete, onEditEmailBody, onPick, on
                     onSelectStep,
                     stepId: action.id
                 }),
+                errorMessage: actionErrors[action.id],
                 isNew: newStepId === action.id,
                 selected: selectedStepId === action.id,
                 onSelect: () => onSelectStep(action.id)
@@ -578,6 +591,7 @@ const getInitialViewport = (canvasWidth: number): {x: number; y: number; zoom: n
 
 type BaseStepSidebarDetail<Type extends string, LabelText extends string> = {
     icon: React.ElementType;
+    isPlaceholderTitle?: boolean;
     title: string;
     label: LabelText;
     type: Type;
@@ -658,7 +672,8 @@ const getStepSidebarDetail = ({automation, autoFocusSubject, stepId, onDelete, o
         return {
             icon: LucideIcon.Mail,
             label: 'Send email',
-            title: action.data.email_subject || 'No subject',
+            isPlaceholderTitle: !action.data.email_subject,
+            title: action.data.email_subject || 'Untitled',
             action,
             autoFocusSubject,
             onDelete: () => onDelete(action.id),
@@ -891,7 +906,7 @@ const StepSidebarContent: React.FC<{detail: StepSidebarDetail}> = ({detail}) => 
                     </div>
                     <div className='min-w-0'>
                         <span className='block text-xs text-text-secondary'>{detail.label}</span>
-                        <h2 className='truncate text-base leading-tight font-medium text-foreground'>{detail.title}</h2>
+                        <h2 className={cn('truncate text-base leading-tight font-medium text-foreground', detail.isPlaceholderTitle && 'opacity-50')}>{detail.title}</h2>
                     </div>
                 </div>
             </div>
@@ -939,6 +954,7 @@ const StepSidebar: React.FC<{detail: StepSidebarDetail | null; isEmailModalOpen:
 };
 
 type AutomationCanvasProps = {
+    actionErrors?: Record<string, string>;
     automation?: AutomationDetail;
     isLoading: boolean;
     isError: boolean;
@@ -955,7 +971,7 @@ const insertActionByType = {
     send_email: insertSendEmailAction
 };
 
-const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoading, isError, onChange}) => {
+const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, automation, isLoading, isError, onChange}) => {
     const [newStepId, setNewStepId] = useState<string | null>(null);
     const [emailModalMode, setEmailModalMode] = useState<EmailModalMode>('edit');
     const [emailModalStepId, setEmailModalStepId] = useState<string | null>(null);
@@ -1067,6 +1083,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             return null;
         }
         return buildGraph({
+            actionErrors,
             automation,
             disabled: automation.actions.length >= MAX_AUTOMATION_ACTIONS,
             onDelete: handleDelete,
@@ -1077,7 +1094,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
             newStepId,
             selectedStepId
         });
-    }, [automation, handleContextMenuEditEmail, handleContextMenuPreviewEmail, handleDelete, handlePick, newStepId, selectedStepId]);
+    }, [actionErrors, automation, handleContextMenuEditEmail, handleContextMenuPreviewEmail, handleDelete, handlePick, newStepId, selectedStepId]);
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -5,7 +5,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
 import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction, updateSendEmailAction, updateWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, BackgroundVariant, Controls, Edge, Handle, Node, NodeProps, Position, ReactFlow, useReactFlow, useViewport} from '@xyflow/react';
-import {Banner, Button, Checkbox, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Banner, Button, Checkbox, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import type {EmailModalMode} from './types';
 
@@ -945,6 +945,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
     const [emailModalMode, setEmailModalMode] = useState<EmailModalMode>('edit');
     const [emailModalStepId, setEmailModalStepId] = useState<string | null>(null);
     const [selectedStep, setSelectedStep] = useState<SelectedStep | null>(null);
+    const [deleteConfirmationActionId, setDeleteConfirmationActionId] = useState<string | null>(null);
     const selectedStepId = selectedStep?.id ?? null;
 
     const handlePick = useCallback((type: StepPickerType, anchor: CanvasAnchor) => {
@@ -982,8 +983,23 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         const next = removeAction({detail: automation, actionId});
         setEmailModalStepId(currentId => (currentId === actionId ? null : currentId));
         setSelectedStep(null);
+        setDeleteConfirmationActionId(null);
         onChange(next);
     }, [automation, onChange]);
+
+    const handleRequestDelete = useCallback((actionId: string) => {
+        if (!automation) {
+            return;
+        }
+
+        const action = automation.actions.find(item => item.id === actionId);
+        if (action?.type === 'send_email') {
+            setDeleteConfirmationActionId(action.id);
+            return;
+        }
+
+        handleDelete(actionId);
+    }, [automation, handleDelete]);
 
     const handleUpdateWait = useCallback((actionId: string, waitHours: number) => {
         if (!automation) {
@@ -1022,6 +1038,10 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
         ? automation.actions.find((action): action is AutomationSendEmailAction => action.id === emailModalStepId && action.type === 'send_email')
         : undefined;
 
+    const deleteConfirmationAction = automation && deleteConfirmationActionId
+        ? automation.actions.find((action): action is AutomationSendEmailAction => action.id === deleteConfirmationActionId && action.type === 'send_email')
+        : undefined;
+
     const initialViewport = useRef(getInitialViewport(window.innerWidth));
 
     const graph = useMemo(() => {
@@ -1043,7 +1063,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,
-        onDelete: handleDelete,
+        onDelete: handleRequestDelete,
         onUpdateWait: handleUpdateWait,
         onUpdateSubject: handleUpdateSubject,
         onEditEmail: handleEditEmail,
@@ -1124,7 +1144,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
                 <Background variant={BackgroundVariant.Dots} />
                 <AutomationCanvasControls />
             </ReactFlow>
-            <StepSidebar detail={sidebarDetail} isEmailModalOpen={Boolean(emailModalAction)} onClose={clearDetail} />
+            <StepSidebar detail={sidebarDetail} isEmailModalOpen={Boolean(emailModalAction) || Boolean(deleteConfirmationAction)} onClose={clearDetail} />
             {emailModalAction && automation && (
                 <EmailContentModal
                     initialLexical={emailModalAction.data.email_lexical}
@@ -1137,6 +1157,36 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({automation, isLoadin
                     }}
                 />
             )}
+            <AlertDialog
+                open={Boolean(deleteConfirmationAction)}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setDeleteConfirmationActionId(null);
+                    }
+                }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete this email?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This email will be removed from the automation. Save or publish the automation to apply this change.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <Button
+                            variant='destructive'
+                            onClick={() => {
+                                if (deleteConfirmationAction) {
+                                    handleDelete(deleteConfirmationAction.id);
+                                }
+                            }}
+                        >
+                            Delete email
+                        </Button>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 };

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -19,7 +19,7 @@ const NODE_GAP_Y = 180;
 const INITIAL_VIEWPORT_Y = 40;
 const VIEWPORT_ANIMATION_DURATION = 180;
 const NODE_ENTER_ANIMATION_DURATION = 250;
-const DISABLED_REASON = `Limit of ${formatNumber(MAX_AUTOMATION_ACTIONS)} steps reached`;
+const DISABLED_REASON = 'Maximum steps added';
 const DEFAULT_EDGE_STROKE = 'var(--xy-edge-stroke)';
 const ZOOM_PRESETS = [1.5, 1, 0.75, 0.5, 0.25];
 
@@ -210,7 +210,7 @@ const TailNode: React.FC<NodeProps<TailFlowNode>> = ({data}) => {
     if (data.disabled) {
         return (
             <div
-                className='flex h-12 w-64 items-center justify-center rounded-lg border border-border-default bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_18px,var(--color-gray-100)_18px,var(--color-gray-100)_34px)] text-sm font-medium text-text-secondary'
+                className='flex h-12 w-64 items-center justify-center rounded-lg border border-border-default bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_12px,var(--color-gray-100)_12px,var(--color-gray-100)_24px)] text-sm font-medium text-text-secondary'
                 data-testid='step-limit-tail-node'
             >
                 <HiddenHandle position={Position.Top} type='target' />

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -5,7 +5,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
 import {AutomationAction, AutomationDetail, AutomationSendEmailAction, AutomationWaitAction, InsertActionAnchor, MAX_AUTOMATION_ACTIONS, insertSendEmailAction, insertWaitAction, removeAction, updateSendEmailAction, updateWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Background, BackgroundVariant, Controls, Edge, Handle, Node, NodeProps, Position, ReactFlow, useReactFlow, useViewport} from '@xyflow/react';
-import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Banner, Button, Checkbox, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Banner, Button, Checkbox, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, Label, LoadingIndicator, Popover, PopoverContent, PopoverTrigger, Select, SelectTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import type {EmailModalMode} from './types';
 
@@ -208,28 +208,15 @@ const TailNode: React.FC<NodeProps<TailFlowNode>> = ({data}) => {
     const triggerClassName = 'flex h-12 w-64 items-center justify-center rounded-lg border border-dashed border-border-default bg-surface-page transition-colors hover:border-border-strong focus-visible:border-border-strong focus-visible:outline-none';
 
     if (data.disabled) {
-        const content = (
+        return (
             <div
-                aria-disabled='true'
-                className={cn(triggerClassName, 'cursor-not-allowed opacity-60')}
-                data-testid='add-step-tail-button'
+                className='flex h-12 w-64 items-center justify-center rounded-lg border border-border-default bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_18px,var(--color-gray-100)_18px,var(--color-gray-100)_34px)] text-sm font-medium text-text-secondary'
+                data-testid='step-limit-tail-node'
             >
                 <HiddenHandle position={Position.Top} type='target' />
-                <LucideIcon.Plus className='size-5 text-text-secondary' strokeWidth={1.5} />
+                <LucideIcon.Milestone className='mr-2 size-4' strokeWidth={1.5} />
+                {data.disabledReason}
             </div>
-        );
-        if (!data.disabledReason) {
-            return content;
-        }
-        return (
-            <TooltipProvider delayDuration={150}>
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <span tabIndex={0}>{content}</span>
-                    </TooltipTrigger>
-                    <TooltipContent>{data.disabledReason}</TooltipContent>
-                </Tooltip>
-            </TooltipProvider>
         );
     }
 
@@ -888,7 +875,7 @@ const SendEmailSidebarBody: React.FC<{
                 onClick={onEditEmail}
             >
                 <LucideIcon.Pencil className='size-4' />
-                Edit email
+                Edit email content
             </Button>
             <div className='mt-auto pt-6'>
                 <DeleteStepButton onClick={onDelete} />

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -43,6 +43,7 @@ type StepNodeDisplayData = {
     label: string;
     isPlaceholderValue?: boolean;
     value?: string;
+    warningMessage?: string;
 };
 
 type NodeContextMenuItem = {
@@ -109,10 +110,11 @@ const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: Ste
                     aria-pressed={data.selected}
                     className={cn(
                         'flex w-64 items-center gap-3 rounded-lg border border-transparent bg-surface-elevated p-3 text-left text-sm text-foreground shadow-sm transition-all focus-visible:border-border-strong focus-visible:outline-none',
-                        data.errorMessage && 'items-start',
+                        (data.errorMessage || data.warningMessage) && 'items-start',
                         !data.selected && 'hover:border-border-strong',
                         data.selected && !data.errorMessage && 'border-gray-700 shadow-[inset_0_0_0_1px_var(--color-gray-700),0_1px_2px_0_rgb(0_0_0_/_0.05)]',
                         data.errorMessage && 'border-destructive',
+                        !data.errorMessage && data.warningMessage && 'border-yellow-600',
                         data.isNew && 'animate-in fade-in-0 zoom-in-90 duration-250 ease-out motion-reduce:animate-none',
                         className
                     )}
@@ -162,15 +164,17 @@ const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: Ste
 
 const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
     const Icon = data.icon;
+    const statusMessage = data.errorMessage || data.warningMessage;
     return (
         <>
-            <div className={cn('flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary', data.errorMessage && 'mt-[3px]')}>
+            <div className={cn('flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-text-secondary', statusMessage && 'mt-[3px]')}>
                 <Icon className='size-4' />
             </div>
             <div className='flex min-w-0 flex-col text-left'>
                 <span className='text-xs text-text-secondary'>{data.label}</span>
                 {data.value && <span className={cn('truncate font-medium', data.isPlaceholderValue && 'opacity-50')}>{data.value}</span>}
                 {data.errorMessage && <span className='mt-1 text-xs text-destructive'>{data.errorMessage}</span>}
+                {!data.errorMessage && data.warningMessage && <span className='mt-1 text-xs text-yellow-600'>{data.warningMessage}</span>}
             </div>
         </>
     );
@@ -351,6 +355,25 @@ export const formatWait = (hours: number): string => {
     return hours === 1 ? '1 hour' : `${hours} hours`;
 };
 
+const isEmptyEmailLexical = (lexical: string | null | undefined): boolean => {
+    if (!lexical) {
+        return true;
+    }
+
+    try {
+        const parsed = JSON.parse(lexical);
+        const children = parsed?.root?.children;
+
+        if (!children || children.length === 0) {
+            return true;
+        }
+
+        return children.length === 1 && children[0].type === 'paragraph' && (!children[0].children || children[0].children.length === 0);
+    } catch {
+        return true;
+    }
+};
+
 const buildActionData = (action: AutomationAction): StepNodeDisplayData => {
     switch (action.type) {
     case 'wait':
@@ -360,7 +383,8 @@ const buildActionData = (action: AutomationAction): StepNodeDisplayData => {
             icon: LucideIcon.Mail,
             isPlaceholderValue: !action.data.email_subject,
             label: 'Send email',
-            value: action.data.email_subject || 'Untitled'
+            value: action.data.email_subject || 'Untitled',
+            warningMessage: isEmptyEmailLexical(action.data.email_lexical) ? 'Empty email body' : undefined
         };
     default: {
         const _exhaustive: never = action;

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -839,7 +839,7 @@ const WaitSidebarBody: React.FC<{
                 </InputGroup>
                 {showValidationError && (
                     <FieldError className='text-xs' id='automation-wait-days-error'>
-                        Enter a whole number between 1 and {formatNumber(MAX_WAIT_DAYS)} days.
+                        Enter a delay between 1 and {formatNumber(MAX_WAIT_DAYS)} days
                     </FieldError>
                 )}
             </SidebarField>

--- a/apps/posts/src/views/Automations/components/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/automation-canvas.tsx
@@ -611,7 +611,6 @@ type WaitStepSidebarDetail = ActionStepSidebarDetail<AutomationWaitAction, 'Wait
 };
 
 type SendEmailStepSidebarDetail = ActionStepSidebarDetail<AutomationSendEmailAction, 'Send email'> & {
-    autoFocusSubject: boolean;
     onUpdateSubject: (subject: string) => void;
     onEditEmail: () => void;
 };
@@ -627,7 +626,6 @@ const automationSlugMemberTiers: Record<string, MemberTier[]> = {
 
 type StepSidebarDetailOptions = {
     automation: AutomationDetail;
-    autoFocusSubject: boolean;
     onDelete: (actionId: string) => void;
     onUpdateWait: (actionId: string, waitHours: number) => void;
     onUpdateSubject: (actionId: string, subject: string) => void;
@@ -635,7 +633,7 @@ type StepSidebarDetailOptions = {
     stepId: string | null;
 };
 
-const getStepSidebarDetail = ({automation, autoFocusSubject, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
+const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpdateSubject, onEditEmail}: StepSidebarDetailOptions): StepSidebarDetail | null => {
     if (!stepId) {
         return null;
     }
@@ -675,7 +673,6 @@ const getStepSidebarDetail = ({automation, autoFocusSubject, stepId, onDelete, o
             isPlaceholderTitle: !action.data.email_subject,
             title: action.data.email_subject || 'Untitled',
             action,
-            autoFocusSubject,
             onDelete: () => onDelete(action.id),
             onUpdateSubject: (subject: string) => onUpdateSubject(action.id, subject),
             onEditEmail: () => onEditEmail(action.id),
@@ -840,18 +837,15 @@ const WaitSidebarBody: React.FC<{
 
 const SendEmailSidebarBody: React.FC<{
     action: AutomationSendEmailAction;
-    autoFocusSubject: boolean;
     onUpdateSubject: (subject: string) => void;
     onEditEmail: () => void;
     onDelete: () => void;
-}> = ({action, autoFocusSubject, onUpdateSubject, onEditEmail, onDelete}) => {
+}> = ({action, onUpdateSubject, onEditEmail, onDelete}) => {
     const subjectInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
-        if (autoFocusSubject) {
-            subjectInputRef.current?.focus({preventScroll: true});
-        }
-    }, [action.id, autoFocusSubject]);
+        subjectInputRef.current?.focus({preventScroll: true});
+    }, [action.id]);
 
     return (
         <div className='flex flex-1 flex-col gap-5'>
@@ -886,7 +880,7 @@ const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     case 'wait':
         return <WaitSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onUpdate={detail.onUpdate} />;
     case 'send_email':
-        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} autoFocusSubject={detail.autoFocusSubject} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
+        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
     default: {
         const _exhaustive: never = detail;
         throw new Error(`Unknown sidebar type: ${_exhaustive}`);
@@ -963,7 +957,6 @@ type AutomationCanvasProps = {
 
 type SelectedStep = {
     id: string;
-    shouldFocusSubject?: boolean;
 };
 
 const insertActionByType = {
@@ -992,10 +985,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
         const insertedAction = next.actions.find(action => !automation.actions.some(existingAction => existingAction.id === action.id));
         setNewStepId(insertedAction?.id ?? null);
         if (insertedAction) {
-            setSelectedStep({
-                id: insertedAction.id,
-                shouldFocusSubject: insertedAction.type === 'send_email' ? true : undefined
-            });
+            setSelectedStep({id: insertedAction.id});
         }
         onChange(next);
     }, [automation, onChange]);
@@ -1098,7 +1088,6 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
 
     const sidebarDetail = automation ? getStepSidebarDetail({
         automation,
-        autoFocusSubject: Boolean(selectedStep?.shouldFocusSubject),
         onDelete: handleRequestDelete,
         onUpdateWait: handleUpdateWait,
         onUpdateSubject: handleUpdateSubject,

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -111,7 +111,10 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
         || automatedEmails[0]
     )?.id || '';
 
-    const {formState, saveState, updateForm, setFormState, setErrors, handleSave, okProps, errors, validate} = useForm({
+    // Saving commits whatever the user has — including an empty subject or body — to the
+    // automation draft. Completeness is only enforced when publishing the automation or
+    // sending a test email (see validateForTest below), not when saving a draft.
+    const {formState, saveState, updateForm, setFormState, setErrors, handleSave, okProps, errors, clearError} = useForm({
         initialState: {
             subject: initialSubject || '',
             lexical: initialLexical || ''
@@ -120,9 +123,14 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
         onSave: async (state) => {
             onSave({subject: state.subject, lexical: state.lexical});
         },
-        onSaveError: handleError,
-        onValidate: getEmailValidationErrors
+        onSaveError: handleError
     });
+
+    const validateForTest = useCallback((): boolean => {
+        const newErrors = getEmailValidationErrors(formState);
+        setErrors(newErrors);
+        return Object.values(newErrors).every(error => !error);
+    }, [formState, setErrors]);
     const saveButtonLabel = okProps.label || 'Save';
     const {previewFrameState, enterPreview, exitPreview} = useEmailPreview({
         automatedEmailId: previewAutomatedEmailId,
@@ -290,7 +298,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
                                                     Test
                                                 </Button>
                                                 {showTestDropdown && (
-                                                    <TestEmailDropdown automatedEmailId={previewAutomatedEmailId} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
+                                                    <TestEmailDropdown automatedEmailId={previewAutomatedEmailId} lexical={formState.lexical} subject={formState.subject} validateForm={validateForTest} onClose={() => setShowTestDropdown(false)} />
                                                 )}
                                             </div>
                                         </div>
@@ -313,6 +321,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
                                                         const nextSubject = e.target.value;
                                                         setPreviewSubjectOverride(nextSubject);
                                                         updateForm(state => ({...state, subject: nextSubject}));
+                                                        clearError('subject');
                                                     }}
                                                 />
                                                 {errors.subject && <span className='mt-2 block text-xs text-destructive'>{errors.subject}</span>}

--- a/apps/posts/src/views/Automations/components/email-modal/use-email-preview.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/use-email-preview.ts
@@ -66,6 +66,7 @@ export const useEmailPreview = ({automatedEmailId, previewWelcomeEmail, setError
     const exitPreview = () => {
         previewRequestIdRef.current += 1;
         setPreviewState({status: 'idle'});
+        setErrors({});
     };
 
     const enterPreview = async (draft: EmailDraft) => {
@@ -73,17 +74,16 @@ export const useEmailPreview = ({automatedEmailId, previewWelcomeEmail, setError
         previewRequestIdRef.current = requestId;
 
         const validationErrors = getEmailValidationErrors(draft);
-        setErrors(validationErrors);
-
-        const hasValidationErrors = Boolean(validationErrors.subject || validationErrors.lexical);
-        if (hasValidationErrors) {
+        if (validationErrors.lexical) {
+            setErrors({lexical: validationErrors.lexical});
             setPreviewState({
                 status: 'invalid',
-                message: validationErrors.subject || validationErrors.lexical
+                message: validationErrors.lexical
             });
             return;
         }
 
+        setErrors({});
         setPreviewState({status: 'loading'});
 
         try {

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -358,6 +358,9 @@ const AutomationEditor: React.FC = () => {
         case undefined:
             throw new Error('Cannot publish an automation that has not loaded.');
         case 'active':
+            if (!validateActionErrors(draft, 'idle')) {
+                return;
+            }
             setEditState('confirming re-publish');
             break;
         case 'inactive':

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -10,6 +10,26 @@ import {useConfirmUnload, useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
 
 const SUBJECT_REQUIRED_MESSAGE = 'Add a subject line.';
+const EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE = 'One or more emails in this automation do not have a body. Are you sure you want to save and publish this automation?';
+
+const isEmptyEmailLexical = (lexical: string | null | undefined): boolean => {
+    if (!lexical) {
+        return true;
+    }
+
+    try {
+        const parsed = JSON.parse(lexical);
+        const children = parsed?.root?.children;
+
+        if (!children || children.length === 0) {
+            return true;
+        }
+
+        return children.length === 1 && children[0].type === 'paragraph' && (!children[0].children || children[0].children.length === 0);
+    } catch {
+        return true;
+    }
+};
 
 const editableSlice = (automation: AutomationDetail) => ({
     status: automation.status,
@@ -24,6 +44,7 @@ const isFailedEditState = (editState: AutomationEditState): boolean => {
     case 'failed to save':
     case 'failed to unpublish':
         return true;
+    case 'confirming empty-body publish':
     case 'confirming re-publish':
     case 'confirming unpublish':
     case 'idle':
@@ -50,6 +71,10 @@ const getActionErrors = (automation: AutomationDetail): Record<string, string> =
 
     return errors;
 };
+
+const hasEmptyEmailBodies = (automation: AutomationDetail): boolean => (
+    automation.actions.some(action => action.type === 'send_email' && isEmptyEmailLexical(action.data.email_lexical))
+);
 
 const AutomationEditor: React.FC = () => {
     const {id = ''} = useParams<{id: string}>();
@@ -98,6 +123,20 @@ const AutomationEditor: React.FC = () => {
         ));
     };
 
+    const validateActionErrors = (automationToValidate: AutomationDetail, errorState: AutomationEditState): boolean => {
+        const nextActionErrors = getActionErrors(automationToValidate);
+        if (Object.keys(nextActionErrors).length > 0) {
+            setActionErrors(nextActionErrors);
+            setEditState(errorState);
+            toast.error('Could not save automation', {
+                description: 'Fix the highlighted steps and try again.'
+            });
+            return false;
+        }
+
+        return true;
+    };
+
     const save = (statusToSave?: AutomationStatus) => {
         if (!draft) {
             throw new Error('Cannot edit an automation that has not loaded.');
@@ -132,17 +171,11 @@ const AutomationEditor: React.FC = () => {
         }
         }
 
-        setEditState(requestState);
-
-        const nextActionErrors = getActionErrors(draft);
-        if (Object.keys(nextActionErrors).length > 0) {
-            setActionErrors(nextActionErrors);
-            setEditState(errorState);
-            toast.error('Could not save automation', {
-                description: 'Fix the highlighted steps and try again.'
-            });
+        if (!validateActionErrors(draft, errorState)) {
             return;
         }
+
+        setEditState(requestState);
 
         editMutation.mutate(
             {
@@ -167,6 +200,8 @@ const AutomationEditor: React.FC = () => {
         );
     };
 
+    const hasEmptyEmailBodyWarnings = draft ? hasEmptyEmailBodies(draft) : false;
+    let isConfirmEmptyBodyPublishAlertOpen = false;
     let isConfirmUnpublishAlertOpen = false;
     let isConfirmRepublishAlertOpen = false;
     let isEditRequestActive = false;
@@ -236,6 +271,12 @@ const AutomationEditor: React.FC = () => {
             </>
         );
         break;
+    case 'confirming empty-body publish':
+        isConfirmEmptyBodyPublishAlertOpen = true;
+        isSaveButtonEnabled = false;
+        isPublishButtonEnabled = false;
+        isTurnOffButtonEnabled = false;
+        break;
     case 'confirming unpublish':
         isConfirmUnpublishAlertOpen = true;
         isSaveButtonEnabled = false;
@@ -272,6 +313,19 @@ const AutomationEditor: React.FC = () => {
         throw new Error(`Unhandled edit state: ${_exhaustive}`);
     }
     }
+
+    const onConfirmEmptyBodyPublishOpenChange = (open: boolean): void => {
+        setEditState((oldEditState) => {
+            switch (oldEditState) {
+            case 'confirming empty-body publish':
+                return open ? oldEditState : 'idle';
+            case 'idle':
+                return open ? 'confirming empty-body publish' : oldEditState;
+            default:
+                return oldEditState;
+            }
+        });
+    };
 
     const onConfirmUnpublishOpenChange = (open: boolean): void => {
         setEditState((oldEditState) => {
@@ -310,6 +364,13 @@ const AutomationEditor: React.FC = () => {
             setEditState('confirming re-publish');
             break;
         case 'inactive':
+            if (!validateActionErrors(draft, 'failed to publish')) {
+                return;
+            }
+            if (hasEmptyEmailBodies(draft)) {
+                setEditState('confirming empty-body publish');
+                return;
+            }
             save('active');
             break;
         default: {
@@ -379,6 +440,26 @@ const AutomationEditor: React.FC = () => {
             </AlertDialog>
 
             <AlertDialog
+                open={isConfirmEmptyBodyPublishAlertOpen}
+                onOpenChange={onConfirmEmptyBodyPublishOpenChange}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Publish automation with empty emails?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <Button onClick={() => save('active')}>
+                            Publish automation
+                        </Button>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog
                 open={isConfirmUnpublishAlertOpen}
                 onOpenChange={onConfirmUnpublishOpenChange}
             >
@@ -410,7 +491,7 @@ const AutomationEditor: React.FC = () => {
                     <AlertDialogHeader>
                         <AlertDialogTitle>Update automation?</AlertDialogTitle>
                         <AlertDialogDescription>
-                            This will update the automation for new runs of the automation, as well as any actively-running ones.
+                            {hasEmptyEmailBodyWarnings ? `${EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE} This will update the automation for new runs of the automation, as well as any actively-running ones.` : 'This will update the automation for new runs of the automation, as well as any actively-running ones.'}
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -197,11 +197,22 @@ const AutomationEditor: React.FC = () => {
                     setActionErrors({});
                     setEditState('idle');
                 },
-                onError: () => {
+                onError: (error) => {
+                    void error;
+                    const nextActionErrors = newStatus === 'active' ? getActionErrors(draft) : {};
+                    const hasActionErrors = Object.keys(nextActionErrors).length > 0;
+                    if (hasActionErrors) {
+                        setActionErrors(nextActionErrors);
+                    }
+
                     setEditState(errorState);
-                    toast.error('Automation couldn’t be saved', {
-                        description: 'Fix the highlighted steps and try again.'
-                    });
+                    if (hasActionErrors) {
+                        toast.error('Automation couldn’t be saved', {
+                            description: 'Fix the highlighted steps and try again.'
+                        });
+                    } else {
+                        toast.error('Automation couldn’t be saved');
+                    }
                 }
             }
         );

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -128,7 +128,7 @@ const AutomationEditor: React.FC = () => {
         if (Object.keys(nextActionErrors).length > 0) {
             setActionErrors(nextActionErrors);
             setEditState(errorState);
-            toast.error('Could not save automation', {
+            toast.error('Automation couldn’t be saved', {
                 description: 'Fix the highlighted steps and try again.'
             });
             return false;
@@ -192,8 +192,8 @@ const AutomationEditor: React.FC = () => {
                 },
                 onError: () => {
                     setEditState(errorState);
-                    toast.error('Could not save automation', {
-                        description: 'Fix any highlighted steps and try again.'
+                    toast.error('Automation couldn’t be saved', {
+                        description: 'Fix the highlighted steps and try again.'
                     });
                 }
             }

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -4,9 +4,12 @@ import React from 'react';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, type ButtonProps, LoadingIndicator} from '@tryghost/shade/components';
 import {AutomationDetail, AutomationStatus, useEditAutomation, useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
 import {dequal} from 'dequal';
+import {toast} from 'sonner';
 import {useBlocker} from 'react-router';
 import {useConfirmUnload, useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
+
+const SUBJECT_REQUIRED_MESSAGE = 'Add a subject line.';
 
 const editableSlice = (automation: AutomationDetail) => ({
     status: automation.status,
@@ -36,6 +39,18 @@ const isFailedEditState = (editState: AutomationEditState): boolean => {
     }
 };
 
+const getActionErrors = (automation: AutomationDetail): Record<string, string> => {
+    const errors: Record<string, string> = {};
+
+    for (const action of automation.actions) {
+        if (action.type === 'send_email' && !action.data.email_subject.trim()) {
+            errors[action.id] = SUBJECT_REQUIRED_MESSAGE;
+        }
+    }
+
+    return errors;
+};
+
 const AutomationEditor: React.FC = () => {
     const {id = ''} = useParams<{id: string}>();
 
@@ -46,6 +61,7 @@ const AutomationEditor: React.FC = () => {
 
     const editMutation = useEditAutomation();
     const [editState, setEditState] = React.useState<AutomationEditState>('idle');
+    const [actionErrors, setActionErrors] = React.useState<Record<string, string>>({});
 
     // Draft is the user-facing, locally mutable copy. The React Query cache stays as server truth;
     // staged edits (adding steps, etc.) live here until the user publishes. Seeded once when the
@@ -67,6 +83,16 @@ const AutomationEditor: React.FC = () => {
 
     const onDraftChange = (next: AutomationDetail) => {
         setDraft(next);
+        setActionErrors((oldErrors) => {
+            if (Object.keys(oldErrors).length === 0) {
+                return oldErrors;
+            }
+
+            const nextErrors = getActionErrors(next);
+            return Object.fromEntries(
+                Object.entries(oldErrors).filter(([actionId]) => nextErrors[actionId])
+            );
+        });
         setEditState(prev => (
             isFailedEditState(prev) ? 'idle' : prev
         ));
@@ -108,6 +134,16 @@ const AutomationEditor: React.FC = () => {
 
         setEditState(requestState);
 
+        const nextActionErrors = getActionErrors(draft);
+        if (Object.keys(nextActionErrors).length > 0) {
+            setActionErrors(nextActionErrors);
+            setEditState(errorState);
+            toast.error('Could not save automation', {
+                description: 'Fix the highlighted steps and try again.'
+            });
+            return;
+        }
+
         editMutation.mutate(
             {
                 id: draft.id,
@@ -118,9 +154,15 @@ const AutomationEditor: React.FC = () => {
             {
                 onSuccess: (response) => {
                     setDraft(response.automations[0]);
+                    setActionErrors({});
                     setEditState('idle');
                 },
-                onError: () => setEditState(errorState)
+                onError: () => {
+                    setEditState(errorState);
+                    toast.error('Could not save automation', {
+                        description: 'Fix any highlighted steps and try again.'
+                    });
+                }
             }
         );
     };
@@ -306,6 +348,7 @@ const AutomationEditor: React.FC = () => {
             />
 
             <AutomationCanvas
+                actionErrors={actionErrors}
                 automation={draft}
                 isError={isError}
                 isLoading={isLoadingAutomation}

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -10,7 +10,8 @@ import {useConfirmUnload, useParams} from '@tryghost/admin-x-framework';
 import type {AutomationEditState} from './types';
 
 const SUBJECT_REQUIRED_MESSAGE = 'Add a subject line.';
-const EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE = 'One or more emails in this automation do not have a body. Are you sure you want to save and publish this automation?';
+const BODY_REQUIRED_MESSAGE = 'Add an email body.';
+const SUBJECT_AND_BODY_REQUIRED_MESSAGE = 'Add a subject line and email body.';
 
 const isEmptyEmailLexical = (lexical: string | null | undefined): boolean => {
     if (!lexical) {
@@ -44,7 +45,6 @@ const isFailedEditState = (editState: AutomationEditState): boolean => {
     case 'failed to save':
     case 'failed to unpublish':
         return true;
-    case 'confirming empty-body publish':
     case 'confirming re-publish':
     case 'confirming unpublish':
     case 'idle':
@@ -64,17 +64,24 @@ const getActionErrors = (automation: AutomationDetail): Record<string, string> =
     const errors: Record<string, string> = {};
 
     for (const action of automation.actions) {
-        if (action.type === 'send_email' && !action.data.email_subject.trim()) {
+        if (action.type !== 'send_email') {
+            continue;
+        }
+
+        const missingSubject = !action.data.email_subject.trim();
+        const missingBody = isEmptyEmailLexical(action.data.email_lexical);
+
+        if (missingSubject && missingBody) {
+            errors[action.id] = SUBJECT_AND_BODY_REQUIRED_MESSAGE;
+        } else if (missingSubject) {
             errors[action.id] = SUBJECT_REQUIRED_MESSAGE;
+        } else if (missingBody) {
+            errors[action.id] = BODY_REQUIRED_MESSAGE;
         }
     }
 
     return errors;
 };
-
-const hasEmptyEmailBodies = (automation: AutomationDetail): boolean => (
-    automation.actions.some(action => action.type === 'send_email' && isEmptyEmailLexical(action.data.email_lexical))
-);
 
 const AutomationEditor: React.FC = () => {
     const {id = ''} = useParams<{id: string}>();
@@ -171,7 +178,7 @@ const AutomationEditor: React.FC = () => {
         }
         }
 
-        if (!validateActionErrors(draft, errorState)) {
+        if (newStatus === 'active' && !validateActionErrors(draft, errorState)) {
             return;
         }
 
@@ -200,8 +207,6 @@ const AutomationEditor: React.FC = () => {
         );
     };
 
-    const hasEmptyEmailBodyWarnings = draft ? hasEmptyEmailBodies(draft) : false;
-    let isConfirmEmptyBodyPublishAlertOpen = false;
     let isConfirmUnpublishAlertOpen = false;
     let isConfirmRepublishAlertOpen = false;
     let isEditRequestActive = false;
@@ -271,12 +276,6 @@ const AutomationEditor: React.FC = () => {
             </>
         );
         break;
-    case 'confirming empty-body publish':
-        isConfirmEmptyBodyPublishAlertOpen = true;
-        isSaveButtonEnabled = false;
-        isPublishButtonEnabled = false;
-        isTurnOffButtonEnabled = false;
-        break;
     case 'confirming unpublish':
         isConfirmUnpublishAlertOpen = true;
         isSaveButtonEnabled = false;
@@ -313,19 +312,6 @@ const AutomationEditor: React.FC = () => {
         throw new Error(`Unhandled edit state: ${_exhaustive}`);
     }
     }
-
-    const onConfirmEmptyBodyPublishOpenChange = (open: boolean): void => {
-        setEditState((oldEditState) => {
-            switch (oldEditState) {
-            case 'confirming empty-body publish':
-                return open ? oldEditState : 'idle';
-            case 'idle':
-                return open ? 'confirming empty-body publish' : oldEditState;
-            default:
-                return oldEditState;
-            }
-        });
-    };
 
     const onConfirmUnpublishOpenChange = (open: boolean): void => {
         setEditState((oldEditState) => {
@@ -364,13 +350,6 @@ const AutomationEditor: React.FC = () => {
             setEditState('confirming re-publish');
             break;
         case 'inactive':
-            if (!validateActionErrors(draft, 'failed to publish')) {
-                return;
-            }
-            if (hasEmptyEmailBodies(draft)) {
-                setEditState('confirming empty-body publish');
-                return;
-            }
             save('active');
             break;
         default: {
@@ -440,26 +419,6 @@ const AutomationEditor: React.FC = () => {
             </AlertDialog>
 
             <AlertDialog
-                open={isConfirmEmptyBodyPublishAlertOpen}
-                onOpenChange={onConfirmEmptyBodyPublishOpenChange}
-            >
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>Publish automation with empty emails?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            {EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE}
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <Button onClick={() => save('active')}>
-                            Publish automation
-                        </Button>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
-
-            <AlertDialog
                 open={isConfirmUnpublishAlertOpen}
                 onOpenChange={onConfirmUnpublishOpenChange}
             >
@@ -491,7 +450,7 @@ const AutomationEditor: React.FC = () => {
                     <AlertDialogHeader>
                         <AlertDialogTitle>Update automation?</AlertDialogTitle>
                         <AlertDialogDescription>
-                            {hasEmptyEmailBodyWarnings ? `${EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE} This will update the automation for new runs of the automation, as well as any actively-running ones.` : 'This will update the automation for new runs of the automation, as well as any actively-running ones.'}
+                            This will update the automation for new runs of the automation, as well as any actively-running ones.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -353,10 +353,11 @@ const AutomationEditor: React.FC = () => {
     };
 
     const onPublish = (): void => {
-        const draftStatus = draft?.status;
-        switch (draftStatus) {
-        case undefined:
+        if (!draft) {
             throw new Error('Cannot publish an automation that has not loaded.');
+        }
+
+        switch (draft.status) {
         case 'active':
             if (!validateActionErrors(draft, 'idle')) {
                 return;
@@ -367,7 +368,7 @@ const AutomationEditor: React.FC = () => {
             save('active');
             break;
         default: {
-            const _exhaustive: never = draftStatus;
+            const _exhaustive: never = draft.status;
             throw new Error(`Unhandled status: ${_exhaustive}`);
         }
         }

--- a/apps/posts/src/views/Automations/types.ts
+++ b/apps/posts/src/views/Automations/types.ts
@@ -4,7 +4,6 @@ export type AutomationEditState =
   | 'publishing'
   | 're-publishing'
   | 'unpublishing'
-  | 'confirming empty-body publish'
   | 'confirming unpublish'
   | 'confirming re-publish'
   | 'failed to save'

--- a/apps/posts/src/views/Automations/types.ts
+++ b/apps/posts/src/views/Automations/types.ts
@@ -4,6 +4,7 @@ export type AutomationEditState =
   | 'publishing'
   | 're-publishing'
   | 'unpublishing'
+  | 'confirming empty-body publish'
   | 'confirming unpublish'
   | 'confirming re-publish'
   | 'failed to save'

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1085,6 +1085,10 @@ describe('AutomationEditor', () => {
         const button = await screen.findByRole('button', {name: 'Retry'});
         expect(button).not.toBeDisabled();
         expect(button).toHaveClass('bg-destructive');
+        expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved');
+        expect(mockToastError).not.toHaveBeenCalledWith('Automation couldn’t be saved', {
+            description: 'Fix the highlighted steps and try again.'
+        });
         expect(screen.queryByText(/Couldn.t publish automation/)).not.toBeInTheDocument();
     });
 

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -468,7 +468,7 @@ describe('AutomationEditor', () => {
         expect(emailStep).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByTestId('modal-initial-mode')).toHaveTextContent('edit');
         expect(screen.getByTestId('modal-initial-subject')).toHaveTextContent('Welcome to The Blueprint');
-        expect(screen.getByTestId('modal-initial-lexical')).toHaveTextContent('{"root":{"children":[]}}');
+        expect(screen.getByTestId('modal-initial-lexical')).toHaveTextContent(NON_EMPTY_EMAIL_LEXICAL);
     });
 
     it('opens the email editor preview from the send email node right-click menu', async () => {

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1594,9 +1594,9 @@ describe('AutomationEditor', () => {
         expect(screen.queryByTestId('add-step-tail-button')).not.toBeInTheDocument();
         const limitNode = screen.getByTestId('step-limit-tail-node');
         expect(limitNode).toHaveClass('border-border-default');
-        expect(limitNode).toHaveClass('bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_18px,var(--color-gray-100)_18px,var(--color-gray-100)_34px)]');
+        expect(limitNode).toHaveClass('bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_12px,var(--color-gray-100)_12px,var(--color-gray-100)_24px)]');
         expect(limitNode.querySelector('svg')).toBeInTheDocument();
-        expect(limitNode).toHaveTextContent(`Limit of ${MAX_AUTOMATION_ACTIONS} steps reached`);
+        expect(limitNode).toHaveTextContent('Maximum steps added');
         // The edge + uses a real <button> element.
         expect(screen.getByTestId('add-step-button-wait-0-wait-1')).toBeDisabled();
     });

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1173,6 +1173,9 @@ describe('AutomationEditor', () => {
         expect(insertedNode).toHaveClass('animate-in');
         expect(insertedNode).toHaveClass('zoom-in-90');
         expect(insertedNode).toHaveAttribute('aria-pressed', 'true');
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).getByRole('heading', {name: 'Untitled email'})).toBeInTheDocument();
+        expect(within(sidebar).getByDisplayValue('Untitled email')).toHaveFocus();
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
     });
 

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -767,7 +767,13 @@ describe('AutomationEditor', () => {
         const waitInput = within(sidebar).getByDisplayValue('1');
 
         for (const value of ['2e1', '+2']) {
+            fireEvent.focus(waitInput);
             fireEvent.change(waitInput, {target: {value}});
+
+            expect(waitInput).toHaveAttribute('aria-invalid', 'false');
+            expect(within(sidebar).queryByText('Enter a whole number between 1 and 30 days.')).not.toBeInTheDocument();
+
+            fireEvent.blur(waitInput);
 
             expect(waitInput).toHaveAttribute('aria-invalid', 'true');
             expect(waitInput).toHaveAttribute('aria-describedby', 'automation-wait-days-error');

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -5,6 +5,16 @@ import {RouterProvider, createMemoryRouter} from 'react-router';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 
+const {mockToastError} = vi.hoisted(() => ({
+    mockToastError: vi.fn()
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        error: mockToastError
+    }
+}));
+
 // Stub the email content editor modal — its real internals (Koenig + email API
 // hooks) are out of scope here. The stub exposes the seed props and a save button
 // so we can assert the canvas wiring (open → seed → onSave → draft → publish).
@@ -198,6 +208,7 @@ describe('AutomationEditor', () => {
         mockViewportZoom = 1;
         mockEditMutation.isLoading = false;
         mockEditMutation.variables = undefined;
+        mockToastError.mockReset();
     });
 
     it('renders the loading state while the automation is fetching', () => {
@@ -1168,15 +1179,94 @@ describe('AutomationEditor', () => {
         fireEvent.click(within(picker).getByText('Email'));
 
         // The new send_email step renders with the placeholder subject.
-        const insertedNode = screen.getByRole('button', {name: 'Send email: Untitled email'});
-        expect(screen.getAllByText('Untitled email')).toHaveLength(2);
+        const insertedNode = screen.getByRole('button', {name: 'Send email: Untitled'});
+        expect(within(insertedNode).getByText('Untitled')).toHaveClass('opacity-50');
         expect(insertedNode).toHaveClass('animate-in');
         expect(insertedNode).toHaveClass('zoom-in-90');
         expect(insertedNode).toHaveAttribute('aria-pressed', 'true');
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
-        expect(within(sidebar).getByRole('heading', {name: 'Untitled email'})).toBeInTheDocument();
-        expect(within(sidebar).getByDisplayValue('Untitled email')).toHaveFocus();
+        expect(within(sidebar).getByRole('heading', {name: 'Untitled'})).toHaveClass('opacity-50');
+        expect(within(sidebar).getByPlaceholderText('Subject line')).toHaveFocus();
+        expect(within(sidebar).getByPlaceholderText('Subject line')).toHaveValue('');
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+    });
+
+    it('shows a toast and highlights email cards with missing subjects when saving fails validation', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Email'));
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalledWith('Could not save automation', {
+            description: 'Fix the highlighted steps and try again.'
+        });
+
+        let emailStep = screen.getByRole('button', {name: 'Send email: Untitled'});
+        expect(emailStep).toHaveAttribute('aria-invalid', 'true');
+        expect(emailStep).toHaveClass('items-start');
+        expect(within(emailStep).getByText('Add a subject line.').closest('div')?.previousElementSibling).toHaveClass('mt-[3px]');
+        expect(within(emailStep).getByText('Add a subject line.')).toHaveClass('text-destructive');
+        expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        fireEvent.change(within(sidebar).getByPlaceholderText('Subject line'), {
+            target: {value: 'Welcome subject'}
+        });
+
+        emailStep = screen.getByRole('button', {name: 'Send email: Welcome subject'});
+        expect(emailStep).not.toHaveAttribute('aria-invalid', 'true');
+        expect(within(emailStep).queryByText('Add a subject line.')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                actions: expect.arrayContaining([
+                    expect.objectContaining({
+                        type: 'send_email',
+                        data: expect.objectContaining({email_subject: 'Welcome subject'})
+                    })
+                ])
+            }),
+            expect.any(Object)
+        );
+    });
+
+    it('does not show new missing-subject errors until the next save validation', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Email'));
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).getByText('Add a subject line.')).toBeInTheDocument();
+
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        const subjectInput = within(sidebar).getByPlaceholderText('Subject line');
+        fireEvent.change(subjectInput, {target: {value: 'Temporary subject'}});
+        expect(within(screen.getByRole('button', {name: 'Send email: Temporary subject'})).queryByText('Add a subject line.')).not.toBeInTheDocument();
+
+        fireEvent.change(subjectInput, {target: {value: ''}});
+        expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).queryByText('Add a subject line.')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).getByText('Add a subject line.')).toBeInTheDocument();
     });
 
     it('inserts a step between two existing actions via the in-edge + button', async () => {

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1857,16 +1857,16 @@ describe('AutomationEditor', () => {
         await stageLocalEdit();
         fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
 
-        const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
-        expect(within(dialog).queryByText(/empty/i)).not.toBeInTheDocument();
-
-        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));
-
+        expect(screen.queryByRole('alertdialog', {name: 'Update automation?'})).not.toBeInTheDocument();
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
         expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
             description: 'Fix the highlighted steps and try again.'
         });
-        expect(within(screen.getByRole('alertdialog', {name: 'Update automation?'})).getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        expect(emailStep).toHaveAttribute('aria-invalid', 'true');
+        expect(within(emailStep).getByText('Add an email body.')).toHaveClass('text-destructive');
     });
 
     it('spins the modal button while publishing changes to an active automation', async () => {

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -771,13 +771,13 @@ describe('AutomationEditor', () => {
             fireEvent.change(waitInput, {target: {value}});
 
             expect(waitInput).toHaveAttribute('aria-invalid', 'false');
-            expect(within(sidebar).queryByText('Enter a whole number between 1 and 30 days.')).not.toBeInTheDocument();
+            expect(within(sidebar).queryByText('Enter a delay between 1 and 30 days')).not.toBeInTheDocument();
 
             fireEvent.blur(waitInput);
 
             expect(waitInput).toHaveAttribute('aria-invalid', 'true');
             expect(waitInput).toHaveAttribute('aria-describedby', 'automation-wait-days-error');
-            expect(within(sidebar).getByText('Enter a whole number between 1 and 30 days.')).toBeInTheDocument();
+            expect(within(sidebar).getByText('Enter a delay between 1 and 30 days')).toBeInTheDocument();
             expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
         }
     });
@@ -1259,7 +1259,7 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Save'}));
 
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
-        expect(mockToastError).toHaveBeenCalledWith('Could not save automation', {
+        expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
             description: 'Fix the highlighted steps and try again.'
         });
 

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -538,7 +538,7 @@ describe('AutomationEditor', () => {
         expect(waitStep).toHaveAttribute('aria-pressed', 'false');
         expect(emailStep).toHaveAttribute('aria-pressed', 'true');
         expect(within(sidebar).getByRole('heading', {name: 'Welcome to The Blueprint'})).toBeInTheDocument();
-        expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toBeInTheDocument();
+        expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toHaveFocus();
         expect(within(sidebar).queryByText('Sender')).not.toBeInTheDocument();
         expect(within(sidebar).queryByText('Reply-to')).not.toBeInTheDocument();
         expect(within(sidebar).getByRole('button', {name: 'Edit email'})).toBeEnabled();

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -559,7 +559,7 @@ describe('AutomationEditor', () => {
         expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toHaveFocus();
         expect(within(sidebar).queryByText('Sender')).not.toBeInTheDocument();
         expect(within(sidebar).queryByText('Reply-to')).not.toBeInTheDocument();
-        expect(within(sidebar).getByRole('button', {name: 'Edit email'})).toBeEnabled();
+        expect(within(sidebar).getByRole('button', {name: 'Edit email content'})).toBeEnabled();
         expect(within(sidebar).getByRole('button', {name: 'Delete step'})).toBeEnabled();
     });
 
@@ -613,7 +613,7 @@ describe('AutomationEditor', () => {
 
         fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
-        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email content'}));
 
         // The modal opens, seeded from the step's current content.
         expect(screen.getByTestId('email-content-modal')).toBeInTheDocument();
@@ -660,7 +660,7 @@ describe('AutomationEditor', () => {
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
         expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toBeInTheDocument();
 
-        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email content'}));
         fireEvent.click(screen.getByTestId('modal-save'));
 
         expect(within(sidebar).getByDisplayValue('Edited via modal')).toBeInTheDocument();
@@ -1563,7 +1563,7 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
     });
 
-    it('disables both + affordances when the action limit is reached', () => {
+    it('replaces the tail + affordance with limit text when the action limit is reached', () => {
         const filled: AutomationDetail = {
             ...automationDetail,
             actions: Array.from({length: MAX_AUTOMATION_ACTIONS}, (_, index) => ({
@@ -1585,8 +1585,12 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        // The tail is a div with role=button; check aria-disabled instead of the disabled attribute.
-        expect(screen.getByTestId('add-step-tail-button')).toHaveAttribute('aria-disabled', 'true');
+        expect(screen.queryByTestId('add-step-tail-button')).not.toBeInTheDocument();
+        const limitNode = screen.getByTestId('step-limit-tail-node');
+        expect(limitNode).toHaveClass('border-border-default');
+        expect(limitNode).toHaveClass('bg-[repeating-linear-gradient(135deg,var(--color-white)_0,var(--color-white)_18px,var(--color-gray-100)_18px,var(--color-gray-100)_34px)]');
+        expect(limitNode.querySelector('svg')).toBeInTheDocument();
+        expect(limitNode).toHaveTextContent(`Limit of ${MAX_AUTOMATION_ACTIONS} steps reached`);
         // The edge + uses a real <button> element.
         expect(screen.getByTestId('add-step-button-wait-0-wait-1')).toBeDisabled();
     });

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -489,6 +489,76 @@ describe('AutomationEditor', () => {
         expect(screen.getByTestId('modal-initial-mode')).toHaveTextContent('preview');
     });
 
+    it('asks for confirmation before deleting a send email step with a body from the node right-click menu', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        fireEvent.contextMenu(emailStep);
+        fireEvent.click(await screen.findByRole('menuitem', {name: 'Delete'}));
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Delete this email?'});
+        expect(within(dialog).getByText('This email will be removed from the automation. Save or publish the automation to apply this change.')).toBeInTheDocument();
+
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Delete email'}));
+
+        expect(screen.queryByRole('button', {name: 'Send email: Welcome to The Blueprint'})).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Wait: 1 day'})).toBeInTheDocument();
+    });
+
+    it('asks for confirmation before deleting a send email step with only a body from the node right-click menu', async () => {
+        const bodyOnly: AutomationDetail = {
+            ...automationDetail,
+            actions: automationDetail.actions.map(action => (
+                action.type === 'send_email'
+                    ? {
+                        ...action,
+                        data: {
+                            ...action.data,
+                            email_subject: ''
+                        }
+                    }
+                    : action
+            ))
+        };
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [bodyOnly]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Untitled'});
+        fireEvent.contextMenu(emailStep);
+        fireEvent.click(await screen.findByRole('menuitem', {name: 'Delete'}));
+
+        expect(screen.getByRole('alertdialog', {name: 'Delete this email?'})).toBeInTheDocument();
+    });
+
+    it('deletes a send email step without confirmation from the node right-click menu when it has no body', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [withEmptyEmailBodies(automationDetail)]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        fireEvent.contextMenu(emailStep);
+        fireEvent.click(await screen.findByRole('menuitem', {name: 'Delete'}));
+
+        expect(screen.queryByRole('alertdialog', {name: 'Delete this email?'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Send email: Welcome to The Blueprint'})).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Wait: 1 day'})).toBeInTheDocument();
+    });
+
     it('opens the email editor from an email node double-click without opening the sidebar', async () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [automationDetail]},
@@ -1467,6 +1537,24 @@ describe('AutomationEditor', () => {
         expect(screen.queryByRole('alertdialog', {name: 'Delete this email?'})).not.toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'})).toBeInTheDocument();
         expect(screen.getByRole('complementary', {name: 'Step details'})).toBeInTheDocument();
+    });
+
+    it('deletes a send email step without confirmation from the sidebar when it has no body', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [withEmptyEmailBodies(automationDetail)]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Delete step'}));
+
+        expect(screen.queryByRole('alertdialog', {name: 'Delete this email?'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Send email: Welcome to The Blueprint'})).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Wait: 1 day'})).toBeInTheDocument();
     });
 
     it('deletes a send email step after confirmation and keeps the wait step in place', () => {

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1180,7 +1180,9 @@ describe('AutomationEditor', () => {
 
         // The new send_email step renders with the placeholder subject.
         const insertedNode = screen.getByRole('button', {name: 'Send email: Untitled'});
+        expect(insertedNode).toHaveClass('border-yellow-600');
         expect(within(insertedNode).getByText('Untitled')).toHaveClass('opacity-50');
+        expect(within(insertedNode).getByText('Empty email body')).toHaveClass('text-yellow-600');
         expect(insertedNode).toHaveClass('animate-in');
         expect(insertedNode).toHaveClass('zoom-in-90');
         expect(insertedNode).toHaveAttribute('aria-pressed', 'true');
@@ -1214,8 +1216,11 @@ describe('AutomationEditor', () => {
         let emailStep = screen.getByRole('button', {name: 'Send email: Untitled'});
         expect(emailStep).toHaveAttribute('aria-invalid', 'true');
         expect(emailStep).toHaveClass('items-start');
+        expect(emailStep).toHaveClass('border-destructive');
+        expect(emailStep).not.toHaveClass('border-yellow-600');
         expect(within(emailStep).getByText('Add a subject line.').closest('div')?.previousElementSibling).toHaveClass('mt-[3px]');
         expect(within(emailStep).getByText('Add a subject line.')).toHaveClass('text-destructive');
+        expect(within(emailStep).queryByText('Empty email body')).not.toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
 
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
@@ -1225,7 +1230,9 @@ describe('AutomationEditor', () => {
 
         emailStep = screen.getByRole('button', {name: 'Send email: Welcome subject'});
         expect(emailStep).not.toHaveAttribute('aria-invalid', 'true');
+        expect(emailStep).toHaveClass('border-yellow-600');
         expect(within(emailStep).queryByText('Add a subject line.')).not.toBeInTheDocument();
+        expect(within(emailStep).getByText('Empty email body')).toHaveClass('text-yellow-600');
 
         fireEvent.click(screen.getByRole('button', {name: 'Save'}));
         expect(mockEditMutation.mutate).toHaveBeenCalledWith(

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -10,7 +10,6 @@ const {mockToastError} = vi.hoisted(() => ({
 }));
 
 const NON_EMPTY_EMAIL_LEXICAL = '{"root":{"children":[{"type":"paragraph","children":[{"type":"text","text":"Welcome email body"}]}]}}';
-const EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE = 'One or more emails in this automation do not have a body. Are you sure you want to save and publish this automation?';
 
 vi.mock('sonner', () => ({
     toast: {
@@ -867,7 +866,7 @@ describe('AutomationEditor', () => {
         );
     });
 
-    it('confirms before publishing an inactive automation with empty email bodies', () => {
+    it('blocks publishing an inactive automation with an empty email body', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [withEmptyEmailBodies({...automationDetail, status: 'inactive'})]},
             isLoading: false,
@@ -878,19 +877,16 @@ describe('AutomationEditor', () => {
 
         fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
 
-        const dialog = screen.getByRole('alertdialog', {name: 'Publish automation with empty emails?'});
-        expect(within(dialog).getByText(EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE)).toBeInTheDocument();
+        expect(screen.queryByRole('alertdialog', {name: 'Publish automation with empty emails?'})).not.toBeInTheDocument();
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
+            description: 'Fix the highlighted steps and try again.'
+        });
 
-        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish automation'}));
-
-        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
-            expect.objectContaining({
-                id: 'automation-id-1',
-                status: 'active'
-            }),
-            expect.any(Object)
-        );
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        expect(emailStep).toHaveAttribute('aria-invalid', 'true');
+        expect(emailStep).toHaveClass('border-destructive');
+        expect(within(emailStep).getByText('Add an email body.')).toHaveClass('text-destructive');
     });
 
     it('saves an inactive automation without publishing it', async () => {
@@ -915,6 +911,28 @@ describe('AutomationEditor', () => {
         expect(mutateCall.status).toBe('inactive');
         expect(mutateCall.actions).toHaveLength(3);
         expect(mutateCall.edges).toHaveLength(2);
+    });
+
+    it('saves an inactive draft with an empty email subject and body', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        // A freshly added email step has an empty subject and body — saving a draft must still be allowed.
+        fireEvent.click(screen.getByTestId('add-step-tail-button'));
+        const picker = await screen.findByTestId('step-picker');
+        fireEvent.click(within(picker).getByText('Email'));
+
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(mockToastError).not.toHaveBeenCalled();
+        const mutateCall = mockEditMutation.mutate.mock.calls.at(-1)![0];
+        expect(mutateCall.status).toBe('inactive');
+        expect(screen.queryByText('Add a subject line and email body.')).not.toBeInTheDocument();
     });
 
     it('shows the dropdown for active automations', () => {
@@ -1243,7 +1261,7 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
     });
 
-    it('shows a toast and highlights email cards with missing subjects when saving fails validation', async () => {
+    it('shows a toast and highlights email steps with missing content when publishing fails validation', async () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},
             isLoading: false,
@@ -1256,7 +1274,7 @@ describe('AutomationEditor', () => {
         const picker = await screen.findByTestId('step-picker');
         fireEvent.click(within(picker).getByText('Email'));
 
-        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
 
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
         expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
@@ -1268,29 +1286,37 @@ describe('AutomationEditor', () => {
         expect(emailStep).toHaveClass('items-start');
         expect(emailStep).toHaveClass('border-destructive');
         expect(emailStep).not.toHaveClass('border-yellow-600');
-        expect(within(emailStep).getByText('Add a subject line.').closest('div')?.previousElementSibling).toHaveClass('mt-[3px]');
-        expect(within(emailStep).getByText('Add a subject line.')).toHaveClass('text-destructive');
+        expect(within(emailStep).getByText('Add a subject line and email body.').closest('div')?.previousElementSibling).toHaveClass('mt-[3px]');
+        expect(within(emailStep).getByText('Add a subject line and email body.')).toHaveClass('text-destructive');
         expect(within(emailStep).queryByText('Empty email body')).not.toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
 
+        // Filling only the subject leaves the body invalid, so the step stays blocked.
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
         fireEvent.change(within(sidebar).getByPlaceholderText('Subject line'), {
             target: {value: 'Welcome subject'}
         });
 
         emailStep = screen.getByRole('button', {name: 'Send email: Welcome subject'});
-        expect(emailStep).not.toHaveAttribute('aria-invalid', 'true');
-        expect(emailStep).toHaveClass('border-yellow-600');
-        expect(within(emailStep).queryByText('Add a subject line.')).not.toBeInTheDocument();
-        expect(within(emailStep).getByText('Empty email body')).toHaveClass('text-yellow-600');
+        expect(emailStep).toHaveAttribute('aria-invalid', 'true');
+        expect(emailStep).toHaveClass('border-destructive');
 
-        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        // Adding body content via the modal clears the error and lets the publish through.
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email content'}));
+        fireEvent.click(await screen.findByTestId('modal-save'));
+
+        emailStep = screen.getByRole('button', {name: 'Send email: Edited via modal'});
+        expect(emailStep).not.toHaveAttribute('aria-invalid', 'true');
+        expect(within(emailStep).queryByText('Add an email body.')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
         expect(mockEditMutation.mutate).toHaveBeenCalledWith(
             expect.objectContaining({
+                status: 'active',
                 actions: expect.arrayContaining([
                     expect.objectContaining({
                         type: 'send_email',
-                        data: expect.objectContaining({email_subject: 'Welcome subject'})
+                        data: expect.objectContaining({email_subject: 'Edited via modal'})
                     })
                 ])
             }),
@@ -1298,7 +1324,7 @@ describe('AutomationEditor', () => {
         );
     });
 
-    it('does not show new missing-subject errors until the next save validation', async () => {
+    it('does not surface new step errors until the next publish validation', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},
             isLoading: false,
@@ -1307,22 +1333,23 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        fireEvent.click(screen.getByTestId('add-step-tail-button'));
-        const picker = await screen.findByTestId('step-picker');
-        fireEvent.click(within(picker).getByText('Email'));
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        const subjectInput = within(sidebar).getByDisplayValue('Welcome to The Blueprint');
 
-        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        fireEvent.change(subjectInput, {target: {value: ''}});
+        expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).queryByText('Add a subject line.')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
         expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).getByText('Add a subject line.')).toBeInTheDocument();
 
-        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
-        const subjectInput = within(sidebar).getByPlaceholderText('Subject line');
         fireEvent.change(subjectInput, {target: {value: 'Temporary subject'}});
         expect(within(screen.getByRole('button', {name: 'Send email: Temporary subject'})).queryByText('Add a subject line.')).not.toBeInTheDocument();
 
         fireEvent.change(subjectInput, {target: {value: ''}});
         expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).queryByText('Add a subject line.')).not.toBeInTheDocument();
 
-        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
         expect(within(screen.getByRole('button', {name: 'Send email: Untitled'})).getByText('Add a subject line.')).toBeInTheDocument();
     });
 
@@ -1726,7 +1753,7 @@ describe('AutomationEditor', () => {
         );
     });
 
-    it('warns before publishing changes to an active automation with empty email bodies', async () => {
+    it('blocks publishing changes to an active automation with an empty email body', async () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [withEmptyEmailBodies(automationDetail)]},
             isLoading: false,
@@ -1739,20 +1766,15 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
 
         const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
-        expect(within(dialog).getByText(new RegExp(EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE.replace(/[.?]/g, '\\$&')))).toBeInTheDocument();
-        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+        expect(within(dialog).queryByText(/empty/i)).not.toBeInTheDocument();
 
         fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));
 
-        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
-            {
-                id: 'automation-id-1',
-                status: 'active',
-                actions: expect.any(Array),
-                edges: expect.any(Array)
-            },
-            expect.any(Object)
-        );
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
+            description: 'Fix the highlighted steps and try again.'
+        });
+        expect(within(screen.getByRole('alertdialog', {name: 'Update automation?'})).getByRole('button', {name: 'Retry'})).toBeInTheDocument();
     });
 
     it('spins the modal button while publishing changes to an active automation', async () => {

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -9,6 +9,9 @@ const {mockToastError} = vi.hoisted(() => ({
     mockToastError: vi.fn()
 }));
 
+const NON_EMPTY_EMAIL_LEXICAL = '{"root":{"children":[{"type":"paragraph","children":[{"type":"text","text":"Welcome email body"}]}]}}';
+const EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE = 'One or more emails in this automation do not have a body. Are you sure you want to save and publish this automation?';
+
 vi.mock('sonner', () => ({
     toast: {
         error: mockToastError
@@ -30,7 +33,7 @@ vi.mock('@src/views/Automations/components/email-modal/email-content-modal', () 
             <span data-testid='modal-initial-mode'>{initialMode ?? 'edit'}</span>
             <span data-testid='modal-initial-subject'>{initialSubject}</span>
             <span data-testid='modal-initial-lexical'>{initialLexical}</span>
-            <button data-testid='modal-save' type='button' onClick={() => onSave({subject: 'Edited via modal', lexical: '{"root":{"children":[{"type":"paragraph"}]}}'})}>save</button>
+            <button data-testid='modal-save' type='button' onClick={() => onSave({subject: 'Edited via modal', lexical: NON_EMPTY_EMAIL_LEXICAL})}>save</button>
             <button data-testid='modal-close' type='button' onClick={onClose}>close</button>
         </div>
     )
@@ -166,7 +169,7 @@ const automationDetail: AutomationDetail = {
             type: 'send_email',
             data: {
                 email_subject: 'Welcome to The Blueprint',
-                email_lexical: '{"root":{"children":[]}}',
+                email_lexical: NON_EMPTY_EMAIL_LEXICAL,
                 email_sender_name: null,
                 email_sender_email: null,
                 email_sender_reply_to: null,
@@ -196,6 +199,21 @@ const renderEditor = () => {
         ...render(<RouterProvider router={router} />)
     };
 };
+
+const withEmptyEmailBodies = (fixture: AutomationDetail): AutomationDetail => ({
+    ...fixture,
+    actions: fixture.actions.map(action => (
+        action.type === 'send_email'
+            ? {
+                ...action,
+                data: {
+                    ...action.data,
+                    email_lexical: '{"root":{"children":[]}}'
+                }
+            }
+            : action
+    ))
+});
 
 describe('AutomationEditor', () => {
     beforeEach(() => {
@@ -600,7 +618,7 @@ describe('AutomationEditor', () => {
         // The modal opens, seeded from the step's current content.
         expect(screen.getByTestId('email-content-modal')).toBeInTheDocument();
         expect(screen.getByTestId('modal-initial-subject')).toHaveTextContent('Welcome to The Blueprint');
-        expect(screen.getByTestId('modal-initial-lexical')).toHaveTextContent('{"root":{"children":[]}}');
+        expect(screen.getByTestId('modal-initial-lexical')).toHaveTextContent(NON_EMPTY_EMAIL_LEXICAL);
 
         // Saving in the modal commits to the local draft only — no API call.
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
@@ -620,7 +638,7 @@ describe('AutomationEditor', () => {
                         id: 'action-email',
                         data: expect.objectContaining({
                             email_subject: 'Edited via modal',
-                            email_lexical: '{"root":{"children":[{"type":"paragraph"}]}}'
+                            email_lexical: NON_EMPTY_EMAIL_LEXICAL
                         })
                     })
                 ])
@@ -839,6 +857,32 @@ describe('AutomationEditor', () => {
                 actions: automationDetail.actions,
                 edges: automationDetail.edges
             },
+            expect.any(Object)
+        );
+    });
+
+    it('confirms before publishing an inactive automation with empty email bodies', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [withEmptyEmailBodies({...automationDetail, status: 'inactive'})]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Publish automation with empty emails?'});
+        expect(within(dialog).getByText(EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE)).toBeInTheDocument();
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish automation'}));
+
+        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 'automation-id-1',
+                status: 'active'
+            }),
             expect.any(Object)
         );
     });
@@ -1657,6 +1701,35 @@ describe('AutomationEditor', () => {
         const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
         expect(within(dialog).getByText(/new runs of the automation/)).toBeInTheDocument();
         expect(within(dialog).getByText(/actively-running ones/)).toBeInTheDocument();
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));
+
+        expect(mockEditMutation.mutate).toHaveBeenCalledWith(
+            {
+                id: 'automation-id-1',
+                status: 'active',
+                actions: expect.any(Array),
+                edges: expect.any(Array)
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('warns before publishing changes to an active automation with empty email bodies', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [withEmptyEmailBodies(automationDetail)]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        await stageLocalEdit();
+        fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Update automation?'});
+        expect(within(dialog).getByText(new RegExp(EMPTY_BODY_PUBLISH_CONFIRMATION_MESSAGE.replace(/[.?]/g, '\\$&')))).toBeInTheDocument();
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
 
         fireEvent.click(within(dialog).getByRole('button', {name: 'Publish changes'}));

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1269,7 +1269,7 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
     });
 
-    it('deletes a send email step and keeps the wait step in place', () => {
+    it('asks for confirmation before deleting a send email step', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [automationDetail]},
             isLoading: false,
@@ -1281,6 +1281,31 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
         fireEvent.click(within(sidebar).getByRole('button', {name: 'Delete step'}));
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Delete this email?'});
+        expect(within(dialog).getByText('This email will be removed from the automation. Save or publish the automation to apply this change.')).toBeInTheDocument();
+
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Cancel'}));
+
+        expect(screen.queryByRole('alertdialog', {name: 'Delete this email?'})).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'})).toBeInTheDocument();
+        expect(screen.getByRole('complementary', {name: 'Step details'})).toBeInTheDocument();
+    });
+
+    it('deletes a send email step after confirmation and keeps the wait step in place', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Delete step'}));
+        const dialog = screen.getByRole('alertdialog', {name: 'Delete this email?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Delete email'}));
 
         expect(screen.queryByRole('button', {name: 'Send email: Welcome to The Blueprint'})).not.toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Wait: 1 day'})).toBeInTheDocument();

--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -25,7 +25,9 @@ const messages = {
     invalidAutomationEdgeEndpoint: 'Automation edges must reference actions in the submitted graph.',
     duplicateAutomationEdge: 'Automation edges must be unique.',
     invalidAutomationEdge: 'Automation edges cannot connect an action to itself.',
-    invalidAutomationGraphShape: 'Automation graph must be a single linear path without branches or cycles.'
+    invalidAutomationGraphShape: 'Automation graph must be a single linear path without branches or cycles.',
+    emptyEmailSubjectWhenActive: 'Active automations require a subject line for every email.',
+    emptyEmailBodyWhenActive: 'Active automations require a body for every email.'
 };
 
 const objectIdSchema = z.string().refine(value => ObjectId.isValid(value));
@@ -42,7 +44,7 @@ const sendEmailActionSchema = z.object({
     id: objectIdSchema,
     type: z.literal('send_email'),
     data: z.object({
-        email_subject: z.string().min(1),
+        email_subject: z.string(),
         email_lexical: z.string().refine((value) => {
             try {
                 JSON.parse(value);
@@ -126,7 +128,46 @@ function validateEditData(data: unknown): EditAutomationData {
     }
 
     validateGraph(result.data.actions, result.data.edges);
+    validateActiveEmailSteps(result.data.status, result.data.actions);
     return result.data;
+}
+
+// Drafts may persist empty email steps, but an active automation must have a
+// complete subject and body for every email it sends — mirroring the editor's
+// publish-time validation.
+function validateActiveEmailSteps(status: EditAutomationData['status'], actions: EditAutomationData['actions']) {
+    if (status !== 'active') {
+        return;
+    }
+
+    for (const action of actions) {
+        if (action.type !== 'send_email') {
+            continue;
+        }
+
+        if (!action.data.email_subject.trim()) {
+            throwValidationError(messages.emptyEmailSubjectWhenActive, 'actions');
+        }
+
+        if (isEmptyLexical(action.data.email_lexical)) {
+            throwValidationError(messages.emptyEmailBodyWhenActive, 'actions');
+        }
+    }
+}
+
+function isEmptyLexical(lexical: string): boolean {
+    try {
+        const parsed = JSON.parse(lexical);
+        const children = parsed?.root?.children;
+
+        if (!children || children.length === 0) {
+            return true;
+        }
+
+        return children.length === 1 && children[0].type === 'paragraph' && (!children[0].children || children[0].children.length === 0);
+    } catch {
+        return true;
+    }
 }
 
 function buildInvalidAutomationPayloadMessage(issues: z.core.$ZodIssue[]) {

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -62,6 +62,28 @@ const buildLinearEdges = actions => actions.slice(1).map((action, index) => ({
     target_action_id: action.id
 }));
 
+const EMPTY_EMAIL_LEXICAL = JSON.stringify({
+    root: {children: [], direction: null, format: '', indent: 0, type: 'root', version: 1}
+});
+
+const NON_EMPTY_EMAIL_LEXICAL = JSON.stringify({
+    root: {children: [{type: 'paragraph', children: [{type: 'text', text: 'Lorem ipsum.'}]}], direction: null, format: '', indent: 0, type: 'root', version: 1}
+});
+
+const buildSendEmailAction = (dataOverrides = {}) => ({
+    id: ObjectId().toHexString(),
+    type: 'send_email',
+    data: {
+        email_subject: 'Welcome',
+        email_lexical: NON_EMPTY_EMAIL_LEXICAL,
+        email_sender_name: null,
+        email_sender_email: null,
+        email_sender_reply_to: null,
+        email_design_setting_id: '64b6f7b7c8f1a2b3c4d5e6f7',
+        ...dataOverrides
+    }
+});
+
 describe('Automations API', function () {
     let agent;
     let schedulerKey;
@@ -329,6 +351,112 @@ describe('Automations API', function () {
                 })
                 .expectStatus(422)
                 .expect(cacheInvalidateHeaderNotSet());
+        });
+
+        it('allows saving an inactive draft with an empty email subject and body', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            const automationId = browseBody.automations[0].id;
+            const emailAction = buildSendEmailAction({email_subject: '', email_lexical: EMPTY_EMAIL_LEXICAL});
+
+            const {body: editBody} = await agent
+                .put(`automations/${automationId}`)
+                .body({
+                    automations: [{
+                        status: 'inactive',
+                        actions: [emailAction],
+                        edges: []
+                    }]
+                })
+                .expectStatus(200)
+                .expect(cacheInvalidateHeaderNotSet());
+
+            assert.equal(editBody.automations[0].status, 'inactive');
+            assert.equal(editBody.automations[0].actions[0].data.email_subject, '');
+        });
+
+        it('rejects activating an automation with an empty email subject', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            const automationId = browseBody.automations[0].id;
+
+            const {body: beforeBody} = await agent
+                .get(`automations/${automationId}`)
+                .expectStatus(200);
+
+            await agent
+                .put(`automations/${automationId}`)
+                .body({
+                    automations: [{
+                        status: 'active',
+                        actions: [buildSendEmailAction({email_subject: ''})],
+                        edges: []
+                    }]
+                })
+                .expectStatus(422)
+                .expect(cacheInvalidateHeaderNotSet());
+
+            const {body: afterBody} = await agent
+                .get(`automations/${automationId}`)
+                .expectStatus(200);
+
+            assert.deepEqual(afterBody, beforeBody);
+        });
+
+        it('rejects activating an automation with an empty email body', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            const automationId = browseBody.automations[0].id;
+
+            const {body: beforeBody} = await agent
+                .get(`automations/${automationId}`)
+                .expectStatus(200);
+
+            await agent
+                .put(`automations/${automationId}`)
+                .body({
+                    automations: [{
+                        status: 'active',
+                        actions: [buildSendEmailAction({email_lexical: EMPTY_EMAIL_LEXICAL})],
+                        edges: []
+                    }]
+                })
+                .expectStatus(422)
+                .expect(cacheInvalidateHeaderNotSet());
+
+            const {body: afterBody} = await agent
+                .get(`automations/${automationId}`)
+                .expectStatus(200);
+
+            assert.deepEqual(afterBody, beforeBody);
+        });
+
+        it('allows activating an automation with complete email steps', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            const automationId = browseBody.automations[0].id;
+
+            const {body: editBody} = await agent
+                .put(`automations/${automationId}`)
+                .body({
+                    automations: [{
+                        status: 'active',
+                        actions: [buildSendEmailAction()],
+                        edges: []
+                    }]
+                })
+                .expectStatus(200)
+                .expect(cacheInvalidateHeaderNotSet());
+
+            assert.equal(editBody.automations[0].status, 'active');
         });
 
         it('rejects an empty edit payload', async function () {

--- a/ghost/core/test/unit/server/services/automations/automations-api.test.js
+++ b/ghost/core/test/unit/server/services/automations/automations-api.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const ObjectId = require('bson-objectid').default;
+
+const automationsApi = require('../../../../../core/server/services/automations/automations-api');
+
+const EMPTY_EMAIL_LEXICAL = JSON.stringify({
+    root: {children: [], direction: null, format: '', indent: 0, type: 'root', version: 1}
+});
+
+const NON_EMPTY_EMAIL_LEXICAL = JSON.stringify({
+    root: {children: [{type: 'paragraph', children: [{type: 'text', text: 'Lorem ipsum.'}]}], direction: null, format: '', indent: 0, type: 'root', version: 1}
+});
+
+const buildSendEmailAction = (dataOverrides = {}) => ({
+    id: ObjectId().toHexString(),
+    type: 'send_email',
+    data: {
+        email_subject: 'Welcome',
+        email_lexical: NON_EMPTY_EMAIL_LEXICAL,
+        email_sender_name: null,
+        email_sender_email: null,
+        email_sender_reply_to: null,
+        email_design_setting_id: '64b6f7b7c8f1a2b3c4d5e6f7',
+        ...dataOverrides
+    }
+});
+
+describe('automations API edit validation', function () {
+    const automationId = ObjectId().toHexString();
+
+    it('rejects activating an automation with an empty email subject', async function () {
+        await assert.rejects(
+            automationsApi.edit(automationId, {
+                status: 'active',
+                actions: [buildSendEmailAction({email_subject: ''})],
+                edges: []
+            }),
+            /subject line/
+        );
+    });
+
+    it('rejects activating an automation with an empty email body', async function () {
+        await assert.rejects(
+            automationsApi.edit(automationId, {
+                status: 'active',
+                actions: [buildSendEmailAction({email_lexical: EMPTY_EMAIL_LEXICAL})],
+                edges: []
+            }),
+            /body/
+        );
+    });
+});


### PR DESCRIPTION
closes [NY-1301](https://linear.app/ghost/issue/NY-1301/design-onsave-warning-error)

### What changed

- Added a confirmation dialog before deleting send email steps from the Automations canvas.
- Kept the existing immediate deletion behavior for non-email steps.
- allows saving automations with send_email steps that have an empty body/subject, but does not allow publishing the automation until those fields are filled in.
- Added unit coverage for cancelling and confirming email deletion.


This replaces https://github.com/TryGhost/Ghost/pull/28309 but has a few extra pieces of cleanup and fixes merge conflicts from other automations changes