### PR TITLE
Fixed commit-msg hook warning on emoji-prefixed commits

### DIFF
--- a/.github/hooks/commit-msg.bash
+++ b/.github/hooks/commit-msg.bash
@@ -81,7 +81,11 @@ fi
 # Check for emoji in user-facing changes
 if [[ "$subject" =~ ^[^[:space:]]*[[:space:]] ]]; then
     first_word="${subject%% *}"
-    if [[ ! "$first_word" =~ ^[[:punct:]] ]]; then
+    # Emoji are multi-byte (non-ASCII), so detect them by stripping every ASCII
+    # byte and seeing if anything is left. The previous check tested the first word
+    # against [[:punct:]], which never matches an emoji — so the warning fired on
+    # *every* correctly-prefixed commit (🐛, ✨, …) and passed on plain ASCII.
+    if [[ -z "$(printf '%s' "$first_word" | LC_ALL=C tr -d '\000-\177')" ]]; then
         echo -e "${yellow}Warning: User-facing changes should start with an emoji${no_color}"
         echo -e "Common emojis: ✨ (Feature), 🎨 (Improvement), 🐛 (Bug Fix), 🌐 (i18n), 💡 (User-facing)"
     fi


### PR DESCRIPTION
## Problem

The `commit-msg` hook's "user-facing changes should start with an emoji" check never recognizes an actual emoji, so the warning fires on **every** commit that correctly follows our emoji convention.

In `.github/hooks/commit-msg.bash` it tested the first word against POSIX `[[:punct:]]`:

```bash
if [[ ! "$first_word" =~ ^[[:punct:]] ]]; then
    echo "Warning: User-facing changes should start with an emoji"
fi
```

Emoji (🐛 ✨ 🎨 🌐 💡) are not punctuation, so the negated test is always true → the warning always prints. Ironically a non-emoji prefix like `*Fixed` or `:bug:` *passed* the check.

## Solution

Detect emoji by stripping ASCII bytes from the first word and checking whether anything (a multi-byte emoji) remains:

```bash
if [[ -z "$(printf '%s' "$first_word" | LC_ALL=C tr -d '\000-\177')" ]]; then
    echo "Warning: User-facing changes should start with an emoji"
fi
```

`tr` is portable across the macOS/Linux shells contributors use, and this keeps the check a non-blocking warning.

## Testing

Verified against representative subjects:

| Subject | Before | After |
|---|---|---|
| `🐛 Fixed …` | ⚠️ warns (wrong) | ✅ ok |
| `✨ Added …` | ⚠️ warns (wrong) | ✅ ok |
| `🌐 Updated …` | ⚠️ warns (wrong) | ✅ ok |
| `Fixed …` (no emoji) | ⚠️ warns | ⚠️ warns |
| `*Fixed …` | ✅ ok (wrong) | ⚠️ warns |

ref https://linear.app/ghost/issue/PLA-76