### PR TITLE
Added a variable for readability in automation repository test

### DIFF
--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -5,10 +5,12 @@ import {createFakeDatabaseAutomationsRepository} from '../../../../../core/serve
 import type {AutomationAction, AutomationsRepository} from '../../../../../core/server/services/automations/automations-repository';
 import type {DatabaseSync, SQLInputValue} from 'node:sqlite';
 
+const HOUR_MS = 60 * 60 * 1000;
+
 const addHours = (dateCol: unknown, hours: number): Date => {
     assert(typeof dateCol === 'string', 'Expected date column to be a string');
     const start = new Date(dateCol).valueOf();
-    const delta = hours * 60 * 60 * 1000;
+    const delta = hours * HOUR_MS;
     return new Date(start + delta);
 };
 


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1286
ref https://github.com/TryGhost/Ghost/pull/28120

This is a test-only change that just makes things a little easier to read. I think it's useful on its own, but it'll also be useful for [an upcoming change](https://github.com/TryGhost/Ghost/pull/28120).
