### PR TITLE
Fixed admin search index refetching every keystroke

### DIFF
--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -11,6 +11,7 @@ import {on} from '@ember/object/evented';
 import {inject as service} from '@ember/service';
 
 const BLANK_LEXICAL = '{"root":{"children":[{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}';
+const SEARCH_INDEXED_FIELDS = ['title', 'slug', 'status', 'visibility', 'publishedAtUTC'];
 
 // ember-cli-shims doesn't export these so we must get them manually
 const {Comparable} = Ember;
@@ -440,12 +441,18 @@ export default Model.extend(Comparable, ValidationEngine, {
         this.set('publishedAtUTC', publishedAtUTC);
     },
 
-    // when a published post is updated, unpublished, or deleted we expire the search content cache
+    // when indexed post fields are updated or deleted we expire the search content cache
     save() {
-        const [oldStatus] = this.changedAttributes().status || [];
+        const changedAttributes = this.changedAttributes();
+        const previousUrl = this.url;
+        const previousPublishedAtUTC = this.publishedAtUTC?.valueOf();
+        const searchIndexedFieldChanged = SEARCH_INDEXED_FIELDS.some(field => changedAttributes[field]);
 
         return this._super(...arguments).then((res) => {
-            if (this.status === 'published' || oldStatus === 'published') {
+            const urlChanged = previousUrl !== this.url;
+            const publishedAtUTCChanged = previousPublishedAtUTC !== this.publishedAtUTC?.valueOf();
+
+            if (this.isDeleted || searchIndexedFieldChanged || urlChanged || publishedAtUTCChanged) {
                 this.search.expireContent();
             }
 

--- a/ghost/admin/app/services/search.js
+++ b/ghost/admin/app/services/search.js
@@ -32,7 +32,7 @@ export default class SearchService extends Service {
         }
 
         // start loading immediately in the background
-        this.refreshContentTask.perform();
+        this.refreshContentTask.unlinked().perform();
 
         // debounce searches to 200ms to avoid thrashing CPU
         yield timeout(200);

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -65,6 +65,7 @@
     "broccoli-terser-sourcemap": "4.1.1",
     "chai": "catalog:",
     "chai-dom": "1.12.1",
+    "chalk": "catalog:",
     "codemirror": "5.65.21",
     "cssnano": "4.1.10",
     "element-resize-detector": "1.2.4",

--- a/ghost/admin/tests/integration/models/post-test.js
+++ b/ghost/admin/tests/integration/models/post-test.js
@@ -21,10 +21,21 @@ describe('Integration: Model: post', function () {
             search.isContentStale = false;
         });
 
-        it('expires on published save', async function () {
+        it('expires when published title changes', async function () {
             const serverPost = this.server.create('post', {status: 'published'});
 
             const postModel = await store.find('post', serverPost.id);
+            postModel.title = 'New title';
+            await postModel.save();
+
+            expect(search.isContentStale, 'stale flag after save').to.be.true;
+        });
+
+        it('expires when draft title changes', async function () {
+            const serverPost = this.server.create('post', {status: 'draft'});
+
+            const postModel = await store.find('post', serverPost.id);
+            postModel.title = 'New title';
             await postModel.save();
 
             expect(search.isContentStale, 'stale flag after save').to.be.true;
@@ -68,11 +79,21 @@ describe('Integration: Model: post', function () {
             expect(search.isContentStale, 'stale flag after save').to.be.false;
         });
 
-        it('does not expire on draft delete', async function () {
+        it('expires on draft delete', async function () {
             const serverPost = this.server.create('post', {status: 'draft'});
 
             const postModel = await store.find('post', serverPost.id);
             await postModel.destroyRecord();
+
+            expect(search.isContentStale, 'stale flag after save').to.be.true;
+        });
+
+        it('does not expire when non-search content changes', async function () {
+            const serverPost = this.server.create('post', {status: 'published'});
+
+            const postModel = await store.find('post', serverPost.id);
+            postModel.html = '<p>Updated content</p>';
+            await postModel.save();
 
             expect(search.isContentStale, 'stale flag after save').to.be.false;
         });

--- a/ghost/admin/tests/integration/services/search-test.js
+++ b/ghost/admin/tests/integration/services/search-test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import {authenticateSession} from 'ember-simple-auth/test-support';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
@@ -29,6 +30,16 @@ const suites = [{
     }
 }];
 
+function searchIndexRequests(server) {
+    return server.pretender.handledRequests.filter(request => request.url.includes('/search-index/'));
+}
+
+function wait(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
 suites.forEach((suite) => {
     describe(suite.name, function () {
         const hooks = setupTest();
@@ -57,6 +68,10 @@ suites.forEach((suite) => {
             firstUser = this.server.create('user', {name: 'First user', slug: 'first-user'});
         });
 
+        afterEach(function () {
+            sinon.restore();
+        });
+
         it('is using correct provider', async function () {
             suite.confirmProvider.bind(this)();
         });
@@ -75,6 +90,60 @@ suites.forEach((suite) => {
 
             expect(results[0].options[0].visibility).to.equal('members');
             expect(results[0].options[0].publishedAt).to.equal('2024-05-08T16:21:07.000Z');
+        });
+
+        it('does not refresh cached content for subsequent searches', async function () {
+            await search.searchTask.perform('first');
+
+            expect(searchIndexRequests(this.server), 'initial search index requests').to.have.length(4);
+
+            await search.searchTask.perform('post');
+
+            expect(searchIndexRequests(this.server), 'later search index requests').to.have.length(4);
+        });
+
+        it('keeps the content cache fresh after a restarted search waits for an in-flight refresh', async function () {
+            this.server.timing = 500;
+
+            search.searchTask.perform('fir');
+            await search.searchTask.perform('first');
+
+            expect(searchIndexRequests(this.server), 'initial search index requests').to.have.length(4);
+
+            await search.searchTask.perform('post');
+
+            expect(searchIndexRequests(this.server), 'later search index requests').to.have.length(4);
+        });
+
+        it('keeps one provider refresh alive across restarted searches', async function () {
+            let resolveRefresh;
+            const provider = search.provider;
+            const refreshPromise = new Promise((resolve) => {
+                resolveRefresh = resolve;
+            });
+
+            sinon.stub(provider.refreshContentTask, 'perform').returns(refreshPromise);
+            sinon.stub(provider.searchTask, 'perform').returns([]);
+
+            search.searchTask.perform('t');
+            await wait(250);
+
+            search.searchTask.perform('te');
+            await wait(250);
+
+            const finalSearch = search.searchTask.perform('tes');
+            await wait(250);
+
+            expect(provider.refreshContentTask.perform, 'provider refresh starts').to.have.been.calledOnce;
+
+            resolveRefresh();
+            await finalSearch;
+
+            expect(search.isContentStale, 'stale flag after shared refresh').to.be.false;
+
+            await search.searchTask.perform('post');
+
+            expect(provider.refreshContentTask.perform, 'provider refresh starts after cached search').to.have.been.calledOnce;
         });
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     chai:
       specifier: 4.5.0
       version: 4.5.0
+    chalk:
+      specifier: 4.1.2
+      version: 4.1.2
     clsx:
       specifier: 2.1.1
       version: 2.1.1
@@ -2044,6 +2047,9 @@ importers:
       chai-dom:
         specifier: 1.12.1
         version: 1.12.1(chai@4.5.0)
+      chalk:
+        specifier: 'catalog:'
+        version: 4.1.2
       codemirror:
         specifier: 5.65.21
         version: 5.65.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,6 +76,7 @@ catalog:
   bson-objectid: 2.0.4
   c8: 11.0.0
   chai: 4.5.0
+  chalk: 4.1.2
   clsx: 2.1.1
   concurrently: 10.0.0
   cross-fetch: 4.1.0


### PR DESCRIPTION
## Summary
- Keeps admin search index refreshes alive across restartable search keystrokes
- Expires cached admin search content when indexed post fields change or posts are deleted
- Adds the direct chalk dependency required by the admin Ember build under pnpm

## Root cause
`searchTask` is restartable, so refresh task instances started from it were cancelled on later keystrokes while the underlying AJAX requests continued. That left the cache stale and allowed another full search-index refresh to start.

The fix starts refreshes with `refreshContentTask.unlinked().perform()` so the refresh task is not linked to the restartable search task that triggered it. That lets the in-flight index refresh complete and update the shared cache, while the provider's `drop` task behavior still prevents duplicate refreshes from starting.