### PR TITLE
Fixed generate-data CLI failing to load TypeScript modules

### DIFF
--- a/ghost/core/core/cli/command.js
+++ b/ghost/core/core/cli/command.js
@@ -1,3 +1,10 @@
+// Register the tsx CommonJS loader so dev-only CLI commands (generate-data,
+// repl, timetravel) can require TypeScript modules directly. These commands run
+// via bare `node index.js <command>`, which — unlike `pnpm dev` (nodemon
+// --import=tsx) or the production build (tsc) — has no TS resolution otherwise.
+// They are restricted to development/local environments, where tsx is available.
+require('tsx/cjs');
+
 const cli = require('@tryghost/pretty-cli');
 const logging = cli.ui.log;
 const chalk = require('chalk');


### PR DESCRIPTION
`pnpm reset:data` broke after #28388 converted the topological-sort seeder utility to TypeScript.

The `generate-data`/`repl`/`timetravel` CLI commands run via bare `node index.js`, which has no TypeScript resolution — unlike `pnpm dev` (nodemon `--import=tsx`) or the production build (`tsc`). So `require('./utils/topological-sort')` failed with `Cannot find module`.

These commands are dev/local-only, where tsx is always installed. Registering the tsx CommonJS loader at the CLI dispatch point lets them require `.ts` files regardless of how they're invoked, covering all three `reset:data*` scripts and the VS Code task.