### PR TITLE
🐛 Fixed paid checkout returning to homepage instead of originating page

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.69.4",
+  "version": "2.69.5",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -493,6 +493,11 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             const identity = await api.member.identity();
             const url = endpointFor({type: 'members', resource: 'create-stripe-checkout-session'});
 
+            if (!successUrl) {
+                const checkoutSuccessUrl = window.location.href.startsWith(siteUrlObj.href) ? new URL(window.location.href) : new URL(siteUrl);
+                checkoutSuccessUrl.searchParams.set('stripe', 'success');
+                successUrl = checkoutSuccessUrl.href;
+            }
             if (!cancelUrl) {
                 const checkoutCancelUrl = window.location.href.startsWith(siteUrlObj.href) ? new URL(window.location.href) : new URL(siteUrl);
                 checkoutCancelUrl.searchParams.set('stripe', 'cancel');

--- a/apps/portal/test/api.test.js
+++ b/apps/portal/test/api.test.js
@@ -227,3 +227,91 @@ describe('Portal API member checkout', () => {
         });
     });
 });
+
+describe('Portal API plan checkout', () => {
+    let originalLocation;
+
+    const mockCheckoutFetch = () => {
+        vi.spyOn(window, 'fetch').mockImplementation((url) => {
+            if (url.includes('/members/api/session/')) {
+                return Promise.resolve(new Response('identity-token', {status: 200}));
+            }
+
+            return Promise.resolve(new Response(JSON.stringify({
+                url: 'https://checkout.stripe.com/plan-session'
+            }), {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }));
+        });
+    };
+
+    const lastCheckoutBody = () => {
+        const call = window.fetch.mock.calls.find(([url]) => url.includes('/members/api/create-stripe-checkout-session/'));
+        return JSON.parse(call[1].body);
+    };
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        originalLocation = window.location;
+        delete window.location;
+        window.location = {
+            href: 'https://example.com/paid-article/',
+            assign: vi.fn()
+        };
+    });
+
+    afterEach(() => {
+        window.location = originalLocation;
+    });
+
+    test('derives a contextual successUrl from the current page when none is supplied', async () => {
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+        mockCheckoutFetch();
+
+        await ghostApi.member.checkoutPlan({
+            plan: 'price_123',
+            tierId: 'tier_123',
+            cadence: 'month'
+        });
+
+        const body = lastCheckoutBody();
+        expect(body.successUrl).toBe('https://example.com/paid-article/?stripe=success');
+        expect(body.cancelUrl).toBe('https://example.com/paid-article/?stripe=cancel');
+    });
+
+    test('falls back to the site root when the current page is off-site', async () => {
+        window.location.href = 'https://evil.example.org/phishing/';
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+        mockCheckoutFetch();
+
+        await ghostApi.member.checkoutPlan({
+            plan: 'price_123',
+            tierId: 'tier_123',
+            cadence: 'month'
+        });
+
+        const body = lastCheckoutBody();
+        expect(body.successUrl).toBe('https://example.com/?stripe=success');
+        expect(body.cancelUrl).toBe('https://example.com/?stripe=cancel');
+    });
+
+    test('preserves an explicitly supplied successUrl', async () => {
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+        mockCheckoutFetch();
+
+        await ghostApi.member.checkoutPlan({
+            plan: 'price_123',
+            tierId: 'tier_123',
+            cadence: 'month',
+            successUrl: 'https://example.com/custom-welcome/',
+            cancelUrl: 'https://example.com/custom-cancel/'
+        });
+
+        const body = lastCheckoutBody();
+        expect(body.successUrl).toBe('https://example.com/custom-welcome/');
+        expect(body.cancelUrl).toBe('https://example.com/custom-cancel/');
+    });
+});


### PR DESCRIPTION
## Summary

When a member starts a paid signup or upgrade from a page other than the homepage, Portal returned them to the **site root** after a successful Stripe Checkout (e.g. `https://example.com/?stripe=success`) instead of the page where checkout began. Cancelling checkout already returned to the originating page, so the behaviour was inconsistent — and especially disruptive for paywall flows, where a member who just paid to unlock an article was bounced to the homepage instead of back to the article.

## Root cause

`checkoutPlan()` in `apps/portal/src/utils/api.js` already derived a contextual `cancelUrl` from `window.location` when none was supplied, but had **no equivalent fallback for `successUrl`**. The two standard callers (signup and upgrade in `apps/portal/src/actions.js`) don't pass one, so `successUrl` arrived at the backend as `undefined` and Ghost fell back to the configured site-root default (`stripe-api.js` → `checkoutSessionSuccessUrl`).

## Fix

Derive a contextual `successUrl` from `window.location` when none is supplied, mirroring the existing `cancelUrl` logic. This is the same approach `continueGiftCheckout()` already uses for gift flows (and matches #27643 / #27827).

No backend change is needed: `sanitizeReturnUrl()` already enforces that return URLs are same-origin / within the site subpath, so the contextual URL flows through safely.

### Behaviour preserved
- **Welcome-page tiers** — the server still overrides the success URL with a configured tier welcome page (`_generateSuccessUrl`); the contextual URL only applies when no welcome page is set.
- **New-email signup** — the contextual URL becomes the post-signup magic-link `referrer`, so the member returns to the originating page after confirming (an improvement over the previous site-root referrer).

## Tests

Added unit tests in `apps/portal/test/api.test.js` covering:
- contextual `successUrl`/`cancelUrl` derived from the current page when none supplied
- fallback to the site root when the current location is off-site (open-redirect guard)
- explicitly-supplied `successUrl`/`cancelUrl` are preserved

ref https://linear.app/ghost/issue/PLA-86
fixes https://github.com/TryGhost/Ghost/issues/28369