### PR TITLE
Added image-dimensions cache warming at edit time

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -336,6 +336,7 @@ async function initServices() {
     const donationService = require('./server/services/donations');
     const giftService = require('./server/services/gifts');
     const recommendationsService = require('./server/services/recommendations');
+    const imageDimensionsPrecompute = require('./server/services/image-dimensions-precompute');
     const emailAddressService = require('./server/services/email-address');
     const statsService = require('./server/services/stats');
     const explorePingService = require('./server/services/explore-ping');
@@ -377,6 +378,7 @@ async function initServices() {
         mediaInliner.init(),
         donationService.init(),
         recommendationsService.init(),
+        imageDimensionsPrecompute.init(),
         statsService.init(),
         explorePingService.init(),
         giftService.init({

--- a/ghost/core/core/server/services/image-dimensions-precompute/index.js
+++ b/ghost/core/core/server/services/image-dimensions-precompute/index.js
@@ -1,0 +1,31 @@
+const events = require('../../lib/common/events');
+const jobsService = require('../jobs');
+const ImageDimensionsPrecomputeService = require('./service');
+
+class ImageDimensionsPrecomputeServiceWrapper {
+    init() {
+        if (this.service) {
+            return;
+        }
+
+        // Required lazily so the cache:imageSizes adapter is resolved after adapters boot.
+        const {cachedImageSizeFromUrl} = require('../../lib/image');
+
+        this.service = new ImageDimensionsPrecomputeService({
+            getCachedImageSizeFromUrl: url => cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url),
+            jobService: {
+                async addJob(name, fn) {
+                    return jobsService.addJob({
+                        name,
+                        job: fn,
+                        offloaded: false
+                    });
+                }
+            }
+        });
+
+        this.service.listen(events);
+    }
+}
+
+module.exports = new ImageDimensionsPrecomputeServiceWrapper();

--- a/ghost/core/core/server/services/image-dimensions-precompute/service.js
+++ b/ghost/core/core/server/services/image-dimensions-precompute/service.js
@@ -1,0 +1,168 @@
+const logging = require('@tryghost/logging');
+
+// Settings keys whose values are image URLs that {{ghost_head}} resolves dimensions for.
+const SETTING_KEYS = ['logo', 'icon', 'cover_image', 'og_image', 'twitter_image'];
+
+/**
+ * Proactively warms the image-dimensions cache (the `cache:imageSizes` adapter) whenever
+ * an image URL is assigned/changed on a post, user, or setting.
+ *
+ * `{{ghost_head}}` builds SEO meta on every render and, on a cache miss, synchronously
+ * probes external image hosts to read their dimensions (see core/frontend/meta/image-dimensions.js).
+ * By warming the cache at edit time we move that probe off the render hot path: the render
+ * reads an already-populated entry instead of opening a fresh connection per request. With the
+ * `cache:imageSizes` adapter pointed at Redis, the warm entry is shared across all processes
+ * of an instance, so it is probed once per unique URL rather than once per process.
+ *
+ * Warming is best-effort: it runs in a fire-and-forget job and can never break a save.
+ */
+class ImageDimensionsPrecomputeService {
+    /**
+     * @param {object} deps
+     * @param {(url: string) => Promise<any>} deps.getCachedImageSizeFromUrl - probes + caches dimensions for a URL
+     * @param {{addJob: (name: string, fn: () => Promise<any>) => Promise<any>}} deps.jobService - inline (in-process) job queue
+     */
+    constructor({getCachedImageSizeFromUrl, jobService}) {
+        this.getCachedImageSizeFromUrl = getCachedImageSizeFromUrl;
+        this.jobService = jobService;
+    }
+
+    /**
+     * @param {{on: (event: string, listener: Function) => void}} events
+     */
+    listen(events) {
+        events.on('post.added', this.handlePostChange.bind(this));
+        events.on('post.edited', this.handlePostChange.bind(this));
+        events.on('page.added', this.handlePostChange.bind(this));
+        events.on('page.edited', this.handlePostChange.bind(this));
+
+        events.on('user.added', this.handleUserChange.bind(this));
+        // `user.edited` fires unconditionally on every user update (including the
+        // `activated.edited` case), so we don't subscribe to `user.activated.edited`
+        // as well — that would just enqueue the same warm job twice.
+        events.on('user.edited', this.handleUserChange.bind(this));
+
+        for (const key of SETTING_KEYS) {
+            events.on(`settings.${key}.edited`, this.handleSettingChange.bind(this));
+        }
+    }
+
+    /**
+     * Don't warm during imports or internal/fixture writes — those touch large numbers of
+     * records at once and would flood the queue with probe jobs.
+     * @private
+     */
+    shouldSkip(options) {
+        return !!(options && (options.importing || (options.context && options.context.internal)));
+    }
+
+    handlePostChange(model, options) {
+        if (this.shouldSkip(options)) {
+            return;
+        }
+        // og_image/twitter_image live on the posts_meta relation; feature_image on the post.
+        const postsMeta = typeof model.related === 'function' ? model.related('posts_meta') : null;
+        return this.warm([
+            ...this.changedImageUrls(model, ['feature_image']),
+            ...(postsMeta ? this.changedImageUrls(postsMeta, ['og_image', 'twitter_image']) : [])
+        ]);
+    }
+
+    handleUserChange(model, options) {
+        if (this.shouldSkip(options)) {
+            return;
+        }
+        return this.warm(this.changedImageUrls(model, ['profile_image', 'cover_image']));
+    }
+
+    handleSettingChange(model, options) {
+        if (this.shouldSkip(options)) {
+            return;
+        }
+        // The setting's image URL lives in its `value` column.
+        return this.warm(this.changedImageUrls(model, ['value']));
+    }
+
+    /**
+     * Returns the current values of `fields` that actually changed in this save.
+     *
+     * This is important: model saves fire for unrelated reasons (e.g. a user's
+     * `last_seen` is updated on every request), and we must not probe an image
+     * URL that didn't change — otherwise every request would enqueue a probe.
+     *
+     * @param {object} model
+     * @param {string[]} fields
+     * @returns {string[]}
+     */
+    changedImageUrls(model, fields) {
+        const urls = [];
+        for (const field of fields) {
+            const value = model.get(field);
+            if (!value) {
+                continue;
+            }
+            if (!this.didFieldChange(model, field)) {
+                continue;
+            }
+            urls.push(value);
+        }
+        return urls;
+    }
+
+    /**
+     * Whether `field` changed in the save that triggered this event.
+     *
+     * We can't use bookshelf's `model.hasChanged(field)` here: bookshelf resets
+     * `model.changed` (what `hasChanged()` reads) *before* it fires the `*.added`/
+     * `*.edited` events, so by the time this listener runs `hasChanged()` reports
+     * nothing as changed. Ghost snapshots the change set onto `model._changed` (and
+     * copies it onto the `posts_meta` relation in the post model) precisely so it
+     * survives the event — so we consult that snapshot instead.
+     *
+     * When no snapshot is available (non-bookshelf/test models) we treat the field
+     * as changed so the value is still warmed.
+     *
+     * @param {object} model
+     * @param {string} field
+     * @returns {boolean}
+     * @private
+     */
+    didFieldChange(model, field) {
+        if (model && typeof model._changed === 'object' && model._changed !== null) {
+            return Object.prototype.hasOwnProperty.call(model._changed, field);
+        }
+        return true;
+    }
+
+    /**
+     * Enqueue a best-effort job that populates the dimensions cache for each unique, non-empty URL.
+     * Returns the job promise so callers/tests can await completion (production listeners ignore it).
+     * @param {Array<string|null|undefined|false>} urls
+     */
+    warm(urls) {
+        const unique = [...new Set((urls || []).filter(Boolean))];
+        if (!unique.length) {
+            return;
+        }
+
+        try {
+            return this.jobService.addJob('precompute-image-dimensions', async () => {
+                for (const url of unique) {
+                    try {
+                        // getCachedImageSizeFromUrl probes once + caches, short-circuits on a hit,
+                        // and already swallows + logs transient errors (returning null).
+                        await this.getCachedImageSizeFromUrl(url);
+                    } catch (err) {
+                        logging.error(err);
+                    }
+                }
+            });
+        } catch (err) {
+            // Best-effort: failing to enqueue the job must never break the save that triggered it.
+            logging.error(err);
+        }
+    }
+}
+
+module.exports = ImageDimensionsPrecomputeService;
+module.exports.SETTING_KEYS = SETTING_KEYS;

--- a/ghost/core/test/unit/server/services/image-dimensions-precompute/service.test.js
+++ b/ghost/core/test/unit/server/services/image-dimensions-precompute/service.test.js
@@ -1,0 +1,245 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const logging = require('@tryghost/logging');
+const ImageDimensionsPrecomputeService = require('../../../../../core/server/services/image-dimensions-precompute/service');
+
+// Build a minimal bookshelf-like model: get() reads properties, related() reads relations.
+// `changed` optionally lists which fields changed in this save. Ghost exposes that as the
+// `_changed` snapshot — bookshelf has already reset `model.changed` (what `hasChanged()`
+// reads) by the time the `*.edited`/`*.added` event fires, so the service consults
+// `_changed` instead. When `changed` is omitted there is no `_changed` at all (mirrors
+// non-bookshelf/test models), in which case every field is treated as changed.
+function createModel(properties = {}, relations = {}, changed) {
+    const model = {
+        get: property => properties[property],
+        related: relation => relations[relation]
+    };
+    if (changed) {
+        model._changed = {};
+        for (const field of changed) {
+            model._changed[field] = properties[field];
+        }
+    }
+    return model;
+}
+
+describe('ImageDimensionsPrecomputeService', function () {
+    let getCachedImageSizeFromUrl;
+    let addJob;
+    let jobService;
+    let service;
+
+    beforeEach(function () {
+        getCachedImageSizeFromUrl = sinon.stub().resolves({width: 10, height: 10});
+        // Run enqueued jobs immediately so we can assert on their effects.
+        addJob = sinon.stub().callsFake(async (name, fn) => fn());
+        jobService = {addJob};
+        service = new ImageDimensionsPrecomputeService({getCachedImageSizeFromUrl, jobService});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('listen', function () {
+        it('subscribes to post, user and settings events', function () {
+            const on = sinon.stub();
+            service.listen({on});
+
+            const subscribed = on.getCalls().map(call => call.args[0]);
+            assert.ok(subscribed.includes('post.added'));
+            assert.ok(subscribed.includes('post.edited'));
+            assert.ok(subscribed.includes('page.added'));
+            assert.ok(subscribed.includes('page.edited'));
+            assert.ok(subscribed.includes('user.added'));
+            assert.ok(subscribed.includes('user.edited'));
+            // `user.edited` already covers the active-user case, so we must not also
+            // subscribe to `user.activated.edited` (it would double-enqueue the job).
+            assert.ok(!subscribed.includes('user.activated.edited'));
+            for (const key of ImageDimensionsPrecomputeService.SETTING_KEYS) {
+                assert.ok(subscribed.includes(`settings.${key}.edited`), `missing settings.${key}.edited`);
+            }
+        });
+    });
+
+    describe('warm', function () {
+        it('enqueues a single job and warms each unique non-empty URL once', async function () {
+            await service.warm([
+                'https://example.com/a.jpg',
+                'https://example.com/a.jpg', // duplicate
+                'https://example.com/b.jpg',
+                null,
+                undefined,
+                '',
+                false
+            ]);
+
+            assert.equal(addJob.callCount, 1);
+            assert.equal(addJob.firstCall.args[0], 'precompute-image-dimensions');
+            assert.equal(getCachedImageSizeFromUrl.callCount, 2);
+            const warmed = getCachedImageSizeFromUrl.getCalls().map(call => call.args[0]);
+            assert.deepEqual(warmed, ['https://example.com/a.jpg', 'https://example.com/b.jpg']);
+        });
+
+        it('does not enqueue a job when there are no usable URLs', async function () {
+            await service.warm([null, undefined, '', false]);
+            assert.equal(addJob.callCount, 0);
+        });
+
+        it('is best-effort: a rejecting getter does not throw out of the job', async function () {
+            const errorStub = sinon.stub(logging, 'error');
+            getCachedImageSizeFromUrl.rejects(new Error('probe failed'));
+
+            await service.warm(['https://example.com/broken.jpg']);
+
+            assert.equal(addJob.callCount, 1);
+            assert.ok(errorStub.calledOnce);
+        });
+
+        it('is best-effort: a throwing job enqueue does not propagate', function () {
+            const errorStub = sinon.stub(logging, 'error');
+            addJob.throws(new Error('queue shut down'));
+
+            assert.doesNotThrow(() => service.warm(['https://example.com/a.jpg']));
+            assert.ok(errorStub.calledOnce);
+        });
+    });
+
+    describe('handlePostChange', function () {
+        it('warms feature_image plus posts_meta og/twitter images', async function () {
+            const model = createModel(
+                {feature_image: 'https://example.com/feature.jpg'},
+                {posts_meta: createModel({
+                    og_image: 'https://example.com/og.jpg',
+                    twitter_image: 'https://example.com/twitter.jpg'
+                })}
+            );
+
+            await service.handlePostChange(model, {});
+
+            const warmed = getCachedImageSizeFromUrl.getCalls().map(call => call.args[0]);
+            assert.deepEqual(warmed, [
+                'https://example.com/feature.jpg',
+                'https://example.com/og.jpg',
+                'https://example.com/twitter.jpg'
+            ]);
+        });
+
+        it('handles a missing posts_meta relation', async function () {
+            const model = createModel({feature_image: 'https://example.com/feature.jpg'}, {});
+            await service.handlePostChange(model, {});
+            assert.equal(getCachedImageSizeFromUrl.callCount, 1);
+            assert.equal(getCachedImageSizeFromUrl.firstCall.args[0], 'https://example.com/feature.jpg');
+        });
+
+        it('does nothing when no image fields are set', function () {
+            const model = createModel({feature_image: null}, {posts_meta: createModel({})});
+            service.handlePostChange(model, {});
+            assert.equal(addJob.callCount, 0);
+        });
+
+        it('skips importing writes', function () {
+            const model = createModel({feature_image: 'https://example.com/feature.jpg'}, {});
+            service.handlePostChange(model, {importing: true});
+            assert.equal(addJob.callCount, 0);
+        });
+
+        it('skips internal-context writes', function () {
+            const model = createModel({feature_image: 'https://example.com/feature.jpg'}, {});
+            service.handlePostChange(model, {context: {internal: true}});
+            assert.equal(addJob.callCount, 0);
+        });
+
+        it('only warms image fields that changed when change tracking is available', async function () {
+            // feature_image set but unchanged (e.g. an unrelated edit) -> not warmed
+            const model = createModel(
+                {feature_image: 'https://example.com/feature.jpg'},
+                {posts_meta: createModel({og_image: 'https://example.com/og.jpg'}, {}, ['og_image'])},
+                ['title'] // only title changed
+            );
+
+            await service.handlePostChange(model, {});
+
+            const warmed = getCachedImageSizeFromUrl.getCalls().map(call => call.args[0]);
+            assert.deepEqual(warmed, ['https://example.com/og.jpg']);
+        });
+    });
+
+    describe('handleUserChange', function () {
+        it('warms profile_image and cover_image', async function () {
+            const model = createModel({
+                profile_image: 'https://example.com/profile.jpg',
+                cover_image: 'https://example.com/cover.jpg'
+            });
+
+            await service.handleUserChange(model, {});
+
+            const warmed = getCachedImageSizeFromUrl.getCalls().map(call => call.args[0]);
+            assert.deepEqual(warmed, [
+                'https://example.com/profile.jpg',
+                'https://example.com/cover.jpg'
+            ]);
+        });
+
+        it('does not warm when only non-image fields changed (e.g. last_seen)', function () {
+            // Mirrors updateLastSeen(): the user is saved but profile_image is unchanged.
+            const model = createModel(
+                {profile_image: 'https://example.com/profile.jpg', last_seen: 'now'},
+                {},
+                ['last_seen']
+            );
+
+            service.handleUserChange(model, {});
+
+            assert.equal(addJob.callCount, 0);
+            assert.equal(getCachedImageSizeFromUrl.callCount, 0);
+        });
+
+        it('uses the _changed snapshot, not hasChanged() (which is reset before the event)', function () {
+            // Regression: bookshelf resets `model.changed` before firing the `*.edited`
+            // event, so `hasChanged()` always reports nothing changed by the time we run.
+            // The change set only survives on `_changed`. A model whose `hasChanged()`
+            // says "nothing changed" but whose `_changed` snapshot includes profile_image
+            // must still be warmed.
+            const model = createModel(
+                {profile_image: 'https://example.com/profile.jpg'},
+                {},
+                ['profile_image']
+            );
+            // Mirror real bookshelf: hasChanged() reads the (already reset) `changed` map.
+            model.hasChanged = () => false;
+
+            service.handleUserChange(model, {});
+
+            assert.equal(getCachedImageSizeFromUrl.callCount, 1);
+            assert.equal(getCachedImageSizeFromUrl.firstCall.args[0], 'https://example.com/profile.jpg');
+        });
+    });
+
+    describe('handleSettingChange', function () {
+        it('warms the setting value', async function () {
+            const model = createModel({key: 'logo', value: 'https://example.com/logo.png'});
+            await service.handleSettingChange(model, {});
+            assert.equal(getCachedImageSizeFromUrl.callCount, 1);
+            assert.equal(getCachedImageSizeFromUrl.firstCall.args[0], 'https://example.com/logo.png');
+        });
+
+        it('does nothing when the setting value is empty', function () {
+            const model = createModel({key: 'logo', value: ''});
+            service.handleSettingChange(model, {});
+            assert.equal(addJob.callCount, 0);
+        });
+
+        it('does not warm when the value did not change', function () {
+            // Setting row saved but `value` unchanged (some other column changed).
+            const model = createModel(
+                {key: 'logo', value: 'https://example.com/logo.png'},
+                {},
+                ['updated_at']
+            );
+            service.handleSettingChange(model, {});
+            assert.equal(addJob.callCount, 0);
+            assert.equal(getCachedImageSizeFromUrl.callCount, 0);
+        });
+    });
+});


### PR DESCRIPTION
- {{ghost_head}} resolves dimensions for up to 5 images (cover, author, og, twitter, logo) on every render; on a cache miss this synchronously probes external image hosts on the render hot path
- in production this became a connection storm: many instances behind one NAT egress IP, no warm cache between renders, tipping probes over the timeout and raising IMAGE_SIZE_URL "Probe unresponsive" ~17x on gateway boxes
- this adds a listener service that warms the cache:imageSizes adapter via a best-effort offloaded job whenever an image URL is set/changed on a post, user, or setting, so render reads a pre-populated entry instead of probing
- pooling (keep-alive agent) and the injectable cache adapter already landed; warming is the remaining piece. With the cache adapter pointed at Redis the warm entry is shared across an instance's processes (one probe per unique URL)
- best-effort by design: runs off the request path, swallows errors, and skips importing/internal writes so bulk operations don't flood the queue. A pooled render-time probe survives only as a self-healing fallback on a cold miss