### PR TITLE
Changed members filter state to preserve unknown NQL filter properties

### DIFF
--- a/apps/posts/src/views/filters/filter-ast.test.ts
+++ b/apps/posts/src/views/filters/filter-ast.test.ts
@@ -1,6 +1,15 @@
 import nql from '@tryghost/nql-lang';
 import {describe, expect, it} from 'vitest';
-import {extractComparator, extractFieldName} from './filter-ast';
+import {extractAndClauses, extractComparator, extractFieldName, serializeAstToNql} from './filter-ast';
+import type {AstNode} from './filter-ast';
+
+function parse(filter: string): AstNode {
+    return nql.parse(filter, {preserveRelativeDates: true}) as AstNode;
+}
+
+function roundTrip(filter: string): string | undefined {
+    return serializeAstToNql(parse(filter));
+}
 
 describe('filter-ast helpers', () => {
     it('extracts simple field names', () => {
@@ -39,5 +48,102 @@ describe('filter-ast helpers', () => {
 
         expect(extractFieldName(compoundNode)).toBeUndefined();
         expect(extractComparator(compoundNode)).toBeUndefined();
+    });
+});
+
+describe('extractAndClauses', () => {
+    it('returns the children of a root AND', () => {
+        expect(extractAndClauses(parse('status:paid+label:vip+email_count:>5'))).toEqual([
+            {status: 'paid'},
+            {label: 'vip'},
+            {email_count: {$gt: 5}}
+        ]);
+    });
+
+    it('keeps parenthesized groups as a single clause', () => {
+        expect(extractAndClauses(parse('(status:paid,label:vip)+created_at:>now+7d'))).toEqual([
+            {$or: [{status: 'paid'}, {label: 'vip'}]},
+            {created_at: {$gt: {$relativeDate: {op: 'add', amount: 7, unit: 'days'}}}}
+        ]);
+    });
+
+    it('treats a filter without a root AND as a single clause', () => {
+        expect(extractAndClauses(parse('status:paid,label:vip'))).toEqual([
+            {$or: [{status: 'paid'}, {label: 'vip'}]}
+        ]);
+    });
+});
+
+describe('serializeAstToNql', () => {
+    it('round-trips comparisons, lists and booleans', () => {
+        expect(roundTrip('status:paid')).toBe('status:paid');
+        expect(roundTrip('status:-free')).toBe('status:-free');
+        expect(roundTrip('email_count:>5')).toBe('email_count:>5');
+        expect(roundTrip('email_count:>=5+email_count:<=10')).toBe('email_count:>=5+email_count:<=10');
+        expect(roundTrip('label:[vip,gold]')).toBe('label:[vip,gold]');
+        expect(roundTrip('label:-[vip,gold]')).toBe('label:-[vip,gold]');
+        expect(roundTrip('subscribed:true+email_disabled:0')).toBe('subscribed:true+email_disabled:0');
+        expect(roundTrip('deleted_at:null')).toBe('deleted_at:null');
+    });
+
+    it('round-trips contains, starts-with, ends-with and negated regex forms', () => {
+        expect(roundTrip('name:~\'jamie\'')).toBe('name:~\'jamie\'');
+        expect(roundTrip('name:~^\'jamie\'')).toBe('name:~^\'jamie\'');
+        expect(roundTrip('name:~$\'jamie\'')).toBe('name:~$\'jamie\'');
+        expect(roundTrip('name:-~\'jamie\'')).toBe('name:-~\'jamie\'');
+        expect(roundTrip('name:~\'a+b.c\'')).toBe('name:~\'a+b.c\'');
+    });
+
+    it('round-trips relative dates', () => {
+        expect(roundTrip('created_at:>=now-30d')).toBe('created_at:>=now-30d');
+        expect(roundTrip('expiry:<now+2w')).toBe('expiry:<now+2w');
+    });
+
+    it('round-trips compounds, parenthesizing nested groups but not a root OR', () => {
+        expect(roundTrip('status:paid,label:vip')).toBe('status:paid,label:vip');
+        expect(roundTrip('(status:paid,label:vip)')).toBe('status:paid,label:vip');
+        expect(roundTrip('status:free+(label:vip,name:jamie)')).toBe('status:free+(label:vip,name:jamie)');
+        expect(roundTrip('(subscribed:true+email_disabled:0),status:comped')).toBe('(subscribed:true+email_disabled:0),status:comped');
+    });
+
+    it('quotes values that would change type or fail to lex when bare', () => {
+        expect(roundTrip('label:\'two words\'')).toBe('label:\'two words\'');
+        expect(roundTrip('label:\'123\'')).toBe('label:\'123\'');
+        expect(roundTrip('label:\'true\'')).toBe('label:\'true\'');
+        expect(roundTrip('label:\'now-7d\'')).toBe('label:\'now-7d\'');
+        expect(roundTrip('label:\'it\\\'s\'')).toBe('label:\'it\\\'s\'');
+        expect(roundTrip('created_at:<\'2024-01-01 00:00:00\'')).toBe('created_at:<\'2024-01-01 00:00:00\'');
+    });
+
+    it('emits lexer-safe literals bare', () => {
+        expect(roundTrip('email:jamie@example.com')).toBe('email:jamie@example.com');
+        expect(roundTrip('newsletters.slug:weekly-news')).toBe('newsletters.slug:weekly-news');
+    });
+
+    it('reparses to the identical AST', () => {
+        const filters = [
+            'count.active_stripe_customers:>1',
+            '(status:paid,label:vip)+name:~\'a+b\'',
+            'created_at:>=now-30d+label:-[vip]',
+            'subscribed:false,email_disabled:1'
+        ];
+
+        for (const filter of filters) {
+            const serialized = serializeAstToNql(parse(filter));
+
+            expect(serialized).toBeDefined();
+            expect(parse(serialized as string)).toEqual(parse(filter));
+        }
+    });
+
+    it('returns undefined for shapes the parser cannot produce', () => {
+        expect(serializeAstToNql({})).toBeUndefined();
+        expect(serializeAstToNql({status: 'paid', label: 'vip'})).toBeUndefined();
+        expect(serializeAstToNql({$unknown: [{status: 'paid'}]})).toBeUndefined();
+        expect(serializeAstToNql({status: {$exists: true}})).toBeUndefined();
+        expect(serializeAstToNql({email_count: -5})).toBeUndefined();
+        expect(serializeAstToNql({name: {$regex: /jamie/}})).toBeUndefined();
+        expect(serializeAstToNql({name: {$regex: /jam.e/i}})).toBeUndefined();
+        expect(serializeAstToNql({label: {$in: []}})).toBeUndefined();
     });
 });

--- a/apps/posts/src/views/filters/filter-ast.ts
+++ b/apps/posts/src/views/filters/filter-ast.ts
@@ -20,6 +20,259 @@ export function extractFieldName(node: AstNode): string | undefined {
     return field;
 }
 
+/**
+ * Returns the top-level AND clauses of a parsed filter. A filter without a
+ * root `$and` is a single clause. Parenthesized groups stay intact as one
+ * clause because the parser nests them as a single child node.
+ */
+export function extractAndClauses(node: AstNode): AstNode[] {
+    if (Array.isArray(node.$and)) {
+        return node.$and.filter(isPlainObject);
+    }
+
+    return [node];
+}
+
+// Mirrors the lexer: a bare (unquoted) literal must not collide with the
+// keyword, number, or relative-date token forms, and may only use characters
+// the LITERAL rule accepts without escaping.
+const BARE_LITERAL = /^[a-zA-Z_][\w.@-]*$/;
+const KEYWORD_LITERALS = new Set(['true', 'false', 'null']);
+const RELATIVE_DATE_LITERAL = /^now[-+]\d+[dwMyhms]$/;
+const FIELD_KEY = /^[a-zA-Z_][a-zA-Z0-9_.]*$/;
+
+const COMPARISON_PREFIXES: Record<string, string> = {
+    $ne: '-',
+    $gt: '>',
+    $lt: '<',
+    $gte: '>=',
+    $lte: '<='
+};
+
+// Inverts scope.relDateToAbsolute's `preserveRelativeDates` output.
+const RELATIVE_DATE_UNITS: Record<string, string> = {
+    days: 'd',
+    weeks: 'w',
+    months: 'M',
+    years: 'y',
+    hours: 'h',
+    minutes: 'm',
+    seconds: 's'
+};
+
+// The characters scope.stringToRegExp escapes when building a RegExp.
+const REGEX_ESCAPED_CHARS = '.*+?^$(){}|[]\\';
+
+function quoteString(value: string): string {
+    return `'${value.replace(/(['"])/g, '\\$1')}'`;
+}
+
+function serializeString(value: string): string | undefined {
+    if (value.length === 0) {
+        return undefined;
+    }
+
+    if (BARE_LITERAL.test(value) && !KEYWORD_LITERALS.has(value.toLowerCase()) && !RELATIVE_DATE_LITERAL.test(value)) {
+        return value;
+    }
+
+    return quoteString(value);
+}
+
+function serializeRelativeDate(value: Record<string, unknown>): string | undefined {
+    const {op, amount, unit} = value as {op?: unknown; amount?: unknown; unit?: unknown};
+    const sign = op === 'add' ? '+' : op === 'sub' ? '-' : undefined;
+    const unitLetter = typeof unit === 'string' ? RELATIVE_DATE_UNITS[unit] : undefined;
+
+    if (!sign || !unitLetter || typeof amount !== 'number' || !Number.isInteger(amount) || amount < 0) {
+        return undefined;
+    }
+
+    return `now${sign}${amount}${unitLetter}`;
+}
+
+function serializeScalar(value: unknown): string | undefined {
+    if (value === null) {
+        return 'null';
+    }
+
+    if (typeof value === 'boolean') {
+        return String(value);
+    }
+
+    if (typeof value === 'number') {
+        // Negative numbers have no literal form: `field:-5` parses as $ne.
+        return Number.isInteger(value) && value >= 0 ? String(value) : undefined;
+    }
+
+    if (typeof value === 'string') {
+        return serializeString(value);
+    }
+
+    if (isPlainObject(value) && isPlainObject(value.$relativeDate)) {
+        return serializeRelativeDate(value.$relativeDate);
+    }
+
+    return undefined;
+}
+
+/**
+ * Recovers the `~`/`~^`/`~$` form from a RegExp built by scope.stringToRegExp.
+ * Anything that couldn't have come from it (other flags, unescaped regex
+ * syntax, both anchors) is unserializable.
+ */
+function serializeRegex(value: unknown, negated: boolean): string | undefined {
+    if (!(value instanceof RegExp) || value.flags !== 'i') {
+        return undefined;
+    }
+
+    const source = value.source;
+    let literal = '';
+    let startAnchor = false;
+    let endAnchor = false;
+
+    for (let index = 0; index < source.length; index += 1) {
+        const char = source[index];
+
+        if (char === '\\') {
+            const next = source[index + 1];
+
+            if (next === undefined || !REGEX_ESCAPED_CHARS.includes(next)) {
+                return undefined;
+            }
+
+            literal += next;
+            index += 1;
+        } else if (char === '^' && index === 0) {
+            startAnchor = true;
+        } else if (char === '$' && index === source.length - 1) {
+            endAnchor = true;
+        } else if (REGEX_ESCAPED_CHARS.includes(char)) {
+            return undefined;
+        } else {
+            literal += char;
+        }
+    }
+
+    if ((startAnchor && endAnchor) || literal.length === 0) {
+        return undefined;
+    }
+
+    const operator = startAnchor ? '~^' : endAnchor ? '~$' : '~';
+
+    return `${negated ? '-' : ''}${operator}${quoteString(literal)}`;
+}
+
+function serializeInList(values: unknown, negated: boolean): string | undefined {
+    if (!Array.isArray(values) || values.length === 0) {
+        return undefined;
+    }
+
+    const parts = values.map(serializeScalar);
+
+    if (parts.some(part => part === undefined)) {
+        return undefined;
+    }
+
+    return `${negated ? '-' : ''}[${parts.join(',')}]`;
+}
+
+function serializeValueExpr(value: unknown): string | undefined {
+    if (isPlainObject(value)) {
+        if (isPlainObject(value.$relativeDate)) {
+            return serializeScalar(value);
+        }
+
+        const entries = Object.entries(value);
+
+        if (entries.length !== 1) {
+            return undefined;
+        }
+
+        const [operator, operand] = entries[0];
+
+        if (operator === '$regex') {
+            return serializeRegex(operand, false);
+        }
+
+        if (operator === '$not') {
+            return serializeRegex(operand, true);
+        }
+
+        if (operator === '$in') {
+            return serializeInList(operand, false);
+        }
+
+        if (operator === '$nin') {
+            return serializeInList(operand, true);
+        }
+
+        const prefix = COMPARISON_PREFIXES[operator];
+
+        if (!prefix) {
+            return undefined;
+        }
+
+        const scalar = serializeScalar(operand);
+
+        return scalar === undefined ? undefined : `${prefix}${scalar}`;
+    }
+
+    return serializeScalar(value);
+}
+
+function serializeNode(node: unknown, isRoot: boolean): string | undefined {
+    if (!isPlainObject(node)) {
+        return undefined;
+    }
+
+    // Double-parenthesized groups can leave a `yg` wrapper in the AST.
+    const unwrapped = isPlainObject(node.yg) ? node.yg : node;
+    const keys = Object.keys(unwrapped);
+
+    if (keys.length !== 1) {
+        return undefined;
+    }
+
+    const [key] = keys;
+
+    if (key === '$and' || key === '$or') {
+        const children = unwrapped[key];
+
+        if (!Array.isArray(children) || children.length === 0) {
+            return undefined;
+        }
+
+        const parts = children.map(child => serializeNode(child, false));
+
+        if (parts.some(part => part === undefined)) {
+            return undefined;
+        }
+
+        const joined = parts.join(key === '$and' ? '+' : ',');
+
+        return isRoot ? joined : `(${joined})`;
+    }
+
+    if (!FIELD_KEY.test(key)) {
+        return undefined;
+    }
+
+    const valueText = serializeValueExpr(unwrapped[key]);
+
+    return valueText === undefined ? undefined : `${key}:${valueText}`;
+}
+
+/**
+ * Serializes a parsed AST node back to NQL. The inverse of nql-lang's parser
+ * for every shape it can emit; returns undefined for anything it can't
+ * faithfully round-trip, so callers can drop the clause rather than corrupt
+ * it. OR groups are parenthesized except at the root, where bare OR is valid.
+ */
+export function serializeAstToNql(node: AstNode): string | undefined {
+    return serializeNode(node, true);
+}
+
 export function extractComparator(node: AstNode): {field: string; operator: string; value: unknown} | undefined {
     const field = extractFieldName(node);
 

--- a/apps/posts/src/views/filters/filter-query-core.test.ts
+++ b/apps/posts/src/views/filters/filter-query-core.test.ts
@@ -1,6 +1,6 @@
+import {combineNqlAndClauses, dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates} from './filter-query-core';
 import {defineFields} from './filter-types';
 import {describe, expect, it} from 'vitest';
-import {dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates} from './filter-query-core';
 import {numberCodec, scalarCodec} from './filter-codecs';
 import type {AstNode} from './filter-ast';
 import type {FilterPredicate} from './filter-types';
@@ -118,5 +118,20 @@ describe('filter-query-core', () => {
 
         expect([...fieldKeys]).toEqual(['created_at', 'created_at_utc']);
         expect(hasFieldKey(ast, fieldKeys)).toBe(true);
+    });
+});
+
+describe('combineNqlAndClauses', () => {
+    it('joins clauses with AND and skips empty entries', () => {
+        expect(combineNqlAndClauses(['status:paid', undefined, 'label:vip'])).toBe('status:paid+label:vip');
+    });
+
+    it('parenthesizes clauses with a top-level OR so precedence survives the join', () => {
+        expect(combineNqlAndClauses(['status:paid', 'label:vip,name:jamie'])).toBe('status:paid+(label:vip,name:jamie)');
+    });
+
+    it('returns a single clause verbatim and undefined when nothing remains', () => {
+        expect(combineNqlAndClauses(['status:paid,label:vip'])).toBe('status:paid,label:vip');
+        expect(combineNqlAndClauses([undefined])).toBeUndefined();
     });
 });

--- a/apps/posts/src/views/filters/filter-query-core.ts
+++ b/apps/posts/src/views/filters/filter-query-core.ts
@@ -15,6 +15,28 @@ export function parseFilterToAst(filter: string): AstNode | undefined {
     }
 }
 
+/**
+ * Joins clauses back into a single NQL filter. AND binds tighter than OR in
+ * NQL, so clauses with a root-level OR are parenthesized before joining.
+ */
+export function combineNqlAndClauses(clauses: Array<string | undefined>): string | undefined {
+    const present = clauses.filter((clause): clause is string => Boolean(clause));
+
+    if (present.length === 0) {
+        return undefined;
+    }
+
+    if (present.length === 1) {
+        return present[0];
+    }
+
+    return present.map((clause) => {
+        const ast = parseFilterToAst(clause);
+
+        return ast && Array.isArray(ast.$or) ? `(${clause})` : clause;
+    }).join('+');
+}
+
 export function stampPredicates(predicates: ParsedPredicate[]): FilterPredicate[] {
     return predicates.map((predicate, index) => ({
         ...predicate,

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.test.tsx
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.test.tsx
@@ -35,7 +35,7 @@ describe('shouldDelayMembersDateFilterHydration', () => {
 });
 
 describe('useMembersFilterState', () => {
-    it('drops unsupported OR filters and rewrites the URL canonically', async () => {
+    it('preserves unsupported OR filters in the URL and the nql output', async () => {
         const {result} = renderHook(() => {
             const state = useMembersFilterState('UTC');
             const [searchParams] = useSearchParams();
@@ -49,15 +49,15 @@ describe('useMembersFilterState', () => {
         });
 
         await waitFor(() => {
-            expect(result.current.query).toBe('');
+            expect(result.current.nql).toBe('status:paid,label:vip');
         });
 
         expect(result.current.filters).toEqual([]);
-        expect(result.current.nql).toBeUndefined();
-        expect(result.current.hasFilterOrSearch).toBe(false);
+        expect(result.current.query).toBe('filter=status%3Apaid%2Clabel%3Avip');
+        expect(result.current.hasFilterOrSearch).toBe(true);
     });
 
-    it('parses the multiple active Stripe customers filter into a predicate', async () => {
+    it('preserves raw filters on unknown fields', async () => {
         const {result} = renderHook(() => {
             const state = useMembersFilterState('UTC');
             const [searchParams] = useSearchParams();
@@ -74,19 +74,15 @@ describe('useMembersFilterState', () => {
             expect(result.current.nql).toBe('count.active_stripe_customers:>1');
         });
 
-        expect(result.current.filters).toEqual([
-            {
-                id: 'count.active_stripe_customers:1',
-                field: 'count.active_stripe_customers',
-                operator: 'is-greater',
-                values: [1]
-            }
-        ]);
+        expect(result.current.filters).toEqual([]);
         expect(result.current.query).toBe('filter=count.active_stripe_customers%3A%3E1');
         expect(result.current.hasFilterOrSearch).toBe(true);
+        expect(result.current.hasUnknownFilters).toBe(true);
     });
 
-    it('drops unsupported multiple active Stripe customers filter values', async () => {
+    it('preserves unknown-field filters regardless of their value', async () => {
+        // Unlike a codec, preservation doesn't whitelist specific forms —
+        // anything that parses as NQL is passed through for the API to judge.
         const {result} = renderHook(() => {
             const state = useMembersFilterState('UTC');
             const [searchParams] = useSearchParams();
@@ -100,15 +96,14 @@ describe('useMembersFilterState', () => {
         });
 
         await waitFor(() => {
-            expect(result.current.query).toBe('');
+            expect(result.current.nql).toBe('count.active_stripe_customers:>2');
         });
 
         expect(result.current.filters).toEqual([]);
-        expect(result.current.nql).toBeUndefined();
-        expect(result.current.hasFilterOrSearch).toBe(false);
+        expect(result.current.query).toBe('filter=count.active_stripe_customers%3A%3E2');
     });
 
-    it('retains supported filters and rewrites mixed URLs canonically', async () => {
+    it('retains supported filters and preserves unknown clauses in mixed URLs', async () => {
         const {result} = renderHook(() => {
             const state = useMembersFilterState('UTC');
             const [searchParams] = useSearchParams();
@@ -122,15 +117,82 @@ describe('useMembersFilterState', () => {
         });
 
         await waitFor(() => {
-            expect(result.current.nql).toBe('created_at:<=\'2024-02-01T23:59:59.999Z\'');
+            expect(result.current.nql).toBe('created_at:<=\'2024-02-01T23:59:59.999Z\'+(status:paid,label:vip)');
         });
 
         expect(result.current.filters.map(({field, operator, values}) => ({field, operator, values}))).toEqual([
             {field: 'created_at', operator: 'is-or-less', values: ['2024-02-01']}
         ]);
-        expect(result.current.nql).toBe('created_at:<=\'2024-02-01T23:59:59.999Z\'');
         expect(result.current.hasFilterOrSearch).toBe(true);
-        expect(result.current.query).toBe('filter=created_at%3A%3C%3D%272024-02-01T23%3A59%3A59.999Z%27');
+        expect(result.current.query).toBe(new URLSearchParams({
+            filter: 'created_at:<=\'2024-02-01T23:59:59.999Z\'+(status:paid,label:vip)'
+        }).toString());
+    });
+
+    it('keeps unknown clauses when chips are edited and parenthesizes OR clauses on recombine', async () => {
+        const {result} = renderHook(() => {
+            const state = useMembersFilterState('UTC');
+            const [searchParams] = useSearchParams();
+
+            return {
+                ...state,
+                query: searchParams.toString()
+            };
+        }, {
+            wrapper: createWrapper('/?filter=status:free,label:vip')
+        });
+
+        await waitFor(() => {
+            expect(result.current.nql).toBe('status:free,label:vip');
+        });
+
+        act(() => {
+            result.current.setFilters([
+                {
+                    id: '1',
+                    field: 'status',
+                    operator: 'is',
+                    values: ['paid']
+                }
+            ], {replace: false});
+        });
+
+        expect(result.current.nql).toBe('status:paid+(status:free,label:vip)');
+        expect(result.current.query).toBe(new URLSearchParams({
+            filter: 'status:paid+(status:free,label:vip)'
+        }).toString());
+    });
+
+    it('keeps unknown clauses when search changes and clears them with clearAll', async () => {
+        const {result} = renderHook(() => {
+            const state = useMembersFilterState('UTC');
+            const [searchParams] = useSearchParams();
+
+            return {
+                ...state,
+                query: searchParams.toString()
+            };
+        }, {
+            wrapper: createWrapper('/?filter=count.active_stripe_customers%3A%3E1')
+        });
+
+        await waitFor(() => {
+            expect(result.current.nql).toBe('count.active_stripe_customers:>1');
+        });
+
+        act(() => {
+            result.current.setSearch('jamie', {replace: false});
+        });
+
+        expect(result.current.query).toBe('filter=count.active_stripe_customers%3A%3E1&search=jamie');
+
+        act(() => {
+            result.current.clearAll({replace: false});
+        });
+
+        expect(result.current.query).toBe('');
+        expect(result.current.nql).toBeUndefined();
+        expect(result.current.hasFilterOrSearch).toBe(false);
     });
 
     it('reads Ember-style filter params and keeps search separate', () => {

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.ts
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.ts
@@ -1,6 +1,7 @@
 import {Filter} from '@tryghost/shade/patterns';
+import {combineNqlAndClauses} from '../../filters/filter-query-core';
 import {getMemberFields} from '../member-fields';
-import {hasTimezoneSensitiveMemberFilter, isPredicateEnabled, parseMemberFilter, serializeMemberFilters} from '../member-filter-query';
+import {hasTimezoneSensitiveMemberFilter, isPredicateEnabled, parseMemberFilterState, serializeMemberFilters} from '../member-filter-query';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useSearchParams} from 'react-router';
 import type {MemberFields} from '../member-fields';
@@ -18,11 +19,13 @@ interface UseMembersFilterStateReturn {
     clearFilters: (options?: SetFiltersOptions) => void;
     clearAll: (options?: SetFiltersOptions) => void;
     hasFilterOrSearch: boolean;
+    hasUnknownFilters: boolean;
 }
 
 interface ToSearchParamsOptions {
     baseSearchParams: URLSearchParams;
     filters: Filter[];
+    unknownClauses: string[];
     search: string;
     timezone: string;
     fields: MemberFields;
@@ -47,9 +50,16 @@ function getEnabledFilters(filters: Filter[], fields: MemberFields): Filter[] {
     return filters.filter(predicate => isPredicateEnabled(predicate, fields));
 }
 
-function toSearchParams({baseSearchParams, filters, search, timezone, fields}: ToSearchParamsOptions): URLSearchParams {
+function buildFilterNql(filters: Filter[], unknownClauses: string[], timezone: string, fields: MemberFields): string | undefined {
+    return combineNqlAndClauses([
+        serializeMemberFilters(getEnabledFilters(filters, fields), timezone),
+        ...unknownClauses
+    ]);
+}
+
+function toSearchParams({baseSearchParams, filters, unknownClauses, search, timezone, fields}: ToSearchParamsOptions): URLSearchParams {
     const params = new URLSearchParams(baseSearchParams);
-    const filter = serializeMemberFilters(getEnabledFilters(filters, fields), timezone);
+    const filter = buildFilterNql(filters, unknownClauses, timezone, fields);
 
     params.delete('filter');
     params.delete('search');
@@ -65,6 +75,13 @@ function toSearchParams({baseSearchParams, filters, search, timezone, fields}: T
     return params;
 }
 
+/**
+ * Filter state for the members list, synced with the `filter`/`search` URL
+ * params. NQL clauses the filter UI can't represent (unknown fields, OR
+ * groups, operators the field map doesn't advertise) are preserved: they stay
+ * in the URL and in `nql` alongside any chips the user edits, and are only
+ * removed by `clearFilters`/`clearAll`.
+ */
 export function useMembersFilterState(timezone: string): UseMembersFilterStateReturn {
     const fields = useMemo(() => getMemberFields(), []);
     const [searchParams, setSearchParams] = useSearchParams();
@@ -72,8 +89,8 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
     const filterParam = useMemo(() => searchParams.get('filter') ?? undefined, [searchParams]);
     const currentQuery = useMemo(() => searchParams.toString(), [searchParams]);
 
-    const parsedFilters = useMemo(() => {
-        return getEnabledFilters(parseMemberFilter(filterParam, timezone), fields);
+    const {predicates: parsedFilters, unknownClauses} = useMemo(() => {
+        return parseMemberFilterState(filterParam, timezone, fields);
     }, [filterParam, timezone, fields]);
     const [filters, setDraftFilters] = useState<Filter[]>(parsedFilters);
 
@@ -82,8 +99,8 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
     }, [searchParams]);
 
     const nql = useMemo(() => {
-        return serializeMemberFilters(getEnabledFilters(filters, fields), timezone);
-    }, [filters, timezone, fields]);
+        return buildFilterNql(filters, unknownClauses, timezone, fields);
+    }, [filters, unknownClauses, timezone, fields]);
 
     useEffect(() => {
         if (currentQuery !== lastWrittenQueryRef.current) {
@@ -100,6 +117,7 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters,
+            unknownClauses,
             search,
             timezone,
             fields
@@ -110,13 +128,14 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
             lastWrittenQueryRef.current = nextQuery;
             setSearchParams(nextParams, {replace: true});
         }
-    }, [currentQuery, filters, search, searchParams, setSearchParams, timezone, fields]);
+    }, [currentQuery, filters, unknownClauses, search, searchParams, setSearchParams, timezone, fields]);
 
     const setFilters = useCallback((nextFilters: Filter[], setOptions: SetFiltersOptions = {}) => {
         const replace = setOptions.replace ?? true;
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters: nextFilters,
+            unknownClauses,
             search,
             timezone,
             fields
@@ -125,13 +144,14 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
         setDraftFilters(nextFilters);
         lastWrittenQueryRef.current = nextParams.toString();
         setSearchParams(nextParams, {replace});
-    }, [search, searchParams, setSearchParams, timezone, fields]);
+    }, [search, searchParams, setSearchParams, timezone, fields, unknownClauses]);
 
     const setSearch = useCallback((nextSearch: string, setOptions: SetFiltersOptions = {}) => {
         const replace = setOptions.replace ?? true;
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters,
+            unknownClauses,
             search: nextSearch,
             timezone,
             fields
@@ -139,12 +159,13 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
 
         lastWrittenQueryRef.current = nextParams.toString();
         setSearchParams(nextParams, {replace});
-    }, [filters, searchParams, setSearchParams, timezone, fields]);
+    }, [filters, unknownClauses, searchParams, setSearchParams, timezone, fields]);
 
     const clearFilters = useCallback(({replace = true}: SetFiltersOptions = {}) => {
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters: [],
+            unknownClauses: [],
             search,
             timezone,
             fields
@@ -159,6 +180,7 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
         const nextParams = toSearchParams({
             baseSearchParams: searchParams,
             filters: [],
+            unknownClauses: [],
             search: '',
             timezone,
             fields
@@ -177,6 +199,7 @@ export function useMembersFilterState(timezone: string): UseMembersFilterStateRe
         setSearch,
         clearFilters,
         clearAll,
-        hasFilterOrSearch: Boolean(nql) || search.length > 0
+        hasFilterOrSearch: Boolean(nql) || search.length > 0,
+        hasUnknownFilters: unknownClauses.length > 0
     };
 }

--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -41,8 +41,7 @@ describe('memberFields', () => {
             'opened_emails.post_id',
             'clicked_links.post_id',
             'newsletter_feedback',
-            'offer_redemptions',
-            'count.active_stripe_customers'
+            'offer_redemptions'
         ]);
     });
 

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -1,9 +1,7 @@
 import {DATE_FILTER_OPERATORS, DEFAULT_DATE_OPERATOR} from '../filters/filter-date';
-import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD, MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER} from './multiple-active-subscriptions';
 import {dateCodec, numberCodec, scalarCodec, setCodec, textCodec} from '../filters/filter-codecs';
 import {defineFields} from '../filters/filter-types';
 import {escapeNqlString} from '../filters/filter-normalization';
-import {extractComparator} from '../filters/filter-ast';
 import {withFutureRelativeOperator, withPastRelativeOperator} from '../filters/filter-relative-date';
 import type {FilterCodec} from '../filters/filter-types';
 
@@ -90,30 +88,6 @@ const feedbackCodec: FilterCodec = {
         }
 
         return [`(feedback.post_id:${escapeNqlString(postId)}+feedback.score:${predicate.operator})`];
-    }
-};
-
-const multipleActiveSubscriptionsCodec: FilterCodec = {
-    parse(node, ctx) {
-        const comparator = extractComparator(node as Record<string, unknown>);
-
-        // The API only supports the exact `count.active_stripe_customers:>1` form
-        if (!comparator || comparator.field !== ctx.key || comparator.operator !== '$gt' || comparator.value !== 1) {
-            return null;
-        }
-
-        return {
-            field: ctx.key,
-            operator: 'is-greater',
-            values: [1]
-        };
-    },
-    serialize(predicate) {
-        if (predicate.operator !== 'is-greater' || predicate.values[0] !== 1) {
-            return null;
-        }
-
-        return [MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER];
     }
 };
 
@@ -423,17 +397,6 @@ const baseMemberFields = defineFields({
             }
         },
         codec: setCodec({quoteStrings: true, serializeSingletonAsScalar: true})
-    },
-    // Intentionally absent from `useMemberFilterFields`, so it never appears
-    // in the filter UI — it's only reachable via the multiple active
-    // subscriptions banner's "View members" link.
-    [MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD]: {
-        operators: ['is-greater'],
-        ui: {
-            label: 'Multiple active subscriptions',
-            type: 'number'
-        },
-        codec: multipleActiveSubscriptionsCodec
     }
 });
 

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 import {getMemberFields} from './member-fields';
-import {hasTimezoneSensitiveMemberFilter, isPredicateEnabled, parseMemberFilter, serializeMemberFilters} from './member-filter-query';
+import {hasTimezoneSensitiveMemberFilter, isPredicateEnabled, parseMemberFilter, parseMemberFilterState, serializeMemberFilters} from './member-filter-query';
 import type {FilterPredicate} from '../filters/filter-types';
 
 function stripIds(predicates: FilterPredicate[]) {
@@ -309,5 +309,57 @@ describe('isPredicateEnabled', () => {
             {field: 'not_a_real_field', operator: 'is', values: ['anything']},
             fields
         )).toBe(false);
+    });
+});
+
+describe('parseMemberFilterState', () => {
+    const fields = getMemberFields();
+
+    it('partitions a filter into enabled predicates and unknown clauses', () => {
+        const state = parseMemberFilterState(
+            'count.active_stripe_customers:>1+status:paid+(label:vip,name:jamie)',
+            'UTC',
+            fields
+        );
+
+        expect(stripIds(state.predicates)).toEqual([
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+        expect(state.unknownClauses).toEqual([
+            'count.active_stripe_customers:>1',
+            'label:vip,name:jamie'
+        ]);
+    });
+
+    it('treats clauses with only disabled predicates as unknown', () => {
+        // `subscriptions.current_period_end` only advertises the future
+        // direction, so the past form has no UI representation.
+        const state = parseMemberFilterState('subscriptions.current_period_end:>=now-7d', 'UTC', fields);
+
+        expect(state.predicates).toEqual([]);
+        expect(state.unknownClauses).toEqual(['subscriptions.current_period_end:>=now-7d']);
+    });
+
+    it('keeps unwrapped root compounds as predicates rather than unknown clauses', () => {
+        const state = parseMemberFilterState('subscribed:true+email_disabled:0', 'UTC', fields);
+
+        expect(stripIds(state.predicates)).toEqual([
+            {field: 'subscribed', operator: 'is', values: ['subscribed']}
+        ]);
+        expect(state.unknownClauses).toEqual([]);
+    });
+
+    it('drops filters that are not valid NQL', () => {
+        expect(parseMemberFilterState('status:+label:vip', 'UTC', fields)).toEqual({
+            predicates: [],
+            unknownClauses: []
+        });
+    });
+
+    it('returns empty state for empty input', () => {
+        expect(parseMemberFilterState(undefined, 'UTC', fields)).toEqual({
+            predicates: [],
+            unknownClauses: []
+        });
     });
 });

--- a/apps/posts/src/views/members/member-filter-query.ts
+++ b/apps/posts/src/views/members/member-filter-query.ts
@@ -1,4 +1,5 @@
 import {dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates, stampPredicates} from '../filters/filter-query-core';
+import {extractAndClauses, serializeAstToNql} from '../filters/filter-ast';
 import {memberFields} from './member-fields';
 import {resolveField} from '../filters/resolve-field';
 import type {AstNode} from '../filters/filter-ast';
@@ -189,13 +190,23 @@ const MEMBER_COMPOUND_MATCHERS: CompoundMatcher[] = [
     matchFeedbackGroupedNode
 ];
 
-function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
+function matchMemberCompoundNode(node: AstNode): ParsedPredicate | null {
     for (const matcher of MEMBER_COMPOUND_MATCHERS) {
         const parsed = matcher(node);
 
         if (parsed) {
-            return [parsed];
+            return parsed;
         }
+    }
+
+    return null;
+}
+
+function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
+    const matched = matchMemberCompoundNode(node);
+
+    if (matched) {
+        return [matched];
     }
 
     const compound = getCompoundChildren(node);
@@ -207,18 +218,74 @@ function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
     return dispatchSimpleNodes([node], memberFields, timezone);
 }
 
+export interface ParsedMemberFilterState {
+    predicates: FilterPredicate[];
+    unknownClauses: string[];
+}
+
+interface MemberFilterClause {
+    node: AstNode;
+    predicates: ParsedPredicate[];
+}
+
 /**
- * Parses NQL into predicates. Pure: callers are responsible for filtering the
- * output via `isPredicateEnabled` against the field map they want to enforce.
+ * Parses NQL and splits the AST into its top-level AND clauses, each parsed
+ * independently. Clauses the member field map can't represent come back with
+ * an empty `predicates` array, so callers can preserve their NQL instead of
+ * silently dropping properties they don't understand.
  */
-export function parseMemberFilter(filter: string | undefined, timezone: string): FilterPredicate[] {
+function parseMemberFilterClauses(filter: string | undefined, timezone: string): MemberFilterClause[] {
     const ast = parseFilterToAst(filter ?? '');
 
     if (!ast) {
         return [];
     }
 
-    return stampPredicates(parseMemberNode(ast, timezone));
+    // Legacy Ember compounds can span the whole filter without parentheses
+    // (e.g. `subscribed:true+email_disabled:0`), so the matchers get a shot
+    // at the root before the filter is split into clauses.
+    const rootCompound = matchMemberCompoundNode(ast);
+
+    if (rootCompound) {
+        return [{node: ast, predicates: [rootCompound]}];
+    }
+
+    return extractAndClauses(ast).map(node => ({node, predicates: parseMemberNode(node, timezone)}));
+}
+
+/**
+ * Parses NQL into the state the filter UI works with: predicates for every
+ * clause the field map can represent (enforced via `isPredicateEnabled`),
+ * plus the re-serialized NQL of every clause it cannot. Unknown clauses
+ * still filter the member list — they just have no UI representation.
+ */
+export function parseMemberFilterState(filter: string | undefined, timezone: string, fields: MemberFields): ParsedMemberFilterState {
+    const known: ParsedPredicate[] = [];
+    const unknownClauses: string[] = [];
+
+    for (const clause of parseMemberFilterClauses(filter, timezone)) {
+        const enabled = clause.predicates.filter(predicate => isPredicateEnabled(predicate, fields));
+
+        if (enabled.length > 0) {
+            known.push(...enabled);
+        } else {
+            const nql = serializeAstToNql(clause.node);
+
+            if (nql !== undefined) {
+                unknownClauses.push(nql);
+            }
+        }
+    }
+
+    return {predicates: stampPredicates(known), unknownClauses};
+}
+
+/**
+ * Parses NQL into predicates. Pure: callers are responsible for filtering the
+ * output via `isPredicateEnabled` against the field map they want to enforce.
+ */
+export function parseMemberFilter(filter: string | undefined, timezone: string): FilterPredicate[] {
+    return stampPredicates(parseMemberFilterClauses(filter, timezone).flatMap(clause => clause.predicates));
 }
 
 export function hasTimezoneSensitiveMemberFilter(filter: string | undefined): boolean {

--- a/apps/posts/src/views/members/members-view-state.test.ts
+++ b/apps/posts/src/views/members/members-view-state.test.ts
@@ -13,7 +13,8 @@ describe('members-view-state', () => {
         expect(canBulkDeleteMembers([], '(subscriptions.status:active,status:free)')).toBe(false);
     });
 
-    it('disables bulk delete for the multiple active subscriptions filter', () => {
-        expect(canBulkDeleteMembers([{field: 'count.active_stripe_customers'}], 'count.active_stripe_customers:>1')).toBe(false);
+    it('disables bulk delete for filters preserved as unknown NQL clauses', () => {
+        expect(canBulkDeleteMembers([], 'count.active_stripe_customers:>1')).toBe(false);
+        expect(canBulkDeleteMembers([{field: 'status'}], 'status:paid+count.active_stripe_customers:>1', true)).toBe(false);
     });
 });

--- a/apps/posts/src/views/members/members-view-state.ts
+++ b/apps/posts/src/views/members/members-view-state.ts
@@ -1,20 +1,23 @@
-import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD} from './multiple-active-subscriptions';
-
 const BULK_DELETE_RESTRICTED_FILTERS = [
     'subscriptions.plan_interval',
     'subscriptions.status',
     'subscriptions.start_date',
     'subscriptions.current_period_end',
     'conversion',
-    'offer_redemptions',
-    MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD
+    'offer_redemptions'
 ];
 
 type FilterLike = {
     field: string;
 };
 
-export function canBulkDeleteMembers(filters: FilterLike[], _nql?: string): boolean {
+export function canBulkDeleteMembers(filters: FilterLike[], _nql?: string, hasUnknownFilters = false): boolean {
+    // Unknown NQL clauses have no filter UI representation, so we can't vouch
+    // for the bulk-destroy endpoint supporting them.
+    if (hasUnknownFilters) {
+        return false;
+    }
+
     if (_nql && filters.length === 0) {
         return false;
     }

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -15,7 +15,6 @@ import {buildMemberListSearchParams, getMemberActiveColumns} from './member-quer
 import {canBulkDeleteMembers, shouldShowMembersLoading} from './members-view-state';
 import {checkStripeEnabled, getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
-import {isMultipleActiveSubscriptionsPredicate} from './multiple-active-subscriptions';
 import {shouldDelayMembersDateFilterHydration, useMembersFilterState} from './hooks/use-members-filter-state';
 import {useActiveMemberView, useMemberViews} from './hooks/use-member-views';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
@@ -45,7 +44,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
     const setHeaderContentRef = useCallback((node: HTMLDivElement | null) => {
         headerRef.current = node?.closest('[data-list-page="header"]') as HTMLDivElement | null;
     }, []);
-    const {filters, nql, search, setFilters, setSearch, hasFilterOrSearch, clearAll} = useMembersFilterState(timezone);
+    const {filters, nql, search, setFilters, setSearch, hasFilterOrSearch, hasUnknownFilters, clearAll} = useMembersFilterState(timezone);
     const location = useLocation();
     const savedViews = useMemberViews();
     const activeView = useActiveMemberView(savedViews, nql);
@@ -54,19 +53,13 @@ const MembersPage: React.FC<MembersPageProps> = ({
     const [searchInput, setSearchInput] = useState(search);
     const [debouncedSearch] = useDebounce(searchInput, SEARCH_DEBOUNCE_MS);
 
-    // The multiple active subscriptions predicate is applied via the banner's
-    // "View members" link and has no filter UI, so keep it out of the filter bar.
-    const visibleFilters = useMemo(() => {
-        return filters.filter(filter => !isMultipleActiveSubscriptionsPredicate(filter));
-    }, [filters]);
-
     const activeColumns = useMemo(() => {
         return getMemberActiveColumns(filters);
     }, [filters]);
 
     const canBulkDelete = useMemo(() => {
-        return canBulkDeleteMembers(filters, nql);
-    }, [filters, nql]);
+        return canBulkDeleteMembers(filters, nql, hasUnknownFilters);
+    }, [filters, nql, hasUnknownFilters]);
 
     const searchParams = useMemo(() => {
         return buildMemberListSearchParams({
@@ -95,7 +88,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
     });
 
     const totalMembers = data?.meta?.pagination?.total ?? 0;
-    const hasFilters = visibleFilters.length > 0;
+    const hasFilters = filters.length > 0;
     const shouldShowMobileSearchRow = showMobileSearch;
     const shouldShowFiltersRow = hasFilters;
     const shouldShowMembersHelpCards = !hasFilterOrSearch && !shouldShowLoading && !isError && totalMembers < MEMBERS_HELP_CARDS_LIMIT;
@@ -161,7 +154,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                     {!hasFilters && (
                                         <MembersFilters
                                             activeView={activeView}
-                                            filters={visibleFilters}
+                                            filters={filters}
                                             iconOnly={true}
                                             nql={nql}
                                             savedViews={savedViews}
@@ -197,7 +190,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                 {shouldShowFiltersRow && (
                                     <MembersFilters
                                         activeView={activeView}
-                                        filters={visibleFilters}
+                                        filters={filters}
                                         nql={nql}
                                         savedViews={savedViews}
                                         onFiltersChange={setFilters}

--- a/apps/posts/src/views/members/multiple-active-subscriptions.test.ts
+++ b/apps/posts/src/views/members/multiple-active-subscriptions.test.ts
@@ -1,10 +1,8 @@
 import {
-    MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD,
     MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER,
     buildDismissedMultipleActiveSubscriptionsPreference,
     getMultipleActiveSubscriptionsBannerPreference,
     isMultipleActiveSubscriptionsFilter,
-    isMultipleActiveSubscriptionsPredicate,
     parseAccessibilityPreferences
 } from './multiple-active-subscriptions';
 import {describe, expect, it} from 'vitest';
@@ -14,11 +12,6 @@ describe('multiple active subscriptions helpers', () => {
         expect(isMultipleActiveSubscriptionsFilter(MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER)).toBe(true);
         expect(isMultipleActiveSubscriptionsFilter(`${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER}+status:paid`)).toBe(false);
         expect(isMultipleActiveSubscriptionsFilter(undefined)).toBe(false);
-    });
-
-    it('matches predicates by field', () => {
-        expect(isMultipleActiveSubscriptionsPredicate({field: MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD})).toBe(true);
-        expect(isMultipleActiveSubscriptionsPredicate({field: 'status'})).toBe(false);
     });
 
     it('parses invalid accessibility JSON as empty preferences', () => {

--- a/apps/posts/src/views/members/multiple-active-subscriptions.ts
+++ b/apps/posts/src/views/members/multiple-active-subscriptions.ts
@@ -1,8 +1,7 @@
 import {z} from 'zod';
 import type {User} from '@tryghost/admin-x-framework/api/users';
 
-export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD = 'count.active_stripe_customers';
-export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER = `${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD}:>1`;
+export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER = 'count.active_stripe_customers:>1';
 
 const MultipleActiveSubscriptionsBannerPreferenceSchema = z.looseObject({
     dismissedCount: z.number().finite().optional().catch(undefined),
@@ -18,10 +17,6 @@ export type MultipleActiveSubscriptionsBannerPreference = z.infer<typeof Multipl
 
 export function isMultipleActiveSubscriptionsFilter(nql: string | undefined): boolean {
     return nql === MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER;
-}
-
-export function isMultipleActiveSubscriptionsPredicate(predicate: {field: string}): boolean {
-    return predicate.field === MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD;
 }
 
 export function parseAccessibilityPreferences(accessibility: string | null | undefined): AccessibilityPreferences {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/28232

The multiple-active-subscriptions filter shipped in #28232 as a **hidden filter field**: `count.active_stripe_customers` is registered in the member field map with a codec that only round-trips the exact `:>1` form, the members page filters the predicate out of the visible filter bar, and the field is listed in the bulk-delete restrictions. That works, but every future bare filter pays the same tax — a field registration, a strict codec, a UI exclusion, and a bulk-delete entry — and any NQL the field map doesn't know about is still silently scrubbed from the URL, breaking hand-crafted and legacy Ember filter links.

This PR proposes the alternative we'd like to discuss as a team: make the filter state preserve **any** NQL it can't represent, and delete the hidden-field machinery entirely.

- The `filter` param is parsed once and split into its top-level AND clauses via the AST. Clauses that map to filter chips behave as before; every other valid clause (unknown fields, OR groups, operators the field map doesn't advertise) is carried through the URL writeback, the `nql` output (so it still filters the member list via the API), and chip edits. Only "clear" actions remove them.
- Since nql-lang has no AST→string serializer, this adds one (`serializeAstToNql`) as the inverse of the parser for every shape its grammar can emit, including the `~`/`~^`/`~$` regex forms and preserved relative dates. It's deliberately conservative: anything it can't faithfully round-trip returns undefined and the clause is dropped rather than risk writing corrupted NQL back to the URL.
- When recombining clauses, root-level OR clauses are parenthesized (AND binds tighter than OR in NQL) so precedence survives the join.
- The hook exposes `hasUnknownFilters` and bulk delete is disabled whenever unknown clauses are present, since we can't vouch for the bulk-destroy endpoint supporting them — this replaces the bulk-delete restriction the hidden field provided.

Banner behaviour is unchanged (it still exact-matches its filter in `nql`). Differences from the hidden-field approach worth weighing:

- Unknown filters aren't whitelisted per-form: `count.active_stripe_customers:>2` (or any valid NQL) is preserved and left for the API to validate, where the codec previously dropped everything except `:>1`.
- Unknown clauses never become predicates, so there's no `visibleFilters` filtering in the members page and nothing for saved views/active columns to special-case.
- Adding a chip on top of an unknown filter ANDs the two together instead of requiring the field to be parseable.