### PR TITLE
🐛 Fixed non-deterministic member attribution resolution

### DIFF
--- a/ghost/core/core/server/services/member-attribution/member-attribution-service.js
+++ b/ghost/core/core/server/services/member-attribution/member-attribution-service.js
@@ -142,7 +142,12 @@ class MemberAttributionService {
      * @returns {Promise<import('./attribution-builder').AttributionResource|null>}
      */
     async getMemberCreatedAttribution(memberId) {
-        const memberCreatedEvent = await this.models.MemberCreatedEvent.findOne({member_id: memberId}, {require: false, withRelated: []});
+        // A member can have more than one created event row (member_id is not unique),
+        // so order deterministically to avoid non-deterministic attribution resolution.
+        const memberCreatedEvent = await this.models.MemberCreatedEvent
+            .where('member_id', memberId)
+            .query(qb => qb.orderBy('created_at', 'desc').orderBy('id', 'desc'))
+            .fetch({require: false, withRelated: []});
         if (!memberCreatedEvent) {
             return null;
         }
@@ -163,7 +168,12 @@ class MemberAttributionService {
      * @returns {Promise<import('./attribution-builder').AttributionResource|null>}
      */
     async getSubscriptionCreatedAttribution(subscriptionId) {
-        const subscriptionCreatedEvent = await this.models.SubscriptionCreatedEvent.findOne({subscription_id: subscriptionId}, {require: false, withRelated: []});
+        // A subscription can have more than one created event row (subscription_id is not unique),
+        // so order deterministically to avoid non-deterministic attribution resolution.
+        const subscriptionCreatedEvent = await this.models.SubscriptionCreatedEvent
+            .where('subscription_id', subscriptionId)
+            .query(qb => qb.orderBy('created_at', 'desc').orderBy('id', 'desc'))
+            .fetch({require: false, withRelated: []});
         if (!subscriptionCreatedEvent) {
             return null;
         }

--- a/ghost/core/test/unit/server/services/member-attribution/service.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/service.test.js
@@ -2,6 +2,17 @@ const assert = require('node:assert/strict');
 
 const MemberAttributionService = require('../../../../../core/server/services/member-attribution/member-attribution-service');
 
+// Mocks a Bookshelf model that is queried via `.where(...).query(...).fetch(...)`,
+// resolving the fetch to the given event (or null).
+function createEventModelMock(event) {
+    const chainable = {
+        where: () => chainable,
+        query: () => chainable,
+        fetch: async () => event
+    };
+    return chainable;
+}
+
 describe('MemberAttributionService', function () {
     describe('Constructor', function () {
         it('doesn\'t throw', function () {
@@ -268,9 +279,7 @@ describe('MemberAttributionService', function () {
         it('returns null when no event exists', async function () {
             const service = new MemberAttributionService({
                 models: {
-                    MemberCreatedEvent: {
-                        findOne: () => null
-                    }
+                    MemberCreatedEvent: createEventModelMock(null)
                 }
             });
 
@@ -281,21 +290,19 @@ describe('MemberAttributionService', function () {
         it('returns attribution from event', async function () {
             const service = new MemberAttributionService({
                 models: {
-                    MemberCreatedEvent: {
-                        findOne: () => ({
-                            get: function (key) {
-                                const values = {
-                                    attribution_id: 'attr_123',
-                                    attribution_url: '/test',
-                                    attribution_type: 'post',
-                                    referrer_source: 'source',
-                                    referrer_medium: 'medium',
-                                    referrer_url: 'https://referrer.com'
-                                };
-                                return values[key];
-                            }
-                        })
-                    }
+                    MemberCreatedEvent: createEventModelMock({
+                        get: function (key) {
+                            const values = {
+                                attribution_id: 'attr_123',
+                                attribution_url: '/test',
+                                attribution_type: 'post',
+                                referrer_source: 'source',
+                                referrer_medium: 'medium',
+                                referrer_url: 'https://referrer.com'
+                            };
+                            return values[key];
+                        }
+                    })
                 },
                 attributionBuilder: {
                     build: function (attribution) {
@@ -326,9 +333,7 @@ describe('MemberAttributionService', function () {
         it('returns null when no event exists', async function () {
             const service = new MemberAttributionService({
                 models: {
-                    SubscriptionCreatedEvent: {
-                        findOne: () => null
-                    }
+                    SubscriptionCreatedEvent: createEventModelMock(null)
                 }
             });
 
@@ -339,21 +344,19 @@ describe('MemberAttributionService', function () {
         it('returns attribution from event', async function () {
             const service = new MemberAttributionService({
                 models: {
-                    SubscriptionCreatedEvent: {
-                        findOne: () => ({
-                            get: function (key) {
-                                const values = {
-                                    attribution_id: 'attr_123',
-                                    attribution_url: '/test',
-                                    attribution_type: 'post',
-                                    referrer_source: 'source',
-                                    referrer_medium: 'medium',
-                                    referrer_url: 'https://referrer.com'
-                                };
-                                return values[key];
-                            }
-                        })
-                    }
+                    SubscriptionCreatedEvent: createEventModelMock({
+                        get: function (key) {
+                            const values = {
+                                attribution_id: 'attr_123',
+                                attribution_url: '/test',
+                                attribution_type: 'post',
+                                referrer_source: 'source',
+                                referrer_medium: 'medium',
+                                referrer_url: 'https://referrer.com'
+                            };
+                            return values[key];
+                        }
+                    })
                 },
                 attributionBuilder: {
                     build: function (attribution) {


### PR DESCRIPTION
## Summary

Makes member- and subscription-created attribution lookups deterministic.

`getMemberCreatedAttribution` and `getSubscriptionCreatedAttribution` in `member-attribution-service.js` looked up the created event with `findOne({member_id})` / `findOne({subscription_id})`. Those columns are **not unique** and the queries had no `ORDER BY`, so when more than one created-event row existed for a member or subscription the database could return an arbitrary row — making attribution resolution non-deterministic (and a source of flakiness).

The lookups now order by `created_at, id` (descending) and fetch the most recent row, matching the existing deterministic pattern already used in `member-created-event.js`.

## Changes
- `member-attribution-service.js`: `findOne(...)` → `.where(col, id).query(qb => qb.orderBy('created_at','desc').orderBy('id','desc')).fetch(...)` in both created-attribution lookups
- `service.test.js`: updated the model mocks to the new `.where().query().fetch()` chain

## Testing
- `pnpm --dir ghost/core test:single test/unit/server/services/member-attribution/service.test.js` — 20 passing
- `pnpm --dir ghost/core test:single test/e2e-server/services/member-attribution.test.js` — 16 passing
- lint clean

## Context
Found while reviewing #23146 — this core attribution fix was bundled with an unrelated serializer field addition, so it's been split out into its own PR.