### PR TITLE
🎨 Added warning and filter for members with multiple active subscriptions

### DIFF
--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -30,7 +30,6 @@ interface MembersPageProps {
     emailAnalyticsEnabled: boolean;
     hasStripeEnabled: boolean;
     membershipsEnabled: boolean;
-    multipleSubsFilterEnabled: boolean;
     timezone: string;
 }
 
@@ -38,7 +37,6 @@ const MembersPage: React.FC<MembersPageProps> = ({
     emailAnalyticsEnabled,
     hasStripeEnabled,
     membershipsEnabled,
-    multipleSubsFilterEnabled,
     timezone
 }) => {
     const headerRef = useRef<HTMLDivElement | null>(null);
@@ -212,7 +210,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                 )}
                             </FilterBar>
                         )}
-                        {hasStripeEnabled && multipleSubsFilterEnabled && (
+                        {hasStripeEnabled && (
                             <MultipleActiveSubscriptionsBanner
                                 nql={nql}
                                 search={search}
@@ -322,14 +320,12 @@ const Members: React.FC = () => {
     const membershipsEnabled = membersSignupAccess !== 'none';
     const emailAnalyticsEnabled = configData.config.emailAnalytics === true;
     const hasStripeEnabled = checkStripeEnabled(settingsData.settings, configData.config);
-    const multipleSubsFilterEnabled = configData.config.labs?.multipleSubsFilter === true;
 
     return (
         <MembersPage
             emailAnalyticsEnabled={emailAnalyticsEnabled}
             hasStripeEnabled={hasStripeEnabled}
             membershipsEnabled={membershipsEnabled}
-            multipleSubsFilterEnabled={multipleSubsFilterEnabled}
             timezone={timezone}
         />
     );

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -26,8 +26,7 @@ const GA_FEATURES = [
     'commentsThreads',
     'commentsPinning',
     'featurebaseFeedback',
-    'dangerZoneResetAuth',
-    'multipleSubsFilter'
+    'dangerZoneResetAuth'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -31,7 +31,6 @@ Object {
       "lexicalIndicators": true,
       "llmsTxt": true,
       "members": true,
-      "multipleSubsFilter": true,
       "pictureImageFormats": true,
       "smarterCounts": true,
       "stripeAutomaticTax": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1803,7 +1803,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5459",
+  "content-length": "5431",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3721/

Members with multiple active Stripe subscriptions are usually paying twice without realising it, and until now there was no easy way for site owners to spot them. The Members list now shows a banner whenever any members have multiple active subscriptions, with a link to filter down to the affected members so the duplicates can be resolved. How it works is documented in the [duplicate subscription warning help doc](https://ghost.org/help/duplicate-subscription-warning/).