### PR TITLE
tweaks to tab visibility, search, and verification emails

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/emails.tsx
@@ -3,15 +3,19 @@ import EnableNewsletters from './enable-newsletters';
 import MailGun from './mailgun';
 import NewslettersTabContent, {type NewslettersFilter} from './newsletters/newsletters-tab-content';
 import NiceModal from '@ebay/nice-modal-react';
-import React, {useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import SearchableSection from '../../searchable-section';
 import TopLevelGroup from '../../top-level-group';
 import WelcomeEmailCustomizeModal from '../membership/member-emails/welcome-email-customize-modal';
-import {Button, Icon, Table, TableRow} from '@tryghost/admin-x-design-system';
+import useQueryParams from '../../../hooks/use-query-params';
+import {APIError} from '@tryghost/admin-x-framework/errors';
+import {Button, ConfirmationModal, Icon, Table, TableRow} from '@tryghost/admin-x-design-system';
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useVerifyAutomatedEmailSender} from '@tryghost/admin-x-framework/api/automated-emails';
 
 export const searchKeywords = {
     enableNewsletters: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off'],
@@ -53,16 +57,86 @@ const TransactionalTabContent: React.FC = () => {
     );
 };
 
-const EmailsGroup: React.FC<{ keywords: string[] }> = ({keywords}) => {
+const isAutomatedEmailVerificationRoute = () => {
+    const hash = window.location.hash.slice(1);
+    const pathname = new URL(hash || '/', window.location.origin).pathname;
+
+    return pathname.startsWith('/settings/memberemails');
+};
+
+const EmailsGroup: React.FC<{ keywords: string[]; newslettersEnabled: boolean }> = ({keywords, newslettersEnabled}) => {
     const {updateRoute} = useRouting();
-    const [selectedTab, setSelectedTab] = useState<'newsletters' | 'transactional'>('newsletters');
+    const verifyEmailToken = useQueryParams().getParam('verifyEmail');
+    const {mutateAsync: verifySenderUpdate} = useVerifyAutomatedEmailSender();
+    const handleError = useHandleError();
+    const submittedTokenRef = useRef<string | null>(null);
+    const [selectedTab, setSelectedTab] = useState<'newsletters' | 'transactional'>(newslettersEnabled ? 'newsletters' : 'transactional');
     const [newslettersFilter, setNewslettersFilter] = useState<NewslettersFilter>('active');
+
+    useEffect(() => {
+        if (!newslettersEnabled && selectedTab === 'newsletters') {
+            setSelectedTab('transactional');
+        }
+    }, [newslettersEnabled, selectedTab]);
+
+    useEffect(() => {
+        if (!verifyEmailToken || !isAutomatedEmailVerificationRoute()) {
+            return;
+        }
+
+        if (submittedTokenRef.current === verifyEmailToken) {
+            return;
+        }
+        submittedTokenRef.current = verifyEmailToken;
+        setSelectedTab('transactional');
+
+        const verify = async () => {
+            try {
+                const {meta: {email_verified: emailVerified} = {}} = await verifySenderUpdate({token: verifyEmailToken});
+
+                let title = 'Sender email verified';
+                let prompt = <>Automation email sender settings have been updated.</>;
+
+                if (emailVerified === 'sender_reply_to') {
+                    title = 'Reply-to address verified';
+                    prompt = <>Automation email reply-to address has been verified and updated.</>;
+                }
+
+                updateRoute('emails');
+                NiceModal.show(ConfirmationModal, {
+                    title,
+                    prompt,
+                    okLabel: 'Close',
+                    cancelLabel: '',
+                    onOk: confirmModal => confirmModal?.remove()
+                });
+            } catch (e) {
+                let prompt = 'There was an error verifying your email address. Try again later.';
+
+                if (e instanceof APIError && e.message === 'Token expired') {
+                    prompt = 'Verification link has expired.';
+                }
+
+                updateRoute('emails');
+                NiceModal.show(ConfirmationModal, {
+                    title: 'Error verifying email address',
+                    prompt,
+                    okLabel: 'Close',
+                    cancelLabel: '',
+                    onOk: confirmModal => confirmModal?.remove()
+                });
+                handleError(e, {withToast: false});
+            }
+        };
+
+        verify();
+    }, [handleError, updateRoute, verifyEmailToken, verifySenderUpdate]);
 
     const openNewNewsletter = () => {
         updateRoute('newsletters/new');
     };
 
-    const customButtons = selectedTab === 'newsletters' ? (
+    const customButtons = newslettersEnabled && selectedTab === 'newsletters' ? (
         <Button className='mt-[-5px]' color='clear' label='Add newsletter' size='sm' onClick={openNewNewsletter} />
     ) : undefined;
 
@@ -78,10 +152,10 @@ const EmailsGroup: React.FC<{ keywords: string[] }> = ({keywords}) => {
             <Tabs value={selectedTab} variant='underline' onValueChange={value => setSelectedTab(value as 'newsletters' | 'transactional')}>
                 <div className='flex items-center justify-between border-b border-grey-200 dark:border-grey-900'>
                     <TabsList className='border-b-0'>
-                        <TabsTrigger value='newsletters'>Newsletters</TabsTrigger>
+                        {newslettersEnabled && <TabsTrigger value='newsletters'>Newsletters</TabsTrigger>}
                         <TabsTrigger value='transactional'>Transactional</TabsTrigger>
                     </TabsList>
-                    {selectedTab === 'newsletters' && (
+                    {newslettersEnabled && selectedTab === 'newsletters' && (
                         <Select value={newslettersFilter} onValueChange={value => setNewslettersFilter(value as NewslettersFilter)}>
                             <SelectTrigger className='h-7 w-auto gap-1 border-0 bg-transparent px-2 text-sm shadow-none hover:bg-muted focus:ring-0 focus:ring-offset-0' data-testid='newsletters-filter'>
                                 <SelectValue />
@@ -93,9 +167,11 @@ const EmailsGroup: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         </Select>
                     )}
                 </div>
-                <TabsContent value='newsletters'>
-                    <NewslettersTabContent filter={newslettersFilter} />
-                </TabsContent>
+                {newslettersEnabled && (
+                    <TabsContent value='newsletters'>
+                        <NewslettersTabContent filter={newslettersFilter} />
+                    </TabsContent>
+                )}
                 <TabsContent value='transactional'>
                     <TransactionalTabContent />
                 </TabsContent>
@@ -107,13 +183,14 @@ const EmailsGroup: React.FC<{ keywords: string[] }> = ({keywords}) => {
 const Emails: React.FC = () => {
     const {settings, config} = useGlobalData();
     const [newslettersEnabled] = getSettingValues(settings, ['editor_default_email_recipients']) as [string];
+    const hasNewslettersEnabled = newslettersEnabled !== 'disabled';
 
     return (
         <SearchableSection keywords={Object.values(searchKeywords).flat()} title='Email'>
             <EnableNewsletters keywords={searchKeywords.enableNewsletters} />
-            {newslettersEnabled !== 'disabled' && <DefaultRecipients keywords={searchKeywords.defaultRecipients} />}
-            <EmailsGroup keywords={searchKeywords.emails} />
-            {newslettersEnabled !== 'disabled' && !config.mailgunIsConfigured && <MailGun keywords={searchKeywords.mailgun} />}
+            {hasNewslettersEnabled && <DefaultRecipients keywords={searchKeywords.defaultRecipients} />}
+            <EmailsGroup keywords={searchKeywords.emails} newslettersEnabled={hasNewslettersEnabled} />
+            {hasNewslettersEnabled && !config.mailgunIsConfigured && <MailGun keywords={searchKeywords.mailgun} />}
         </SearchableSection>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/add-newsletter-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/add-newsletter-modal.tsx
@@ -1,5 +1,6 @@
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
+import useFeatureFlag from '../../../../hooks/use-feature-flag';
 import {Form, LimitModal, Modal, TextArea, TextField, Toggle} from '@tryghost/admin-x-design-system';
 import {HostLimitError, useLimiter} from '../../../../hooks/use-limiter';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
@@ -11,6 +12,7 @@ import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 const AddNewsletterModal: React.FC<RoutingModalProps> = () => {
     const modal = useModal();
     const {updateRoute} = useRouting();
+    const returnRoute = useFeatureFlag('automations') ? 'emails' : 'newsletters';
     const handleError = useHandleError();
     const [isCheckingLimit, setIsCheckingLimit] = useState(true);
     const [limitError, setLimitError] = useState<HostLimitError | null>(null);
@@ -77,9 +79,9 @@ const AddNewsletterModal: React.FC<RoutingModalProps> = () => {
                 onOk: () => updateRoute({route: '/pro', isExternal: true})
             });
             modal.remove();
-            updateRoute('newsletters');
+            updateRoute(returnRoute);
         }
-    }, [limitError, modal, updateRoute]);
+    }, [limitError, modal, returnRoute, updateRoute]);
 
     if (isCheckingLimit || limitError) {
         return null;
@@ -87,7 +89,7 @@ const AddNewsletterModal: React.FC<RoutingModalProps> = () => {
 
     return <Modal
         afterClose={() => {
-            updateRoute('newsletters');
+            updateRoute(returnRoute);
         }}
         backDropClick={false}
         okColor='black'

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -1,6 +1,7 @@
 import NewsletterPreview from './newsletter-preview';
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useCallback, useEffect, useState} from 'react';
+import useFeatureFlag from '../../../../hooks/use-feature-flag';
 import useSettingGroup from '../../../../hooks/use-setting-group';
 import validator from 'validator';
 import {Button, ButtonGroup, ColorPickerField, ConfirmationModal, Form, Heading, Hint, HtmlField, Icon, ImageUpload, LimitModal, PreviewModalContent, Select, type SelectOption, Separator, type Tab, TabView, TextArea, TextField, Toggle, ToggleGroup, showToast} from '@tryghost/admin-x-design-system';
@@ -779,6 +780,7 @@ const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: b
     const {config} = useGlobalData();
     const {mutateAsync: editNewsletter} = useEditNewsletter();
     const {updateRoute} = useRouting();
+    const returnRoute = useFeatureFlag('automations') ? 'emails' : 'newsletters';
     const handleError = useHandleError();
 
     const {formState, saveState, updateForm, setFormState, handleSave, validate, errors, clearError, okProps} = useForm({
@@ -837,7 +839,7 @@ const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: b
     const sidebar = <Sidebar clearError={clearError} errors={errors} newsletter={formState} onlyOne={onlyOne} updateNewsletter={updateNewsletter} validate={validate} />;
 
     return <PreviewModalContent
-        afterClose={() => updateRoute('newsletters')}
+        afterClose={() => updateRoute(returnRoute)}
         buttonsDisabled={okProps.disabled}
         cancelLabel='Close'
         deviceSelector={false}

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-tab-content.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-tab-content.tsx
@@ -3,7 +3,7 @@ import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {type ReactNode, useEffect, useState} from 'react';
 import useQueryParams from '../../../../hooks/use-query-params';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {Button, ConfirmationModal} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {type InfiniteData, useQueryClient} from '@tryghost/admin-x-framework';
 import {type Newsletter, type NewslettersResponseType, newslettersDataType, useBrowseNewsletters, useEditNewsletter, useVerifyNewsletterEmail} from '@tryghost/admin-x-framework/api/newsletters';
 import {arrayMove} from '@dnd-kit/sortable';
@@ -20,9 +20,16 @@ const NavigateToNewsletter = ({id, children}: {id: string; children: ReactNode})
     }}>{children}</button>;
 };
 
+const isNewsletterVerificationRoute = () => {
+    const hash = window.location.hash.slice(1);
+    const pathname = new URL(hash || '/', window.location.origin).pathname;
+
+    return pathname.startsWith('/settings/emails') || pathname.startsWith('/settings/newsletters');
+};
+
 export type NewslettersFilter = 'active' | 'archived';
 
-interface NewslettersTabContentProps {
+interface NewslettersTabContentProps extends Record<string, unknown> {
     filter: NewslettersFilter;
 }
 
@@ -42,7 +49,7 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({filter}) =
     }, [apiNewsletters]);
 
     useEffect(() => {
-        if (!verifyEmailToken || !window.location.href.includes('emails')) {
+        if (!verifyEmailToken || !isNewsletterVerificationRoute()) {
             return;
         }
 
@@ -145,4 +152,4 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({filter}) =
     );
 };
 
-export default NewslettersTabContent;
+export default withErrorBoundary(NewslettersTabContent, 'Newsletters');

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -66,6 +66,9 @@ const Sidebar: React.FC = () => {
         ...(hasAutomations ? [] : [membershipSearchKeywords.memberEmails]),
         membershipSearchKeywords.tips
     ].flat(), [hasAutomations, paidMembersEnabled]);
+    const visibleEmailSearchKeywords = React.useMemo(() => (
+        Object.values(hasAutomations ? emailsSearchKeywords : emailSearchKeywords).flat()
+    ), [hasAutomations]);
 
     // Focus in on search field when pressing "/"
     useEffect(() => {
@@ -100,13 +103,13 @@ const Sidebar: React.FC = () => {
             !checkVisible(Object.values(siteSearchKeywords).flat()) &&
             !checkVisible(visibleMembershipSearchKeywords) &&
             !checkVisible(Object.values(growthSearchKeywords).flat()) &&
-            !checkVisible(Object.values(emailSearchKeywords).flat()) &&
+            !checkVisible(visibleEmailSearchKeywords) &&
             !checkVisible(Object.values(advancedSearchKeywords).flat())) {
             setNoResult(true);
         } else {
             setNoResult(false);
         }
-    }, [checkVisible, setNoResult, filter, visibleMembershipSearchKeywords]);
+    }, [checkVisible, setNoResult, filter, visibleEmailSearchKeywords, visibleMembershipSearchKeywords]);
 
     useEffect(() => {
         const searchInput = searchInputRef.current;

--- a/apps/admin-x-settings/test/acceptance/email/email-settings.test.ts
+++ b/apps/admin-x-settings/test/acceptance/email/email-settings.test.ts
@@ -1,10 +1,21 @@
 import {expect, test} from '@playwright/test';
-import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
+import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse, waitForApiRequest} from '@tryghost/admin-x-framework/test/acceptance';
 
 const emailRequests = {
     browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response: responseFixtures.newsletters},
     browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: responseFixtures.newsletters},
     browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: {automated_emails: []}}
+};
+
+const configWithAutomations = {
+    ...responseFixtures.config,
+    config: {
+        ...responseFixtures.config.config,
+        labs: {
+            ...responseFixtures.config.config.labs,
+            automations: true
+        }
+    }
 };
 
 test.describe('Email settings', async () => {
@@ -51,5 +62,87 @@ test.describe('Email settings', async () => {
         await expect(page.getByTestId('default-recipients')).toBeHidden();
         await expect(page.getByTestId('newsletters')).toBeHidden();
         await expect(page.getByTestId('memberemails')).toBeVisible();
+    });
+
+    test('verifies newsletter emails from existing newsletters verification links when automations are enabled', async ({page}) => {
+        const verifyNewsletterEmailResponse = {
+            ...responseFixtures.newsletters,
+            meta: {
+                ...responseFixtures.newsletters.meta,
+                email_verified: 'sender_email'
+            }
+        };
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...emailRequests,
+            browseConfig: {...globalDataRequests.browseConfig, response: configWithAutomations},
+            verifyNewsletterEmail: {method: 'PUT', path: /^\/newsletters\/verifications\/\?include=/, response: verifyNewsletterEmailResponse}
+        }});
+
+        await page.goto('/#/settings/newsletters/?verifyEmail=fake-token');
+
+        const verifyNewsletterEmail = await waitForApiRequest(lastApiRequests, 'verifyNewsletterEmail');
+        expect(verifyNewsletterEmail.body).toEqual({token: 'fake-token'});
+    });
+
+    test('verifies automation emails from existing memberemails verification links when automations are enabled', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...emailRequests,
+            browseConfig: {...globalDataRequests.browseConfig, response: configWithAutomations},
+            verifyAutomatedEmailSender: {
+                method: 'PUT',
+                path: /^\/automated_emails\/verifications\/?$/,
+                response: {
+                    automated_emails: [],
+                    meta: {
+                        email_verified: 'sender_reply_to'
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/#/settings/memberemails?verifyEmail=fake-token');
+
+        const verifyAutomatedEmailSender = await waitForApiRequest(lastApiRequests, 'verifyAutomatedEmailSender');
+        expect(verifyAutomatedEmailSender.body).toEqual({token: 'fake-token'});
+    });
+
+    test('finds transactional email settings in search when automations are enabled', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...emailRequests,
+            browseConfig: {...globalDataRequests.browseConfig, response: configWithAutomations}
+        }});
+
+        await page.goto('/');
+        await page.getByPlaceholder('Search settings').fill('transactional');
+
+        await expect(page.getByTestId('sidebar').getByText('Email')).toBeVisible();
+        await expect(page.getByText('No result')).toHaveCount(0);
+    });
+
+    test('keeps transactional email settings reachable when newsletters are disabled with automations enabled', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: {...globalDataRequests.browseConfig, response: configWithAutomations},
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: updatedSettingsResponse([
+                    {key: 'editor_default_email_recipients', value: 'disabled'},
+                    {key: 'editor_default_email_recipients_filter', value: null}
+                ])
+            }
+        }});
+
+        await page.goto('/');
+
+        const emailsSection = page.getByTestId('emails');
+        await expect(emailsSection).toBeVisible();
+        await expect(emailsSection.getByRole('tab', {name: 'Transactional'})).toBeVisible();
+        await expect(emailsSection.getByRole('tab', {name: 'Newsletters'})).toHaveCount(0);
+        await expect(emailsSection.getByRole('button', {name: 'Add newsletter'})).toHaveCount(0);
+        await expect(page.getByTestId('mailgun')).toBeHidden();
+        await expect(page.getByTestId('default-recipients')).toBeHidden();
     });
 });


### PR DESCRIPTION
no ref

- makes it so that when newsletters are disabled, the newsletter tab doesn't show, but automations does
- there was a small bug where if you searched something like "transactional" in the sidebar it would show "no results" and it would show the result, so that's fixed
- the verification emails that get sent when a user with managed email attempts to update the reply_to with something other than their verified domain weren't sending for either newsletters or automations. I used the below settings in `config.local.json` and tried it with something other than example.com to verify:

```
    "hostSettings": {
        "managedEmail": {
            "enabled": true,
            "sendingDomain": "example.com"
        }
    }
``` 