### PR TITLE
Fixed broken search clearing on the members page

### DIFF
--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -20,7 +20,7 @@ import {shouldDelayMembersDateFilterHydration, useMembersFilterState} from './ho
 import {useActiveMemberView, useMemberViews} from './hooks/use-member-views';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useBrowseMembersInfinite} from '@tryghost/admin-x-framework/api/members';
-import {useDebounce} from 'use-debounce';
+import {useDebouncedCallback} from 'use-debounce';
 import {useLocation, useSearchParams} from 'react-router';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -52,7 +52,9 @@ const MembersPage: React.FC<MembersPageProps> = ({
     const [showMobileSearch, setShowMobileSearch] = useState(false);
     const [mobileSearchOpenedByUser, setMobileSearchOpenedByUser] = useState(false);
     const [searchInput, setSearchInput] = useState(search);
-    const [debouncedSearch] = useDebounce(searchInput, SEARCH_DEBOUNCE_MS);
+    const commitSearch = useDebouncedCallback((value: string) => {
+        setSearch(value);
+    }, SEARCH_DEBOUNCE_MS);
 
     // The multiple active subscriptions predicate is applied via the banner's
     // "View members" link and has no filter UI, so keep it out of the filter bar.
@@ -101,15 +103,19 @@ const MembersPage: React.FC<MembersPageProps> = ({
     const shouldShowMemberControls = hasFilterOrSearch || totalMembers > 0;
     const shouldShowMembersHelpCards = !hasFilterOrSearch && !shouldShowLoading && !isError && totalMembers < MEMBERS_HELP_CARDS_LIMIT;
 
+    // Keep the input in sync with the committed search whenever it changes for
+    // any reason other than typing (browser back/forward, "Show all members",
+    // saved views), and drop any pending commit so the new value wins instead
+    // of being overwritten by a stale keystroke.
     useEffect(() => {
         setSearchInput(search);
-    }, [search]);
+        commitSearch.cancel();
+    }, [search, commitSearch]);
 
-    useEffect(() => {
-        if (debouncedSearch !== search) {
-            setSearch(debouncedSearch);
-        }
-    }, [debouncedSearch, search, setSearch]);
+    const handleSearchChange = (value: string) => {
+        setSearchInput(value);
+        commitSearch(value);
+    };
 
     const handleMobileSearchToggle = () => {
         if (showMobileSearch) {
@@ -123,6 +129,11 @@ const MembersPage: React.FC<MembersPageProps> = ({
     };
 
     const filtersClassName = 'flex-col gap-4 lg:flex-row lg:items-center sidebar:gap-6 lg:gap-6';
+    const handleShowAllMembers = () => {
+        commitSearch.cancel();
+        setSearchInput('');
+        clearAll({replace: false});
+    };
 
     return (
         <MainLayout>
@@ -150,7 +161,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                             <div className="hidden lg:flex">
                                                 <MembersHeaderSearch
                                                     search={searchInput}
-                                                    onSearchChange={setSearchInput}
+                                                    onSearchChange={handleSearchChange}
                                                 />
                                             </div>
                                             <Button
@@ -197,7 +208,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                             ariaLabel="Search members mobile"
                                             autoFocus={mobileSearchOpenedByUser}
                                             search={searchInput}
-                                            onSearchChange={setSearchInput}
+                                            onSearchChange={handleSearchChange}
                                         />
                                     </div>
                                 )}
@@ -244,7 +255,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                     actions={
                                         <Button
                                             variant="outline"
-                                            onClick={() => clearAll({replace: false})}
+                                            onClick={handleShowAllMembers}
                                         >
                                             Show all members
                                         </Button>


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1386/show-all-members-button-broken

The View all members button wouldn't clear the search properly. This fixes that and also makes sure it works with browser controls.
