### PR TITLE
Allowed i18n methods to be called if required before init

### DIFF
--- a/ghost/core/core/server/services/i18n.js
+++ b/ghost/core/core/server/services/i18n.js
@@ -1,15 +1,31 @@
+const assert = require('node:assert/strict');
 const debug = require('@tryghost/debug')('i18n');
 
 let i18nInstance;
 
-module.exports.init = function () {
+exports.changeLanguage = (...args) => {
+    assert(i18nInstance, 'Expected i18n instance to be initialized');
+    return i18nInstance.changeLanguage(...args);
+};
+
+exports.dir = (...args) => {
+    assert(i18nInstance, 'Expected i18n instance to be initialized');
+    return i18nInstance.dir(...args);
+};
+
+exports.t = (...args) => {
+    assert(i18nInstance, 'Expected i18n instance to be initialized');
+    return i18nInstance.t(...args);
+};
+
+exports.init = () => {
     const i18n = require('@tryghost/i18n');
     const events = require('../lib/common/events');
     const settingsCache = require('../../shared/settings-cache');
 
     const locale = settingsCache.get('locale') || 'en';
 
-    module.exports = i18nInstance = i18n(locale, 'ghost');
+    i18nInstance = i18n(locale, 'ghost');
 
     events.on('settings.locale.edited', (model) => {
         debug('locale changed, updating i18n to', model.get('value'));

--- a/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
@@ -459,9 +459,6 @@ describe('PaymentsService', function () {
     });
 
     describe('getDonationPriceNickname', function () {
-        // i18n.init() reassigns module.exports to the live instance, so re-require to reach it.
-        const i18nInstance = require('../../../../../../../core/server/services/i18n');
-
         function createService(title) {
             return new PaymentsService({
                 settingsCache: {
@@ -473,7 +470,7 @@ describe('PaymentsService', function () {
         }
 
         afterEach(function () {
-            i18nInstance.changeLanguage('en');
+            i18n.changeLanguage('en');
         });
 
         it('builds the nickname from the site title', function () {
@@ -482,7 +479,7 @@ describe('PaymentsService', function () {
         });
 
         it('localizes the prefix while keeping the site title interpolated', async function () {
-            await i18nInstance.changeLanguage('fr');
+            await i18n.changeLanguage('fr');
             const service = createService('Mon Site');
             assert.equal(service.getDonationPriceNickname(), 'Soutenir Mon Site');
         });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/28393

*This change should have no user impact.*

If the i18n service was imported before it was initialized, its reference would be forever stale. For example, this would fail if it was run before `i18n.init()`:

```js
const {t} = require('./services/i18n');
// ...some time later...
console.log(t('foo'));
```

This hadn't happened yet, but we did have a test workaround for it. And an upcoming change ran into this problem, so it's time to fix it.

I think this is a useful change on its own, but will also be useful for [an upcoming change](https://github.com/TryGhost/Ghost/pull/28393).
