### PR TITLE
Removed dead hasMultipleProductsFeature helper from Portal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.69.0",
+  "version": "2.69.1",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isArchivedTier, isComplimentaryMember, isGiftMember, isPaidMember, arePaidMembersEnabled, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getSubscriptionExpiry, getMemberSubscription, getMemberTierName, hasOnlyFreePlan, isArchivedTier, isComplimentaryMember, isGiftMember, isPaidMember, arePaidMembersEnabled, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import GiftIcon from '../../../../images/icons/gift.svg?react';
 import LoaderIcon from '../../../../images/icons/loader.svg?react';
@@ -183,8 +183,8 @@ const PaidAccountActions = () => {
         } = subscription || {};
         let planLabel = t('Plan');
 
-        // Show name of tiers if there are multiple tiers
-        if (hasMultipleProductsFeature({site}) && getMemberTierName({member})) {
+        // Show the tier name if the member has one
+        if (getMemberTierName({member})) {
             planLabel = getMemberTierName({member});
         }
         // const hasFreeTrial = subscriptionHasFreeTrial({sub: subscription});

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isArchivedTier, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isGiftMember, isPaidMember} from '../../utils/helpers';
+import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isArchivedTier, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, isComplimentaryMember, isGiftMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 import {translateCadence} from '../../utils/helpers';
@@ -91,7 +91,6 @@ const Header = ({showConfirmation, confirmationType, pendingOffer}) => {
 };
 
 const CancelSubscriptionButton = ({member, onCancelSubscription, action, brandColor}) => {
-    const {site} = useContext(AppContext);
     if (!member.paid) {
         return null;
     }
@@ -127,7 +126,7 @@ const CancelSubscriptionButton = ({member, onCancelSubscription, action, brandCo
                 disabled={disabled}
                 isPrimary={isPrimary}
                 isDestructive={isDestructive}
-                classes={hasMultipleProductsFeature({site}) ? 'gh-portal-btn-text mt2 mb4' : ''}
+                classes='gh-portal-btn-text mt2 mb4'
                 brandColor={brandColor}
                 label={label}
                 style={{
@@ -154,7 +153,7 @@ const PlanConfirmationSection = ({plan, type, onConfirm}) => {
     const priceString = formatNumber(plan.price);
     const planStartMessage = `${plan.currency_symbol}${priceString}/${translateCadence(plan.interval)} – ${planStartingMessage}`;
     const product = getProductFromPrice({site, priceId: plan?.id});
-    const priceLabel = hasMultipleProductsFeature({site}) ? product?.name : t('Price');
+    const priceLabel = product?.name;
     if (type === 'changePlan') {
         return (
             <div className='gh-portal-logged-out-form-container'>

--- a/apps/portal/src/components/pages/offer-page.js
+++ b/apps/portal/src/components/pages/offer-page.js
@@ -4,7 +4,7 @@ import AppContext from '../../app-context';
 import CheckmarkIcon from '../../images/icons/checkmark.svg?react';
 import CloseButton from '../common/close-button';
 import InputForm from '../common/input-form';
-import {getCurrencySymbol, getProductFromId, hasMultipleProductsFeature, getUpdatedOfferPrice, formatNumber, hasMultipleNewsletters} from '../../utils/helpers';
+import {getCurrencySymbol, getProductFromId, getUpdatedOfferPrice, formatNumber, hasMultipleNewsletters} from '../../utils/helpers';
 import {ValidateInputForm} from '../../utils/form';
 import {interceptAnchorClicks} from '../../utils/links';
 import {sanitizeHtml} from '../../utils/sanitize-html';
@@ -558,15 +558,8 @@ export default class OfferPage extends React.Component {
     }
 
     renderProductLabel({product, offer}) {
-        const {site} = this.context;
-
-        if (hasMultipleProductsFeature({site})) {
-            return (
-                <h4 className="gh-portal-plan-name">{product.name} - {(offer.cadence === 'month' ? t('Monthly') : t('Yearly'))}</h4>
-            );
-        }
         return (
-            <h4 className="gh-portal-plan-name">{(offer.cadence === 'month' ? t('Monthly') : t('Yearly'))}</h4>
+            <h4 className="gh-portal-plan-name">{product.name} - {(offer.cadence === 'month' ? t('Monthly') : t('Yearly'))}</h4>
         );
     }
 

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -303,11 +303,6 @@ export function getRefDomain() {
     return referrerSource;
 }
 
-export function hasMultipleProductsFeature({site}) {
-    const {portal_products: portalProducts} = site || {};
-    return !!portalProducts;
-}
-
 export function hasCommentsEnabled({site}) {
     return site?.comments_enabled && site?.comments_enabled !== 'off';
 }
@@ -418,18 +413,6 @@ export function getAllProductsForSite({site}) {
             currency_symbol: getCurrencySymbol(product.yearlyPrice.currency)
         };
         return product;
-    });
-}
-
-export function hasBenefits({prices, site}) {
-    if (!hasMultipleProductsFeature({site})) {
-        return false;
-    }
-    if (!prices?.length) {
-        return false;
-    }
-    return prices.some((price) => {
-        return price?.benefits?.length;
     });
 }
 

--- a/ghost/i18n/locales/af/portal.json
+++ b/ghost/i18n/locales/af/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Vul asseblief die verpligte velde in",
     "Podcasts": "",
-    "Price": "Prys",
     "Re-enable emails": "Her-aktiveer eposse",
     "Recommendations": "Aanbevelings",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ar/portal.json
+++ b/ghost/i18n/locales/ar/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "{fieldName} يرجى إدخال ",
     "Please fill in required fields": "يرجى ملء الحقول المطلوبة",
     "Podcasts": "",
-    "Price": "السعر",
     "Re-enable emails": "إعادة تفعيل رسائل البريد الالكتروني",
     "Recommendations": "التوصيات",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/bg/portal.json
+++ b/ghost/i18n/locales/bg/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Моля, попълнете {fieldName}",
     "Please fill in required fields": "Моля, попълнете задължителните полета",
     "Podcasts": "Подкасти",
-    "Price": "Цена",
     "Re-enable emails": "Възобновете изпращането на писма",
     "Recommendations": "Препоръки",
     "Redeem your membership": "Активирайте абонамента си",

--- a/ghost/i18n/locales/bn/portal.json
+++ b/ghost/i18n/locales/bn/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "প্রয়োজনীয় ক্ষেত্রগুলি পূরণ করুন",
     "Podcasts": "",
-    "Price": "মূল্য",
     "Re-enable emails": "ইমেলগুলি পুনরায় সক্রিয় করুন",
     "Recommendations": "প্রস্তাবনা",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/bs/portal.json
+++ b/ghost/i18n/locales/bs/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Popuni obavezna polja",
     "Podcasts": "",
-    "Price": "Cijena",
     "Re-enable emails": "Ponovno omogući Email poruke",
     "Recommendations": "Preporuke",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ca/portal.json
+++ b/ghost/i18n/locales/ca/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Si-us-plau, introdueix {fieldName}",
     "Please fill in required fields": "Si-us-plau, omple els camps obligatoris",
     "Podcasts": "",
-    "Price": "Preu",
     "Re-enable emails": "Torna a activar els correus electrònics",
     "Recommendations": "Recomanacions",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -240,7 +240,6 @@
     "Please fill in required fields": "Error message when a required field is missing",
     "Podcasts": "Default heading for the Transistor podcast integration section in Portal",
     "Posts": "Search result header",
-    "Price": "A label to indicate price of a tier",
     "Re-enable emails": "A button for members to turn-back-on emails, if they have been previously disabled as a result of delivery failures",
     "Read more replies": "Link at the bottom of a nested comment thread to open a focused view showing replies beyond the maximum displayed depth",
     "Recommendations": "A suggestion by/for another site of interest to users",

--- a/ghost/i18n/locales/cs/portal.json
+++ b/ghost/i18n/locales/cs/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Prosím zadejte {fieldName}",
     "Please fill in required fields": "Prosím vyplňte povinná pole",
     "Podcasts": "",
-    "Price": "Cena",
     "Re-enable emails": "Znovu povolit e-maily",
     "Recommendations": "Doporučení",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/da/portal.json
+++ b/ghost/i18n/locales/da/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Indtast venligst {fieldName}",
     "Please fill in required fields": "Udfyld venligst påkrævede felter",
     "Podcasts": "",
-    "Price": "Pris",
     "Re-enable emails": "Genaktiver e-mails",
     "Recommendations": "Anbefalinger",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/de-CH/portal.json
+++ b/ghost/i18n/locales/de-CH/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Bitte geben Sie {fieldName} ein",
     "Please fill in required fields": "Bitte alle Pflichtfelder ausfüllen.",
     "Podcasts": "Podcasts",
-    "Price": "Preis",
     "Re-enable emails": "E-Mails wieder aktivieren",
     "Recommendations": "Empfehlungen",
     "Redeem your membership": "Abonnement einlösen",

--- a/ghost/i18n/locales/de/portal.json
+++ b/ghost/i18n/locales/de/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Bitte gib eine/n {fieldName} ein",
     "Please fill in required fields": "Bitte alle Pflichtfelder ausfüllen",
     "Podcasts": "",
-    "Price": "Preis",
     "Re-enable emails": "E-Mails wieder aktivieren",
     "Recommendations": "Empfehlungen",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/el/portal.json
+++ b/ghost/i18n/locales/el/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Συμπληρώστε τα απαιτούμενα πεδία",
     "Podcasts": "",
-    "Price": "Τιμή",
     "Re-enable emails": "Ενεργοποιήστε ξανά τα emails",
     "Recommendations": "Συστάσεις",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "",
     "Podcasts": "",
-    "Price": "",
     "Re-enable emails": "",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/eo/portal.json
+++ b/ghost/i18n/locales/eo/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "",
     "Podcasts": "",
-    "Price": "Kosto",
     "Re-enable emails": "Reŝalti retpoŝtojn",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Por favor ingresa {fieldName}",
     "Please fill in required fields": "Por favor rellena los campos requeridos.",
     "Podcasts": "Podcasts",
-    "Price": "Precio",
     "Re-enable emails": "Reactivar correos electrónicos",
     "Recommendations": "Recomendaciones",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/et/portal.json
+++ b/ghost/i18n/locales/et/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Palun sisestage {fieldName}",
     "Please fill in required fields": "Palun täitke kohustuslikud väljad",
     "Podcasts": "",
-    "Price": "Hind",
     "Re-enable emails": "Luba e-kirjad uuesti",
     "Recommendations": "Soovitused",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/eu/portal.json
+++ b/ghost/i18n/locales/eu/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Sartu {fieldName}",
     "Please fill in required fields": "Bete derrigorrezko eremuak",
     "Podcasts": "",
-    "Price": "Prezioa",
     "Re-enable emails": "Gaitu berriro ePostak",
     "Recommendations": "Gomendioak",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/fa/portal.json
+++ b/ghost/i18n/locales/fa/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "خواهشمند است که موارد الزامی را وارد کنید",
     "Podcasts": "",
-    "Price": "قیمت",
     "Re-enable emails": "فعال\u200cسازی ایمیل\u200cها",
     "Recommendations": "پیشنهادات",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/fi/portal.json
+++ b/ghost/i18n/locales/fi/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Täytä kenttä {fieldName}",
     "Please fill in required fields": "Täytä tarvittavat kentät",
     "Podcasts": "",
-    "Price": "Hinta",
     "Re-enable emails": "Hyväksy sähköpostit uudelleen",
     "Recommendations": "Suositukset",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/fr/portal.json
+++ b/ghost/i18n/locales/fr/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Veuillez saisir votre {fieldName}",
     "Please fill in required fields": "Veuillez remplir les champs requis",
     "Podcasts": "Podcasts",
-    "Price": "Tarification",
     "Re-enable emails": "Réactiver les e-mails",
     "Recommendations": "Suggestions",
     "Redeem your membership": "Activer votre abonnement",

--- a/ghost/i18n/locales/gd/portal.json
+++ b/ghost/i18n/locales/gd/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Lìon a-steach an roinn seo: {fieldName}",
     "Please fill in required fields": "Lìon a-steach na raointean riatanach",
     "Podcasts": "",
-    "Price": "Prìs",
     "Re-enable emails": "Cuir an comas puist-d a-rithist",
     "Recommendations": "Mòlaidhean",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/he/portal.json
+++ b/ghost/i18n/locales/he/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "בבקשה הזינו {fieldName}",
     "Please fill in required fields": "אנא מלאו את השדות הנדרשים",
     "Podcasts": "",
-    "Price": "מחיר",
     "Re-enable emails": "אפשרו שוב מיילים",
     "Recommendations": "המלצות",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/hi/portal.json
+++ b/ghost/i18n/locales/hi/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "कृपया {fieldName} दर्ज करें",
     "Please fill in required fields": "कृपया आवश्यक फ़ील्ड भरें",
     "Podcasts": "",
-    "Price": "कीमत",
     "Re-enable emails": "ईमेल पुनः सक्षम करें",
     "Recommendations": "सिफारिशें",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/hr/portal.json
+++ b/ghost/i18n/locales/hr/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Molimo unesite {fieldName}",
     "Please fill in required fields": "Molimo vas da ispunite obvezna polja",
     "Podcasts": "",
-    "Price": "Cijena",
     "Re-enable emails": "Ponovo omogući slanje e-pošte",
     "Recommendations": "Preporuke",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/hu/portal.json
+++ b/ghost/i18n/locales/hu/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Kérjük, add meg {fieldName}",
     "Please fill in required fields": "Kérjük, töltsd ki az összes mezőt",
     "Podcasts": "",
-    "Price": "Ár",
     "Re-enable emails": "E-mailek aktiválása",
     "Recommendations": "Ajánlott oldalak",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/id/portal.json
+++ b/ghost/i18n/locales/id/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Silakan masukkan {fieldName}",
     "Please fill in required fields": "Harap isi kolom yang wajib diisi",
     "Podcasts": "",
-    "Price": "Harga",
     "Re-enable emails": "Aktifkan kembali email",
     "Recommendations": "Rekomendasi",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/is/portal.json
+++ b/ghost/i18n/locales/is/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Vinsamlegast fyllið í nauðsynlega reiti",
     "Podcasts": "",
-    "Price": "Verð",
     "Re-enable emails": "Fá tölvupósta að nýju",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/it/portal.json
+++ b/ghost/i18n/locales/it/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Per favore inserisci {fieldName}",
     "Please fill in required fields": "Si prega di compilare i campi obbligatori",
     "Podcasts": "Podcast",
-    "Price": "Prezzo",
     "Re-enable emails": "Riattiva le email",
     "Recommendations": "Consigliati",
     "Redeem your membership": "Riscatta il tuo abbonamento",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "{fieldName}を入力してください",
     "Please fill in required fields": "必須項目に入力してください",
     "Podcasts": "",
-    "Price": "価格",
     "Re-enable emails": "メールを再有効化する",
     "Recommendations": "おすすめ",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ko/portal.json
+++ b/ghost/i18n/locales/ko/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "{fieldName}을(를) 입력해 주세요",
     "Please fill in required fields": "필수 항목을 입력해 주세요",
     "Podcasts": "",
-    "Price": "가격",
     "Re-enable emails": "이메일 재활성화",
     "Recommendations": "추천",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/kz/portal.json
+++ b/ghost/i18n/locales/kz/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Қажет жерлерді толтырыңыз",
     "Podcasts": "",
-    "Price": "Бағасы",
     "Re-enable emails": "Электрондық хаттарды қайта қосу",
     "Recommendations": "Ұсыныстар",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/lt/portal.json
+++ b/ghost/i18n/locales/lt/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Užpildykite visus privalomus laukus",
     "Podcasts": "",
-    "Price": "Kaina",
     "Re-enable emails": "Iš naujo įjungti el. laiškus",
     "Recommendations": "Rekomendacijos",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/lv/portal.json
+++ b/ghost/i18n/locales/lv/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Lūdzu, ievadiet {fieldName}",
     "Please fill in required fields": "Lūdzu, aizpildiet obligātos laukus",
     "Podcasts": "",
-    "Price": "Cena",
     "Re-enable emails": "Atkārtoti iespējot e-pastus",
     "Recommendations": "Ieteikumi",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/mk/portal.json
+++ b/ghost/i18n/locales/mk/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Ве молиме пополнете ги задолжителните полиња",
     "Podcasts": "",
-    "Price": "Цена",
     "Re-enable emails": "Овозможете пораки",
     "Recommendations": "Препораки",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/mn/portal.json
+++ b/ghost/i18n/locales/mn/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "{fieldName} оруулна уу",
     "Please fill in required fields": "Шаардлагатай талбаруудыг бөглөнө үү",
     "Podcasts": "",
-    "Price": "Үнэ",
     "Re-enable emails": "Имэйлийг дахин идэвхжүүлэх",
     "Recommendations": "Санал болгох",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ms/portal.json
+++ b/ghost/i18n/locales/ms/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Sila isikan medan yang diperlukan",
     "Podcasts": "",
-    "Price": "Harga",
     "Re-enable emails": "Membolehkan semula e-mel",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/nb/portal.json
+++ b/ghost/i18n/locales/nb/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Vennligst oppgi {fieldName}",
     "Please fill in required fields": "Vennligst fyll inn påkrevde felt",
     "Podcasts": "",
-    "Price": "Pris",
     "Re-enable emails": "Re-aktiver e-poster",
     "Recommendations": "Anbefalinger",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ne/portal.json
+++ b/ghost/i18n/locales/ne/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "",
     "Podcasts": "",
-    "Price": "",
     "Re-enable emails": "",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/nl/portal.json
+++ b/ghost/i18n/locales/nl/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Voer {fieldName} in",
     "Please fill in required fields": "Vul de vereiste velden in",
     "Podcasts": "",
-    "Price": "Prijs",
     "Re-enable emails": "E-mails weer inschakelen",
     "Recommendations": "Aanbevelingen",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Ver gilde og fyll inn dei obligatoriske felta",
     "Podcasts": "",
-    "Price": "Pris",
     "Re-enable emails": "Aktiver e-postar på ny",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/pa/portal.json
+++ b/ghost/i18n/locales/pa/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "ਕਿਰਪਾ ਕਰਕੇ {fieldName} ਦਾਖਲ ਕਰੋ",
     "Please fill in required fields": "ਕਿਰਪਾ ਕਰਕੇ ਲੋੜੀਂਦੇ ਖੇਤਰ ਭਰੋ",
     "Podcasts": "",
-    "Price": "ਕੀਮਤ",
     "Re-enable emails": "ਈਮੇਲਾਂ ਨੂੰ ਮੁੜ-ਸਮਰੱਥ ਕਰੋ",
     "Recommendations": "ਸਿਫ਼ਾਰਸ਼ਾਂ",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/pl/portal.json
+++ b/ghost/i18n/locales/pl/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Proszę wypełnić {fieldName}",
     "Please fill in required fields": "Wypełnij wymagane pola",
     "Podcasts": "",
-    "Price": "Cena",
     "Re-enable emails": "Włącz ponownie emaile",
     "Recommendations": "Rekomendacje",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Por favor, insira {fieldName}",
     "Please fill in required fields": "Por favor, preencha os campos obrigatórios",
     "Podcasts": "Podcasts",
-    "Price": "Preço",
     "Re-enable emails": "Reativar e-mails",
     "Recommendations": "Recomendações",
     "Redeem your membership": "Resgatar sua assinatura",

--- a/ghost/i18n/locales/pt/portal.json
+++ b/ghost/i18n/locales/pt/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Insira por favor {fieldName} ",
     "Please fill in required fields": "Preencha os campos obrigatórios",
     "Podcasts": "",
-    "Price": "Preço",
     "Re-enable emails": "Reativar emails",
     "Recommendations": "Recomendações",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ro/portal.json
+++ b/ghost/i18n/locales/ro/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Vă rugăm să completați câmpurile necesare",
     "Podcasts": "",
-    "Price": "Preț",
     "Re-enable emails": "Activează din nou emailurile",
     "Recommendations": "Recomandări",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ru/portal.json
+++ b/ghost/i18n/locales/ru/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Пожалуйста, введите {fieldName}",
     "Please fill in required fields": "Пожалуйста, заполните обязательные поля",
     "Podcasts": "",
-    "Price": "Цена",
     "Re-enable emails": "Подписаться повторно",
     "Recommendations": "Рекомендации",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/si/portal.json
+++ b/ghost/i18n/locales/si/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "කරුණාකර required files පිරවීමට කටයුතු කරන්න",
     "Podcasts": "",
-    "Price": "මිල",
     "Re-enable emails": "ඉමේල් නැවත සක්\u200dරීය කරන්න",
     "Recommendations": "නිර්දේශි\u200bත",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/sk/portal.json
+++ b/ghost/i18n/locales/sk/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Prosím zadajte {fieldName}",
     "Please fill in required fields": "Prosím vyplňte požadované polia.",
     "Podcasts": "",
-    "Price": "Cena",
     "Re-enable emails": "Obnoviť emaily",
     "Recommendations": "Odporúčania",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/sl/portal.json
+++ b/ghost/i18n/locales/sl/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Vnesite {fieldName}",
     "Please fill in required fields": "Izpolnite potrebna polja",
     "Podcasts": "",
-    "Price": "Cena",
     "Re-enable emails": "Ponovno omogočite e-pošto",
     "Recommendations": "Priporočila",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/sq/portal.json
+++ b/ghost/i18n/locales/sq/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Ju lutem plotesoni fushat e kerkuara",
     "Podcasts": "",
-    "Price": "Çmimi",
     "Re-enable emails": "Ri-aktivizo emailet",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/sr-Cyrl/portal.json
+++ b/ghost/i18n/locales/sr-Cyrl/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Молимо Вас унесите {fieldName}",
     "Please fill in required fields": "Молимо Вас попуните обавезна поља",
     "Podcasts": "",
-    "Price": "Цена",
     "Re-enable emails": "Поново омогућите email-ове",
     "Recommendations": "Препоруке",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/sr/portal.json
+++ b/ghost/i18n/locales/sr/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Molimo Vas unesite {fieldName}",
     "Please fill in required fields": "Molimo Vas popunite obavezna polja",
     "Podcasts": "",
-    "Price": "Cena",
     "Re-enable emails": "Ponovo omogućite email-ove",
     "Recommendations": "Preporuke",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/sv/portal.json
+++ b/ghost/i18n/locales/sv/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Vänligen ange {fieldName}",
     "Please fill in required fields": "Vänligen fyll i alla obligatoriska fält",
     "Podcasts": "",
-    "Price": "Pris",
     "Re-enable emails": "Återaktivera e-post",
     "Recommendations": "Rekommendationer",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/sw/portal.json
+++ b/ghost/i18n/locales/sw/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "Tafadhali jaza sehemu zinazohitajika",
     "Podcasts": "",
-    "Price": "Bei",
     "Re-enable emails": "Washa tena barua pepe",
     "Recommendations": "Mapendekezo",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ta/portal.json
+++ b/ghost/i18n/locales/ta/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "{fieldName} ஐ உள்ளிடவும்",
     "Please fill in required fields": "தேவையான புலங்களை நிரப்பவும்",
     "Podcasts": "",
-    "Price": "விலை",
     "Re-enable emails": "மின்னஞ்சல்களை மீண்டும் இயக்கு",
     "Recommendations": "பரிந்துரைகள்",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/th/portal.json
+++ b/ghost/i18n/locales/th/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "กรุณากรอกข้อมูลในช่องให้ครบถ้วน",
     "Podcasts": "",
-    "Price": "ราคา",
     "Re-enable emails": "เปิดใช้งานอีเมลนี้อีกครั้ง",
     "Recommendations": "รายการแนะนำ",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/tr/portal.json
+++ b/ghost/i18n/locales/tr/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Lütfen {fieldName} girin",
     "Please fill in required fields": "Lütfen gerekli alanları doldurunuz",
     "Podcasts": "Podcastler",
-    "Price": "Fiyat",
     "Re-enable emails": "E-postaları yeniden etkinleştir",
     "Recommendations": "Tavsiyeler",
     "Redeem your membership": "Üyeliğinizi kullanın",

--- a/ghost/i18n/locales/uk/portal.json
+++ b/ghost/i18n/locales/uk/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Будь ласка, введіть {fieldName}",
     "Please fill in required fields": "Будь ласка, заповніть обов'язкові поля",
     "Podcasts": "",
-    "Price": "Ціна",
     "Re-enable emails": "Знову включити пошту",
     "Recommendations": "Рекомендації",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/ur/portal.json
+++ b/ghost/i18n/locales/ur/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "براہ کرم مطلوبہ شعبے بھریں",
     "Podcasts": "",
-    "Price": "قیمت",
     "Re-enable emails": "ای میلز کو دوبارہ چالو کریں",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/uz/portal.json
+++ b/ghost/i18n/locales/uz/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "",
     "Please fill in required fields": "",
     "Podcasts": "",
-    "Price": "Narx",
     "Re-enable emails": "Elektron pochta xabarlarini qayta yoqing",
     "Recommendations": "",
     "Redeem your membership": "",

--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "Xin nhập {fieldName}",
     "Please fill in required fields": "Vui lòng điền các mục bắt buộc",
     "Podcasts": "Podcast",
-    "Price": "Giá gói",
     "Re-enable emails": "Kích hoạt lại email",
     "Recommendations": "Đề xuất",
     "Redeem your membership": "Đổi gói thành viên của bạn",

--- a/ghost/i18n/locales/zh-Hant/portal.json
+++ b/ghost/i18n/locales/zh-Hant/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "請輸入{fieldName}",
     "Please fill in required fields": "請填寫必填項目",
     "Podcasts": "播客",
-    "Price": "價格",
     "Re-enable emails": "重新啟用電子郵件",
     "Recommendations": "所有推薦",
     "Redeem your membership": "兌換您的會員資格",

--- a/ghost/i18n/locales/zh/portal.json
+++ b/ghost/i18n/locales/zh/portal.json
@@ -179,7 +179,6 @@
     "Please enter {fieldName}": "请输入{fieldName}",
     "Please fill in required fields": "请填写必须项目",
     "Podcasts": "播客",
-    "Price": "价格",
     "Re-enable emails": "重新启用电子邮件",
     "Recommendations": "推荐",
     "Redeem your membership": "兑换您的会员资格",


### PR DESCRIPTION
no issue

`hasMultipleProductsFeature({site})` returned `!!site.portal_products`. It was added in 2021 to gate the single-vs-multiple-tiers signup UI behind a feature flag, but `portal_products` is now always populated, so the helper always returned `true` and every conditional guarding on it was a dead branch.

Why it's always true:
- **Live runtime:** `site` comes from the Content API and runs through `transformApiSiteData`, which sets `site.portal_products` whenever the tiers have a `visibility` value. The `products.visibility` column is `nullable: false` (defaults to `none`/`public`) and is always serialized, and there's always at least one tier — so the branch always runs and assigns an array (even an empty array is truthy).
- **Portal settings preview:** the only consumer that builds the preview URL is `admin-x-settings` (`get-portal-preview-url.ts`), which unconditionally appends the `portalProducts` query param, so Portal always parses it into an array rather than leaving it `null`.

There is no code path that produces a `site` where `portal_products` is `null`/absent, so the helper could only ever return `true`.

This PR:
- Removes `hasMultipleProductsFeature` and inlines its four call sites to the `true` case (`account-plan-page.js`, `offer-page.js`, `paid-account-actions.js`), dropping the now-unused `site` lookups and imports.
- Removes `hasBenefits`, which had no remaining callers once its only logic — the `hasMultipleProductsFeature` guard — was gone.