### PR TITLE
Added enabledChannels config for filtering update-check notifications

### DIFF
--- a/ghost/core/core/server/services/update-check/index.js
+++ b/ghost/core/core/server/services/update-check/index.js
@@ -24,7 +24,8 @@ const {NotificationEmailService} = require('../notifications/notification-email'
 module.exports = async ({
     rethrowErrors = false,
     forceUpdate = config.get('updateCheck:forceUpdate'),
-    updateCheckUrl = config.get('updateCheck:url')
+    updateCheckUrl = config.get('updateCheck:url'),
+    enabledChannels = config.get('notifications:enabledChannels')
 } = {}) => {
     if (!forceUpdate) {
         const allowedCheckEnvironments = ['development', 'production'];
@@ -67,6 +68,7 @@ module.exports = async ({
             checkEndpoint: updateCheckUrl,
             isPrivacyDisabled: config.isPrivacyDisabled('useUpdateCheck'),
             notificationGroups: config.get('notificationGroups'),
+            enabledChannels,
             siteUrl: urlUtils.urlFor('home', true),
             forceUpdate,
             ghostVersion: ghostVersion.original,

--- a/ghost/core/core/server/services/update-check/run-update-check.js
+++ b/ghost/core/core/server/services/update-check/run-update-check.js
@@ -48,7 +48,8 @@ if (parentPort) {
     await updateCheck({
         rethrowErrors: true,
         forceUpdate: workerData.forceUpdate,
-        updateCheckUrl: workerData.updateCheckUrl
+        updateCheckUrl: workerData.updateCheckUrl,
+        enabledChannels: workerData.enabledChannels
     });
 
     postParentPortMessage(`Ran update check`);

--- a/ghost/core/core/server/services/update-check/update-check-service.js
+++ b/ghost/core/core/server/services/update-check/update-check-service.js
@@ -34,6 +34,21 @@ function normalizeNotifications(response) {
     return [];
 }
 
+function channelOf(notification) {
+    if (notification.channel) {
+        return notification.channel;
+    }
+    if (!notification.custom) {
+        return 'release';
+    }
+    const hasAlertMessage = Array.isArray(notification.messages)
+        && notification.messages.some(message => message && message.type === 'alert');
+    if (hasAlertMessage) {
+        return 'security';
+    }
+    return 'custom';
+}
+
 /**
  * Update Checker Class
  *
@@ -63,6 +78,7 @@ class UpdateCheckService {
      * @param {string} options.config.checkEndpoint - update check service URL
      * @param {boolean} [options.config.isPrivacyDisabled]
      * @param {string[]} [options.config.notificationGroups] - example values ["migration", "something"]
+     * @param {string[]} [options.config.enabledChannels] - notification channels this install accepts. Undefined means accept all (default). Empty array means accept none. Known channels today: 'release', 'security', 'custom'.
      * @param {boolean} [options.config.rethrowErrors] - allows to force throwing errors (useful in worker threads)
      * @param {string} options.config.siteUrl - Ghost instance URL
      * @param {boolean} [options.config.forceUpdate]
@@ -334,6 +350,12 @@ class UpdateCheckService {
         }, internal);
 
         let notifications = normalizeNotifications(response);
+
+        const enabledChannels = this.config.enabledChannels;
+        if (Array.isArray(enabledChannels)) {
+            const accepted = new Set(enabledChannels);
+            notifications = notifications.filter(notification => accepted.has(channelOf(notification)));
+        }
 
         // CASE: Hook into received notifications and decide whether you are allowed to receive custom group messages.
         if (notificationGroups.length) {

--- a/ghost/core/test/integration/jobs/update-check.test.js
+++ b/ghost/core/test/integration/jobs/update-check.test.js
@@ -126,4 +126,127 @@ describe('Run Update Check', function () {
         assert.equal(ourNotification.message, '<p>Integration test alert</p>');
         assert.equal(ourNotification.custom, true);
     });
+
+    describe('channel filtering', function () {
+        const RELEASE_NOTIFICATION_ID = 'channel-filter-release-msg';
+
+        function mockReleaseResponse() {
+            return http.createServer((req, res) => {
+                res.writeHead(200, {'Content-Type': 'application/json'});
+                res.end(JSON.stringify({
+                    id: 99999,
+                    version: '6.45.0',
+                    messages: [{
+                        id: RELEASE_NOTIFICATION_ID,
+                        version: '^6',
+                        content: '<p>Ghost v6.45.0 has been released</p>',
+                        top: false,
+                        dismissible: true,
+                        type: 'info'
+                    }],
+                    created_at: '2026-06-08T00:00:00.000Z',
+                    custom: false,
+                    next_check: Math.floor(Date.now() / 1000) + 86400
+                }));
+            });
+        }
+
+        async function runWorker(enabledChannels) {
+            mockUpdateServer = mockReleaseResponse();
+            mockUpdateServer.listen(0);
+            const port = mockUpdateServer.address().port;
+
+            const data = {
+                forceUpdate: true,
+                updateCheckUrl: `http://127.0.0.1:${port}`
+            };
+            if (enabledChannels !== undefined) {
+                data.enabledChannels = enabledChannels;
+            }
+
+            await jobService.addJob({name: JOB_NAME, job: JOB_PATH, data});
+            await jobService.awaitCompletion(JOB_NAME);
+
+            const setting = await models.Settings.findOne(
+                {key: 'notifications'},
+                {context: {internal: true}}
+            );
+            const stored = JSON.parse(setting.get('value'));
+            return stored.find(n => n.id === RELEASE_NOTIFICATION_ID);
+        }
+
+        it('persists every channel when enabledChannels is undefined', async function () {
+            const persisted = await runWorker(undefined);
+            assert.ok(persisted, 'Expected the release notification to be persisted when no channel filter is configured');
+        });
+
+        it('persists no channels when enabledChannels is the empty array', async function () {
+            const persisted = await runWorker([]);
+            assert.equal(persisted, undefined, 'Expected the release notification to be dropped when the channel allowlist is empty');
+        });
+
+        it('drops a notification whose channel is excluded from the allowlist', async function () {
+            const persisted = await runWorker(['security']);
+            assert.equal(persisted, undefined, 'Expected the release notification to be dropped when only the security channel is enabled');
+        });
+
+        it('persists a notification whose channel is in the allowlist', async function () {
+            const persisted = await runWorker(['release']);
+            assert.ok(persisted, 'Expected the release notification to be persisted when the release channel is enabled');
+        });
+
+        it('classifies a custom alert notification as the security channel', async function () {
+            const SECURITY_NOTIFICATION_ID = 'channel-filter-security-msg';
+
+            mockUpdateServer = http.createServer((req, res) => {
+                res.writeHead(200, {'Content-Type': 'application/json'});
+                res.end(JSON.stringify({
+                    id: 99998,
+                    version: 'all-security',
+                    messages: [{
+                        id: SECURITY_NOTIFICATION_ID,
+                        version: '^6',
+                        content: '<p>Critical security advisory</p>',
+                        top: true,
+                        dismissible: false,
+                        type: 'alert'
+                    }],
+                    created_at: '2026-06-08T00:00:00.000Z',
+                    custom: true,
+                    next_check: Math.floor(Date.now() / 1000) + 86400
+                }));
+            });
+            mockUpdateServer.listen(0);
+            const port = mockUpdateServer.address().port;
+
+            // The alert branch reaches notificationEmailService.send, which
+            // would ECONNREFUSE on localhost SMTP without a stub transport.
+            const owner = await models.User.findOne(
+                {email: 'ghost@example.com'},
+                {context: {internal: true}, withRelated: ['roles']}
+            );
+            await owner.save({status: 'active'}, {patch: true, context: {internal: true}});
+            process.env.mail__transport = 'stub';
+
+            await jobService.addJob({
+                name: JOB_NAME,
+                job: JOB_PATH,
+                data: {
+                    forceUpdate: true,
+                    updateCheckUrl: `http://127.0.0.1:${port}`,
+                    enabledChannels: ['security']
+                }
+            });
+            await jobService.awaitCompletion(JOB_NAME);
+
+            const setting = await models.Settings.findOne(
+                {key: 'notifications'},
+                {context: {internal: true}}
+            );
+            const stored = JSON.parse(setting.get('value'));
+            const persisted = stored.find(n => n.id === SECURITY_NOTIFICATION_ID);
+
+            assert.ok(persisted, 'Expected the security alert to be persisted when the security channel is enabled');
+        });
+    });
 });


### PR DESCRIPTION
## Problem

Update-check today returns release notifications, security alerts, and custom messages to every install that talks to the upstream service. The Ghost client has no way to opt out of a category — `notificationGroups` filters individual custom messages by regex but doesn't gate the categories themselves, and there's an unconditional bypass that lets every release notification through regardless of config.

That's fine for most self-hosters. It isn't fine for hosters who manage releases on behalf of their customers and don't want their users prompted to "click here to upgrade" — the release category needs to be suppressible without that hoster's identity leaking into Ghost code or coordinating with the upstream service.

## Solution

Notifications are grouped into named channels. Today the channel is derived from the existing wire shape — non-custom is `release`, custom-alert is `security`, everything else is `custom`. Upstream is free to start sending an explicit `channel` field whenever it wants; if it does, that field wins. No wire-format change is required today.

Hosters configure which channels their install accepts via `notifications.enabledChannels` in Ghost config. The value is three-state:

- **Undefined**: accept every channel. This is the default and preserves current behaviour for self-hosters.
- **Empty array**: accept nothing. Useful for kiosk-style installs that opt out of all update-check notifications.
- **Explicit list**: accept only the named channels.

Channels not in the list are dropped before being written to settings. Nothing about the read path or the email path needs to know about channels — the filter runs once at the worker, so neither the banner nor the alert email surface for excluded channels.

This gives any hoster a clean, generic way to control which categories of notification their customers see. Nothing in Ghost knows about Pro or any other particular hoster — Pro just happens to be the first install of this primitive.

It's also the natural starting shape for per-channel presentation routing later (banner-only, banner+email, etc.). Today's `enabledChannels` is the degenerate slice of that fuller config; the migration when the routing matrix is needed is mechanical.

Integration tests cover all three states by spawning the real worker against a mock upstream response and asserting on the persisted `settings.notifications` row.
