### PR TITLE
Improved E2E MySQL restore speed

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -68,6 +68,11 @@ GHOST_E2E_MODE=build pnpm --filter @tryghost/e2e infra:up
 GHOST_E2E_MODE=build GHOST_E2E_IMAGE=ghost-e2e:local pnpm --filter @tryghost/e2e test
 ```
 
+Build-mode E2E infra uses tmpfs-backed MySQL storage by default so database
+snapshot restore cycles stay fast and isolated from local development data.
+Set `GHOST_E2E_MYSQL_TMPFS=false` to use the normal Docker volume instead, or
+`GHOST_E2E_MYSQL_TMPFS_SIZE=4g` to adjust the tmpfs size.
+
 For a CI-like local preflight (pulls Playwright + gateway images and starts infra), run:
 
 ```bash

--- a/e2e/compose.e2e.tmpfs.yaml
+++ b/e2e/compose.e2e.tmpfs.yaml
@@ -1,0 +1,5 @@
+services:
+  mysql:
+    volumes: !override []
+    tmpfs:
+      - /var/lib/mysql:rw,size=${GHOST_E2E_MYSQL_TMPFS_SIZE:-2g}

--- a/e2e/scripts/infra-down.sh
+++ b/e2e/scripts/infra-down.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 cd "$REPO_ROOT"
 
-compose_files=(-f compose.dev.yaml -f compose.dev.analytics.yaml)
+compose_files=(-f compose.dev.yaml -f e2e/compose.e2e.tmpfs.yaml -f compose.dev.analytics.yaml)
 services=(analytics tb-cli tinybird-local mailpit redis mysql)
 
 docker compose "${compose_files[@]}" stop "${services[@]}"

--- a/e2e/scripts/infra-up.sh
+++ b/e2e/scripts/infra-up.sh
@@ -10,6 +10,7 @@ cd "$REPO_ROOT"
 MODE="$(resolve_e2e_mode)"
 export GHOST_E2E_MODE="$MODE"
 ANALYTICS_ENABLED="${GHOST_E2E_ANALYTICS:-true}"
+MYSQL_TMPFS_ENABLED="${GHOST_E2E_MYSQL_TMPFS:-true}"
 
 if [[ "$MODE" != "build" ]]; then
   DEV_COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME:-ghost-dev}"
@@ -24,6 +25,10 @@ fi
 
 compose_files=(-f compose.dev.yaml)
 services=(mysql redis mailpit)
+
+if [[ "$MODE" == "build" && "$MYSQL_TMPFS_ENABLED" != "false" ]]; then
+  compose_files+=(-f e2e/compose.e2e.tmpfs.yaml)
+fi
 
 if [[ "$ANALYTICS_ENABLED" == "true" ]]; then
   compose_files+=(-f compose.dev.analytics.yaml)


### PR DESCRIPTION
## Context

E2E build-mode tests repeatedly clone the base database from a MySQL dump. Local profiling showed this restore path was dominated by persistent Docker volume IO rather than SQL command overhead.

This changes build-mode E2E infra to run MySQL with `/var/lib/mysql` on tmpfs by default. Dev-mode E2E and regular `pnpm dev` continue to use the normal `mysql-data` Docker volume.

## Details

- added `e2e/compose.e2e.tmpfs.yaml`
- build-mode `e2e/scripts/infra-up.sh` includes the tmpfs override by default
- `GHOST_E2E_MYSQL_TMPFS=false` opts out to the normal Docker volume
- `GHOST_E2E_MYSQL_TMPFS_SIZE=4g` can adjust the tmpfs size
- `infra-down.sh` includes the override so stop commands target the same service definition

## Local measurements

Targeted slice: `tests/admin/members-legacy/stripe-webhooks.test.ts`, build/container mode, host readiness enabled.

- normal compose volume: `41.08s`
  - `mysql.restoreDatabaseFromSnapshot.import`: `2.57s avg`, `4.01s max`
- manual tmpfs MySQL run 1: `24.89s`
  - restore import: `~245ms avg`
- manual tmpfs MySQL run 2: `23.12s`
  - restore import: `~245ms avg`

Default mixed slice (`members/list` + `posts/publish-flow`) on tmpfs:

- `24.00s`
- restore import: `~216ms/cycle`

## Validation

- `docker compose -f compose.dev.yaml -f e2e/compose.e2e.tmpfs.yaml config` confirms the named MySQL volume is removed and tmpfs is configured
- `GHOST_E2E_MODE=build GHOST_E2E_ANALYTICS=false bash e2e/scripts/infra-up.sh` created a healthy MySQL container with `/var/lib/mysql` backed by tmpfs
- `GHOST_E2E_MYSQL_TMPFS=false ... infra-up.sh` recreated MySQL on the normal Docker volume
- `bash -n e2e/scripts/infra-up.sh e2e/scripts/infra-down.sh`
- `git diff --check`

## Follow-up validation wanted

CI should confirm memory headroom on the full shard matrix, including analytics-enabled jobs.