### PR TITLE
Removed stale comment replies count fallback

### DIFF
--- a/apps/posts/src/views/comments/components/comment-metrics.tsx
+++ b/apps/posts/src/views/comments/components/comment-metrics.tsx
@@ -95,7 +95,7 @@ export function CommentMetrics({
     const [reportsModalOpen, setReportsModalOpen] = useState(false);
     const repliesLink = buildThreadLink(searchParams, comment.id);
 
-    const repliesCount = comment.count?.direct_replies ?? comment.count?.replies ?? comment.replies?.length ?? 0; // TODO: remove replies fallback once backend is fully rolled out
+    const repliesCount = comment.count?.direct_replies ?? comment.replies?.length ?? 0;
     const likesCount = comment.count?.likes ?? 0;
     const dislikesCount = dislikesEnabled ? (comment.count?.dislikes ?? 0) : 0;
     const reportsCount = comment.count?.reports ?? 0;


### PR DESCRIPTION
This removes the obsolete `count.replies` fallback from comment moderation metrics now that `count.direct_replies` is fully deployed.

The UI still falls back to loaded reply objects when needed, but no longer reads the legacy aggregate during metric rendering.

Validated with `pnpm --filter @tryghost/posts lint`.