### PR TITLE
Fixed web analytics toggle state

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/analytics.tsx
@@ -17,8 +17,8 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
         handleEditingChange
     } = useSettingGroup();
 
-    const [trackEmailOpens, trackEmailClicks, trackMemberSources, outboundLinkTagging, isWebAnalyticsConfigured, isWebAnalyticsEnabled] = getSettingValues(localSettings, [
-        'email_track_opens', 'email_track_clicks', 'members_track_sources', 'outbound_link_tagging', 'web_analytics_configured', 'web_analytics_enabled'
+    const [trackEmailOpens, trackEmailClicks, trackMemberSources, outboundLinkTagging, webAnalytics, isWebAnalyticsConfigured] = getSettingValues(localSettings, [
+        'email_track_opens', 'email_track_clicks', 'members_track_sources', 'outbound_link_tagging', 'web_analytics', 'web_analytics_configured'
     ]) as boolean[];
     const isEmailTrackClicksReadOnly = isSettingReadOnly(localSettings, 'email_track_clicks');
 
@@ -43,11 +43,13 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
         handleEditingChange(true);
     };
 
+    const isWebAnalyticsChecked = Boolean(isWebAnalyticsConfigured && !isWebAnalyticsLimited && webAnalytics);
+
     const inputs = (
         <SettingGroupContent className="analytics-settings gap-y-0!" columns={1}>
             <Toggle
                 align='center'
-                checked={isWebAnalyticsEnabled}
+                checked={isWebAnalyticsChecked}
                 containerClasses='py-4'
                 direction='rtl'
                 disabled={!isWebAnalyticsConfigured || isWebAnalyticsLimited}


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1321
ref https://github.com/TryGhost/Ghost/pull/28384

**What:** Updated the analytics settings switch to read its checked state from `web_analytics`, while still forcing it off when analytics is unconfigured or plan-limited. Previously, it was pulling from the wrong place.

**Why:** This was a dormant bug. It happened to work. In a future change, this bug will appear, so we need to fix it now.
