### PR TITLE
Removed stale `@tryghost/errors` declaration

### DIFF
--- a/ghost/core/core/server/api/endpoints/libraries.d.ts
+++ b/ghost/core/core/server/api/endpoints/libraries.d.ts
@@ -1,4 +1,3 @@
 // Type declarations for untyped modules used by TypeScript endpoints
 declare module '@tryghost/api-framework';
 declare module '@tryghost/tpl';
-declare module '@tryghost/errors';


### PR DESCRIPTION
no ref

This is a types-only change.

`@tryghost/errors` has types. But we claimed that it didn't in this file! This removes that.
