### PR TITLE
Fixed update-check worker missing email-address init

### DIFF
--- a/ghost/core/core/server/services/update-check/run-update-check.js
+++ b/ghost/core/core/server/services/update-check/run-update-check.js
@@ -40,6 +40,9 @@ if (parentPort) {
 
     const tiers = require('../tiers');
     await tiers.init();
+
+    const emailAddress = require('../email-address');
+    emailAddress.init();
     // Finished INIT
 
     await updateCheck({

--- a/ghost/core/test/integration/jobs/update-check.test.js
+++ b/ghost/core/test/integration/jobs/update-check.test.js
@@ -10,9 +10,13 @@ const JOB_PATH = path.resolve(__dirname, '../../../core/server/services/update-c
 
 describe('Run Update Check', function () {
     let mockUpdateServer;
-    let previousMailTransport;
+    let baselineMailTransport;
 
     before(testUtils.setup('default'));
+
+    beforeEach(function () {
+        baselineMailTransport = process.env.mail__transport;
+    });
 
     afterEach(async function () {
         if (mockUpdateServer) {
@@ -22,11 +26,10 @@ describe('Run Update Check', function () {
         await models.Settings.edit({key: 'notifications', value: '[]'}, {context: {internal: true}});
         // Remove the job so the next test can re-register it
         await jobService.removeJob(JOB_NAME).catch(() => {});
-        if (previousMailTransport === undefined) {
+        if (baselineMailTransport === undefined) {
             delete process.env.mail__transport;
         } else {
-            process.env.mail__transport = previousMailTransport;
-            previousMailTransport = undefined;
+            process.env.mail__transport = baselineMailTransport;
         }
     });
 
@@ -79,7 +82,6 @@ describe('Run Update Check', function () {
         // Worker threads inherit process.env, so this routes the worker's
         // GhostMailer to nodemailer-stub-transport. Without it the worker
         // hits the default SMTP transport and ECONNREFUSEs on localhost:587.
-        previousMailTransport = process.env.mail__transport;
         process.env.mail__transport = 'stub';
 
         mockUpdateServer = http.createServer((req, res) => {

--- a/ghost/core/test/integration/jobs/update-check.test.js
+++ b/ghost/core/test/integration/jobs/update-check.test.js
@@ -10,6 +10,7 @@ const JOB_PATH = path.resolve(__dirname, '../../../core/server/services/update-c
 
 describe('Run Update Check', function () {
     let mockUpdateServer;
+    let previousMailTransport;
 
     before(testUtils.setup('default'));
 
@@ -21,6 +22,12 @@ describe('Run Update Check', function () {
         await models.Settings.edit({key: 'notifications', value: '[]'}, {context: {internal: true}});
         // Remove the job so the next test can re-register it
         await jobService.removeJob(JOB_NAME).catch(() => {});
+        if (previousMailTransport === undefined) {
+            delete process.env.mail__transport;
+        } else {
+            process.env.mail__transport = previousMailTransport;
+            previousMailTransport = undefined;
+        }
     });
 
     it('successfully executes the update checker', async function () {
@@ -58,6 +65,23 @@ describe('Run Update Check', function () {
     });
 
     it('stores an alert-type custom notification end-to-end', async function () {
+        // Default fixtures leave the Owner inactive, so the alert branch's
+        // users.browse returns no recipients and the email send returns
+        // early without exercising the mailer pipeline. Activate the Owner
+        // so the worker actually drives the full notificationEmailService
+        // path that production hits.
+        const owner = await models.User.findOne(
+            {email: 'ghost@example.com'},
+            {context: {internal: true}, withRelated: ['roles']}
+        );
+        await owner.save({status: 'active'}, {patch: true, context: {internal: true}});
+
+        // Worker threads inherit process.env, so this routes the worker's
+        // GhostMailer to nodemailer-stub-transport. Without it the worker
+        // hits the default SMTP transport and ECONNREFUSEs on localhost:587.
+        previousMailTransport = process.env.mail__transport;
+        process.env.mail__transport = 'stub';
+
         mockUpdateServer = http.createServer((req, res) => {
             res.writeHead(200, {'Content-Type': 'application/json'});
             res.end(JSON.stringify({


### PR DESCRIPTION
## Problem

Custom update-check notifications marked as `alert` never reach the admin: no in-app banner is stored, and no critical-alert email is sent. The background worker exits before either side effect runs.

The worker thread initialises a subset of services on boot but skips the email-address service. Worker threads do not share the main process's module state, so the main process's init does not propagate. When the alert branch reaches the mailer, accessing the default from-address throws because the email-address service is undefined. The worker rethrows by design, exiting the function before the notification is persisted.

A related SQL bug from a previous fix was masking this failure mode. Once that fix landed on main, this exposure surfaced as a separate `TypeError`.

## Solution

Initialise the email-address service in the worker's init sequence so the alert branch can resolve the from-address through the same path the main process uses.

Strengthened the integration test to activate the Owner fixture so the user lookup returns a recipient and the worker actually exercises the full notification email pipeline. The previous test relied on the default inactive Owner, which short-circuited the email path before it could surface this regression. Routed the worker's mailer to a stub transport via process env so it doesn't try to connect to local SMTP in tests. Verified by reverting just the worker init change: the test fails with the same `TypeError` that staging logged.
