### PR TITLE
Improve llms-full generation bounds

### DIFF
--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -6,10 +6,16 @@ const {
 
 const DEFAULT_BUDGET = 5 * 1024 * 1024;
 const TRUNCATION_FOOTER = '\n_Truncated after 5 MiB. Use `/llms.txt` for the complete index of older public content._\n';
+const RECENT_POSTS_FOOTER = '\n_Includes the latest 500 public posts. Use `/llms.txt` for the complete index of older public content._\n';
 const FULL_PAGE_SIZE = 100;
+const FULL_POST_LIMIT = 500;
 
 function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUtils, models, routing, api, fullTxtBudget}) {
-    const BUDGET = (fullTxtBudget || DEFAULT_BUDGET) - Buffer.byteLength(TRUNCATION_FOOTER, 'utf8');
+    const footerBudget = Math.max(
+        Buffer.byteLength(TRUNCATION_FOOTER, 'utf8'),
+        Buffer.byteLength(RECENT_POSTS_FOOTER, 'utf8')
+    );
+    const BUDGET = (fullTxtBudget || DEFAULT_BUDGET) - footerBudget;
     function isEnabled() {
         return labs.isSet('llmsTxt') && !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
     }
@@ -67,46 +73,55 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
 
         let output = header;
         let wasTruncated = false;
+        let wasLimited = false;
 
         const pageResult = await appendBoundedSectionPaginated(output, 'Pages', 'page');
         output = pageResult.output;
         wasTruncated = pageResult.wasTruncated;
 
         if (!wasTruncated) {
-            const postResult = await appendBoundedSectionPaginated(output, 'Posts', 'post');
+            const postResult = await appendBoundedSectionPaginated(output, 'Posts', 'post', {maxEntries: FULL_POST_LIMIT});
             output = postResult.output;
             wasTruncated = postResult.wasTruncated;
+            wasLimited = postResult.wasLimited;
         }
 
         if (wasTruncated) {
             output += TRUNCATION_FOOTER;
+        } else if (wasLimited) {
+            output += RECENT_POSTS_FOOTER;
         }
 
         return output.trimEnd() + '\n';
     }
 
-    async function appendBoundedSectionPaginated(prefix, heading, type) {
+    async function appendBoundedSectionPaginated(prefix, heading, type, {maxEntries = null} = {}) {
         const headingBlock = `${prefix}## ${heading}\n`;
 
         if (Buffer.byteLength(headingBlock, 'utf8') > BUDGET) {
-            return {output: prefix, wasTruncated: true};
+            return {output: prefix, wasTruncated: true, wasLimited: false};
         }
 
         let output = headingBlock;
+        let outputBytes = Buffer.byteLength(output, 'utf8');
         let wasTruncated = false;
+        let wasLimited = false;
         let page = 1;
         let hasMore = true;
+        let entriesRendered = 0;
 
-        while (hasMore && !wasTruncated) {
+        while (hasMore && !wasTruncated && !wasLimited) {
             const result = await fetchFullEntries(type, page);
             const entries = result.entries;
             hasMore = result.hasMore;
 
             if (!entries.length && page === 1) {
                 const emptySection = `${output}_No public content available._\n`;
+                const emptySectionBytes = Buffer.byteLength(emptySection, 'utf8');
 
-                if (Buffer.byteLength(emptySection, 'utf8') <= BUDGET) {
+                if (emptySectionBytes <= BUDGET) {
                     output = emptySection;
+                    outputBytes = emptySectionBytes;
                 } else {
                     wasTruncated = true;
                 }
@@ -115,21 +130,33 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
             }
 
             for (const entry of entries) {
-                const formattedEntry = buildFullEntry(entry);
-                const candidate = `${output}${formattedEntry}\n`;
+                if (maxEntries && entriesRendered >= maxEntries) {
+                    wasLimited = true;
+                    break;
+                }
 
-                if (Buffer.byteLength(candidate, 'utf8') > BUDGET) {
+                const formattedEntry = buildFullEntry(entry);
+                const entryBlock = `${formattedEntry}\n`;
+                const entryBytes = Buffer.byteLength(entryBlock, 'utf8');
+
+                if (outputBytes + entryBytes > BUDGET) {
                     wasTruncated = true;
                     break;
                 }
 
-                output = candidate;
+                output = `${output}${entryBlock}`;
+                outputBytes += entryBytes;
+                entriesRendered += 1;
+            }
+
+            if (maxEntries && entriesRendered >= maxEntries && hasMore) {
+                wasLimited = true;
             }
 
             page += 1;
         }
 
-        return {output, wasTruncated};
+        return {output, wasTruncated, wasLimited};
     }
 
     function buildHeader() {

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -210,6 +210,51 @@ describe('Unit: frontend/services/llms/service', function () {
         assert.match(llmsFullTxt, /Truncated after 5 MiB/);
     });
 
+    it('limits llms-full.txt to the latest 500 posts', async function () {
+        const calls = [];
+        const models = {
+            Post: {
+                findPage: async function (options) {
+                    calls.push(options);
+
+                    if (options.filter.includes('type:page')) {
+                        return {data: []};
+                    }
+
+                    const pageStart = (options.page - 1) * 100;
+                    return {
+                        data: Array.from({length: 100}, (_, index) => {
+                            const postIndex = pageStart + index;
+                            return {
+                                toJSON: () => ({
+                                    id: `post-${postIndex}`,
+                                    title: `Post ${postIndex}`,
+                                    slug: `post-${postIndex}`,
+                                    plaintext: `Post ${postIndex} body`,
+                                    type: 'post'
+                                })
+                            };
+                        })
+                    };
+                }
+            }
+        };
+        const urlMap = Object.fromEntries(Array.from({length: 600}, (_, index) => [
+            `post-${index}`,
+            `https://example.com/post-${index}/`
+        ]));
+        const service = createService({models, urlMap});
+
+        const llmsFullTxt = await service.getLlmsFullTxt();
+
+        const postCalls = calls.filter(call => call.filter.includes('type:post'));
+        assert.equal(postCalls.length, 5);
+        assert.match(llmsFullTxt, /### Post 499/);
+        assert.doesNotMatch(llmsFullTxt, /### Post 500/);
+        assert.match(llmsFullTxt, /Includes the latest 500 public posts/);
+        assert.match(llmsFullTxt, /Use `\/llms\.txt` for the complete index/);
+    });
+
     it('computes fresh output on every call (no cache)', async function () {
         let callCount = 0;
 


### PR DESCRIPTION
## Summary

- Bounds `/llms-full.txt` generation to the latest 500 public posts, while keeping `/llms.txt` as the complete public content index.
- Tracks the generated output size incrementally so the 5 MiB budget check does not repeatedly measure the full growing response.
- Adds footer copy when the post-count cap is reached, pointing readers to `/llms.txt` for older public content.

## Testing

- [x] `pnpm test:single test/unit/frontend/services/llms/service.test.js`
- [x] `pnpm exec eslint --cache -- 'core/frontend/services/llms/service.js' 'test/unit/frontend/services/llms/service.test.js'`
- [x] `pnpm lint` — completed with existing warnings and no errors
- [x] `git diff --check`
