### PR TITLE
Gate IndexNow pings behind privacy config

### DIFF
--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -83,7 +83,10 @@ export const BASE_GHOST_ENV = [
     // Email configuration
     'mail__transport=SMTP',
     'mail__options__host=ghost-dev-mailpit',
-    'mail__options__port=1025'
+    'mail__options__port=1025',
+
+    // Disable IndexNow pings (tests run with real network access)
+    'privacy__useIndexNow=false'
 ] as const;
 
 export const TEST_ENVIRONMENT = {

--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -27,6 +27,7 @@ const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const request = require('@tryghost/request');
 const settingsCache = require('../../shared/settings-cache');
+const config = require('../../shared/config');
 const labs = require('../../shared/labs');
 const events = require('../lib/common/events');
 
@@ -72,6 +73,11 @@ async function ping(post) {
 
     // Skip if site is private
     if (settingsCache.get('is_private')) {
+        return;
+    }
+
+    // Skip if IndexNow pings are disabled via privacy config
+    if (config.isPrivacyDisabled('useIndexNow')) {
         return;
     }
 

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -7,6 +7,7 @@ const testUtils = require('../../../utils');
 const indexnow = rewire('../../../../core/server/services/indexnow');
 const events = require('../../../../core/server/lib/common/events');
 const settingsCache = require('../../../../core/shared/settings-cache');
+const config = require('../../../../core/shared/config');
 const labs = require('../../../../core/shared/labs');
 const logging = require('@tryghost/logging');
 const urlService = require('../../../../core/server/services/url');
@@ -16,16 +17,19 @@ describe('IndexNow', function () {
     let loggingStub;
     let settingsCacheStub;
     let labsStub;
+    let privacyDisabledStub;
 
     beforeEach(function () {
         eventStub = sinon.stub(events, 'on');
         settingsCacheStub = sinon.stub(settingsCache, 'get');
         labsStub = sinon.stub(labs, 'isSet');
+        privacyDisabledStub = sinon.stub(config, 'isPrivacyDisabled');
 
-        // Default: IndexNow enabled, site not private, API key set
+        // Default: IndexNow enabled, site not private, API key set, privacy not disabled
         labsStub.withArgs('indexnow').returns(true);
         settingsCacheStub.withArgs('is_private').returns(false);
         settingsCacheStub.withArgs('indexnow_api_key').returns('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
+        privacyDisabledStub.withArgs('useIndexNow').returns(false);
     });
 
     afterEach(function () {
@@ -316,6 +320,19 @@ describe('IndexNow', function () {
 
         it('when labs.indexnow is false should not execute ping', async function () {
             labsStub.withArgs('indexnow').returns(false);
+
+            const pingRequest = nock('https://api.indexnow.org')
+                .get(/\/indexnow/)
+                .reply(200);
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+
+            await ping(testPost);
+
+            assert.equal(pingRequest.isDone(), false);
+        });
+
+        it('when privacy.useIndexNow is disabled should not execute ping', async function () {
+            privacyDisabledStub.withArgs('useIndexNow').returns(true);
 
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)


### PR DESCRIPTION
## Summary

IndexNow notifies search engines when content is published or updated by pinging an external API. Tests and local dev run against real networks, so the ping can fire from non-production environments.

This gates the ping behind Ghost's existing privacy config:

- `config.isPrivacyDisabled('useIndexNow')` short-circuits the ping, consistent with `update-check`, `gravatar`, and structured data
- Can be disabled via `privacy: {useIndexNow: false}` or `privacy: {useTinfoil: true}`
- **Default behaviour is unchanged** — with no privacy config set, the ping still fires in production
- Also sets `privacy__useIndexNow=false` in the e2e environment, which boots Ghost with real network access

## Tests

- Added a unit test asserting the ping is skipped when `privacy.useIndexNow` is disabled
- Existing IndexNow unit tests pass
