### PR TITLE
🐛 Fix translation review never triggering on auto-labelled PRs

### DIFF
--- a/.github/scripts/i18n-review/SETUP.md
+++ b/.github/scripts/i18n-review/SETUP.md
@@ -45,25 +45,35 @@ back to the Sonnet default if unset.
 
 ## 2. What fires the workflow
 
-The workflow runs on three events, all gated on `affects:i18n`:
+The workflow is gated on a `paths` filter — the PR must touch a file under
+`ghost/i18n/locales/**` — and runs on these events:
 
 | Event | Trigger | Notes |
 |---|---|---|
-| `pull_request_target.labeled` | When a maintainer adds the `affects:i18n` label | The most common path. Fires once per label-add. |
-| `pull_request_target.synchronize` | When new commits are pushed to a PR that already has the label | The bot re-runs and posts a fresh advisory review. Prior runs are not auto-deleted — GitHub does not allow deleting a submitted review. |
+| `pull_request_target.opened` / `.reopened` | When a PR touching a locale file is opened/reopened | The most common path. Fires from a real PR-author event, so it is not subject to the `GITHUB_TOKEN` suppression below. |
+| `pull_request_target.synchronize` | When new commits are pushed to a PR touching a locale file | The bot re-runs and posts a fresh advisory review. Prior runs are not auto-deleted — GitHub does not allow deleting a submitted review. |
+| `pull_request_target.labeled` | When a maintainer adds the `affects:i18n` label | Kept purely as a **manual re-trigger** — a human removing + re-adding the label fires a fresh run. |
 | `workflow_dispatch` | Manual run from the Actions tab with PR number + optional model override | Used to retroactively review existing PRs (see §3) or to A/B compare models. |
+
+> **Why not key off the `affects:i18n` label?** The label is applied
+> automatically by the label-actions workflow using the default
+> `GITHUB_TOKEN`. GitHub deliberately does **not** start new workflow runs
+> from events triggered by `GITHUB_TOKEN`, so a `labeled`-only trigger
+> silently never fired on auto-labelled contributor PRs. Keying off the
+> `paths` filter on PR-author events avoids that trap entirely. The final,
+> precise gate is still the script itself, which only reviews
+> `ghost/i18n/locales/<locale>/<namespace>.json` files (excluding `en/`).
 
 Concurrency is set to `cancel-in-progress` per PR, so rapid pushes only
 result in one live run reviewing the latest commit.
 
 ## 3. Retroactively review existing labelled PRs
 
-PRs that already have the `affects:i18n` label when this workflow lands
-**will not auto-trigger** — GitHub doesn't replay the `labeled` event.
-They'll start being reviewed when:
+PRs opened before this workflow landed **will not auto-trigger** — GitHub
+doesn't replay past `opened` events. They'll start being reviewed when:
 
 - A new commit is pushed (fires `synchronize`), or
-- A maintainer removes and re-adds the label, or
+- A maintainer removes and re-adds the `affects:i18n` label, or
 - A maintainer kicks them off manually.
 
 To kick one off manually:

--- a/.github/workflows/translation-review.yml
+++ b/.github/workflows/translation-review.yml
@@ -1,6 +1,7 @@
 name: Translation Review
 
-# Posts an advisory (non-approving) review on translation PRs labelled `affects:i18n`.
+# Posts an advisory (non-approving) review on PRs that touch per-locale
+# translation files.
 #
 # The job runs from `main` (NOT the PR head) and never executes any code
 # from the PR — it only reads the PR's locale-file changes via the GitHub
@@ -12,10 +13,20 @@ name: Translation Review
 #
 # The bot uses a `COMMENT`-event review — it cannot approve a PR and the
 # review never blocks merge.
+#
+# Triggering: we key off the `paths` filter below (the PR touches a locale
+# file) on real PR-author events — `opened`/`reopened`/`synchronize` — rather
+# than the `affects:i18n` label. That label is applied automatically by the
+# label-actions workflow via the default `GITHUB_TOKEN`, and GitHub does NOT
+# start new workflow runs from events triggered by `GITHUB_TOKEN`, so a
+# `labeled`-only trigger silently never fired on auto-labelled PRs. The
+# `labeled` type is kept purely as a manual re-trigger for maintainers.
 
 on:
   pull_request_target:
-    types: [labeled, synchronize]
+    types: [opened, reopened, synchronize, labeled]
+    paths:
+      - 'ghost/i18n/locales/**'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -48,8 +59,8 @@ jobs:
     if: |
       github.repository_owner == 'TryGhost' && (
         github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'affects:i18n') ||
-        (github.event_name == 'pull_request_target' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'affects:i18n'))
+        (github.event_name == 'pull_request_target' && github.event.action != 'labeled') ||
+        (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'affects:i18n')
       )
     steps:
       - name: Checkout main (trusted ref — never the PR head)


### PR DESCRIPTION
no ref

## Problem

The Translation Review workflow ([`translation-review.yml`](.github/workflows/translation-review.yml)) triggered only on `pull_request_target` `labeled` / `synchronize`, gated on the `affects:i18n` label.

That label is applied automatically by the label-actions workflow using the default `GITHUB_TOKEN`. GitHub [deliberately does not start new workflow runs from events triggered by `GITHUB_TOKEN`](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), so the `labeled` path has produced **zero** runs since the workflow shipped.

Reviews still appeared because i18n PRs almost always get a follow-up push (a translator iterating, or a "Merge branch 'main'" commit) which raises a `synchronize` event — and that's what actually ran the job. The bug stayed hidden until a PR was opened, auto-labelled, and never pushed to again (e.g. #28462), which got no review at all.

### Evidence (PR #28434)
- `10:23:49` `affects:i18n` added by `github-actions[bot]` → **no run**
- `13:32:07` push "Merge branch 'main'" → `synchronize` → run `13:32:14` → review `13:32:37`
- `14:24:38` push "Merge branch 'main'" → `synchronize` → run `14:24:45` → review `14:25:05`

Every run that produced a review was `synchronize`; none fired at label-time. Same pattern across every i18n PR sampled.

## Fix

Trigger on real PR-author events (`opened` / `reopened` / `synchronize`) gated by a `paths` filter on `ghost/i18n/locales/**`, instead of relying on the bot-applied label. These events come from the PR author (not `GITHUB_TOKEN`), so they aren't suppressed. `labeled` is kept only as a manual maintainer re-trigger (remove + re-add the label).

The review script remains the precise final gate — it only reviews `ghost/i18n/locales/<locale>/<namespace>.json` (excluding `en/`) and exits cheaply otherwise, so the broader `paths` glob costs at most a no-op checkout.

No change to the security posture: still `pull_request_target` checking out `main` (never the PR head), reading the diff via API only, with the existing file/line/timeout abuse guards intact.

SETUP.md updated to document the new triggers and the `GITHUB_TOKEN` rationale.