### PR TITLE
Guarded against missing automated email for member events

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -1067,6 +1067,13 @@ module.exports = class EventRepository {
 
         const data = models.map((model) => {
             const automatedEmail = model.related('automatedEmail');
+            if (!automatedEmail || !automatedEmail.id) {
+                // TODO(NY-1334) This won't necessarily be an error in the future.
+                throw new errors.InternalServerError({
+                    message: `Automated email recipient ${model.id} has no associated automated email`
+                });
+            }
+
             const automation = automatedEmail.related('automation');
             if (!automation || !automation.id) {
                 throw new errors.InternalServerError({


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1336

This change should have no user impact.

In the future, `automated_email_recipients.automated_email_id` will be nullable. This throws an explicit error if that happens.

I think this is a useful change on its own, but it'll also be useful when this field might be nullable.
