### PR TITLE
Forwarded worker event-bus emits to the main process

### DIFF
--- a/ghost/core/core/server/lib/common/events.js
+++ b/ghost/core/core/server/lib/common/events.js
@@ -12,8 +12,10 @@
  */
 
 const events = require('events');
+const {EventEmitter} = events;
+const {parentPort, isMainThread} = require('worker_threads');
 
-class EventRegistry extends events.EventEmitter {
+class EventRegistry extends EventEmitter {
     /**
      * This is method is semi-hack to make sure listeners are only registered once
      * during the lifetime of the process. And example problem it solves is
@@ -29,5 +31,148 @@ class EventRegistry extends events.EventEmitter {
 
 const eventRegistryInstance = new EventRegistry();
 eventRegistryInstance.setMaxListeners(100);
+
+// EventEmitter internals; forwarding them across processes makes no sense
+// (newListener/removeListener describe local subscription state; error has
+// special "throw if unhandled" semantics that mustn't be replicated remotely).
+const SKIP_FORWARD = new Set(['newListener', 'removeListener', 'error']);
+
+// Wraps emit payloads so they survive structuredClone across worker_threads
+// IPC. Two transformations:
+//   1. Bookshelf model instances → plain `{__model: model.toJSON()}` envelope,
+//      rehydrated on the receiving side into an adapter that exposes the same
+//      .get/.toJSON/.attributes the listener expects.
+//   2. Other objects (e.g. Bookshelf options) → deep-cleaned of values that
+//      structuredClone rejects. Bookshelf attaches query callbacks like
+//      `(data) => this.trigger('query', data)` and a Knex transaction handle
+//      to the options object, neither of which clone or matter to listeners.
+function isLikelyBookshelfModel(arg) {
+    return arg && typeof arg === 'object'
+        && typeof arg.toJSON === 'function'
+        && arg.attributes && typeof arg.attributes === 'object';
+}
+
+// Recursively drops values structuredClone can't carry (functions, symbols,
+// class instances with methods). Preserves primitives, Date, plain objects,
+// and arrays. Depth limit guards against pathological cycles.
+function toCloneable(value, depth = 0) {
+    if (depth > 10 || value === null || value === undefined) {
+        return value === undefined ? undefined : null;
+    }
+    const type = typeof value;
+    if (type === 'function' || type === 'symbol') {
+        return undefined;
+    }
+    if (type !== 'object') {
+        return value;
+    }
+    if (value instanceof Date) {
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return value
+            .map(v => toCloneable(v, depth + 1))
+            .filter(v => v !== undefined);
+    }
+    const cleaned = {};
+    for (const key of Object.keys(value)) {
+        const sub = toCloneable(value[key], depth + 1);
+        if (sub !== undefined) {
+            cleaned[key] = sub;
+        }
+    }
+    return cleaned;
+}
+
+// Sentinel key for the Bookshelf-model envelope. Chosen to be unlikely to
+// collide with anything a legitimate event payload would carry, so the
+// deserializer can use its presence as a discriminator without risking
+// rewriting normal data.
+const BOOKSHELF_ENVELOPE_KEY = '__ghostBookshelfModelJSON';
+
+function serializeArg(arg) {
+    if (isLikelyBookshelfModel(arg)) {
+        return {[BOOKSHELF_ENVELOPE_KEY]: arg.toJSON()};
+    }
+    return toCloneable(arg);
+}
+
+function deserializeArg(arg) {
+    if (arg
+        && typeof arg === 'object'
+        && Object.prototype.hasOwnProperty.call(arg, BOOKSHELF_ENVELOPE_KEY)
+        && arg[BOOKSHELF_ENVELOPE_KEY]
+        && typeof arg[BOOKSHELF_ENVELOPE_KEY] === 'object') {
+        const json = arg[BOOKSHELF_ENVELOPE_KEY];
+        return {
+            get(key) {
+                return json[key];
+            },
+            toJSON() {
+                return json;
+            },
+            attributes: json
+        };
+    }
+    return arg;
+}
+
+if (!isMainThread && parentPort) {
+    const localEmit = EventEmitter.prototype.emit.bind(eventRegistryInstance);
+    const warnedForUnserializableEvent = new Set();
+
+    eventRegistryInstance.emit = function (name, ...args) {
+        // Local listeners must fire deterministically regardless of what
+        // happens on the wire, so emit locally first and only then forward.
+        const result = localEmit(name, ...args);
+
+        if (typeof name === 'string' && !SKIP_FORWARD.has(name)) {
+            try {
+                parentPort.postMessage({
+                    type: 'ghost-event-forward',
+                    name,
+                    args: args.map(serializeArg)
+                });
+            } catch (err) {
+                if (!warnedForUnserializableEvent.has(name)) {
+                    warnedForUnserializableEvent.add(name);
+                    // Lazy require to keep this module free of logging
+                    // dependencies during boot.
+                    try {
+                        require('@tryghost/logging').warn({
+                            event: {name: 'events.forward.skipped'},
+                            eventName: name,
+                            err
+                        }, 'Cross-process event forwarding skipped: payload not serializable');
+                    } catch (logErr) {
+                        // Logging unavailable; nothing useful to do
+                    }
+                }
+            }
+        }
+
+        return result;
+    };
+}
+
+/**
+ * Replays an event message that was forwarded from a worker process. Called
+ * by the job-service worker message handler. Returns true if the message was
+ * recognised as a forwarded event (and thus consumed), false otherwise so
+ * other handlers can process the message.
+ *
+ * @param {*} message
+ * @returns {boolean}
+ */
+eventRegistryInstance.replayForwarded = function replayForwarded(message) {
+    if (!message || typeof message !== 'object' || message.type !== 'ghost-event-forward') {
+        return false;
+    }
+    const args = Array.isArray(message.args) ? message.args.map(deserializeArg) : [];
+    // Use the prototype emit directly so any wrapper installed on this
+    // instance (e.g. the worker-side forwarder) isn't re-invoked here.
+    EventEmitter.prototype.emit.apply(eventRegistryInstance, [message.name, ...args]);
+    return true;
+};
 
 module.exports = eventRegistryInstance;

--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -17,6 +17,13 @@ const errorHandler = (error, workerMeta) => {
 const events = require('../../lib/common/events');
 
 const workerMessageHandler = ({name, message}) => {
+    // Events emitted on the shared events bus from inside a worker are
+    // forwarded across the IPC boundary by core/server/lib/common/events.js
+    // and replayed here so parent-side subscribers (e.g. settingsCache) react
+    // as if the event originated locally.
+    if (events.replayForwarded(message)) {
+        return;
+    }
     if (typeof message === 'string') {
         logging.info(`Worker for job ${name} sent a message: ${message}`);
     }

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -62,7 +62,7 @@
             "minWait": 3600000,
             "maxWait": 3600000,
             "lifetime": 3600,
-            "freeRetries":4
+            "freeRetries": 99
         },
         "private_block": {
             "minWait": 3600000,

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -58,7 +58,7 @@
             "minWait": 3600000,
             "maxWait": 3600000,
             "lifetime": 3600,
-            "freeRetries":4
+            "freeRetries": 99
         },
         "private_block": {
             "minWait": 3600000,

--- a/ghost/core/test/e2e-api/admin/notifications.test.js
+++ b/ghost/core/test/e2e-api/admin/notifications.test.js
@@ -1,5 +1,8 @@
 const assert = require('node:assert/strict');
+const http = require('http');
+const path = require('path');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const jobService = require('../../../core/server/services/jobs/job-service');
 const {anyContentVersion, anyObjectId, anyEtag, anyLocationFor} = matchers;
 
 const matchNotification = {
@@ -156,6 +159,90 @@ describe('Notifications API', function () {
             await agent
                 .get('notifications')
                 .expectStatus(403);
+        });
+    });
+
+    describe('Surfaces notifications added by background workers', function () {
+        const UPDATE_CHECK_JOB = 'update-check';
+        const UPDATE_CHECK_JOB_PATH = path.resolve(
+            __dirname,
+            '../../../core/server/services/update-check/run-update-check.js'
+        );
+        let mockUpdateServer;
+        let baselineMailTransport;
+
+        before(async function () {
+            await agent.loginAsOwner();
+        });
+
+        beforeEach(function () {
+            baselineMailTransport = process.env.mail__transport;
+        });
+
+        afterEach(async function () {
+            if (mockUpdateServer) {
+                mockUpdateServer.close();
+                mockUpdateServer = null;
+            }
+            await jobService.removeJob(UPDATE_CHECK_JOB).catch(() => {});
+            if (baselineMailTransport === undefined) {
+                delete process.env.mail__transport;
+            } else {
+                process.env.mail__transport = baselineMailTransport;
+            }
+        });
+
+        it('returns a worker-added notification on a subsequent admin read', async function () {
+            // Route the worker's mailer at the stub transport so the alert
+            // branch's email send doesn't try to connect to localhost SMTP.
+            process.env.mail__transport = 'stub';
+
+            const notificationId = 'worker-added-cross-process-notification';
+
+            // Mock update server returning a single custom alert that the
+            // update-check worker will persist to settings.notifications.
+            mockUpdateServer = http.createServer((req, res) => {
+                res.writeHead(200, {'Content-Type': 'application/json'});
+                res.end(JSON.stringify({
+                    id: 99999,
+                    version: 'all-test',
+                    messages: [{
+                        id: notificationId,
+                        version: '^6',
+                        content: '<p>Cross-process visibility test</p>',
+                        top: true,
+                        dismissible: false,
+                        type: 'alert'
+                    }],
+                    created_at: '2026-06-08T00:00:00.000Z',
+                    custom: true,
+                    next_check: Math.floor(Date.now() / 1000) + 86400
+                }));
+            });
+            mockUpdateServer.listen(0);
+            const port = mockUpdateServer.address().port;
+
+            await jobService.addJob({
+                name: UPDATE_CHECK_JOB,
+                job: UPDATE_CHECK_JOB_PATH,
+                data: {
+                    forceUpdate: true,
+                    updateCheckUrl: `http://127.0.0.1:${port}`
+                }
+            });
+            await jobService.awaitCompletion(UPDATE_CHECK_JOB);
+
+            // The observable contract: an authenticated admin GET to the
+            // notifications endpoint returns the notification the worker just
+            // persisted. The test does not care how that freshness is
+            // achieved.
+            const {body} = await agent.get('notifications').expectStatus(200);
+            const surfaced = body.notifications.find(n => n.id === notificationId);
+
+            assert.ok(
+                surfaced,
+                'Expected the worker-added notification to be returned by GET /notifications'
+            );
         });
     });
 


### PR DESCRIPTION
## Problem

State writes performed inside a Bree worker leave main-process subscribers stale. Specifically: when the update-check worker called `notifications.add`, the notification was correctly persisted to the database, but the main process's in-memory settings cache never refreshed. The admin notifications endpoint kept returning the pre-worker snapshot, so the alert banner did not render until Ghost was restarted.

The shared events bus is process-local. Workers and the main process each instantiate their own emitter. Events fired in one process never reach subscribers in the other. The cache freshness contract, several model-listener hooks, and any future worker that touches cached settings all silently break across this boundary.

## Solution

Bridge the events bus across the worker boundary. When the module is loaded inside a worker thread, every emit is also posted across the parent port. The main process replays the message on its own emitter from inside the existing worker message handler. Subscribers receive the event identically to a local emission, so settings cache, model-listener hooks, and anything else listening continue to work without changes.

The serializer is the only piece with surface area worth thinking about. Bookshelf models are unwrapped via their toJSON method and rehydrated on the receiving side into an adapter that preserves the get, toJSON, and attributes shape listeners expect. Other objects are deep-cleaned of values that structured-clone rejects (Bookshelf attaches query callbacks and a Knex transaction handle to option objects, neither of which listeners read). EventEmitter internals are intentionally not forwarded.

If a payload can't be cloned for any reason, the bridge logs once per event name and skips the forward. The local emit always runs regardless, so worker-side behaviour is unchanged.

Added an HTTP-level test that spawns the update-check worker and asserts the admin notifications endpoint returns the worker-added notification on the next read. The test exercises the contract the admin UI depends on without observing the bridge mechanism. Bumped the test environment's per-IP login limiter so multi-login files don't trip it; the dedicated rate-limiting test reads its threshold from config so it stays accurate.
