### PR TITLE
Fixed cancelled subscriptions counting in multiple subscriptions warning

### DIFF
--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -210,6 +210,7 @@ const Member = ghostBookshelf.Model.extend({
                     .from('members_stripe_customers')
                     .innerJoin('members_stripe_customers_subscriptions', 'members_stripe_customers_subscriptions.customer_id', 'members_stripe_customers.customer_id')
                     .where('members_stripe_customers_subscriptions.status', 'active')
+                    .where('members_stripe_customers_subscriptions.cancel_at_period_end', false)
                     .groupBy('members_stripe_customers.member_id')
                     .havingRaw('COUNT(DISTINCT members_stripe_customers_subscriptions.customer_id) > 1')
                     .as('multiple_active_stripe_customers');

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -78,7 +78,7 @@ async function createGiftMember(data) {
     return member;
 }
 
-async function createStripeCustomerWithSubscription(member, customerId, subscriptionId, status = 'active') {
+async function createStripeCustomerWithSubscription(member, customerId, subscriptionId, {status = 'active', cancelAtPeriodEnd = false} = {}) {
     const now = new Date();
 
     await knex('members_stripe_customers').insert({
@@ -95,6 +95,7 @@ async function createStripeCustomerWithSubscription(member, customerId, subscrip
         customer_id: customerId,
         subscription_id: subscriptionId,
         status,
+        cancel_at_period_end: cancelAtPeriodEnd,
         current_period_end: now,
         start_date: now,
         created_at: now,
@@ -690,9 +691,10 @@ describe('Members API', function () {
         const emails = [
             'multiple-active-stripe-customers@example.com',
             'same-active-stripe-customer@example.com',
-            'trialing-stripe-customers@example.com'
+            'trialing-stripe-customers@example.com',
+            'cancelling-stripe-customers@example.com'
         ];
-        const customerIds = ['cus_matching_1', 'cus_matching_2', 'cus_same_1', 'cus_trialing_1', 'cus_trialing_2'];
+        const customerIds = ['cus_matching_1', 'cus_matching_2', 'cus_same_1', 'cus_trialing_1', 'cus_trialing_2', 'cus_cancelling_1', 'cus_cancelling_2'];
 
         try {
             const matchingMember = await createMember({
@@ -727,8 +729,15 @@ describe('Members API', function () {
                 email: emails[2],
                 status: 'free'
             });
-            await createStripeCustomerWithSubscription(trialingMember, 'cus_trialing_1', 'sub_trialing_1', 'trialing');
-            await createStripeCustomerWithSubscription(trialingMember, 'cus_trialing_2', 'sub_trialing_2', 'trialing');
+            await createStripeCustomerWithSubscription(trialingMember, 'cus_trialing_1', 'sub_trialing_1', {status: 'trialing'});
+            await createStripeCustomerWithSubscription(trialingMember, 'cus_trialing_2', 'sub_trialing_2', {status: 'trialing'});
+
+            const cancellingMember = await createMember({
+                email: emails[3],
+                status: 'free'
+            });
+            await createStripeCustomerWithSubscription(cancellingMember, 'cus_cancelling_1', 'sub_cancelling_1');
+            await createStripeCustomerWithSubscription(cancellingMember, 'cus_cancelling_2', 'sub_cancelling_2', {cancelAtPeriodEnd: true});
 
             const filter = encodeURIComponent('count.active_stripe_customers:>1');
             const res = await agent


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3722/

The multiple-active-subscriptions members filter added in #28232 was returning too many members. Stripe keeps a cancelled subscription's status as `active` until the end of its billing period, so after a site owner contacted affected members and the extra subscriptions were cancelled, those members kept showing in the filter and the warning banner until their billing periods ended — making it look like the problem hadn't been resolved.

The filter's subquery now also requires `cancel_at_period_end` to be false, so a subscription that's running out its term after cancellation no longer counts as active. Cancelling an extra subscription immediately removes the member from the filter and the banner count.