### PR TITLE
Hid paid welcome automation if stripe not enabled

### DIFF
--- a/apps/posts/src/views/Automations/automations.tsx
+++ b/apps/posts/src/views/Automations/automations.tsx
@@ -1,14 +1,12 @@
 import AutomationsList from './components/automations-list';
-import MainLayout from '@components/layout/main-layout';
+import MainLayout from '@src/components/layout/main-layout';
 import React from 'react';
 import {ListPage} from '@tryghost/shade/page-templates';
 import {PageHeader} from '@tryghost/shade/patterns';
-import {useBrowseAutomations} from '@tryghost/admin-x-framework/api/automations';
+import {useVisibleAutomations} from './hooks/use-visible-automations';
 
 const Automations: React.FC = () => {
-    const {data, error, isError, isLoading} = useBrowseAutomations({
-        defaultErrorHandler: false
-    });
+    const {automations, error, isError, isLoading} = useVisibleAutomations();
 
     if (isError) {
         throw error || new Error('Failed to load automations');
@@ -25,7 +23,7 @@ const Automations: React.FC = () => {
                     </PageHeader>
                 </ListPage.Header>
                 <ListPage.Body>
-                    <AutomationsList automations={data?.automations} isLoading={isLoading} />
+                    <AutomationsList automations={automations} isLoading={isLoading} />
                 </ListPage.Body>
             </ListPage>
         </MainLayout>

--- a/apps/posts/src/views/Automations/hooks/use-visible-automations.ts
+++ b/apps/posts/src/views/Automations/hooks/use-visible-automations.ts
@@ -1,0 +1,25 @@
+import {WELCOME_EMAIL_SLUGS} from '../utils/default-welcome-email-values';
+import {checkStripeEnabled, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import {useBrowseAutomations} from '@tryghost/admin-x-framework/api/automations';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import type {Config} from '@tryghost/admin-x-framework/api/config';
+
+export const useVisibleAutomations = () => {
+    const {data, error, isError, isLoading} = useBrowseAutomations({
+        defaultErrorHandler: false
+    });
+    const {data: settingsData, isLoading: isSettingsLoading} = useBrowseSettings();
+    const {data: configData, isLoading: isConfigLoading} = useBrowseConfig();
+
+    const stripeEnabled = checkStripeEnabled(settingsData?.settings || [], (configData?.config || {}) as Config);
+    const automations = stripeEnabled
+        ? data?.automations
+        : data?.automations?.filter(automation => automation.slug !== WELCOME_EMAIL_SLUGS.paid);
+
+    return {
+        automations,
+        error,
+        isError,
+        isLoading: isLoading || isSettingsLoading || isConfigLoading
+    };
+};

--- a/apps/posts/test/unit/views/automations/automations.test.tsx
+++ b/apps/posts/test/unit/views/automations/automations.test.tsx
@@ -1,0 +1,117 @@
+import Automations from '@src/views/Automations/automations';
+import {MemoryRouter} from 'react-router';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+
+const mockUseBrowseAutomations = vi.fn();
+const mockUseBrowseSettings = vi.fn();
+const mockUseBrowseConfig = vi.fn();
+
+vi.mock('@tryghost/admin-x-framework/api/automations', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/automations')>(
+        '@tryghost/admin-x-framework/api/automations'
+    );
+    return {
+        ...actual,
+        useBrowseAutomations: (...args: unknown[]) => mockUseBrowseAutomations(...args)
+    };
+});
+
+vi.mock('@tryghost/admin-x-framework/api/settings', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/settings')>(
+        '@tryghost/admin-x-framework/api/settings'
+    );
+    return {
+        ...actual,
+        useBrowseSettings: () => mockUseBrowseSettings()
+    };
+});
+
+vi.mock('@tryghost/admin-x-framework/api/config', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/config')>(
+        '@tryghost/admin-x-framework/api/config'
+    );
+    return {
+        ...actual,
+        useBrowseConfig: () => mockUseBrowseConfig()
+    };
+});
+
+const automations = [{
+    id: 'automation-id-1',
+    name: 'Welcome Email (Free)',
+    slug: 'member-welcome-email-free',
+    status: 'active' as const
+}, {
+    id: 'automation-id-2',
+    name: 'Welcome Email (Paid)',
+    slug: 'member-welcome-email-paid',
+    status: 'inactive' as const
+}];
+
+const stripeConnectedSettings = {
+    settings: [
+        {key: 'stripe_connect_secret_key', value: 'sk_connect_123'},
+        {key: 'stripe_connect_publishable_key', value: 'pk_connect_123'}
+    ]
+};
+
+const renderPage = () => render(<MemoryRouter><Automations /></MemoryRouter>);
+
+describe('Automations', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseBrowseAutomations.mockReturnValue({data: {automations}, isError: false, isLoading: false});
+        mockUseBrowseSettings.mockReturnValue({data: stripeConnectedSettings, isLoading: false});
+        mockUseBrowseConfig.mockReturnValue({data: {config: {}}, isLoading: false});
+    });
+
+    it('shows free and paid sequences when Stripe is connected', () => {
+        renderPage();
+
+        expect(screen.getByText('Welcome Email (Free)')).toBeInTheDocument();
+        expect(screen.getByText('Welcome Email (Paid)')).toBeInTheDocument();
+    });
+
+    it('hides the paid sequence when Stripe is not connected', () => {
+        mockUseBrowseSettings.mockReturnValue({data: {settings: []}, isLoading: false});
+
+        renderPage();
+
+        expect(screen.getByText('Welcome Email (Free)')).toBeInTheDocument();
+        expect(screen.queryByText('Welcome Email (Paid)')).not.toBeInTheDocument();
+    });
+
+    it('hides the paid sequence when only Connect keys exist but stripeDirect is required', () => {
+        mockUseBrowseConfig.mockReturnValue({data: {config: {stripeDirect: true}}, isLoading: false});
+
+        renderPage();
+
+        expect(screen.getByText('Welcome Email (Free)')).toBeInTheDocument();
+        expect(screen.queryByText('Welcome Email (Paid)')).not.toBeInTheDocument();
+    });
+
+    it('renders the loading skeleton while automations data loads', () => {
+        mockUseBrowseAutomations.mockReturnValue({data: undefined, isLoading: true});
+
+        renderPage();
+
+        expect(screen.getByTestId('automations-list-loading')).toBeInTheDocument();
+    });
+
+    it('renders the loading skeleton while settings load', () => {
+        mockUseBrowseSettings.mockReturnValue({data: undefined, isLoading: true});
+
+        renderPage();
+
+        expect(screen.getByTestId('automations-list-loading')).toBeInTheDocument();
+    });
+
+    it('renders the loading skeleton while config loads', () => {
+        mockUseBrowseConfig.mockReturnValue({data: undefined, isLoading: true});
+
+        renderPage();
+
+        expect(screen.getByTestId('automations-list-loading')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
no ref

If a site does not have stripe enabled, we don't want to show the paid welcome automation in the table on the `/automations` page. This is the same thing we did for welcome emails.