### PR TITLE
Grouped @types/* with their runtime package in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -191,6 +191,108 @@
             "dependencyDashboardApproval": true
         },
 
+        // Keep `@types/*` aligned with the runtime major they describe. Type defs
+        // for a different major than what actually runs are silently wrong at best
+        // (e.g. @types/express 5 vs Express 4) and build-breaking at worst
+        // (@types/react 19 fails the @tryghost/shade build under React 18) — this
+        // is what stalled the grouped "Update Types packages (major)" PR (#28307).
+        // Two mechanisms, with the major-dashboard-approval rule above as the human
+        // backstop for any types-ahead major that still slips through:
+        //
+        // 1. @types/node has no `node` npm package to pair with — it tracks the
+        //    Node.js runtime declared in `engines`, not a dependency — so a hard
+        //    version cap is the only lever. Raise it when we bump the Node engine.
+        {
+            "description": "Cap @types/node at the installed Node major (engines: ^22.13.1)",
+            "matchPackageNames": [
+                "@types/node"
+            ],
+            "allowedVersions": "<23"
+        },
+
+        // 2. Every other @types/* is grouped WITH the runtime package it describes
+        //    (rules below) so a runtime major and its type-definition major travel
+        //    in the same PR and land together, instead of the types racing ahead.
+        //    This is self-maintaining — no per-package caps to hand-raise on each
+        //    upgrade (a stale cap silently flips from guard to blocker once the
+        //    runtime moves, as happened with supertest 6 -> 7).
+        //
+        // Any @types/* with NO managed runtime peer is left as its own individual
+        // PR rather than lumped into one mega "Types packages (major)" PR (so one
+        // breaking type can't block the rest). Ordering matters: this ungroup
+        // default comes BEFORE the pairings so the pairings (later) win for paired
+        // packages, and the pairings come BEFORE the react17/eslint9/tailwind3
+        // catalog rules below so those version-lane groups still win for their own
+        // depTypes (e.g. react@17 in the react17 catalog stays in its own PR).
+        {
+            "description": "Unpaired @types/* majors get their own PR, not one mega Types group",
+            "matchPackageNames": [
+                "@types/**"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "groupName": null
+        },
+        {
+            "description": "React runtime + its type defs bump together",
+            "groupName": "React",
+            "matchPackageNames": [
+                "react",
+                "react-dom",
+                "@types/react",
+                "@types/react-dom"
+            ]
+        },
+        {
+            "description": "Express runtime + its type defs bump together",
+            "groupName": "Express",
+            "matchPackageNames": [
+                "express",
+                "@types/express"
+            ]
+        },
+        {
+            "description": "jest runtime + its type defs bump together",
+            "groupName": "jest",
+            "matchPackageNames": [
+                "jest",
+                "@types/jest"
+            ]
+        },
+        {
+            "description": "supertest runtime + its type defs bump together",
+            "groupName": "supertest",
+            "matchPackageNames": [
+                "supertest",
+                "@types/supertest"
+            ]
+        },
+        {
+            "description": "dockerode runtime + its type defs bump together",
+            "groupName": "dockerode",
+            "matchPackageNames": [
+                "dockerode",
+                "@types/dockerode"
+            ]
+        },
+        {
+            "description": "nodemailer runtime + its type defs bump together",
+            "groupName": "nodemailer",
+            "matchPackageNames": [
+                "nodemailer",
+                "@types/nodemailer"
+            ]
+        },
+        {
+            "description": "sinon runtime + its type defs bump together",
+            "groupName": "sinon",
+            "matchPackageNames": [
+                "sinon",
+                "@types/sinon"
+            ]
+        },
+
         // Group NQL packages separately from other TryGhost packages
         {
             "groupName": "NQL packages",


### PR DESCRIPTION
Follow-up to the grouped major Renovate PR #28307, which tried to bump several `@types/*` packages **past the runtime major actually installed**. Type definitions for a different major than what runs are silently wrong at best (e.g. `@types/express` 5 describing APIs Express 4 doesn't have) and build-breaking at worst — `@types/react` 19 fails the `@tryghost/shade` build under React 18.

### Approach: pair types with their runtime, don't cap
Rather than hand-maintained `allowedVersions` caps (which go stale and silently flip from *guard* to *blocker* the moment the runtime moves — exactly what happened when `supertest` went 6 → 7 mid-review), each `@types/*` is **grouped with the runtime package it describes** so a runtime major and its type-definition major travel in the same PR and land together:

- **React** (`react`, `react-dom`, `@types/react`, `@types/react-dom`)
- **Express**, **jest**, **supertest**, **dockerode**, **nodemailer**, **sinon**

This is self-maintaining — no caps to remember to raise on each upgrade. The existing `major → dependencyDashboardApproval: true` rule remains the human backstop for anything that still slips through.

### Two exceptions
- **`@types/node`** keeps a hard `allowedVersions: "<23"` cap — it tracks the Node.js engine (`engines: ^22.13.1`), not an npm dependency, so there's no package to pair it with. Raise it when the Node engine bumps.
- **Unpaired `@types/*`** (no managed runtime peer) stay individual PRs rather than one mega "Types packages (major)" group, so one breaking type can't block the rest.

### Ordering
The pairings sit after the ungroup-default and before the `react17`/`eslint9`/`tailwind3` catalog rules, so those version-lane groups still win for their own depTypes (e.g. `react@17` in the react17 catalog stays in its own PR, not the React group).

### Validation
`renovate-config-validator` passes on the added rules (the single `toolSettings` notice is pre-existing on `main` and unrelated — it only surfaces when the validator runs in standalone "global config" mode).

Related: #28307, #28445