### PR TITLE
Restored polymorphic update-check response handling

### DIFF
--- a/ghost/core/core/server/services/update-check/update-check-service.js
+++ b/ghost/core/core/server/services/update-check/update-check-service.js
@@ -16,6 +16,24 @@ const messages = {
     checkingForUpdatesFailedHelp: 'If you get this error repeatedly, please seek help from {url}'
 };
 
+// The service's current response is a single notification at the top
+// level; the wrapped and bare-array shapes are accepted for forward-compat.
+function normalizeNotifications(response) {
+    if (!response) {
+        return [];
+    }
+    if (_.isArray(response.notifications)) {
+        return response.notifications;
+    }
+    if (_.isArray(response)) {
+        return response;
+    }
+    if (response.messages) {
+        return [response];
+    }
+    return [];
+}
+
 /**
  * Update Checker Class
  *
@@ -315,7 +333,7 @@ class UpdateCheckService {
             }]
         }, internal);
 
-        let notifications = (response && _.isArray(response.notifications)) ? response.notifications : [];
+        let notifications = normalizeNotifications(response);
 
         // CASE: Hook into received notifications and decide whether you are allowed to receive custom group messages.
         if (notificationGroups.length) {
@@ -425,7 +443,7 @@ class UpdateCheckService {
             }
 
             const response = await this.updateCheckRequest();
-            const notifications = (response && _.isArray(response.notifications)) ? response.notifications : [];
+            const notifications = normalizeNotifications(response);
 
             this.logging.info({
                 event: {name: 'update-check.response.received'},

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -599,6 +599,100 @@ describe('Update Check', function () {
         });
     });
 
+    describe('Response shapes', function () {
+        const releaseNotification = {
+            id: 1312,
+            version: 'v6.44.1',
+            messages: [{
+                id: '0f17c191-87ab-46ad-8884-5d99aa3fdee8',
+                version: '^6',
+                content: 'Ghost v6.44.1 has been released.',
+                top: false,
+                dismissible: true,
+                type: 'info'
+            }],
+            created_at: '2026-06-05T16:53:08.000Z',
+            custom: false,
+            next_check: 1781018713
+        };
+
+        const customNotification = {
+            version: 'all-test',
+            messages: [{
+                id: 'all-test-msg',
+                version: '^6',
+                content: 'Critical security update.',
+                top: true,
+                dismissible: false,
+                type: 'alert'
+            }],
+            created_at: '2026-06-04T21:15:00.000Z',
+            custom: true,
+            next_check: 1781018713
+        };
+
+        function makeService(notificationsAddStub) {
+            return new UpdateCheckService({
+                api: {
+                    settings: {read: settingsStub, edit: settingsStub},
+                    users: {
+                        browse: sinon.stub().resolves({
+                            users: [{email: 'a@b.c', roles: [{name: 'Owner'}]}]
+                        })
+                    },
+                    notifications: {add: notificationsAddStub}
+                },
+                config: {
+                    checkEndpoint: 'https://updates.ghost.org',
+                    siteUrl: 'https://localhost:2368/test',
+                    isPrivacyDisabled: false,
+                    ghostVersion: '6.44.0'
+                },
+                request: request,
+                notificationEmailService: {send: sinon.stub().resolves()}
+            });
+        }
+
+        it('handles a bare-object response with messages at the top level', async function () {
+            nock('https://updates.ghost.org')
+                .post('/')
+                .reply(200, JSON.stringify(releaseNotification), {'Content-Type': 'application/json'});
+
+            const addStub = sinon.stub().resolves();
+            await makeService(addStub).check();
+
+            sinon.assert.calledOnce(addStub);
+            const added = addStub.firstCall.args[0].notifications[0];
+            assert.equal(added.id, releaseNotification.messages[0].id);
+            assert.equal(added.message, releaseNotification.messages[0].content);
+        });
+
+        it('handles a wrapped {notifications:[...]} response', async function () {
+            nock('https://updates.ghost.org')
+                .post('/')
+                .reply(200, JSON.stringify({
+                    notifications: [releaseNotification, customNotification],
+                    next_check: 1781018713
+                }), {'Content-Type': 'application/json'});
+
+            const addStub = sinon.stub().resolves();
+            await makeService(addStub).check();
+
+            sinon.assert.calledTwice(addStub);
+        });
+
+        it('handles a bare-array response', async function () {
+            nock('https://updates.ghost.org')
+                .post('/')
+                .reply(200, JSON.stringify([releaseNotification, customNotification]), {'Content-Type': 'application/json'});
+
+            const addStub = sinon.stub().resolves();
+            await makeService(addStub).check();
+
+            sinon.assert.calledTwice(addStub);
+        });
+    });
+
     describe('Error handling', function () {
         it('logs an error when error', function () {
             const updateCheckService = new UpdateCheckService({


### PR DESCRIPTION
## Problem

The previous PR collapsed `updateCheckResponse`’s response-shape handling down to `{notifications: [...]}` on the assumption the bare-object and bare-array branches were dead. They weren’t. Both update-check services emit a single notification at the top level today, so the collapse silently stopped any notification from ever reaching the admin — no release alerts, no critical-security advisories.

## Solution

Restored the polymorphic normalisation. Three accepted shapes:

- `{notifications: [...]}` — wrapped, the future-proof form
- `[notification, ...]` — bare array
- `{messages: [...], next_check, ...}` — single notification at the top level (the current contract)

Added tests that exercise each shape end-to-end through `check()` so a future refactor can’t strip a still-needed branch.