### PR TITLE
Fix `CacheManager.prototype.get` type

### DIFF
--- a/ghost/core/core/shared/settings-cache/cache-manager.js
+++ b/ghost/core/core/shared/settings-cache/cache-manager.js
@@ -179,7 +179,7 @@ class CacheManager {
      * In which case the full JSON version of the model will be resolved
      *
      * @param {string} key
-     * @param {object} options
+     * @param {object} [options]
      * @return {*}
      */
     get(key, options) {


### PR DESCRIPTION
no ref

The second argument was optional. This fixes a bunch of type errors.