### PR TITLE
🐛 Fixed block scalars being added to downloaded redirects

### DIFF
--- a/ghost/core/core/server/services/custom-redirects/redirect-config-parser.ts
+++ b/ghost/core/core/server/services/custom-redirects/redirect-config-parser.ts
@@ -131,11 +131,13 @@ export const serializeToYaml = (redirects: RedirectConfig[]): string => {
 // Section headers are emitted by hand because js-yaml quotes
 // numeric-string keys (`"301":`), diverging from the unquoted form
 // every existing redirects.yaml file ships with. Pairs go through
-// js-yaml so block scalars and special-char escaping stay correct.
+// js-yaml so special-char escaping stays correct. lineWidth: -1
+// disables line folding so long URLs aren't rewritten into `>-`
+// block scalars the user never authored.
 const formatSection = (statusCode: '301' | '302', redirects: RedirectConfig[]): string => {
     const lines = [`${statusCode}:`];
     for (const redirect of redirects) {
-        const pair = yaml.dump({[redirect.from]: redirect.to});
+        const pair = yaml.dump({[redirect.from]: redirect.to}, {lineWidth: -1});
         for (const line of pair.split('\n')) {
             if (line === '') {
                 continue;

--- a/ghost/core/test/unit/server/services/custom-redirects/redirect-config-parser.test.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/redirect-config-parser.test.ts
@@ -248,6 +248,21 @@ describe('UNIT: redirect-config-parser', function () {
             );
         });
 
+        it('does not fold long values into block scalars', function () {
+            // js-yaml's default lineWidth (80) folds long values into
+            // `>-` block scalars, injecting markup the user never wrote.
+            const longTo = '/very/long/destination/path/that/is/definitely/longer/than/eighty/characters/total/';
+            const redirects = [
+                {from: '/old/', to: longTo, permanent: true}
+            ];
+
+            const yamlString = serializeToYaml(redirects);
+
+            assert.doesNotMatch(yamlString, />-/, 'no folded block scalar markup');
+            assert.match(yamlString, new RegExp(`/old/: ${longTo}`));
+            assert.deepEqual(parseYaml(yamlString), redirects);
+        });
+
         it('emits unquoted 301 / 302 section headers', function () {
             // Self-hosters diff downloaded files against VCS-tracked
             // originals — quoted numeric keys would create spurious diffs.


### PR DESCRIPTION
ref [ONC-1827](https://linear.app/ghost/issue/ONC-1827/block-scalars-being-added-to-redirects)

## Problem

Downloading redirects as YAML rewrote long URL values into `>-` folded block scalars that the user never authored:

```yaml
301:
  /old/: >-
    /very/long/destination/path/that/is/definitely/longer/than/eighty/characters/
```

This didn't break redirects, but it injected undocumented markup into the user's file, causing confusion (reported by a customer who edited the markup out, re-uploaded, and saw Ghost add it back on the next download).

## Root cause

`serializeToYaml` in `redirect-config-parser.ts` calls `yaml.dump()`, which defaults to js-yaml's `lineWidth: 80`. Any value longer than 80 chars gets folded into a block scalar.

## Fix

Pass `{lineWidth: -1}` to disable line folding, so values are emitted verbatim on a single line. Values containing real newlines still use a literal block scalar (`|-`) and round-trip correctly through `parseYaml`.

## Testing

Added a red/green unit test (`does not fold long values into block scalars`) asserting a long `to` URL produces no `>-` markup and round-trips intact. Verified the test fails without the fix and passes with it. All 23 `redirect-config-parser` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)