### PR TITLE
Fixed IndexNow status-code detection (429/422/403 mislabelled as ping_failed)

### DIFF
--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -138,9 +138,11 @@ async function ping(post) {
         }, `${INDEXNOW_LOG_KEY} Successfully pinged ${url}`);
     } catch (err) {
         // Log errors but don't throw - IndexNow failures shouldn't disrupt publishing
+        const statusCode = err.statusCode ?? err.response?.statusCode ?? null;
+
         let eventName;
         let error;
-        if (err.statusCode === 429) {
+        if (statusCode === 429) {
             // Rate limited by IndexNow - we have no retry/backoff, so the ping is dropped
             eventName = 'indexnow.rate_limited';
             error = new errors.TooManyRequestsError({
@@ -149,8 +151,7 @@ async function ping(post) {
                 context: tpl(messages.requestFailedError, {service: 'IndexNow'}),
                 help: tpl(messages.requestFailedHelp, {url: 'https://ghost.org/docs/'})
             });
-        } else if (err.statusCode === 422) {
-            // 422 means the URL is invalid or key doesn't match
+        } else if (statusCode === 422 || statusCode === 403) {
             eventName = 'indexnow.key_validation_failed';
             error = new errors.ValidationError({
                 err,
@@ -171,7 +172,7 @@ async function ping(post) {
         logging.warn({
             event: {name: eventName},
             post: {id: post.id, slug: post.slug, url},
-            http: {response: {status_code: err.statusCode ?? null}},
+            http: {response: {status_code: statusCode}},
             err: error
         }, `${INDEXNOW_LOG_KEY} ${error.message}`);
     }

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const _ = require('lodash');
 const nock = require('nock');
 const rewire = require('rewire');
+const errors = require('@tryghost/errors');
 const testUtils = require('../../../utils');
 const indexnow = rewire('../../../../core/server/services/indexnow');
 const events = require('../../../../core/server/lib/common/events');
@@ -434,6 +435,81 @@ describe('IndexNow', function () {
             sinon.assert.calledOnce(loggingStub);
             assert.equal(loggingStub.args[0][0].event.name, 'indexnow.ping_failed');
             assert.equal(loggingStub.args[0][0].http.response.status_code, 204);
+        });
+    });
+
+    describe('ping() error classification (got HTTPError shape)', function () {
+        const ping = indexnow.__get__('ping');
+        let resetIndexNow;
+
+        beforeEach(function () {
+            sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/my-post/');
+            loggingStub = sinon.stub(logging, 'warn');
+        });
+
+        afterEach(function () {
+            if (resetIndexNow) {
+                resetIndexNow();
+                resetIndexNow = null;
+            }
+        });
+
+        function makeHttpError(statusCode) {
+            const err = new Error(`Response code ${statusCode}`);
+            err.name = 'HTTPError';
+            err.code = 'ERR_NON_2XX_3XX_RESPONSE';
+            err.response = {statusCode};
+            return err;
+        }
+
+        async function pingWithHttpError(statusCode) {
+            resetIndexNow = indexnow.__set__('request', sinon.stub().rejects(makeHttpError(statusCode)));
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+            await ping(testPost);
+        }
+
+        it('classifies a 429 (status on err.response.statusCode) as rate_limited', async function () {
+            await pingWithHttpError(429);
+
+            sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.rate_limited');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 429);
+        });
+
+        it('classifies a 422 (status on err.response.statusCode) as key_validation_failed', async function () {
+            await pingWithHttpError(422);
+
+            sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.key_validation_failed');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 422);
+        });
+
+        it('classifies a 403 (key not valid) as key_validation_failed', async function () {
+            await pingWithHttpError(403);
+
+            sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.key_validation_failed');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 403);
+        });
+
+        it('classifies other 5xx errors (status on err.response.statusCode) as ping_failed', async function () {
+            await pingWithHttpError(503);
+
+            sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.ping_failed');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 503);
+        });
+
+        it('still classifies a GhostError carrying err.statusCode (manual throw) correctly', async function () {
+            const err = new errors.TooManyRequestsError({message: 'manual', statusCode: 429});
+            resetIndexNow = indexnow.__set__('request', sinon.stub().rejects(err));
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+
+            await ping(testPost);
+
+            sinon.assert.calledOnce(loggingStub);
+            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.rate_limited');
+            assert.equal(loggingStub.args[0][0].http.response.status_code, 429);
         });
     });
 


### PR DESCRIPTION
## Summary

IndexNow failures were mis-detecting the HTTP status code, so rate-limits (429) and key-validation errors (422/403) were silently mislabelled as the generic `indexnow.ping_failed` (with `status_code: null`).

The classification in the `ping()` catch block keyed off `err.statusCode`, but for a non-2xx response `got` throws an `HTTPError` whose status lives at `err.response.statusCode`, **not** `err.statusCode`. So in production those branches never matched and every 429/422/403 fell through to the generic failure branch — making rate-limiting and key problems invisible in our structured logs.

## Changes

- Derive the status once and use it everywhere:
  ```js
  const statusCode = err.statusCode ?? err.response?.statusCode ?? null;
  ```
  This handles both got's `HTTPError` (status on `err.response.statusCode`) and the existing manual unexpected-2xx throw (status on `err.statusCode`).
- Classify on `statusCode`: `429 → indexnow.rate_limited`; `422`/`403 → indexnow.key_validation_failed` (403 = key not valid / key file not found — the same class of problem as 422); everything else → `indexnow.ping_failed`. Log the real `http.response.status_code`.
- Tests: added a block that throws the real got `HTTPError` shape (status only on `err.response.statusCode`) covering 429 / 422 / 403 / 503, plus the manual-throw shape. These would have caught the original bug (the previous nock-based tests passed only because the request library happens to flatten `statusCode` onto the error in some versions).

No behavioural change to pinging itself — this is observability only (correct event names + status codes).

## Test
- `pnpm test:single test/unit/server/services/indexnow.test.js` — 27 passing.
