### PR TITLE
Updated automations email modal to stay open on save

### DIFF
--- a/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
@@ -498,7 +498,6 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
                     onClose={closeEmailModal}
                     onSave={({subject, lexical}) => {
                         onChange(updateSendEmailAction({detail: automation, actionId: emailModalAction.id, emailSubject: subject, emailLexical: lexical}));
-                        closeEmailModal();
                     }}
                 />
             )}

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -693,8 +693,9 @@ describe('AutomationEditor', () => {
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
         fireEvent.click(screen.getByTestId('modal-save'));
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
-        // The modal closes after saving.
-        expect(screen.queryByTestId('email-content-modal')).not.toBeInTheDocument();
+        // The modal stays open after saving; Close is the only way out.
+        expect(screen.getByTestId('email-content-modal')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('modal-close'));
 
         // Publishing persists the edited content.
         fireEvent.click(screen.getByRole('button', {name: 'Publish changes'}));


### PR DESCRIPTION
no ref

https://github.com/TryGhost/Ghost/pull/28438 was meant to make it so the automations email editor would stay open after you saved changes, but there was still a `closeEmailModal()` in the `onSave` handler.

This fixes that!