### PR TITLE
Improved members E2E cleanup

### DIFF
--- a/e2e/helpers/services/members/members-service.ts
+++ b/e2e/helpers/services/members/members-service.ts
@@ -85,4 +85,11 @@ export class MembersService {
         }
         return data.members[0];
     }
+
+    async deleteAll(): Promise<void> {
+        const response = await this.request.delete(`${this.adminEndpoint}/members?all=true`);
+        if (!response.ok()) {
+            throw new Error(`Failed to delete members: ${response.status()}`);
+        }
+    }
 }

--- a/e2e/tests/admin/members/bulk-actions.test.ts
+++ b/e2e/tests/admin/members/bulk-actions.test.ts
@@ -1,14 +1,13 @@
 import {MemberFactory, createMemberFactory} from '@/data-factory';
 import {MembersListPage} from '@/admin-pages';
+import {MembersService} from '@/helpers/services/members';
 import {expect, test} from '@/helpers/playwright';
-import {usePerTestIsolation} from '@/helpers/playwright/isolation';
-
-usePerTestIsolation();
 
 test.describe('Ghost Admin - Members Bulk Actions', () => {
     let memberFactory: MemberFactory;
 
     test.beforeEach(async ({page}) => {
+        await new MembersService(page.request).deleteAll();
         memberFactory = createMemberFactory(page.request);
     });
 

--- a/e2e/tests/admin/members/list.test.ts
+++ b/e2e/tests/admin/members/list.test.ts
@@ -1,13 +1,13 @@
 import {MemberDetailsPage, MembersListPage} from '@/admin-pages';
 import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {MembersService} from '@/helpers/services/members';
 import {expect, test} from '@/helpers/playwright';
 
 test.describe('Ghost Admin - Members List', () => {
     let memberFactory: MemberFactory;
 
     test.beforeEach(async ({page}) => {
-        const response = await page.request.delete('/ghost/api/admin/members?all=true');
-        expect(response.ok()).toBeTruthy();
+        await new MembersService(page.request).deleteAll();
         memberFactory = createMemberFactory(page.request);
     });
 


### PR DESCRIPTION
## Summary
- add `MembersService.deleteAll()` for targeted member cleanup in E2E tests
- replace the direct members-list API cleanup with the service helper
- remove per-test isolation from members bulk-actions and reset members before each test

Because E2E files run with one worker per file, these member UI tests can reset the member rows they depend on instead of restoring the full database between every test. This keeps the cleanup explicit while avoiding raw Admin API calls in each test file.

## Validation
- pnpm --filter @tryghost/e2e test:types
- pnpm --filter @tryghost/e2e exec eslint helpers/services/members/members-service.ts tests/admin/members/list.test.ts tests/admin/members/bulk-actions.test.ts
- git diff --check

## Local research signal
- members/bulk-actions collapsed from 2 environment cycles to 1 in shard validation
