### PR TITLE
Changed Ghost dev mounts to match installed workspaces

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -60,13 +60,13 @@ services:
     working_dir: /home/ghost/ghost/core
     command: ["pnpm", "dev"]
     volumes:
-      - ./ghost:/home/ghost/ghost
-      # ghost/admin has workspace:* deps on apps/* (e.g. @tryghost/admin-x-framework).
-      # The dev Dockerfile only stages ghost/{core,i18n,parse-email-address}
-      # package.jsons at build time; mounting apps/ here makes the workspace
-      # graph complete at runtime. pnpm 10 tolerated the missing packages;
-      # pnpm 11 strict-validates and fails without this mount.
-      - ./apps:/home/ghost/apps
+      # Keep the runtime workspace graph aligned with the packages installed
+      # by docker/ghost-dev/Dockerfile. Mounting all of ghost/ exposes
+      # ghost/admin, which depends on apps/* and causes pnpm to repair the
+      # workspace before running scripts.
+      - ./ghost/core:/home/ghost/ghost/core
+      - ./ghost/i18n:/home/ghost/ghost/i18n
+      - ./ghost/parse-email-address:/home/ghost/ghost/parse-email-address
       # Mount specific content subdirectories to preserve themes/adapters from source
       - ghost-dev-data:/home/ghost/ghost/core/content/data
       - ghost-dev-images:/home/ghost/ghost/core/content/images
@@ -78,6 +78,7 @@ services:
       NODE_ENV: development
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       DEBUG: ${DEBUG:-}
+      pnpm_config_verify_deps_before_run: "false"
       database__client: mysql2
       database__connection__host: mysql
       database__connection__user: root

--- a/e2e/helpers/environment/service-managers/ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/ghost-manager.ts
@@ -214,6 +214,10 @@ export class GhostManager {
             `url=http://localhost:${this.getGatewayPort()}`
         ];
 
+        if (this.config.mode === 'dev') {
+            env.push('pnpm_config_verify_deps_before_run=false');
+        }
+
         // Add Tinybird config if available
         // Static endpoints are set here; tokens are loaded from a host-generated
         // e2e/data/state/tinybird.json file when present.
@@ -318,7 +322,7 @@ export class GhostManager {
 
     /**
      * Get volume binds for Ghost container based on mode.
-     * - dev: Mount ghost directory for source code (hot reload)
+     * - dev: Mount backend workspace packages for source code (hot reload)
      * - build: No source mounts, fully self-contained image
      */
     private getGhostBinds(): string[] {
@@ -328,7 +332,11 @@ export class GhostManager {
         ];
 
         if (this.config.mode === 'dev') {
-            binds.push(`${REPO_ROOT}/ghost:/home/ghost/ghost`);
+            binds.push(
+                `${REPO_ROOT}/ghost/core:/home/ghost/ghost/core`,
+                `${REPO_ROOT}/ghost/i18n:/home/ghost/ghost/i18n`,
+                `${REPO_ROOT}/ghost/parse-email-address:/home/ghost/ghost/parse-email-address`
+            );
         }
 
         return binds;


### PR DESCRIPTION
## What changed

- Narrowed the `ghost-dev` source mounts to the backend workspaces installed by the dev image.
- Removed the runtime `apps/` mount from the backend container.
- Disabled pnpm's script-time dependency verifier for the backend dev container.
- Updated dev-mode E2E worker containers to use the same narrowed backend workspace mounts and pnpm verifier override.

## Why

The dev image installs dependencies for `ghost/core`, `ghost/i18n`, and `ghost/parse-email-address`, but the runtime mounts exposed a broader workspace graph. With pnpm 11, that mismatch can trigger a dependency repair/install before `pnpm dev` starts.

Keeping the mounted source graph aligned with the image install should avoid that startup install path for both the main dev container and dev-mode E2E worker containers.

## Validation

- `docker compose -f compose.dev.yaml config --quiet`
- Standalone `docker run` probe using the narrowed mounts and `pnpm_config_verify_deps_before_run=false`; Ghost went straight to `nodemon` with no pnpm install output.

Note: `pnpm --filter @tryghost/e2e test:types` could not run in the fresh PR worktree because that worktree has no `node_modules` (`tsc: command not found`).
