### PR TITLE
Improved E2E isolation for measured hotspots

### DIFF
--- a/e2e/tests/admin/billing/force-upgrade.test.ts
+++ b/e2e/tests/admin/billing/force-upgrade.test.ts
@@ -1,6 +1,5 @@
 import {BillingPage, NAV_ITEMS, SidebarPage} from '@/helpers/pages';
 import {expect, test} from '@/helpers/playwright';
-import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 
 const MOCK_BILLING_URL = 'https://billing.mock.test';
 
@@ -30,8 +29,6 @@ const FORCE_UPGRADE_BMA_HTML = `
 </body>
 </html>
 `;
-
-usePerTestIsolation();
 
 test.describe('Ghost Admin - Force Upgrade Mode', () => {
     test.use({
@@ -99,18 +96,6 @@ test.describe('Ghost Admin - Force Upgrade Mode', () => {
         await expect(billingPage.billingIframe).toBeHidden();
     });
 
-    test('Sign out is accessible', async ({page}) => {
-        const sidebarPage = new SidebarPage(page);
-        const billingPage = new BillingPage(page);
-        await sidebarPage.goto();
-
-        await billingPage.waitForBillingIframe();
-        await sidebarPage.userDropdownTrigger.click();
-        await sidebarPage.signOutLink.click();
-
-        await expect(page).toHaveURL(/signin/);
-    });
-
     test('Ember-handled tag detail route shows billing iframe', async ({page}) => {
         const sidebarPage = new SidebarPage(page);
         const billingPage = new BillingPage(page);
@@ -118,5 +103,21 @@ test.describe('Ghost Admin - Force Upgrade Mode', () => {
 
         const billingIframe = await billingPage.waitForBillingIframe();
         await expect(billingIframe).toBeVisible();
+    });
+
+    test.describe('signed-out navigation', () => {
+        test.use({isolation: 'per-test'});
+
+        test('Sign out is accessible', async ({page}) => {
+            const sidebarPage = new SidebarPage(page);
+            const billingPage = new BillingPage(page);
+            await sidebarPage.goto();
+
+            await billingPage.waitForBillingIframe();
+            await sidebarPage.userDropdownTrigger.click();
+            await sidebarPage.signOutLink.click();
+
+            await expect(page).toHaveURL(/signin/);
+        });
     });
 });

--- a/e2e/tests/admin/members/bulk-actions.test.ts
+++ b/e2e/tests/admin/members/bulk-actions.test.ts
@@ -1,14 +1,13 @@
 import {MemberFactory, createMemberFactory} from '@/data-factory';
 import {MembersListPage} from '@/admin-pages';
 import {expect, test} from '@/helpers/playwright';
-import {usePerTestIsolation} from '@/helpers/playwright/isolation';
-
-usePerTestIsolation();
 
 test.describe('Ghost Admin - Members Bulk Actions', () => {
     let memberFactory: MemberFactory;
 
     test.beforeEach(async ({page}) => {
+        const response = await page.request.delete('/ghost/api/admin/members?all=true');
+        expect(response.ok()).toBeTruthy();
         memberFactory = createMemberFactory(page.request);
     });
 


### PR DESCRIPTION
## Summary
- keep only the billing sign-out test in per-test isolation because it invalidates the authenticated session
- allow the remaining force-upgrade tests to share a per-file environment
- remove broad per-test isolation from members bulk-actions and reset member state through the Admin API

## Validation
- pnpm --filter @tryghost/e2e test:types
- pnpm --filter @tryghost/e2e exec eslint tests/admin/billing/force-upgrade.test.ts tests/admin/members/bulk-actions.test.ts
- git diff --check

## Local research signal
- billing/force-upgrade on admin shard 1/10: 58.11s / 6 cycles -> 24.57s / 2 cycles
- members/bulk-actions collapsed from 2 cycles to 1; shard score is noisier because changing isolation changes shard composition
- combined admin shard 1/10: 79.38s -> 63.44s with 0 failures
