### PR TITLE
Made `automated_email_recipients.automated_email_id` nullable

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.45/2026-06-11-16-04-43-make-automated-email-recipient-email-id-nullable.js
+++ b/ghost/core/core/server/data/migrations/versions/6.45/2026-06-11-16-04-43-make-automated-email-recipient-email-id-nullable.js
@@ -1,0 +1,19 @@
+const {createSetNullableMigration} = require('../../utils');
+
+const nullableMigration = createSetNullableMigration('automated_email_recipients', 'automated_email_id', {disableForeignKeyChecks: true});
+
+module.exports = {
+    config: nullableMigration.config,
+
+    async up(config) {
+        await nullableMigration.up(config);
+    },
+
+    async down(config) {
+        // This should be impossible in practice, but we can't make the column required if anything is null.
+        await config.transacting('automated_email_recipients')
+            .whereNull('automated_email_id')
+            .del();
+        await nullableMigration.down(config);
+    }
+};

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1223,7 +1223,7 @@ module.exports = {
     },
     automated_email_recipients: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        automated_email_id: {type: 'string', maxlength: 24, nullable: false, references: 'welcome_email_automated_emails.id'},
+        automated_email_id: {type: 'string', maxlength: 24, nullable: true, references: 'welcome_email_automated_emails.id'},
         member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
         member_uuid: {type: 'string', maxlength: 36, nullable: false},
         member_email: {type: 'string', maxlength: 191, nullable: false},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '1ee10868a4aab312b91dc7169a1c92db';
+    const currentSchemaHash = 'cfbd3876f444389196059722536cb39b';
     const currentFixturesHash = '823aa0e8a8f083e80e271c47836a7e5d';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1335

This change should have no user impact.

Soon, this field will no longer be set in all cases (for automation emails). This prepares us for that by making the relevant field nullable. Nobody sets this to null yet, but we will soon!
