### PR TITLE
Made minor cleanup to subdirectory check

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/index.js
+++ b/ghost/core/core/frontend/apps/private-blogging/index.js
@@ -18,10 +18,8 @@ const messages = {
 const PRIVATE_KEYWORD = 'private';
 
 let checkSubdir = function checkSubdir() {
-    let paths = '';
-
     if (urlUtils.getSubdir()) {
-        paths = urlUtils.getSubdir().split('/');
+        const paths = urlUtils.getSubdir().split('/');
 
         if (paths.pop() === PRIVATE_KEYWORD) {
             logging.error(new errors.InternalServerError({


### PR DESCRIPTION
no ref

We previously had code like this:

```js
let foo;
if (condition) {
    foo = initializeFoo();
    // ...
}
```

But because that variable was never initialized outside the conditional,
we can simplify it to:

```js
if (condition) {
    const foo = initializeFoo();
    // ...
}
```

This also fixes a type error.
