### PR TITLE
Improved string escaping for NQL filters and email From headers

### DIFF
--- a/ghost/admin/app/components/gh-resource-select.js
+++ b/ghost/admin/app/components/gh-resource-select.js
@@ -11,6 +11,15 @@ import {tracked} from '@glimmer/tracking';
 
 const DEBOUNCE_MS = 200;
 
+// Escape single quotes so a search term can be safely embedded in a
+// single-quoted NQL filter string (e.g. `title:~'<term>'`). The NQL lexer
+// only treats `\'`/`\"` as escapes and reads a lone backslash literally, so
+// escaping every quote (globally) is sufficient and does not corrupt terms
+// containing backslashes.
+function escapeNqlString(term) {
+    return String(term).replace(/'/g, '\\\'');
+}
+
 function mapResource(resource) {
     return {
         id: resource.id,
@@ -162,13 +171,13 @@ export default class GhResourceSelect extends Component {
         const options = yield [];
 
         if (this.args.type === 'email') {
-            const posts = yield this.store.query('post', {filter: '(status:published,status:sent)+newsletter_id:-null+title:~\'' + searchTerm.replace('\'', '\\\'') + '\'', limit: '10', fields: 'id,title'});
+            const posts = yield this.store.query('post', {filter: '(status:published,status:sent)+newsletter_id:-null+title:~\'' + escapeNqlString(searchTerm) + '\'', limit: '10', fields: 'id,title'});
             options.push(...posts.map(mapResource));
             return options;
         }
 
-        const posts = yield this.store.query('post', {filter: 'status:published+title:~\'' + searchTerm.replace('\'', '\\\'') + '\'', limit: '10', fields: 'id,title'});
-        const pages = yield this.store.query('page', {filter: 'status:published+title:~\'' + searchTerm.replace('\'', '\\\'') + '\'', limit: '10', fields: 'id,title'});
+        const posts = yield this.store.query('post', {filter: 'status:published+title:~\'' + escapeNqlString(searchTerm) + '\'', limit: '10', fields: 'id,title'});
+        const pages = yield this.store.query('page', {filter: 'status:published+title:~\'' + escapeNqlString(searchTerm) + '\'', limit: '10', fields: 'id,title'});
 
         if (posts.length > 0) {
             options.push(...posts.map(mapResource));

--- a/ghost/admin/app/components/gh-resource-select.js
+++ b/ghost/admin/app/components/gh-resource-select.js
@@ -11,13 +11,15 @@ import {tracked} from '@glimmer/tracking';
 
 const DEBOUNCE_MS = 200;
 
-// Escape single quotes so a search term can be safely embedded in a
-// single-quoted NQL filter string (e.g. `title:~'<term>'`). The NQL lexer
-// only treats `\'`/`\"` as escapes and reads a lone backslash literally, so
-// escaping every quote (globally) is sufficient and does not corrupt terms
-// containing backslashes.
+// Escape a search term and wrap it in single quotes for safe embedding in an
+// NQL filter (e.g. `title:~<result>`). Returns the *quoted* string to match the
+// `escapeNqlString` contract used elsewhere (apps/posts, admin-x-framework).
+// Only single quotes are escaped: the NQL lexer treats just `\'`/`\"` as escapes
+// and reads a lone backslash literally. Verified against @tryghost/nql — escaping
+// every quote prevents breakout, and backslashes must NOT be doubled (doubling
+// corrupts terms containing a backslash, e.g. `a\b` would be searched as `a\\b`).
 function escapeNqlString(term) {
-    return String(term).replace(/'/g, '\\\'');
+    return '\'' + String(term).replace(/'/g, '\\\'') + '\'';
 }
 
 function mapResource(resource) {
@@ -171,13 +173,13 @@ export default class GhResourceSelect extends Component {
         const options = yield [];
 
         if (this.args.type === 'email') {
-            const posts = yield this.store.query('post', {filter: '(status:published,status:sent)+newsletter_id:-null+title:~\'' + escapeNqlString(searchTerm) + '\'', limit: '10', fields: 'id,title'});
+            const posts = yield this.store.query('post', {filter: '(status:published,status:sent)+newsletter_id:-null+title:~' + escapeNqlString(searchTerm), limit: '10', fields: 'id,title'});
             options.push(...posts.map(mapResource));
             return options;
         }
 
-        const posts = yield this.store.query('post', {filter: 'status:published+title:~\'' + escapeNqlString(searchTerm) + '\'', limit: '10', fields: 'id,title'});
-        const pages = yield this.store.query('page', {filter: 'status:published+title:~\'' + escapeNqlString(searchTerm) + '\'', limit: '10', fields: 'id,title'});
+        const posts = yield this.store.query('post', {filter: 'status:published+title:~' + escapeNqlString(searchTerm), limit: '10', fields: 'id,title'});
+        const pages = yield this.store.query('page', {filter: 'status:published+title:~' + escapeNqlString(searchTerm), limit: '10', fields: 'id,title'});
 
         if (posts.length > 0) {
             options.push(...posts.map(mapResource));

--- a/ghost/admin/app/services/labels-manager.js
+++ b/ghost/admin/app/services/labels-manager.js
@@ -73,6 +73,9 @@ export default class LabelsManagerService extends Service {
     @task({restartable: true})
     *searchLabelsTask(term, {page = 1} = {}) {
         yield timeout(250);
+        // Escape every single quote so the term is safely embedded in the
+        // single-quoted NQL filter below. NQL reads a lone backslash literally
+        // (only `\'`/`\"` are escapes), so quotes alone need escaping.
         const safeTerm = term.replace(/'/g, `\\'`);
         const labels = yield this.store.query('label', {filter: `name:~'${safeTerm}'`, limit: PAGE_SIZE, page, order: 'name asc'});
 

--- a/ghost/admin/app/services/tags-manager.js
+++ b/ghost/admin/app/services/tags-manager.js
@@ -23,6 +23,9 @@ export default class TagsManagerService extends Service {
     *searchTagsTask(term, {page = 1} = {}) {
         // debounce the search
         yield timeout(250);
+        // Escape every single quote so the term is safely embedded in the
+        // single-quoted NQL filter below. NQL reads a lone backslash literally
+        // (only `\'`/`\"` are escapes), so quotes alone need escaping.
         const safeTerm = term.replace(/'/g, `\\'`);
         return yield this.store.query('tag', {filter: `tags.name:~'${safeTerm}'`, limit: 100, page, order: 'name asc'});
     }

--- a/ghost/admin/tests/integration/services/labels-manager-test.js
+++ b/ghost/admin/tests/integration/services/labels-manager-test.js
@@ -81,6 +81,19 @@ describe('Integration: Service: labels-manager', function () {
         });
     });
 
+    it('escapes every single quote in search filters, not just the first', async function () {
+        const store = this.owner.lookup('service:store');
+        const labelsManager = this.owner.lookup('service:labels-manager');
+
+        const results = buildCollection([], {page: 1, pages: 1});
+        const queryStub = sinon.stub(store, 'query').resolves(results);
+
+        await labelsManager.searchLabelsTask.perform('a\'b\'c');
+
+        expect(queryStub.calledOnce).to.be.true;
+        expect(queryStub.firstCall.args[1].filter).to.equal('name:~\'a\\\'b\\\'c\'');
+    });
+
     it('registers search results so they are findable by slug', async function () {
         const store = this.owner.lookup('service:store');
         const labelsManager = this.owner.lookup('service:labels-manager');

--- a/ghost/core/core/server/services/email-address/email-address-parser.js
+++ b/ghost/core/core/server/services/email-address/email-address-parser.js
@@ -46,7 +46,7 @@ module.exports = class EmailAddressParser {
             return email.address;
         }
 
-        const escapedName = email.name.replace(/"/g, '\\"');
+        const escapedName = email.name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
         /**
          * https://linear.app/ghost/issue/ONC-969

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -244,7 +244,10 @@ class EmailRenderer {
     }
 
     #getRawFromAddress(post, newsletter) {
-        let senderName = this.#settingsCache.get('title') ? this.#settingsCache.get('title').replace(/"/g, '\\"') : '';
+        // Pass the raw name through; EmailAddressParser.stringify() is the single
+        // point that escapes it for the RFC5322 quoted-string From header. Escaping
+        // here too would double-escape (e.g. a title containing a double quote).
+        let senderName = this.#settingsCache.get('title') || '';
         if (newsletter.get('sender_name')) {
             senderName = newsletter.get('sender_name');
         }

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1088,9 +1088,11 @@ module.exports = class RouterController {
         }
 
         const requestedNewsletterNames = requestedNewsletters.map(newsletter => newsletter.name);
-        // Escape quotes so each name is safely embedded in the single-quoted
-        // NQL filter below. NQL reads a lone backslash literally (only `\'`/`\"`
-        // are escapes), so escaping quotes alone is sufficient.
+        // Each name is embedded in a single-quoted item of an NQL `name:[...]`
+        // array, so both quote characters are escaped (a name may contain either,
+        // and the array syntax is stricter than the `~'...'` search operator).
+        // NQL reads a lone backslash literally (only `\'`/`\"` are escapes), so
+        // escaping the quotes alone is sufficient — backslashes are left as-is.
         const requestedNewsletterNamesFilter = requestedNewsletterNames.map(newsletter => `'${newsletter.replace(/("|')/g, '\\$1')}'`);
         const matchedNewsletters = (await this._newslettersService.getAll({
             filter: `name:[${requestedNewsletterNamesFilter}]`,

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1088,6 +1088,9 @@ module.exports = class RouterController {
         }
 
         const requestedNewsletterNames = requestedNewsletters.map(newsletter => newsletter.name);
+        // Escape quotes so each name is safely embedded in the single-quoted
+        // NQL filter below. NQL reads a lone backslash literally (only `\'`/`\"`
+        // are escapes), so escaping quotes alone is sufficient.
         const requestedNewsletterNamesFilter = requestedNewsletterNames.map(newsletter => `'${newsletter.replace(/("|')/g, '\\$1')}'`);
         const matchedNewsletters = (await this._newslettersService.getAll({
             filter: `name:[${requestedNewsletterNamesFilter}]`,

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1089,10 +1089,11 @@ module.exports = class RouterController {
 
         const requestedNewsletterNames = requestedNewsletters.map(newsletter => newsletter.name);
         // Each name is embedded in a single-quoted item of an NQL `name:[...]`
-        // array, so both quote characters are escaped (a name may contain either,
-        // and the array syntax is stricter than the `~'...'` search operator).
-        // NQL reads a lone backslash literally (only `\'`/`\"` are escapes), so
-        // escaping the quotes alone is sufficient — backslashes are left as-is.
+        // array, so both quote characters are escaped (a name may contain either).
+        // NQL has no `\\` escape — a lone backslash is read literally — so we
+        // escape quotes only; doubling backslashes would corrupt names that
+        // legitimately contain one. This keeps any injected operators inside the
+        // quoted string, preventing filter breakout.
         const requestedNewsletterNamesFilter = requestedNewsletterNames.map(newsletter => `'${newsletter.replace(/("|')/g, '\\$1')}'`);
         const matchedNewsletters = (await this._newslettersService.getAll({
             filter: `name:[${requestedNewsletterNamesFilter}]`,

--- a/ghost/core/test/unit/server/services/email-address/email-address-parser.test.ts
+++ b/ghost/core/test/unit/server/services/email-address/email-address-parser.test.ts
@@ -100,5 +100,15 @@ describe('EmailAddressParser', function () {
             });
             assert.equal(email, '"This is my awesome name" <test@example.com>');
         });
+
+        it('escapes backslashes and double quotes in the name', function () {
+            // Regression: the name is escaped once here (the single escaping point),
+            // backslash before quote, so it stays a valid RFC 5322 quoted-string.
+            const email = EmailAddressParser.stringify({
+                address: 'test@example.com',
+                name: 'a\\b"c'
+            });
+            assert.equal(email, '"a\\\\b\\"c" <test@example.com>');
+        });
     });
 });


### PR DESCRIPTION
## Summary
Resolves the `js/incomplete-sanitization` CodeQL alerts around NQL filter and email-header string building. (Split out from the broader code-scanning triage — the GitHub Actions permissions changes are in a separate PR so they can be reviewed in isolation.)

- `gh-resource-select` escaped only the **first** quote in NQL search filters (`String.replace` with a string argument) — now escapes every quote via a shared helper.
- The email `From` name was escaped in `email-renderer` **and again** in `EmailAddressParser.stringify`, double-escaping any title containing a `"`. The renderer now passes the raw name so `stringify` is the single escaping point — which also covers the previously unescaped newsletter `sender_name`.
- `email-address-parser` now escapes backslashes before quotes.
- NQL filter sites that already escape all quotes are left functionally unchanged: NQL reads a lone backslash literally (verified against `@tryghost/nql`), so doubling backslashes would corrupt legitimate search terms. Added explanatory comments.

## Notes
- No user-facing behavior change, except correctly-formed email `From` headers for sites whose title or sender name contains a double quote.

## Test plan
- `ghost/core` `email-address-parser` + `email-renderer` unit suites pass; lint-staged eslint clean on all changed files.
- Email `From` double-escape fix verified empirically against `EmailAddressParser.stringify` (raw → stringify yields correct single-escaping).
- NQL escaping verified empirically against `@tryghost/nql`: breakout attempts parse as a single `name` condition, benign terms (`O'Brien`, `a\b`) round-trip.
