### PR TITLE
Admin notifications not visible in dark mode

### DIFF
--- a/ghost/admin/app/styles/components/notifications.css
+++ b/ghost/admin/app/styles/components/notifications.css
@@ -217,7 +217,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 14px 15px;
-    border-bottom: #dfe1e3 1px solid;
+    border-bottom: var(--whitegrey) 1px solid;
     background-color: var(--white);
     color: var(--black);
 }

--- a/ghost/admin/app/styles/components/notifications.css
+++ b/ghost/admin/app/styles/components/notifications.css
@@ -218,7 +218,8 @@
     align-items: center;
     padding: 14px 15px;
     border-bottom: #dfe1e3 1px solid;
-    background-color: white;
+    background-color: var(--white);
+    color: var(--black);
 }
 
 .gh-alert-content {


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1405/version-update-notification-not-visible-in-dark-mode https://github.com/TryGhost/Ghost/issues/28403

We weren't handling dark mode for Admin notifications.

| Before | After |
|--------|--------|
| <img width="361" height="127" alt="Screenshot 2026-06-08 at 08 58 46" src="https://github.com/user-attachments/assets/83ecc674-8a67-4bd2-aea9-44e53ca03f1d" /> | <img width="358" height="120" alt="Screenshot 2026-06-08 at 08 57 57" src="https://github.com/user-attachments/assets/436bb08a-52d3-43ba-8a13-55e4830444e3" /> |