### PR TITLE
Added quote in reply button to comments-ui

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -703,32 +703,9 @@ function setCommentFormHasUnsavedChanges({data: {id, hasUnsavedChanges}, state}:
     return {openCommentForms: updatedForms};
 }
 
-function setCommentFormInitialHtml({data: {id, initialHtml}, state}: {data: {id: string, initialHtml: string}, state: EditableAppContext}) {
-    const updatedForms = state.openCommentForms.map((f) => {
-        if (f.id === id) {
-            return {...f, initialHtml, hasUnsavedChanges: false};
-        }
-
-        // Return the same reference for untouched forms to preserve referential
-        // equality and avoid needless re-renders.
-        return f;
-    });
-
-    return {openCommentForms: updatedForms};
-}
-
 function closeCommentForm({data: id, state}: {data: string, state: EditableAppContext}) {
     return {openCommentForms: state.openCommentForms.filter(f => f.id !== id)};
 };
-
-// When starting a quoted reply we close any other open reply forms to keep the
-// thread tidy, but preserve the one being quoted into (f.id === id) and any form
-// the user has actually edited (hasUnsavedChanges) so we never silently discard
-// an in-progress draft. A freshly auto-quoted form reports no unsaved changes
-// (see setCommentFormInitialHtml), so it is still eligible to be closed.
-function closeOtherReplyForms({data: id, state}: {data: string, state: EditableAppContext}) {
-    return {openCommentForms: state.openCommentForms.filter(f => f.type !== 'reply' || f.id === id || f.hasUnsavedChanges)};
-}
 
 function setScrollTarget({data: commentId}: {data: string | null}) {
     return {commentIdToScrollTo: commentId};
@@ -743,9 +720,7 @@ export const SyncActions = {
     openPopup,
     closePopup,
     closeCommentForm,
-    closeOtherReplyForms,
     setCommentFormHasUnsavedChanges,
-    setCommentFormInitialHtml,
     setScrollTarget,
     setHashCommentId
 };

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -693,9 +693,25 @@ function setCommentFormHasUnsavedChanges({data: {id, hasUnsavedChanges}, state}:
     const updatedForms = state.openCommentForms.map((f) => {
         if (f.id === id) {
             return {...f, hasUnsavedChanges};
-        } else {
-            return {...f};
-        };
+        }
+
+        // Return the same reference for untouched forms to preserve referential
+        // equality and avoid needless re-renders.
+        return f;
+    });
+
+    return {openCommentForms: updatedForms};
+}
+
+function setCommentFormInitialHtml({data: {id, initialHtml}, state}: {data: {id: string, initialHtml: string}, state: EditableAppContext}) {
+    const updatedForms = state.openCommentForms.map((f) => {
+        if (f.id === id) {
+            return {...f, initialHtml, hasUnsavedChanges: false};
+        }
+
+        // Return the same reference for untouched forms to preserve referential
+        // equality and avoid needless re-renders.
+        return f;
     });
 
     return {openCommentForms: updatedForms};
@@ -705,8 +721,13 @@ function closeCommentForm({data: id, state}: {data: string, state: EditableAppCo
     return {openCommentForms: state.openCommentForms.filter(f => f.id !== id)};
 };
 
+// When starting a quoted reply we close any other open reply forms to keep the
+// thread tidy, but preserve the one being quoted into (f.id === id) and any form
+// the user has actually edited (hasUnsavedChanges) so we never silently discard
+// an in-progress draft. A freshly auto-quoted form reports no unsaved changes
+// (see setCommentFormInitialHtml), so it is still eligible to be closed.
 function closeOtherReplyForms({data: id, state}: {data: string, state: EditableAppContext}) {
-    return {openCommentForms: state.openCommentForms.filter(f => f.type !== 'reply' || f.id === id)};
+    return {openCommentForms: state.openCommentForms.filter(f => f.type !== 'reply' || f.id === id || f.hasUnsavedChanges)};
 }
 
 function setScrollTarget({data: commentId}: {data: string | null}) {
@@ -724,6 +745,7 @@ export const SyncActions = {
     closeCommentForm,
     closeOtherReplyForms,
     setCommentFormHasUnsavedChanges,
+    setCommentFormInitialHtml,
     setScrollTarget,
     setHashCommentId
 };

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -705,6 +705,10 @@ function closeCommentForm({data: id, state}: {data: string, state: EditableAppCo
     return {openCommentForms: state.openCommentForms.filter(f => f.id !== id)};
 };
 
+function closeOtherReplyForms({data: id, state}: {data: string, state: EditableAppContext}) {
+    return {openCommentForms: state.openCommentForms.filter(f => f.type !== 'reply' || f.id === id)};
+}
+
 function setScrollTarget({data: commentId}: {data: string | null}) {
     return {commentIdToScrollTo: commentId};
 }
@@ -718,6 +722,7 @@ export const SyncActions = {
     openPopup,
     closePopup,
     closeCommentForm,
+    closeOtherReplyForms,
     setCommentFormHasUnsavedChanges,
     setScrollTarget,
     setHashCommentId

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -45,7 +45,6 @@ export type OpenCommentForm = {
         id: string,
         html: string
     },
-    initialHtml?: string,
     type: 'reply' | 'edit',
     hasUnsavedChanges: boolean
 }

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -41,6 +41,10 @@ export type OpenCommentForm = {
     parent_id?: string,
     in_reply_to_id?: string,
     in_reply_to_snippet?: string,
+    pendingQuote?: {
+        id: string,
+        html: string
+    },
     type: 'reply' | 'edit',
     hasUnsavedChanges: boolean
 }

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -45,6 +45,7 @@ export type OpenCommentForm = {
         id: string,
         html: string
     },
+    initialHtml?: string,
     type: 'reply' | 'edit',
     hasUnsavedChanges: boolean
 }
@@ -137,4 +138,22 @@ export const useLabs = () => {
     } catch {
         return {};
     }
+};
+
+// Shared gate for actions that require a member on a sufficient tier (Reply,
+// Quote in reply, ...). Returns a callback that opens the CTA upgrade/signup
+// popup and returns false when the visitor isn't allowed, otherwise true.
+export const useRequireMemberTier = () => {
+    const {isMember, hasRequiredTier, dispatchAction} = useAppContext();
+
+    return React.useCallback((commentId?: string) => {
+        if (!isMember || !hasRequiredTier) {
+            // Pass the comment id so the CTA's "Sign in" can return the reader to
+            // this comment after signing in (see cta-box).
+            dispatchAction('openPopup', {type: 'ctaPopup', commentId});
+            return false;
+        }
+
+        return true;
+    }, [isMember, hasRequiredTier, dispatchAction]);
 };

--- a/apps/comments-ui/src/components/content/buttons/quote-reply-button.tsx
+++ b/apps/comments-ui/src/components/content/buttons/quote-reply-button.tsx
@@ -7,36 +7,48 @@ type Props = {
     quoteInReply: () => void;
 };
 
-function getClampedPosition(button: HTMLButtonElement, quoteSelection: QuoteSelection) {
-    const ownerWindow = button.ownerDocument.defaultView || window;
-    const {width, height} = button.getBoundingClientRect();
+function getClampedPosition(ownerWindow: Window, size: {width: number, height: number}, quoteSelection: QuoteSelection) {
     const horizontalMargin = 8;
     const verticalMargin = 8;
-    const halfWidth = width / 2;
+    const halfWidth = size.width / 2;
 
     return {
         left: Math.min(
             Math.max(quoteSelection.left, halfWidth + horizontalMargin),
             ownerWindow.innerWidth - halfWidth - horizontalMargin
         ),
-        top: Math.max(quoteSelection.top, height + verticalMargin)
+        top: Math.max(quoteSelection.top, size.height + verticalMargin)
     };
 }
 
 const QuoteReplyButton: React.FC<Props> = ({quoteSelection, quoteInReply}) => {
     const {t} = useAppContext();
     const buttonRef = useRef<HTMLButtonElement | null>(null);
+    // The button's label never changes, so measure it once instead of forcing a
+    // synchronous layout on every selection/scroll tick.
+    const sizeRef = useRef<{width: number, height: number} | null>(null);
     const [position, setPosition] = useState(() => ({
         left: quoteSelection.left,
         top: quoteSelection.top
     }));
 
     useLayoutEffect(() => {
-        if (!buttonRef.current) {
+        const button = buttonRef.current;
+
+        if (!button) {
             return;
         }
 
-        setPosition(getClampedPosition(buttonRef.current, quoteSelection));
+        if (!sizeRef.current) {
+            const {width, height} = button.getBoundingClientRect();
+            sizeRef.current = {width, height};
+        }
+
+        const ownerWindow = button.ownerDocument.defaultView || window;
+        const next = getClampedPosition(ownerWindow, sizeRef.current, quoteSelection);
+        setPosition(previous => (
+            previous.left === next.left && previous.top === next.top ? previous : next
+        ));
     }, [quoteSelection]);
 
     return (

--- a/apps/comments-ui/src/components/content/buttons/quote-reply-button.tsx
+++ b/apps/comments-ui/src/components/content/buttons/quote-reply-button.tsx
@@ -1,0 +1,71 @@
+import React, {useLayoutEffect, useRef, useState} from 'react';
+import {QuoteSelection} from '../hooks/use-quote-selection';
+import {useAppContext} from '../../../app-context';
+
+type Props = {
+    quoteSelection: QuoteSelection;
+    quoteInReply: () => void;
+};
+
+function getClampedPosition(button: HTMLButtonElement, quoteSelection: QuoteSelection) {
+    const ownerWindow = button.ownerDocument.defaultView || window;
+    const {width, height} = button.getBoundingClientRect();
+    const horizontalMargin = 8;
+    const verticalMargin = 8;
+    const halfWidth = width / 2;
+
+    return {
+        left: Math.min(
+            Math.max(quoteSelection.left, halfWidth + horizontalMargin),
+            ownerWindow.innerWidth - halfWidth - horizontalMargin
+        ),
+        top: Math.max(quoteSelection.top, height + verticalMargin)
+    };
+}
+
+const QuoteReplyButton: React.FC<Props> = ({quoteSelection, quoteInReply}) => {
+    const {t} = useAppContext();
+    const buttonRef = useRef<HTMLButtonElement | null>(null);
+    const [position, setPosition] = useState(() => ({
+        left: quoteSelection.left,
+        top: quoteSelection.top
+    }));
+
+    useLayoutEffect(() => {
+        if (!buttonRef.current) {
+            return;
+        }
+
+        setPosition(getClampedPosition(buttonRef.current, quoteSelection));
+    }, [quoteSelection]);
+
+    return (
+        <button
+            ref={buttonRef}
+            className="fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md bg-neutral-900 px-3 py-2 font-sans text-sm font-semibold leading-none text-white shadow-lg transition-colors hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200"
+            data-testid="quote-reply-button"
+            style={{
+                left: position.left,
+                top: position.top
+            }}
+            type="button"
+            onClick={quoteInReply}
+            onMouseDown={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+            }}
+            onTouchEnd={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                quoteInReply();
+            }}
+            onTouchStart={(event) => {
+                event.stopPropagation();
+            }}
+        >
+            {t('Quote in reply')}
+        </button>
+    );
+};
+
+export default QuoteReplyButton;

--- a/apps/comments-ui/src/components/content/buttons/quote-reply-button.tsx
+++ b/apps/comments-ui/src/components/content/buttons/quote-reply-button.tsx
@@ -1,10 +1,19 @@
+import QuoteReplyIcon from '../../../images/icons/quote-reply.svg?react';
 import React, {useLayoutEffect, useRef, useState} from 'react';
 import {QuoteSelection} from '../hooks/use-quote-selection';
 import {useAppContext} from '../../../app-context';
 
+type QuoteButtonPlacement = 'selection' | 'gutter';
+
+type QuoteButtonPosition = {
+    left: number;
+    top: number;
+    placement: QuoteButtonPlacement;
+};
+
 type Props = {
     quoteSelection: QuoteSelection;
-    quoteInReply: () => void;
+    quoteInReply: (quoteHtml?: string) => void;
 };
 
 function getClampedPosition(ownerWindow: Window, size: {width: number, height: number}, quoteSelection: QuoteSelection) {
@@ -17,19 +26,77 @@ function getClampedPosition(ownerWindow: Window, size: {width: number, height: n
             Math.max(quoteSelection.left, halfWidth + horizontalMargin),
             ownerWindow.innerWidth - halfWidth - horizontalMargin
         ),
-        top: Math.max(quoteSelection.top, size.height + verticalMargin)
+        top: Math.max(quoteSelection.top, size.height + verticalMargin),
+        placement: 'selection' as QuoteButtonPlacement
     };
+}
+
+function isMobileQuoteButton(ownerWindow: Window) {
+    return ownerWindow.matchMedia('(max-width: 480px)').matches;
+}
+
+function getGutterPosition(ownerWindow: Window, quoteSelection: QuoteSelection) {
+    const size = 32;
+    const gap = 8;
+    const verticalMargin = 4;
+    const left = quoteSelection.textLeft - size - gap;
+    const top = quoteSelection.centerTop - (size / 2);
+
+    return {
+        left: Math.max(left, 0),
+        top: Math.min(Math.max(top, verticalMargin), ownerWindow.innerHeight - size - verticalMargin),
+        placement: 'gutter' as QuoteButtonPlacement
+    };
+}
+
+function getPosition(ownerWindow: Window, size: {width: number, height: number}, quoteSelection: QuoteSelection) {
+    return isMobileQuoteButton(ownerWindow)
+        ? getGutterPosition(ownerWindow, quoteSelection)
+        : getClampedPosition(ownerWindow, size, quoteSelection);
+}
+
+function suppressCompatibilityClick(ownerDocument: Document, onCleanup: () => void) {
+    const ownerWindow = ownerDocument.defaultView || window;
+    let timeout: number | null = null;
+    let cleanedUp = false;
+
+    function cleanup() {
+        if (cleanedUp) {
+            return;
+        }
+
+        cleanedUp = true;
+        ownerDocument.removeEventListener('click', stopClick, true);
+        onCleanup();
+    }
+
+    function stopClick(event: MouseEvent) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+
+        if (timeout !== null) {
+            ownerWindow.clearTimeout(timeout);
+        }
+
+        cleanup();
+    }
+
+    ownerDocument.addEventListener('click', stopClick, true);
+    timeout = ownerWindow.setTimeout(cleanup, 700);
 }
 
 const QuoteReplyButton: React.FC<Props> = ({quoteSelection, quoteInReply}) => {
     const {t} = useAppContext();
     const buttonRef = useRef<HTMLButtonElement | null>(null);
+    const handledTouchRef = useRef(false);
     // The button's label never changes, so measure it once instead of forcing a
     // synchronous layout on every selection/scroll tick.
     const sizeRef = useRef<{width: number, height: number} | null>(null);
-    const [position, setPosition] = useState(() => ({
+    const [position, setPosition] = useState<QuoteButtonPosition>(() => ({
         left: quoteSelection.left,
-        top: quoteSelection.top
+        top: quoteSelection.top,
+        placement: 'selection'
     }));
 
     useLayoutEffect(() => {
@@ -45,23 +112,49 @@ const QuoteReplyButton: React.FC<Props> = ({quoteSelection, quoteInReply}) => {
         }
 
         const ownerWindow = button.ownerDocument.defaultView || window;
-        const next = getClampedPosition(ownerWindow, sizeRef.current, quoteSelection);
-        setPosition(previous => (
-            previous.left === next.left && previous.top === next.top ? previous : next
-        ));
+        const updatePosition = () => {
+            const next = getPosition(ownerWindow, sizeRef.current!, quoteSelection);
+            setPosition(previous => (
+                previous.left === next.left && previous.top === next.top && previous.placement === next.placement ? previous : next
+            ));
+        };
+
+        updatePosition();
+
+        ownerWindow.addEventListener('resize', updatePosition);
+        ownerWindow.addEventListener('scroll', updatePosition, true);
+
+        return () => {
+            ownerWindow.removeEventListener('resize', updatePosition);
+            ownerWindow.removeEventListener('scroll', updatePosition, true);
+        };
     }, [quoteSelection]);
+
+    const isGutterButton = position.placement === 'gutter';
 
     return (
         <button
             ref={buttonRef}
-            className="fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md bg-neutral-900 px-3 py-2 font-sans text-sm font-semibold leading-none text-white shadow-lg transition-colors hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200"
+            aria-label={isGutterButton ? t('Quote in reply') : undefined}
+            className={`fixed z-50 bg-neutral-900 font-sans text-sm font-semibold leading-none text-white shadow-lg transition-colors hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200 ${isGutterButton ? 'flex size-8 items-center justify-center rounded-full p-0' : 'whitespace-nowrap rounded-md px-3 py-2'}`}
+            data-placement={position.placement}
             data-testid="quote-reply-button"
             style={{
                 left: position.left,
-                top: position.top
+                top: position.top,
+                transform: isGutterButton ? 'none' : 'translate(-50%, -100%)'
             }}
             type="button"
-            onClick={quoteInReply}
+            onClick={(event) => {
+                if (handledTouchRef.current) {
+                    handledTouchRef.current = false;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    return;
+                }
+
+                quoteInReply(quoteSelection.html);
+            }}
             onMouseDown={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
@@ -69,13 +162,18 @@ const QuoteReplyButton: React.FC<Props> = ({quoteSelection, quoteInReply}) => {
             onTouchEnd={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
-                quoteInReply();
             }}
             onTouchStart={(event) => {
+                event.preventDefault();
                 event.stopPropagation();
+                handledTouchRef.current = true;
+                suppressCompatibilityClick(event.currentTarget.ownerDocument, () => {
+                    handledTouchRef.current = false;
+                });
+                quoteInReply(quoteSelection.html);
             }}
         >
-            {t('Quote in reply')}
+            {isGutterButton ? <QuoteReplyIcon className="size-[18px]" aria-hidden /> : t('Quote in reply')}
         </button>
     );
 };

--- a/apps/comments-ui/src/components/content/buttons/reply-button.tsx
+++ b/apps/comments-ui/src/components/content/buttons/reply-button.tsx
@@ -1,5 +1,5 @@
 import ReplyIcon from '../../../images/icons/reply.svg?react';
-import {Comment, useAppContext} from '../../../app-context';
+import {Comment, useAppContext, useRequireMemberTier} from '../../../app-context';
 
 type Props = {
     comment: Comment;
@@ -9,18 +9,13 @@ type Props = {
 };
 
 const ReplyButton: React.FC<Props> = ({comment, disabled, isReplying, openReplyForm}) => {
-    const {t, dispatchAction, isMember, hasRequiredTier} = useAppContext();
-
-    const canReply = isMember && hasRequiredTier;
+    const {t} = useAppContext();
+    const ensureReplyAccess = useRequireMemberTier();
 
     const handleClick = () => {
-        if (!canReply) {
-            // Pass the comment id so the CTA's "Sign in" can ask Portal to return
-            // the reader to this comment after signing in (see cta-box).
-            dispatchAction('openPopup', {
-                type: 'ctaPopup',
-                commentId: comment.id
-            });
+        // Pass the comment id so the CTA's "Sign in" can return the reader to
+        // this comment after signing in (see cta-box).
+        if (!ensureReplyAccess(comment.id)) {
             return;
         }
         openReplyForm();

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -10,13 +10,22 @@ import ReplyButton from './buttons/reply-button';
 import ReplyForm from './forms/reply-form';
 import ThreadedReplies from './threaded-replies';
 import {Avatar, BlankAvatar} from './avatar';
-import {Comment, OpenCommentForm, useAppContext} from '../../app-context';
+import {Comment, OpenCommentForm, useAppContext, useRequireMemberTier} from '../../app-context';
 import {Transition} from '@headlessui/react';
 import {buildCommentPermalink, findCommentById, formatExplicitTime, getCommentInReplyToSnippet, getMemberNameFromComment} from '../../utils/helpers';
 import {useQuoteSelection} from './hooks/use-quote-selection';
 import {useRelativeTime} from '../../utils/hooks';
 
 type CommentLayoutVariant = 'root' | 'reply';
+
+// Monotonic token that makes each quote insertion's pendingQuote id unique, so
+// ReplyForm re-inserts on every quote action (it skips ids it has already
+// inserted). A counter is deterministic and collision-free, unlike a timestamp.
+let quoteInsertionToken = 0;
+function nextQuoteInsertionToken() {
+    quoteInsertionToken += 1;
+    return quoteInsertionToken;
+}
 
 type AnimatedCommentProps = {
     comment: Comment;
@@ -113,7 +122,8 @@ type PublishedCommentProps = CommentProps & {
     useThreading: boolean;
 }
 const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, parent, openEditMode, useThreading, layoutVariant = 'root', isLastSibling = false}) => {
-    const {dispatchAction, openCommentForms, isAdmin, commentIdToHighlight, commentIdFromHash, isMember, hasRequiredTier, isCommentingDisabled, member} = useAppContext();
+    const {dispatchAction, openCommentForms, isAdmin, commentIdToHighlight, commentIdFromHash, isCommentingDisabled, member} = useAppContext();
+    const ensureReplyAccess = useRequireMemberTier();
     const memberName = member?.name;
     const hasNestedReplies = React.Children.count(children) > 0;
 
@@ -142,17 +152,31 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
             parent_id: parent?.id,
             type: 'reply',
             hasUnsavedChanges: false,
+            // The id is a one-shot insertion token: ReplyForm inserts the quote
+            // exactly once per id, so it must change every time the user quotes
+            // again. A monotonic counter guarantees a fresh, collision-free id.
             pendingQuote: quoteHtml ? {
-                id: `${comment.id}-${Date.now()}`,
+                id: `${comment.id}-${nextQuoteInsertionToken()}`,
                 html: quoteHtml
             } : undefined,
             ...inReplyToDetails
         };
 
+        // Closing sibling reply forms happens here — once we're actually opening
+        // the quoted form — rather than in the quoteInReply click handler. That
+        // way, bailing out earlier (e.g. the member cancels the "add details"
+        // modal) never discards other open forms for nothing.
+        if (quoteHtml) {
+            dispatchAction('closeOtherReplyForms', comment.id);
+        }
+
         await dispatchAction('openCommentForm', newForm);
     }, [comment, parent, dispatchAction]);
 
     const openReplyForm = useCallback(async (quoteHtml?: string) => {
+        // Plain "Reply" toggles the form shut if it's already open for this
+        // comment. Quoting never toggles — it always (re)opens with the new
+        // quote, so the toggle branch is gated on there being no quoteHtml.
         if (!quoteHtml && openForm && openForm.id === comment.id) {
             dispatchAction('closeCommentForm', openForm.id);
         } else if (!memberName) {
@@ -175,16 +199,12 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
     }, [comment.id, dispatchAction, memberName, openForm, openReplyFormWithProfile]);
 
     const quoteInReply = useCallback((quoteHtml: string) => {
-        if (!isMember || !hasRequiredTier) {
-            dispatchAction('openPopup', {
-                type: 'ctaPopup'
-            });
+        if (!ensureReplyAccess()) {
             return;
         }
 
-        dispatchAction('closeOtherReplyForms', comment.id);
         openReplyForm(quoteHtml);
-    }, [comment.id, dispatchAction, hasRequiredTier, isMember, openReplyForm]);
+    }, [ensureReplyAccess, openReplyForm]);
 
     const canShowReplyAction = !isCommentingDisabled && !(isAdmin && comment.status === 'hidden');
     const hasChildReplies = hasNestedReplies || (comment.replies && comment.replies.length > 0);

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -484,10 +484,8 @@ type CommentBodyProps = {
 const CommentBody: React.FC<CommentBodyProps> = ({html, canQuoteInReply, className = '', isHighlighted, onQuoteInReply}) => {
     const {clearQuoteSelection, contentRef, getQuoteHtml, quoteSelection} = useQuoteSelection({disabled: !canQuoteInReply});
 
-    const quoteInReply = React.useCallback(() => {
-        // The quote HTML is serialized lazily from the live selection here, on
-        // click, rather than on every selection change (see use-quote-selection).
-        const quoteHtml = getQuoteHtml();
+    const quoteInReply = React.useCallback((quoteHtmlFromButton?: string) => {
+        const quoteHtml = quoteHtmlFromButton || getQuoteHtml();
 
         if (!quoteHtml) {
             return;

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -162,14 +162,6 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
             ...inReplyToDetails
         };
 
-        // Closing sibling reply forms happens here — once we're actually opening
-        // the quoted form — rather than in the quoteInReply click handler. That
-        // way, bailing out earlier (e.g. the member cancels the "add details"
-        // modal) never discards other open forms for nothing.
-        if (quoteHtml) {
-            dispatchAction('closeOtherReplyForms', comment.id);
-        }
-
         await dispatchAction('openCommentForm', newForm);
     }, [comment, parent, dispatchAction]);
 
@@ -198,12 +190,16 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
         }
     }, [comment.id, dispatchAction, memberName, openForm, openReplyFormWithProfile]);
 
+    // Returns whether the quote was acted on: when the tier gate bails into the
+    // CTA popup the caller keeps the selection (and the quote button) alive, so
+    // dismissing the popup doesn't force the visitor to re-select the text.
     const quoteInReply = useCallback((quoteHtml: string) => {
         if (!ensureReplyAccess()) {
-            return;
+            return false;
         }
 
         openReplyForm(quoteHtml);
+        return true;
     }, [ensureReplyAccess, openReplyForm]);
 
     const canShowReplyAction = !isCommentingDisabled && !(isAdmin && comment.status === 'hidden');
@@ -361,7 +357,10 @@ const ReplyFormBox: React.FC<ReplyFormBoxProps> = ({openForm, parent, useThreadi
     if (!useThreading) {
         return (
             <div className="my-8 sm:my-10">
-                <ReplyForm openForm={openForm} parent={parent} />
+                {/* Keyed so switching the form target (e.g. autoclose swapping in a
+                    form for a sibling reply rendered in this same slot) remounts the
+                    editor instead of reusing it with the previous form's content. */}
+                <ReplyForm key={openForm.id} openForm={openForm} parent={parent} />
             </div>
         );
     }
@@ -382,7 +381,7 @@ const ReplyFormBox: React.FC<ReplyFormBoxProps> = ({openForm, parent, useThreadi
                 data-testid="reply-form-elbow"
                 aria-hidden
             />
-            <ReplyForm openForm={openForm} parent={parent} threadedLayout={true} />
+            <ReplyForm key={openForm.id} openForm={openForm} parent={parent} threadedLayout={true} />
         </div>
     );
 };
@@ -479,24 +478,33 @@ type CommentBodyProps = {
     canQuoteInReply: boolean;
     className?: string;
     isHighlighted?: boolean;
-    onQuoteInReply: (quoteHtml: string) => void;
+    onQuoteInReply: (quoteHtml: string) => boolean;
 }
 
 const CommentBody: React.FC<CommentBodyProps> = ({html, canQuoteInReply, className = '', isHighlighted, onQuoteInReply}) => {
-    const {clearQuoteSelection, contentRef, quoteSelection} = useQuoteSelection({disabled: !canQuoteInReply});
+    const {clearQuoteSelection, contentRef, getQuoteHtml, quoteSelection} = useQuoteSelection({disabled: !canQuoteInReply});
 
     const quoteInReply = React.useCallback(() => {
-        if (!quoteSelection) {
+        // The quote HTML is serialized lazily from the live selection here, on
+        // click, rather than on every selection change (see use-quote-selection).
+        const quoteHtml = getQuoteHtml();
+
+        if (!quoteHtml) {
             return;
         }
 
-        onQuoteInReply(quoteSelection.html);
-        clearQuoteSelection();
-    }, [clearQuoteSelection, onQuoteInReply, quoteSelection]);
+        if (onQuoteInReply(quoteHtml)) {
+            clearQuoteSelection();
+        }
+    }, [clearQuoteSelection, getQuoteHtml, onQuoteInReply]);
 
-    let commentHtml = html;
+    // Memoized: this re-parses and re-serializes the whole comment body, and
+    // CommentBody re-renders on every quote-selection position change.
+    const commentHtml = React.useMemo(() => {
+        if (!isHighlighted) {
+            return html;
+        }
 
-    if (isHighlighted) {
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, 'text/html');
 
@@ -514,8 +522,8 @@ const CommentBody: React.FC<CommentBodyProps> = ({html, canQuoteInReply, classNa
         });
 
         // Serialize the modified html back to a string
-        commentHtml = doc.body.innerHTML;
-    }
+        return doc.body.innerHTML;
+    }, [html, isHighlighted]);
 
     const dangerouslySetInnerHTML = {__html: commentHtml};
 

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -3,6 +3,7 @@ import LikeButton, {DislikeButton} from './buttons/like-button';
 import LikeCount from './buttons/like-count';
 import MoreButton from './buttons/more-button';
 import PinnedLabel from './pinned-label';
+import QuoteReplyButton from './buttons/quote-reply-button';
 import React, {useCallback} from 'react';
 import Replies, {RepliesProps} from './replies';
 import ReplyButton from './buttons/reply-button';
@@ -12,6 +13,7 @@ import {Avatar, BlankAvatar} from './avatar';
 import {Comment, OpenCommentForm, useAppContext} from '../../app-context';
 import {Transition} from '@headlessui/react';
 import {buildCommentPermalink, findCommentById, formatExplicitTime, getCommentInReplyToSnippet, getMemberNameFromComment} from '../../utils/helpers';
+import {useQuoteSelection} from './hooks/use-quote-selection';
 import {useRelativeTime} from '../../utils/hooks';
 
 type CommentLayoutVariant = 'root' | 'reply';
@@ -111,7 +113,8 @@ type PublishedCommentProps = CommentProps & {
     useThreading: boolean;
 }
 const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, parent, openEditMode, useThreading, layoutVariant = 'root', isLastSibling = false}) => {
-    const {dispatchAction, openCommentForms, isAdmin, commentIdToHighlight, commentIdFromHash} = useAppContext();
+    const {dispatchAction, openCommentForms, isAdmin, commentIdToHighlight, commentIdFromHash, isMember, hasRequiredTier, isCommentingDisabled, member} = useAppContext();
+    const memberName = member?.name;
     const hasNestedReplies = React.Children.count(children) > 0;
 
     // Determine if the comment should be displayed with reduced opacity
@@ -126,29 +129,64 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
     // only highlight the reply button for the comment that is being replied to
     const highlightReplyButton = !!(openForm && openForm.id === comment.id);
 
-    const openReplyForm = useCallback(async () => {
-        if (openForm && openForm.id === comment.id) {
-            dispatchAction('closeCommentForm', openForm.id);
-        } else {
-            const inReplyToDetails: Partial<OpenCommentForm> = {};
+    const openReplyFormWithProfile = useCallback(async (quoteHtml?: string) => {
+        const inReplyToDetails: Partial<OpenCommentForm> = {};
 
-            if (parent) {
-                inReplyToDetails.in_reply_to_id = comment.id;
-                inReplyToDetails.in_reply_to_snippet = getCommentInReplyToSnippet(comment);
-            }
-
-            const newForm: OpenCommentForm = {
-                id: comment.id,
-                parent_id: parent?.id,
-                type: 'reply',
-                hasUnsavedChanges: false,
-                ...inReplyToDetails
-            };
-
-            await dispatchAction('openCommentForm', newForm);
+        if (parent) {
+            inReplyToDetails.in_reply_to_id = comment.id;
+            inReplyToDetails.in_reply_to_snippet = getCommentInReplyToSnippet(comment);
         }
-    }, [comment, parent, openForm, dispatchAction]);
 
+        const newForm: OpenCommentForm = {
+            id: comment.id,
+            parent_id: parent?.id,
+            type: 'reply',
+            hasUnsavedChanges: false,
+            pendingQuote: quoteHtml ? {
+                id: `${comment.id}-${Date.now()}`,
+                html: quoteHtml
+            } : undefined,
+            ...inReplyToDetails
+        };
+
+        await dispatchAction('openCommentForm', newForm);
+    }, [comment, parent, dispatchAction]);
+
+    const openReplyForm = useCallback(async (quoteHtml?: string) => {
+        if (!quoteHtml && openForm && openForm.id === comment.id) {
+            dispatchAction('closeCommentForm', openForm.id);
+        } else if (!memberName) {
+            dispatchAction('openPopup', {
+                type: 'addDetailsPopup',
+                expertiseAutofocus: false,
+                callback: function (succeeded: boolean) {
+                    if (!succeeded) {
+                        return;
+                    }
+
+                    // The callback runs before this component receives the updated
+                    // member details, so open the form directly after a successful save.
+                    void openReplyFormWithProfile(quoteHtml);
+                }
+            });
+        } else {
+            await openReplyFormWithProfile(quoteHtml);
+        }
+    }, [comment.id, dispatchAction, memberName, openForm, openReplyFormWithProfile]);
+
+    const quoteInReply = useCallback((quoteHtml: string) => {
+        if (!isMember || !hasRequiredTier) {
+            dispatchAction('openPopup', {
+                type: 'ctaPopup'
+            });
+            return;
+        }
+
+        dispatchAction('closeOtherReplyForms', comment.id);
+        openReplyForm(quoteHtml);
+    }, [comment.id, dispatchAction, hasRequiredTier, isMember, openReplyForm]);
+
+    const canShowReplyAction = !isCommentingDisabled && !(isAdmin && comment.status === 'hidden');
     const hasChildReplies = hasNestedReplies || (comment.replies && comment.replies.length > 0);
     const hasReplies = displayReplyForm || hasChildReplies;
     const avatar = (<Avatar member={comment.member} />);
@@ -178,7 +216,7 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
                 ) : (
                     <>
                         <CommentHeader className={hiddenClass} comment={comment} useThreading={useThreading} />
-                        <CommentBody className={hiddenClass} html={comment.html} isHighlighted={isHighlighted} />
+                        <CommentBody canQuoteInReply={canShowReplyAction} className={hiddenClass} html={comment.html} isHighlighted={isHighlighted} onQuoteInReply={quoteInReply} />
                         <CommentMenu
                             comment={comment}
                             highlightReplyButton={highlightReplyButton}
@@ -418,11 +456,24 @@ const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = '', u
 
 type CommentBodyProps = {
     html: string;
+    canQuoteInReply: boolean;
     className?: string;
     isHighlighted?: boolean;
+    onQuoteInReply: (quoteHtml: string) => void;
 }
 
-const CommentBody: React.FC<CommentBodyProps> = ({html, className = '', isHighlighted}) => {
+const CommentBody: React.FC<CommentBodyProps> = ({html, canQuoteInReply, className = '', isHighlighted, onQuoteInReply}) => {
+    const {clearQuoteSelection, contentRef, quoteSelection} = useQuoteSelection({disabled: !canQuoteInReply});
+
+    const quoteInReply = React.useCallback(() => {
+        if (!quoteSelection) {
+            return;
+        }
+
+        onQuoteInReply(quoteSelection.html);
+        clearQuoteSelection();
+    }, [clearQuoteSelection, onQuoteInReply, quoteSelection]);
+
     let commentHtml = html;
 
     if (isHighlighted) {
@@ -450,7 +501,10 @@ const CommentBody: React.FC<CommentBodyProps> = ({html, className = '', isHighli
 
     return (
         <div className={`mt mb-2 flex flex-row items-center gap-4 pr-4 ${className}`}>
-            <div dangerouslySetInnerHTML={dangerouslySetInnerHTML} className="gh-comment-content -mx-1 text-pretty rounded-md px-1 font-sans text-md leading-normal text-neutral-900 [overflow-wrap:anywhere] dark:text-white/85 sm:text-lg" data-testid="comment-content"/>
+            <div dangerouslySetInnerHTML={dangerouslySetInnerHTML} ref={contentRef} className="gh-comment-content -mx-1 text-pretty rounded-md px-1 font-sans text-md leading-normal text-neutral-900 [overflow-wrap:anywhere] dark:text-white/85 sm:text-lg" data-testid="comment-content"/>
+            {quoteSelection && (
+                <QuoteReplyButton quoteInReply={quoteInReply} quoteSelection={quoteSelection} />
+            )}
         </div>
     );
 };

--- a/apps/comments-ui/src/components/content/forms/form.tsx
+++ b/apps/comments-ui/src/components/content/forms/form.tsx
@@ -35,8 +35,6 @@ export const FormEditor: React.FC<FormEditorProps> = ({comment, submit, progress
 
                 if (comment && openForm.type === 'edit') {
                     hasUnsavedChanges = editor.getHTML() !== comment.html;
-                } else if (openForm.initialHtml !== undefined) {
-                    hasUnsavedChanges = editor.getHTML() !== openForm.initialHtml;
                 }
 
                 // avoid unnecessary state updates to prevent infinite loops

--- a/apps/comments-ui/src/components/content/forms/form.tsx
+++ b/apps/comments-ui/src/components/content/forms/form.tsx
@@ -31,9 +31,13 @@ export const FormEditor: React.FC<FormEditorProps> = ({comment, submit, progress
     useEffect(() => {
         if (editor && openForm) {
             const checkContent = () => {
-                const hasUnsavedChanges = comment && openForm.type === 'edit' ?
-                    editor.getHTML() !== comment.html :
-                    !editor.isEmpty;
+                let hasUnsavedChanges = !editor.isEmpty;
+
+                if (comment && openForm.type === 'edit') {
+                    hasUnsavedChanges = editor.getHTML() !== comment.html;
+                } else if (openForm.initialHtml !== undefined) {
+                    hasUnsavedChanges = editor.getHTML() !== openForm.initialHtml;
+                }
 
                 // avoid unnecessary state updates to prevent infinite loops
                 if (openForm.hasUnsavedChanges !== hasUnsavedChanges) {

--- a/apps/comments-ui/src/components/content/forms/reply-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/reply-form.tsx
@@ -1,6 +1,7 @@
 import {Comment, OpenCommentForm, useAppContext} from '../../../app-context';
 import {Editor} from '@tiptap/react';
 import {Form, FormWrapper} from './form';
+import {Fragment, DOMParser as ProseMirrorDOMParser, Slice} from '@tiptap/pm/model';
 import {TextSelection} from '@tiptap/pm/state';
 import {isMobile, scrollToElement} from '../../../utils/helpers';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
@@ -13,40 +14,27 @@ type Props = {
     threadedLayout?: boolean;
 }
 
-function findCursorMarkerPosition(editor: Editor, marker: string) {
-    let markerPosition: number | null = null;
+function createQuoteNode(editor: Editor, quoteHtml: string) {
+    const ownerDocument = editor.view.dom.ownerDocument;
+    const container = ownerDocument.createElement('div');
+    container.innerHTML = quoteHtml;
 
-    editor.state.doc.descendants((node, position) => {
-        if (markerPosition !== null) {
-            return false;
-        }
-
-        if (node.isText) {
-            const markerIndex = node.text?.indexOf(marker) ?? -1;
-
-            if (markerIndex > -1) {
-                markerPosition = position + markerIndex;
-                return false;
-            }
-        }
-
-        return true;
-    });
-
-    return markerPosition;
+    const content = ProseMirrorDOMParser.fromSchema(editor.schema).parseSlice(container, {preserveWhitespace: 'full'}).content;
+    return editor.schema.nodes.blockquote.create(null, content);
 }
 
-function removeCursorMarker(editor: Editor, marker: string) {
-    const markerPosition = findCursorMarkerPosition(editor, marker);
+function insertQuote(editor: Editor, quoteHtml: string) {
+    const quoteNode = createQuoteNode(editor, quoteHtml);
+    const paragraphNode = editor.schema.nodes.paragraph.create();
+    const insertPosition = editor.state.selection.from;
+    const quoteContent = new Slice(Fragment.fromArray([quoteNode, paragraphNode]), 0, 0);
+    const transaction = editor.state.tr.replaceSelection(quoteContent);
+    const cursorPosition = insertPosition + quoteNode.nodeSize + 1;
 
-    if (markerPosition === null) {
-        return null;
-    }
-    const transaction = editor.state.tr.delete(markerPosition, markerPosition + marker.length);
-    transaction.setSelection(TextSelection.create(transaction.doc, markerPosition));
+    transaction.setSelection(TextSelection.create(transaction.doc, cursorPosition));
     editor.view.dispatch(transaction);
 
-    return markerPosition;
+    return cursorPosition;
 }
 
 const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) => {
@@ -56,7 +44,12 @@ const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) 
 
     const config = useMemo(() => ({
         placeholder: t('Reply to comment'),
-        autofocus: true
+        // TipTap's autofocus fires from a setTimeout after editor creation and
+        // rewrites the editor selection into the DOM. For a quote-initiated form
+        // the insertion effect below already focuses synchronously, so the
+        // delayed autofocus would only race the user's next text selection and
+        // steal it. Plain reply forms keep autofocus.
+        autofocus: !openForm.pendingQuote
     }), []);
 
     const {editor} = useEditor(config);
@@ -67,17 +60,44 @@ const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) 
         }
 
         insertedQuoteId.current = openForm.pendingQuote.id;
-        const cursorMarker = `GHOST_QUOTE_CURSOR_${openForm.pendingQuote.id}`;
         const ownerWindow = editor.view.dom.ownerDocument.defaultView || window;
+        // Whether the form was empty *before* we insert the quote. Only an
+        // otherwise-empty form may have its unsaved-changes baseline reset to the
+        // quote: if the user already has a draft (e.g. they typed, then quoted a
+        // second snippet), folding that draft into the baseline would mark it
+        // "saved" and make it eligible for silent auto-close — losing their text.
+        const wasEmpty = editor.isEmpty;
 
-        editor.chain().focus().insertContent(`<blockquote>${openForm.pendingQuote.html}</blockquote><p>${cursorMarker}</p>`).run();
-        const cursorPosition = removeCursorMarker(editor, cursorMarker);
+        editor.commands.focus();
+        const cursorPosition = insertQuote(editor, openForm.pendingQuote.html);
+
+        if (wasEmpty) {
+            // Record the post-insertion HTML as the form's baseline so the
+            // auto-inserted quote alone is not treated as an unsaved change (see
+            // form.tsx checkContent). The form only becomes "dirty" once the user
+            // types beyond the quote, which is what keeps it from being auto-closed.
+            dispatchAction('setCommentFormInitialHtml', {id: openForm.id, initialHtml: editor.getHTML()});
+        }
 
         // TipTap can resolve selection backwards from the inserted blockquote.
         // Reapply the exact trailing paragraph cursor position after focus settles.
-        ownerWindow.requestAnimationFrame(() => {
-            ownerWindow.setTimeout(() => {
-                if (editor.isDestroyed || cursorPosition === null) {
+        let timeoutId: number | null = null;
+        const frameId = ownerWindow.requestAnimationFrame(() => {
+            timeoutId = ownerWindow.setTimeout(() => {
+                // Bail if the editor was torn down, or if the user edited the doc
+                // down to before our target position (re-applying a stale,
+                // out-of-range position makes TextSelection.create throw).
+                if (editor.isDestroyed || cursorPosition > editor.state.doc.content.size) {
+                    return;
+                }
+
+                // Bail if the document selection has left the editor in the
+                // meantime (e.g. the user is already selecting their next quote):
+                // the editor selection IS the document selection, so reapplying
+                // would steal that in-progress selection.
+                const domSelection = editor.view.dom.ownerDocument.getSelection();
+
+                if (domSelection?.anchorNode && !editor.view.dom.contains(domSelection.anchorNode)) {
                     return;
                 }
 
@@ -87,7 +107,17 @@ const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) 
                 editor.view.focus();
             }, 0);
         });
-    }, [editor, openForm.pendingQuote]);
+
+        // Cancel the deferred cursor placement if the form unmounts or the quote
+        // changes before it runs, so it can't fire against a stale/destroyed editor.
+        return () => {
+            ownerWindow.cancelAnimationFrame(frameId);
+
+            if (timeoutId !== null) {
+                ownerWindow.clearTimeout(timeoutId);
+            }
+        };
+    }, [dispatchAction, editor, openForm.id, openForm.pendingQuote]);
 
     const submit = useCallback(async ({html}) => {
         // Send comment to server

--- a/apps/comments-ui/src/components/content/forms/reply-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/reply-form.tsx
@@ -14,19 +14,44 @@ type Props = {
 const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) => {
     const {postId, dispatchAction, t} = useAppContext();
     const [, setForm] = useRefCallback<HTMLDivElement>(scrollToElement);
-    const insertedQuoteId = useRef<string | null>(null);
+
+    // The quote present when the form first opens is seeded as the editor's
+    // initial content (below) rather than inserted after mount. Inserting post-
+    // mount races the editor's async creation on mobile — the form opens but the
+    // quote is dropped, forcing a second tap. Seeding makes it part of the
+    // document at creation, so it's there in a single action. Captured once via
+    // a ref so re-renders don't change it.
+    const initialQuote = useRef(openForm.pendingQuote);
+    // The seeded quote counts as already inserted; the effect below only handles
+    // subsequent re-quotes into an already-open (already-mounted) editor.
+    const insertedQuoteId = useRef<string | null>(initialQuote.current?.id ?? null);
 
     const config = useMemo(() => ({
         placeholder: t('Reply to comment'),
+        // Seed the opening quote as initial content so it exists at editor
+        // creation (see initialQuote above). Empty for plain reply forms.
+        content: initialQuote.current ? `<blockquote>${initialQuote.current.html}</blockquote><p></p>` : '',
         // TipTap's autofocus fires from a setTimeout after editor creation and
-        // rewrites the editor selection into the DOM. For a quote-initiated form
-        // the insertion effect below already focuses synchronously, so the
-        // delayed autofocus would only race the user's next text selection and
-        // steal it. Plain reply forms keep autofocus.
+        // rewrites the editor selection into the DOM, racing (and stealing) a
+        // text selection the user makes right after a quote form opens. Quote
+        // forms focus via the effect below instead; plain reply forms keep
+        // autofocus. (On iOS neither raises the keyboard — the editor is created
+        // after the tap's gesture window closes — but desktop focuses either way.)
         autofocus: !openForm.pendingQuote
     }), []);
 
     const {editor} = useEditor(config);
+
+    useEffect(() => {
+        // Focus after a seeded quote (cursor in the trailing paragraph) once the
+        // editor exists. A direct focus() avoids TipTap autofocus's deferred
+        // selection-steal; autofocus is disabled for quote forms above.
+        if (!editor || !initialQuote.current) {
+            return;
+        }
+
+        editor.commands.focus('end');
+    }, [editor]);
 
     useEffect(() => {
         if (!editor || !openForm.pendingQuote || insertedQuoteId.current === openForm.pendingQuote.id) {
@@ -35,11 +60,11 @@ const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) 
 
         insertedQuoteId.current = openForm.pendingQuote.id;
 
-        // insertContent parses against the editor schema (with the editor's
-        // preserveWhitespace: 'full' parse options), replaces the empty paragraph
-        // in place when the form is empty, and leaves the cursor in the trailing
-        // paragraph. The inserted quote counts as content, so the form reports
-        // unsaved changes (see form.tsx checkContent) and is never auto-closed.
+        // Re-quoting into an already-open form: the editor already exists, so
+        // inserting here is race-free (the first quote is seeded as initial
+        // content above). insertContent parses against the editor schema, leaves
+        // the cursor in the trailing paragraph, and counts as content so the form
+        // reports unsaved changes (see form.tsx checkContent) and isn't auto-closed.
         editor.chain()
             .focus()
             .insertContent(`<blockquote>${openForm.pendingQuote.html}</blockquote><p></p>`)

--- a/apps/comments-ui/src/components/content/forms/reply-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/reply-form.tsx
@@ -1,7 +1,9 @@
 import {Comment, OpenCommentForm, useAppContext} from '../../../app-context';
+import {Editor} from '@tiptap/react';
 import {Form, FormWrapper} from './form';
+import {TextSelection} from '@tiptap/pm/state';
 import {isMobile, scrollToElement} from '../../../utils/helpers';
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useEditor} from '../../../utils/hooks';
 import {useRefCallback} from '../../../utils/hooks';
 
@@ -11,9 +13,46 @@ type Props = {
     threadedLayout?: boolean;
 }
 
+function findCursorMarkerPosition(editor: Editor, marker: string) {
+    let markerPosition: number | null = null;
+
+    editor.state.doc.descendants((node, position) => {
+        if (markerPosition !== null) {
+            return false;
+        }
+
+        if (node.isText) {
+            const markerIndex = node.text?.indexOf(marker) ?? -1;
+
+            if (markerIndex > -1) {
+                markerPosition = position + markerIndex;
+                return false;
+            }
+        }
+
+        return true;
+    });
+
+    return markerPosition;
+}
+
+function removeCursorMarker(editor: Editor, marker: string) {
+    const markerPosition = findCursorMarkerPosition(editor, marker);
+
+    if (markerPosition === null) {
+        return null;
+    }
+    const transaction = editor.state.tr.delete(markerPosition, markerPosition + marker.length);
+    transaction.setSelection(TextSelection.create(transaction.doc, markerPosition));
+    editor.view.dispatch(transaction);
+
+    return markerPosition;
+}
+
 const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) => {
     const {postId, dispatchAction, t} = useAppContext();
     const [, setForm] = useRefCallback<HTMLDivElement>(scrollToElement);
+    const insertedQuoteId = useRef<string | null>(null);
 
     const config = useMemo(() => ({
         placeholder: t('Reply to comment'),
@@ -21,6 +60,34 @@ const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) 
     }), []);
 
     const {editor} = useEditor(config);
+
+    useEffect(() => {
+        if (!editor || !openForm.pendingQuote || insertedQuoteId.current === openForm.pendingQuote.id) {
+            return;
+        }
+
+        insertedQuoteId.current = openForm.pendingQuote.id;
+        const cursorMarker = `GHOST_QUOTE_CURSOR_${openForm.pendingQuote.id}`;
+        const ownerWindow = editor.view.dom.ownerDocument.defaultView || window;
+
+        editor.chain().focus().insertContent(`<blockquote>${openForm.pendingQuote.html}</blockquote><p>${cursorMarker}</p>`).run();
+        const cursorPosition = removeCursorMarker(editor, cursorMarker);
+
+        // TipTap can resolve selection backwards from the inserted blockquote.
+        // Reapply the exact trailing paragraph cursor position after focus settles.
+        ownerWindow.requestAnimationFrame(() => {
+            ownerWindow.setTimeout(() => {
+                if (editor.isDestroyed || cursorPosition === null) {
+                    return;
+                }
+
+                editor.view.dispatch(
+                    editor.state.tr.setSelection(TextSelection.create(editor.state.doc, cursorPosition))
+                );
+                editor.view.focus();
+            }, 0);
+        });
+    }, [editor, openForm.pendingQuote]);
 
     const submit = useCallback(async ({html}) => {
         // Send comment to server

--- a/apps/comments-ui/src/components/content/forms/reply-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/reply-form.tsx
@@ -1,8 +1,5 @@
 import {Comment, OpenCommentForm, useAppContext} from '../../../app-context';
-import {Editor} from '@tiptap/react';
 import {Form, FormWrapper} from './form';
-import {Fragment, DOMParser as ProseMirrorDOMParser, Slice} from '@tiptap/pm/model';
-import {TextSelection} from '@tiptap/pm/state';
 import {isMobile, scrollToElement} from '../../../utils/helpers';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useEditor} from '../../../utils/hooks';
@@ -12,29 +9,6 @@ type Props = {
     openForm: OpenCommentForm;
     parent: Comment;
     threadedLayout?: boolean;
-}
-
-function createQuoteNode(editor: Editor, quoteHtml: string) {
-    const ownerDocument = editor.view.dom.ownerDocument;
-    const container = ownerDocument.createElement('div');
-    container.innerHTML = quoteHtml;
-
-    const content = ProseMirrorDOMParser.fromSchema(editor.schema).parseSlice(container, {preserveWhitespace: 'full'}).content;
-    return editor.schema.nodes.blockquote.create(null, content);
-}
-
-function insertQuote(editor: Editor, quoteHtml: string) {
-    const quoteNode = createQuoteNode(editor, quoteHtml);
-    const paragraphNode = editor.schema.nodes.paragraph.create();
-    const insertPosition = editor.state.selection.from;
-    const quoteContent = new Slice(Fragment.fromArray([quoteNode, paragraphNode]), 0, 0);
-    const transaction = editor.state.tr.replaceSelection(quoteContent);
-    const cursorPosition = insertPosition + quoteNode.nodeSize + 1;
-
-    transaction.setSelection(TextSelection.create(transaction.doc, cursorPosition));
-    editor.view.dispatch(transaction);
-
-    return cursorPosition;
 }
 
 const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) => {
@@ -60,64 +34,17 @@ const ReplyForm: React.FC<Props> = ({openForm, parent, threadedLayout = false}) 
         }
 
         insertedQuoteId.current = openForm.pendingQuote.id;
-        const ownerWindow = editor.view.dom.ownerDocument.defaultView || window;
-        // Whether the form was empty *before* we insert the quote. Only an
-        // otherwise-empty form may have its unsaved-changes baseline reset to the
-        // quote: if the user already has a draft (e.g. they typed, then quoted a
-        // second snippet), folding that draft into the baseline would mark it
-        // "saved" and make it eligible for silent auto-close — losing their text.
-        const wasEmpty = editor.isEmpty;
 
-        editor.commands.focus();
-        const cursorPosition = insertQuote(editor, openForm.pendingQuote.html);
-
-        if (wasEmpty) {
-            // Record the post-insertion HTML as the form's baseline so the
-            // auto-inserted quote alone is not treated as an unsaved change (see
-            // form.tsx checkContent). The form only becomes "dirty" once the user
-            // types beyond the quote, which is what keeps it from being auto-closed.
-            dispatchAction('setCommentFormInitialHtml', {id: openForm.id, initialHtml: editor.getHTML()});
-        }
-
-        // TipTap can resolve selection backwards from the inserted blockquote.
-        // Reapply the exact trailing paragraph cursor position after focus settles.
-        let timeoutId: number | null = null;
-        const frameId = ownerWindow.requestAnimationFrame(() => {
-            timeoutId = ownerWindow.setTimeout(() => {
-                // Bail if the editor was torn down, or if the user edited the doc
-                // down to before our target position (re-applying a stale,
-                // out-of-range position makes TextSelection.create throw).
-                if (editor.isDestroyed || cursorPosition > editor.state.doc.content.size) {
-                    return;
-                }
-
-                // Bail if the document selection has left the editor in the
-                // meantime (e.g. the user is already selecting their next quote):
-                // the editor selection IS the document selection, so reapplying
-                // would steal that in-progress selection.
-                const domSelection = editor.view.dom.ownerDocument.getSelection();
-
-                if (domSelection?.anchorNode && !editor.view.dom.contains(domSelection.anchorNode)) {
-                    return;
-                }
-
-                editor.view.dispatch(
-                    editor.state.tr.setSelection(TextSelection.create(editor.state.doc, cursorPosition))
-                );
-                editor.view.focus();
-            }, 0);
-        });
-
-        // Cancel the deferred cursor placement if the form unmounts or the quote
-        // changes before it runs, so it can't fire against a stale/destroyed editor.
-        return () => {
-            ownerWindow.cancelAnimationFrame(frameId);
-
-            if (timeoutId !== null) {
-                ownerWindow.clearTimeout(timeoutId);
-            }
-        };
-    }, [dispatchAction, editor, openForm.id, openForm.pendingQuote]);
+        // insertContent parses against the editor schema (with the editor's
+        // preserveWhitespace: 'full' parse options), replaces the empty paragraph
+        // in place when the form is empty, and leaves the cursor in the trailing
+        // paragraph. The inserted quote counts as content, so the form reports
+        // unsaved changes (see form.tsx checkContent) and is never auto-closed.
+        editor.chain()
+            .focus()
+            .insertContent(`<blockquote>${openForm.pendingQuote.html}</blockquote><p></p>`)
+            .run();
+    }, [editor, openForm.pendingQuote]);
 
     const submit = useCallback(async ({html}) => {
         // Send comment to server

--- a/apps/comments-ui/src/components/content/hooks/use-quote-selection.ts
+++ b/apps/comments-ui/src/components/content/hooks/use-quote-selection.ts
@@ -1,0 +1,254 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+export type QuoteSelection = {
+    html: string;
+    left: number;
+    top: number;
+};
+
+type QuoteSelectionEntry = {
+    clear: () => void;
+    contentElement: HTMLDivElement;
+    update: () => void;
+};
+
+function getNodeElement(node: Node) {
+    return node.nodeType === Node.ELEMENT_NODE ? node as Element : node.parentElement;
+}
+
+function isBlockElement(node: Node) {
+    return node.nodeType === Node.ELEMENT_NODE && ['BLOCKQUOTE', 'P'].includes((node as Element).tagName);
+}
+
+function appendNormalizedSelectionNode(output: HTMLDivElement, node: Node, inlineWrapper: {current: HTMLParagraphElement | null}) {
+    if (isBlockElement(node)) {
+        inlineWrapper.current = null;
+        output.appendChild(node);
+        return;
+    }
+
+    if (node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()) {
+        return;
+    }
+
+    if (!inlineWrapper.current) {
+        inlineWrapper.current = output.ownerDocument.createElement('p');
+        output.appendChild(inlineWrapper.current);
+    }
+
+    inlineWrapper.current.appendChild(node);
+}
+
+function getSelectionHtml(range: Range) {
+    const ownerDocument = range.startContainer.ownerDocument || document;
+    const container = ownerDocument.createElement('div');
+    container.appendChild(range.cloneContents());
+
+    const output = ownerDocument.createElement('div');
+    const inlineWrapper = {current: null as HTMLParagraphElement | null};
+
+    Array.from(container.childNodes).forEach((node) => {
+        appendNormalizedSelectionNode(output, node, inlineWrapper);
+    });
+
+    return output.innerHTML.trim();
+}
+
+function getEntryForSelection(entries: Set<QuoteSelectionEntry>, ownerDocument: Document) {
+    const selection = ownerDocument.getSelection();
+
+    if (!selection || selection.isCollapsed || selection.rangeCount !== 1 || !selection.toString().trim()) {
+        return null;
+    }
+
+    const range = selection.getRangeAt(0);
+    const startElement = getNodeElement(range.startContainer);
+    const endElement = getNodeElement(range.endContainer);
+
+    if (!startElement || !endElement) {
+        return null;
+    }
+
+    return Array.from(entries).find(({contentElement}) => (
+        contentElement.contains(startElement) && contentElement.contains(endElement)
+    )) ?? null;
+}
+
+function isRangeInsideElement(range: Range, element: Element) {
+    const startElement = getNodeElement(range.startContainer);
+    const endElement = getNodeElement(range.endContainer);
+
+    return !!startElement && !!endElement && element.contains(startElement) && element.contains(endElement);
+}
+
+function createQuoteSelectionManager(ownerDocument: Document) {
+    const ownerWindow = ownerDocument.defaultView || window;
+    const entries = new Set<QuoteSelectionEntry>();
+    let activeEntry: QuoteSelectionEntry | null = null;
+
+    const clearActiveEntry = () => {
+        activeEntry?.clear();
+        activeEntry = null;
+    };
+
+    const updateActiveEntry = () => {
+        const nextActiveEntry = getEntryForSelection(entries, ownerDocument);
+
+        if (!nextActiveEntry) {
+            clearActiveEntry();
+            return;
+        }
+
+        if (activeEntry && activeEntry !== nextActiveEntry) {
+            activeEntry.clear();
+        }
+
+        activeEntry = nextActiveEntry;
+        activeEntry.update();
+    };
+
+    const updateAfterSelectionSettles = () => {
+        ownerWindow.setTimeout(updateActiveEntry, 0);
+    };
+
+    ownerDocument.addEventListener('selectionchange', updateActiveEntry);
+    ownerDocument.addEventListener('mouseup', updateAfterSelectionSettles);
+    ownerDocument.addEventListener('touchend', updateAfterSelectionSettles);
+    ownerWindow.addEventListener('resize', clearActiveEntry);
+    ownerWindow.addEventListener('scroll', clearActiveEntry, true);
+
+    return {
+        register(entry: QuoteSelectionEntry) {
+            entries.add(entry);
+        },
+
+        unregister(entry: QuoteSelectionEntry) {
+            entries.delete(entry);
+
+            if (activeEntry === entry) {
+                activeEntry = null;
+            }
+        },
+
+        isEmpty() {
+            return entries.size === 0;
+        },
+
+        destroy() {
+            ownerDocument.removeEventListener('selectionchange', updateActiveEntry);
+            ownerDocument.removeEventListener('mouseup', updateAfterSelectionSettles);
+            ownerDocument.removeEventListener('touchend', updateAfterSelectionSettles);
+            ownerWindow.removeEventListener('resize', clearActiveEntry);
+            ownerWindow.removeEventListener('scroll', clearActiveEntry, true);
+        }
+    };
+}
+
+const quoteSelectionManagers = new WeakMap<Document, ReturnType<typeof createQuoteSelectionManager>>();
+
+function getQuoteSelectionManager(ownerDocument: Document) {
+    const existingManager = quoteSelectionManagers.get(ownerDocument);
+
+    if (existingManager) {
+        return existingManager;
+    }
+
+    const manager = createQuoteSelectionManager(ownerDocument);
+    quoteSelectionManagers.set(ownerDocument, manager);
+    return manager;
+}
+
+export function useQuoteSelection({disabled}: {disabled: boolean}) {
+    const contentRef = useRef<HTMLDivElement | null>(null);
+    const [quoteSelection, setQuoteSelection] = useState<QuoteSelection | null>(null);
+
+    const clearQuoteSelection = useCallback(() => {
+        setQuoteSelection(null);
+    }, []);
+
+    const updateQuoteSelection = useCallback(() => {
+        const contentElement = contentRef.current;
+
+        if (!contentElement || disabled) {
+            clearQuoteSelection();
+            return;
+        }
+
+        const ownerDocument = contentElement.ownerDocument;
+        const selection = ownerDocument.getSelection();
+
+        if (!selection || selection.isCollapsed || selection.rangeCount !== 1 || !selection.toString().trim()) {
+            clearQuoteSelection();
+            return;
+        }
+
+        const range = selection.getRangeAt(0);
+
+        if (!isRangeInsideElement(range, contentElement)) {
+            clearQuoteSelection();
+            return;
+        }
+
+        const quoteHtml = getSelectionHtml(range);
+
+        if (!quoteHtml) {
+            clearQuoteSelection();
+            return;
+        }
+
+        let rect = range.getBoundingClientRect();
+
+        if (rect.width === 0 && rect.height === 0) {
+            rect = range.getClientRects()[0];
+        }
+
+        if (!rect) {
+            clearQuoteSelection();
+            return;
+        }
+
+        setQuoteSelection({
+            html: quoteHtml,
+            left: rect.left + (rect.width / 2),
+            top: rect.top - 8
+        });
+    }, [clearQuoteSelection, disabled]);
+
+    useEffect(() => {
+        const contentElement = contentRef.current;
+
+        if (!contentElement) {
+            return;
+        }
+
+        if (disabled) {
+            clearQuoteSelection();
+            return;
+        }
+
+        const ownerDocument = contentElement.ownerDocument;
+        const manager = getQuoteSelectionManager(ownerDocument);
+        const entry: QuoteSelectionEntry = {
+            clear: clearQuoteSelection,
+            contentElement,
+            update: updateQuoteSelection
+        };
+
+        manager.register(entry);
+
+        return () => {
+            manager.unregister(entry);
+
+            if (manager.isEmpty()) {
+                manager.destroy();
+                quoteSelectionManagers.delete(ownerDocument);
+            }
+        };
+    }, [clearQuoteSelection, disabled, updateQuoteSelection]);
+
+    return {
+        clearQuoteSelection,
+        contentRef,
+        quoteSelection
+    };
+}

--- a/apps/comments-ui/src/components/content/hooks/use-quote-selection.ts
+++ b/apps/comments-ui/src/components/content/hooks/use-quote-selection.ts
@@ -1,8 +1,11 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 export type QuoteSelection = {
+    html: string;
     left: number;
+    textLeft: number;
     top: number;
+    centerTop: number;
 };
 
 type QuoteSelectionEntry = {
@@ -194,6 +197,7 @@ function getQuoteSelectionManager(ownerDocument: Document) {
 
 export function useQuoteSelection({disabled}: {disabled: boolean}) {
     const contentRef = useRef<HTMLDivElement | null>(null);
+    const quoteHtmlRef = useRef<string | null>(null);
     const [quoteSelection, setQuoteSelection] = useState<QuoteSelection | null>(null);
 
     const clearQuoteSelection = useCallback(() => {
@@ -201,8 +205,8 @@ export function useQuoteSelection({disabled}: {disabled: boolean}) {
     }, []);
 
     // Runs on every selection/scroll event while a selection is active, so it
-    // only reads the selection rect. Serializing the selected HTML is deferred
-    // to getQuoteHtml (called once, on button click).
+    // only reads the selection rect and caches the selected HTML for mobile
+    // browsers that clear the live selection while the quote button is tapped.
     const updateQuoteSelection = useCallback((range: Range) => {
         const contentElement = contentRef.current;
 
@@ -222,20 +226,32 @@ export function useQuoteSelection({disabled}: {disabled: boolean}) {
             return;
         }
 
+        const quoteHtml = getSelectionHtml(range) || null;
+
+        if (!quoteHtml) {
+            clearQuoteSelection();
+            return;
+        }
+
+        quoteHtmlRef.current = quoteHtml;
+
         const left = rect.left + (rect.width / 2);
+        const textLeft = rect.left;
         const top = rect.top - 8;
+        const centerTop = rect.top + (rect.height / 2);
 
         // Keep the previous object when the position is unchanged so React can
         // bail out of re-rendering the comment body.
         setQuoteSelection(previous => (
-            previous && previous.left === left && previous.top === top
+            previous && previous.html === quoteHtml && previous.left === left && previous.textLeft === textLeft && previous.top === top && previous.centerTop === centerTop
                 ? previous
-                : {left, top}
+                : {centerTop, html: quoteHtml, left, textLeft, top}
         ));
     }, [clearQuoteSelection, disabled]);
 
-    // Serializes the current selection into normalized quote HTML. Returns null
-    // when there is no valid selection inside this comment body.
+    // Serializes the current selection into normalized quote HTML. Falls back
+    // to the last valid quote HTML because mobile browsers can clear the live
+    // selection before the quote button's touch handler runs.
     const getQuoteHtml = useCallback(() => {
         const contentElement = contentRef.current;
 
@@ -245,17 +261,17 @@ export function useQuoteSelection({disabled}: {disabled: boolean}) {
 
         const selection = contentElement.ownerDocument.getSelection();
 
-        if (!selection || selection.isCollapsed || selection.rangeCount !== 1 || !selection.toString().trim()) {
-            return null;
+        if (selection && !selection.isCollapsed && selection.rangeCount === 1 && selection.toString().trim()) {
+            const range = selection.getRangeAt(0);
+
+            if (isRangeInsideElement(range, contentElement)) {
+                const quoteHtml = getSelectionHtml(range) || null;
+                quoteHtmlRef.current = quoteHtml;
+                return quoteHtml;
+            }
         }
 
-        const range = selection.getRangeAt(0);
-
-        if (!isRangeInsideElement(range, contentElement)) {
-            return null;
-        }
-
-        return getSelectionHtml(range) || null;
+        return quoteHtmlRef.current;
     }, [disabled]);
 
     useEffect(() => {

--- a/apps/comments-ui/src/components/content/hooks/use-quote-selection.ts
+++ b/apps/comments-ui/src/components/content/hooks/use-quote-selection.ts
@@ -1,7 +1,6 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 export type QuoteSelection = {
-    html: string;
     left: number;
     top: number;
 };
@@ -9,7 +8,7 @@ export type QuoteSelection = {
 type QuoteSelectionEntry = {
     clear: () => void;
     contentElement: HTMLDivElement;
-    update: () => void;
+    update: (range: Range) => void;
 };
 
 function getNodeElement(node: Node) {
@@ -36,7 +35,10 @@ function appendNormalizedSelectionNode(output: HTMLDivElement, node: Node, inlin
         return;
     }
 
-    if (node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()) {
+    // Drop whitespace-only text nodes between blocks (e.g. the newline between
+    // two <p>s), but keep them while an inline wrapper is open: the space
+    // between two adjacent inline elements (<a>x</a> <a>y</a>) is significant.
+    if (node.nodeType === Node.TEXT_NODE && !node.textContent?.trim() && !inlineWrapper.current) {
         return;
     }
 
@@ -78,9 +80,11 @@ function getEntryForSelection(entries: Set<QuoteSelectionEntry>, ownerDocument: 
         return null;
     }
 
-    return Array.from(entries).find(({contentElement}) => (
+    const entry = Array.from(entries).find(({contentElement}) => (
         contentElement.contains(startElement) && contentElement.contains(endElement)
-    )) ?? null;
+    ));
+
+    return entry ? {entry, range} : null;
 }
 
 function isRangeInsideElement(range: Range, element: Element) {
@@ -106,23 +110,33 @@ function createQuoteSelectionManager(ownerDocument: Document) {
     };
 
     const updateActiveEntry = () => {
-        const nextActiveEntry = getEntryForSelection(entries, ownerDocument);
+        const match = getEntryForSelection(entries, ownerDocument);
 
-        if (!nextActiveEntry) {
+        if (!match) {
             clearActiveEntry();
             return;
         }
 
-        if (activeEntry && activeEntry !== nextActiveEntry) {
+        if (activeEntry && activeEntry !== match.entry) {
             activeEntry.clear();
         }
 
-        activeEntry = nextActiveEntry;
-        activeEntry.update();
+        activeEntry = match.entry;
+        activeEntry.update(match.range);
     };
 
     const updateAfterSelectionSettles = () => {
         ownerWindow.setTimeout(updateActiveEntry, 0);
+    };
+
+    // Scrolling/resizing can move an existing selection but never create one, so
+    // skip the selection validation and entry scan entirely while no button is up.
+    const repositionActiveEntry = () => {
+        if (!activeEntry) {
+            return;
+        }
+
+        updateActiveEntry();
     };
 
     ownerDocument.addEventListener('selectionchange', updateActiveEntry);
@@ -134,8 +148,8 @@ function createQuoteSelectionManager(ownerDocument: Document) {
     // programmatically (focus, scrollIntoView) right around the moments users
     // make selections, which would permanently hide the button since the
     // selection itself never re-fires selectionchange.
-    ownerWindow.addEventListener('resize', updateActiveEntry);
-    ownerWindow.addEventListener('scroll', updateActiveEntry, true);
+    ownerWindow.addEventListener('resize', repositionActiveEntry);
+    ownerWindow.addEventListener('scroll', repositionActiveEntry, true);
 
     return {
         register(entry: QuoteSelectionEntry) {
@@ -158,8 +172,8 @@ function createQuoteSelectionManager(ownerDocument: Document) {
             ownerDocument.removeEventListener('selectionchange', updateActiveEntry);
             ownerDocument.removeEventListener('mouseup', updateAfterSelectionSettles);
             ownerDocument.removeEventListener('touchend', updateAfterSelectionSettles);
-            ownerWindow.removeEventListener('resize', updateActiveEntry);
-            ownerWindow.removeEventListener('scroll', updateActiveEntry, true);
+            ownerWindow.removeEventListener('resize', repositionActiveEntry);
+            ownerWindow.removeEventListener('scroll', repositionActiveEntry, true);
         }
     };
 }
@@ -186,32 +200,13 @@ export function useQuoteSelection({disabled}: {disabled: boolean}) {
         setQuoteSelection(null);
     }, []);
 
-    const updateQuoteSelection = useCallback(() => {
+    // Runs on every selection/scroll event while a selection is active, so it
+    // only reads the selection rect. Serializing the selected HTML is deferred
+    // to getQuoteHtml (called once, on button click).
+    const updateQuoteSelection = useCallback((range: Range) => {
         const contentElement = contentRef.current;
 
         if (!contentElement || disabled) {
-            clearQuoteSelection();
-            return;
-        }
-
-        const ownerDocument = contentElement.ownerDocument;
-        const selection = ownerDocument.getSelection();
-
-        if (!selection || selection.isCollapsed || selection.rangeCount !== 1 || !selection.toString().trim()) {
-            clearQuoteSelection();
-            return;
-        }
-
-        const range = selection.getRangeAt(0);
-
-        if (!isRangeInsideElement(range, contentElement)) {
-            clearQuoteSelection();
-            return;
-        }
-
-        const quoteHtml = getSelectionHtml(range);
-
-        if (!quoteHtml) {
             clearQuoteSelection();
             return;
         }
@@ -227,12 +222,41 @@ export function useQuoteSelection({disabled}: {disabled: boolean}) {
             return;
         }
 
-        setQuoteSelection({
-            html: quoteHtml,
-            left: rect.left + (rect.width / 2),
-            top: rect.top - 8
-        });
+        const left = rect.left + (rect.width / 2);
+        const top = rect.top - 8;
+
+        // Keep the previous object when the position is unchanged so React can
+        // bail out of re-rendering the comment body.
+        setQuoteSelection(previous => (
+            previous && previous.left === left && previous.top === top
+                ? previous
+                : {left, top}
+        ));
     }, [clearQuoteSelection, disabled]);
+
+    // Serializes the current selection into normalized quote HTML. Returns null
+    // when there is no valid selection inside this comment body.
+    const getQuoteHtml = useCallback(() => {
+        const contentElement = contentRef.current;
+
+        if (!contentElement || disabled) {
+            return null;
+        }
+
+        const selection = contentElement.ownerDocument.getSelection();
+
+        if (!selection || selection.isCollapsed || selection.rangeCount !== 1 || !selection.toString().trim()) {
+            return null;
+        }
+
+        const range = selection.getRangeAt(0);
+
+        if (!isRangeInsideElement(range, contentElement)) {
+            return null;
+        }
+
+        return getSelectionHtml(range) || null;
+    }, [disabled]);
 
     useEffect(() => {
         const contentElement = contentRef.current;
@@ -269,6 +293,7 @@ export function useQuoteSelection({disabled}: {disabled: boolean}) {
     return {
         clearQuoteSelection,
         contentRef,
+        getQuoteHtml,
         quoteSelection
     };
 }

--- a/apps/comments-ui/src/components/content/hooks/use-quote-selection.ts
+++ b/apps/comments-ui/src/components/content/hooks/use-quote-selection.ts
@@ -16,10 +16,19 @@ function getNodeElement(node: Node) {
     return node.nodeType === Node.ELEMENT_NODE ? node as Element : node.parentElement;
 }
 
+// NOTE: only <p> and <blockquote> are treated as block-level here. Any other
+// block the comment HTML might contain (lists, headings, <pre>, ...) falls
+// through to the inline branch below and gets wrapped in a <p>, which can
+// produce invalid markup. Kept narrow on the assumption comment bodies only
+// ever contain these two block types — revisit if that schema widens.
 function isBlockElement(node: Node) {
     return node.nodeType === Node.ELEMENT_NODE && ['BLOCKQUOTE', 'P'].includes((node as Element).tagName);
 }
 
+// Normalises a raw selection fragment into clean block-level HTML: loose inline
+// nodes (text, <a>, <strong>, ...) are collected into a shared <p> wrapper while
+// existing blocks are passed through untouched. This guarantees the reply
+// editor's ProseMirror schema can parse the quote as a valid blockquote body.
 function appendNormalizedSelectionNode(output: HTMLDivElement, node: Node, inlineWrapper: {current: HTMLParagraphElement | null}) {
     if (isBlockElement(node)) {
         inlineWrapper.current = null;
@@ -81,6 +90,11 @@ function isRangeInsideElement(range: Range, element: Element) {
     return !!startElement && !!endElement && element.contains(startElement) && element.contains(endElement);
 }
 
+// A single manager per document owns the global selection listeners and tracks
+// every mounted comment body as an "entry". Centralising here (rather than one
+// set of document listeners per comment) keeps listener count flat regardless of
+// thread size and lets us enforce a single active quote button across all
+// comments — and reject selections that span more than one comment body.
 function createQuoteSelectionManager(ownerDocument: Document) {
     const ownerWindow = ownerDocument.defaultView || window;
     const entries = new Set<QuoteSelectionEntry>();
@@ -114,8 +128,14 @@ function createQuoteSelectionManager(ownerDocument: Document) {
     ownerDocument.addEventListener('selectionchange', updateActiveEntry);
     ownerDocument.addEventListener('mouseup', updateAfterSelectionSettles);
     ownerDocument.addEventListener('touchend', updateAfterSelectionSettles);
-    ownerWindow.addEventListener('resize', clearActiveEntry);
-    ownerWindow.addEventListener('scroll', clearActiveEntry, true);
+    // Reposition (rather than dismiss) on scroll/resize: the button is fixed-
+    // positioned from the selection's viewport rect, so it has to track the
+    // selection as it moves. Dismissing would also be fragile — browsers scroll
+    // programmatically (focus, scrollIntoView) right around the moments users
+    // make selections, which would permanently hide the button since the
+    // selection itself never re-fires selectionchange.
+    ownerWindow.addEventListener('resize', updateActiveEntry);
+    ownerWindow.addEventListener('scroll', updateActiveEntry, true);
 
     return {
         register(entry: QuoteSelectionEntry) {
@@ -138,8 +158,8 @@ function createQuoteSelectionManager(ownerDocument: Document) {
             ownerDocument.removeEventListener('selectionchange', updateActiveEntry);
             ownerDocument.removeEventListener('mouseup', updateAfterSelectionSettles);
             ownerDocument.removeEventListener('touchend', updateAfterSelectionSettles);
-            ownerWindow.removeEventListener('resize', clearActiveEntry);
-            ownerWindow.removeEventListener('scroll', clearActiveEntry, true);
+            ownerWindow.removeEventListener('resize', updateActiveEntry);
+            ownerWindow.removeEventListener('scroll', updateActiveEntry, true);
         }
     };
 }

--- a/apps/comments-ui/src/components/popups/close-button.tsx
+++ b/apps/comments-ui/src/components/popups/close-button.tsx
@@ -6,7 +6,7 @@ type Props = {
 }
 const CloseButton: React.FC<Props> = ({close}) => {
     return (
-        <button className="absolute right-6 top-5 opacity-30 transition-opacity duration-100 ease-out hover:opacity-40 sm:right-8 sm:top-9" type="button" onClick={close}>
+        <button className="absolute right-6 top-5 opacity-30 transition-opacity duration-100 ease-out hover:opacity-40 sm:right-8 sm:top-9" data-testid="close-popup-button" type="button" onClick={close}>
             <CloseIcon className="size-5 p-1 pr-0" />
         </button>
     );

--- a/apps/comments-ui/src/images/icons/quote-reply.svg
+++ b/apps/comments-ui/src/images/icons/quote-reply.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 14a2 2 0 0 0 2-2V8h-2"/>
+  <path d="M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z"/>
+  <path d="M8 14a2 2 0 0 0 2-2V8H8"/>
+</svg>

--- a/apps/comments-ui/test/e2e/actions.test.ts
+++ b/apps/comments-ui/test/e2e/actions.test.ts
@@ -567,14 +567,21 @@ test.describe('Actions', async () => {
         const replyButton = parentComment.getByTestId('reply-button');
         await replyButton.click();
 
-        // Wait for reply form to appear
+        const detailsFrame = page.frameLocator('iframe[title="addDetailsPopup"]');
+        await expect(detailsFrame.getByTestId('profile-modal')).toBeVisible();
+        await expect(frame.getByTestId('reply-form')).toHaveCount(0);
+
+        await detailsFrame.getByTestId('name-input').fill('Replying Member');
+        await detailsFrame.getByTestId('save-button').click();
+
+        // Wait for reply form to appear after details are saved
         const replyForm = frame.getByTestId('reply-form');
         await expect(replyForm).toBeVisible();
 
-        // The reply form should NOT show the parent comment author's name
-        // It should either show nothing, "Anonymous", or prompt for a name
-        // but definitely NOT "Named Author"
+        // The reply form should show the logged-in member's saved name,
+        // not the parent comment author's name
         const memberName = replyForm.getByTestId('member-name');
+        await expect(memberName).toHaveText('Replying Member');
         await expect(memberName).not.toHaveText('Named Author');
     });
 

--- a/apps/comments-ui/test/e2e/quote-reply.test.ts
+++ b/apps/comments-ui/test/e2e/quote-reply.test.ts
@@ -49,6 +49,7 @@ test.describe('Quote replies', async () => {
         await expect(editor.locator('blockquote')).toHaveText('comment 1');
         await editor.type('Reply text');
         await replyForm.getByTestId('submit-form-button').click();
+        await expect.poll(() => mockedApi.comments[0].replies.length).toBe(1);
 
         expect(mockedApi.comments[0].replies).toHaveLength(1);
         expect(mockedApi.comments[0].replies[0].html).toBe('<blockquote><p>comment 1</p></blockquote><p>Reply text</p>');
@@ -74,7 +75,7 @@ test.describe('Quote replies', async () => {
         await expect(detailsFrame.getByTestId('profile-modal')).toBeVisible();
         await expect(frame.getByTestId('reply-form')).toHaveCount(0);
 
-        await detailsFrame.locator('button').last().click();
+        await detailsFrame.getByTestId('close-popup-button').click();
         await expect(detailsFrame.getByTestId('profile-modal')).not.toBeVisible();
         await expect(frame.getByTestId('reply-form')).toHaveCount(0);
 
@@ -140,6 +141,79 @@ test.describe('Quote replies', async () => {
         await expect(frame.getByTestId('reply-form').getByText('comment 2')).toBeVisible();
     });
 
+    test('keeps an existing quoted reply form with unsaved changes when quoting a different comment', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const firstComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 1'});
+        await selectText(firstComment.getByTestId('comment-content'), /comment 1/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        const firstReplyForm = frame.getByTestId('reply-form');
+        const firstEditor = firstReplyForm.getByTestId('form-editor');
+        await waitEditorFocused(firstEditor);
+        await firstEditor.type('Draft reply');
+        await expect(firstReplyForm).toContainText('Draft reply');
+
+        const secondComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 2'});
+        await selectText(secondComment.getByTestId('comment-content'), /comment 2/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        await expect(frame.getByTestId('reply-form')).toHaveCount(2);
+        await expect(frame.getByTestId('reply-form').filter({hasText: 'Draft reply'})).toHaveCount(1);
+        await expect(frame.getByTestId('reply-form').filter({hasText: 'comment 2'})).toHaveCount(1);
+    });
+
+    test('keeps an in-progress draft when re-quoting the same comment, then quoting another', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const firstComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 1'});
+        await selectText(firstComment.getByTestId('comment-content'), /comment 1/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        const firstReplyForm = frame.getByTestId('reply-form');
+        const firstEditor = firstReplyForm.getByTestId('form-editor');
+        await waitEditorFocused(firstEditor);
+        await firstEditor.type('Draft reply');
+        await expect(firstReplyForm).toContainText('Draft reply');
+
+        // Re-quote the same comment after typing: the second quote must not fold
+        // the draft into the "saved" baseline (which previously discarded it).
+        await selectText(firstComment.getByTestId('comment-content'), /comment 1/);
+        await frame.getByTestId('quote-reply-button').click();
+        await expect(firstReplyForm).toContainText('Draft reply');
+
+        // Quoting a different comment now keeps the still-dirty first form open
+        // rather than silently auto-closing it and losing the draft.
+        const secondComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 2'});
+        await selectText(secondComment.getByTestId('comment-content'), /comment 2/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        await expect(frame.getByTestId('reply-form')).toHaveCount(2);
+        await expect(frame.getByTestId('reply-form').filter({hasText: 'Draft reply'})).toHaveCount(1);
+    });
+
     test('preserves selected inline HTML when quoting', async ({page}) => {
         mockedApi.addComment({
             html: '<p>This is <a href="https://example.com">linked text</a>.</p>'
@@ -160,9 +234,13 @@ test.describe('Quote replies', async () => {
         await waitEditorFocused(editor);
         await editor.type('Reply text');
         await replyForm.getByTestId('submit-form-button').click();
+        await expect.poll(() => mockedApi.comments[0].replies.length).toBe(1);
 
-        expect(mockedApi.comments[0].replies[0].html).toContain('<blockquote><p><a target="_blank" rel="noopener noreferrer nofollow" href="https://example.com">linked text</a></p></blockquote>');
-        expect(mockedApi.comments[0].replies[0].html).toContain('<p>Reply text</p>');
+        // Assert the structure (link preserved inside the quoted blockquote) without
+        // pinning the exact serialized attribute order, which TipTap controls.
+        const replyHtml = mockedApi.comments[0].replies[0].html;
+        expect(replyHtml).toMatch(/<blockquote><p><a [^>]*href="https:\/\/example\.com"[^>]*>linked text<\/a><\/p><\/blockquote>/);
+        expect(replyHtml).toContain('<p>Reply text</p>');
     });
 
     test('does not show the quote action for selections spanning comments', async ({page}) => {
@@ -247,6 +325,7 @@ test.describe('Quote replies', async () => {
         await waitEditorFocused(editor);
         await editor.type('Replying to nested');
         await replyForm.getByTestId('submit-form-button').click();
+        await expect.poll(() => mockedApi.comments[0].replies.length).toBe(2);
 
         const newReply = mockedApi.comments[0].replies[1];
         expect(newReply.parent_id).toBe('parent-comment');

--- a/apps/comments-ui/test/e2e/quote-reply.test.ts
+++ b/apps/comments-ui/test/e2e/quote-reply.test.ts
@@ -1,13 +1,11 @@
 import {Locator, expect, test} from '@playwright/test';
-import {MOCKED_SITE_URL, MockedApi, initialize, mockAdminAuthFrame, selectText, waitEditorFocused} from '../utils/e2e';
+import {MockedApi, initialize, selectText, waitEditorFocused} from '../utils/e2e';
 import {buildReply} from '../utils/fixtures';
 
-const admin = MOCKED_SITE_URL + '/ghost/';
-
-async function selectElementContents(locator: Locator) {
+async function selectElement(locator: Locator) {
     await locator.evaluate((element) => {
         const range = element.ownerDocument.createRange();
-        range.selectNodeContents(element);
+        range.selectNode(element);
 
         const selection = element.ownerDocument.getSelection();
         selection?.removeAllRanges();
@@ -154,7 +152,7 @@ test.describe('Quote replies', async () => {
         });
 
         const comment = frame.getByTestId('comment-component').nth(0);
-        await selectElementContents(comment.getByTestId('comment-content').locator('a'));
+        await selectElement(comment.getByTestId('comment-content').locator('a'));
         await frame.getByTestId('quote-reply-button').click();
 
         const replyForm = frame.getByTestId('reply-form');
@@ -198,23 +196,24 @@ test.describe('Quote replies', async () => {
     });
 
     test('does not show the quote action when the reply action is hidden', async ({page}) => {
-        mockedApi.addComment({
-            html: '<p>Hidden comment text</p>',
-            status: 'hidden'
+        mockedApi.setMember({
+            name: 'Disabled Member',
+            can_comment: false
         });
-        await mockAdminAuthFrame({page, admin});
+        mockedApi.addComment({
+            html: '<p>Visible comment text</p>'
+        });
 
         const {frame} = await initialize({
             mockedApi,
             page,
-            publication: 'Publisher Weekly',
-            admin
+            publication: 'Publisher Weekly'
         });
 
-        const hiddenComment = frame.getByTestId('comment-component').filter({hasText: 'Hidden comment text'});
-        await expect(hiddenComment.getByTestId('reply-button')).toHaveCount(0);
+        const comment = frame.getByTestId('comment-component').filter({hasText: 'Visible comment text'});
+        await expect(comment.getByTestId('reply-button')).toHaveCount(0);
 
-        await selectText(hiddenComment.getByTestId('comment-content'), /Hidden comment/);
+        await selectText(comment.getByTestId('comment-content'), /Visible comment/);
         await expect(frame.getByTestId('quote-reply-button')).toHaveCount(0);
     });
 

--- a/apps/comments-ui/test/e2e/quote-reply.test.ts
+++ b/apps/comments-ui/test/e2e/quote-reply.test.ts
@@ -1,0 +1,257 @@
+import {Locator, expect, test} from '@playwright/test';
+import {MOCKED_SITE_URL, MockedApi, initialize, mockAdminAuthFrame, selectText, waitEditorFocused} from '../utils/e2e';
+import {buildReply} from '../utils/fixtures';
+
+const admin = MOCKED_SITE_URL + '/ghost/';
+
+async function selectElementContents(locator: Locator) {
+    await locator.evaluate((element) => {
+        const range = element.ownerDocument.createRange();
+        range.selectNodeContents(element);
+
+        const selection = element.ownerDocument.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+    });
+}
+
+test.describe('Quote replies', async () => {
+    let mockedApi: MockedApi;
+
+    test.beforeEach(async () => {
+        mockedApi = new MockedApi({});
+        mockedApi.setMember({
+            name: 'John Doe',
+            expertise: 'Software development'
+        });
+    });
+
+    test('quotes selected comment text into a reply', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const comment = frame.getByTestId('comment-component').nth(0);
+        await selectText(comment.getByTestId('comment-content'), /comment 1/);
+
+        const quoteButton = frame.getByTestId('quote-reply-button');
+        await expect(quoteButton).toBeVisible();
+        await quoteButton.click();
+
+        const replyForm = frame.getByTestId('reply-form');
+        const editor = replyForm.getByTestId('form-editor');
+        await waitEditorFocused(editor);
+
+        await expect(editor.locator('blockquote')).toHaveText('comment 1');
+        await editor.type('Reply text');
+        await replyForm.getByTestId('submit-form-button').click();
+
+        expect(mockedApi.comments[0].replies).toHaveLength(1);
+        expect(mockedApi.comments[0].replies[0].html).toBe('<blockquote><p>comment 1</p></blockquote><p>Reply text</p>');
+    });
+
+    test('opens the profile modal before opening a quoted reply when quoting without a name', async ({page}) => {
+        mockedApi.setMember({name: null, expertise: 'Software development'});
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const comment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 1'});
+        await selectText(comment.getByTestId('comment-content'), /comment 1/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        const detailsFrame = page.frameLocator('iframe[title="addDetailsPopup"]');
+        await expect(detailsFrame.getByTestId('profile-modal')).toBeVisible();
+        await expect(frame.getByTestId('reply-form')).toHaveCount(0);
+
+        await detailsFrame.locator('button').last().click();
+        await expect(detailsFrame.getByTestId('profile-modal')).not.toBeVisible();
+        await expect(frame.getByTestId('reply-form')).toHaveCount(0);
+
+        await selectText(comment.getByTestId('comment-content'), /comment 1/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        await detailsFrame.getByTestId('name-input').fill('John Doe');
+        await detailsFrame.getByTestId('save-button').click();
+
+        const replyForm = frame.getByTestId('reply-form');
+        await expect(replyForm).toBeVisible();
+        await expect(replyForm.getByTestId('form-editor').locator('blockquote')).toHaveText('comment 1');
+    });
+
+    test('uses inverse colors in dark mode', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly',
+            colorScheme: 'dark'
+        });
+
+        const comment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 1'});
+        await selectText(comment.getByTestId('comment-content'), /comment 1/);
+
+        const quoteButton = frame.getByTestId('quote-reply-button');
+        await expect(quoteButton).toBeVisible();
+        await expect(quoteButton).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+        await expect(quoteButton).toHaveCSS('color', 'rgb(23, 23, 23)');
+    });
+
+    test('closes an existing quoted reply form when quoting a different comment', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const firstComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 1'});
+        await selectText(firstComment.getByTestId('comment-content'), /comment 1/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        await expect(frame.getByTestId('reply-form')).toHaveCount(1);
+        await expect(frame.getByTestId('reply-form').getByText('comment 1')).toBeVisible();
+
+        const secondComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 2'});
+        await selectText(secondComment.getByTestId('comment-content'), /comment 2/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        await expect(frame.getByTestId('reply-form')).toHaveCount(1);
+        await expect(frame.getByTestId('reply-form').getByText('comment 1')).not.toBeVisible();
+        await expect(frame.getByTestId('reply-form').getByText('comment 2')).toBeVisible();
+    });
+
+    test('preserves selected inline HTML when quoting', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is <a href="https://example.com">linked text</a>.</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const comment = frame.getByTestId('comment-component').nth(0);
+        await selectElementContents(comment.getByTestId('comment-content').locator('a'));
+        await frame.getByTestId('quote-reply-button').click();
+
+        const replyForm = frame.getByTestId('reply-form');
+        const editor = replyForm.getByTestId('form-editor');
+        await waitEditorFocused(editor);
+        await editor.type('Reply text');
+        await replyForm.getByTestId('submit-form-button').click();
+
+        expect(mockedApi.comments[0].replies[0].html).toContain('<blockquote><p><a target="_blank" rel="noopener noreferrer nofollow" href="https://example.com">linked text</a></p></blockquote>');
+        expect(mockedApi.comments[0].replies[0].html).toContain('<p>Reply text</p>');
+    });
+
+    test('does not show the quote action for selections spanning comments', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        await frame.getByTestId('comment-content').nth(0).evaluate((firstComment) => {
+            const secondComment = firstComment.ownerDocument.querySelectorAll('[data-testid="comment-content"]')[1];
+            const firstText = firstComment.querySelector('p')!.firstChild!;
+            const secondText = secondComment.querySelector('p')!.firstChild!;
+            const range = firstComment.ownerDocument.createRange();
+            range.setStart(firstText, 8);
+            range.setEnd(secondText, 8);
+
+            const selection = firstComment.ownerDocument.getSelection();
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+        });
+
+        await expect(frame.getByTestId('quote-reply-button')).toHaveCount(0);
+    });
+
+    test('does not show the quote action when the reply action is hidden', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>Hidden comment text</p>',
+            status: 'hidden'
+        });
+        await mockAdminAuthFrame({page, admin});
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly',
+            admin
+        });
+
+        const hiddenComment = frame.getByTestId('comment-component').filter({hasText: 'Hidden comment text'});
+        await expect(hiddenComment.getByTestId('reply-button')).toHaveCount(0);
+
+        await selectText(hiddenComment.getByTestId('comment-content'), /Hidden comment/);
+        await expect(frame.getByTestId('quote-reply-button')).toHaveCount(0);
+    });
+
+    test('quotes nested replies using the same target as Reply', async ({page}) => {
+        mockedApi.addComment({
+            id: 'parent-comment',
+            html: '<p>Parent comment</p>',
+            replies: [
+                buildReply({
+                    id: 'nested-reply',
+                    html: '<p>Nested reply text</p>'
+                })
+            ]
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly',
+            labs: {
+                commentsThreads: true
+            }
+        });
+
+        const nestedReply = frame.getByTestId('comment-component').nth(1);
+        await selectText(nestedReply.getByTestId('comment-content'), /Nested reply/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        const replyForm = frame.getByTestId('reply-form');
+        const editor = replyForm.getByTestId('form-editor');
+        await waitEditorFocused(editor);
+        await editor.type('Replying to nested');
+        await replyForm.getByTestId('submit-form-button').click();
+
+        const newReply = mockedApi.comments[0].replies[1];
+        expect(newReply.parent_id).toBe('parent-comment');
+        expect(newReply.in_reply_to_id).toBe('nested-reply');
+        expect(newReply.html).toBe('<blockquote><p>Nested reply</p></blockquote><p>Replying to nested</p>');
+    });
+});

--- a/apps/comments-ui/test/e2e/quote-reply.test.ts
+++ b/apps/comments-ui/test/e2e/quote-reply.test.ts
@@ -55,6 +55,71 @@ test.describe('Quote replies', async () => {
         expect(mockedApi.comments[0].replies[0].html).toBe('<blockquote><p>comment 1</p></blockquote><p>Reply text</p>');
     });
 
+    test('shows the quote action as a left gutter icon button on mobile', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is mobile comment 1</p>'
+        });
+
+        const {frame} = await initialize({
+            bodyStyle: 'margin:0',
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        await page.setViewportSize({width: 390, height: 700});
+
+        const comment = frame.getByTestId('comment-component').nth(0);
+        await selectText(comment.getByTestId('comment-content'), /comment 1/);
+
+        const quoteButton = frame.getByTestId('quote-reply-button');
+        await expect(quoteButton).toBeVisible();
+        await expect(quoteButton).toHaveAttribute('data-placement', 'gutter');
+
+        const selectionRect = await comment.getByTestId('comment-content').evaluate(() => {
+            const range = document.getSelection()?.getRangeAt(0);
+            const rect = range?.getBoundingClientRect();
+
+            return rect ? {
+                bottom: rect.bottom,
+                left: rect.left,
+                top: rect.top
+            } : null;
+        });
+        const buttonRect = await quoteButton.evaluate((button) => {
+            const rect = button.getBoundingClientRect();
+            return {
+                height: rect.height,
+                left: rect.left,
+                right: rect.right,
+                top: rect.top,
+                width: rect.width
+            };
+        });
+
+        expect(selectionRect).not.toBeNull();
+        expect(Math.round(buttonRect.width)).toBe(32);
+        expect(Math.round(buttonRect.height)).toBe(32);
+        expect(Math.round(buttonRect.left)).toBeGreaterThanOrEqual(0);
+        expect(Math.round(buttonRect.right)).toBeLessThanOrEqual(Math.round(selectionRect!.left));
+        expect(Math.round(buttonRect.top + (buttonRect.height / 2))).toBe(Math.round((selectionRect!.top + selectionRect!.bottom) / 2));
+
+        await quoteButton.evaluate((button) => {
+            button.addEventListener('touchstart', () => {
+                document.getSelection()?.removeAllRanges();
+            }, {capture: true, once: true});
+        });
+        await quoteButton.dispatchEvent('touchstart', {
+            changedTouches: [],
+            targetTouches: [],
+            touches: []
+        });
+
+        const editor = frame.getByTestId('reply-form').getByTestId('form-editor');
+        await waitEditorFocused(editor);
+        await expect(editor.locator('blockquote')).toHaveText('comment 1');
+    });
+
     test('opens the profile modal before opening a quoted reply when quoting without a name', async ({page}) => {
         mockedApi.setMember({name: null, expertise: 'Software development'});
         mockedApi.addComment({

--- a/apps/comments-ui/test/e2e/quote-reply.test.ts
+++ b/apps/comments-ui/test/e2e/quote-reply.test.ts
@@ -1,5 +1,5 @@
 import {Locator, expect, test} from '@playwright/test';
-import {MockedApi, initialize, selectText, waitEditorFocused} from '../utils/e2e';
+import {MockedApi, getEditorModifierKey, initialize, selectText, waitEditorFocused} from '../utils/e2e';
 import {buildReply} from '../utils/fixtures';
 
 async function selectElement(locator: Locator) {
@@ -111,7 +111,7 @@ test.describe('Quote replies', async () => {
         await expect(quoteButton).toHaveCSS('color', 'rgb(23, 23, 23)');
     });
 
-    test('closes an existing quoted reply form when quoting a different comment', async ({page}) => {
+    test('keeps an existing quoted reply form open when quoting a different comment', async ({page}) => {
         mockedApi.addComment({
             html: '<p>This is comment 1</p>'
         });
@@ -132,12 +132,78 @@ test.describe('Quote replies', async () => {
         await expect(frame.getByTestId('reply-form')).toHaveCount(1);
         await expect(frame.getByTestId('reply-form').getByText('comment 1')).toBeVisible();
 
+        // A quoted form contains content the user explicitly created, so it
+        // counts as having unsaved changes and is never silently auto-closed.
+        const secondComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 2'});
+        await selectText(secondComment.getByTestId('comment-content'), /comment 2/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        await expect(frame.getByTestId('reply-form')).toHaveCount(2);
+        await expect(frame.getByTestId('reply-form').getByText('comment 1')).toBeVisible();
+        await expect(frame.getByTestId('reply-form').getByText('comment 2')).toBeVisible();
+    });
+
+    test('keeps a quoted reply form open when replying to a different comment', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const firstComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 1'});
+        await selectText(firstComment.getByTestId('comment-content'), /comment 1/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        await expect(frame.getByTestId('reply-form')).toHaveCount(1);
+        await expect(frame.getByTestId('reply-form').getByText('comment 1')).toBeVisible();
+
+        // Opening a plain reply elsewhere must not destroy the visible quote.
+        const secondComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 2'});
+        await secondComment.getByTestId('reply-button').click();
+
+        await expect(frame.getByTestId('reply-form')).toHaveCount(2);
+        await expect(frame.getByTestId('reply-form').getByText('comment 1')).toBeVisible();
+    });
+
+    test('auto-closes a quoted reply form once it has been emptied', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const firstComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 1'});
+        await selectText(firstComment.getByTestId('comment-content'), /comment 1/);
+        await frame.getByTestId('quote-reply-button').click();
+
+        const firstEditor = frame.getByTestId('reply-form').getByTestId('form-editor');
+        await waitEditorFocused(firstEditor);
+        // Use the editor's own select-all binding (Mod-a) rather than the
+        // browser-native one, which handles the blockquote boundary unreliably.
+        await firstEditor.press(`${getEditorModifierKey()}+KeyA`);
+        await firstEditor.press('Backspace');
+
+        // An emptied form has no content worth preserving, so quoting elsewhere
+        // tidies it away like any other empty form.
         const secondComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 2'});
         await selectText(secondComment.getByTestId('comment-content'), /comment 2/);
         await frame.getByTestId('quote-reply-button').click();
 
         await expect(frame.getByTestId('reply-form')).toHaveCount(1);
-        await expect(frame.getByTestId('reply-form').getByText('comment 1')).not.toBeVisible();
         await expect(frame.getByTestId('reply-form').getByText('comment 2')).toBeVisible();
     });
 
@@ -198,14 +264,14 @@ test.describe('Quote replies', async () => {
         await firstEditor.type('Draft reply');
         await expect(firstReplyForm).toContainText('Draft reply');
 
-        // Re-quote the same comment after typing: the second quote must not fold
-        // the draft into the "saved" baseline (which previously discarded it).
+        // Re-quote the same comment after typing: the draft must survive the
+        // second insertion.
         await selectText(firstComment.getByTestId('comment-content'), /comment 1/);
         await frame.getByTestId('quote-reply-button').click();
         await expect(firstReplyForm).toContainText('Draft reply');
 
-        // Quoting a different comment now keeps the still-dirty first form open
-        // rather than silently auto-closing it and losing the draft.
+        // Quoting a different comment keeps the first form open rather than
+        // silently auto-closing it and losing the draft.
         const secondComment = frame.getByTestId('comment-component').filter({hasText: 'This is comment 2'});
         await selectText(secondComment.getByTestId('comment-content'), /comment 2/);
         await frame.getByTestId('quote-reply-button').click();
@@ -241,6 +307,44 @@ test.describe('Quote replies', async () => {
         const replyHtml = mockedApi.comments[0].replies[0].html;
         expect(replyHtml).toMatch(/<blockquote><p><a [^>]*href="https:\/\/example\.com"[^>]*>linked text<\/a><\/p><\/blockquote>/);
         expect(replyHtml).toContain('<p>Reply text</p>');
+    });
+
+    test('preserves whitespace between adjacent inline elements when quoting', async ({page}) => {
+        mockedApi.addComment({
+            html: '<p>See <a href="https://a.example">first link</a> <a href="https://b.example">second link</a></p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        // Select from inside the first link through the second link, so the
+        // whitespace-only text node between them sits at the top level of the
+        // cloned selection fragment.
+        await frame.getByTestId('comment-content').nth(0).evaluate((element) => {
+            const links = element.querySelectorAll('a');
+            const range = element.ownerDocument.createRange();
+            range.setStart(links[0].firstChild!, 0);
+            range.setEnd(links[1].firstChild!, links[1].firstChild!.textContent!.length);
+
+            const selection = element.ownerDocument.getSelection();
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+        });
+
+        const replyForm = frame.getByTestId('reply-form');
+        await frame.getByTestId('quote-reply-button').click();
+        const editor = replyForm.getByTestId('form-editor');
+        await waitEditorFocused(editor);
+        await editor.type('Reply text');
+        await replyForm.getByTestId('submit-form-button').click();
+        await expect.poll(() => mockedApi.comments[0].replies.length).toBe(1);
+
+        // The space between the two links must survive into the quote.
+        const replyHtml = mockedApi.comments[0].replies[0].html;
+        expect(replyHtml).toMatch(/first link<\/a> <a [^>]*>second link/);
     });
 
     test('does not show the quote action for selections spanning comments', async ({page}) => {

--- a/apps/comments-ui/test/utils/e2e.ts
+++ b/apps/comments-ui/test/utils/e2e.ts
@@ -190,6 +190,18 @@ export async function initialize({mockedApi, page, bodyStyle, labs = {}, key = '
 export async function selectText(locator: Locator, pattern: string | RegExp): Promise<void> {
     await locator.evaluate(
         (element, {pattern: p}) => {
+            // A real text selection starts with a pointer-down, which blurs any
+            // focused element outside the selection target (e.g. an open reply
+            // editor). Mirror that here: a still-focused ProseMirror editor
+            // re-asserts its own DOM selection and would wipe this one. Note:
+            // duck-typed because instanceof HTMLElement is unreliable across
+            // the evaluate/iframe realm boundary.
+            const activeElement = element.ownerDocument.activeElement as HTMLElement | null;
+
+            if (activeElement && typeof activeElement.blur === 'function' && !activeElement.contains(element)) {
+                activeElement.blur();
+            }
+
             let textNode = element.childNodes[0];
 
             while (textNode.nodeType !== Node.TEXT_NODE && textNode.childNodes.length) {
@@ -224,7 +236,7 @@ export async function setClipboard(page, text) {
 }
 
 export function getModifierKey() {
-    const os = require('os'); // eslint-disable-line @typescript-eslint/no-var-requires
+    const os = require('os'); // eslint-disable-line @typescript-eslint/no-require-imports
     const platform = os.platform();
     if (platform === 'darwin') {
         return 'Meta';

--- a/apps/comments-ui/test/utils/e2e.ts
+++ b/apps/comments-ui/test/utils/e2e.ts
@@ -235,6 +235,8 @@ export async function setClipboard(page, text) {
     await page.keyboard.press(`${modifier}+KeyC`);
 }
 
+// Modifier for native browser shortcuts (clipboard etc.), which follow the
+// host OS. For editor keymap shortcuts use getEditorModifierKey() instead.
 export function getModifierKey() {
     const os = require('os'); // eslint-disable-line @typescript-eslint/no-require-imports
     const platform = os.platform();
@@ -243,6 +245,15 @@ export function getModifierKey() {
     } else {
         return 'Control';
     }
+}
+
+// Modifier for ProseMirror/TipTap keymap shortcuts (Mod-). The editor derives
+// its platform from navigator.userAgent (vite-plugin-strip-fingerprinting
+// rewrites ProseMirror's platform checks to use the UA), and Playwright's
+// Desktop Chrome descriptor pins a Windows UA on every host — so the editor
+// always binds Mod to Control, regardless of the OS running the tests.
+export function getEditorModifierKey() {
+    return 'Control';
 }
 
 export function addMultipleComments(api, numComments) {

--- a/ghost/i18n/locales/af/comments.json
+++ b/ghost/i18n/locales/af/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Een minuut gelede",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ar/comments.json
+++ b/ghost/i18n/locales/ar/comments.json
@@ -52,6 +52,7 @@
     "One min ago": " منذ دقيقة واحدة",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/bg/comments.json
+++ b/ghost/i18n/locales/bg/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Преди минута",
     "Pin comment": "Залепи коментара",
     "Pinned": "Залепен",
+    "Quote in reply": "",
     "Read more replies": "Още отговори",
     "Remove dislike": "Отмени нехаресването",
     "Remove like": "Отмени харесването",

--- a/ghost/i18n/locales/bn/comments.json
+++ b/ghost/i18n/locales/bn/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/bs/comments.json
+++ b/ghost/i18n/locales/bs/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Prije jedan minut",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ca/comments.json
+++ b/ghost/i18n/locales/ca/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Fa un minut",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -240,6 +240,7 @@
     "Please fill in required fields": "Error message when a required field is missing",
     "Podcasts": "Default heading for the Transistor podcast integration section in Portal",
     "Posts": "Search result header",
+    "Quote in reply": "Floating action shown after selecting text in a comment to start a reply with that selection quoted",
     "Re-enable emails": "A button for members to turn-back-on emails, if they have been previously disabled as a result of delivery failures",
     "Read more replies": "Link at the bottom of a nested comment thread to open a focused view showing replies beyond the maximum displayed depth",
     "Recommendations": "A suggestion by/for another site of interest to users",

--- a/ghost/i18n/locales/cs/comments.json
+++ b/ghost/i18n/locales/cs/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Před jednou minutou",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/da/comments.json
+++ b/ghost/i18n/locales/da/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Et minut siden",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/de-CH/comments.json
+++ b/ghost/i18n/locales/de-CH/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Vor einer Minute",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/de/comments.json
+++ b/ghost/i18n/locales/de/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Vor einer Minute",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/el/comments.json
+++ b/ghost/i18n/locales/el/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Πριν από ένα λεπτό",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/en/comments.json
+++ b/ghost/i18n/locales/en/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/eo/comments.json
+++ b/ghost/i18n/locales/eo/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/es/comments.json
+++ b/ghost/i18n/locales/es/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Hace un minuto",
     "Pin comment": "Fijar comentario",
     "Pinned": "Fijado",
+    "Quote in reply": "",
     "Read more replies": "Ver más respuestas",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/et/comments.json
+++ b/ghost/i18n/locales/et/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Üks minut tagasi",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/eu/comments.json
+++ b/ghost/i18n/locales/eu/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Duela minutu bat",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/fa/comments.json
+++ b/ghost/i18n/locales/fa/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "یک دقیقه پیش",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/fi/comments.json
+++ b/ghost/i18n/locales/fi/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Minuutti sitten",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/fr/comments.json
+++ b/ghost/i18n/locales/fr/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Il y a une minute",
     "Pin comment": "Épingler le commentaire",
     "Pinned": "Épinglé",
+    "Quote in reply": "",
     "Read more replies": "Voir plus de réponses",
     "Remove dislike": "Annuler le « Je n’aime pas »",
     "Remove like": "Annuler le « J’aime »",

--- a/ghost/i18n/locales/gd/comments.json
+++ b/ghost/i18n/locales/gd/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "O chionn mionaid",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/he/comments.json
+++ b/ghost/i18n/locales/he/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "לפני דקה",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/hi/comments.json
+++ b/ghost/i18n/locales/hi/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "एक मिनट पहले",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/hr/comments.json
+++ b/ghost/i18n/locales/hr/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Prije jedne minute",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/hu/comments.json
+++ b/ghost/i18n/locales/hu/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Egy perce",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/id/comments.json
+++ b/ghost/i18n/locales/id/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Satu menit yang lalu",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/is/comments.json
+++ b/ghost/i18n/locales/is/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/it/comments.json
+++ b/ghost/i18n/locales/it/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Un minuto fa",
     "Pin comment": "Fissa commento",
     "Pinned": "Fissato",
+    "Quote in reply": "",
     "Read more replies": "Leggi più risposte",
     "Remove dislike": "Rimuovi Non mi piace",
     "Remove like": "Rimuovi Mi piace",

--- a/ghost/i18n/locales/ja/comments.json
+++ b/ghost/i18n/locales/ja/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "1分前",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ko/comments.json
+++ b/ghost/i18n/locales/ko/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "1분 전",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/kz/comments.json
+++ b/ghost/i18n/locales/kz/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Бір минут бұрын",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/lt/comments.json
+++ b/ghost/i18n/locales/lt/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Prieš minutę",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/lv/comments.json
+++ b/ghost/i18n/locales/lv/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Pirms minūtes",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/mk/comments.json
+++ b/ghost/i18n/locales/mk/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/mn/comments.json
+++ b/ghost/i18n/locales/mn/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Нэг минутын өмнө",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ms/comments.json
+++ b/ghost/i18n/locales/ms/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/nb/comments.json
+++ b/ghost/i18n/locales/nb/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Ett minutt siden",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ne/comments.json
+++ b/ghost/i18n/locales/ne/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "एक मिनेट अघि",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/nl/comments.json
+++ b/ghost/i18n/locales/nl/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Eén min geleden",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/nn/comments.json
+++ b/ghost/i18n/locales/nn/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/pa/comments.json
+++ b/ghost/i18n/locales/pa/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "ਇੱਕ ਮਿੰਟ ਪਹਿਲਾਂ",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/pl/comments.json
+++ b/ghost/i18n/locales/pl/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Minutę temu",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/pt-BR/comments.json
+++ b/ghost/i18n/locales/pt-BR/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Um minuto atrás",
     "Pin comment": "Fixar comentário",
     "Pinned": "Fixado",
+    "Quote in reply": "",
     "Read more replies": "Ler mais respostas",
     "Remove dislike": "Remover não gostei",
     "Remove like": "Remover gostei",

--- a/ghost/i18n/locales/pt/comments.json
+++ b/ghost/i18n/locales/pt/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "um minuto atrás",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ro/comments.json
+++ b/ghost/i18n/locales/ro/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Acum un minut",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ru/comments.json
+++ b/ghost/i18n/locales/ru/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Минуту назад",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/si/comments.json
+++ b/ghost/i18n/locales/si/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "මිනිත්තුවකට පෙ\u200bර",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/sk/comments.json
+++ b/ghost/i18n/locales/sk/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Pred minútou",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/sl/comments.json
+++ b/ghost/i18n/locales/sl/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Pred eno minuto",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/sq/comments.json
+++ b/ghost/i18n/locales/sq/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Një minutë më parë",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/sr-Cyrl/comments.json
+++ b/ghost/i18n/locales/sr-Cyrl/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Пре минут",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/sr/comments.json
+++ b/ghost/i18n/locales/sr/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Pre minut",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/sv/comments.json
+++ b/ghost/i18n/locales/sv/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "En minut sedan",
     "Pin comment": "Nåla fast kommentar",
     "Pinned": "Fastnålad",
+    "Quote in reply": "",
     "Read more replies": "Läs fler svar",
     "Remove dislike": "Ta bort ogilla",
     "Remove like": "Ta bort gilla",

--- a/ghost/i18n/locales/sw/comments.json
+++ b/ghost/i18n/locales/sw/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ta/comments.json
+++ b/ghost/i18n/locales/ta/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "ஒரு நிமிடம் முன்பு",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/th/comments.json
+++ b/ghost/i18n/locales/th/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/tr/comments.json
+++ b/ghost/i18n/locales/tr/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Bir dakika önce",
     "Pin comment": "Yorumu sabitle",
     "Pinned": "Sabitlendi",
+    "Quote in reply": "",
     "Read more replies": "Daha fazla cevap oku",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/uk/comments.json
+++ b/ghost/i18n/locales/uk/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Одну хвилину тому",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/ur/comments.json
+++ b/ghost/i18n/locales/ur/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/uz/comments.json
+++ b/ghost/i18n/locales/uz/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "",
     "Pin comment": "",
     "Pinned": "",
+    "Quote in reply": "",
     "Read more replies": "",
     "Remove dislike": "",
     "Remove like": "",

--- a/ghost/i18n/locales/vi/comments.json
+++ b/ghost/i18n/locales/vi/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "Một phút trước",
     "Pin comment": "Ghim bình luận",
     "Pinned": "Đã ghim",
+    "Quote in reply": "",
     "Read more replies": "Đọc thêm câu trả lời",
     "Remove dislike": "Bỏ không thích",
     "Remove like": "Bỏ thích",

--- a/ghost/i18n/locales/zh-Hant/comments.json
+++ b/ghost/i18n/locales/zh-Hant/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "一分鐘前",
     "Pin comment": "置頂留言",
     "Pinned": "已置頂",
+    "Quote in reply": "",
     "Read more replies": "閱讀更多回覆",
     "Remove dislike": "取消點踩",
     "Remove like": "取消點讚",

--- a/ghost/i18n/locales/zh/comments.json
+++ b/ghost/i18n/locales/zh/comments.json
@@ -52,6 +52,7 @@
     "One min ago": "一分钟前",
     "Pin comment": "置顶评论",
     "Pinned": "已置顶",
+    "Quote in reply": "",
     "Read more replies": "阅读更多回复",
     "Remove dislike": "取消点踩",
     "Remove like": "取消点赞",


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/BER-3650/add-easy-quote-replies

When highlighting text in a comment, members see a button that they can click to add the selection to the replyform as a blockquote.

<img width="794" alt="Screenshot 2026-06-08 at 20 30 39" src="https://github.com/user-attachments/assets/85a6e46e-1183-458b-8a0b-9cb4da3b9a49" />

<img width="794" alt="Screenshot 2026-06-08 at 20 30 50" src="https://github.com/user-attachments/assets/af4e4d1d-9344-4a0d-92f7-a640db10bd67" />


