### PR TITLE
🐛 Fixed label mutation errors being silently swallowed in the label picker

### DIFF
--- a/apps/admin-x-design-system/src/providers/design-system-provider.tsx
+++ b/apps/admin-x-design-system/src/providers/design-system-provider.tsx
@@ -45,7 +45,7 @@ const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({fetchKoenigL
     return (
         <DesignSystemContext.Provider value={{isAnyTextFieldFocused, setFocusState, fetchKoenigLexical, darkMode}}>
             <GlobalDirtyStateProvider>
-                <Toaster />
+                <Toaster containerClassName="toast-outlet-react-hot-toast" />
                 <NiceModal.Provider>
                     {children}
                 </NiceModal.Provider>

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -107,6 +107,7 @@
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-hot-toast": "catalog:",
+        "sonner": "catalog:",
         "react-router": "catalog:"
     },
     "peerDependencies": {

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -41,6 +41,11 @@
             "require": "./dist/utils/post-utils.cjs",
             "types": "./types/utils/post-utils.d.ts"
         },
+        "./utils/nql": {
+            "import": "./dist/utils/nql.js",
+            "require": "./dist/utils/nql.cjs",
+            "types": "./types/utils/nql.d.ts"
+        },
         "./vite": {
             "import": "./dist/vite.js",
             "require": "./dist/vite.cjs",

--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -1,5 +1,9 @@
 import {InfiniteData} from '@tanstack/react-query';
 import {Meta, createInfiniteQuery, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
+import {apiUrl, useFetchApi} from '../utils/api/fetch-api';
+import {escapeNqlString} from '../utils/nql';
+import {useCallback} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
 
 export type Label = {
     id: string;
@@ -60,6 +64,23 @@ export const useCreateLabel = createMutation<LabelsResponseType, Pick<Label, 'na
         dataType
     }
 });
+
+export const useFindLabelByName = () => {
+    const fetchApi = useFetchApi();
+
+    return useCallback(async (name: string): Promise<Label | undefined> => {
+        const data = await fetchApi<LabelsResponseType>(apiUrl('/labels/', {filter: `name:${escapeNqlString(name)}`, limit: '1'}));
+        return data.labels?.[0];
+    }, [fetchApi]);
+};
+
+export const useInvalidateLabels = () => {
+    const queryClient = useQueryClient();
+
+    return useCallback(() => {
+        queryClient.invalidateQueries([dataType]);
+    }, [queryClient]);
+};
 
 export const useEditLabel = createMutation<LabelsResponseType, Pick<Label, 'id' | 'name'>>({
     method: 'PUT',

--- a/apps/admin-x-framework/src/hooks/use-filterable-api.ts
+++ b/apps/admin-x-framework/src/hooks/use-filterable-api.ts
@@ -1,6 +1,7 @@
 import {useRef} from 'react';
 import {apiUrl, useFetchApi} from '../utils/api/fetch-api';
 import {Meta} from '../utils/api/hooks';
+import {escapeNqlString} from '../utils/nql';
 
 const filterData = <
     Data extends {[k in FilterKey]: string},
@@ -10,10 +11,6 @@ const filterData = <
         return data;
     }
     return data.filter(item => item[filterKey]?.toLowerCase().includes(input.toLowerCase()));
-};
-
-const escapeNqlString = (value: string) => {
-    return '\'' + value.replace(/'/g, '\\\'') + '\'';
 };
 
 const useFilterableApi = <

--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -1,9 +1,27 @@
 import * as Sentry from '@sentry/react';
 import {showToast} from '@tryghost/admin-x-design-system';
+import {toast as sonnerToast} from 'sonner';
 import {useCallback} from 'react';
 import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
 import {APIError, ValidationError} from '../utils/errors';
+
+// There are two toast outlets: admin-x-design-system's DesignSystemProvider
+// renders react-hot-toast (marked with this class), shade's ShadeProvider
+// renders sonner - and the React shell can mount both at once. The marker's
+// presence in the DOM picks the library to emit to.
+function showErrorToast(message: React.ReactNode) {
+    if (document.querySelector('.toast-outlet-react-hot-toast')) {
+        toast.remove();
+        showToast({
+            message,
+            type: 'error'
+        });
+    } else {
+        sonnerToast.dismiss();
+        sonnerToast.error(message);
+    }
+}
 
 /**
  * Generic error handling for API calls. This is enabled by default for queries (can be disabled by
@@ -38,26 +56,15 @@ const useHandleError = () => {
             return;
         }
 
-        toast.remove();
-
         if (error instanceof APIError && error.response?.status === 418) {
             // We use this status in tests to indicate the API request was not mocked -
             // don't show a toast because it may block clicking things in the test
         } else if (error instanceof ValidationError && error.data?.errors[0]) {
-            showToast({
-                message: error.data.errors[0].context || error.data.errors[0].message,
-                type: 'error'
-            });
+            showErrorToast(error.data.errors[0].context || error.data.errors[0].message);
         } else if (error instanceof APIError) {
-            showToast({
-                message: error.message,
-                type: 'error'
-            });
+            showErrorToast(error.message);
         } else {
-            showToast({
-                message: 'Something went wrong, please try again.',
-                type: 'error'
-            });
+            showErrorToast('Something went wrong, please try again.');
         }
     }, [sentryDSN]);
 

--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -6,8 +6,7 @@ import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
 import {APIError, getErrorMessage} from '../utils/errors';
 
-// Stale toasts can cover UI (and block clicks in tests), so both outlets are
-// cleared before showing a new toast - and on the unmocked-request test path
+// Stale toasts can cover UI and block clicks, especially in tests
 function dismissToasts() {
     toast.remove();
     sonnerToast.dismiss();
@@ -68,8 +67,6 @@ const useHandleError = () => {
             // but still clear lingering toasts that would block clicks the same way
             dismissToasts();
         } else if (error instanceof APIError) {
-            // getErrorMessage extracts the human-readable text from
-            // validation errors and falls back to the error's own message
             showErrorToast(getErrorMessage(error, error.message));
         } else {
             showErrorToast('Something went wrong, please try again.');

--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -6,19 +6,25 @@ import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
 import {APIError, ValidationError} from '../utils/errors';
 
+// Stale toasts can cover UI (and block clicks in tests), so both outlets are
+// cleared before showing a new toast - and on the unmocked-request test path
+function dismissToasts() {
+    toast.remove();
+    sonnerToast.dismiss();
+}
+
 // There are two toast outlets: admin-x-design-system's DesignSystemProvider
 // renders react-hot-toast (marked with this class), shade's ShadeProvider
 // renders sonner - and the React shell can mount both at once. The marker's
 // presence in the DOM picks the library to emit to.
 function showErrorToast(message: React.ReactNode) {
+    dismissToasts();
     if (document.querySelector('.toast-outlet-react-hot-toast')) {
-        toast.remove();
         showToast({
             message,
             type: 'error'
         });
     } else {
-        sonnerToast.dismiss();
         sonnerToast.error(message);
     }
 }
@@ -58,7 +64,9 @@ const useHandleError = () => {
 
         if (error instanceof APIError && error.response?.status === 418) {
             // We use this status in tests to indicate the API request was not mocked -
-            // don't show a toast because it may block clicking things in the test
+            // don't show a toast because it may block clicking things in the test,
+            // but still clear lingering toasts that would block clicks the same way
+            dismissToasts();
         } else if (error instanceof ValidationError && error.data?.errors[0]) {
             showErrorToast(error.data.errors[0].context || error.data.errors[0].message);
         } else if (error instanceof APIError) {

--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -4,7 +4,7 @@ import {toast as sonnerToast} from 'sonner';
 import {useCallback} from 'react';
 import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
-import {APIError, ValidationError} from '../utils/errors';
+import {APIError, getErrorMessage} from '../utils/errors';
 
 // Stale toasts can cover UI (and block clicks in tests), so both outlets are
 // cleared before showing a new toast - and on the unmocked-request test path
@@ -67,10 +67,10 @@ const useHandleError = () => {
             // don't show a toast because it may block clicking things in the test,
             // but still clear lingering toasts that would block clicks the same way
             dismissToasts();
-        } else if (error instanceof ValidationError && error.data?.errors[0]) {
-            showErrorToast(error.data.errors[0].context || error.data.errors[0].message);
         } else if (error instanceof APIError) {
-            showErrorToast(error.message);
+            // getErrorMessage extracts the human-readable text from
+            // validation errors and falls back to the error's own message
+            showErrorToast(getErrorMessage(error, error.message));
         } else {
             showErrorToast('Something went wrong, please try again.');
         }

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -121,8 +121,7 @@ const fetchWithXhr = (
 export const useFetchApi = () => {
     const {ghostVersion, sentryDSN} = useFramework();
 
-    // Memoized so hooks built on top (useCallback/useMemo with fetchApi as a
-    // dependency) actually cache instead of rebuilding on every render
+    // Memoized so hooks that depend on fetchApi can cache
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return useCallback(async <ResponseData = any>(
         endpoint: string | URL,

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react';
+import {useCallback} from 'react';
 import {useFramework} from '../../providers/framework-provider';
 import {APIError, MaintenanceError, ServerUnreachableError, TimeoutError} from '../errors';
 import {getGhostPaths} from '../helpers';
@@ -120,8 +121,10 @@ const fetchWithXhr = (
 export const useFetchApi = () => {
     const {ghostVersion, sentryDSN} = useFramework();
 
+    // Memoized so hooks built on top (useCallback/useMemo with fetchApi as a
+    // dependency) actually cache instead of rebuilding on every render
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return async <ResponseData = any>(
+    return useCallback(async <ResponseData = any>(
         endpoint: string | URL,
         {
             method = 'GET',
@@ -222,7 +225,7 @@ export const useFetchApi = () => {
         // this can't happen, but TS isn't smart enough to undeerstand that the loop will never exit without an error or return
         // because of retry + attempts usage combination
         return undefined as never;
-    };
+    }, [ghostVersion, sentryDSN]);
 };
 
 const {apiRoot, activityPubRoot} = getGhostPaths();

--- a/apps/admin-x-framework/src/utils/errors.ts
+++ b/apps/admin-x-framework/src/utils/errors.ts
@@ -110,6 +110,16 @@ export class ValidationError extends JSONError {
 
 export const errorsWithMessage = [ValidationError, ThemeValidationError, HostLimitError, EmailError];
 
+// The API error serializer puts the human-readable text in `context`;
+// `message` is only a generic summary
+export function getErrorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ValidationError && error.data?.errors[0]) {
+        return error.data.errors[0].context || error.data.errors[0].message;
+    }
+
+    return fallback;
+}
+
 // Frontend errors
 
 export class AlreadyExistsError extends Error {

--- a/apps/admin-x-framework/src/utils/nql.ts
+++ b/apps/admin-x-framework/src/utils/nql.ts
@@ -1,0 +1,3 @@
+export function escapeNqlString(value: string): string {
+    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')}'`;
+}

--- a/apps/admin-x-framework/src/utils/nql.ts
+++ b/apps/admin-x-framework/src/utils/nql.ts
@@ -1,5 +1,9 @@
-// NQL only unescapes \' and \" inside quoted strings - a lone backslash is a
-// literal character, so escaping backslashes would query a different value
+// NQL's only escape sequences are \' and \" - there is no \\, so a backslash
+// is a literal character and doubling it would query a different value.
+// Escaping just quotes is still injection-safe: because \\ is never an escape
+// pair, the backslash emitted before a quote always parses as the \' escape,
+// so no input (including trailing or adjacent backslashes) can turn an
+// escaped quote back into a string terminator.
 export function escapeNqlString(value: string): string {
     return `'${value.replace(/'/g, '\\\'')}'`;
 }

--- a/apps/admin-x-framework/src/utils/nql.ts
+++ b/apps/admin-x-framework/src/utils/nql.ts
@@ -1,3 +1,5 @@
+// NQL only unescapes \' and \" inside quoted strings - a lone backslash is a
+// literal character, so escaping backslashes would query a different value
 export function escapeNqlString(value: string): string {
-    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')}'`;
+    return `'${value.replace(/'/g, '\\\'')}'`;
 }

--- a/apps/admin-x-framework/test/unit/api/labels.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/labels.test.tsx
@@ -88,7 +88,7 @@ describe('labels api', () => {
         });
     });
 
-    it('escapes backslashes in the lookup filter', async () => {
+    it('does not escape backslashes in the lookup filter', async () => {
         await withMockFetch({
             json: {labels: []},
             headers: {'content-type': 'application/json'},
@@ -101,8 +101,10 @@ describe('labels api', () => {
                 await result.current('trailing\\');
             });
 
+            // NQL keeps lone backslashes literal and only unescapes \' and \",
+            // so a doubled backslash would query a two-backslash name
             const url = new URL(mock.calls[0][0] as string);
-            expect(url.searchParams.get('filter')).toBe(String.raw`name:'trailing\\'`);
+            expect(url.searchParams.get('filter')).toBe(String.raw`name:'trailing\'`);
         });
     });
 

--- a/apps/admin-x-framework/test/unit/api/labels.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/labels.test.tsx
@@ -1,0 +1,136 @@
+import {act} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {ValidationError} from '../../../src/utils/errors';
+import {renderHookWithProviders} from '../../../src/test/test-utils';
+import {useCreateLabel, useEditLabel, useFindLabelByName} from '../../../src/api/labels';
+import {withMockFetch} from '../../utils/mock-fetch';
+
+const {mockShowToast, mockSonnerError} = vi.hoisted(() => ({
+    mockShowToast: vi.fn(),
+    mockSonnerError: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-design-system', async (importOriginal) => {
+    const original = await importOriginal<typeof import('@tryghost/admin-x-design-system')>();
+    return {...original, showToast: mockShowToast};
+});
+
+vi.mock('sonner', () => ({
+    toast: {
+        error: mockSonnerError,
+        dismiss: vi.fn()
+    }
+}));
+
+const duplicateLabelResponse = {
+    errors: [{
+        code: 'VALIDATION',
+        context: 'Label already exists',
+        details: null,
+        ghostErrorCode: null,
+        help: null,
+        id: 'label-error-id',
+        message: 'Validation error, cannot save label.',
+        property: null,
+        type: 'ValidationError'
+    }]
+};
+
+const existingLabel = {
+    id: 'label-1',
+    name: 'Existing label',
+    slug: 'existing-label',
+    created_at: '',
+    updated_at: ''
+};
+
+const mockErrorFetch = {
+    json: duplicateLabelResponse,
+    headers: {'content-type': 'application/json'},
+    ok: false,
+    status: 422
+};
+
+describe('labels api', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('rejects duplicate creates without reporting - the picker owns recovery', async () => {
+        await withMockFetch(mockErrorFetch, async () => {
+            const {result} = renderHookWithProviders(() => useCreateLabel());
+
+            await act(async () => {
+                await expect(result.current.mutateAsync({name: 'Existing label'})).rejects.toBeInstanceOf(ValidationError);
+            });
+
+            expect(mockShowToast).not.toHaveBeenCalled();
+            expect(mockSonnerError).not.toHaveBeenCalled();
+        });
+    });
+
+    it('finds a label by name', async () => {
+        await withMockFetch({
+            json: {labels: [existingLabel]},
+            headers: {'content-type': 'application/json'},
+            ok: true,
+            status: 200
+        }, async (mock) => {
+            const {result} = renderHookWithProviders(() => useFindLabelByName());
+
+            await act(async () => {
+                await expect(result.current(`O'Existing label`)).resolves.toEqual(existingLabel);
+            });
+
+            const url = new URL(mock.calls[0][0] as string);
+            expect(url.searchParams.get('filter')).toBe(String.raw`name:'O\'Existing label'`);
+            expect(url.searchParams.get('limit')).toBe('1');
+        });
+    });
+
+    it('escapes backslashes in the lookup filter', async () => {
+        await withMockFetch({
+            json: {labels: []},
+            headers: {'content-type': 'application/json'},
+            ok: true,
+            status: 200
+        }, async (mock) => {
+            const {result} = renderHookWithProviders(() => useFindLabelByName());
+
+            await act(async () => {
+                await result.current('trailing\\');
+            });
+
+            const url = new URL(mock.calls[0][0] as string);
+            expect(url.searchParams.get('filter')).toBe(String.raw`name:'trailing\\'`);
+        });
+    });
+
+    it('resolves undefined when no label matches the name', async () => {
+        await withMockFetch({
+            json: {labels: []},
+            headers: {'content-type': 'application/json'},
+            ok: true,
+            status: 200
+        }, async () => {
+            const {result} = renderHookWithProviders(() => useFindLabelByName());
+
+            await act(async () => {
+                await expect(result.current('Missing label')).resolves.toBeUndefined();
+            });
+        });
+    });
+
+    it('rejects duplicate edits without reporting - the edit row surfaces them', async () => {
+        await withMockFetch(mockErrorFetch, async () => {
+            const {result} = renderHookWithProviders(() => useEditLabel());
+
+            await act(async () => {
+                await expect(result.current.mutateAsync({id: 'label-1', name: 'Existing label'})).rejects.toBeInstanceOf(ValidationError);
+            });
+
+            expect(mockShowToast).not.toHaveBeenCalled();
+            expect(mockSonnerError).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
@@ -24,11 +24,19 @@ vi.mock('react-hot-toast', () => ({
     }
 }));
 
+vi.mock('sonner', () => ({
+    toast: {
+        error: vi.fn(),
+        dismiss: vi.fn()
+    }
+}));
+
 const mockShowToast = vi.fn();
 const mockToastRemove = vi.fn();
 
 import * as Sentry from '@sentry/react';
 import {showToast} from '@tryghost/admin-x-design-system';
+import {toast as sonnerToast} from 'sonner';
 import toast from 'react-hot-toast';
 
 const createWrapper = (sentryDSN?: string): React.FC<{children: ReactNode}> => {
@@ -151,7 +159,7 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(toast.remove).toHaveBeenCalled();
+        expect(sonnerToast.dismiss).toHaveBeenCalled();
     });
 
     it('does not show toast when withToast is false', () => {
@@ -162,6 +170,7 @@ describe('useHandleError', () => {
         result.current(error, {withToast: false});
 
         expect(showToast).not.toHaveBeenCalled();
+        expect(sonnerToast.error).not.toHaveBeenCalled();
     });
 
     it('does not show toast for 418 status (test indicator)', () => {
@@ -174,6 +183,28 @@ describe('useHandleError', () => {
         result.current(error);
 
         expect(showToast).not.toHaveBeenCalled();
+        expect(sonnerToast.error).not.toHaveBeenCalled();
+    });
+
+    it('routes toasts to react-hot-toast when its outlet is mounted', () => {
+        const outlet = document.createElement('div');
+        outlet.className = 'toast-outlet-react-hot-toast';
+        document.body.appendChild(outlet);
+
+        try {
+            const wrapper = createWrapper();
+            const {result} = renderHook(() => useHandleError(), {wrapper});
+
+            result.current(new Error('Test error'));
+
+            expect(showToast).toHaveBeenCalledWith({
+                message: 'Something went wrong, please try again.',
+                type: 'error'
+            });
+            expect(sonnerToast.error).not.toHaveBeenCalled();
+        } finally {
+            outlet.remove();
+        }
     });
 
     it('shows validation error message from context', () => {
@@ -199,10 +230,8 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(showToast).toHaveBeenCalledWith({
-            message: 'This field must be filled out',
-            type: 'error'
-        });
+        expect(sonnerToast.error).toHaveBeenCalledWith('This field must be filled out');
+        expect(showToast).not.toHaveBeenCalled();
     });
 
     it('shows validation error message when no context available', () => {
@@ -228,10 +257,7 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(showToast).toHaveBeenCalledWith({
-            message: 'Field is required',
-            type: 'error'
-        });
+        expect(sonnerToast.error).toHaveBeenCalledWith('Field is required');
     });
 
     it('shows API error message', () => {
@@ -242,10 +268,7 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(showToast).toHaveBeenCalledWith({
-            message: 'API Error occurred',
-            type: 'error'
-        });
+        expect(sonnerToast.error).toHaveBeenCalledWith('API Error occurred');
     });
 
     it('shows generic error message for unknown errors', () => {
@@ -256,10 +279,7 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(showToast).toHaveBeenCalledWith({
-            message: 'Something went wrong, please try again.',
-            type: 'error'
-        });
+        expect(sonnerToast.error).toHaveBeenCalledWith('Something went wrong, please try again.');
     });
 
     it('handles string errors', () => {
@@ -269,10 +289,7 @@ describe('useHandleError', () => {
         result.current('String error');
 
         expect(console.error).toHaveBeenCalledWith('String error'); // eslint-disable-line no-console
-        expect(showToast).toHaveBeenCalledWith({
-            message: 'Something went wrong, please try again.',
-            type: 'error'
-        });
+        expect(sonnerToast.error).toHaveBeenCalledWith('Something went wrong, please try again.');
     });
 
     it('handles null/undefined errors', () => {
@@ -282,9 +299,6 @@ describe('useHandleError', () => {
         result.current(null);
 
         expect(console.error).toHaveBeenCalledWith(null); // eslint-disable-line no-console
-        expect(showToast).toHaveBeenCalledWith({
-            message: 'Something went wrong, please try again.',
-            type: 'error'
-        });
+        expect(sonnerToast.error).toHaveBeenCalledWith('Something went wrong, please try again.');
     });
 });

--- a/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
@@ -186,6 +186,21 @@ describe('useHandleError', () => {
         expect(sonnerToast.error).not.toHaveBeenCalled();
     });
 
+    it('still clears lingering toasts for 418 status', () => {
+        const wrapper = createWrapper();
+        const {result} = renderHook(() => useHandleError(), {wrapper});
+
+        const mockResponse = new Response(null, {status: 418});
+        const error = new APIError(mockResponse);
+
+        result.current(error);
+
+        // A stale toast can cover UI and block clicks in tests, so the
+        // unmocked-request path must clear toasts even without showing one
+        expect(toast.remove).toHaveBeenCalled();
+        expect(sonnerToast.dismiss).toHaveBeenCalled();
+    });
+
     it('routes toasts to react-hot-toast when its outlet is mounted', () => {
         const outlet = document.createElement('div');
         outlet.className = 'toast-outlet-react-hot-toast';

--- a/apps/admin-x-framework/test/unit/utils/errors.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/errors.test.ts
@@ -13,6 +13,7 @@ import {
     ValidationError,
     AlreadyExistsError,
     errorsWithMessage,
+    getErrorMessage,
     ErrorResponse
 } from '../../../src/utils/errors';
 
@@ -305,6 +306,40 @@ describe('errors utils', () => {
             expect(errorsWithMessage).toContain(ThemeValidationError);
             expect(errorsWithMessage).toContain(HostLimitError);
             expect(errorsWithMessage).toContain(EmailError);
+        });
+    });
+
+    describe('getErrorMessage', () => {
+        const makeValidationError = (context: string | null) => {
+            const data: ErrorResponse = {
+                errors: [{
+                    code: 'VALIDATION',
+                    context,
+                    details: null,
+                    ghostErrorCode: null,
+                    help: 'Help text',
+                    id: 'error-id',
+                    message: 'Validation error, cannot edit label.',
+                    property: null,
+                    type: 'ValidationError'
+                }]
+            };
+            return new ValidationError({} as Response, data);
+        };
+
+        it('returns the context of a ValidationError', () => {
+            const error = makeValidationError('Label already exists');
+            expect(getErrorMessage(error, 'Fallback message')).toBe('Label already exists');
+        });
+
+        it('falls back to the error message when context is empty', () => {
+            const error = makeValidationError(null);
+            expect(getErrorMessage(error, 'Fallback message')).toBe('Validation error, cannot edit label.');
+        });
+
+        it('returns the fallback for other errors', () => {
+            expect(getErrorMessage(new Error('boom'), 'Fallback message')).toBe('Fallback message');
+            expect(getErrorMessage(undefined, 'Fallback message')).toBe('Fallback message');
         });
     });
 

--- a/apps/posts/src/components/label-picker/can-create-label.ts
+++ b/apps/posts/src/components/label-picker/can-create-label.ts
@@ -1,0 +1,9 @@
+import {Label} from '@tryghost/admin-x-framework/api/labels';
+
+export function canCreateLabel(labels: Label[], query: string): boolean {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+        return false;
+    }
+    return !labels.some(label => label.name.toLowerCase() === normalized);
+}

--- a/apps/posts/src/components/label-picker/edit-row.tsx
+++ b/apps/posts/src/components/label-picker/edit-row.tsx
@@ -1,16 +1,16 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {Button} from '@tryghost/shade/components';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
+import {getErrorMessage} from '@tryghost/admin-x-framework/errors';
 
 interface EditRowProps {
     label: Label;
     onSave: (id: string, name: string) => Promise<void>;
     onCancel: () => void;
     onDelete: (id: string) => Promise<void>;
-    isDuplicateName?: (name: string, excludeId?: string) => boolean;
 }
 
-export const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isDuplicateName}) => {
+export const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete}) => {
     const [name, setName] = useState(label.name);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [error, setError] = useState('');
@@ -24,28 +24,17 @@ export const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDele
         inputRef.current?.select();
     }, []);
 
-    const validate = (value: string): string => {
-        const trimmed = value.trim();
-        if (!trimmed) {
-            return 'Name is required';
-        }
-        if (isDuplicateName?.(trimmed, label.id)) {
-            return 'A label with this name already exists';
-        }
-        return '';
-    };
-
     const handleSave = async () => {
-        const validationError = validate(name);
-        if (validationError) {
-            setError(validationError);
+        if (!name.trim()) {
+            setError('Name is required');
             return;
         }
         setIsSaving(true);
         try {
             await onSave(label.id, name.trim());
             onCancel();
-        } catch {
+        } catch (saveError) {
+            setError(getErrorMessage(saveError, 'Failed to save label, please try again.'));
             setIsSaving(false);
         }
     };

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -114,9 +114,6 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                     variant="ghost"
                     onClick={async () => {
                         try {
-                            // Selection happens inside createLabel against live
-                            // state - toggling here from a pre-await snapshot
-                            // could deselect the new label
                             const newLabel = await picker.createLabel(searchInput.trim());
                             if (newLabel) {
                                 clearSearch();

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -114,11 +114,11 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                     variant="ghost"
                     onClick={async () => {
                         try {
+                            // Selection happens inside createLabel against live
+                            // state - toggling here from a pre-await snapshot
+                            // could deselect the new label
                             const newLabel = await picker.createLabel(searchInput.trim());
                             if (newLabel) {
-                                if (!values.includes(newLabel.slug)) {
-                                    picker.toggleLabel(newLabel.slug);
-                                }
                                 clearSearch();
                             }
                         } catch {
@@ -131,7 +131,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                 </Button>
             </div>
         );
-    }, [picker, values]);
+    }, [picker]);
 
     return (
         <Popover

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -12,6 +12,7 @@ import {
 import {EditRow} from './edit-row';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {canCreateLabel} from './can-create-label';
 import {useLabelPicker} from '@src/hooks/use-label-picker';
 import type {CustomRendererProps, ValueSource} from '@tryghost/shade/patterns';
 
@@ -58,7 +59,6 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
             return (
                 <EditRow
                     key={labelId}
-                    isDuplicateName={picker.isDuplicateName}
                     label={label}
                     onCancel={() => setEditingLabelId(null)}
                     onDelete={async (id) => {
@@ -102,7 +102,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
     }, [editingLabelId, picker]);
 
     const renderFooter = useCallback(({searchInput, clearSearch}: FooterRenderProps) => {
-        const showCreate = searchInput.trim() && picker.canCreateFromSearch(searchInput);
+        const showCreate = canCreateLabel(picker.labels, searchInput);
         if (!showCreate) {
             return null;
         }
@@ -113,11 +113,17 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                     disabled={picker.isCreating}
                     variant="ghost"
                     onClick={async () => {
-                        const newLabel = await picker.createLabel(searchInput.trim());
-                        if (newLabel) {
-                            picker.toggleLabel(newLabel.slug);
+                        try {
+                            const newLabel = await picker.createLabel(searchInput.trim());
+                            if (newLabel) {
+                                if (!values.includes(newLabel.slug)) {
+                                    picker.toggleLabel(newLabel.slug);
+                                }
+                                clearSearch();
+                            }
+                        } catch {
+                            // Already reported via toast - keep the typed name for retry
                         }
-                        clearSearch();
                     }}
                 >
                     <LucideIcon.Plus className="size-4" />
@@ -125,7 +131,7 @@ const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, valu
                 </Button>
             </div>
         );
-    }, [picker]);
+    }, [picker, values]);
 
     return (
         <Popover

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -103,11 +103,10 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
             return;
         }
         try {
+            // Selection happens inside onCreate against live state - toggling
+            // here from a pre-await snapshot could deselect the new label
             const newLabel = await onCreate(search.trim());
             if (newLabel) {
-                if (!selectedSlugs.includes(newLabel.slug)) {
-                    onToggle(newLabel.slug);
-                }
                 onSearchClear?.();
             }
         } catch {

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -103,8 +103,6 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
             return;
         }
         try {
-            // Selection happens inside onCreate against live state - toggling
-            // here from a pre-await snapshot could deselect the new label
             const newLabel = await onCreate(search.trim());
             if (newLabel) {
                 onSearchClear?.();

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -11,6 +11,7 @@ import {
 import {EditRow} from './edit-row';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {canCreateLabel} from './can-create-label';
 
 export interface LabelPickerProps {
     labels: Label[];
@@ -19,13 +20,11 @@ export interface LabelPickerProps {
     resolvedSelectedLabels?: Label[];
     onToggle: (slug: string) => void;
     // Creation
-    canCreateFromSearch?: (inputValue: string) => boolean;
     onCreate?: (name: string) => Promise<Label | undefined>;
     isCreating?: boolean;
     // Editing
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
-    isDuplicateName?: (name: string, excludeId?: string) => boolean;
 }
 
 // --- LabelRow: single label item with overlapping check/edit icon ---
@@ -76,8 +75,6 @@ interface LabelListItemsProps {
     onToggle: (slug: string) => void;
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
-    isDuplicateName?: (name: string, excludeId?: string) => boolean;
-    canCreateFromSearch?: (inputValue: string) => boolean;
     onCreate?: (name: string) => Promise<Label | undefined>;
     isCreating?: boolean;
     onSearchClear?: () => void;
@@ -90,8 +87,6 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
     onToggle,
     onEdit,
     onDelete,
-    isDuplicateName,
-    canCreateFromSearch,
     onCreate,
     isCreating,
     onSearchClear
@@ -101,15 +96,22 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
     const visibleLabels = normalizedSearch
         ? labels.filter(label => label.name.toLowerCase().includes(normalizedSearch))
         : labels;
-    const showCreate = !!onCreate && search.trim() && canCreateFromSearch?.(search);
+    const showCreate = !!onCreate && canCreateLabel(labels, search);
     const showEdit = !!onEdit;
     const handleCreate = async () => {
-        if (onCreate) {
+        if (!onCreate) {
+            return;
+        }
+        try {
             const newLabel = await onCreate(search.trim());
             if (newLabel) {
-                onToggle(newLabel.slug);
+                if (!selectedSlugs.includes(newLabel.slug)) {
+                    onToggle(newLabel.slug);
+                }
+                onSearchClear?.();
             }
-            onSearchClear?.();
+        } catch {
+            // Already reported via toast - keep the typed name for retry
         }
     };
 
@@ -137,7 +139,6 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
                         editingLabelId === label.id ? (
                             <EditRow
                                 key={label.id}
-                                isDuplicateName={isDuplicateName}
                                 label={label}
                                 onCancel={() => setEditingLabelId(null)}
                                 onDelete={handleDelete}
@@ -205,12 +206,10 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
     selectedSlugs,
     resolvedSelectedLabels,
     onToggle,
-    canCreateFromSearch,
     onCreate,
     isCreating,
     onEdit,
-    onDelete,
-    isDuplicateName
+    onDelete
 }) => {
     const selectedLabels = resolvedSelectedLabels || selectedSlugs
         .map(slug => labels.find(l => l.slug === slug))
@@ -218,9 +217,7 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
 
     return (
         <ComboboxPicker
-            canCreateFromSearch={canCreateFromSearch}
             isCreating={isCreating}
-            isDuplicateName={isDuplicateName}
             labels={labels}
             optionSource={optionSource}
             selectedLabels={selectedLabels}
@@ -241,12 +238,10 @@ interface ComboboxPickerProps {
     selectedLabels: Label[];
     selectedSlugs: string[];
     onToggle: (slug: string) => void;
-    canCreateFromSearch?: (inputValue: string) => boolean;
     onCreate?: (name: string) => Promise<Label | undefined>;
     isCreating?: boolean;
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
-    isDuplicateName?: (name: string, excludeId?: string) => boolean;
 }
 
 const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
@@ -255,12 +250,10 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     selectedLabels,
     selectedSlugs,
     onToggle,
-    canCreateFromSearch,
     onCreate,
     isCreating,
     onEdit,
-    onDelete,
-    isDuplicateName
+    onDelete
 }) => {
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState('');
@@ -334,9 +327,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
                         <Command shouldFilter={false}>
                             <CommandList className="max-h-64 overflow-y-auto">
                                 <LabelListItems
-                                    canCreateFromSearch={canCreateFromSearch}
                                     isCreating={isCreating}
-                                    isDuplicateName={isDuplicateName}
                                     labels={labels}
                                     search={search}
                                     selectedSlugs={selectedSlugs}

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,4 +1,4 @@
-import {APIError, ValidationError} from '@tryghost/admin-x-framework/errors';
+import {APIError} from '@tryghost/admin-x-framework/errors';
 import {Label, useCreateLabel, useDeleteLabel, useEditLabel, useFindLabelByName, useInvalidateLabels} from '@tryghost/admin-x-framework/api/labels';
 import {ValueSource} from '@tryghost/shade/patterns';
 import {useCallback, useMemo, useRef, useState} from 'react';
@@ -110,8 +110,10 @@ export function useLabelPicker({
         } catch (error) {
             // A rejected duplicate (e.g. created by another admin since the
             // list loaded) is adopted as if the create succeeded - the lookup
-            // confirms it exists
-            if (error instanceof ValidationError) {
+            // confirms it exists. Keyed on the 422 status because the
+            // ValidationError class also covers 403s, which must not be
+            // masked as a successful adoption
+            if (error instanceof APIError && error.response?.status === 422) {
                 let existing;
                 try {
                     existing = await findLabelByName(trimmed);

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -19,6 +19,8 @@ export interface UseLabelPickerResult {
     resolvedSelectedLabels: Label[];
 
     toggleLabel: (slug: string) => void;
+    // Creates the label (or adopts an existing duplicate) and selects it;
+    // failures are reported via toast and rethrown
     createLabel: (name: string) => Promise<Label | undefined>;
     editLabel: (id: string, name: string) => Promise<void>;
     deleteLabel: (id: string) => Promise<void>;
@@ -58,7 +60,11 @@ export function useLabelPicker({
         onSearchChange: setSearchValue
     };
 
-    const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
+    const {mutateAsync: createLabelMutation} = useCreateLabel();
+    // Local state rather than the mutation's isLoading so it also covers the
+    // duplicate-adoption lookup - the create action stays disabled until the
+    // whole operation settles
+    const [isCreating, setIsCreating] = useState(false);
     const {mutateAsync: editLabelMutation} = useEditLabel();
     const {mutateAsync: deleteLabelMutation} = useDeleteLabel();
     const findLabelByName = useFindLabelByName();
@@ -79,14 +85,28 @@ export function useLabelPicker({
         }
     }, [onSelectionChange]);
 
+    // Idempotent, unlike toggleLabel: selecting after an await must not
+    // deselect a label that became selected while the request was in flight
+    const selectLabel = useCallback((slug: string) => {
+        const current = selectedSlugsRef.current;
+        if (!current.includes(slug)) {
+            onSelectionChange([...current, slug]);
+        }
+    }, [onSelectionChange]);
+
     const createLabel = useCallback(async (name: string): Promise<Label | undefined> => {
         const trimmed = name.trim();
         if (!trimmed) {
             return undefined;
         }
+        setIsCreating(true);
         try {
             const result = await createLabelMutation({name: trimmed});
-            return result?.labels?.[0];
+            const created = result?.labels?.[0];
+            if (created) {
+                selectLabel(created.slug);
+            }
+            return created;
         } catch (error) {
             // A rejected duplicate (e.g. created by another admin since the
             // list loaded) is adopted as if the create succeeded - the lookup
@@ -100,13 +120,16 @@ export function useLabelPicker({
                 }
                 if (existing) {
                     invalidateLabels();
+                    selectLabel(existing.slug);
                     return existing;
                 }
             }
             handleError(error);
             throw error;
+        } finally {
+            setIsCreating(false);
         }
-    }, [createLabelMutation, findLabelByName, handleError, invalidateLabels]);
+    }, [createLabelMutation, findLabelByName, handleError, invalidateLabels, selectLabel]);
 
     const editLabel = useCallback(async (id: string, name: string) => {
         const trimmed = name.trim();

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,6 +1,8 @@
-import {Label, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
+import {APIError, ValidationError} from '@tryghost/admin-x-framework/errors';
+import {Label, useCreateLabel, useDeleteLabel, useEditLabel, useFindLabelByName, useInvalidateLabels} from '@tryghost/admin-x-framework/api/labels';
 import {ValueSource} from '@tryghost/shade/patterns';
 import {useCallback, useMemo, useRef, useState} from 'react';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useLabelValueSource} from './filter-sources/use-label-value-source';
 import type {ComboboxOptionSource} from '@tryghost/shade/components';
 
@@ -20,8 +22,6 @@ export interface UseLabelPickerResult {
     createLabel: (name: string) => Promise<Label | undefined>;
     editLabel: (id: string, name: string) => Promise<void>;
     deleteLabel: (id: string) => Promise<void>;
-    isDuplicateName: (name: string, excludeId?: string) => boolean;
-    canCreateFromSearch: (inputValue: string) => boolean;
     isCreating: boolean;
 }
 
@@ -61,6 +61,9 @@ export function useLabelPicker({
     const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
     const {mutateAsync: editLabelMutation} = useEditLabel();
     const {mutateAsync: deleteLabelMutation} = useDeleteLabel();
+    const findLabelByName = useFindLabelByName();
+    const invalidateLabels = useInvalidateLabels();
+    const handleError = useHandleError();
 
     // Ref to always read the latest selectedSlugs in callbacks,
     // avoiding stale closures and keeping callbacks stable
@@ -76,32 +79,38 @@ export function useLabelPicker({
         }
     }, [onSelectionChange]);
 
-    const isDuplicateName = useCallback((name: string, excludeId?: string) => {
-        const normalized = name.trim().toLowerCase();
-        return labels.some(l => l.name.toLowerCase() === normalized && l.id !== excludeId);
-    }, [labels]);
-
-    const canCreateFromSearch = useCallback((inputValue: string) => {
-        const trimmed = inputValue.trim();
-        if (!trimmed) {
-            return false;
-        }
-        return !isDuplicateName(trimmed);
-    }, [isDuplicateName]);
-
     const createLabel = useCallback(async (name: string): Promise<Label | undefined> => {
         const trimmed = name.trim();
-        if (!trimmed || isDuplicateName(trimmed)) {
+        if (!trimmed) {
             return undefined;
         }
-        const result = await createLabelMutation({name: trimmed});
-        const newLabel = result?.labels?.[0];
-        return newLabel;
-    }, [createLabelMutation, isDuplicateName]);
+        try {
+            const result = await createLabelMutation({name: trimmed});
+            return result?.labels?.[0];
+        } catch (error) {
+            // A rejected duplicate (e.g. created by another admin since the
+            // list loaded) is adopted as if the create succeeded - the lookup
+            // confirms it exists
+            if (error instanceof ValidationError) {
+                let existing;
+                try {
+                    existing = await findLabelByName(trimmed);
+                } catch {
+                    // report the original rejection below
+                }
+                if (existing) {
+                    invalidateLabels();
+                    return existing;
+                }
+            }
+            handleError(error);
+            throw error;
+        }
+    }, [createLabelMutation, findLabelByName, handleError, invalidateLabels]);
 
     const editLabel = useCallback(async (id: string, name: string) => {
         const trimmed = name.trim();
-        if (!trimmed || isDuplicateName(trimmed, id)) {
+        if (!trimmed) {
             return;
         }
         const oldLabel = labels.find(l => l.id === id);
@@ -114,18 +123,30 @@ export function useLabelPicker({
                 onSelectionChange(current.map(s => (s === oldLabel.slug ? updatedLabel.slug : s)));
             }
         }
-    }, [editLabelMutation, isDuplicateName, labels, onSelectionChange]);
+    }, [editLabelMutation, labels, onSelectionChange]);
 
     const deleteLabel = useCallback(async (id: string) => {
         const label = labels.find(l => l.id === id);
-        await deleteLabelMutation(id);
+        try {
+            await deleteLabelMutation(id);
+        } catch (error) {
+            // A label that is already gone fulfils the delete; anything else
+            // is unexpected, so report it and rethrow for the edit row to
+            // reset its state
+            if (error instanceof APIError && error.response?.status === 404) {
+                invalidateLabels();
+            } else {
+                handleError(error);
+                throw error;
+            }
+        }
         if (label) {
             const current = selectedSlugsRef.current;
             if (current.includes(label.slug)) {
                 onSelectionChange(current.filter(s => s !== label.slug));
             }
         }
-    }, [deleteLabelMutation, labels, onSelectionChange]);
+    }, [deleteLabelMutation, handleError, invalidateLabels, labels, onSelectionChange]);
 
     return {
         labels,
@@ -138,8 +159,6 @@ export function useLabelPicker({
         createLabel,
         editLabel,
         deleteLabel,
-        isDuplicateName,
-        canCreateFromSearch,
         isCreating
     };
 }

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -19,8 +19,7 @@ export interface UseLabelPickerResult {
     resolvedSelectedLabels: Label[];
 
     toggleLabel: (slug: string) => void;
-    // Creates the label (or adopts an existing duplicate) and selects it;
-    // failures are reported via toast and rethrown
+    // Creates or adopts the label and selects it; failures are reported and rethrown
     createLabel: (name: string) => Promise<Label | undefined>;
     editLabel: (id: string, name: string) => Promise<void>;
     deleteLabel: (id: string) => Promise<void>;
@@ -61,9 +60,7 @@ export function useLabelPicker({
     };
 
     const {mutateAsync: createLabelMutation} = useCreateLabel();
-    // Local state rather than the mutation's isLoading so it also covers the
-    // duplicate-adoption lookup - the create action stays disabled until the
-    // whole operation settles
+    // Unlike the mutation's isLoading, this also covers the adoption lookup
     const [isCreating, setIsCreating] = useState(false);
     const {mutateAsync: editLabelMutation} = useEditLabel();
     const {mutateAsync: deleteLabelMutation} = useDeleteLabel();
@@ -85,8 +82,8 @@ export function useLabelPicker({
         }
     }, [onSelectionChange]);
 
-    // Idempotent, unlike toggleLabel: selecting after an await must not
-    // deselect a label that became selected while the request was in flight
+    // Idempotent, unlike toggleLabel - selecting after an await must not
+    // deselect a label that was picked while the request was in flight
     const selectLabel = useCallback((slug: string) => {
         const current = selectedSlugsRef.current;
         if (!current.includes(slug)) {
@@ -109,10 +106,8 @@ export function useLabelPicker({
             return created;
         } catch (error) {
             // A rejected duplicate (e.g. created by another admin since the
-            // list loaded) is adopted as if the create succeeded - the lookup
-            // confirms it exists. Keyed on the 422 status because the
-            // ValidationError class also covers 403s, which must not be
-            // masked as a successful adoption
+            // list loaded) is adopted as if the create succeeded. Keyed on
+            // 422 because the ValidationError class also covers 403s
             if (error instanceof APIError && error.response?.status === 422) {
                 let existing;
                 try {

--- a/apps/posts/src/views/filters/filter-normalization.ts
+++ b/apps/posts/src/views/filters/filter-normalization.ts
@@ -1,8 +1,6 @@
 import {Temporal} from 'temporal-polyfill';
 
-export function escapeNqlString(value: string): string {
-    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')}'`;
-}
+export {escapeNqlString} from '@tryghost/admin-x-framework/utils/nql';
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 const LEGACY_UTC_DATE_TIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?$/;

--- a/apps/posts/src/views/members/components/bulk-action-modals/add-label-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/add-label-modal.tsx
@@ -52,9 +52,7 @@ export function AddLabelModal({
                 </DialogHeader>
 
                 <LabelPicker
-                    canCreateFromSearch={picker.canCreateFromSearch}
                     isCreating={picker.isCreating}
-                    isDuplicateName={picker.isDuplicateName}
                     labels={picker.labels}
                     optionSource={picker.optionSource}
                     resolvedSelectedLabels={picker.resolvedSelectedLabels}

--- a/apps/posts/src/views/members/components/bulk-action-modals/import-members/components/mapping-step.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/import-members/components/mapping-step.tsx
@@ -163,9 +163,7 @@ export function MappingStep({
                         <div className="mt-5">
                             <label className="mb-1 block text-sm font-semibold">Label these members</label>
                             <LabelPicker
-                                canCreateFromSearch={labelPicker.canCreateFromSearch}
                                 isCreating={labelPicker.isCreating}
-                                isDuplicateName={labelPicker.isDuplicateName}
                                 labels={labelPicker.labels}
                                 optionSource={labelPicker.optionSource}
                                 resolvedSelectedLabels={labelPicker.resolvedSelectedLabels}

--- a/apps/posts/src/views/members/components/bulk-action-modals/remove-label-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/remove-label-modal.tsx
@@ -85,7 +85,6 @@ export function RemoveLabelModal({
                 </DialogHeader>
 
                 <LabelPicker
-                    isDuplicateName={picker.isDuplicateName}
                     labels={picker.labels.filter(label => memberLabelSlugs.has(label.slug))}
                     optionSource={{
                         ...availableOptionSource,

--- a/apps/posts/src/views/members/hooks/resource-search-filter.test.ts
+++ b/apps/posts/src/views/members/hooks/resource-search-filter.test.ts
@@ -7,7 +7,8 @@ describe('resource-search-filter', () => {
         expect(buildResourceFilter('status:published', '')).toBe('status:published');
     });
 
-    it('escapes trailing backslashes in search queries', () => {
-        expect(buildResourceFilter('status:published', 'draft\\')).toBe('status:published+title:~\'draft\\\\\'');
+    it('keeps trailing backslashes literal in search queries', () => {
+        // NQL has no \\ escape - a lone backslash is a literal character
+        expect(buildResourceFilter('status:published', 'draft\\')).toBe(String.raw`status:published+title:~'draft\'`);
     });
 });

--- a/apps/posts/test/unit/components/label-picker/can-create-label.test.ts
+++ b/apps/posts/test/unit/components/label-picker/can-create-label.test.ts
@@ -1,0 +1,21 @@
+import {canCreateLabel} from '@src/components/label-picker/can-create-label';
+import {describe, expect, it} from 'vitest';
+
+const labels = [{id: '1', name: 'Existing Label', slug: 'existing-label', created_at: '', updated_at: ''}];
+
+describe('canCreateLabel', () => {
+    it('hides create for an exact match regardless of case and surrounding whitespace', () => {
+        expect(canCreateLabel(labels, 'existing label')).toBe(false);
+        expect(canCreateLabel(labels, '  Existing Label  ')).toBe(false);
+    });
+
+    it('allows create for partial matches and new names', () => {
+        expect(canCreateLabel(labels, 'Existing')).toBe(true);
+        expect(canCreateLabel(labels, 'New Label')).toBe(true);
+    });
+
+    it('disallows create for empty input', () => {
+        expect(canCreateLabel(labels, '   ')).toBe(false);
+        expect(canCreateLabel([], '')).toBe(false);
+    });
+});

--- a/apps/posts/test/unit/components/label-picker/edit-row.test.tsx
+++ b/apps/posts/test/unit/components/label-picker/edit-row.test.tsx
@@ -1,0 +1,102 @@
+import {EditRow} from '@src/components/label-picker/edit-row';
+import {ErrorResponse, ValidationError} from '@tryghost/admin-x-framework/errors';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import type {ComponentProps} from 'react';
+
+const label = {
+    id: '1',
+    name: 'Existing',
+    slug: 'existing',
+    created_at: '',
+    updated_at: ''
+};
+
+function makeValidationError(context: string) {
+    const data: ErrorResponse = {
+        errors: [{
+            code: 'VALIDATION',
+            context,
+            details: null,
+            ghostErrorCode: null,
+            help: '',
+            id: 'error-id',
+            message: 'Validation error, cannot edit label.',
+            property: null,
+            type: 'ValidationError'
+        }]
+    };
+    return new ValidationError({url: '', status: 422} as unknown as Response, data);
+}
+
+function renderEditRow(overrides: Partial<ComponentProps<typeof EditRow>> = {}) {
+    const props = {
+        label,
+        onSave: vi.fn().mockResolvedValue(undefined),
+        onCancel: vi.fn(),
+        onDelete: vi.fn().mockResolvedValue(undefined),
+        ...overrides
+    };
+    render(<EditRow {...props} />);
+    return props;
+}
+
+describe('EditRow', () => {
+    it('closes the row after a successful save', async () => {
+        const {onSave, onCancel} = renderEditRow();
+
+        fireEvent.change(screen.getByRole('textbox'), {target: {value: 'Renamed'}});
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        await waitFor(() => expect(onCancel).toHaveBeenCalled());
+        expect(onSave).toHaveBeenCalledWith('1', 'Renamed');
+    });
+
+    it('shows the server validation message inline when the save is rejected', async () => {
+        const {onCancel} = renderEditRow({
+            onSave: vi.fn().mockRejectedValue(makeValidationError('Label already exists'))
+        });
+
+        fireEvent.change(screen.getByRole('textbox'), {target: {value: 'Duplicate beyond first page'}});
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(await screen.findByText('Label already exists')).toBeInTheDocument();
+        // The row stays open so the user can fix the name
+        expect(onCancel).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', {name: 'Save'})).toBeEnabled();
+    });
+
+    it('shows a generic message when the save fails unexpectedly', async () => {
+        renderEditRow({
+            onSave: vi.fn().mockRejectedValue(new Error('Network down'))
+        });
+
+        fireEvent.change(screen.getByRole('textbox'), {target: {value: 'Renamed'}});
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(await screen.findByText('Failed to save label, please try again.')).toBeInTheDocument();
+    });
+
+    it('clears the error when the name is changed', async () => {
+        renderEditRow({
+            onSave: vi.fn().mockRejectedValue(makeValidationError('Label already exists'))
+        });
+
+        fireEvent.change(screen.getByRole('textbox'), {target: {value: 'Duplicate'}});
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+        await screen.findByText('Label already exists');
+
+        fireEvent.change(screen.getByRole('textbox'), {target: {value: 'Duplicate 2'}});
+
+        expect(screen.queryByText('Label already exists')).not.toBeInTheDocument();
+    });
+
+    it('requires a name without calling onSave', async () => {
+        const {onSave} = renderEditRow();
+
+        fireEvent.change(screen.getByRole('textbox'), {target: {value: '   '}});
+        fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(await screen.findByText('Name is required')).toBeInTheDocument();
+        expect(onSave).not.toHaveBeenCalled();
+    });
+});

--- a/apps/posts/test/unit/components/label-picker/label-filter-renderer.test.tsx
+++ b/apps/posts/test/unit/components/label-picker/label-filter-renderer.test.tsx
@@ -53,7 +53,7 @@ function renderFilterAndSearch(searchText: string, values: string[] = []) {
 }
 
 describe('LabelFilterRenderer', () => {
-    it('toggles the new label and clears the search after a successful create', async () => {
+    it('clears the search after a successful create without re-toggling the selection', async () => {
         const picker = makePicker({
             createLabel: vi.fn().mockResolvedValue({
                 id: '1',
@@ -67,8 +67,10 @@ describe('LabelFilterRenderer', () => {
         const searchInput = renderFilterAndSearch('New Label');
         fireEvent.click(screen.getByRole('button', {name: 'Create "New Label"'}));
 
-        await waitFor(() => expect(picker.toggleLabel).toHaveBeenCalledWith('new-label'));
-        expect(picker.createLabel).toHaveBeenCalledWith('New Label');
+        await waitFor(() => expect(picker.createLabel).toHaveBeenCalledWith('New Label'));
+        // Selection happens inside createLabel - toggling here too could
+        // deselect the label if the selection changed during the request
+        expect(picker.toggleLabel).not.toHaveBeenCalled();
         expect(searchInput).toHaveValue('');
     });
 

--- a/apps/posts/test/unit/components/label-picker/label-filter-renderer.test.tsx
+++ b/apps/posts/test/unit/components/label-picker/label-filter-renderer.test.tsx
@@ -1,0 +1,116 @@
+import LabelFilterRenderer from '@src/components/label-picker/label-filter-renderer';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {useLabelPicker} from '@src/hooks/use-label-picker';
+import type {CustomRendererProps} from '@tryghost/shade/patterns';
+
+vi.mock('@src/hooks/use-label-picker', () => ({
+    useLabelPicker: vi.fn()
+}));
+
+const mockUseLabelPicker = vi.mocked(useLabelPicker);
+
+// cmdk scrolls the selected item into view, which jsdom doesn't implement
+Element.prototype.scrollIntoView = () => {};
+
+function makePicker(overrides: Partial<ReturnType<typeof useLabelPicker>> = {}) {
+    const picker: ReturnType<typeof useLabelPicker> = {
+        labels: [],
+        optionSource: {
+            options: [],
+            isInitialLoad: false,
+            isSearching: false,
+            isLoadingMore: false,
+            hasMore: false,
+            loadMore: vi.fn(),
+            shouldClientFilter: false,
+            onSearchChange: vi.fn()
+        },
+        selectedSlugs: [],
+        resolvedSelectedLabels: [],
+        toggleLabel: vi.fn(),
+        createLabel: vi.fn().mockResolvedValue(undefined),
+        editLabel: vi.fn().mockResolvedValue(undefined),
+        deleteLabel: vi.fn().mockResolvedValue(undefined),
+        isCreating: false,
+        ...overrides
+    };
+    mockUseLabelPicker.mockReturnValue(picker);
+    return picker;
+}
+
+function renderFilterAndSearch(searchText: string, values: string[] = []) {
+    const props = {
+        field: {valueSource: undefined},
+        values,
+        onChange: vi.fn()
+    } as unknown as CustomRendererProps<string>;
+    render(<LabelFilterRenderer {...props} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Select...'}));
+    const searchInput = screen.getByPlaceholderText('Search labels...');
+    fireEvent.change(searchInput, {target: {value: searchText}});
+    return searchInput;
+}
+
+describe('LabelFilterRenderer', () => {
+    it('toggles the new label and clears the search after a successful create', async () => {
+        const picker = makePicker({
+            createLabel: vi.fn().mockResolvedValue({
+                id: '1',
+                name: 'New Label',
+                slug: 'new-label',
+                created_at: '',
+                updated_at: ''
+            })
+        });
+
+        const searchInput = renderFilterAndSearch('New Label');
+        fireEvent.click(screen.getByRole('button', {name: 'Create "New Label"'}));
+
+        await waitFor(() => expect(picker.toggleLabel).toHaveBeenCalledWith('new-label'));
+        expect(picker.createLabel).toHaveBeenCalledWith('New Label');
+        expect(searchInput).toHaveValue('');
+    });
+
+    it('keeps the typed name when creation fails', async () => {
+        const picker = makePicker({
+            createLabel: vi.fn().mockRejectedValue(new Error('Label already exists'))
+        });
+
+        const searchInput = renderFilterAndSearch('Duplicate beyond first page');
+        fireEvent.click(screen.getByRole('button', {name: 'Create "Duplicate beyond first page"'}));
+
+        await waitFor(() => expect(picker.createLabel).toHaveBeenCalledWith('Duplicate beyond first page'));
+        expect(picker.toggleLabel).not.toHaveBeenCalled();
+        expect(searchInput).toHaveValue('Duplicate beyond first page');
+    });
+
+    it('does not deselect an adopted label that is already selected', async () => {
+        const picker = makePicker({
+            createLabel: vi.fn().mockResolvedValue({
+                id: '1',
+                name: 'Adopted Label',
+                slug: 'adopted-label',
+                created_at: '',
+                updated_at: ''
+            })
+        });
+
+        const searchInput = renderFilterAndSearch('Adopted Label', ['adopted-label']);
+        fireEvent.click(screen.getByRole('button', {name: 'Create "Adopted Label"'}));
+
+        await waitFor(() => expect(picker.createLabel).toHaveBeenCalledWith('Adopted Label'));
+        expect(picker.toggleLabel).not.toHaveBeenCalled();
+        expect(searchInput).toHaveValue('');
+    });
+
+    it('hides the create action when an exact match is already loaded', () => {
+        makePicker({
+            labels: [{id: '1', name: 'Existing-Label', slug: 'existing-label', created_at: '', updated_at: ''}]
+        });
+
+        renderFilterAndSearch('existing-label');
+
+        expect(screen.queryByRole('button', {name: 'Create "existing-label"'})).not.toBeInTheDocument();
+    });
+});

--- a/apps/posts/test/unit/hooks/use-label-picker.test.tsx
+++ b/apps/posts/test/unit/hooks/use-label-picker.test.tsx
@@ -16,7 +16,7 @@ const {mockCreateLabel, mockEditLabel, mockDeleteLabel, mockFindLabelByName, moc
 // These mocks bypass the framework mutations' error reporting, so the tests
 // cover only the hook's own contract: what resolves, rejects, and adopts
 vi.mock('@tryghost/admin-x-framework/api/labels', () => ({
-    useCreateLabel: () => ({mutateAsync: mockCreateLabel, isLoading: false}),
+    useCreateLabel: () => ({mutateAsync: mockCreateLabel}),
     useEditLabel: () => ({mutateAsync: mockEditLabel}),
     useDeleteLabel: () => ({mutateAsync: mockDeleteLabel}),
     useFindLabelByName: () => mockFindLabelByName,
@@ -100,11 +100,12 @@ describe('useLabelPicker', () => {
     });
 
     describe('createLabel', () => {
-        it('returns the created label on success', async () => {
+        it('returns and selects the created label on success', async () => {
             const newLabel = {id: '2', name: 'New', slug: 'new', created_at: '', updated_at: ''};
             mockCreateLabel.mockResolvedValue({labels: [newLabel]});
+            const onSelectionChange = vi.fn();
 
-            const {result} = renderLabelPicker();
+            const {result} = renderLabelPicker({onSelectionChange});
 
             let created;
             await act(async () => {
@@ -112,14 +113,16 @@ describe('useLabelPicker', () => {
             });
 
             expect(created).toEqual(newLabel);
+            expect(onSelectionChange).toHaveBeenCalledWith(['new']);
         });
 
-        it('adopts the existing label when the API rejects a duplicate', async () => {
+        it('adopts and selects the existing label when the API rejects a duplicate', async () => {
             const existing = {id: '9', name: 'Duplicate', slug: 'duplicate', created_at: '', updated_at: ''};
             mockCreateLabel.mockRejectedValue(makeValidationError('Label already exists'));
             mockFindLabelByName.mockResolvedValue(existing);
+            const onSelectionChange = vi.fn();
 
-            const {result} = renderLabelPicker();
+            const {result} = renderLabelPicker({onSelectionChange});
 
             let created;
             await act(async () => {
@@ -127,8 +130,57 @@ describe('useLabelPicker', () => {
             });
 
             expect(created).toEqual(existing);
+            expect(onSelectionChange).toHaveBeenCalledWith(['duplicate']);
             expect(mockInvalidateLabels).toHaveBeenCalled();
             expect(mockHandleError).not.toHaveBeenCalled();
+        });
+
+        it('does not deselect an adopted label that is already selected', async () => {
+            const existing = {id: '9', name: 'Duplicate', slug: 'duplicate', created_at: '', updated_at: ''};
+            mockCreateLabel.mockRejectedValue(makeValidationError('Label already exists'));
+            mockFindLabelByName.mockResolvedValue(existing);
+            const onSelectionChange = vi.fn();
+
+            const {result} = renderLabelPicker({
+                labels: [{id: '9', name: 'Duplicate', slug: 'duplicate'}],
+                selectedSlugs: ['duplicate'],
+                onSelectionChange
+            });
+
+            await act(async () => {
+                await result.current.createLabel('Duplicate');
+            });
+
+            expect(onSelectionChange).not.toHaveBeenCalled();
+        });
+
+        it('stays creating while the duplicate adoption lookup is in flight', async () => {
+            const existing = {id: '9', name: 'Duplicate', slug: 'duplicate', created_at: '', updated_at: ''};
+            mockCreateLabel.mockRejectedValue(makeValidationError('Label already exists'));
+            let resolveLookup!: (label: typeof existing) => void;
+            mockFindLabelByName.mockImplementation(() => new Promise((resolve) => {
+                resolveLookup = resolve;
+            }));
+
+            const {result} = renderLabelPicker();
+
+            let createPromise!: Promise<unknown>;
+            await act(async () => {
+                createPromise = result.current.createLabel('Duplicate');
+                // Let the create rejection propagate to the adoption lookup
+                await Promise.resolve();
+            });
+
+            // The create action must stay disabled until the lookup settles,
+            // otherwise a second create can race the first and deselect it
+            expect(result.current.isCreating).toBe(true);
+
+            await act(async () => {
+                resolveLookup(existing);
+                await createPromise;
+            });
+
+            expect(result.current.isCreating).toBe(false);
         });
 
         it('reports the original rejection when the duplicate lookup fails', async () => {

--- a/apps/posts/test/unit/hooks/use-label-picker.test.tsx
+++ b/apps/posts/test/unit/hooks/use-label-picker.test.tsx
@@ -1,0 +1,273 @@
+import {APIError, ErrorResponse, ValidationError} from '@tryghost/admin-x-framework/errors';
+import {act, renderHook} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {useLabelPicker} from '@src/hooks/use-label-picker';
+import type {ValueSource} from '@tryghost/shade/patterns';
+
+const {mockCreateLabel, mockEditLabel, mockDeleteLabel, mockFindLabelByName, mockInvalidateLabels, mockHandleError} = vi.hoisted(() => ({
+    mockCreateLabel: vi.fn(),
+    mockEditLabel: vi.fn(),
+    mockDeleteLabel: vi.fn(),
+    mockFindLabelByName: vi.fn(),
+    mockInvalidateLabels: vi.fn(),
+    mockHandleError: vi.fn()
+}));
+
+// These mocks bypass the framework mutations' error reporting, so the tests
+// cover only the hook's own contract: what resolves, rejects, and adopts
+vi.mock('@tryghost/admin-x-framework/api/labels', () => ({
+    useCreateLabel: () => ({mutateAsync: mockCreateLabel, isLoading: false}),
+    useEditLabel: () => ({mutateAsync: mockEditLabel}),
+    useDeleteLabel: () => ({mutateAsync: mockDeleteLabel}),
+    useFindLabelByName: () => mockFindLabelByName,
+    useInvalidateLabels: () => mockInvalidateLabels
+}));
+
+vi.mock('@tryghost/admin-x-framework/hooks', () => ({
+    useHandleError: () => mockHandleError
+}));
+
+vi.mock('@src/hooks/filter-sources/use-label-value-source', () => ({
+    useLabelValueSource: () => ({
+        id: 'test.labels.default',
+        useOptions: () => ({
+            options: [],
+            isInitialLoad: false,
+            isSearching: false,
+            isLoadingMore: false,
+            hasMore: false,
+            loadMore: () => {}
+        })
+    })
+}));
+
+type TestLabel = {id: string; name: string; slug: string};
+
+function makeValidationError(context: string) {
+    const data: ErrorResponse = {
+        errors: [{
+            code: 'VALIDATION',
+            context,
+            details: null,
+            ghostErrorCode: null,
+            help: '',
+            id: 'error-id',
+            message: 'Validation error, cannot save label.',
+            property: null,
+            type: 'ValidationError'
+        }]
+    };
+    return new ValidationError({url: '', status: 422} as unknown as Response, data);
+}
+
+function makeValueSource(labels: TestLabel[]): ValueSource<string> {
+    return {
+        id: 'test.labels',
+        useOptions: () => ({
+            options: labels.map(label => ({
+                value: label.slug,
+                label: label.name,
+                metadata: {id: label.id}
+            })),
+            isInitialLoad: false,
+            isSearching: false,
+            isLoadingMore: false,
+            hasMore: false,
+            loadMore: () => {}
+        })
+    };
+}
+
+function renderLabelPicker({
+    labels = [{id: '1', name: 'Existing', slug: 'existing'}],
+    selectedSlugs = [],
+    onSelectionChange = vi.fn()
+}: {
+    labels?: TestLabel[];
+    selectedSlugs?: string[];
+    onSelectionChange?: (slugs: string[]) => void;
+} = {}) {
+    return renderHook(() => useLabelPicker({
+        selectedSlugs,
+        onSelectionChange,
+        valueSource: makeValueSource(labels)
+    }));
+}
+
+describe('useLabelPicker', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('createLabel', () => {
+        it('returns the created label on success', async () => {
+            const newLabel = {id: '2', name: 'New', slug: 'new', created_at: '', updated_at: ''};
+            mockCreateLabel.mockResolvedValue({labels: [newLabel]});
+
+            const {result} = renderLabelPicker();
+
+            let created;
+            await act(async () => {
+                created = await result.current.createLabel('New');
+            });
+
+            expect(created).toEqual(newLabel);
+        });
+
+        it('adopts the existing label when the API rejects a duplicate', async () => {
+            const existing = {id: '9', name: 'Duplicate', slug: 'duplicate', created_at: '', updated_at: ''};
+            mockCreateLabel.mockRejectedValue(makeValidationError('Label already exists'));
+            mockFindLabelByName.mockResolvedValue(existing);
+
+            const {result} = renderLabelPicker();
+
+            let created;
+            await act(async () => {
+                created = await result.current.createLabel('Duplicate');
+            });
+
+            expect(created).toEqual(existing);
+            expect(mockInvalidateLabels).toHaveBeenCalled();
+            expect(mockHandleError).not.toHaveBeenCalled();
+        });
+
+        it('reports the original rejection when the duplicate lookup fails', async () => {
+            const validationError = makeValidationError('Label already exists');
+            mockCreateLabel.mockRejectedValue(validationError);
+            mockFindLabelByName.mockRejectedValue(new Error('Lookup failed'));
+
+            const {result} = renderLabelPicker();
+
+            await act(async () => {
+                await expect(result.current.createLabel('Duplicate')).rejects.toBe(validationError);
+            });
+
+            expect(mockHandleError).toHaveBeenCalledWith(validationError);
+        });
+
+        it('reports and rethrows validation errors with no matching label', async () => {
+            const validationError = makeValidationError('Name is too long');
+            mockCreateLabel.mockRejectedValue(validationError);
+            mockFindLabelByName.mockResolvedValue(undefined);
+
+            const {result} = renderLabelPicker();
+
+            await act(async () => {
+                await expect(result.current.createLabel('Rejected name')).rejects.toBe(validationError);
+            });
+
+            expect(mockHandleError).toHaveBeenCalledWith(validationError);
+        });
+
+        it('reports and rethrows non-validation errors without a lookup', async () => {
+            const serverError = new Error('Network down');
+            mockCreateLabel.mockRejectedValue(serverError);
+
+            const {result} = renderLabelPicker();
+
+            await act(async () => {
+                await expect(result.current.createLabel('New label')).rejects.toBe(serverError);
+            });
+
+            expect(mockFindLabelByName).not.toHaveBeenCalled();
+            expect(mockHandleError).toHaveBeenCalledWith(serverError);
+        });
+
+        it('skips the request for empty names', async () => {
+            const {result} = renderLabelPicker();
+
+            let created;
+            await act(async () => {
+                created = await result.current.createLabel('   ');
+            });
+
+            expect(created).toBeUndefined();
+            expect(mockCreateLabel).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('editLabel', () => {
+        it('rethrows server errors', async () => {
+            const serverError = new Error('Label already exists');
+            mockEditLabel.mockRejectedValue(serverError);
+
+            const {result} = renderLabelPicker();
+
+            await act(async () => {
+                await expect(result.current.editLabel('1', 'Renamed')).rejects.toBe(serverError);
+            });
+        });
+
+        it('swaps the selected slug when an edit changes it', async () => {
+            const onSelectionChange = vi.fn();
+            mockEditLabel.mockResolvedValue({
+                labels: [{id: '1', name: 'Renamed', slug: 'renamed', created_at: '', updated_at: ''}]
+            });
+
+            const {result} = renderLabelPicker({
+                selectedSlugs: ['existing'],
+                onSelectionChange
+            });
+
+            await act(async () => {
+                await result.current.editLabel('1', 'Renamed');
+            });
+
+            expect(onSelectionChange).toHaveBeenCalledWith(['renamed']);
+        });
+    });
+
+    describe('deleteLabel', () => {
+        it('rethrows server errors and keeps the selection', async () => {
+            const serverError = new Error('Cannot delete label');
+            mockDeleteLabel.mockRejectedValue(serverError);
+            const onSelectionChange = vi.fn();
+
+            const {result} = renderLabelPicker({
+                selectedSlugs: ['existing'],
+                onSelectionChange
+            });
+
+            await act(async () => {
+                await expect(result.current.deleteLabel('1')).rejects.toBe(serverError);
+            });
+
+            expect(mockHandleError).toHaveBeenCalledWith(serverError);
+            expect(onSelectionChange).not.toHaveBeenCalled();
+        });
+
+        it('treats an already-deleted label as deleted', async () => {
+            const notFound = new APIError({status: 404, url: ''} as unknown as Response);
+            mockDeleteLabel.mockRejectedValue(notFound);
+            const onSelectionChange = vi.fn();
+
+            const {result} = renderLabelPicker({
+                selectedSlugs: ['existing'],
+                onSelectionChange
+            });
+
+            await act(async () => {
+                await result.current.deleteLabel('1');
+            });
+
+            expect(mockInvalidateLabels).toHaveBeenCalled();
+            expect(onSelectionChange).toHaveBeenCalledWith([]);
+        });
+
+        it('removes the deleted label from the selection on success', async () => {
+            mockDeleteLabel.mockResolvedValue(undefined);
+            const onSelectionChange = vi.fn();
+
+            const {result} = renderLabelPicker({
+                selectedSlugs: ['existing'],
+                onSelectionChange
+            });
+
+            await act(async () => {
+                await result.current.deleteLabel('1');
+            });
+
+            expect(onSelectionChange).toHaveBeenCalledWith([]);
+        });
+    });
+});

--- a/apps/posts/test/unit/hooks/use-label-picker.test.tsx
+++ b/apps/posts/test/unit/hooks/use-label-picker.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@src/hooks/filter-sources/use-label-value-source', () => ({
 
 type TestLabel = {id: string; name: string; slug: string};
 
-function makeValidationError(context: string) {
+function makeValidationError(context: string, status = 422) {
     const data: ErrorResponse = {
         errors: [{
             code: 'VALIDATION',
@@ -57,7 +57,7 @@ function makeValidationError(context: string) {
             type: 'ValidationError'
         }]
     };
-    return new ValidationError({url: '', status: 422} as unknown as Response, data);
+    return new ValidationError({url: '', status} as unknown as Response, data);
 }
 
 function makeValueSource(labels: TestLabel[]): ValueSource<string> {
@@ -209,6 +209,23 @@ describe('useLabelPicker', () => {
             });
 
             expect(mockHandleError).toHaveBeenCalledWith(validationError);
+        });
+
+        it('does not adopt on permission errors even though they share the ValidationError class', async () => {
+            // handle-response maps server NoPermissionError (403) responses to
+            // the ValidationError class - a denied create must not be masked
+            // as a successful adoption of the existing label
+            const permissionError = makeValidationError('You do not have permission', 403);
+            mockCreateLabel.mockRejectedValue(permissionError);
+
+            const {result} = renderLabelPicker();
+
+            await act(async () => {
+                await expect(result.current.createLabel('Existing')).rejects.toBe(permissionError);
+            });
+
+            expect(mockFindLabelByName).not.toHaveBeenCalled();
+            expect(mockHandleError).toHaveBeenCalledWith(permissionError);
         });
 
         it('reports and rethrows non-validation errors without a lookup', async () => {

--- a/apps/posts/test/unit/utils/filter-normalization.test.ts
+++ b/apps/posts/test/unit/utils/filter-normalization.test.ts
@@ -6,8 +6,10 @@ describe('filter-normalization', () => {
         expect(escapeNqlString('can\'t stop')).toBe('\'can\\\'t stop\'');
     });
 
-    it('escapes backslashes before single quotes for NQL strings', () => {
-        expect(escapeNqlString('test\\\'value')).toBe('\'test\\\\\\\'value\'');
+    it('keeps backslashes literal for NQL strings', () => {
+        // NQL only unescapes \' and \" - lone backslashes are literal
+        // characters, so doubling them would query a different value
+        expect(escapeNqlString('test\\\'value')).toBe(String.raw`'test\\'value'`);
     });
 
     it('computes UTC day bounds from a site timezone date', () => {

--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -126,8 +126,12 @@ export class MembersListPage extends AdminPage {
         await this.page.getByRole('option', {name: new RegExp(String.raw`^${escaped}\b`)}).click();
     }
 
+    get multiselectSearchInput(): Locator {
+        return this.page.locator('[cmdk-input]');
+    }
+
     async searchMultiselectOptions(query: string): Promise<void> {
-        await this.page.locator('[cmdk-input]').fill(query);
+        await this.multiselectSearchInput.fill(query);
     }
 
     get editLabelInput(): Locator {

--- a/e2e/tests/admin/members/label-lifecycle.test.ts
+++ b/e2e/tests/admin/members/label-lifecycle.test.ts
@@ -1,0 +1,64 @@
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {MembersListPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Members Label Lifecycle', () => {
+    let memberFactory: MemberFactory;
+    let membersPage: MembersListPage;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+        await memberFactory.createMany([
+            {name: 'Labelled Member', email: 'labelled@example.com', labels: ['Existing-Label']}
+        ]);
+        membersPage = new MembersListPage(page);
+        await membersPage.goto();
+        await membersPage.addMultiselectFilter('Label', ['Existing-Label']);
+        await membersPage.openFilterValue('Label');
+    });
+
+    test('creates a label, adopts an out-of-band duplicate, deletes it and recreates it', async ({page}) => {
+        await membersPage.searchMultiselectOptions('Lifecycle-One');
+        await page.getByRole('button', {name: 'Create "Lifecycle-One"'}).click();
+        await expect(page.getByRole('option', {name: /Lifecycle-One/})).toBeVisible();
+
+        // An exact match among the loaded labels hides the create action
+        await membersPage.searchMultiselectOptions('Lifecycle-One');
+        await expect(page.getByRole('option', {name: /Lifecycle-One/})).toBeVisible();
+        await expect(page.getByRole('button', {name: 'Create "Lifecycle-One"'})).toBeHidden();
+
+        // A label created outside this session (e.g. by another admin) is not
+        // in the loaded list, so the create action shows; creating it adopts
+        // and selects the existing label instead of surfacing an error. This
+        // relies on the picker's client-side label cache staying stale while
+        // the popover is open
+        await memberFactory.createMany([
+            {name: 'Sneaky Member', email: 'sneaky@example.com', labels: ['Sneaky-Label']}
+        ]);
+        await membersPage.searchMultiselectOptions('Sneaky-Label');
+        await page.getByRole('button', {name: 'Create "Sneaky-Label"'}).click();
+        await expect(page.getByRole('option', {name: /Sneaky-Label/})).toBeVisible();
+        await expect(page.getByText('Label already exists')).toBeHidden();
+        await expect(membersPage.multiselectSearchInput).toHaveValue('');
+
+        await membersPage.searchMultiselectOptions('Lifecycle-Two');
+        await page.getByRole('button', {name: 'Create "Lifecycle-Two"'}).click();
+        await expect(page.getByRole('option', {name: /Lifecycle-Two/})).toBeVisible();
+
+        // The inline edit affordance only renders on unselected options, so
+        // deselect the label created (and auto-selected) above before deleting
+        await membersPage.searchMultiselectOptions('');
+        await membersPage.selectMultiselectOption('Lifecycle-One');
+        await page.getByRole('button', {name: 'Edit label Lifecycle-One'}).click();
+        await page.getByRole('button', {name: 'Delete', exact: true}).click();
+        await page.getByRole('button', {name: 'Delete', exact: true}).click();
+        await expect(page.getByRole('option', {name: /Lifecycle-One/})).toBeHidden();
+
+        await membersPage.searchMultiselectOptions('Lifecycle-One');
+        await page.getByRole('button', {name: 'Create "Lifecycle-One"'}).click();
+        await expect(page.getByRole('option', {name: /Lifecycle-One/})).toBeVisible();
+    });
+});

--- a/ghost/core/core/server/api/endpoints/labels.js
+++ b/ghost/core/core/server/api/endpoints/labels.js
@@ -9,6 +9,21 @@ const messages = {
 
 const ALLOWED_INCLUDES = ['count.members'];
 
+// SQLITE_CONSTRAINT covers more than unique violations, but schema validation
+// rejects null/oversize names before the database, so only the unique
+// constraint on name/slug can reach this catch
+const isUniqueConstraintViolation = (error) => {
+    return error.code === 'ER_DUP_ENTRY' || error.code === 'SQLITE_CONSTRAINT';
+};
+
+const handleDuplicateNameError = (error) => {
+    if (isUniqueConstraintViolation(error)) {
+        throw new errors.ValidationError({message: tpl(messages.labelAlreadyExists)});
+    }
+
+    throw error;
+};
+
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
     docName: 'labels',
@@ -89,13 +104,7 @@ const controller = {
         permissions: true,
         query(frame) {
             return models.Label.add(frame.data.labels[0], frame.options)
-                .catch((error) => {
-                    if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
-                        throw new errors.ValidationError({message: tpl(messages.labelAlreadyExists)});
-                    }
-
-                    throw error;
-                });
+                .catch(handleDuplicateNameError);
         }
     },
 
@@ -119,7 +128,9 @@ const controller = {
         },
         permissions: true,
         async query(frame) {
-            const model = await models.Label.edit(frame.data.labels[0], frame.options);
+            const model = await models.Label.edit(frame.data.labels[0], frame.options)
+                .catch(handleDuplicateNameError);
+
             if (!model) {
                 throw new errors.NotFoundError({
                     message: tpl(messages.labelNotFound)

--- a/ghost/core/test/e2e-api/admin/__snapshots__/labels.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/labels.test.js.snap
@@ -252,6 +252,47 @@ Object {
 }
 `;
 
+exports[`Labels API Errors when adding label with a name over the schema limit 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Validation failed for name.",
+      "details": Array [
+        Object {
+          "instancePath": "/labels/0/name",
+          "keyword": "maxLength",
+          "message": "must NOT have more than 191 characters",
+          "params": Object {
+            "limit": 191,
+          },
+          "schemaPath": "labels#/definitions/label/properties/name/maxLength",
+        },
+      ],
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot save label.",
+      "property": "name",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Labels API Errors when adding label with a name over the schema limit 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "445",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Labels API Errors when adding label with the same name 1: [body] 1`] = `
 Object {
   "errors": Array [
@@ -275,6 +316,68 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "242",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Labels API Errors when editing label to a name that already exists 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Label already exists",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot edit label.",
+      "property": null,
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Labels API Errors when editing label to a name that already exists 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "242",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Labels API Errors when editing non-existent label 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Resource could not be found.",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found error, cannot edit label.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Labels API Errors when editing non-existent label 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "256",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/labels.test.js
+++ b/ghost/core/test/e2e-api/admin/labels.test.js
@@ -111,6 +111,85 @@ describe('Labels API', function () {
             });
     });
 
+    it('Errors when editing label to a name that already exists', async function () {
+        const loggingStub = sinon.stub(logging, 'error');
+
+        const {body: targetBody} = await agent
+            .post('labels')
+            .body({labels: [{
+                name: 'rename-target'
+            }]})
+            .expectStatus(201);
+
+        const {body} = await agent
+            .post('labels')
+            .body({labels: [{
+                name: 'rename-me'
+            }]})
+            .expectStatus(201);
+
+        const id = body.labels[0].id;
+
+        await agent
+            .put(`labels/${id}`)
+            .body({labels: [{name: 'rename-target'}]})
+            .expectStatus(422)
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            });
+        sinon.assert.calledOnce(loggingStub);
+
+        await agent
+            .delete(`labels/${id}`)
+            .expectStatus(204);
+
+        await agent
+            .delete(`labels/${targetBody.labels[0].id}`)
+            .expectStatus(204);
+    });
+
+    it('Errors when adding label with a name over the schema limit', async function () {
+        const loggingStub = sinon.stub(logging, 'error');
+        await agent
+            .post('labels')
+            .body({labels: [{
+                name: 'a'.repeat(192)
+            }]})
+            .expectStatus(422)
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            });
+        sinon.assert.calledOnce(loggingStub);
+    });
+
+    it('Errors when editing non-existent label', async function () {
+        await agent
+            .put('labels/abcd1234abcd1234abcd1234')
+            .body({labels: [{name: 'does not matter'}]})
+            .expectStatus(404)
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            });
+    });
+
     it('Can destroy', async function () {
         const {body} = await agent
             .get('labels/slug/test/')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,6 +857,9 @@ importers:
       react-router:
         specifier: 'catalog:'
         version: 7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sonner:
+        specifier: 'catalog:'
+        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'


### PR DESCRIPTION
## Issue

fixes https://linear.app/ghost/issue/BER-3493/label-createedit-mutation-errors-are-silently-swallowed

## Problem

Label create, edit and delete failures in the posts label picker gave the user no feedback. The client-side duplicate-name check only saw locally-loaded labels, so duplicates slipped through to the API and the rejection was silently swallowed. Renaming a label to an existing name was worse: the API returned an unhandled 500 instead of a validation error.

While fixing this we found error toasts never rendered in any shade-based admin app (Posts, including the members screens, and Analytics): the global error handler only emitted toasts to the library whose outlet is mounted in Settings, so query and mutation errors in newer apps went nowhere.

## Solution

- The API is now the single source of truth for label name validation: unique constraint violations map to a 422 validation error on both add and edit, with the happy and error paths pinned by API tests.
- The global error handler now routes each toast to whichever toast outlet the current screen has mounted, restoring error toasts across Posts, members and Analytics — and showing exactly one toast even where both outlets are mounted at once.
- The label picker no longer duplicates domain validation. Failures propagate and are surfaced: edit failures render inline in the edit row; creating a name that already exists adopts and selects the existing label as if it had been created; deleting a label that is already gone counts as deleted. Only genuinely unexpected failures (such as a delete that did not go through) surface as error toasts. The create action is hidden when an exactly-matching label is already visible in the list.
- A browser e2e test covers the full label lifecycle: create, duplicate adoption for an out-of-band label, inline delete, and recreating a deleted name.

## Notes

- The toast outlet fix is its own commit and is broader than labels — it restores all error toasts in shade-based apps, including automatic query-error reporting.
- The duplicate-rename 500 predates this change; the Linear issue assumed the API already returned a validation error for it.
- Mutation error handling stays per call site: the picker maps API outcomes to user intent rather than routing everything through a generic reporter. Making automatic mutation error reporting the framework default remains a follow-up (54 existing call sites handle errors themselves and would double-report today).
- This supersedes the approach in #27943.

