### PR TITLE
Added least-privilege permissions to release and stale workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+# The release job pushes via an SSH deploy key and authenticates to the
+# GitHub API with a PAT, so the default GITHUB_TOKEN only needs read access.
+permissions:
+  contents: read
+
 jobs:
   release:
     if: github.repository == 'TryGhost/Ghost'

--- a/.github/workflows/stale-i18n.yml
+++ b/.github/workflows/stale-i18n.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'
+# actions/stale labels, comments on, and closes stale i18n PRs.
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   stale:
     if: github.repository_owner == 'TryGhost'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'
+# actions/stale labels, comments on, and closes stale issues and PRs.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 jobs:
   stale:
     if: github.repository_owner == 'TryGhost'


### PR DESCRIPTION
## Summary
Resolves the `actions/missing-workflow-permissions` CodeQL alerts on the release and stale workflows.

### `release.yml` → `contents: read`
The `release` job pushes via an **SSH deploy key** (`webfactory/ssh-agent`, bypasses branch protection) and polls the GitHub API with a **PAT** (`CANARY_DOCKER_BUILD`). The workflow's own `GITHUB_TOKEN` is never used for writes, so `contents: read` (for checkout) is sufficient.

### `stale.yml` → `contents: read`, `issues: write`, `pull-requests: write`
`actions/stale` labels, comments on, and closes stale **issues and PRs**.

### `stale-i18n.yml` → `contents: read`, `pull-requests: write`
Same action, but this one only operates on **PRs** (`only-labels: affects:i18n`), so it doesn't need `issues: write`.

## Notes
- These three are low-risk and clearly scoped (single-job workflows). Split out from [the ci.yml permissions PR](https://github.com/TryGhost/Ghost/pull/28488), which needed per-job auditing.
