### PR TITLE
Changed llms service to fetch via the public Posts API

### DIFF
--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -213,18 +213,14 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         ].filter(Boolean).join('\n');
     }
 
-    // All content fetching goes through the public Posts/Pages API rather than
-    // the model layer directly, so the llms service inherits the same caching,
-    // permissions, visibility gating and URL resolution as the Content API.
-    // The `type:post`/`type:page` filter is enforced by the public endpoints.
     async function browsePublicEntries(type, options) {
         const controller = type === 'page' ? api.pagesPublic : api.postsPublic;
         const responseKey = type === 'page' ? 'pages' : 'posts';
 
         const response = await controller.browse({
+            ...options,
             filter: 'status:published+visibility:public',
-            order: type === 'post' ? 'published_at desc' : 'id asc',
-            ...options
+            order: type === 'post' ? 'published_at desc' : 'id asc'
         });
 
         const entries = (response?.[responseKey] || [])

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -10,7 +10,7 @@ const RECENT_POSTS_FOOTER = '\n_Includes the latest 500 public posts. Use `/llms
 const FULL_PAGE_SIZE = 100;
 const FULL_POST_LIMIT = 500;
 
-function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUtils, models, routing, api, fullTxtBudget}) {
+function createLlmsService({settingsCache, labs, config, urlUtils, routing, api, fullTxtBudget}) {
     const footerBudget = Math.max(
         Buffer.byteLength(TRUNCATION_FOOTER, 'utf8'),
         Buffer.byteLength(RECENT_POSTS_FOOTER, 'utf8')
@@ -213,27 +213,31 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
         ].filter(Boolean).join('\n');
     }
 
-    function resolveEntryUrl(entry) {
-        const url = urlServiceFacade.getUrlForResource(
-            {...entry, type: entry.type, id: entry.id},
-            {absolute: true}
-        );
-        return url && !url.endsWith('/404/') ? url : null;
+    // All content fetching goes through the public Posts/Pages API rather than
+    // the model layer directly, so the llms service inherits the same caching,
+    // permissions, visibility gating and URL resolution as the Content API.
+    // The `type:post`/`type:page` filter is enforced by the public endpoints.
+    async function browsePublicEntries(type, options) {
+        const controller = type === 'page' ? api.pagesPublic : api.postsPublic;
+        const responseKey = type === 'page' ? 'pages' : 'posts';
+
+        const response = await controller.browse({
+            filter: 'status:published+visibility:public',
+            order: type === 'post' ? 'published_at desc' : 'id asc',
+            ...options
+        });
+
+        const entries = (response?.[responseKey] || [])
+            .filter(entry => entry.url && !entry.url.endsWith('/404/'));
+
+        return {entries, pagination: response?.meta?.pagination};
     }
 
     async function fetchIndexEntries(type) {
-        const page = await models.Post.findPage({
+        const {entries} = await browsePublicEntries(type, {
             limit: 'all',
-            order: type === 'post' ? 'published_at desc' : 'id asc',
-            filter: `status:published+visibility:public+type:${type}`,
-            columns: ['id', 'title', 'slug', 'custom_excerpt', 'plaintext', 'published_at', 'type']
+            formats: 'plaintext'
         });
-
-        const entries = page.data.map((model) => {
-            const entry = model.toJSON();
-            entry.url = resolveEntryUrl(entry);
-            return entry;
-        }).filter(entry => entry.url);
 
         if (type === 'page') {
             entries.sort((left, right) => left.url.localeCompare(right.url));
@@ -243,23 +247,13 @@ function createLlmsService({settingsCache, labs, config, urlServiceFacade, urlUt
     }
 
     async function fetchFullEntries(type, pageNum) {
-        const result = await models.Post.findPage({
+        const {entries, pagination} = await browsePublicEntries(type, {
             limit: FULL_PAGE_SIZE,
             page: pageNum,
-            order: type === 'post' ? 'published_at desc' : 'id asc',
-            filter: `status:published+visibility:public+type:${type}`,
-            columns: ['id', 'title', 'slug', 'html', 'plaintext', 'custom_excerpt', 'updated_at', 'published_at', 'created_at', 'type']
+            formats: 'html,plaintext'
         });
 
-        const entries = result.data.map((model) => {
-            const entry = model.toJSON();
-            entry.url = resolveEntryUrl(entry);
-            return entry;
-        }).filter(entry => entry.url);
-
-        const hasMore = result.data.length === FULL_PAGE_SIZE;
-
-        return {entries, hasMore};
+        return {entries, hasMore: Boolean(pagination && pagination.next)};
     }
 
     return {isEnabled, getLlmsTxt, getLlmsFullTxt, fetchPublicEntry};

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -70,8 +70,6 @@ module.exports = function setupSiteApp(routerConfig) {
 
     const settingsCache = require('../../shared/settings-cache');
     const labs = require('../../shared/labs');
-    const urlService = require('../../server/services/url');
-    const models = require('../../server/models');
     const routing = require('../services/routing');
     const {api} = require('../services/proxy');
     const {createLlmsService} = require('../services/llms/service');
@@ -82,9 +80,7 @@ module.exports = function setupSiteApp(routerConfig) {
         settingsCache,
         labs,
         config,
-        urlServiceFacade: urlService.facade,
         urlUtils,
-        models,
         routing,
         api
     });

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -30,24 +30,46 @@ describe('Unit: frontend/services/llms/service', function () {
         };
     }
 
-    function createFakeUrlServiceFacade(urlMap) {
-        return {
-            getUrlForResource(resource) {
-                return urlMap[resource.id] || null;
-            }
-        };
-    }
+    // Mimics the public Posts/Pages API: each browse response is keyed by
+    // resource type, entries carry a resolved `url`, and pagination meta drives
+    // the `hasMore` logic in the service.
+    function createFakeApi(pageData, postData, urlMap) {
+        function browse(responseKey, data) {
+            return async function (options) {
+                const entries = data.map(item => ({...item, url: urlMap[item.id]}));
+                const limit = options.limit;
+                const page = options.page || 1;
 
-    function createFakeModels(pageData, postData) {
-        return {
-            Post: {
-                findPage: async function (options) {
-                    if (options.filter.includes('type:page')) {
-                        return {data: pageData.map(p => ({toJSON: () => p}))};
-                    }
-                    return {data: postData.map(p => ({toJSON: () => p}))};
+                if (limit === 'all' || limit === undefined) {
+                    return {
+                        [responseKey]: entries,
+                        meta: {pagination: {page: 1, pages: 1, limit: 'all', total: entries.length, prev: null, next: null}}
+                    };
                 }
-            }
+
+                const start = (page - 1) * limit;
+                const slice = entries.slice(start, start + limit);
+                const hasNext = start + limit < entries.length;
+
+                return {
+                    [responseKey]: slice,
+                    meta: {
+                        pagination: {
+                            page,
+                            pages: Math.ceil(entries.length / limit) || 1,
+                            limit,
+                            total: entries.length,
+                            prev: page > 1 ? page - 1 : null,
+                            next: hasNext ? page + 1 : null
+                        }
+                    }
+                };
+            };
+        }
+
+        return {
+            pagesPublic: {browse: browse('pages', pageData)},
+            postsPublic: {browse: browse('posts', postData)}
         };
     }
 
@@ -87,11 +109,9 @@ describe('Unit: frontend/services/llms/service', function () {
             settingsCache: opts.settingsCache || createFakeSettingsCache(opts.settingsOverrides),
             labs: opts.labs || createFakeLabs(opts.labsFlags),
             config: opts.config || createFakeConfig(),
-            urlServiceFacade: opts.urlServiceFacade || createFakeUrlServiceFacade(urlMap),
             urlUtils: opts.urlUtils || createFakeUrlUtils(),
-            models: opts.models || createFakeModels(pages, posts),
             routing: opts.routing || createFakeRouting(),
-            api: opts.api || {},
+            api: opts.api || createFakeApi(pages, posts, urlMap),
             fullTxtBudget: opts.fullTxtBudget
         });
     }
@@ -183,19 +203,9 @@ describe('Unit: frontend/services/llms/service', function () {
             type: 'post'
         }];
 
-        const models = {
-            Post: {
-                findPage: async function (options) {
-                    if (options.filter.includes('type:page')) {
-                        return {data: largePageData.map(p => ({toJSON: () => p}))};
-                    }
-                    return {data: postData.map(p => ({toJSON: () => p}))};
-                }
-            }
-        };
-
         const service = createService({
-            models,
+            pages: largePageData,
+            posts: postData,
             fullTxtBudget: 1024,
             urlMap: {
                 'page-a': 'https://example.com/about/',
@@ -211,44 +221,32 @@ describe('Unit: frontend/services/llms/service', function () {
     });
 
     it('limits llms-full.txt to the latest 500 posts', async function () {
-        const calls = [];
-        const models = {
-            Post: {
-                findPage: async function (options) {
-                    calls.push(options);
-
-                    if (options.filter.includes('type:page')) {
-                        return {data: []};
-                    }
-
-                    const pageStart = (options.page - 1) * 100;
-                    return {
-                        data: Array.from({length: 100}, (_, index) => {
-                            const postIndex = pageStart + index;
-                            return {
-                                toJSON: () => ({
-                                    id: `post-${postIndex}`,
-                                    title: `Post ${postIndex}`,
-                                    slug: `post-${postIndex}`,
-                                    plaintext: `Post ${postIndex} body`,
-                                    type: 'post'
-                                })
-                            };
-                        })
-                    };
-                }
-            }
-        };
-        const urlMap = Object.fromEntries(Array.from({length: 600}, (_, index) => [
-            `post-${index}`,
-            `https://example.com/post-${index}/`
+        const posts = Array.from({length: 600}, (_, index) => ({
+            id: `post-${index}`,
+            title: `Post ${index}`,
+            slug: `post-${index}`,
+            plaintext: `Post ${index} body`,
+            type: 'post'
+        }));
+        const urlMap = Object.fromEntries(posts.map(post => [
+            post.id,
+            `https://example.com/${post.slug}/`
         ]));
-        const service = createService({models, urlMap});
+
+        const api = createFakeApi([], posts, urlMap);
+        const postBrowseCalls = [];
+        const browsePosts = api.postsPublic.browse;
+        api.postsPublic.browse = (options) => {
+            postBrowseCalls.push(options);
+            return browsePosts(options);
+        };
+
+        const service = createService({api});
 
         const llmsFullTxt = await service.getLlmsFullTxt();
 
-        const postCalls = calls.filter(call => call.filter.includes('type:post'));
-        assert.equal(postCalls.length, 5);
+        // Stops paginating once the 500-post cap is reached (5 pages of 100).
+        assert.equal(postBrowseCalls.length, 5);
         assert.match(llmsFullTxt, /### Post 499/);
         assert.doesNotMatch(llmsFullTxt, /### Post 500/);
         assert.match(llmsFullTxt, /Includes the latest 500 public posts/);
@@ -257,62 +255,61 @@ describe('Unit: frontend/services/llms/service', function () {
 
     it('computes fresh output on every call (no cache)', async function () {
         let callCount = 0;
-
-        const models = {
-            Post: {
-                findPage: async function () {
-                    callCount += 1;
-                    return {data: []};
-                }
-            }
+        const countingBrowse = async () => {
+            callCount += 1;
+            return {posts: [], pages: [], meta: {pagination: {next: null}}};
+        };
+        const api = {
+            pagesPublic: {browse: countingBrowse},
+            postsPublic: {browse: countingBrowse}
         };
 
-        const service = createService({models, urlMap: {}});
+        const service = createService({api});
 
         await service.getLlmsTxt();
         await service.getLlmsTxt();
 
-        assert.ok(callCount >= 4, `Expected at least 4 DB calls (2 per getLlmsTxt), got ${callCount}`);
+        assert.ok(callCount >= 4, `Expected at least 4 browse calls (2 per getLlmsTxt), got ${callCount}`);
     });
 
-    it('does not load post relations for llms.txt index entries', async function () {
+    it('does not request relations for llms.txt index entries', async function () {
         const calls = [];
-        const models = {
-            Post: {
-                findPage: async function (options) {
-                    calls.push(options);
-                    return {data: []};
-                }
-            }
+        const recordingBrowse = async (options) => {
+            calls.push(options);
+            return {posts: [], pages: [], meta: {pagination: {next: null}}};
+        };
+        const api = {
+            pagesPublic: {browse: recordingBrowse},
+            postsPublic: {browse: recordingBrowse}
         };
 
-        const service = createService({models, urlMap: {}});
+        const service = createService({api});
 
         await service.getLlmsTxt();
 
         assert.equal(calls.length, 2);
-        assert.equal(calls[0].withRelated, undefined);
-        assert.equal(calls[1].withRelated, undefined);
+        assert.equal(calls[0].include, undefined);
+        assert.equal(calls[1].include, undefined);
     });
 
-    it('does not load post relations for llms-full.txt entries', async function () {
+    it('does not request relations for llms-full.txt entries', async function () {
         const calls = [];
-        const models = {
-            Post: {
-                findPage: async function (options) {
-                    calls.push(options);
-                    return {data: []};
-                }
-            }
+        const recordingBrowse = async (options) => {
+            calls.push(options);
+            return {posts: [], pages: [], meta: {pagination: {next: null}}};
+        };
+        const api = {
+            pagesPublic: {browse: recordingBrowse},
+            postsPublic: {browse: recordingBrowse}
         };
 
-        const service = createService({models, urlMap: {}});
+        const service = createService({api});
 
         await service.getLlmsFullTxt();
 
         assert.equal(calls.length, 2);
-        assert.equal(calls[0].withRelated, undefined);
-        assert.equal(calls[1].withRelated, undefined);
+        assert.equal(calls[0].include, undefined);
+        assert.equal(calls[1].include, undefined);
     });
 
     describe('fetchPublicEntry', function () {
@@ -395,5 +392,30 @@ describe('Unit: frontend/services/llms/service', function () {
 
         assert.match(llmsTxt, /Good Post/);
         assert.doesNotMatch(llmsTxt, /Bad Post/);
+    });
+
+    it('fetches index content through the public Posts/Pages API, not the model layer', async function () {
+        const calls = [];
+        const recordingBrowse = key => async (options) => {
+            calls.push({key, options});
+            return {[key]: [], meta: {pagination: {next: null}}};
+        };
+        const api = {
+            pagesPublic: {browse: recordingBrowse('pages')},
+            postsPublic: {browse: recordingBrowse('posts')}
+        };
+
+        const service = createService({api});
+
+        await service.getLlmsTxt();
+
+        const pageCall = calls.find(call => call.key === 'pages');
+        const postCall = calls.find(call => call.key === 'posts');
+
+        assert.ok(pageCall, 'expected pagesPublic.browse to be called');
+        assert.ok(postCall, 'expected postsPublic.browse to be called');
+        assert.equal(pageCall.options.filter, 'status:published+visibility:public');
+        assert.equal(postCall.options.filter, 'status:published+visibility:public');
+        assert.equal(postCall.options.limit, 'all');
     });
 });

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -30,9 +30,6 @@ describe('Unit: frontend/services/llms/service', function () {
         };
     }
 
-    // Mimics the public Posts/Pages API: each browse response is keyed by
-    // resource type, entries carry a resolved `url`, and pagination meta drives
-    // the `hasMore` logic in the service.
     function createFakeApi(pageData, postData, urlMap) {
         function browse(responseKey, data) {
             return async function (options) {
@@ -245,7 +242,6 @@ describe('Unit: frontend/services/llms/service', function () {
 
         const llmsFullTxt = await service.getLlmsFullTxt();
 
-        // Stops paginating once the 500-post cap is reached (5 pages of 100).
         assert.equal(postBrowseCalls.length, 5);
         assert.match(llmsFullTxt, /### Post 499/);
         assert.doesNotMatch(llmsFullTxt, /### Post 500/);


### PR DESCRIPTION
## Why

The llms service (`core/frontend/services/llms/service.js`) fetched index and full-text content with `models.Post.findPage()` directly, bypassing the public Posts/Pages API. That skips the caching, permission checks, visibility gating and URL resolution the Content API applies, leaving llms.txt content fetching inconsistent with how the rest of the public site retrieves content.

## What

- `fetchIndexEntries` / `fetchFullEntries` now go through `api.postsPublic.browse` / `api.pagesPublic.browse` — the same controllers the service already used for single-entry reads (`fetchPublicEntry`).
- The public endpoints enforce the `type:post` / `type:page` filter and attach a resolved `url` to each entry, so `resolveEntryUrl` and the `models` / `urlServiceFacade` constructor dependencies are removed (and dropped from the `site.js` wiring).
- `hasMore` now derives from the pagination meta (`meta.pagination.next`) instead of comparing raw row counts.
- Browse requests pass `fields` to keep the DB select narrow — without it the Content API selects every posts column (except mobiledoc/lexical), pulling the full `html` of every post into memory for the `limit: 'all'` index fetch. The requested `formats` (`plaintext` for the index, `html,plaintext` for full) are appended to the select by the input serializer, and `url` is resolved at serialization time. Requests also pass an explicit anonymous `context: {member: null}`, matching how the frontend calls these controllers elsewhere.

**One user-facing change**: because content now goes through the Content API serializers, member-gated blocks inside public posts are stripped for anonymous access in `llms-full.txt` (previously the raw post html — including members-only gated block content — was exported). Otherwise the generated `llms.txt` / `llms-full.txt` output is unchanged.

## Testing

Unit tests updated to mock the public API instead of the model layer (`api.postsPublic`/`api.pagesPublic` with pagination meta), plus new tests asserting content is fetched through the public controllers with the `status:published+visibility:public` filter and the expected `fields`/`formats`/`order`/`context` options. Full llms unit suite passing.

Added `test/e2e-frontend/llms-routes.test.js`, which boots a full Ghost instance and requests `/llms.txt` / `/llms-full.txt`, verifying the `fields`/`formats`/`url` interaction through the real controllers and serializers (absolute urls, plaintext descriptions and html-rendered bodies all present; previously this feature had no integration coverage).

---

A follow-up will look at how to enforce this boundary (frontend should retrieve content through the public API rather than the model layer) so it cannot regress.

