### PR TITLE
🐛 Fixed missing "New member" button on small viewports

### DIFF
--- a/apps/posts/src/views/members/components/members-actions.tsx
+++ b/apps/posts/src/views/members/components/members-actions.tsx
@@ -267,6 +267,7 @@ const MembersActions: React.FC<MembersActionsProps> = ({
             <Button asChild>
                 <a aria-label="New member" className="inline-flex items-center" href={newMemberHref}>
                     <span className="hidden sm:inline">New member</span>
+                    <span className="sm:hidden"><LucideIcon.Plus /></span>
                 </a>
             </Button>
 


### PR DESCRIPTION
## Summary
- The "New member" button label on the Members list was hidden below the `sm` breakpoint, leaving an empty button.
- Added a Plus icon that renders in place of the label on small viewports.

ref https://linear.app/tryghost/issue/DES-1408

## Test plan
- [ ] Open the Members list in the admin
- [ ] Resize the viewport below the `sm` breakpoint and verify a Plus icon is shown in the "New member" button
- [ ] Resize above the `sm` breakpoint and verify the "New member" label is shown
- [ ] Click the button on both sizes and confirm navigation to the new-member flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)