### PR TITLE
Disabled CodeRabbit's docstrings check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,3 +6,6 @@ reviews:
   sequence_diagrams: false
   estimate_code_review_effort: false
   poem: false
+  pre_merge_checks:
+    docstrings:
+      mode: "off"


### PR DESCRIPTION
no ref

[CodeRabbit can check for docstrings][0], which we don't care about. See an example false positive [here][1] (under the "Pre-merge checks" section).

[0]: https://docs.coderabbit.ai/reference/configuration#param-docstrings-1
[1]: https://github.com/TryGhost/Ghost/pull/28426#issuecomment-4653400098
