### PR TITLE
Gate self-hosted Renovate workflow to TryGhost/Ghost

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -48,6 +48,11 @@ permissions:
 
 jobs:
   renovate:
+    # Never run on forks: both `schedule` and `workflow_dispatch` can fire on a
+    # fork that has Actions enabled, and this job mints the Renovate GitHub App
+    # token. Matches the fork guard used across the rest of the repo's
+    # privileged workflows.
+    if: github.repository == 'TryGhost/Ghost'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
## Problem

`.github/workflows/renovate.yml` has no fork guard. Both of its triggers can fire on a fork:

- **`schedule`** — runs on a fork once the fork owner enables Actions
- **`workflow_dispatch`** — any fork owner can trigger it manually

The job mints the Renovate GitHub App token via `actions/create-github-app-token`. On a fork it would fail on the missing secrets, but the correct behavior is to not let the job start at all.

## Fix

Add the `if: github.repository == 'TryGhost/Ghost'` job-level guard — the same pattern already used by every other privileged workflow in this repo (`release.yml`, `ci.yml`, `devcontainer-build.yml`, `create-release-branch.yml`, `publish-tb-cli.yml`).