### PR TITLE
Triggered an update-check on boot when forceUpdate is enabled

### DIFF
--- a/ghost/core/core/server/services/update-check/index.js
+++ b/ghost/core/core/server/services/update-check/index.js
@@ -90,4 +90,18 @@ module.exports.scheduleRecurringJobs = () => {
         job: require('path').resolve(__dirname, 'run-update-check.js'),
         name: 'update-check'
     });
+
+    // CDN-fronted admin routes don't reach Ghost, so the admin-controller
+    // trigger path can't fire. Run a one-off through the same job-runner the
+    // daily cron uses — same worker code path, observable in the job system.
+    if (config.get('updateCheck:forceUpdate')) {
+        jobsService.addJob({
+            job: require('path').resolve(__dirname, 'run-update-check.js'),
+            name: 'update-check-boot',
+            data: {
+                forceUpdate: true,
+                updateCheckUrl: config.get('updateCheck:url')
+            }
+        });
+    }
 };

--- a/ghost/core/test/integration/jobs/update-check.test.js
+++ b/ghost/core/test/integration/jobs/update-check.test.js
@@ -1,42 +1,49 @@
 const assert = require('node:assert/strict');
 const http = require('http');
 const path = require('path');
+const sinon = require('sinon');
 const testUtils = require('../../utils');
 const jobService = require('../../../core/server/services/jobs/job-service');
+const updateCheckService = require('../../../core/server/services/update-check');
+const config = require('../../../core/shared/config');
 
 const JOB_NAME = 'update-check';
+const BOOT_JOB_NAME = 'update-check-boot';
 const JOB_PATH = path.resolve(__dirname, '../../../core/server/services/update-check/run-update-check.js');
 
 describe('Run Update Check', function () {
     let mockUpdateServer;
+    let mockUpdateServerRequestCount;
 
     before(testUtils.setup('default'));
 
-    afterEach(function () {
+    beforeEach(function () {
+        mockUpdateServerRequestCount = 0;
+        // The boot path runs in a separate worker thread so nock can't
+        // intercept; a real HTTP server is the only reliable observation point.
+        mockUpdateServer = http.createServer((req, res) => {
+            mockUpdateServerRequestCount += 1;
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            res.end(JSON.stringify({hello: 'world'}));
+        });
+        mockUpdateServer.listen(0);
+    });
+
+    afterEach(async function () {
         if (mockUpdateServer) {
             mockUpdateServer.close();
         }
+        // bree rejects duplicate job names; remove any we registered so the
+        // next test starts clean. Errors swallowed because not every test
+        // registers every job.
+        await jobService.removeJob(JOB_NAME).catch(() => {});
+        await jobService.removeJob(BOOT_JOB_NAME).catch(() => {});
+        sinon.restore();
     });
 
     it('successfully executes the update checker', async function () {
-        let mockUpdateServerRequestCount = 0;
-
-        // Initialise mock update server - We use a mock server here instead of
-        // nock because the update-check job will be executed in a separate
-        // process which will prevent nock from intercepting HTTP requests
-        mockUpdateServer = http.createServer((req, res) => {
-            mockUpdateServerRequestCount += 1;
-
-            res.writeHead(200, {'Content-Type': 'application/json'});
-
-            res.end(JSON.stringify({hello: 'world'}));
-        });
-
-        mockUpdateServer.listen(0); // Listen on random port
-
         const mockUpdateServerPort = mockUpdateServer.address().port;
 
-        // Trigger the update-check job and wait for it to finish
         await jobService.addJob({
             name: JOB_NAME,
             job: JOB_PATH,
@@ -48,7 +55,40 @@ describe('Run Update Check', function () {
 
         await jobService.awaitCompletion(JOB_NAME);
 
-        // Assert that the mock update server received a request (which means the update-check job ran successfully)
         assert.equal(mockUpdateServerRequestCount, 1, 'Expected mock server to receive 1 request');
+    });
+
+    describe('scheduleRecurringJobs', function () {
+        it('runs an immediate update-check on boot when forceUpdate is true', async function () {
+            const mockUpdateServerPort = mockUpdateServer.address().port;
+            sinon.stub(config, 'get')
+                .callThrough()
+                .withArgs('updateCheck:forceUpdate').returns(true)
+                .withArgs('updateCheck:url').returns(`http://127.0.0.1:${mockUpdateServerPort}`);
+
+            updateCheckService.scheduleRecurringJobs();
+
+            await jobService.awaitCompletion(BOOT_JOB_NAME);
+
+            assert.equal(mockUpdateServerRequestCount, 1, 'Expected mock server to receive 1 request from the boot-time check');
+        });
+
+        it('does not run an immediate update-check on boot when forceUpdate is false', async function () {
+            const mockUpdateServerPort = mockUpdateServer.address().port;
+            sinon.stub(config, 'get')
+                .callThrough()
+                .withArgs('updateCheck:forceUpdate').returns(false)
+                .withArgs('updateCheck:url').returns(`http://127.0.0.1:${mockUpdateServerPort}`);
+
+            updateCheckService.scheduleRecurringJobs();
+
+            // Give the event loop ample time for a misfire to land before
+            // asserting the negative.
+            await new Promise((resolve) => {
+                setTimeout(resolve, 200);
+            });
+
+            assert.equal(mockUpdateServerRequestCount, 0, 'Expected mock server to receive 0 requests');
+        });
     });
 });


### PR DESCRIPTION
## Problem

`updateCheck.forceUpdate: true` is the standard escape hatch for testing the update-check service — it bypasses the daily-throttle (`next_update_check`) and the `NODE_ENV` allowlist. But the *trigger* on a non-throttled cycle today is `web/admin/controller.js:30`, which fires `updateCheck()` on every admin request.

On any production-shaped host where `/ghost/` is fronted by a CDN cache (e.g. Ghost(Pro) and most managed-host setups), admin requests don't reach the Ghost server at all — they're served from cache. The admin-controller path effectively never runs. `forceUpdate` becomes useless for the "restart Ghost, see the new update-check response within seconds" loop that testing depends on, because the only remaining trigger is the once-per-day randomised cron.

## Solution

When `updateCheck.forceUpdate` is enabled, also enqueue a one-off update-check job on boot — same job-runner code path as the daily cron, just without an `at` schedule so it runs immediately. Restart Ghost → check runs within a second → result visible.

```diff
 module.exports.scheduleRecurringJobs = () => {
     // ... existing daily cron registration unchanged ...
+
+    if (config.get('updateCheck:forceUpdate')) {
+        jobsService.addJob({
+            job: require('path').resolve(__dirname, 'run-update-check.js'),
+            name: 'update-check-boot',
+            data: {
+                forceUpdate: true,
+                updateCheckUrl: config.get('updateCheck:url')
+            }
+        });
+    }
 };
```

The boot job's `updateCheckResponse` writes `next_update_check`, so the throttle state for any subsequent admin-controller-triggered checks is correctly set after boot finishes.

## Why this shape

- **Overload `forceUpdate` instead of a new flag.** Already opt-in, already test-only, already off in production. Adding a `runOnBoot` would mean two test flags both need to be set.
- **`jobsService.addJob`, not `setImmediate`.** Both fire-and-forget the same logical action, but the job-runner gives us:
  - Same code path as the daily cron (both invoke `run-update-check.js` in a worker thread) — one path, not two.
  - Observability via the job system.
  - Testability via `jobService.awaitCompletion(name)` — straightforward outcome-based tests.
- **Different job name (`update-check-boot`).** bree rejects duplicate job names; the daily cron is `update-check`. Separate name keeps both registerable.

## What it doesn't fix

Production sites without `forceUpdate` still rely on the daily cron alone if their admin route is CDN-cached. A general "every restart reaches out" change has bigger blast radius on the update-check service — out of scope here. This is a testing-only affordance.

## Tests

Two new integration tests in `test/integration/jobs/update-check.test.js`, alongside the existing `successfully executes the update checker` test:

- `runs an immediate update-check on boot when forceUpdate is true` — calls `scheduleRecurringJobs()`, awaits the boot job's completion, asserts the mock HTTP server received the request.
- `does not run an immediate update-check on boot when forceUpdate is false` — calls `scheduleRecurringJobs()`, waits 200ms for any misfire, asserts the mock HTTP server received nothing.

Both observe the outcome (HTTP request lands or doesn't) via a real mock HTTP server. Nock can't intercept across worker thread boundaries, so a real local server is the only reliable observation point — same pattern the existing integration test uses.

`pnpm test:single test/integration/jobs/update-check.test.js` — 3 passing.
