### PR TITLE
Fixed search-index endpoints eager loading unused author+tag data

### DIFF
--- a/ghost/core/core/server/api/endpoints/search-index-public.js
+++ b/ghost/core/core/server/api/endpoints/search-index-public.js
@@ -1,6 +1,17 @@
 const models = require('../../models');
+const config = require('../../../shared/config');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const postsService = getPostServiceInstance();
+
+const urlRelationsWhenLazyRouting = () => {
+    if (config.get('lazyRouting')) {
+        return {
+            withRelated: ['tags', 'authors']
+        };
+    }
+
+    return {};
+};
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
@@ -16,7 +27,7 @@ const controller = {
                 limit: '10000',
                 order: 'updated_at DESC',
                 columns: ['id', 'slug', 'title', 'excerpt', 'url', 'updated_at', 'visibility'],
-                withRelated: ['tags', 'authors']
+                ...urlRelationsWhenLazyRouting()
             };
 
             return postsService.browsePosts(options);

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -1,6 +1,17 @@
 const models = require('../../models');
+const config = require('../../../shared/config');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const postsService = getPostServiceInstance();
+
+const urlRelationsWhenLazyRouting = () => {
+    if (config.get('lazyRouting')) {
+        return {
+            withRelated: ['tags', 'authors']
+        };
+    }
+
+    return {};
+};
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
@@ -19,7 +30,7 @@ const controller = {
                 limit: '10000',
                 order: 'updated_at DESC',
                 columns: ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility'],
-                withRelated: ['tags', 'authors']
+                ...urlRelationsWhenLazyRouting()
             };
 
             return postsService.browsePosts(options);
@@ -39,7 +50,7 @@ const controller = {
                 limit: '10000',
                 order: 'updated_at DESC',
                 columns: ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility'],
-                withRelated: ['tags', 'authors']
+                ...urlRelationsWhenLazyRouting()
             };
 
             return postsService.browsePosts(options);


### PR DESCRIPTION
no issue

## Summary
- stopped Admin and Content API search-index post/page requests from eager-loading tags and authors by default
- preserved relation loading when `lazyRouting` is enabled because URL generation can need those relations

## Problem
Large sites can spend unnecessary query and mapping work loading post/page relations that search-index responses never return or consume.