### PR TITLE
Improved force upgrade E2E isolation

### DIFF
--- a/e2e/tests/admin/billing/force-upgrade.test.ts
+++ b/e2e/tests/admin/billing/force-upgrade.test.ts
@@ -1,6 +1,5 @@
 import {BillingPage, NAV_ITEMS, SidebarPage} from '@/helpers/pages';
 import {expect, test} from '@/helpers/playwright';
-import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 
 const MOCK_BILLING_URL = 'https://billing.mock.test';
 
@@ -30,8 +29,6 @@ const FORCE_UPGRADE_BMA_HTML = `
 </body>
 </html>
 `;
-
-usePerTestIsolation();
 
 test.describe('Ghost Admin - Force Upgrade Mode', () => {
     test.use({
@@ -99,16 +96,20 @@ test.describe('Ghost Admin - Force Upgrade Mode', () => {
         await expect(billingPage.billingIframe).toBeHidden();
     });
 
-    test('Sign out is accessible', async ({page}) => {
-        const sidebarPage = new SidebarPage(page);
-        const billingPage = new BillingPage(page);
-        await sidebarPage.goto();
+    test.describe('signed-out navigation', () => {
+        test.use({isolation: 'per-test'});
 
-        await billingPage.waitForBillingIframe();
-        await sidebarPage.userDropdownTrigger.click();
-        await sidebarPage.signOutLink.click();
+        test('Sign out is accessible', async ({page}) => {
+            const sidebarPage = new SidebarPage(page);
+            const billingPage = new BillingPage(page);
+            await sidebarPage.goto();
 
-        await expect(page).toHaveURL(/signin/);
+            await billingPage.waitForBillingIframe();
+            await sidebarPage.userDropdownTrigger.click();
+            await sidebarPage.signOutLink.click();
+
+            await expect(page).toHaveURL(/signin/);
+        });
     });
 
     test('Ember-handled tag detail route shows billing iframe', async ({page}) => {


### PR DESCRIPTION
## Summary
- remove broad per-test isolation from force-upgrade E2E tests
- keep only the sign-out path in a per-test `describe` because it invalidates the authenticated session
- allow the remaining force-upgrade tests to share the file-level environment

Playwright supports `test.use()` at describe scope, and our fixture resolves isolation from the per-test option. The existing Stripe-enabled describe blocks use the same option scoping mechanism.

## Validation
- pnpm --filter @tryghost/e2e test:types
- pnpm --filter @tryghost/e2e exec eslint tests/admin/billing/force-upgrade.test.ts
- git diff --check

## Local research signal
- billing/force-upgrade on admin shard 1/10: 58.11s / 6 cycles -> 24.57s / 2 cycles
