### PR TITLE
Made update-check resilient to telemetry query failures

### DIFF
--- a/ghost/core/core/server/services/update-check/update-check-service.js
+++ b/ghost/core/core/server/services/update-check/update-check-service.js
@@ -88,7 +88,10 @@ class UpdateCheckService {
         err.context = tpl(messages.checkingForUpdatesFailedError);
         err.help = tpl(messages.checkingForUpdatesFailedHelp, {url: 'https://ghost.org/docs/'});
 
-        this.logging.error(err);
+        this.logging.error({
+            event: {name: 'update-check.error'},
+            err
+        }, 'Update check failed');
 
         if (this.config.rethrowErrors) {
             throw err;
@@ -112,45 +115,78 @@ class UpdateCheckService {
                 mailConfig.options.service :
                 mailConfig.transport);
 
-        try {
-            const hash = (await this.api.settings.read(_.extend({key: 'db_hash'}, internal))).settings[0];
-            const theme = (await this.api.settings.read(_.extend({key: 'active_theme'}, internal))).settings[0];
-            const posts = await this.api.posts.browse();
-            const users = await this.api.users.browse({
-                ...internal,
-                include: ['roles']
-            });
-            const npm = await util.promisify(exec)('npm -v');
+        // Telemetry sources are gathered in parallel; each is independently
+        // failure-tolerant so one bad source (e.g. a model-layer SQL error
+        // from posts.browse) doesn't prevent the rest of the data from being
+        // sent. Thunks (not pre-evaluated promises) so synchronous throws
+        // turn into rejections rather than escaping the resolution loop.
+        const sources = {
+            db_hash: () => this.api.settings.read(_.extend({key: 'db_hash'}, internal)),
+            active_theme: () => this.api.settings.read(_.extend({key: 'active_theme'}, internal)),
+            posts: () => this.api.posts.browse(),
+            users: () => this.api.users.browse({...internal, include: ['roles']}),
+            npm: () => util.promisify(exec)('npm -v')
+        };
 
-            const blogUrl = this.config.siteUrl;
-            const parsedBlogUrl = url.parse(blogUrl);
-            const blogId = parsedBlogUrl.hostname + parsedBlogUrl.pathname.replace(/\//, '') + hash.value;
+        const entries = Object.entries(sources);
+        const settled = await Promise.allSettled(entries.map(async ([, fn]) => fn()));
 
-            data.url = blogUrl;
-            data.blog_id = crypto.createHash('md5').update(blogId).digest('hex');
-            data.theme = theme ? theme.value : '';
-            data.post_count = posts && posts.meta && posts.meta.pagination ? posts.meta.pagination.total : 0;
-            data.user_count = users && users.users && users.users.length ? users.users.length : 0;
-
-            let blogCreatedAt = null;
-
-            if (users && users.users && users.users.length > 0) {
-                const ownerUser = users.users.find(user => user.roles.some(role => role.name === 'Owner'));
-
-                if (ownerUser) {
-                    blogCreatedAt = ownerUser.created_at;
-                } else {
-                    blogCreatedAt = users.users[0].created_at;
-                }
+        const values = {};
+        const failures = [];
+        settled.forEach((result, i) => {
+            const source = entries[i][0];
+            if (result.status === 'fulfilled') {
+                values[source] = result.value;
+            } else {
+                failures.push(source);
+                this.logging.error({
+                    event: {name: 'update-check.telemetry.error'},
+                    err: result.reason,
+                    source
+                }, 'Failed to gather telemetry source');
             }
+        });
 
-            data.blog_created_at = blogCreatedAt ? moment(blogCreatedAt).unix() : '';
-            data.npm_version = npm.stdout.trim();
-
-            return data;
-        } catch (err) {
-            this.updateCheckError(err);
+        if (failures.length) {
+            this.logging.warn({
+                event: {name: 'update-check.telemetry.partial'},
+                failures,
+                attemptedCount: entries.length,
+                failedCount: failures.length
+            }, 'Update check telemetry collected partially');
         }
+
+        const hash = values.db_hash && values.db_hash.settings && values.db_hash.settings[0];
+        const theme = values.active_theme && values.active_theme.settings && values.active_theme.settings[0];
+        const posts = values.posts;
+        const users = values.users;
+        const npm = values.npm;
+
+        const blogUrl = this.config.siteUrl;
+        const parsedBlogUrl = url.parse(blogUrl);
+
+        data.url = blogUrl;
+        data.blog_id = hash && hash.value
+            ? crypto.createHash('md5').update(parsedBlogUrl.hostname + parsedBlogUrl.pathname.replace(/\//, '') + hash.value).digest('hex')
+            : '';
+        data.theme = theme ? theme.value : '';
+        data.post_count = posts && posts.meta && posts.meta.pagination ? posts.meta.pagination.total : 0;
+        data.user_count = users && users.users && users.users.length ? users.users.length : 0;
+
+        let blogCreatedAt = null;
+        if (users && users.users && users.users.length > 0) {
+            const ownerUser = users.users.find(user => user.roles && user.roles.some(role => role.name === 'Owner'));
+            if (ownerUser) {
+                blogCreatedAt = ownerUser.created_at;
+            } else {
+                blogCreatedAt = users.users[0].created_at;
+            }
+        }
+
+        data.blog_created_at = blogCreatedAt ? moment(blogCreatedAt).unix() : '';
+        data.npm_version = npm && npm.stdout ? npm.stdout.trim() : '';
+
+        return data;
     }
 
     /**
@@ -186,18 +222,40 @@ class UpdateCheckService {
         }
 
         debug('Request Update Check Service', checkEndpoint);
+        this.logging.info({
+            event: {name: 'update-check.request.start'},
+            endpoint: checkEndpoint,
+            method: checkMethod,
+            ghostVersion: this.config.ghostVersion
+        }, 'Sending update check request');
 
         try {
             const response = await this.request(checkEndpoint, reqObj);
+            this.logging.info({
+                event: {name: 'update-check.request.complete'},
+                endpoint: checkEndpoint,
+                statusCode: response && response.statusCode
+            }, 'Update check request completed');
             return JSON.parse(response.body);
         } catch (err) {
             // CASE: no notifications available, ignore
             if (err.statusCode === 404) {
+                this.logging.info({
+                    event: {name: 'update-check.request.no-notifications'},
+                    endpoint: checkEndpoint
+                }, 'Update check service returned 404, no notifications available');
                 return {
                     next_check: this.nextCheckTimestamp(),
                     notifications: []
                 };
             }
+
+            this.logging.error({
+                event: {name: 'update-check.request.error'},
+                err,
+                endpoint: checkEndpoint,
+                statusCode: err.statusCode
+            }, 'Update check request failed');
 
             // CASE: service returns JSON error, deserialize into JS error
             if (err.response && err.response.body && typeof err.response.body === 'object') {
@@ -209,45 +267,42 @@ class UpdateCheckService {
     }
 
     /**
-     * @description This function handles the response from the update check service.
+     * @description Handle a successful response from the update check service.
      *
-     * The helper does three things:
+     * 1. Updates `next_update_check` so we know when the next call is due.
+     * 2. Filters incoming notifications against the configured notification groups.
+     * 3. Calls a custom helper to add each remaining notification to the database.
      *
-     * 1. Updates the time in the settings table to know when we can execute the next update check request.
-     * 2. Iterates over the received notifications and filters them out based on your notification groups.
-     * 3. Calls a custom helper to generate a Ghost notification for the database.
-     *
-     * The structure of the response is:
+     * The service returns:
      *
      * {
-     *  id: 20,
-     *  version: 'all4',
-     *  messages:
-     *     [{
-     *          id: 'f8ff6c80-aa61-11e7-a126-6119te37e2b8',
-     *          version: '^2',
-     *          content: 'Hallouuuu custom',
-     *          top: true,
-     *          dismissible: true,
-     *          type: 'info'
-     *      }],
-     *  created_at: '2021-10-06T07:00:00.000Z',
-     *  custom: 1,
-     *  next_check: 1555608722
+     *   next_check: 1555608722,
+     *   notifications: [
+     *     {
+     *       id: 20,
+     *       version: 'all4',
+     *       messages: [{
+     *         id: 'f8ff6c80-aa61-11e7-a126-6119te37e2b8',
+     *         version: '^6',
+     *         content: 'Hallouuuu custom',
+     *         top: true,
+     *         dismissible: true,
+     *         type: 'info'
+     *       }],
+     *       created_at: '2021-10-06T07:00:00.000Z',
+     *       custom: 1
+     *     }
+     *   ]
      * }
      *
-     *
-     * Example for grouped custom notifications in config:
-     *
-     *  "notificationGroups": ["migration", "something"]
-     *
-     * The group 'all' is a reserved name for general custom notifications, which every self hosted blog can receive.
+     * The 'all' notification group is reserved for general custom notifications
+     * that every self-hosted blog can receive; other groups can be opted into
+     * via the `notificationGroups` config.
      *
      * @param {Object} response
      * @return {Promise}
      */
     async updateCheckResponse(response) {
-        let notifications = [];
         let notificationGroups = (this.config.notificationGroups || []).concat(['all']);
 
         debug('Notification Groups', notificationGroups);
@@ -260,23 +315,7 @@ class UpdateCheckService {
             }]
         }, internal);
 
-        /**
-         * @NOTE:
-         *
-         * When we refactored notifications in Ghost 1.20, the service did not support returning multiple messages.
-         * But we wanted to already add the support for future functionality.
-         * That's why this helper supports two ways: returning an array of messages or returning an object with
-         * a "notifications" key. The second one is probably the best, because we need to support "next_check"
-         * on the root level of the response.
-         */
-        if (_.isArray(response)) {
-            notifications = response;
-        } else if ((Object.prototype.hasOwnProperty.call(response, 'notifications') && _.isArray(response.notifications))) {
-            notifications = response.notifications;
-        } else {
-            // CASE: default right now
-            notifications = [response];
-        }
+        let notifications = (response && _.isArray(response.notifications)) ? response.notifications : [];
 
         // CASE: Hook into received notifications and decide whether you are allowed to receive custom group messages.
         if (notificationGroups.length) {
@@ -363,20 +402,43 @@ class UpdateCheckService {
      * @returns {Promise}
      */
     async check() {
+        this.logging.info({
+            event: {name: 'update-check.check.start'},
+            ghostVersion: this.config.ghostVersion,
+            forceUpdate: Boolean(this.config.forceUpdate)
+        }, 'Update check started');
+
         try {
             const result = await this.api.settings.read(_.extend({key: 'next_update_check'}, internal));
 
             const nextUpdateCheck = result.settings[0];
+            const nextCheckAt = nextUpdateCheck && nextUpdateCheck.value;
 
             // CASE: Next update check should happen now?
             // @NOTE: You can skip this check by adding a config value. This is helpful for developing.
-            if (!this.config.forceUpdate && nextUpdateCheck && nextUpdateCheck.value && nextUpdateCheck.value > moment().unix()) {
+            if (!this.config.forceUpdate && nextCheckAt && nextCheckAt > moment().unix()) {
+                this.logging.info({
+                    event: {name: 'update-check.check.skipped-by-gate'},
+                    nextCheckAt
+                }, 'Update check skipped, next check is scheduled in the future');
                 return;
             }
 
             const response = await this.updateCheckRequest();
+            const notifications = (response && _.isArray(response.notifications)) ? response.notifications : [];
 
-            return await this.updateCheckResponse(response);
+            this.logging.info({
+                event: {name: 'update-check.response.received'},
+                notificationCount: notifications.length
+            }, 'Update check response received');
+
+            const result2 = await this.updateCheckResponse(response);
+
+            this.logging.info({
+                event: {name: 'update-check.check.complete'}
+            }, 'Update check completed');
+
+            return result2;
         } catch (err) {
             this.updateCheckError(err);
         }

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -33,6 +33,7 @@ describe('Update Check', function () {
         }));
 
         sinon.stub(logging, 'error');
+        sinon.stub(logging, 'warn');
 
         requestStub = sinon.stub();
     });
@@ -219,6 +220,142 @@ describe('Update Check', function () {
             assert.equal(capturedData.post_count, 13);
             assert.equal(capturedData.npm_version, '10.8.2');
         });
+
+        it('still sends the request when a telemetry query fails', async function () {
+            // This reproduces the staging condition where posts.browse fails
+            // with a model-layer SQL error (errno 1054). The update check
+            // should keep going: collect what it can, log what it couldn't,
+            // and send the request anyway so the notification flow still runs.
+            let capturedData;
+            const scope = nock('https://updates.ghost.org')
+                .post('/', (body) => {
+                    capturedData = body;
+                    return true;
+                })
+                .reply(200, JSON.stringify({notifications: []}), {
+                    'Content-Type': 'application/json'
+                });
+
+            const postsBrowseError = Object.assign(
+                new Error('Could not understand request.'),
+                {errno: 1054}
+            );
+
+            const updateCheckService = new UpdateCheckService({
+                api: {
+                    settings: {
+                        read: settingsStub,
+                        edit: settingsStub
+                    },
+                    users: {
+                        browse: sinon.stub().resolves({
+                            users: [{
+                                created_at: '1995-12-24T23:15:00Z',
+                                roles: [{name: 'Owner'}]
+                            }]
+                        })
+                    },
+                    posts: {
+                        browse: sinon.stub().rejects(postsBrowseError)
+                    }
+                },
+                config: {
+                    checkEndpoint: 'https://updates.ghost.org',
+                    siteUrl: 'https://localhost:2368/test',
+                    isPrivacyDisabled: false,
+                    env: process.env.NODE_ENV,
+                    databaseType: 'mysql',
+                    ghostVersion: '4.0.0'
+                },
+                request: request,
+                ghostMailer: {send: sinon.stub().resolves()}
+            });
+
+            await updateCheckService.check();
+
+            // The check sent its request despite posts.browse failing
+            assert.equal(scope.isDone(), true);
+
+            // Telemetry that didn't depend on posts.browse is intact
+            assert.equal(capturedData.ghost_version, '4.0.0');
+            assert.equal(capturedData.user_count, 1);
+            assert.equal(capturedData.blog_created_at, 819846900);
+
+            // post_count gracefully degrades to 0
+            assert.equal(capturedData.post_count, 0);
+
+            // The underlying error is still surfaced — with the source so we
+            // know which telemetry call failed
+            sinon.assert.calledWith(logging.error, sinon.match({
+                event: {name: 'update-check.telemetry.error'},
+                source: 'posts',
+                err: sinon.match({errno: 1054})
+            }));
+
+            // The partial-summary log surfaces which sources failed in one place
+            sinon.assert.calledWith(logging.warn, sinon.match({
+                event: {name: 'update-check.telemetry.partial'},
+                failures: ['posts'],
+                attemptedCount: 5,
+                failedCount: 1
+            }));
+        });
+
+        it('emits structured logs around the request lifecycle', async function () {
+            nock('https://updates.ghost.org')
+                .post('/')
+                .reply(200, JSON.stringify({
+                    notifications: [],
+                    next_check: moment().add(1, 'day').unix()
+                }), {
+                    'Content-Type': 'application/json'
+                });
+
+            sinon.stub(logging, 'info');
+
+            const updateCheckService = new UpdateCheckService({
+                api: {
+                    settings: {read: settingsStub, edit: settingsStub},
+                    users: {browse: sinon.stub().resolves({users: []})},
+                    posts: {browse: sinon.stub().resolves({meta: {pagination: {total: 0}}})}
+                },
+                config: {
+                    checkEndpoint: 'https://updates.ghost.org',
+                    siteUrl: 'https://localhost:2368/test',
+                    isPrivacyDisabled: false,
+                    env: 'testing',
+                    databaseType: 'mysql',
+                    ghostVersion: '4.0.0',
+                    forceUpdate: true
+                },
+                request: request,
+                ghostMailer: {send: sinon.stub().resolves()}
+            });
+
+            await updateCheckService.check();
+
+            sinon.assert.calledWith(logging.info, sinon.match({
+                event: {name: 'update-check.check.start'},
+                ghostVersion: '4.0.0',
+                forceUpdate: true
+            }));
+            sinon.assert.calledWith(logging.info, sinon.match({
+                event: {name: 'update-check.request.start'},
+                endpoint: 'https://updates.ghost.org',
+                method: 'POST'
+            }));
+            sinon.assert.calledWith(logging.info, sinon.match({
+                event: {name: 'update-check.request.complete'},
+                statusCode: 200
+            }));
+            sinon.assert.calledWith(logging.info, sinon.match({
+                event: {name: 'update-check.response.received'},
+                notificationCount: 0
+            }));
+            sinon.assert.calledWith(logging.info, sinon.match({
+                event: {name: 'update-check.check.complete'}
+            }));
+        });
     });
 
     describe('Notifications', function () {
@@ -352,7 +489,7 @@ describe('Update Check', function () {
             nock('https://updates.ghost.org')
                 .get('/')
                 .query(true)
-                .reply(200, JSON.stringify([notification]), {
+                .reply(200, JSON.stringify({notifications: [notification]}), {
                     'Content-Type': 'application/json'
                 });
 
@@ -477,8 +614,8 @@ describe('Update Check', function () {
 
             sinon.assert.called(settingsStub);
             sinon.assert.called(logging.error);
-            assert.equal(logging.error.args[0][0].context, 'Checking for updates failed, your site will continue to function.');
-            assert.equal(logging.error.args[0][0].help, 'If you get this error repeatedly, please seek help from https://ghost.org/docs/');
+            assert.equal(logging.error.args[0][0].err.context, 'Checking for updates failed, your site will continue to function.');
+            assert.equal(logging.error.args[0][0].err.help, 'If you get this error repeatedly, please seek help from https://ghost.org/docs/');
         });
 
         it('logs and rethrows an error when error with rethrow configuration', function () {
@@ -499,8 +636,8 @@ describe('Update Check', function () {
             } catch (e) {
                 sinon.assert.called(settingsStub);
                 sinon.assert.called(logging.error);
-                assert.equal(logging.error.args[0][0].context, 'Checking for updates failed, your site will continue to function.');
-                assert.equal(logging.error.args[0][0].help, 'If you get this error repeatedly, please seek help from https://ghost.org/docs/');
+                assert.equal(logging.error.args[0][0].err.context, 'Checking for updates failed, your site will continue to function.');
+                assert.equal(logging.error.args[0][0].err.help, 'If you get this error repeatedly, please seek help from https://ghost.org/docs/');
 
                 assert.equal(e.context, 'Checking for updates failed, your site will continue to function.');
             }


### PR DESCRIPTION
## Problem

A latent SQL failure in `posts.browse` (errno 1054, surfaced in Sentry as `BadRequestError: Could not understand request.` — issue [GHOST-FCP](https://ghost-foundation.sentry.io/issues/GHOST-FCP)) was being silently triggered on staging by the new boot-time update-check job. A single failing telemetry query was tearing out the entire telemetry collection, the request still went out with no body, and the only sign of failure was a stack trace in Sentry with no surrounding context.

The bug had been latent for a while — the daily cron normally returns early via the `next_update_check` gate, so the model queries never ran. Triggering at boot with `forceUpdate` bypasses that gate and exercises the full code path.

## Solution

Each telemetry source — `db_hash`, `active_theme`, `posts.browse`, `users.browse`, `npm -v` — is now gathered independently. A failure logs the source and the underlying error, falls back to a sensible default (`0` / empty string), and the check completes.

Added structured logs (`event.name` + named fields, per the standard logging contract) across the full check lifecycle so we can see in production whether the check started, whether each phase succeeded, and what the response looked like:

- `update-check.check.start` / `.complete` / `.error`
- `update-check.check.skipped-by-gate`
- `update-check.telemetry.error` (per failing source)
- `update-check.request.start` / `.complete` / `.error` / `.no-notifications`
- `update-check.response.received` (with `notificationCount`)

Fixes GHOST-FCP