### PR TITLE
Restored @slack/webhook dependency for the Ghost(Pro) migrate script

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -89,6 +89,7 @@
     "@faker-js/faker": "catalog:",
     "@isaacs/ttlcache": "1.4.1",
     "@sentry/node": "7.120.4",
+    "@slack/webhook": "7.0.9",
     "@tryghost/adapter-base-cache": "0.1.25",
     "@tryghost/admin-api-schema": "4.7.4",
     "@tryghost/api-framework": "catalog:",

--- a/knip.json
+++ b/knip.json
@@ -5,5 +5,14 @@
     ],
     "ignore": [
         "ghost/core/test/utils/fixtures/themes/**/assets/built/**"
-    ]
+    ],
+    "workspaces": {
+        "ghost/core": {
+            "ignoreDependencies": [
+                "@slack/webhook",
+                "superagent",
+                "superagent-throttle"
+            ]
+        }
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2326,6 +2326,9 @@ importers:
       '@sentry/node':
         specifier: 7.120.4
         version: 7.120.4
+      '@slack/webhook':
+        specifier: 7.0.9
+        version: 7.0.9
       '@tryghost/adapter-base-cache':
         specifier: 0.1.25
         version: 0.1.25
@@ -7017,6 +7020,14 @@ packages:
     deprecated: |-
       Deprecated: no longer maintained and no longer used by Sinon packages. See
         https://github.com/sinonjs/nise/issues/243 for replacement details.
+
+  '@slack/types@2.21.1':
+    resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/webhook@7.0.9':
+    resolution: {integrity: sha512-hMfkQ5Y3Y7FtL+ZYhcxFblidx4Z2LPRFrhY1KJb6NqQdnK6kzTzTS1mjH5taVQIB496eqwpg9FE9mq9BFx0DWw==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@smithy/core@3.24.6':
     resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
@@ -26396,6 +26407,17 @@ snapshots:
       type-detect: 4.1.0
 
   '@sinonjs/text-encoding@0.7.3': {}
+
+  '@slack/types@2.21.1': {}
+
+  '@slack/webhook@7.0.9':
+    dependencies:
+      '@slack/types': 2.21.1
+      '@types/node': 25.9.1
+      axios: 1.16.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@smithy/core@3.24.6':
     dependencies:


### PR DESCRIPTION
## Problem

Ghost(Pro) migrations are currently failing to alert. `migrate.js` (copied into the Ghost(Pro) image at release time) crashes with:

```
Error: Cannot find module '@slack/webhook'
    at Object.notifySlack (/home/ghost/migrate.js:101:31)
```

Because the require lives inside `notifySlack`, the `MODULE_NOT_FOUND` is thrown from inside the migration `catch` blocks **before** `exitCode = 1` is set and before the platform is notified of failure — so the alert never sends, the platform is never told a major migration failed, and the script exits `0`, letting the entrypoint attempt to boot Ghost instead of failing fast at the migrate step (Ghost then fails its own DB state check, so the failure surfaces as an unalerted boot crash-loop).

## Background

- `@slack/webhook`, `superagent` and `superagent-throttle` were deliberately added to `ghost/core` in 5832ab5138 as a workaround for internal Pro adapter files that are copied into the image at release time. Nothing in this repo imports them, so knip/grep cannot see the consumers.
- 8f2ec8de4a (#27720) removed all three in a knip cleanup pass.
- bbc3981b65 restored the superagent packages after Pro crashed at boot (`SchedulingPro` requires them at module load), but `@slack/webhook` was missed — its lazy require meant nothing failed until a migration actually went wrong.

## Changes

- Re-added `@slack/webhook@7.0.9` (the version removed in #27720) to `ghost/core` dependencies
- Pinned all three packages in `knip.json` via a `ghost/core` workspace `ignoreDependencies` entry so the next cleanup pass does not remove them again (verified `pnpm knip` no longer flags any of them)