### PR TITLE
Ignored knex updates in Renovate (defer to PLA-78)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -142,7 +142,19 @@
         // tooling (broccoli-templater, sourcemap-validator) plus old @tryghost/*
         // packages, so it can't be removed from the tree here. Ignore it to stop
         // the unactionable dashboard noise.
-        "lodash.template"
+        "lodash.template",
+
+        // https://linear.app/ghost/issue/PLA-78
+        // https://github.com/TryGhost/Ghost/pull/28180
+        // knex 2.5.x breaks migrations: 2.5.0's password-masking mutates the
+        // shared `config.get('database')` object, which we hand to BOTH knex()
+        // and knex-migrator. With core ahead of knex-migrator's pinned knex
+        // (2.4.2), the password is stripped before knex-migrator connects →
+        // "Access denied (using password: NO)". 2.x is EOL; the real move is
+        // knex 3.x, gated on publishing a knex-3 knex-migrator
+        // (TryGhost/knex-migrator#86, unreleased), bumped in lockstep with core.
+        // Ignore until we do that coordinated upgrade.
+        "knex"
     ],
     "ignorePaths": [
         "test",


### PR DESCRIPTION
Adds `knex` to `ignoreDeps` in `.github/renovate.json5` so Renovate stops re-proposing knex bumps.

### Why
- The Renovate knex 2.5.1 PR ([#28180](https://github.com/TryGhost/Ghost/pull/28180)) **breaks migrations**: knex 2.5.0's password-masking mutates the shared `config.get('database')` object, which Ghost hands to **both** `knex()` and `knex-migrator`. With core ahead of `knex-migrator@5.3.2`'s pinned knex (2.4.2), the password is stripped before knex-migrator connects → `Access denied (using password: NO)`.
- The 2.x line is **EOL**; the real move is **knex 3.x**, which is coupled to a knex-3 `knex-migrator` release ([knex-migrator#86](https://github.com/TryGhost/knex-migrator/pull/86/files), unreleased) and must be bumped in lockstep with core.
- No feature driver for our stack (MySQL2 + `sqlite3` + knex-migrator). This is maintenance/EOL hygiene.

Ignoring `knex` stops the recurring dashboard/PR noise until we do the coordinated upgrade, tracked in **[PLA-78](https://linear.app/ghost/issue/PLA-78)**. The note (with full rationale) lives inline next to the entry, matching the existing `ignoreDeps` convention. Remove the entry once we're on 3.x.

ref PLA-78