### PR TITLE
🐛 Fixed "linked comment is no longer available" error after unhiding a comment

### DIFF
--- a/ghost/core/core/server/services/comments/comments-controller.js
+++ b/ghost/core/core/server/services/comments/comments-controller.js
@@ -208,8 +208,8 @@ module.exports = class CommentsController {
 
     /**
      * Sets the X-Cache-Invalidate response header so the public/member-facing
-     * comments endpoints get evicted when an admin mutates a comment. Shared
-     * with the comments endpoint module so both sites stay in sync.
+     * comments endpoints get evicted when a comment is mutated. Shared with
+     * the comments endpoint module so both sites stay in sync.
      */
     setCacheInvalidationHeaders(model, frame) {
         if (!model) {
@@ -220,7 +220,8 @@ module.exports = class CommentsController {
         const parentId = model.get('parent_id');
         const pathsToInvalidate = [
             postId ? `/api/members/comments/post/${postId}/` : null,
-            parentId ? `/api/members/comments/${parentId}/replies/` : null
+            parentId ? `/api/members/comments/${parentId}/replies/` : null,
+            `/api/members/comments/${model.id}/`
         ].filter(path => path !== null);
 
         frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
@@ -289,15 +290,7 @@ module.exports = class CommentsController {
             );
         }
 
-        if (result) {
-            const postId = result.get('post_id');
-            const parentId = result.get('parent_id');
-            const pathsToInvalidate = [
-                postId ? `/api/members/comments/post/${postId}/` : null,
-                parentId ? `/api/members/comments/${parentId}/replies/` : null
-            ].filter(path => path !== null);
-            frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
-        }
+        this.setCacheInvalidationHeaders(result, frame);
 
         return result;
     }
@@ -327,15 +320,7 @@ module.exports = class CommentsController {
             );
         }
 
-        if (result) {
-            const postId = result.get('post_id');
-            const parentId = result.get('parent_id');
-            const pathsToInvalidate = [
-                postId ? `/api/members/comments/post/${postId}/` : null,
-                parentId ? `/api/members/comments/${parentId}/replies/` : null
-            ].filter(path => path !== null);
-            frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
-        }
+        this.setCacheInvalidationHeaders(result, frame);
 
         return result;
     }
@@ -370,15 +355,7 @@ module.exports = class CommentsController {
 
         const comment = await this.service.getCommentByID(frame.options.id, frame.options);
 
-        if (comment) {
-            const postId = comment.get('post_id');
-            const parentId = comment.get('parent_id');
-            const pathsToInvalidate = [
-                postId ? `/api/members/comments/post/${postId}/` : null,
-                parentId ? `/api/members/comments/${parentId}/replies/` : null
-            ].filter(path => path !== null);
-            frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
-        }
+        this.setCacheInvalidationHeaders(comment, frame);
 
         return result;
     }
@@ -397,15 +374,7 @@ module.exports = class CommentsController {
 
         const comment = await this.service.getCommentByID(frame.options.id, frame.options);
 
-        if (comment) {
-            const postId = comment.get('post_id');
-            const parentId = comment.get('parent_id');
-            const pathsToInvalidate = [
-                postId ? `/api/members/comments/post/${postId}/` : null,
-                parentId ? `/api/members/comments/${parentId}/replies/` : null
-            ].filter(path => path !== null);
-            frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
-        }
+        this.setCacheInvalidationHeaders(comment, frame);
 
         return result;
     }
@@ -461,15 +430,7 @@ module.exports = class CommentsController {
 
         const comment = await this.service.getCommentByID(frame.options.id, frame.options);
 
-        if (comment) {
-            const postId = comment.get('post_id');
-            const parentId = comment.get('parent_id');
-            const pathsToInvalidate = [
-                postId ? `/api/members/comments/post/${postId}/` : null,
-                parentId ? `/api/members/comments/${parentId}/replies/` : null
-            ].filter(path => path !== null);
-            frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
-        }
+        this.setCacheInvalidationHeaders(comment, frame);
 
         return result;
     }
@@ -488,15 +449,7 @@ module.exports = class CommentsController {
 
         const comment = await this.service.getCommentByID(frame.options.id, frame.options);
 
-        if (comment) {
-            const postId = comment.get('post_id');
-            const parentId = comment.get('parent_id');
-            const pathsToInvalidate = [
-                postId ? `/api/members/comments/post/${postId}/` : null,
-                parentId ? `/api/members/comments/${parentId}/replies/` : null
-            ].filter(path => path !== null);
-            frame.setHeader('X-Cache-Invalidate', pathsToInvalidate.join(', '));
-        }
+        this.setCacheInvalidationHeaders(comment, frame);
 
         return result;
     }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -1526,7 +1526,7 @@ Object {
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6e1/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -1538,7 +1538,7 @@ Object {
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6e1/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -1550,7 +1550,7 @@ Object {
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6e1/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/\\$/,
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -7,7 +7,7 @@ const {
     dbUtils,
     matchers
 } = require('../../utils/e2e-framework');
-const {anyEtag, anyErrorId, anyObjectId, anyISODateTime, anyUuid, anyNumber, anyBoolean, anyString, nullable} = matchers;
+const {anyEtag, anyErrorId, anyObjectId, anyISODateTime, anyUuid, anyNumber, anyBoolean, anyString, nullable, stringMatching} = matchers;
 const models = require('../../../core/server/models');
 const db = require('../../../core/server/data/db');
 const security = require('@tryghost/security');
@@ -154,7 +154,7 @@ describe(`Admin Comments API`, function () {
                 }]
             });
 
-            assert.equal(res.headers['x-cache-invalidate'], `/api/members/comments/post/${postId}/`);
+            assert.equal(res.headers['x-cache-invalidate'], `/api/members/comments/post/${postId}/, /api/members/comments/${commentToHide.id}/`);
 
             const {body: {comments: [afterHiding]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
 
@@ -182,7 +182,7 @@ describe(`Admin Comments API`, function () {
 
             assert.equal(
                 res.headers['x-cache-invalidate'],
-                `/api/members/comments/post/${postId}/, /api/members/comments/${parent.id}/replies/`
+                `/api/members/comments/post/${postId}/, /api/members/comments/${parent.id}/replies/, /api/members/comments/${commentToHide.id}/`
             );
 
             const {body: {comments: [afterHiding]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
@@ -202,7 +202,7 @@ describe(`Admin Comments API`, function () {
                 }]
             });
 
-            assert.equal(pinRes.headers['x-cache-invalidate'], `/api/members/comments/post/${postId}/`);
+            assert.equal(pinRes.headers['x-cache-invalidate'], `/api/members/comments/post/${postId}/, /api/members/comments/${commentToPin.id}/`);
             assert.equal(pinRes.body.comments[0].pinned, true);
 
             const pinnedComment = await models.Comment.findOne({id: commentToPin.id});
@@ -226,7 +226,7 @@ describe(`Admin Comments API`, function () {
                 }]
             });
 
-            assert.equal(unpinRes.headers['x-cache-invalidate'], `/api/members/comments/post/${postId}/`);
+            assert.equal(unpinRes.headers['x-cache-invalidate'], `/api/members/comments/post/${postId}/, /api/members/comments/${commentToPin.id}/`);
             assert.equal(unpinRes.body.comments[0].pinned, false);
 
             const unpinnedComment = await models.Comment.findOne({id: commentToPin.id});
@@ -1173,7 +1173,10 @@ describe(`Admin Comments API`, function () {
                 .post(`/api/comments/${comment.get('id')}/like/`)
                 .expectStatus(204)
                 .matchHeaderSnapshot({
-                    etag: anyEtag
+                    etag: anyEtag,
+                    'x-cache-invalidate': stringMatching(
+                        new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/$')
+                    )
                 })
                 .expectEmptyBody();
         });

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -653,7 +653,7 @@ Object {
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -746,7 +746,7 @@ Object {
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -779,7 +779,7 @@ Object {
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -1034,7 +1034,7 @@ Object {
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -1092,7 +1092,7 @@ Object {
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/\\$/,
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -186,10 +186,10 @@ function testBasicErrorResponse(method, url, status, errors) {
  * @param {number} status
  * @returns {any} ExpectRequest
  */
-function testBasicEmptyResponse(method, url, status) {
+function testBasicEmptyResponse(method, url, status, headerMatchers = {}) {
     return membersAgent[method](url)
         .expectStatus(status)
-        .matchHeaderSnapshot({etag: anyEtag})
+        .matchHeaderSnapshot({etag: anyEtag, ...headerMatchers})
         .expectEmptyBody();
 }
 
@@ -1522,7 +1522,10 @@ describe('Comments API', function () {
                     .post(`/api/comments/${comment.get('id')}/like/`)
                     .expectStatus(204)
                     .matchHeaderSnapshot({
-                        etag: anyEtag
+                        etag: anyEtag,
+                        'x-cache-invalidate': stringMatching(
+                            new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/$')
+                        )
                     })
                     .expectEmptyBody();
 
@@ -1543,7 +1546,10 @@ describe('Comments API', function () {
                     .post(`/api/comments/${comment.get('id')}/dislike/`)
                     .expectStatus(204)
                     .matchHeaderSnapshot({
-                        etag: anyEtag
+                        etag: anyEtag,
+                        'x-cache-invalidate': stringMatching(
+                            new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/$')
+                        )
                     })
                     .expectEmptyBody();
 
@@ -1563,7 +1569,11 @@ describe('Comments API', function () {
                     member_id: loggedInMember.id
                 });
 
-                await testBasicEmptyResponse('delete', `/api/comments/${comment.get('id')}/dislike/`, 204);
+                await testBasicEmptyResponse('delete', `/api/comments/${comment.get('id')}/dislike/`, 204, {
+                    'x-cache-invalidate': stringMatching(
+                        new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/$')
+                    )
+                });
 
                 await testGetComments(`/api/comments/${comment.get('id')}/`, [commentMatcher])
                     .expect(({body}) => {
@@ -1709,7 +1719,11 @@ describe('Comments API', function () {
                 });
 
                 // Unlike
-                await testBasicEmptyResponse('delete', `/api/comments/${comment.get('id')}/like/`, 204);
+                await testBasicEmptyResponse('delete', `/api/comments/${comment.get('id')}/like/`, 204, {
+                    'x-cache-invalidate': stringMatching(
+                        new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/$')
+                    )
+                });
 
                 // Check not liked
                 await testGetComments(`/api/comments/${comment.get('id')}/`, [commentMatcher])
@@ -1805,7 +1819,10 @@ describe('Comments API', function () {
                     }]})
                     .expectStatus(200)
                     .matchHeaderSnapshot({
-                        etag: anyEtag
+                        etag: anyEtag,
+                        'x-cache-invalidate': stringMatching(
+                            new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/$')
+                        )
                     })
                     .matchBodySnapshot({
                         comments: [{

--- a/ghost/core/test/unit/server/services/comments/comments-controller.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-controller.test.js
@@ -22,6 +22,7 @@ describe('Comments Service: CommentsController', function () {
 
     function createController({comment = {post_id: 'post-id', parent_id: 'parent-id'}} = {}) {
         const commentModel = comment && {
+            id: 'comment-id',
             get: key => comment[key]
         };
         const service = {
@@ -73,7 +74,7 @@ describe('Comments Service: CommentsController', function () {
         sinon.assert.calledWith(
             frame.setHeader,
             'X-Cache-Invalidate',
-            '/api/members/comments/post/post-id/, /api/members/comments/parent-id/replies/'
+            '/api/members/comments/post/post-id/, /api/members/comments/parent-id/replies/, /api/members/comments/comment-id/'
         );
     });
 
@@ -92,7 +93,24 @@ describe('Comments Service: CommentsController', function () {
         sinon.assert.calledWith(
             frame.setHeader,
             'X-Cache-Invalidate',
-            '/api/members/comments/post/post-id/, /api/members/comments/parent-id/replies/'
+            '/api/members/comments/post/post-id/, /api/members/comments/parent-id/replies/, /api/members/comments/comment-id/'
+        );
+    });
+
+    it('invalidates the single-comment read path for top-level comments', function () {
+        const {controller} = createController();
+        const frame = createFrame();
+        const model = {
+            id: 'comment-id',
+            get: key => ({post_id: 'post-id', parent_id: null})[key]
+        };
+
+        controller.setCacheInvalidationHeaders(model, frame);
+
+        sinon.assert.calledWith(
+            frame.setHeader,
+            'X-Cache-Invalidate',
+            '/api/members/comments/post/post-id/, /api/members/comments/comment-id/'
         );
     });
 


### PR DESCRIPTION
## Problem

Unhiding a comment in admin and then using "View on post" can land on the post with the comments section showing **"The linked comment is no longer available."** instead of scrolling to the comment.

The permalink flow in comments-ui (`fetchScrollTarget`) loads the target via `GET /api/members/comments/:id/` and requires `status === 'published'`. On hosts that cache the members API at the edge (purged via the `X-Cache-Invalidate` header), every comment mutation purged only:

- `/api/members/comments/post/<postId>/`
- `/api/members/comments/<parentId>/replies/`

…but never the single-comment read path. So after unhiding, `/api/members/comments/:id/` kept serving the stale "hidden" payload (while the freshly-purged browse path rendered the comment right below the error). The reverse direction is worse: after **hiding** a comment, the cached read endpoint kept serving its content until TTL.

These purge paths predate the permalink feature (added Dec 2025 in 3df0e8c3f7), which introduced the dependency on the read endpoint — closest precedent is a489d5a3d8, which added the `/replies/` path for the same reason.

## Solution

- `setCacheInvalidationHeaders` now also emits `/api/members/comments/<id>/` (appended last, so existing unanchored matchers stay valid)
- Replaced the six duplicated inline copies of the purge-path logic (member edit, add, like, unlike, dislike, undislike) with calls to the existing shared helper — net −9 lines
- Updated header assertions, added a unit test for the top-level case, regenerated snapshots; sites where the header now contains a dynamically-created comment id use `stringMatching` so snapshots stay stable across runs

Note for review: this only *requests* the purge — worth confirming with the Pro team that the edge purge rules cover `/api/members/comments/:id/` (they should if matching is prefix-based on `/api/members/comments/`).

Local verification: `test/unit/server/services/comments` (39 passing), `test/e2e-api/members-comments` (102 passing, twice — no snapshot drift), `test/e2e-api/admin/comments.test.js` (88 passing), `test/e2e-api/admin/member-commenting.test.js` (30 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)