### PR TITLE
Included sender detail details on `EmailDesignSetting` model

### DIFF
--- a/ghost/core/core/server/models/email-design-setting.js
+++ b/ghost/core/core/server/models/email-design-setting.js
@@ -18,7 +18,10 @@ const EmailDesignSetting = ghostBookshelf.Model.extend({
             title_font_category: 'sans_serif',
             title_font_weight: 'bold',
             image_corners: 'square',
-            show_badge: true
+            show_badge: true,
+            sender_name: null,
+            sender_email: null,
+            sender_reply_to: null
         };
     }
 });


### PR DESCRIPTION
ref 9e9ce74c8fdb5d80912a0f0be795aa491fc792da

This change should have no user impact, and is mostly for clarity.

In 9e9ce74c8fdb5d80912a0f0be795aa491fc792da, we added some nullable fields on the `email_design_settings` table. This updates the model to specify the default values of those fields.
