### PR TITLE
Fixed expired complimentary members not triggering webhooks

### DIFF
--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -9,14 +9,23 @@ const models = require('../../models');
 const sentry = require('../../../shared/sentry');
 const domainEvents = require('@tryghost/domain-events');
 const config = require('../../../shared/config');
+const WorkerModelEventBridge = require('./worker-model-event-bridge');
 const errorHandler = (error, workerMeta) => {
     logging.info(`Capturing error for worker during execution of job: ${workerMeta.name}`);
     logging.error(error);
     sentry.captureException(error);
 };
 const events = require('../../lib/common/events');
+const workerModelEventBridge = new WorkerModelEventBridge({models, events, logging, sentry});
 
 const workerMessageHandler = ({name, message}) => {
+    if (workerModelEventBridge.isModelEventMessage(message)) {
+        // Carries its own `eventName` rather than job-manager's reserved `event` key,
+        // so it routes through the bridge instead of being dispatched as a raw domain event.
+        workerModelEventBridge.handle(message, {jobName: name});
+        return;
+    }
+
     if (typeof message === 'string') {
         logging.info(`Worker for job ${name} sent a message: ${message}`);
     }

--- a/ghost/core/core/server/services/jobs/worker-model-event-bridge.js
+++ b/ghost/core/core/server/services/jobs/worker-model-event-bridge.js
@@ -1,0 +1,137 @@
+const {z} = require('zod');
+const moment = require('moment');
+
+const MODEL_EVENT_TYPE = 'model-event';
+const SUPPORTED_MODEL_EVENTS = {
+    'member.edited': {
+        model: 'Member'
+    }
+};
+
+const attributesSchema = z.record(z.string(), z.unknown());
+
+const messageSchema = z.object({
+    type: z.literal(MODEL_EVENT_TYPE),
+    eventName: z.enum(Object.keys(SUPPORTED_MODEL_EVENTS)),
+    model: z.string(),
+    id: z.string().min(1),
+    previous: attributesSchema,
+    changed: attributesSchema.refine(value => Object.keys(value).length > 0, {
+        message: 'must include at least one changed attribute'
+    }),
+    options: attributesSchema.optional()
+}).refine(message => SUPPORTED_MODEL_EVENTS[message.eventName]?.model === message.model, {
+    message: 'does not match the event',
+    path: ['model']
+});
+
+class WorkerModelEventBridge {
+    constructor({models, events, logging, sentry}) {
+        this.models = models;
+        this.events = events;
+        this.logging = logging;
+        this.sentry = sentry;
+    }
+
+    isModelEventMessage(message) {
+        return isObject(message) && message.type === MODEL_EVENT_TYPE;
+    }
+
+    async handle(message, meta = {}) {
+        const validationError = this.validate(message);
+
+        if (validationError) {
+            this.logging.warn(`Ignoring invalid worker model event from job ${meta.jobName || 'unknown'}: ${validationError}`);
+            return false;
+        }
+
+        try {
+            return await this.emitModelEvent(message);
+        } catch (err) {
+            this.logging.error(err);
+            this.sentry.captureException(err);
+            return false;
+        }
+    }
+
+    validate(message) {
+        const result = messageSchema.safeParse(message);
+
+        if (result.success) {
+            return null;
+        }
+
+        return result.error.issues
+            .map(issue => (issue.path.length ? `${issue.path.join('.')}: ${issue.message}` : issue.message))
+            .join('; ');
+    }
+
+    async emitModelEvent(message) {
+        const Model = this.models[message.model];
+        let model;
+
+        try {
+            model = await Model.findOne({
+                id: message.id
+            }, {
+                require: true,
+                context: {internal: true}
+            });
+        } catch (err) {
+            if (isNotFoundError(err)) {
+                this.logging.warn(`Could not emit worker model event ${message.eventName}: ${message.model} ${message.id} was not found`);
+                return false;
+            }
+
+            throw err;
+        }
+
+        model._previousAttributes = normalizeDates({
+            ...model.attributes,
+            ...message.previous
+        });
+        model._changed = normalizeDates(message.changed);
+
+        const options = normalizeOptions(message.options);
+        this.events.emit(message.eventName, model, options);
+        return true;
+    }
+}
+
+function normalizeOptions(options = {}) {
+    return {
+        ...options,
+        context: {
+            ...options.context,
+            internal: true
+        }
+    };
+}
+
+function normalizeDates(attributes) {
+    const normalized = {...attributes};
+
+    for (const [key, value] of Object.entries(normalized)) {
+        if (key.endsWith('_at') && value && !(value instanceof Date)) {
+            normalized[key] = moment.utc(value).toDate();
+        }
+    }
+
+    return normalized;
+}
+
+function isObject(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNotFoundError(err) {
+    return err && (
+        err.errorType === 'NotFoundError' ||
+        err.name === 'NotFoundError' ||
+        err.message === 'NotFound' ||
+        err.message === 'EmptyResponse'
+    );
+}
+
+module.exports = WorkerModelEventBridge;
+module.exports.MODEL_EVENT_TYPE = MODEL_EVENT_TYPE;

--- a/ghost/core/core/server/services/members/jobs/clean-expired-comped.js
+++ b/ghost/core/core/server/services/members/jobs/clean-expired-comped.js
@@ -57,18 +57,17 @@ if (parentPort) {
             .andWhere('status', 'comped');
 
         const updateMemberIds = membersToUpdate.map(d => d.id);
+        const now = new Date();
 
         // Update all comped members to free
         updatedMembers = await db.knex('members')
             .whereIn('id', updateMemberIds)
             .update({
                 status: 'free',
-                updated_at: db.knex.raw('CURRENT_TIMESTAMP')
+                updated_at: now
             });
 
         const statusEvents = membersToUpdate.map((member) => {
-            const now = db.knex.raw('CURRENT_TIMESTAMP');
-
             return {
                 id: ObjectId().toHexString(),
                 member_id: member.id,
@@ -87,6 +86,28 @@ if (parentPort) {
         // Adds status event for members going comped->free
         for (const chunk of chunks) {
             await db.knex('members_status_events').insert(chunk);
+        }
+
+        if (parentPort) {
+            for (const member of membersToUpdate) {
+                parentPort.postMessage({
+                    type: 'model-event',
+                    eventName: 'member.edited',
+                    model: 'Member',
+                    id: member.id,
+                    previous: {
+                        status: member.status,
+                        updated_at: member.updated_at
+                    },
+                    changed: {
+                        status: 'free',
+                        updated_at: now
+                    },
+                    options: {
+                        context: {internal: true}
+                    }
+                });
+            }
         }
     }
 

--- a/ghost/core/test/unit/server/services/jobs/job-service.test.js
+++ b/ghost/core/test/unit/server/services/jobs/job-service.test.js
@@ -1,0 +1,212 @@
+const assert = require('node:assert/strict');
+const Module = require('module');
+const sinon = require('sinon');
+
+describe('JobService', function () {
+    const jobServicePath = '../../../../../core/server/services/jobs/job-service';
+    let originalLoad;
+    let workerMessageHandler;
+    let handleModelEvent;
+
+    beforeEach(function () {
+        originalLoad = Module._load;
+        handleModelEvent = sinon.stub().resolves(true);
+
+        Module._load = function (request, parent, isMain) {
+            if (request === '@tryghost/job-manager') {
+                return class JobManager {
+                    constructor(options) {
+                        workerMessageHandler = options.workerMessageHandler;
+                    }
+                };
+            }
+
+            if (request === './worker-model-event-bridge') {
+                return class WorkerModelEventBridge {
+                    isModelEventMessage(message) {
+                        return message && message.type === 'model-event';
+                    }
+
+                    handle(message, meta) {
+                        return handleModelEvent(message, meta);
+                    }
+                };
+            }
+
+            if (request === '@tryghost/logging') {
+                return {
+                    info: sinon.stub(),
+                    warn: sinon.stub(),
+                    error: sinon.stub()
+                };
+            }
+
+            if (request === '../../models') {
+                return {Job: {}};
+            }
+
+            if (request === '../../../shared/sentry') {
+                return {captureException: sinon.stub()};
+            }
+
+            if (request === '@tryghost/domain-events') {
+                return {};
+            }
+
+            if (request === '../../../shared/config') {
+                return {};
+            }
+
+            if (request === '../../lib/common/events') {
+                return {emit: sinon.stub()};
+            }
+
+            return originalLoad.call(this, request, parent, isMain);
+        };
+
+        delete require.cache[require.resolve(jobServicePath)];
+        require(jobServicePath);
+    });
+
+    afterEach(function () {
+        Module._load = originalLoad;
+        delete require.cache[require.resolve(jobServicePath)];
+        sinon.restore();
+    });
+
+    it('routes model-event worker messages to the bridge without mutating them', function () {
+        const message = {
+            type: 'model-event',
+            eventName: 'member.edited',
+            model: 'Member',
+            id: 'member-id',
+            previous: {status: 'comped'},
+            changed: {status: 'free'}
+        };
+
+        workerMessageHandler({name: 'clean-expired-comped', message});
+
+        sinon.assert.calledOnceWithExactly(handleModelEvent, {
+            type: 'model-event',
+            eventName: 'member.edited',
+            model: 'Member',
+            id: 'member-id',
+            previous: {status: 'comped'},
+            changed: {status: 'free'}
+        }, {
+            jobName: 'clean-expired-comped'
+        });
+        // No reserved `event` key, so job-manager will not dispatch it as a raw domain event
+        assert.equal(message.event, undefined);
+        assert.equal(message.eventName, 'member.edited');
+    });
+});
+
+describe('JobService model-event bridge wiring', function () {
+    const jobServicePath = '../../../../../core/server/services/jobs/job-service';
+    const bridgePath = '../../../../../core/server/services/jobs/worker-model-event-bridge';
+    let originalLoad;
+    let workerMessageHandler;
+    let emit;
+    let findOne;
+
+    beforeEach(function () {
+        originalLoad = Module._load;
+        emit = sinon.stub();
+        findOne = sinon.stub();
+
+        Module._load = function (request, parent, isMain) {
+            if (request === '@tryghost/job-manager') {
+                return class JobManager {
+                    constructor(options) {
+                        workerMessageHandler = options.workerMessageHandler;
+                    }
+                };
+            }
+
+            if (request === '@tryghost/logging') {
+                return {
+                    info: sinon.stub(),
+                    warn: sinon.stub(),
+                    error: sinon.stub()
+                };
+            }
+
+            if (request === '../../models') {
+                return {Job: {}, Member: {findOne}};
+            }
+
+            if (request === '../../../shared/sentry') {
+                return {captureException: sinon.stub()};
+            }
+
+            if (request === '@tryghost/domain-events') {
+                return {};
+            }
+
+            if (request === '../../../shared/config') {
+                return {};
+            }
+
+            if (request === '../../lib/common/events') {
+                return {emit};
+            }
+
+            return originalLoad.call(this, request, parent, isMain);
+        };
+
+        delete require.cache[require.resolve(jobServicePath)];
+        delete require.cache[require.resolve(bridgePath)];
+        require(jobServicePath);
+    });
+
+    afterEach(function () {
+        Module._load = originalLoad;
+        delete require.cache[require.resolve(jobServicePath)];
+        delete require.cache[require.resolve(bridgePath)];
+        sinon.restore();
+    });
+
+    // Exercises the real bridge (unstubbed) end-to-end: a posted message is reconstructed
+    // into a model and emitted on the events bus that webhooks listen on.
+    it('reconstructs and emits a member.edited event through the real bridge', async function () {
+        const model = {
+            attributes: {
+                id: 'member-id',
+                email: 'member@example.com',
+                status: 'free'
+            }
+        };
+        findOne.resolves(model);
+
+        const emitted = new Promise((resolve) => {
+            emit.callsFake((...args) => resolve(args));
+        });
+
+        workerMessageHandler({
+            name: 'clean-expired-comped',
+            message: {
+                type: 'model-event',
+                eventName: 'member.edited',
+                model: 'Member',
+                id: 'member-id',
+                previous: {status: 'comped'},
+                changed: {status: 'free'}
+            }
+        });
+
+        const [eventName, emittedModel, options] = await emitted;
+
+        sinon.assert.calledOnceWithExactly(findOne, {
+            id: 'member-id'
+        }, {
+            require: true,
+            context: {internal: true}
+        });
+        assert.equal(eventName, 'member.edited');
+        assert.equal(emittedModel, model);
+        assert.equal(emittedModel._previousAttributes.status, 'comped');
+        assert.equal(emittedModel._changed.status, 'free');
+        assert.equal(options.context.internal, true);
+    });
+});

--- a/ghost/core/test/unit/server/services/jobs/worker-model-event-bridge.test.js
+++ b/ghost/core/test/unit/server/services/jobs/worker-model-event-bridge.test.js
@@ -1,0 +1,185 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+
+const WorkerModelEventBridge = require('../../../../../core/server/services/jobs/worker-model-event-bridge');
+
+describe('WorkerModelEventBridge', function () {
+    let models;
+    let events;
+    let logging;
+    let sentry;
+    let bridge;
+
+    beforeEach(function () {
+        models = {
+            Member: {
+                findOne: sinon.stub()
+            }
+        };
+        events = {
+            emit: sinon.stub()
+        };
+        logging = {
+            warn: sinon.stub(),
+            error: sinon.stub()
+        };
+        sentry = {
+            captureException: sinon.stub()
+        };
+        bridge = new WorkerModelEventBridge({models, events, logging, sentry});
+    });
+
+    it('emits a reconstructed member.edited event', async function () {
+        const currentUpdatedAt = new Date('2026-05-29T00:00:00.000Z');
+        const model = {
+            attributes: {
+                id: 'member-id',
+                email: 'member@example.com',
+                status: 'free',
+                updated_at: currentUpdatedAt
+            }
+        };
+
+        models.Member.findOne.resolves(model);
+
+        const result = await bridge.handle({
+            type: 'model-event',
+            eventName: 'member.edited',
+            model: 'Member',
+            id: 'member-id',
+            previous: {
+                status: 'comped',
+                updated_at: '2026-04-28T15:55:45.000Z'
+            },
+            changed: {
+                status: 'free',
+                updated_at: currentUpdatedAt
+            },
+            options: {
+                context: {internal: true}
+            }
+        }, {
+            jobName: 'clean-expired-comped'
+        });
+
+        assert.equal(result, true);
+        sinon.assert.calledOnceWithExactly(models.Member.findOne, {
+            id: 'member-id'
+        }, {
+            require: true,
+            context: {internal: true}
+        });
+
+        assert.equal(model._previousAttributes.id, 'member-id');
+        assert.equal(model._previousAttributes.email, 'member@example.com');
+        assert.equal(model._previousAttributes.status, 'comped');
+        assert.deepEqual(model._previousAttributes.updated_at, new Date('2026-04-28T15:55:45.000Z'));
+        assert.equal(model._changed.status, 'free');
+        assert.deepEqual(model._changed.updated_at, currentUpdatedAt);
+        sinon.assert.calledOnceWithExactly(events.emit, 'member.edited', model, {
+            context: {internal: true}
+        });
+        sinon.assert.notCalled(logging.warn);
+        sinon.assert.notCalled(logging.error);
+        sinon.assert.notCalled(sentry.captureException);
+    });
+
+    it('logs and ignores unsupported model events', async function () {
+        const result = await bridge.handle({
+            type: 'model-event',
+            eventName: 'post.edited',
+            model: 'Post',
+            id: 'post-id',
+            previous: {title: 'Old title'},
+            changed: {title: 'New title'}
+        }, {
+            jobName: 'some-job'
+        });
+
+        assert.equal(result, false);
+        sinon.assert.calledOnce(logging.warn);
+        sinon.assert.notCalled(models.Member.findOne);
+        sinon.assert.notCalled(events.emit);
+        sinon.assert.notCalled(logging.error);
+        sinon.assert.notCalled(sentry.captureException);
+    });
+
+    it('rejects a supported event paired with the wrong model', async function () {
+        const result = await bridge.handle({
+            type: 'model-event',
+            eventName: 'member.edited',
+            model: 'Post',
+            id: 'member-id',
+            previous: {status: 'comped'},
+            changed: {status: 'free'}
+        }, {
+            jobName: 'clean-expired-comped'
+        });
+
+        assert.equal(result, false);
+        sinon.assert.calledOnce(logging.warn);
+        sinon.assert.notCalled(models.Member.findOne);
+        sinon.assert.notCalled(events.emit);
+    });
+
+    it('logs and ignores malformed model event messages', async function () {
+        const result = await bridge.handle({
+            type: 'model-event',
+            eventName: 'member.edited',
+            model: 'Member',
+            id: 'member-id',
+            previous: {status: 'comped'},
+            changed: {}
+        }, {
+            jobName: 'clean-expired-comped'
+        });
+
+        assert.equal(result, false);
+        sinon.assert.calledOnce(logging.warn);
+        sinon.assert.notCalled(models.Member.findOne);
+        sinon.assert.notCalled(events.emit);
+    });
+
+    it('logs missing models without crashing', async function () {
+        const notFoundError = new Error('EmptyResponse');
+        models.Member.findOne.rejects(notFoundError);
+
+        const result = await bridge.handle({
+            type: 'model-event',
+            eventName: 'member.edited',
+            model: 'Member',
+            id: 'missing-member-id',
+            previous: {status: 'comped'},
+            changed: {status: 'free'}
+        }, {
+            jobName: 'clean-expired-comped'
+        });
+
+        assert.equal(result, false);
+        sinon.assert.calledOnce(logging.warn);
+        sinon.assert.notCalled(events.emit);
+        sinon.assert.notCalled(logging.error);
+        sinon.assert.notCalled(sentry.captureException);
+    });
+
+    it('captures handler errors without crashing', async function () {
+        const error = new Error('database unavailable');
+        models.Member.findOne.rejects(error);
+
+        const result = await bridge.handle({
+            type: 'model-event',
+            eventName: 'member.edited',
+            model: 'Member',
+            id: 'member-id',
+            previous: {status: 'comped'},
+            changed: {status: 'free'}
+        }, {
+            jobName: 'clean-expired-comped'
+        });
+
+        assert.equal(result, false);
+        sinon.assert.calledOnceWithExactly(logging.error, error);
+        sinon.assert.calledOnceWithExactly(sentry.captureException, error);
+        sinon.assert.notCalled(events.emit);
+    });
+});

--- a/ghost/core/test/unit/server/services/members/clean-expired-comped.test.js
+++ b/ghost/core/test/unit/server/services/members/clean-expired-comped.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const Module = require('node:module');
 
-const rawTimestamp = {raw: 'CURRENT_TIMESTAMP'};
+const previousUpdatedAt = new Date('2026-04-28T15:55:45.000Z');
 
 describe('Job: Clean expired comped members', function () {
     const jobPath = '../../../../../core/server/services/members/jobs/clean-expired-comped';
@@ -10,12 +10,16 @@ describe('Job: Clean expired comped members', function () {
         delete require.cache[require.resolve(jobPath)];
     });
 
-    it('bumps updated_at when expiring comped members', async function () {
+    it('bumps updated_at and posts model-event messages when expiring comped members', async function () {
         const updateCalls = [];
+        const insertCalls = [];
+        const messages = [];
         const done = new Promise((resolve) => {
             const parentPort = {
                 once() {},
                 postMessage(message) {
+                    messages.push(message);
+
                     if (message === 'done') {
                         resolve();
                     }
@@ -24,7 +28,7 @@ describe('Job: Clean expired comped members', function () {
 
             const restoreRequire = mockRequires({
                 worker_threads: {parentPort},
-                '../../../data/db': createDb(updateCalls)
+                '../../../data/db': createDb(updateCalls, insertCalls)
             });
 
             try {
@@ -36,31 +40,49 @@ describe('Job: Clean expired comped members', function () {
 
         await done;
 
-        assert.deepEqual(updateCalls, [{
-            tableName: 'members',
-            ids: ['member-id'],
-            data: {
+        assert.equal(updateCalls.length, 1);
+        assert.equal(updateCalls[0].tableName, 'members');
+        assert.deepEqual(updateCalls[0].ids, ['member-id']);
+        assert.equal(updateCalls[0].data.status, 'free');
+        assert.ok(updateCalls[0].data.updated_at instanceof Date);
+
+        // Status event shares the same timestamp as the member update (not a raw CURRENT_TIMESTAMP)
+        const statusEventInsert = insertCalls.find(call => call.tableName === 'members_status_events');
+        assert.ok(statusEventInsert);
+        assert.ok(statusEventInsert.rows[0].created_at instanceof Date);
+        assert.deepEqual(statusEventInsert.rows[0].created_at, updateCalls[0].data.updated_at);
+
+        const modelEventMessage = messages.find(message => message && message.type === 'model-event');
+        assert.deepEqual(modelEventMessage, {
+            type: 'model-event',
+            eventName: 'member.edited',
+            model: 'Member',
+            id: 'member-id',
+            previous: {
+                status: 'comped',
+                updated_at: previousUpdatedAt
+            },
+            changed: {
                 status: 'free',
-                updated_at: rawTimestamp
+                updated_at: updateCalls[0].data.updated_at
+            },
+            options: {
+                context: {internal: true}
             }
-        }]);
+        });
+        assert.ok(messages.indexOf(modelEventMessage) < messages.indexOf('done'));
     });
 });
 
-function createDb(updateCalls) {
+function createDb(updateCalls, insertCalls) {
     const knex = function knex(tableName) {
-        return createQuery(tableName, updateCalls);
-    };
-
-    knex.raw = function raw(value) {
-        assert.equal(value, 'CURRENT_TIMESTAMP');
-        return rawTimestamp;
+        return createQuery(tableName, updateCalls, insertCalls);
     };
 
     return {knex};
 }
 
-function createQuery(tableName, updateCalls) {
+function createQuery(tableName, updateCalls, insertCalls) {
     const query = {
         ids: null,
 
@@ -76,7 +98,8 @@ function createQuery(tableName, updateCalls) {
         andWhere() {
             return Promise.resolve([{
                 id: 'member-id',
-                status: 'comped'
+                status: 'comped',
+                updated_at: previousUpdatedAt
             }]);
         },
 
@@ -101,7 +124,8 @@ function createQuery(tableName, updateCalls) {
             return Promise.resolve(query.ids.length);
         },
 
-        insert() {
+        insert(rows) {
+            insertCalls.push({tableName, rows});
             return Promise.resolve();
         }
     };

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 
 const models = require('../../../../../core/server/models');
 
@@ -20,6 +21,7 @@ describe('WebhookService - Serialize', function () {
 
     afterEach(function () {
         tiersService.api = null;
+        sinon.restore();
     });
 
     it('rejects with no arguments', async function () {
@@ -83,5 +85,43 @@ describe('WebhookService - Serialize', function () {
         // @TODO: use snapshot matching here
         assert.equal(result.post.current.title, 'A brand new title', 'The updated title should be present');
         assert.equal(result.post.previous.title, 'Ghostly Kitchen Sink', 'The previous title should also be present');
+    });
+
+    it('can serialize reconstructed member.edited model event state', async function () {
+        const previousUpdatedAt = new Date('2026-04-28T15:55:45.000Z');
+        const currentUpdatedAt = new Date('2026-05-29T00:00:00.000Z');
+        const memberModel = new models.Member({
+            id: 'member-id',
+            uuid: 'member-uuid',
+            email: 'member@example.com',
+            status: 'free',
+            created_at: previousUpdatedAt,
+            updated_at: currentUpdatedAt
+        });
+
+        sinon.stub(memberModel, 'load').resolves(memberModel);
+        memberModel._previousAttributes = {
+            ...memberModel.attributes,
+            status: 'comped',
+            updated_at: previousUpdatedAt
+        };
+        memberModel._changed = {
+            status: 'free',
+            updated_at: currentUpdatedAt
+        };
+
+        const result = await serialize('member.edited', memberModel);
+
+        sinon.assert.calledOnceWithExactly(memberModel.load, [
+            'labels',
+            'products',
+            'newsletters'
+        ]);
+        assert.equal(result.member.current.status, 'free');
+        assert.equal(result.member.current.comped, false);
+        assert.deepEqual(result.member.current.updated_at, currentUpdatedAt);
+        assert.equal(result.member.previous.status, 'comped');
+        assert.deepEqual(result.member.previous.updated_at, previousUpdatedAt);
+        assert.deepEqual(Object.keys(result.member.previous).sort(), ['status', 'updated_at']);
     });
 });


### PR DESCRIPTION
## Summary
- add a narrow worker-to-host model event bridge for allowlisted lifecycle events
- route `model-event` worker messages through the bridge without dispatching them as raw domain events
- emit `member.edited` model-event messages from `clean-expired-comped` after direct DB cleanup
- cover bridge handling, worker message payloads, and webhook member payload serialization

## Test notes
- `pnpm --dir ghost/core test:single test/unit/server/services/jobs/job-service.test.js`
- `pnpm --dir ghost/core test:single test/unit/server/services/jobs/worker-model-event-bridge.test.js`
- `pnpm --dir ghost/core test:single test/unit/server/services/members/clean-expired-comped.test.js`
- `pnpm --dir ghost/core test:single test/unit/server/services/webhooks/serialize.test.js`
- `pnpm --dir ghost/core exec eslint core/server/services/jobs/job-service.js core/server/services/jobs/worker-model-event-bridge.js core/server/services/members/jobs/clean-expired-comped.js test/unit/server/services/jobs/job-service.test.js test/unit/server/services/jobs/worker-model-event-bridge.test.js test/unit/server/services/members/clean-expired-comped.test.js test/unit/server/services/webhooks/serialize.test.js`
