### PR TITLE
Changed Renovate to strict internalChecksFilter

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,6 +37,19 @@
     // Vulnerability-alert PRs require dashboard approval below so they do not
     // bypass the live open-PR cap enforced by the workflow.
     "minimumReleaseAge": "3 days",
+    // Hold updates internally during the release-age soak instead of opening a
+    // PR immediately and gating it with a pending `renovate/stability-days`
+    // status. With the default "flexible" filter, a soaking PR is still an open
+    // PR, so it counts against the live 10-PR cap enforced in
+    // .github/workflows/renovate.yml even though it cannot merge for up to 72h —
+    // soakers were starving creation slots from updates that are actually ready.
+    // "strict" keeps soaking updates as branchless/PR-less internal state until
+    // the soak passes, so a slot is only ever held by a mergeable PR. Trade-off:
+    // we lose day-0 CI signal on an update (breakage now surfaces only once the
+    // PR opens post-soak) and security fixes also stay invisible until their
+    // 72h soak clears (see vulnerabilityAlerts below — the soak already applied,
+    // strict only changes when the PR becomes visible).
+    "internalChecksFilter": "strict",
     "timezone": "Etc/UTC",
     // Restrict Renovate runs to the automerge windows so branch updates
     // (rebasing, force-pushes) happen around the same times automerge


### PR DESCRIPTION
## Summary

Sets `internalChecksFilter: "strict"` in `.github/renovate.json5` so dependency updates are held internally during the 72h `minimumReleaseAge` soak instead of being opened as PRs immediately.

## Problem

The live 10-PR cap is enforced in `.github/workflows/renovate.yml` by counting open Renovate PRs:

```bash
open_count=$(gh pr list --author "app/tryghost-renovate" --state open --json number --jq 'length')
```

That count makes no distinction between a mergeable PR and one whose `renovate/stability-days` status is still PENDING. Under the default `flexible` filter, Renovate opens a PR at the *start* of the soak, so a soaking update — which cannot merge for up to 72h — still occupies one of the 10 cap slots. At/above the cap the workflow switches to maintenance-only and creates no new PRs, so un-mergeable soakers were starving creation slots from updates that are actually ready to land.

## Change

`strict` keeps soaking updates as branchless/PR-less internal state until the soak passes. A PR is only opened once the update is genuinely mergeable, so a cap slot is only ever held by a mergeable PR. This also drops branch-slot pressure and the wasted day-0-through-day-3 CI on updates that weren't mergeable yet.

## Trade-offs

- **No day-0 CI signal** — breakage now surfaces only when the PR opens post-soak, not on day 0.
- **Security PRs stay invisible during their soak** — `vulnerabilityAlerts` keeps its own 3-day `minimumReleaseAge`, and `internalChecksFilter` is global, so CVE fixes are also held until their soak clears. Merge timing is unchanged (the soak already gated it); only the PR's visibility window changes.
- Pending-soak updates remain visible in the Dependency Dashboard.

End-to-end lead time to merge is unchanged — the soak always gated merging; this only changes *when the PR becomes visible*.