### PR TITLE
Fixed "checked" prop for `<Toggle>`

### DIFF
--- a/apps/admin-x-design-system/src/global/form/toggle.stories.tsx
+++ b/apps/admin-x-design-system/src/global/form/toggle.stories.tsx
@@ -19,7 +19,8 @@ export const Default: Story = {
 
 export const Checked: Story = {
     args: {
-        checked: true
+        checked: true,
+        onChange: () => {}
     }
 };
 

--- a/apps/admin-x-design-system/src/global/form/toggle.tsx
+++ b/apps/admin-x-design-system/src/global/form/toggle.tsx
@@ -7,8 +7,7 @@ import * as TogglePrimitive from '@radix-ui/react-switch';
 type ToggleSizes = 'sm' | 'md' | 'lg';
 export type ToggleDirections = 'ltr' | 'rtl';
 
-export interface ToggleProps {
-    checked?: boolean;
+export type ToggleProps = {
     disabled?: boolean;
     name?: string;
     error?: boolean;
@@ -21,11 +20,16 @@ export interface ToggleProps {
     separator?: boolean;
     direction?: ToggleDirections;
     hint?: React.ReactNode;
-    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
     gap?: string;
     align?: 'start' | 'center';
     testId?: string;
-}
+} & (
+    {checked?: undefined; onChange?: undefined} |
+    {
+        checked: boolean;
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    }
+);
 
 const Toggle: React.FC<ToggleProps> = ({
     size,
@@ -107,13 +111,13 @@ const Toggle: React.FC<ToggleProps> = ({
     return (
         <div>
             <div className={`group flex ${align === 'center' ? 'items-center' : 'items-start'} ${gap} dark:text-white ${direction === 'rtl' && 'justify-between'} ${separator && 'pb-2'} ${containerClasses}`}>
-                <TogglePrimitive.Root className={clsx(
+                <TogglePrimitive.Root checked={checked} className={clsx(
                     toggleBgClass,
                     'appearance-none rounded-full bg-grey-300 transition duration-100 dark:bg-grey-800',
                     'enabled:group-hover:opacity-80 enabled:hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-40',
                     sizeStyles,
                     direction === 'rtl' && ' order-2'
-                )} data-testid={testId} defaultChecked={checked} disabled={disabled} id={id} name={name} onCheckedChange={handleCheckedChange}>
+                )} data-testid={testId} disabled={disabled} id={id} name={name} onCheckedChange={handleCheckedChange}>
                     <TogglePrimitive.Thumb className={clsx(
                         thumbSizeStyles,
                         'block translate-x-0.5 rounded-full bg-white transition-transform duration-100 will-change-transform'

--- a/apps/admin-x-design-system/src/global/layout/page.stories.tsx
+++ b/apps/admin-x-design-system/src/global/layout/page.stories.tsx
@@ -443,7 +443,7 @@ export const ExampleDetailScreen: Story = {
                                 <span>Weekly roundup</span>
                             </div>
                             <div className='flex items-center gap-2'>
-                                <Toggle checked />
+                                <Toggle checked onChange={() => {}} />
                                 <span>The Inner Circle</span>
                             </div>
                             <div className='mt-5 rounded border border-red p-4 text-sm text-red'>

--- a/apps/admin-x-settings/src/components/settings/membership/analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/analytics.tsx
@@ -17,8 +17,8 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
         handleEditingChange
     } = useSettingGroup();
 
-    const [trackEmailOpens, trackEmailClicks, trackMemberSources, outboundLinkTagging, isWebAnalyticsConfigured, isWebAnalyticsEnabled] = getSettingValues(localSettings, [
-        'email_track_opens', 'email_track_clicks', 'members_track_sources', 'outbound_link_tagging', 'web_analytics_configured', 'web_analytics_enabled'
+    const [trackEmailOpens, trackEmailClicks, trackMemberSources, outboundLinkTagging, didUserEnableWebAnalytics, isWebAnalyticsConfigured] = getSettingValues(localSettings, [
+        'email_track_opens', 'email_track_clicks', 'members_track_sources', 'outbound_link_tagging', 'web_analytics', 'web_analytics_configured'
     ]) as boolean[];
     const isEmailTrackClicksReadOnly = isSettingReadOnly(localSettings, 'email_track_clicks');
 
@@ -43,14 +43,16 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
         handleEditingChange(true);
     };
 
+    const isWebAnalyticsAvailable = isWebAnalyticsConfigured && !isWebAnalyticsLimited;
+
     const inputs = (
         <SettingGroupContent className="analytics-settings gap-y-0!" columns={1}>
             <Toggle
                 align='center'
-                checked={isWebAnalyticsEnabled}
+                checked={didUserEnableWebAnalytics && isWebAnalyticsAvailable}
                 containerClasses='py-4'
                 direction='rtl'
-                disabled={!isWebAnalyticsConfigured || isWebAnalyticsLimited}
+                disabled={!isWebAnalyticsAvailable}
                 gap='gap-0'
                 hint={
                     !isWebAnalyticsConfigured ?

--- a/apps/admin-x-settings/src/components/settings/membership/stripe/stripe-connect-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/stripe-connect-modal.tsx
@@ -124,6 +124,7 @@ const Connect: React.FC = () => {
             <div className='mb-6 flex items-center justify-between'>
                 <Heading level={3}>Connect with Stripe</Heading>
                 <Toggle
+                    checked={testMode}
                     direction='rtl'
                     label='Test mode'
                     labelClasses={`translate-y-[1px] ${testMode ? 'text-[#EC6803]' : 'text-grey-800'}`}


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1321

*This change should have no user impact.*

This fixes two things with `<Toggle>`:

- Updates the props so the component is either [controlled or uncontrolled][0]. In other words, it should be impossible to pass `checked` without passing `onChange`, and vice-versa.

- Uses `checked`, not `defaultChecked`, to properly control the input. This means we can update `<Toggle>`s without having to extra work to make it re-render.

I think this is useful on its own, but also makes [an upcoming change](https://linear.app/ghost/issue/NY-1321) easier.

[0]: https://react.dev/reference/react-dom/components/input#controlling-an-input-with-a-state-variable