### PR TITLE
Automations minor UX / UI improvements

### DIFF
--- a/apps/posts/src/views/Automations/components/automation-header.tsx
+++ b/apps/posts/src/views/Automations/components/automation-header.tsx
@@ -1,6 +1,6 @@
 import AutomationStatusBadge from './automation-status-badge';
 import React from 'react';
-import {Button, type ButtonProps, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Skeleton} from '@tryghost/shade/components';
+import {Button, type ButtonProps, Skeleton} from '@tryghost/shade/components';
 import {Link} from '@tryghost/admin-x-framework';
 import {LucideIcon} from '@tryghost/shade/utils';
 import type {AutomationDetail} from '@tryghost/admin-x-framework/api/automations';
@@ -58,19 +58,14 @@ const AutomationHeader: React.FC<AutomationHeaderProps> = ({
             </div>
             <div className='flex shrink-0 items-center gap-3'>
                 {status === 'active' && (
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <Button aria-label='Automation options' variant='ghost'>
-                                <LucideIcon.Ellipsis />
-                            </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align='end' className='min-w-40'>
-                            <DropdownMenuItem disabled={!isTurnOffButtonEnabled} onSelect={onTurnOff}>
-                                <LucideIcon.Power className='size-4' />
-                                Turn off
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
+                    <Button
+                        disabled={!isTurnOffButtonEnabled}
+                        variant='outline'
+                        onClick={onTurnOff}
+                    >
+                        <LucideIcon.Power />
+                        Turn off
+                    </Button>
                 )}
                 {status === 'inactive' && (
                     <Button

--- a/apps/posts/src/views/Automations/components/canvas/controls.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/controls.tsx
@@ -48,7 +48,7 @@ export const AutomationCanvasControls: React.FC = () => {
                 <DropdownMenuTrigger asChild>
                     <Button
                         aria-label={`Zoom level ${formatNumber(zoomPercent)}%`}
-                        className='min-w-14 rounded-sm px-2 font-semibold'
+                        className='h-9 min-w-14 rounded-sm px-2 font-semibold'
                         type='button'
                         variant='ghost'
                     >

--- a/apps/posts/src/views/Automations/components/canvas/nodes.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/nodes.tsx
@@ -154,8 +154,8 @@ const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
                 <Icon className='size-4' />
             </div>
             <div className='flex min-w-0 flex-col text-left'>
-                <span className='text-xs text-text-secondary'>{data.label}</span>
-                {data.value && <span className={cn('truncate font-medium', data.isPlaceholderValue && 'opacity-50')}>{data.value}</span>}
+                <span className='text-sm text-text-secondary'>{data.label}</span>
+                {data.value && <span className={cn('truncate text-base font-medium', data.isPlaceholderValue && 'opacity-50')}>{data.value}</span>}
                 {data.errorMessage && <span className='mt-1 text-xs text-destructive'>{data.errorMessage}</span>}
                 {!data.errorMessage && data.warningMessage && <span className='mt-1 text-xs text-yellow-600'>{data.warningMessage}</span>}
             </div>

--- a/apps/posts/src/views/Automations/components/canvas/step-sidebar.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/step-sidebar.tsx
@@ -1,7 +1,7 @@
 import '@xyflow/react/dist/style.css';
 import React, {useEffect, useRef, useState} from 'react';
 import {AutomationDetail, AutomationSendEmailAction, AutomationWaitAction} from '@tryghost/admin-x-framework/api/automations';
-import {Button, Checkbox, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, Label, Select, SelectTrigger} from '@tryghost/shade/components';
+import {Button, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import {MemberTier, StepSidebarDetail} from '../types';
 import {TRIGGER_CANVAS_ID} from './nodes';
@@ -27,13 +27,15 @@ const SidebarField: React.FC<{label: string; children: React.ReactNode; htmlFor?
     </Field>
 );
 
-const ReadOnlySelect: React.FC<{value: string}> = ({value}) => (
-    <Select value={value}>
-        <SelectTrigger disabled>
-            <span>{value}</span>
-        </SelectTrigger>
-    </Select>
-);
+// Public beta limitation: only one trigger type exists, so the read-only Select
+// in the sidebar header would just mirror the title above it.
+// const ReadOnlySelect: React.FC<{value: string}> = ({value}) => (
+//     <Select value={value}>
+//         <SelectTrigger disabled>
+//             <span>{value}</span>
+//         </SelectTrigger>
+//     </Select>
+// );
 
 const DeleteStepButton: React.FC<{onClick: () => void}> = ({onClick}) => (
     <Button
@@ -47,24 +49,30 @@ const DeleteStepButton: React.FC<{onClick: () => void}> = ({onClick}) => (
     </Button>
 );
 
-const TriggerSidebarBody: React.FC<{memberTiers: MemberTier[]}> = ({memberTiers}) => (
-    <div className='flex flex-col gap-5'>
-        <SidebarField label='Trigger'>
-            <ReadOnlySelect value='New member sign up' />
-        </SidebarField>
-        <div className='flex flex-col gap-2'>
-            <span className='text-sm font-medium text-text-secondary'>Members</span>
-            <Label className='flex items-center gap-2 text-sm font-normal text-foreground'>
-                <Checkbox checked={memberTiers.includes('free')} disabled />
-              Free
-            </Label>
-            <Label className='flex items-center gap-2 text-sm font-normal text-foreground'>
-                <Checkbox checked={memberTiers.includes('paid')} disabled />
-              Paid
-            </Label>
+const MEMBER_TIER_LABELS: Record<MemberTier, string> = {
+    free: 'Free',
+    paid: 'Paid'
+};
+
+const TriggerSidebarBody: React.FC<{memberTiers: MemberTier[]}> = ({memberTiers}) => {
+    const selectedTiers = memberTiers.map(tier => MEMBER_TIER_LABELS[tier]).join(', ');
+
+    return (
+        <div className='flex flex-col gap-5'>
+            {/* Public beta limitation: only one trigger type exists, so the read-only Select
+                in the sidebar header would just mirror the title above it.
+            <SidebarField label='Trigger'>
+                <ReadOnlySelect value='New member sign up' />
+            </SidebarField> */}
+            {selectedTiers && (
+                <div className='flex flex-col'>
+                    <span className='text-sm font-medium text-text-secondary'>Members</span>
+                    <span className='text-base text-foreground'>{selectedTiers}</span>
+                </div>
+            )}
         </div>
-    </div>
-);
+    );
+};
 
 const WaitSidebarBody: React.FC<{
   action: AutomationWaitAction;

--- a/apps/posts/src/views/Automations/components/canvas/step-sidebar.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/step-sidebar.tsx
@@ -20,7 +20,7 @@ const getValidWaitDays = (value: string): number | null => {
 
 const SidebarField: React.FC<{label: string; children: React.ReactNode; htmlFor?: string}> = ({children, htmlFor, label}) => (
     <Field>
-        <FieldLabel className='text-xs font-medium text-text-secondary' htmlFor={htmlFor}>
+        <FieldLabel className='text-sm font-medium text-text-secondary' htmlFor={htmlFor}>
             {label}
         </FieldLabel>
         {children}
@@ -53,7 +53,7 @@ const TriggerSidebarBody: React.FC<{memberTiers: MemberTier[]}> = ({memberTiers}
             <ReadOnlySelect value='New member sign up' />
         </SidebarField>
         <div className='flex flex-col gap-2'>
-            <span className='text-xs font-medium text-text-secondary'>Members</span>
+            <span className='text-sm font-medium text-text-secondary'>Members</span>
             <Label className='flex items-center gap-2 text-sm font-normal text-foreground'>
                 <Checkbox checked={memberTiers.includes('free')} disabled />
               Free
@@ -228,7 +228,7 @@ const StepSidebarContent: React.FC<{detail: StepSidebarDetail}> = ({detail}) => 
                         <Icon className='size-4' />
                     </div>
                     <div className='min-w-0'>
-                        <span className='block text-xs text-text-secondary'>{detail.label}</span>
+                        <span className='block text-sm text-text-secondary'>{detail.label}</span>
                         <h2 className={cn('truncate text-base leading-tight font-medium text-foreground', detail.isPlaceholderTitle && 'opacity-50')}>{detail.title}</h2>
                     </div>
                 </div>

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -157,13 +157,10 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
         }
     }, [isDirty, onClose]);
 
-    // Commit to the automation draft, then close the modal.
-    const handleSaveAndClose = useCallback(async () => {
-        const result = await handleSave({fakeWhenUnchanged: true});
-        if (result) {
-            onClose();
-        }
-    }, [handleSave, onClose]);
+    // Commit to the automation draft. The Close button is the only way out of the modal.
+    const handleSaveClick = useCallback(async () => {
+        await handleSave({fakeWhenUnchanged: true});
+    }, [handleSave]);
 
     // Close dropdown when clicking outside
     useEffect(() => {
@@ -182,16 +179,16 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
         };
     }, [showTestDropdown]);
 
-    const handleSaveAndCloseRef = useRef(handleSaveAndClose);
+    const handleSaveClickRef = useRef(handleSaveClick);
     useEffect(() => {
-        handleSaveAndCloseRef.current = handleSaveAndClose;
-    }, [handleSaveAndClose]);
+        handleSaveClickRef.current = handleSaveClick;
+    }, [handleSaveClick]);
 
     useEffect(() => {
         const handleCMDS = (e: KeyboardEvent) => {
             if ((e.metaKey || e.ctrlKey) && e.key === 's') {
                 e.preventDefault();
-                handleSaveAndCloseRef.current();
+                handleSaveClickRef.current();
             }
         };
         window.addEventListener('keydown', handleCMDS);
@@ -271,7 +268,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
                                 <Button variant="outline" onClick={attemptClose}>Close</Button>
                                 <Button
                                     disabled={okProps.disabled}
-                                    onClick={handleSaveAndClose}
+                                    onClick={handleSaveClick}
                                 >
                                     {saveButtonLabel}
                                 </Button>

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -186,7 +186,7 @@ const AutomationEditor: React.FC = () => {
     const isConfirmRepublishAlertOpen = editState.action === 'republish';
     const isEditRequestActive = editState.phase === 'submitting';
     let isSaveButtonEnabled = !!draft && draft.actions.length > 0 && draft.status === 'inactive' && hasUnsavedChanges;
-    let saveButtonVariant: ButtonProps['variant'] = 'secondary';
+    let saveButtonVariant: ButtonProps['variant'] = 'outline';
     let saveButtonChildren: React.ReactNode = 'Save';
     let isPublishButtonEnabled = !!draft && draft.actions.length > 0 && (draft.status === 'inactive' || hasUnsavedChanges);
     let publishButtonVariant: ButtonProps['variant'] = 'default';

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -1005,7 +1005,7 @@ describe('AutomationEditor', () => {
         expect(screen.queryByText('Add a subject line and email body.')).not.toBeInTheDocument();
     });
 
-    it('shows the dropdown for active automations', () => {
+    it('shows the Turn off button for active automations', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [automationDetail]},
             isLoading: false,
@@ -1014,12 +1014,12 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        expect(screen.getByRole('button', {name: 'Automation options'})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Turn off'})).toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled();
         expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument();
     });
 
-    it('hides the dropdown for inactive automations', () => {
+    it('hides the Turn off button for inactive automations', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},
             isLoading: false,
@@ -1028,7 +1028,7 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        expect(screen.queryByRole('button', {name: 'Automation options'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Turn off'})).not.toBeInTheDocument();
     });
 
     it('disables the publish button and shows loading UI while a publish request is in flight', () => {
@@ -1056,11 +1056,9 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        const trigger = screen.getByRole('button', {name: 'Automation options'});
-        fireEvent.pointerDown(trigger, {button: 0, ctrlKey: false});
-        fireEvent.click(trigger);
-        fireEvent.click(await screen.findByRole('menuitem', {name: /Turn off/}));
         fireEvent.click(screen.getByRole('button', {name: 'Turn off'}));
+        const dialog = await screen.findByRole('alertdialog');
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Turn off'}));
 
         expect(screen.getByRole('button', {name: 'Cancel'})).toBeDisabled();
         const turnOff = screen.getByRole('button', {name: 'Turning off...'});
@@ -1092,7 +1090,7 @@ describe('AutomationEditor', () => {
         expect(screen.queryByText(/Couldn.t publish automation/)).not.toBeInTheDocument();
     });
 
-    it('turns off an active automation when confirming from the dropdown', async () => {
+    it('turns off an active automation when confirming from the toolbar', async () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [automationDetail]},
             isLoading: false,
@@ -1101,14 +1099,11 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        const trigger = screen.getByRole('button', {name: 'Automation options'});
-        fireEvent.pointerDown(trigger, {button: 0, ctrlKey: false});
-        fireEvent.click(trigger);
-
-        fireEvent.click(await screen.findByRole('menuitem', {name: /Turn off/}));
-
-        expect(screen.getByText('Turn off this automation?')).toBeInTheDocument();
         fireEvent.click(screen.getByRole('button', {name: 'Turn off'}));
+
+        const dialog = await screen.findByRole('alertdialog');
+        expect(within(dialog).getByText('Turn off this automation?')).toBeInTheDocument();
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Turn off'}));
 
         expect(mockEditMutation.mutate).toHaveBeenCalledWith(
             {
@@ -1130,11 +1125,9 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        const trigger = screen.getByRole('button', {name: 'Automation options'});
-        fireEvent.pointerDown(trigger, {button: 0, ctrlKey: false});
-        fireEvent.click(trigger);
-        fireEvent.click(await screen.findByRole('menuitem', {name: /Turn off/}));
         fireEvent.click(screen.getByRole('button', {name: 'Turn off'}));
+        const dialog = await screen.findByRole('alertdialog');
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Turn off'}));
 
         const button = screen.getByRole('button', {name: 'Turning off...'});
         expect(button).toBeDisabled();
@@ -1153,11 +1146,9 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        const trigger = screen.getByRole('button', {name: 'Automation options'});
-        fireEvent.pointerDown(trigger, {button: 0, ctrlKey: false});
-        fireEvent.click(trigger);
-        fireEvent.click(await screen.findByRole('menuitem', {name: /Turn off/}));
         fireEvent.click(screen.getByRole('button', {name: 'Turn off'}));
+        const dialog = await screen.findByRole('alertdialog');
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Turn off'}));
 
         const button = await screen.findByRole('button', {name: 'Retry'});
         expect(button).not.toBeDisabled();
@@ -1178,11 +1169,9 @@ describe('AutomationEditor', () => {
 
         renderEditor();
 
-        const trigger = screen.getByRole('button', {name: 'Automation options'});
-        fireEvent.pointerDown(trigger, {button: 0, ctrlKey: false});
-        fireEvent.click(trigger);
-        fireEvent.click(await screen.findByRole('menuitem', {name: /Turn off/}));
         fireEvent.click(screen.getByRole('button', {name: 'Turn off'}));
+        const dialog = await screen.findByRole('alertdialog');
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Turn off'}));
 
         await waitFor(() => {
             expect(screen.queryByText('Turn off this automation?')).not.toBeInTheDocument();

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -377,9 +377,9 @@ describe('AutomationEditor', () => {
         expect(trigger).toHaveAttribute('aria-pressed', 'true');
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
         expect(within(sidebar).getByRole('heading', {name: 'Member signs up'})).toBeInTheDocument();
-        expect(within(sidebar).getByText('New member sign up')).toBeInTheDocument();
-        expect(within(sidebar).getByRole('checkbox', {name: 'Free'})).toBeChecked();
-        expect(within(sidebar).getByRole('checkbox', {name: 'Paid'})).not.toBeChecked();
+        expect(within(sidebar).getByText('Members')).toBeInTheDocument();
+        expect(within(sidebar).getByText('Free')).toBeInTheDocument();
+        expect(within(sidebar).queryByText('Paid')).not.toBeInTheDocument();
         expect(within(sidebar).queryByRole('button', {name: /Delete/})).not.toBeInTheDocument();
         expect(within(sidebar).queryByRole('button', {name: /Edit/})).not.toBeInTheDocument();
     });
@@ -595,8 +595,8 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Trigger: Member signs up'}));
 
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
-        expect(within(sidebar).getByRole('checkbox', {name: 'Free'})).not.toBeChecked();
-        expect(within(sidebar).getByRole('checkbox', {name: 'Paid'})).toBeChecked();
+        expect(within(sidebar).getByText('Paid')).toBeInTheDocument();
+        expect(within(sidebar).queryByText('Free')).not.toBeInTheDocument();
     });
 
     it('switches the read-only sidebar content when another step is clicked', () => {


### PR DESCRIPTION
## Summary

A handful of UI refinements across the automations editor:

- **Bumped font sizes on automation nodes and the step sidebar** — node type labels go from `text-xs` → `text-sm` and node titles get an explicit `text-base` for cleaner hierarchy on the canvas. Step sidebar labels match.
- **Fixed Save button closing the automation email editor** — Save (and Cmd+S) now only commit to the automation draft; Close is the only way out of the modal.
- **Synced zoom percentage button height with the +/- controls** — pinned to `h-9` so all three controls match.
- **Promoted Turn off out of the ellipsis menu** — the dropdown only held a single action, so it's now a direct outline button in the toolbar. The Save button was switched to the same `outline` variant so the secondary actions read as a consistent set next to Publish.
- **Simplified the trigger sidebar** — during public beta only one trigger type exists, so the read-only Trigger select is hidden (it just repeated the heading) and the disabled member-tier checkboxes are replaced with a plain comma-separated list of selected tiers.

ref https://linear.app/tryghost/issue/NY-1313/

## Test plan

- [ ] Open the automations editor and confirm node/sidebar typography looks balanced across Trigger, Wait, and Send email nodes.
- [ ] Open the email editor modal — Save / Cmd+S should persist and leave the modal open; Close (or Esc) should remain the only way out.
- [ ] Verify the canvas zoom toolbar reads as one row at the same height.
- [ ] Toggle a published automation off using the toolbar Turn off button — confirmation modal still gates the action and shows the loading state.
- [ ] Open the Trigger sidebar — confirm only the selected member tiers are listed and the duplicate Trigger select is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)