### PR TITLE
Moved update-check triggering from admin route to boot sequence

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -431,6 +431,9 @@ async function initBackgroundServices({config}) {
 
     const updateCheck = require('./server/services/update-check');
     updateCheck.scheduleRecurringJobs();
+    if (config.get('updateCheck:forceUpdate')) {
+        updateCheck.scheduleBootJob();
+    }
 
     const milestonesService = require('./server/services/milestones');
     milestonesService.initAndRun();

--- a/ghost/core/core/server/services/update-check/index.js
+++ b/ghost/core/core/server/services/update-check/index.js
@@ -91,3 +91,10 @@ module.exports.scheduleRecurringJobs = () => {
         name: 'update-check'
     });
 };
+
+module.exports.scheduleBootJob = () => {
+    jobsService.addJob({
+        job: require('path').resolve(__dirname, 'run-update-check.js'),
+        name: 'update-check-boot'
+    });
+};

--- a/ghost/core/core/server/web/admin/controller.js
+++ b/ghost/core/core/server/web/admin/controller.js
@@ -5,7 +5,6 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 const config = require('../../../shared/config');
-const updateCheck = require('../../services/update-check');
 
 const messages = {
     templateError: {
@@ -18,18 +17,13 @@ const messages = {
 /**
  * @description Admin controller to handle /ghost/ requests.
  *
- * Every request to the admin panel will re-trigger the update check service.
- *
  * @param {import('express').Request} req
  * @param {import('express').Response} res
  */
 module.exports = function adminController(req, res) {
     debug('index called');
 
-    // CASE: trigger update check unit and let it run in background, don't block the admin rendering
-    updateCheck();
-
-    const templatePath = path.resolve(config.get('paths').adminAssets, 'index.html');    
+    const templatePath = path.resolve(config.get('paths').adminAssets, 'index.html');
     const headers = {};
 
     try {


### PR DESCRIPTION
## Problem

The admin controller fires an update check on every `/ghost/` request, intended to keep update checks ticking on quiet sites. In production deployments where the admin route is CDN-cached, the request never reaches Ghost, so this trigger silently no-ops in exactly the situation it was added to cover.

## Solution

Removed the admin route trigger and made boot solely responsible for scheduling update checks. The existing daily cron is unchanged; sites with `updateCheck:forceUpdate` enabled additionally get an immediate check at startup so testing the flow does not depend on waiting for the next cron tick.