### PR TITLE
Added least-privilege permissions to the CI workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,56 @@
+# Workflows
+
+How we write GitHub Actions workflows safely. Follow these when adding or editing anything in this directory.
+
+## Token permissions
+
+- **Every workflow declares a top-level `permissions:` block, defaulting to `contents: read`.** This is the floor. A compromised dependency or action in a build/test job cannot push code, publish packages, or comment on issues.
+- **Escalate at the job level, never the top level.** A job-level `permissions:` block fully replaces the default for that job, so grant the extra scope only to the specific job that needs it:
+  - posts a PR comment → `pull-requests: write`
+  - publishes packages → `packages: write`
+  - pushes commits / creates releases → `contents: write`
+  - authenticates via OIDC → `id-token: write`
+- **New jobs start with no extra scope.** Because the default is read-only, an under-scoped job fails loudly rather than running over-privileged. Add only the scope that fails.
+- **Prefer a PAT, deploy key, or OIDC over widening `GITHUB_TOKEN`.** Cross-repo dispatch and releases use dedicated credentials, so those jobs keep `contents: read`.
+
+`permissions:` scopes the `GITHUB_TOKEN` only. It does not protect secrets and does not prevent code from running — it caps the damage of a stolen token, it does not make a job safe.
+
+## Untrusted input
+
+- **Use `pull_request`, not `pull_request_target`.** Fork PRs then run with a read-only token and no access to secrets. Only use `pull_request_target` when you fully control what it runs, and never check out and execute untrusted code under it.
+- **Never interpolate `${{ github.event.* }}` into a `run:` block.** PR titles, branch names, and bodies are attacker-controlled and lead to shell injection. Pass them through `env:` and reference the variable instead:
+
+  ```yaml
+  # Bad — injectable
+  run: echo "${{ github.event.pull_request.title }}"
+
+  # Good
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: echo "$PR_TITLE"
+  ```
+
+## Secrets
+
+- Expose a secret only to the job that uses it. Do not make secrets available to jobs that run untrusted code.
+- Prefer OIDC (`id-token: write`) over long-lived stored secrets where the provider supports it.
+
+## Supply chain
+
+- **Pin every third-party action to a full commit SHA**, with the version as a trailing comment:
+
+  ```yaml
+  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  ```
+
+  A tag or branch ref can be re-pointed at malicious code; a SHA cannot.
+- Install with a frozen lockfile (`pnpm install --frozen-lockfile`).
+
+## Checklist for a new workflow
+
+1. Top-level `permissions: { contents: read }`.
+2. Job-level overrides only where a job needs more.
+3. Trigger is `pull_request` unless `pull_request_target` is genuinely required and safe.
+4. No `${{ github.event.* }}` inside `run:`.
+5. Third-party actions pinned to SHAs.
+6. Secrets scoped to the jobs that use them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ concurrency:
   group: ${{ startsWith(github.ref, 'refs/tags/') && format('release-{0}', github.ref) || github.head_ref || github.ref }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
+# Default least-privilege token for all jobs; jobs that need more declare
+# their own permissions block, which overrides this default.
+permissions:
+  contents: read
+
 jobs:
   job_setup:
     name: Setup
@@ -1405,6 +1410,10 @@ jobs:
     if: always() && needs.job_e2e_tests.result == 'failure'
     needs: [job_e2e_tests, job_setup]
     runs-on: ubuntu-latest
+    # Posts a comment on the PR via `gh pr comment` when E2E tests fail.
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
## Summary
Resolves the `actions/missing-workflow-permissions` CodeQL alerts on **ci.yml** by setting an explicit least-privilege `GITHUB_TOKEN` scope.

- Adds a top-level `permissions: { contents: read }` default.
- Jobs that already declare their own `permissions:` block (build_artifacts, build_e2e_image, build_packages, publish_packages, publish_ghost, create_github_release, notify_release_failure, job_setup) are unaffected — a job-level block fully overrides the top-level default.
- **`job_merge_e2e_reports` gets an explicit `pull-requests: write` override** because it posts a PR comment via `gh pr comment` on E2E failure. Without this, the top-level `contents: read` default would silently break that step.

## Per-job audit (jobs that inherit the new default)
Every un-blocked job was checked for `GITHUB_TOKEN` usage:

| Job | Token usage | Scope needed |
|---|---|---|
| app_version_bump_check, migration_integrity_check, lint, i18n | checkout only | `contents: read` |
| admin-tests, unit-tests, acceptance-tests, legacy-tests, apps_acceptance-tests, ghost-cli | tests; `upload-artifact` uses the Actions runtime token | `contents: read` |
| build_e2e_public_apps | build | `contents: read` |
| e2e_tests | image loaded from artifact; `tb-cli` ghcr pull has a `2>/dev/null` fallback; no `GITHUB_TOKEN` | `contents: read` |
| coverage | `download-artifact` (runtime token) + codecov (own token) | `contents: read` |
| required_tests | gate job, no token | `contents: read` |
| tinybird-tests, deploy_tinybird | dispatch via **PAT** (`TRAFFIC_ANALYTICS_GITHUB_TOKEN`) | `contents: read` |
| trigger_cd | `repository-dispatch` via **PAT** (`CANARY_DOCKER_BUILD`) | `contents: read` |
| **merge_e2e_reports** | **`gh pr comment` via `GITHUB_TOKEN`** | `contents: read` + **`pull-requests: write`** |

## Risk / how to verify
- The only behavioral risk is under-privileging a job. The audit above covers every un-blocked job; the sole writer (`merge_e2e_reports`) has an explicit override.
- Recommend confirming on a test PR that the E2E-failure comment still posts, and that the tinybird/CD dispatch jobs still fire on `main`.


---

## Approach & best practices

This PR also adds [`.github/workflows/README.md`](.github/workflows/README.md) documenting how we write workflows safely, so the pattern here is the team standard going forward:

- **Top-level `permissions: { contents: read }` default in every workflow**; escalate at the **job** level only where a specific job needs more (a job-level block fully replaces the default).
- **New jobs start with no extra scope** — read-only is the floor, so an under-scoped job fails loudly instead of running over-privileged.
- **Prefer PAT / deploy key / OIDC** over widening `GITHUB_TOKEN` (cross-repo dispatch and releases already do this).
- **`permissions:` only scopes the `GITHUB_TOKEN`** — it caps the damage of a stolen token; it does not protect secrets or stop code from running. Those are handled separately: `pull_request` over `pull_request_target`, no `${{ github.event.* }}` interpolation in `run:`, secrets scoped per job, and SHA-pinned actions.

See the README for the full checklist.
