### PR TITLE
Skipped empty-placeholder lines in the i18n translation reviewer

### DIFF
--- a/.github/scripts/i18n-review/src/analyzer.js
+++ b/.github/scripts/i18n-review/src/analyzer.js
@@ -64,6 +64,16 @@ const REVIEW_TOOL = {
     }
 };
 
+// `pnpm translate` seeds every non-English locale with empty `""` placeholders
+// when new keys are added. Those additions trip the path-based `affects:i18n`
+// labeler but carry no translation to review, so we drop them here. Matches a
+// JSON entry whose value is an empty string, e.g. `    "Some key": "",`.
+const EMPTY_PLACEHOLDER_PATTERN = /:\s*""\s*,?\s*$/;
+
+function isEmptyPlaceholder(content) {
+    return EMPTY_PLACEHOLDER_PATTERN.test(content);
+}
+
 export async function analyzePR(prNumber, {octokit, anthropic, owner, repo, model = DEFAULT_MODEL}) {
     const {data: pr} = await octokit.pulls.get({owner, repo, pull_number: prNumber});
     console.log(`PR #${prNumber}: ${pr.title}`);
@@ -99,7 +109,7 @@ export async function analyzePR(prNumber, {octokit, anthropic, owner, repo, mode
             console.warn(`No patch available for ${file.filename} (likely too large) — skipping.`);
             continue;
         }
-        const addedLines = extractAddedLines(file.patch);
+        const addedLines = extractAddedLines(file.patch).filter(l => !isEmptyPlaceholder(l.content));
         if (addedLines.length === 0) continue;
         for (const l of addedLines) {
             const key = `${file.filename}:${l.position}`;

--- a/.github/scripts/i18n-review/test/analyzer.test.js
+++ b/.github/scripts/i18n-review/test/analyzer.test.js
@@ -63,6 +63,73 @@ test('ignores English source locale files', async () => {
     assert.equal(anthropicCalled, false);
 });
 
+test('ignores empty-string placeholder additions seeded by `pnpm translate`', async () => {
+    let anthropicCalled = false;
+    const octokit = createOctokit({
+        files: [{
+            filename: 'ghost/i18n/locales/de/ghost.json',
+            status: 'modified',
+            patch: '@@ -1,1 +1,3 @@\n {\n+  "New key one": "",\n+  "New key two": ""\n }'
+        }]
+    });
+    const anthropic = {
+        messages: {
+            create: async () => {
+                anthropicCalled = true;
+            }
+        }
+    };
+
+    const review = await analyzePR(123, {
+        octokit,
+        anthropic,
+        owner: 'TryGhost',
+        repo: 'Ghost'
+    });
+
+    assert.equal(review, null);
+    assert.equal(anthropicCalled, false);
+    // No file contents should have been fetched — we bail before the network calls.
+    assert.equal(octokit.getContentCalls.length, 0);
+});
+
+test('reviews real translations even when the PR also adds empty placeholders', async () => {
+    let anthropicCalled = false;
+    const octokit = createOctokit({
+        files: [{
+            filename: 'ghost/i18n/locales/de/ghost.json',
+            status: 'modified',
+            patch: '@@ -1,1 +1,3 @@\n {\n+  "Translated": "Übersetzt",\n+  "Placeholder": ""\n }'
+        }]
+    });
+    const anthropic = {
+        messages: {
+            create: async () => {
+                anthropicCalled = true;
+                return {
+                    content: [{
+                        type: 'tool_use',
+                        name: 'post_translation_review',
+                        input: {verdict: 'ok', overall: 'Looks good.', comments: []}
+                    }],
+                    usage: null
+                };
+            }
+        }
+    };
+
+    const review = await analyzePR(123, {
+        octokit,
+        anthropic,
+        owner: 'TryGhost',
+        repo: 'Ghost'
+    });
+
+    assert.equal(anthropicCalled, true);
+    // Only the non-empty line counts toward the review.
+    assert.equal(review.stats.linesReviewed, 1);
+});
+
 test('skips the model call when the PR exceeds the per-PR line cap', async () => {
     const lines = [];
     for (let i = 0; i < 600; i++) {


### PR DESCRIPTION
## Summary

The advisory translation reviewer (`.github/scripts/i18n-review`) runs whenever a PR carries the `affects:i18n` label. That label is applied to any PR touching a locale file, so PRs generated by `pnpm translate` — which seed empty `""` placeholders into every non-English locale when new source keys are added — triggered the reviewer even though there's no translation to review. Each one spent an Anthropic API call to conclude there was nothing to say.

## What changed

`analyzePR` now filters out added diff lines whose JSON value is an empty string (`"Key": ""`) before building the review:

- A **placeholder-only** PR yields zero eligible lines → returns `null` → the workflow exits with "Nothing to review", **no model call**.
- PRs that mix real translations with placeholders are still reviewed, but only the **non-empty** lines count toward `linesReviewed` and are shown to the model.

## Testing

- Added two unit tests in `.github/scripts/i18n-review/test/analyzer.test.js`: placeholder-only PRs bail before any network call; mixed PRs review only the non-empty line.
- `node --test` — all passing.

## Related

The `affects:i18n` label itself is applied upstream by the `label-actions` action (purely path-based today). A companion PR — TryGhost/Actions#112 — makes that labeler diff-aware so empty-placeholder PRs aren't tagged in the first place. This PR is the defense-in-depth layer on the consumer side and is useful independently.