### PR TITLE
Fixed possible false positive in Koenig test util test

### DIFF
--- a/ghost/core/test/unit/server/services/koenig/test-utils/assert-prettified-includes.test.ts
+++ b/ghost/core/test/unit/server/services/koenig/test-utils/assert-prettified-includes.test.ts
@@ -41,15 +41,17 @@ describe('assertPrettifiedIncludes', function () {
         const actual = '<div><p>Hello World</p></div>';
         const expected = '<p>Goodbye World</p>';
 
-        try {
-            assertPrettifiedIncludes(actual, expected);
-        } catch (error) {
-            assert(error instanceof Error);
-            assert.ok(error.message.includes('Received:'));
-            assert.ok(error.message.includes('Expected:'));
-            assert.ok(error.message.includes(actual));
-            assert.ok(error.message.includes(expected));
-        }
+        assert.throws(
+            () => assertPrettifiedIncludes(actual, expected),
+            (error) => {
+                assert(error instanceof Error);
+                assert.ok(error.message.includes('Received:'));
+                assert.ok(error.message.includes('Expected:'));
+                assert.ok(error.message.includes(actual));
+                assert.ok(error.message.includes(expected));
+                return true;
+            }
+        );
     });
 
     it('handles empty strings', function () {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/28426#pullrequestreview-4453343640

This is a test-only change.

`assertPrettifiedIncludes()` had a test that ran some assertions if a function threw, but not if it didn't. This fixes that by using `assert.throws()`.
