### PR TITLE
Convert role utils model helper to TypeScript

### DIFF
--- a/ghost/core/core/server/models/role-utils.ts
+++ b/ghost/core/core/server/models/role-utils.ts
@@ -1,8 +1,29 @@
+import type {ReadonlyDeep} from 'type-fest';
+
+type LoadedPermissionsWithRoles = ReadonlyDeep<{
+    user?: {
+        roles?: Array<{name: string}>;
+    } | null;
+}>;
+
+type RoleFlags = {
+    isOwner: boolean;
+    isAdmin: boolean;
+    isEditor: boolean;
+    isAuthor: boolean;
+    isContributor: boolean;
+    isSuperEditor: boolean;
+    isEitherEditor: boolean;
+};
+
 // check if the user has an assigned role
 // so that we can stop writing this everywhere:
 //_.some(loadedPermissions.user.roles, {name: 'Administrator'})
 
-function checkUserPermissionsForRole(loadedPermissions, roleName) {
+export function checkUserPermissionsForRole(
+    loadedPermissions: LoadedPermissionsWithRoles | null | undefined,
+    roleName: string
+): boolean {
     if (!loadedPermissions?.user?.roles) {
         return false;
     }
@@ -10,9 +31,9 @@ function checkUserPermissionsForRole(loadedPermissions, roleName) {
     return loadedPermissions.user.roles.some(role => role.name === roleName);
 }
 
-function setIsRoles(loadedPermissions) {
+export function setIsRoles(loadedPermissions: LoadedPermissionsWithRoles | null | undefined): RoleFlags {
     // utility function to parse the permissions object and set up all the "is" variables.
-    let resultsObject = {
+    const resultsObject: RoleFlags = {
         isOwner: false,
         isAdmin: false,
         isEditor: false,
@@ -33,6 +54,3 @@ function setIsRoles(loadedPermissions) {
     resultsObject.isEitherEditor = resultsObject.isEditor || resultsObject.isSuperEditor;
     return resultsObject;
 }
-
-exports.setIsRoles = setIsRoles;
-exports.checkUserPermissionsForRole = checkUserPermissionsForRole;

--- a/ghost/core/test/unit/server/models/set-is-roles.test.ts
+++ b/ghost/core/test/unit/server/models/set-is-roles.test.ts
@@ -1,7 +1,6 @@
-const assert = require('node:assert/strict');
-const {assertExists} = require('../../../utils/assertions');
-const {setIsRoles} = require('../../../../core/server/models/role-utils');
-const _ = require('lodash');
+import assert from 'node:assert/strict';
+import _ from 'lodash';
+import {setIsRoles} from '../../../../core/server/models/role-utils';
 
 describe('setIsRoles function behavior', function () {
     // create a fake 'loadedpermissions' object and then confirm the behavior of setIsRoles with it
@@ -61,7 +60,6 @@ describe('setIsRoles function behavior', function () {
 
     it('returns an object', function () {
         let result = setIsRoles(loadedPermissionsEditor);
-        assertExists(result);
         assert(_.isPlainObject(result));
     });
 


### PR DESCRIPTION
no ref

This change should have no user impact.
