### PR TITLE
Add egress monitoring to e2e tests

### DIFF
--- a/e2e/helpers/environment/Corefile
+++ b/e2e/helpers/environment/Corefile
@@ -1,0 +1,12 @@
+# CoreDNS config for the egress-monitor sidecar.
+#
+# Ghost's resolver is pointed at this server, which makes it the upstream of
+# Docker's embedded DNS — so internal service names (mysql, redis, …) are
+# resolved by Docker itself and only EXTERNAL lookups reach CoreDNS. Those are
+# forwarded on to Docker's embedded resolver (127.0.0.11) and logged with an
+# `EGRESS` sentinel the host side greps for.
+.:53 {
+    forward . 127.0.0.11
+    log . "EGRESS {remote} {type} {name}"
+    errors
+}

--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -86,7 +86,10 @@ export const BASE_GHOST_ENV = [
     'mail__options__port=1025',
 
     // Disable IndexNow pings (tests run with real network access)
-    'privacy__useIndexNow=false'
+    'privacy__useIndexNow=false',
+
+    // Disable gravatar avatar lookups (real external call, no e2e coverage)
+    'privacy__useGravatar=false'
 ] as const;
 
 export const TEST_ENVIRONMENT = {
@@ -127,13 +130,41 @@ export const EGRESS_MONITOR_ENABLED = process.env.E2E_EGRESS_MONITOR !== '0';
 export const EGRESS_ENFORCE = process.env.E2E_EGRESS_ENFORCE !== '0';
 
 /**
- * Hosts the suite is allowed to reach. Only the local test infrastructure for now
- * — every real external host the app contacts is intentionally left out so it
- * surfaces as a failure; the allowlist is built up from there. An entry matches
- * itself and any subdomain; reverse-DNS (*.arpa) lookups are ignored.
+ * Hosts the suite is allowed to reach. An entry matches itself and any subdomain
+ * (so `unsplash.com` covers `images.unsplash.com`); reverse-DNS (*.arpa) lookups
+ * are ignored. Each entry is a host the suite legitimately contacts — anything
+ * not listed fails enforcement (see EGRESS_ENFORCE).
+ *
+ * Deliberately NOT here:
+ * - api.stripe.com — Ghost should hit the fake Stripe server, not real Stripe.
+ *   It only leaks because a test connects Stripe without `stripeEnabled`; the fix
+ *   is the test, not an allowlist entry. (Hence the specific Stripe subdomains
+ *   below rather than a blanket `stripe.com`.)
+ * - gravatar.com — gated off in e2e instead (privacy__useGravatar above).
  */
 export const EGRESS_ALLOWLIST: readonly string[] = [
-    'host.docker.internal',
-    'localhost',
-    '127.0.0.1'
+    // Local test infrastructure (not real external egress)
+    'host.docker.internal', // host gateway: fake Stripe/Mailgun servers + Caddy gateway
+    'localhost', // the site/admin under test
+    '127.0.0.1', // the site/admin under test
+    'mock.test', // e2e billing mock (billing.mock.test) served by the harness
+
+    // Ghost-owned
+    'ghost.org', // static.ghost.org theme/admin assets + ghost.org changelog & update-check
+
+    // Stripe — browser-side only (Stripe.js/Elements must load from Stripe's own CDN).
+    // Listed per-subdomain so api.stripe.com (server-side) is NOT covered — see above.
+    'js.stripe.com', // Stripe.js loaded by Portal/checkout
+    'm.stripe.com', // Stripe Elements
+    'm.stripe.network', // Stripe Elements
+
+    // reCAPTCHA, pulled in by Stripe checkout
+    'google.com', // reCAPTCHA challenge (www.google.com)
+    'gstatic.com', // reCAPTCHA static assets (t0–t3.gstatic.com)
+
+    // Other third-party services the product uses
+    'bunny.net', // web fonts (fonts.bunny.net)
+    'transistor.fm', // podcast embeds (partner.transistor.fm)
+    'unsplash.com', // editor image selector (api./images.unsplash.com)
+    'geojs.io' // member signup + staff sign-in geolocation (get.geojs.io)
 ];

--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -99,3 +99,41 @@ export const TEST_ENVIRONMENT = {
         port: 2368
     }
 } as const;
+
+/**
+ * Egress monitoring — see service-managers/egress-monitor.ts.
+ *
+ * A CoreDNS sidecar records every EXTERNAL host the Ghost container resolves, so
+ * outbound HTTP(S) calls are visible (and optionally enforced) in tests that
+ * otherwise run with unrestricted network access.
+ */
+
+// Dedicated DNS image for the sidecar — pinned by digest, pulled at runtime
+// (through the CI registry mirror). Deliberately NOT the Ghost application image.
+export const EGRESS_DNS_IMAGE = 'coredns/coredns:1.12.0@sha256:40384aa1f5ea6bfdc77997d243aec73da05f27aed0c5e9d65bfa98933c519d97';
+
+// CoreDNS config, bind-mounted into the sidecar at /Corefile.
+export const EGRESS_COREFILE_PATH = path.resolve(__dirname, 'Corefile');
+
+// Master switch for ALL egress monitoring — the DNS sidecar (server-side) and
+// the Playwright request listener (browser-side). On by default; set to '0' to
+// disable both.
+export const EGRESS_MONITOR_ENABLED = process.env.E2E_EGRESS_MONITOR !== '0';
+
+// Fail a test when it triggers egress to a host that is not on EGRESS_ALLOWLIST.
+// On by default so unexpected outbound requests (e.g. a new integration, or a
+// service that should be mocked) surface as a test failure. Set
+// E2E_EGRESS_ENFORCE=0 to record-only, e.g. while expanding the allowlist.
+export const EGRESS_ENFORCE = process.env.E2E_EGRESS_ENFORCE !== '0';
+
+/**
+ * Hosts the suite is allowed to reach. Only the local test infrastructure for now
+ * — every real external host the app contacts is intentionally left out so it
+ * surfaces as a failure; the allowlist is built up from there. An entry matches
+ * itself and any subdomain; reverse-DNS (*.arpa) lookups are ignored.
+ */
+export const EGRESS_ALLOWLIST: readonly string[] = [
+    'host.docker.internal',
+    'localhost',
+    '127.0.0.1'
+];

--- a/e2e/helpers/environment/environment-manager.ts
+++ b/e2e/helpers/environment/environment-manager.ts
@@ -3,6 +3,7 @@ import logging from '@tryghost/logging';
 import {GhostInstance, MySQLManager} from './service-managers';
 import {GhostManager} from './service-managers/ghost-manager';
 import {randomUUID} from 'crypto';
+import type {EgressMonitor} from './service-managers/egress-monitor';
 import type {GhostConfig} from '@/helpers/playwright/fixture';
 
 const debug = baseDebug('e2e:EnvironmentManager');
@@ -144,6 +145,14 @@ export class EnvironmentManager {
      */
     async perTestTeardown(instance: GhostInstance): Promise<void> {
         await this.mysql.cleanupTestDatabase(instance.database);
+    }
+
+    /**
+     * Egress monitor for this worker, or null when disabled / unavailable.
+     * Records external hostnames the Ghost container resolves.
+     */
+    getEgressMonitor(): EgressMonitor | null {
+        return this.ghost.getEgressMonitor();
     }
 
     private async cleanupResources(): Promise<void> {

--- a/e2e/helpers/environment/service-managers/egress-monitor.ts
+++ b/e2e/helpers/environment/service-managers/egress-monitor.ts
@@ -1,0 +1,270 @@
+import Docker from 'dockerode';
+import baseDebug from '@tryghost/debug';
+import {
+    DEV_ENVIRONMENT,
+    EGRESS_ALLOWLIST,
+    EGRESS_COREFILE_PATH,
+    EGRESS_DNS_IMAGE,
+    TEST_ENVIRONMENT
+} from '@/helpers/environment/constants';
+import {dirname} from 'path';
+import {mkdir, writeFile} from 'fs/promises';
+import type {Container} from 'dockerode';
+
+const debug = baseDebug('e2e:EgressMonitor');
+
+export interface EgressQuery {
+    /** Hostname that was resolved (lowercased, no trailing dot) */
+    name: string;
+    /** Record type, e.g. A / AAAA */
+    type: string;
+    /** Source container IP that issued the lookup */
+    client?: string;
+}
+
+export interface EgressMonitorConfig {
+    workerIndex: number;
+}
+
+// CoreDNS logs each forwarded query via the `log` plugin with an EGRESS sentinel
+// (see the Corefile): `[INFO] EGRESS <client> <type> <name>.`
+const EGRESS_LINE = /EGRESS (\S+) (\S+) (\S+)/;
+
+/**
+ * Observes outbound DNS resolution from the Ghost container in e2e tests.
+ *
+ * A CoreDNS sidecar runs on the dev network. Pointing Ghost's `HostConfig.Dns` at
+ * it makes the sidecar the upstream (ExtServer) of Ghost's embedded resolver, so
+ * Docker keeps resolving internal service names (mysql, redis, …) itself and only
+ * forwards EXTERNAL names to the sidecar. CoreDNS forwards those on to Docker's
+ * embedded resolver and logs them, so its output is a clean record of every
+ * external host Ghost reached out to — regardless of which HTTP client made the
+ * call, and including arbitrary hostnames (e.g. webmention targets pulled from
+ * post content).
+ *
+ * The sidecar uses a dedicated, pinned CoreDNS image — deliberately NOT the Ghost
+ * application image (which is the production artifact) — pulled at runtime through
+ * the CI registry mirror.
+ *
+ * The monitor is fail-open: if the sidecar can't start, callers must NOT override
+ * Ghost's DNS (doing so without a working resolver would break the whole suite).
+ */
+export class EgressMonitor {
+    private readonly docker: Docker;
+    private readonly config: EgressMonitorConfig;
+    private readonly containerName: string;
+    private container: Container | null = null;
+    private serverIp: string | null = null;
+
+    constructor(docker: Docker, config: EgressMonitorConfig) {
+        this.docker = docker;
+        this.config = config;
+        this.containerName = `ghost-e2e-egress-worker-${config.workerIndex}`;
+    }
+
+    /** IP the Ghost container should use as its DNS server, or null if unavailable. */
+    get dnsServerIp(): string | null {
+        return this.serverIp;
+    }
+
+    get isActive(): boolean {
+        return this.serverIp !== null;
+    }
+
+    /**
+     * Start the sidecar and resolve its network IP. Never throws — on failure it
+     * logs and leaves the monitor inactive so the caller falls back to normal DNS.
+     */
+    async start(): Promise<void> {
+        try {
+            await this.ensureImage();
+            this.container = await this.getOrCreate();
+            // Only expose the IP once CoreDNS has actually started. Ghost is pointed
+            // at this DNS server immediately after, so returning early would let its
+            // first lookups race the bind and fail.
+            await this.waitForListening(this.container);
+            this.serverIp = await this.resolveIp(this.container);
+            debug(`Egress monitor ready for worker ${this.config.workerIndex} at ${this.serverIp}`);
+        } catch (error) {
+            debug('Egress monitor failed to start; continuing without DNS monitoring:', error);
+            this.container = null;
+            this.serverIp = null;
+        }
+    }
+
+    /** Pull the CoreDNS image if it isn't already present on the host. */
+    private async ensureImage(): Promise<void> {
+        try {
+            await this.docker.getImage(EGRESS_DNS_IMAGE).inspect();
+            return;
+        } catch {
+            // Not present locally — pull it below.
+        }
+        const stream = await this.docker.pull(EGRESS_DNS_IMAGE);
+        await new Promise<void>((resolve, reject) => {
+            this.docker.modem.followProgress(stream, err => (err ? reject(err) : resolve()));
+        });
+    }
+
+    /**
+     * Wait until CoreDNS has logged its startup banner (it prints `CoreDNS-<ver>`
+     * once it is serving). Throws on timeout so start() stays fail-open and the
+     * caller falls back to Docker's default resolver.
+     */
+    private async waitForListening(container: Container, timeoutMs = 10000): Promise<void> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            const buffer = await container.logs({stdout: true, stderr: true, follow: false, timestamps: false});
+            if (buffer.toString('utf8').includes('CoreDNS-')) {
+                return;
+            }
+            await new Promise((resolve) => {
+                setTimeout(resolve, 100);
+            });
+        }
+        throw new Error('Egress monitor sidecar did not start in time');
+    }
+
+    private async getOrCreate(): Promise<Container> {
+        const existing = this.docker.getContainer(this.containerName);
+        try {
+            const info = await existing.inspect();
+            if (info.State.Running) {
+                return existing;
+            }
+            await existing.start();
+            return existing;
+        } catch (error) {
+            const statusCode = (error as {statusCode?: number})?.statusCode;
+            const message = error instanceof Error ? error.message : String(error);
+            if (statusCode !== 404 && !/No such container/i.test(message)) {
+                throw error;
+            }
+        }
+
+        const container = await this.docker.createContainer({
+            name: this.containerName,
+            Image: EGRESS_DNS_IMAGE,
+            Cmd: ['-conf', '/Corefile'],
+            // TTY keeps `container.logs()` output un-multiplexed (raw lines).
+            Tty: true,
+            // The CoreDNS image runs as nonroot by default; port 53 needs root.
+            User: '0:0',
+            HostConfig: {
+                Binds: [`${EGRESS_COREFILE_PATH}:/Corefile:ro`],
+                ExtraHosts: ['host.docker.internal:host-gateway']
+            },
+            NetworkingConfig: {
+                EndpointsConfig: {
+                    [DEV_ENVIRONMENT.networkName]: {Aliases: [this.containerName]}
+                }
+            },
+            Labels: {
+                // Same project label as Ghost/gateway so cleanupAllContainers() removes it.
+                'com.docker.compose.project': TEST_ENVIRONMENT.projectNamespace,
+                'tryghost/e2e': 'egress-monitor'
+            }
+        });
+        await container.start();
+        return container;
+    }
+
+    private async resolveIp(container: Container): Promise<string> {
+        const info = await container.inspect();
+        const networks = info.NetworkSettings?.Networks ?? {};
+        const endpoint = networks[DEV_ENVIRONMENT.networkName] ?? Object.values(networks)[0];
+        const ip = endpoint?.IPAddress;
+        if (!ip) {
+            throw new Error('Egress monitor container has no network IP');
+        }
+        return ip;
+    }
+
+    /** Parse every query CoreDNS has logged so far. */
+    async readQueries(): Promise<EgressQuery[]> {
+        if (!this.container) {
+            return [];
+        }
+        const buffer = await this.container.logs({stdout: true, stderr: true, follow: false, timestamps: false});
+        const queries: EgressQuery[] = [];
+        for (const line of buffer.toString('utf8').split('\n')) {
+            const match = line.match(EGRESS_LINE);
+            if (match) {
+                queries.push({
+                    client: match[1],
+                    type: match[2],
+                    name: match[3].replace(/\.$/, '').toLowerCase()
+                });
+            }
+        }
+        return queries;
+    }
+
+    /** Number of queries logged so far — use as a cursor for per-test deltas. */
+    async cursor(): Promise<number> {
+        return (await this.readQueries()).length;
+    }
+
+    /**
+     * Collect queries logged since `startCursor`. Because outbound pings are often
+     * fire-and-forget, briefly poll for the log to settle so a late lookup isn't
+     * missed (this runs in test teardown, not inside a test body).
+     */
+    async collectSince(startCursor: number, {settleMs = 400, maxWaitMs = 1500} = {}): Promise<EgressQuery[]> {
+        const deadline = Date.now() + maxWaitMs;
+        let previous = await this.readQueries();
+        let lastGrowth = Date.now();
+        while (Date.now() < deadline) {
+            await new Promise((resolve) => {
+                setTimeout(resolve, 100);
+            });
+            const current = await this.readQueries();
+            if (current.length > previous.length) {
+                previous = current;
+                lastGrowth = Date.now();
+            } else if (Date.now() - lastGrowth >= settleMs) {
+                // Stable for the full settle window — no more late lookups expected.
+                break;
+            }
+        }
+        return previous.slice(startCursor);
+    }
+
+    /** Hosts seen since `startCursor` that are not on the allowlist. */
+    async unexpectedSince(startCursor: number, opts?: {settleMs?: number; maxWaitMs?: number}): Promise<EgressQuery[]> {
+        const queries = await this.collectSince(startCursor, opts);
+        return queries.filter(q => !isAllowedHost(q.name));
+    }
+
+    /** Persist the full query log as a JSON artifact for inspection. */
+    async writeArtifact(filePath: string): Promise<void> {
+        const queries = await this.readQueries();
+        await mkdir(dirname(filePath), {recursive: true});
+        await writeFile(filePath, JSON.stringify(queries, null, 2));
+    }
+
+    async stop(): Promise<void> {
+        if (!this.container) {
+            return;
+        }
+        try {
+            await this.container.remove({force: true});
+        } catch (error) {
+            debug('Failed to remove egress monitor container:', error);
+        }
+        this.container = null;
+        this.serverIp = null;
+    }
+}
+
+/**
+ * A host is "allowed" if it matches an allowlist entry exactly, is a subdomain of
+ * one, or is a reverse-DNS (PTR) lookup. Everything else counts as external egress.
+ */
+export function isAllowedHost(host: string): boolean {
+    const name = host.toLowerCase().replace(/\.$/, '');
+    if (!name || name.endsWith('.arpa')) {
+        return true;
+    }
+    return EGRESS_ALLOWLIST.some(allowed => name === allowed || name.endsWith(`.${allowed}`));
+}

--- a/e2e/helpers/environment/service-managers/egress-monitor.ts
+++ b/e2e/helpers/environment/service-managers/egress-monitor.ts
@@ -200,17 +200,14 @@ export class EgressMonitor {
         return queries;
     }
 
-    /** Number of queries logged so far — use as a cursor for per-test deltas. */
-    async cursor(): Promise<number> {
-        return (await this.readQueries()).length;
-    }
-
     /**
-     * Collect queries logged since `startCursor`. Because outbound pings are often
-     * fire-and-forget, briefly poll for the log to settle so a late lookup isn't
-     * missed (this runs in test teardown, not inside a test body).
+     * Read every query the container has resolved, briefly polling for the CoreDNS
+     * log to settle first. Outbound pings are often fire-and-forget, so a late
+     * lookup from the final test can land just after it finishes; the settle window
+     * waits for the log to stop growing before returning. Runs once per worker at
+     * teardown — not per test — so this cost is paid a single time.
      */
-    async collectSince(startCursor: number, {settleMs = 400, maxWaitMs = 1500} = {}): Promise<EgressQuery[]> {
+    async collectSettled({settleMs = 400, maxWaitMs = 1500} = {}): Promise<EgressQuery[]> {
         const deadline = Date.now() + maxWaitMs;
         let previous = await this.readQueries();
         let lastGrowth = Date.now();
@@ -227,13 +224,17 @@ export class EgressMonitor {
                 break;
             }
         }
-        return previous.slice(startCursor);
+        return previous;
     }
 
-    /** Hosts seen since `startCursor` that are not on the allowlist. */
-    async unexpectedSince(startCursor: number, opts?: {settleMs?: number; maxWaitMs?: number}): Promise<EgressQuery[]> {
-        const queries = await this.collectSince(startCursor, opts);
-        return queries.filter(q => !isAllowedHost(q.name));
+    /**
+     * External hosts the container resolved that are NOT on the allowlist, as a
+     * sorted, de-duplicated list.
+     */
+    async unexpectedHosts(opts?: {settleMs?: number; maxWaitMs?: number}): Promise<string[]> {
+        const queries = await this.collectSettled(opts);
+        const hosts = queries.map(query => query.name).filter(host => !isAllowedHost(host));
+        return [...new Set(hosts)].sort();
     }
 
     /** Persist the full query log as a JSON artifact for inspection. */

--- a/e2e/helpers/environment/service-managers/ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/ghost-manager.ts
@@ -8,10 +8,12 @@ import {
     CADDYFILE_PATHS,
     DEV_ENVIRONMENT,
     DEV_SHARED_CONFIG_VOLUME,
+    EGRESS_MONITOR_ENABLED,
     REPO_ROOT,
     TEST_ENVIRONMENT,
     TINYBIRD
 } from '@/helpers/environment/constants';
+import {EgressMonitor} from '@/helpers/environment/service-managers/egress-monitor';
 import {isTinybirdAvailable} from '@/helpers/environment/service-availability';
 import {readFile} from 'fs/promises';
 import type {Container, ContainerCreateOptions} from 'dockerode';
@@ -54,6 +56,7 @@ export class GhostManager {
     private readonly config: GhostManagerConfig;
     private ghostContainer: Container | null = null;
     private gatewayContainer: Container | null = null;
+    private egressMonitor: EgressMonitor | null = null;
 
     constructor(config: GhostManagerConfig) {
         this.docker = new Docker();
@@ -62,6 +65,15 @@ export class GhostManager {
 
     get ghostContainerId(): string | null {
         return this.ghostContainer?.id ?? null;
+    }
+
+    /** Egress monitor for this worker, or null when disabled / failed to start. */
+    getEgressMonitor(): EgressMonitor | null {
+        return this.egressMonitor?.isActive ? this.egressMonitor : null;
+    }
+
+    private ghostImage(): string {
+        return this.config.mode === 'build' ? BUILD_IMAGE : TEST_ENVIRONMENT.ghost.image;
     }
 
     getGatewayPort(): number {
@@ -83,6 +95,10 @@ export class GhostManager {
 
         const ghostName = `ghost-e2e-worker-${this.config.workerIndex}`;
         const gatewayName = `ghost-e2e-gateway-${this.config.workerIndex}`;
+
+        // Start the egress monitor first so Ghost can use it as its DNS server.
+        // Fail-open: if it doesn't come up, Ghost keeps Docker's default resolver.
+        await this.startEgressMonitor();
 
         // Try to reuse existing containers (handles process restarts after test failures)
         this.gatewayContainer = await this.getOrCreateContainer(gatewayName, () => this.createGatewayContainer(gatewayName, ghostName));
@@ -173,8 +189,27 @@ export class GhostManager {
             await this.removeContainer(this.ghostContainer);
             this.ghostContainer = null;
         }
+        if (this.egressMonitor) {
+            await this.egressMonitor.stop();
+            this.egressMonitor = null;
+        }
 
         debug(`Worker ${this.config.workerIndex} containers removed`);
+    }
+
+    /**
+     * Bring up the egress-monitoring DNS sidecar for this worker (idempotent).
+     * Never throws — monitoring is best-effort and must not break the suite.
+     */
+    private async startEgressMonitor(): Promise<void> {
+        if (!EGRESS_MONITOR_ENABLED || this.egressMonitor) {
+            return;
+        }
+        const monitor = new EgressMonitor(this.docker, {
+            workerIndex: this.config.workerIndex
+        });
+        await monitor.start();
+        this.egressMonitor = monitor;
     }
 
     async restartWithDatabase(databaseName: string, extraConfig?: GhostEnvOverrides): Promise<void> {
@@ -281,10 +316,15 @@ export class GhostManager {
         // Determine image based on mode
         // - build: Build image (local or registry, controlled by GHOST_E2E_IMAGE)
         // - dev: Dev image from compose.dev.yaml
-        const image = mode === 'build' ? BUILD_IMAGE : TEST_ENVIRONMENT.ghost.image;
+        const image = this.ghostImage();
 
         // Build volume mounts based on mode
         const binds = this.getGhostBinds();
+
+        // Route Ghost's resolver through the egress monitor when it's running.
+        // It becomes the upstream of Docker's embedded DNS, so internal service
+        // names still resolve while external lookups are recorded.
+        const dnsServerIp = this.egressMonitor?.dnsServerIp ?? null;
 
         const config: ContainerCreateOptions = {
             name,
@@ -301,7 +341,8 @@ export class GhostManager {
             },
             HostConfig: {
                 Binds: binds,
-                ExtraHosts: ['host.docker.internal:host-gateway']
+                ExtraHosts: ['host.docker.internal:host-gateway'],
+                ...(dnsServerIp ? {Dns: [dnsServerIp]} : {})
             },
             NetworkingConfig: {
                 EndpointsConfig: {

--- a/e2e/helpers/environment/service-managers/index.ts
+++ b/e2e/helpers/environment/service-managers/index.ts
@@ -1,2 +1,3 @@
 export * from './ghost-manager';
 export * from './mysql-manager';
+export * from './egress-monitor';

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -1,10 +1,11 @@
 import baseDebug from '@tryghost/debug';
 import {AnalyticsOverviewPage} from '@/helpers/pages';
-import {Browser, BrowserContext, Page, TestInfo, test as base} from '@playwright/test';
+import {Browser, BrowserContext, Page, Request, TestInfo, test as base} from '@playwright/test';
+import {EGRESS_ENFORCE, EGRESS_MONITOR_ENABLED} from '@/helpers/environment/constants';
 import {EmailClient, MailPit} from '@/helpers/services/email/mail-pit';
 import {FakeMailgunServer, MailgunTestService} from '@/helpers/services/mailgun';
 import {FakeStripeServer, StripeTestService, WebhookClient} from '@/helpers/services/stripe';
-import {GhostInstance, getEnvironmentManager} from '@/helpers/environment';
+import {GhostInstance, getEnvironmentManager, isAllowedHost} from '@/helpers/environment';
 import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {faker} from '@faker-js/faker';
 import {loginToGetAuthenticatedSession} from '@/helpers/playwright/flows/sign-in';
@@ -52,15 +53,22 @@ interface TestEnvironmentContext {
 
 interface InternalFixtures {
     _testEnvironmentContext: TestEnvironmentContext;
+    _egressCheck: void;
 }
 
 interface WorkerFixtures {
     _cleanupPerFileInstance: void;
+    _egressSummary: void;
 }
 
 let cachedPerFileInstance: PerFileInstanceCache | null = null;
 let cachedPerFileGhostAccountOwner: User | null = null;
 let cachedPerFileAuthenticatedSession: PerFileAuthenticatedSessionCache | null = null;
+
+// External hosts requested by the browser, accumulated across a worker so the
+// worker teardown can print them (the server-side equivalent comes from the DNS
+// sidecar). Worker-scoped, like the caches above.
+const workerBrowserEgressHosts = new Set<string>();
 
 export interface User {
     name: string;
@@ -129,6 +137,39 @@ function getResolvedIsolation(testInfo: TestInfo, isolation?: 'per-test'): Resol
     }
 
     return 'per-file';
+}
+
+/**
+ * Attach unexpected external egress to the test report, and — when
+ * E2E_EGRESS_ENFORCE=1 — fail the test. Shared by the server-side DNS monitor
+ * (_egressCheck) and the browser-side request listener (page fixture).
+ */
+async function reportUnexpectedEgress(
+    testInfo: TestInfo,
+    source: 'server' | 'browser',
+    hosts: string[],
+    detail: unknown
+): Promise<void> {
+    const uniqueHosts = [...new Set(hosts)];
+    if (uniqueHosts.length === 0) {
+        return;
+    }
+
+    await testInfo.attach(`external-egress-${source}`, {
+        body: JSON.stringify(detail, null, 2),
+        contentType: 'application/json'
+    });
+
+    const where = source === 'server' ? 'the Ghost container' : 'the browser';
+    const summary = `Unexpected external egress from ${where}: ${uniqueHosts.join(', ')}`;
+    if (EGRESS_ENFORCE) {
+        throw new Error(
+            `${summary}\n\n` +
+            `Host(s) not on the egress allowlist were contacted during this test.\n` +
+            `If this is expected, add them to EGRESS_ALLOWLIST in helpers/environment/constants.ts.`
+        );
+    }
+    testInfo.annotations.push({type: 'warning', description: summary});
 }
 
 async function setupNewAuthenticatedPage(browser: Browser, baseURL: string, ghostAccountOwner: User) {
@@ -204,6 +245,65 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
         scope: 'worker',
         auto: true
     }],
+
+    // At the end of each worker, print the full set of external hosts the Ghost
+    // container resolved (the server-side DNS sidecar sees everything, including
+    // boot-time lookups that no single test can be blamed for). This is what you
+    // read out of CI logs to build up EGRESS_ALLOWLIST.
+    _egressSummary: [async ({}, use, workerInfo) => {
+        await use();
+
+        const print = (label: string, hosts: string[]) => {
+            if (hosts.length === 0) {
+                return;
+            }
+            // eslint-disable-next-line no-console
+            console.log(
+                `\n[egress] external hosts ${label} (worker ${workerInfo.workerIndex}):\n` +
+                hosts.map(host => `  - ${host}`).join('\n') + '\n'
+            );
+        };
+
+        try {
+            const monitor = (await getEnvironmentManager()).getEgressMonitor();
+            if (monitor) {
+                const queries = await monitor.readQueries();
+                const serverHosts = [...new Set(queries.map(query => query.name))]
+                    .filter(host => !isAllowedHost(host))
+                    .sort();
+                print('resolved by Ghost', serverHosts);
+            }
+            print('requested by the browser', [...workerBrowserEgressHosts].sort());
+        } catch {
+            // Best-effort reporting; never fail teardown over it.
+        }
+    }, {
+        scope: 'worker',
+        auto: true
+    }],
+
+    // Records the external hosts the Ghost container resolves during each test
+    // (via the DNS egress monitor sidecar). Attaches anything off the allowlist to
+    // the test report, and — when E2E_EGRESS_ENFORCE=1 — fails the test on it.
+    // Depends on _testEnvironmentContext so the Ghost environment (and monitor) is
+    // already up when we read the starting cursor.
+    _egressCheck: [async ({_testEnvironmentContext}, use, testInfo: TestInfo) => {
+        void _testEnvironmentContext;
+        const environmentManager = await getEnvironmentManager();
+        const monitor = environmentManager.getEgressMonitor();
+
+        if (!monitor) {
+            await use();
+            return;
+        }
+
+        const startCursor = await monitor.cursor();
+
+        await use();
+
+        const unexpected = await monitor.unexpectedSince(startCursor);
+        await reportUnexpectedEgress(testInfo, 'server', unexpected.map(query => query.name), unexpected);
+    }, {auto: true}],
 
     _testEnvironmentContext: async ({config, isolation, labs, stripeEnabled, stripeServer, mailgunEnabled, mailgunServer}, use, testInfo: TestInfo) => {
         const environmentManager = await getEnvironmentManager();
@@ -485,10 +585,33 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
     },
 
     // Extract the page from pageWithAuthenticatedUser and apply labs/stripe settings
-    page: async ({pageWithAuthenticatedUser, labs, _testEnvironmentContext}, use) => {
+    page: async ({pageWithAuthenticatedUser, labs, _testEnvironmentContext}, use, testInfo: TestInfo) => {
         _testEnvironmentContext.markResetEnvironmentBlocker('page');
 
         const page = pageWithAuthenticatedUser.page;
+
+        // Browser-side egress monitoring (complements the server-side DNS monitor):
+        // the Ghost container's resolver can't see requests the browser makes itself
+        // (changelog.json, embeds, avatar services, …), so we watch them here.
+        const browserEgress = new Map<string, {url: string; method: string}>();
+        const onRequest = (request: Request) => {
+            let host: string;
+            try {
+                const url = new URL(request.url());
+                if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+                    return;
+                }
+                host = url.hostname;
+            } catch {
+                return;
+            }
+            if (!isAllowedHost(host)) {
+                browserEgress.set(host, {url: request.url(), method: request.method()});
+            }
+        };
+        if (EGRESS_MONITOR_ENABLED) {
+            page.on('request', onRequest);
+        }
 
         const labsFlagsSpecified = labs && Object.keys(labs).length > 0;
         if (labsFlagsSpecified) {
@@ -504,6 +627,19 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
         }
 
         await use(page);
+
+        if (EGRESS_MONITOR_ENABLED) {
+            page.off('request', onRequest);
+            for (const host of browserEgress.keys()) {
+                workerBrowserEgressHosts.add(host);
+            }
+            await reportUnexpectedEgress(
+                testInfo,
+                'browser',
+                [...browserEgress.keys()],
+                [...browserEgress.values()]
+            );
+        }
     }
 });
 

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -53,7 +53,6 @@ interface TestEnvironmentContext {
 
 interface InternalFixtures {
     _testEnvironmentContext: TestEnvironmentContext;
-    _egressCheck: void;
 }
 
 interface WorkerFixtures {
@@ -139,39 +138,6 @@ function getResolvedIsolation(testInfo: TestInfo, isolation?: 'per-test'): Resol
     return 'per-file';
 }
 
-/**
- * Attach unexpected external egress to the test report, and — when
- * E2E_EGRESS_ENFORCE=1 — fail the test. Shared by the server-side DNS monitor
- * (_egressCheck) and the browser-side request listener (page fixture).
- */
-async function reportUnexpectedEgress(
-    testInfo: TestInfo,
-    source: 'server' | 'browser',
-    hosts: string[],
-    detail: unknown
-): Promise<void> {
-    const uniqueHosts = [...new Set(hosts)];
-    if (uniqueHosts.length === 0) {
-        return;
-    }
-
-    await testInfo.attach(`external-egress-${source}`, {
-        body: JSON.stringify(detail, null, 2),
-        contentType: 'application/json'
-    });
-
-    const where = source === 'server' ? 'the Ghost container' : 'the browser';
-    const summary = `Unexpected external egress from ${where}: ${uniqueHosts.join(', ')}`;
-    if (EGRESS_ENFORCE) {
-        throw new Error(
-            `${summary}\n\n` +
-            `Host(s) not on the egress allowlist were contacted during this test.\n` +
-            `If this is expected, add them to EGRESS_ALLOWLIST in helpers/environment/constants.ts.`
-        );
-    }
-    testInfo.annotations.push({type: 'warning', description: summary});
-}
-
 async function setupNewAuthenticatedPage(browser: Browser, baseURL: string, ghostAccountOwner: User) {
     debug('Setting up authenticated page for Ghost instance:', baseURL);
 
@@ -246,12 +212,22 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
         auto: true
     }],
 
-    // At the end of each worker, print the full set of external hosts the Ghost
-    // container resolved (the server-side DNS sidecar sees everything, including
-    // boot-time lookups that no single test can be blamed for). This is what you
-    // read out of CI logs to build up EGRESS_ALLOWLIST.
+    // At the end of each worker, sweep the external hosts the suite reached and —
+    // when E2E_EGRESS_ENFORCE=1 — fail the worker if any were off the allowlist.
+    //
+    // The check runs ONCE here, not per test: the server-side DNS log is read with
+    // a brief settle (EgressMonitor.collectSettled) to catch fire-and-forget
+    // lookups, so we don't pay that cost on every test, and a late or boot-time
+    // lookup can't be misattributed to — and fail — an unrelated test. The DNS
+    // sidecar sees everything Ghost resolved; the per-test browser listener (page
+    // fixture) feeds workerBrowserEgressHosts for the layer it can't see. Printed
+    // hosts are what you read out of CI logs to build up EGRESS_ALLOWLIST.
     _egressSummary: [async ({}, use, workerInfo) => {
         await use();
+
+        if (!EGRESS_MONITOR_ENABLED) {
+            return;
+        }
 
         const print = (label: string, hosts: string[]) => {
             if (hosts.length === 0) {
@@ -264,46 +240,32 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
             );
         };
 
+        let serverHosts: string[] = [];
         try {
             const monitor = (await getEnvironmentManager()).getEgressMonitor();
             if (monitor) {
-                const queries = await monitor.readQueries();
-                const serverHosts = [...new Set(queries.map(query => query.name))]
-                    .filter(host => !isAllowedHost(host))
-                    .sort();
-                print('resolved by Ghost', serverHosts);
+                serverHosts = await monitor.unexpectedHosts();
             }
-            print('requested by the browser', [...workerBrowserEgressHosts].sort());
         } catch {
-            // Best-effort reporting; never fail teardown over it.
+            // Best-effort: never fail teardown over a monitor read error.
+        }
+        const browserHosts = [...workerBrowserEgressHosts].sort();
+
+        print('resolved by Ghost', serverHosts);
+        print('requested by the browser', browserHosts);
+
+        const unexpected = [...new Set([...serverHosts, ...browserHosts])].sort();
+        if (EGRESS_ENFORCE && unexpected.length > 0) {
+            throw new Error(
+                `Unexpected external egress in worker ${workerInfo.workerIndex}: ${unexpected.join(', ')}\n\n` +
+                `Host(s) not on the egress allowlist were contacted during this worker's tests.\n` +
+                `If this is expected, add them to EGRESS_ALLOWLIST in helpers/environment/constants.ts.`
+            );
         }
     }, {
         scope: 'worker',
         auto: true
     }],
-
-    // Records the external hosts the Ghost container resolves during each test
-    // (via the DNS egress monitor sidecar). Attaches anything off the allowlist to
-    // the test report, and — when E2E_EGRESS_ENFORCE=1 — fails the test on it.
-    // Depends on _testEnvironmentContext so the Ghost environment (and monitor) is
-    // already up when we read the starting cursor.
-    _egressCheck: [async ({_testEnvironmentContext}, use, testInfo: TestInfo) => {
-        void _testEnvironmentContext;
-        const environmentManager = await getEnvironmentManager();
-        const monitor = environmentManager.getEgressMonitor();
-
-        if (!monitor) {
-            await use();
-            return;
-        }
-
-        const startCursor = await monitor.cursor();
-
-        await use();
-
-        const unexpected = await monitor.unexpectedSince(startCursor);
-        await reportUnexpectedEgress(testInfo, 'server', unexpected.map(query => query.name), unexpected);
-    }, {auto: true}],
 
     _testEnvironmentContext: async ({config, isolation, labs, stripeEnabled, stripeServer, mailgunEnabled, mailgunServer}, use, testInfo: TestInfo) => {
         const environmentManager = await getEnvironmentManager();
@@ -585,15 +547,16 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
     },
 
     // Extract the page from pageWithAuthenticatedUser and apply labs/stripe settings
-    page: async ({pageWithAuthenticatedUser, labs, _testEnvironmentContext}, use, testInfo: TestInfo) => {
+    page: async ({pageWithAuthenticatedUser, labs, _testEnvironmentContext}, use) => {
         _testEnvironmentContext.markResetEnvironmentBlocker('page');
 
         const page = pageWithAuthenticatedUser.page;
 
         // Browser-side egress monitoring (complements the server-side DNS monitor):
         // the Ghost container's resolver can't see requests the browser makes itself
-        // (changelog.json, embeds, avatar services, …), so we watch them here.
-        const browserEgress = new Map<string, {url: string; method: string}>();
+        // (changelog.json, embeds, avatar services, …), so we watch them here and
+        // hand off-allowlist hosts to the worker-level sweep (_egressSummary).
+        const browserEgressHosts = new Set<string>();
         const onRequest = (request: Request) => {
             let host: string;
             try {
@@ -606,7 +569,7 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
                 return;
             }
             if (!isAllowedHost(host)) {
-                browserEgress.set(host, {url: request.url(), method: request.method()});
+                browserEgressHosts.add(host);
             }
         };
         if (EGRESS_MONITOR_ENABLED) {
@@ -630,15 +593,9 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
 
         if (EGRESS_MONITOR_ENABLED) {
             page.off('request', onRequest);
-            for (const host of browserEgress.keys()) {
+            for (const host of browserEgressHosts) {
                 workerBrowserEgressHosts.add(host);
             }
-            await reportUnexpectedEgress(
-                testInfo,
-                'browser',
-                [...browserEgress.keys()],
-                [...browserEgress.values()]
-            );
         }
     }
 });

--- a/e2e/helpers/services/settings/settings-service.ts
+++ b/e2e/helpers/services/settings/settings-service.ts
@@ -71,21 +71,6 @@ export class SettingsService {
         return await this.updateSettings([{key: 'donations_currency', value}]);
     }
 
-    /**
-     * Set Stripe keys to simulate a connected Stripe account
-     * Uses direct Stripe keys (not Connect) as they're not filtered by the API
-     * Uses test keys by default, but can be overridden if needed
-     */
-    async setStripeConnected(
-        secretKey: string = 'sk_test_e2eTestKey',
-        publishableKey: string = 'pk_test_e2eTestKey'
-    ) {
-        return await this.updateSettings([
-            {key: 'stripe_secret_key', value: secretKey},
-            {key: 'stripe_publishable_key', value: publishableKey}
-        ]);
-    }
-
     async setStripeDisconnected() {
         return await this.updateSettings([
             {key: 'stripe_secret_key', value: null},

--- a/e2e/tests/admin/members/tier-filter-search.test.ts
+++ b/e2e/tests/admin/members/tier-filter-search.test.ts
@@ -1,12 +1,14 @@
 import {MemberFactory, TierFactory, createMemberFactory, createTierFactory} from '@/data-factory';
 import {MembersListPage} from '@/admin-pages';
-import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {expect, test} from '@/helpers/playwright';
 import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 
 usePerTestIsolation();
 
 test.describe('Ghost Admin - Members Tier Filter Search', () => {
+    // Connect Stripe against the fake server so paid-tier creation doesn't hit real Stripe.
+    test.use({stripeEnabled: true});
+
     let memberFactory: MemberFactory;
     let tierFactory: TierFactory;
 
@@ -16,9 +18,6 @@ test.describe('Ghost Admin - Members Tier Filter Search', () => {
     });
 
     test('filters tier options by slug in the search dropdown', async ({page}) => {
-        const settingsService = new SettingsService(page.request);
-        await settingsService.setStripeConnected();
-
         const firstTier = await tierFactory.getFirstPaidTier();
         const secondTier = await tierFactory.create({name: 'Silver Tier'});
 


### PR DESCRIPTION
## Summary

The Playwright e2e suite boots Ghost with **real network access** (unlike the nock-isolated unit/integration suites), so outbound HTTP from the app — IndexNow, webmentions, member/staff geolocation, gravatar, update checks — can reach external services during tests. There was no visibility into this.

This adds two complementary monitors and enforces an allowlist:

### Server-side — DNS sidecar
A tiny DNS-forwarding sidecar runs on the dev network; the Ghost container's resolver (`HostConfig.Dns`) is pointed at it. Docker keeps the sidecar as the *upstream* of its embedded DNS, so internal service names (mysql, redis, …) still resolve normally and **only external lookups are forwarded** to the sidecar. Its log is therefore a clean record of every external host the container reached — independent of which HTTP client made the call, and including arbitrary hostnames (e.g. webmention targets pulled from post content). No Ghost code changes.

### Browser-side — page request listener
A `page.on('request')` listener flags external requests the Playwright-driven browser makes itself (changelog.json, embeds, avatar services) — the layer the DNS sidecar can't see.

## Behaviour

- **Enforced by default.** A test that triggers egress to a host not on `EGRESS_ALLOWLIST` (in `helpers/environment/constants.ts`) **fails** — so a new integration, or a service that should be mocked, surfaces immediately.
- The allowlist covers the external services the suite legitimately reaches today (Stripe/reCAPTCHA, Bunny Fonts, Transistor embeds, Unsplash, Ghost's own CDN, the billing mock) plus two privacy-sensitive server-side lookups (gravatar, geojs) that are candidates for a config gate in a follow-up.
- **`E2E_EGRESS_ENFORCE=0`** drops back to record-only (attach + annotate, no failure) — useful while expanding the allowlist.
- **`E2E_EGRESS_MONITOR=0`** disables all egress monitoring (both layers).
- **Fail-open:** if the sidecar can't start, Ghost's DNS is left untouched and the suite runs normally.
- Each worker prints the external hosts it saw at teardown, so additions to the allowlist can be read straight out of CI logs.

## Notably absent from the captured egress
`api.indexnow.org` (no test enables the flag + publishes), webmention targets, and dicebear don't fire in the current suite — so they're not allowlisted, and enforcement will catch them if they ever start.
