### PR TITLE
Created dormant automation tables

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "6.45.1-rc.0",
+  "version": "6.46.0-rc.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",

--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -60,6 +60,11 @@ const BACKUP_TABLES = [
     'outbox',
     'gifts',
     'automations',
+    'automation_actions',
+    'automation_action_edges',
+    'automation_action_revisions',
+    'automation_run_steps',
+    'automation_runs',
     'welcome_email_automation_runs',
     'welcome_email_automated_emails'
 ];

--- a/ghost/core/core/server/data/migrations/versions/6.46/2026-06-14-02-38-59-create-automation-tables.js
+++ b/ghost/core/core/server/data/migrations/versions/6.46/2026-06-14-02-38-59-create-automation-tables.js
@@ -1,0 +1,51 @@
+const {addTable, combineNonTransactionalMigrations} = require('../../utils');
+
+module.exports = combineNonTransactionalMigrations(
+    addTable('automation_actions', {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false},
+        deleted_at: {type: 'dateTime', nullable: true},
+        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', cascadeDelete: true},
+        type: {type: 'string', maxlength: 50, nullable: false, validations: {isIn: [['wait', 'send_email']]}}
+    }),
+    addTable('automation_action_revisions', {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        wait_hours: {type: 'integer', nullable: true, unsigned: true},
+        email_subject: {type: 'string', maxlength: 300, nullable: true},
+        email_lexical: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+        email_design_setting_id: {type: 'string', maxlength: 24, nullable: true, references: 'email_design_settings.id', setNullDelete: true},
+        '@@UNIQUE_CONSTRAINTS@@': [
+            ['created_at', 'action_id']
+        ]
+    }),
+    addTable('automation_action_edges', {
+        source_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        target_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        '@@PRIMARY_KEY@@': ['source_action_id', 'target_action_id']
+    }),
+    addTable('automation_runs', {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false},
+        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', cascadeDelete: true},
+        member_id: {type: 'string', maxlength: 24, nullable: true, references: 'members.id', setNullDelete: true, index: true},
+        member_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}}
+    }),
+    addTable('automation_run_steps', {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false},
+        automation_run_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_runs.id', cascadeDelete: true},
+        automation_action_revision_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_action_revisions.id', cascadeDelete: true},
+        ready_at: {type: 'dateTime', nullable: false},
+        step_attempts: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
+        started_at: {type: 'dateTime', nullable: true},
+        finished_at: {type: 'dateTime', nullable: true},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'automation disabled', 'failed', 'finished', 'member changed status', 'member unsubscribed']]}},
+        locked_by: {type: 'string', maxlength: 191, nullable: true},
+        locked_at: {type: 'dateTime', nullable: true}
+    })
+);

--- a/ghost/core/core/server/data/migrations/versions/6.46/2026-06-14-02-38-59-create-automation-tables.js
+++ b/ghost/core/core/server/data/migrations/versions/6.46/2026-06-14-02-38-59-create-automation-tables.js
@@ -6,13 +6,13 @@ module.exports = combineNonTransactionalMigrations(
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false},
         deleted_at: {type: 'dateTime', nullable: true},
-        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', cascadeDelete: true},
+        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', restrictDelete: true},
         type: {type: 'string', maxlength: 50, nullable: false, validations: {isIn: [['wait', 'send_email']]}}
     }),
     addTable('automation_action_revisions', {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
-        action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', restrictDelete: true},
         wait_hours: {type: 'integer', nullable: true, unsigned: true},
         email_subject: {type: 'string', maxlength: 300, nullable: true},
         email_lexical: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
@@ -22,15 +22,15 @@ module.exports = combineNonTransactionalMigrations(
         ]
     }),
     addTable('automation_action_edges', {
-        source_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
-        target_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        source_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', restrictDelete: true},
+        target_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', restrictDelete: true},
         '@@PRIMARY_KEY@@': ['source_action_id', 'target_action_id']
     }),
     addTable('automation_runs', {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false},
-        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', cascadeDelete: true},
+        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', restrictDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: true, references: 'members.id', setNullDelete: true, index: true},
         member_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}}
     }),
@@ -38,8 +38,8 @@ module.exports = combineNonTransactionalMigrations(
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false},
-        automation_run_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_runs.id', cascadeDelete: true},
-        automation_action_revision_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_action_revisions.id', cascadeDelete: true},
+        automation_run_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_runs.id', restrictDelete: true},
+        automation_action_revision_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_action_revisions.id', restrictDelete: true},
         ready_at: {type: 'dateTime', nullable: false},
         step_attempts: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         started_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -503,6 +503,9 @@ function createTable(table, transaction = db.knex, tableSpec = schema[table]) {
         if (tableSpec['@@UNIQUE_CONSTRAINTS@@']) {
             tableSpec['@@UNIQUE_CONSTRAINTS@@'].forEach(unique => t.unique(unique));
         }
+        if (tableSpec['@@PRIMARY_KEY@@']) {
+            t.primary(tableSpec['@@PRIMARY_KEY@@']);
+        }
     });
 }
 

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -58,6 +58,8 @@ function addTableColumn(tableName, tableBuilder, columnName, columnSpec = schema
 
     if (Object.prototype.hasOwnProperty.call(columnSpec, 'cascadeDelete') && columnSpec.cascadeDelete === true) {
         column.onDelete('CASCADE');
+    } else if (Object.prototype.hasOwnProperty.call(columnSpec, 'restrictDelete') && columnSpec.restrictDelete === true) {
+        column.onDelete('RESTRICT');
     } else if (Object.prototype.hasOwnProperty.call(columnSpec, 'setNullDelete') && columnSpec.setNullDelete === true) {
         column.onDelete('SET NULL');
     }

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1192,6 +1192,53 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
     },
+    automation_actions: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false},
+        deleted_at: {type: 'dateTime', nullable: true},
+        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', cascadeDelete: true},
+        type: {type: 'string', maxlength: 50, nullable: false, validations: {isIn: [['wait', 'send_email']]}}
+    },
+    automation_action_revisions: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        wait_hours: {type: 'integer', nullable: true, unsigned: true},
+        email_subject: {type: 'string', maxlength: 300, nullable: true},
+        email_lexical: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+        email_design_setting_id: {type: 'string', maxlength: 24, nullable: true, references: 'email_design_settings.id', setNullDelete: true},
+        '@@UNIQUE_CONSTRAINTS@@': [
+            ['created_at', 'action_id']
+        ]
+    },
+    automation_action_edges: {
+        source_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        target_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        '@@PRIMARY_KEY@@': ['source_action_id', 'target_action_id']
+    },
+    automation_runs: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false},
+        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', cascadeDelete: true},
+        member_id: {type: 'string', maxlength: 24, nullable: true, references: 'members.id', setNullDelete: true, index: true},
+        member_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}}
+    },
+    automation_run_steps: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false},
+        automation_run_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_runs.id', cascadeDelete: true},
+        automation_action_revision_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_action_revisions.id', cascadeDelete: true},
+        ready_at: {type: 'dateTime', nullable: false},
+        step_attempts: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
+        started_at: {type: 'dateTime', nullable: true},
+        finished_at: {type: 'dateTime', nullable: true},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'automation disabled', 'failed', 'finished', 'member changed status', 'member unsubscribed']]}},
+        locked_by: {type: 'string', maxlength: 191, nullable: true},
+        locked_at: {type: 'dateTime', nullable: true}
+    },
     welcome_email_automated_emails: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         welcome_email_automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', constraintName: 'weae_automation_id_foreign', cascadeDelete: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1197,13 +1197,13 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false},
         deleted_at: {type: 'dateTime', nullable: true},
-        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', cascadeDelete: true},
+        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', restrictDelete: true},
         type: {type: 'string', maxlength: 50, nullable: false, validations: {isIn: [['wait', 'send_email']]}}
     },
     automation_action_revisions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
-        action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', restrictDelete: true},
         wait_hours: {type: 'integer', nullable: true, unsigned: true},
         email_subject: {type: 'string', maxlength: 300, nullable: true},
         email_lexical: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
@@ -1213,15 +1213,15 @@ module.exports = {
         ]
     },
     automation_action_edges: {
-        source_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
-        target_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', cascadeDelete: true},
+        source_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', restrictDelete: true},
+        target_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', restrictDelete: true},
         '@@PRIMARY_KEY@@': ['source_action_id', 'target_action_id']
     },
     automation_runs: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false},
-        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', cascadeDelete: true},
+        automation_id: {type: 'string', maxlength: 24, nullable: false, references: 'automations.id', restrictDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: true, references: 'members.id', setNullDelete: true, index: true},
         member_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}}
     },
@@ -1229,8 +1229,8 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false},
-        automation_run_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_runs.id', cascadeDelete: true},
-        automation_action_revision_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_action_revisions.id', cascadeDelete: true},
+        automation_run_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_runs.id', restrictDelete: true},
+        automation_action_revision_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_action_revisions.id', restrictDelete: true},
         ready_at: {type: 'dateTime', nullable: false},
         step_attempts: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         started_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.45.1-rc.0",
+  "version": "6.46.0-rc.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -25,6 +25,11 @@ describe('Exporter', function () {
         const tables = [
             'actions',
             'api_keys',
+            'automation_action_edges',
+            'automation_action_revisions',
+            'automation_actions',
+            'automation_run_steps',
+            'automation_runs',
             'automated_email_recipients',
             'automations',
             'benefits',

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '38765804bec64fb2dbdeb1612b6fc196';
+    const currentSchemaHash = 'c35d4c05893f208ab95b59d8d3eb59bf';
     const currentFixturesHash = '823aa0e8a8f083e80e271c47836a7e5d';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'cfbd3876f444389196059722536cb39b';
+    const currentSchemaHash = '38765804bec64fb2dbdeb1612b6fc196';
     const currentFixturesHash = '823aa0e8a8f083e80e271c47836a7e5d';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -53,7 +53,7 @@ describe('schema validations', function () {
             assert(_.isPlainObject(table));
 
             _.each(table, function (column, columnName) {
-                if (['@@INDEXES@@', '@@UNIQUE_CONSTRAINTS@@'].includes(columnName)) {
+                if (['@@INDEXES@@', '@@UNIQUE_CONSTRAINTS@@', '@@PRIMARY_KEY@@'].includes(columnName)) {
                     return;
                 }
 

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -32,6 +32,7 @@ const VALID_KEYS = {
         'references',
         'constraintName',
         'cascadeDelete',
+        'restrictDelete',
         'setNullDelete',
         'index'
     ],

--- a/ghost/core/test/unit/server/data/seeders/data-generator.test.js
+++ b/ghost/core/test/unit/server/data/seeders/data-generator.test.js
@@ -44,6 +44,9 @@ describe('Data Generator', function () {
                             table.index(indexes);
                         }
                         break;
+                    } else if (rowName === '@@PRIMARY_KEY@@') {
+                        table.primary(row);
+                        break;
                     }
 
                     let rowChain = table[row.type.toLowerCase()](rowName);


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1305

This creates empty automation tables which we'll soon fill in. You might wish to compare these to the [temporary in-memory database][0] we've been using.

[0]: https://github.com/TryGhost/Ghost/blob/983f2e74f02479208c22426508935ebd99bd7e06/ghost/core/core/server/services/automations/temporary-fake-database.ts#L50-L114