### PR TITLE
Switched to Knex for fake automations database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,11 +512,7 @@ jobs:
         # installing/linking it when restoring from a cached store. --force
         # ensures all optional deps are installed regardless.
         run: |
-          if [ "${{ matrix.env.DB }}" = "sqlite3" ]; then
-            pnpm install --frozen-lockfile --force
-          else
-            pnpm install --frozen-lockfile
-          fi
+          pnpm install --frozen-lockfile --force
 
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0

--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -2,7 +2,7 @@
 import errors from '@tryghost/errors';
 import tpl from '@tryghost/tpl';
 import ObjectId from 'bson-objectid';
-import type {DatabaseSync} from 'node:sqlite';
+import type {Knex} from 'knex';
 import {z} from 'zod';
 import {createFakeDatabaseAutomationsRepository} from './fake-database-automations-repository';
 import type {
@@ -71,15 +71,15 @@ const editAutomationDataSchema = z.object({
     edges: z.array(edgeSchema)
 }).strict();
 
-let testDatabase: DatabaseSync | null = null;
+let testDatabase: Knex | null = null;
 
 const repository = createFakeDatabaseAutomationsRepository({
-    getDatabase: () => {
+    getDatabase: async () => {
         if (process.env.NODE_ENV?.startsWith('testing')) {
-            testDatabase ??= temporaryFakeAutomationsDatabase.createTemporaryFakeAutomationsDatabase();
+            testDatabase ??= await temporaryFakeAutomationsDatabase.createTemporaryFakeAutomationsDatabase();
             return testDatabase;
         }
-        return temporaryFakeAutomationsDatabase.getTemporaryFakeAutomationsDatabase();
+        return await temporaryFakeAutomationsDatabase.getTemporaryFakeAutomationsDatabase();
     }
 });
 

--- a/ghost/core/core/server/services/automations/fake-database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/fake-database-automations-repository.ts
@@ -3,8 +3,7 @@ import tpl from '@tryghost/tpl';
 import crypto from 'node:crypto';
 import ObjectId from 'bson-objectid';
 import {dequal} from 'dequal';
-import knex, {type Knex} from 'knex';
-import type {DatabaseSync, SQLInputValue} from 'node:sqlite';
+import {type Knex} from 'knex';
 import {MEMBER_WELCOME_EMAIL_SLUGS} from '../member-welcome-emails/constants';
 import type {
     Automation,
@@ -21,7 +20,6 @@ import {LOCK_TIMEOUT_MS} from './constants';
 import type {ExclusifyUnion, ReadonlyDeep} from 'type-fest';
 
 const HOUR_MS = 60 * 60 * 1000;
-const queryBuilder = knex({client: 'sqlite', useNullAsDefault: true});
 
 const messages = {
     invalidAutomationActionRevision: 'Automation action "{actionId}" of type "{actionType}" is missing required revision field "{field}".',
@@ -97,43 +95,19 @@ type RevisionDataFor<ActionDataT> = {
 type WaitRevisionData = RevisionDataFor<WaitActionData>;
 type SendEmailRevisionData = RevisionDataFor<SendEmailActionData>;
 
-function toNativeQuery(builder: Knex.QueryBuilder) {
-    const {sql, bindings} = builder.toSQL().toNative();
-    return {
-        sql,
-        bindings: bindings as SQLInputValue[]
-    };
-}
-
-function getRow(database: DatabaseSync, builder: Knex.QueryBuilder) {
-    const {sql, bindings} = toNativeQuery(builder);
-    return database.prepare(sql).get(...bindings);
-}
-
-function getRows(database: DatabaseSync, builder: Knex.QueryBuilder) {
-    const {sql, bindings} = toNativeQuery(builder);
-    return database.prepare(sql).all(...bindings);
-}
-
-function runQuery(database: DatabaseSync, builder: Knex.QueryBuilder) {
-    const {sql, bindings} = toNativeQuery(builder);
-    return database.prepare(sql).run(...bindings);
-}
-
 export function createFakeDatabaseAutomationsRepository({
     getDatabase
 }: {
-    getDatabase: () => DatabaseSync;
+    getDatabase: () => Promise<Knex>;
 }): AutomationsRepository {
     return {
         async browse(): Promise<Page<AutomationSummary>> {
-            const database = getDatabase();
+            const knex = await getDatabase();
 
-            return withTransaction(database, () => {
-                const rows = loadAutomations(database).map(row => buildAutomationSummary(row));
-
+            return await knex.transaction(async (trx) => {
+                const rows = await loadAutomations(trx);
                 return {
-                    data: rows,
+                    data: rows.map(row => buildAutomationSummary(row)),
                     meta: {
                         pagination: buildPagination(rows.length)
                     }
@@ -142,37 +116,36 @@ export function createFakeDatabaseAutomationsRepository({
         },
 
         async getById(id: string): Promise<Automation | null> {
-            const database = getDatabase();
-            return withTransaction(database, () => {
-                const automation = loadAutomation(database, id);
+            const knex = await getDatabase();
+            return await knex.transaction(async (trx) => {
+                const automation = await loadAutomation(trx, id);
 
                 if (!automation) {
                     return null;
                 }
 
-                return buildAutomation(database, automation);
+                return await buildAutomation(trx, automation);
             });
         },
 
         async edit(id: string, data: EditAutomationData): Promise<Automation | null> {
-            const database = getDatabase();
-
-            return withTransaction(database, () => {
-                const automation = loadAutomation(database, id);
+            const knex = await getDatabase();
+            return await knex.transaction(async (trx) => {
+                const automation = await loadAutomation(trx, id);
 
                 if (!automation) {
                     return null;
                 }
 
-                const updatedAutomation = updateAutomation(database, {
+                const updatedAutomation = await updateAutomation(trx, {
                     ...automation,
                     status: data.status,
                     updated_at: new Date().toISOString()
                 });
 
-                replaceAutomationGraph(database, updatedAutomation.id, data.actions, data.edges);
+                await replaceAutomationGraph(trx, updatedAutomation.id, data.actions, data.edges);
 
-                return buildAutomation(database, updatedAutomation);
+                return await buildAutomation(trx, updatedAutomation);
             });
         },
 
@@ -181,54 +154,41 @@ export function createFakeDatabaseAutomationsRepository({
             memberId: string;
             memberStatus: 'free' | 'paid';
         }): Promise<void> {
-            const database = getDatabase();
+            const knex = await getDatabase();
 
-            return withTransaction(database, () => trigger(database, options));
+            return await knex.transaction(trx => trigger(trx, options));
         },
 
         async fetchAndLockSteps(limit: number): Promise<{
             steps: AutomationStepToRun[],
             nextStepReadyAt: null | Date;
         }> {
-            const database = getDatabase();
+            const knex = await getDatabase();
 
-            return withTransaction(database, () => fetchAndLockSteps(database, limit));
+            return await knex.transaction(trx => fetchAndLockSteps(trx, limit));
         },
 
         async finishStepAndEnqueueNext(step: AutomationStepToRun): Promise<Date | null> {
-            const database = getDatabase();
+            const knex = await getDatabase();
 
-            return withTransaction(database, () => finishStepAndEnqueueNext(database, step));
+            return await knex.transaction(trx => finishStepAndEnqueueNext(trx, step));
         },
 
         async markStepTerminal(step: AutomationStepToRun, status: AutomationStepTerminalStatus): Promise<boolean> {
-            const database = getDatabase();
+            const knex = await getDatabase();
 
-            return withTransaction(database, () => markStepTerminal(database, step, status));
+            return await knex.transaction(trx => markStepTerminal(trx, step, status));
         },
 
         async retryStep(step: AutomationStepToRun, retryAt: Date): Promise<boolean> {
-            const database = getDatabase();
+            const knex = await getDatabase();
 
-            return withTransaction(database, () => retryStep(database, step, retryAt));
+            return await knex.transaction(trx => retryStep(trx, step, retryAt));
         }
     };
 }
 
-function withTransaction<T>(database: DatabaseSync, operation: () => T): T {
-    database.exec('BEGIN TRANSACTION');
-
-    try {
-        const result = operation();
-        database.exec('COMMIT');
-        return result;
-    } catch (error) {
-        database.exec('ROLLBACK');
-        throw error;
-    }
-}
-
-function trigger(database: DatabaseSync, {
+async function trigger(trx: Knex.Transaction, {
     memberEmail,
     memberId,
     memberStatus
@@ -236,8 +196,8 @@ function trigger(database: DatabaseSync, {
     memberEmail: string;
     memberId: string;
     memberStatus: 'free' | 'paid';
-}>): void {
-    const firstAction = findFirstActionRevision(database, memberStatus);
+}>): Promise<void> {
+    const firstAction = await findFirstActionRevision(trx, memberStatus);
     if (!firstAction) {
         return;
     }
@@ -256,8 +216,8 @@ function trigger(database: DatabaseSync, {
         member_email: memberEmail
     };
 
-    runQuery(database, queryBuilder('automation_runs').insert(run));
-    insertRunStep(database, {
+    await trx('automation_runs').insert(run);
+    await insertRunStep(trx, {
         automationRunId: run.id,
         automationActionRevisionId: firstAction.automation_action_revision_id,
         now,
@@ -265,7 +225,7 @@ function trigger(database: DatabaseSync, {
     });
 }
 
-function insertRunStep(database: DatabaseSync, {
+async function insertRunStep(trx: Knex.Transaction, {
     automationRunId,
     automationActionRevisionId,
     now,
@@ -275,23 +235,23 @@ function insertRunStep(database: DatabaseSync, {
     automationActionRevisionId: string;
     now: Date;
     readyAt: Date;
-}>): void {
+}>): Promise<void> {
     const nowString = now.toISOString();
 
-    runQuery(database, queryBuilder('automation_run_steps').insert({
+    await trx('automation_run_steps').insert({
         id: ObjectId().toHexString(),
         created_at: nowString,
         updated_at: nowString,
         automation_run_id: automationRunId,
         automation_action_revision_id: automationActionRevisionId,
         ready_at: readyAt.toISOString()
-    }));
+    });
 }
 
-function fetchAndLockSteps(database: DatabaseSync, limit: number): {
+async function fetchAndLockSteps(trx: Knex.Transaction, limit: number): Promise<{
     steps: AutomationStepToRun[],
     nextStepReadyAt: null | Date;
-} {
+}> {
     // Two things make this tricky:
     //
     // - We want to do row-level locking, so multiple calls don't step on each other.
@@ -310,7 +270,7 @@ function fetchAndLockSteps(database: DatabaseSync, limit: number): {
     const lockId = crypto.randomUUID();
 
     // 1. Select up to `limit` candidate rows.
-    const candidates = getRows(database, queryBuilder('automation_run_steps')
+    const candidates: ReadonlyArray<{id: string}> = await trx('automation_run_steps')
         .select('id')
         .where('status', 'pending')
         .where('ready_at', '<=', nowString)
@@ -324,18 +284,18 @@ function fetchAndLockSteps(database: DatabaseSync, limit: number): {
             'created_at',
             'id'
         ])
-        .limit(limit)) as unknown as ReadonlyArray<{id: string}>;
+        .limit(limit);
     if (candidates.length === 0) {
         return {
             steps: [],
-            nextStepReadyAt: findNextPendingReadyAt(database, staleLockCutoff)
+            nextStepReadyAt: await findNextPendingReadyAt(trx, staleLockCutoff)
         };
     }
 
     const candidateIds = candidates.map(candidate => candidate.id);
 
     // 2. Try to lock those rows.
-    runQuery(database, queryBuilder('automation_run_steps')
+    await trx('automation_run_steps')
         .update({
             locked_by: lockId,
             locked_at: nowString,
@@ -350,10 +310,10 @@ function fetchAndLockSteps(database: DatabaseSync, limit: number): {
             builder
                 .whereNull('locked_by')
                 .orWhere('locked_at', '<', staleLockCutoffString);
-        }));
+        });
 
     // 3. Select any rows we successfully locked.
-    const rows = getRows(database, queryBuilder('automation_run_steps as step')
+    const rows: StepToRunRow[] = await trx('automation_run_steps as step')
         .select(
             'step.id as id',
             'step.locked_by as locked_by',
@@ -382,23 +342,24 @@ function fetchAndLockSteps(database: DatabaseSync, limit: number): {
             'step.ready_at',
             'step.created_at',
             'step.id'
-        ])) as unknown as StepToRunRow[];
+        ]);
 
     return {
         steps: rows.map(row => buildStepToRun(row)),
-        nextStepReadyAt: findNextPendingReadyAt(database, staleLockCutoff)
+        nextStepReadyAt: await findNextPendingReadyAt(trx, staleLockCutoff)
     };
 }
 
-function findNextPendingReadyAt(database: DatabaseSync, staleLockCutoff: Readonly<Date>): Date | null {
-    const row = getRow(database, queryBuilder('automation_run_steps')
+async function findNextPendingReadyAt(trx: Knex.Transaction, staleLockCutoff: Readonly<Date>): Promise<Date | null> {
+    const row = await trx('automation_run_steps')
         .min({next_ready_at: 'ready_at'})
         .where('status', 'pending')
         .where((builder) => {
             builder
                 .whereNull('locked_by')
                 .orWhere('locked_at', '<', staleLockCutoff.toISOString());
-        })) as {next_ready_at: string | null} | undefined;
+        })
+        .first();
     return row?.next_ready_at ? new Date(row.next_ready_at) : null;
 }
 
@@ -440,10 +401,10 @@ function buildStepToRun(row: ReadonlyDeep<StepToRunRow>): AutomationStepToRun {
     }
 }
 
-function findFirstActionRevision(database: DatabaseSync, memberStatus: 'free' | 'paid'): NextActionRevisionRow | null {
+async function findFirstActionRevision(trx: Knex.Transaction, memberStatus: 'free' | 'paid'): Promise<NextActionRevisionRow | null> {
     const automationSlug: NonNullable<string> = MEMBER_WELCOME_EMAIL_SLUGS[memberStatus];
 
-    const row = getRow(database, queryBuilder('automations as automation')
+    const row = await trx('automations as automation')
         .select(
             'automation.id as automation_id',
             'actions.id as action_id',
@@ -456,33 +417,33 @@ function findFirstActionRevision(database: DatabaseSync, memberStatus: 'free' | 
         .where('automation.slug', automationSlug)
         .where('automation.status', 'active')
         .whereNull('actions.deleted_at')
-        .whereNotExists(queryBuilder('automation_action_edges as edge')
+        .whereNotExists(trx('automation_action_edges as edge')
             .select('edge.target_action_id')
             .innerJoin('automation_actions as source_actions', 'source_actions.id', 'edge.source_action_id')
             .whereNull('source_actions.deleted_at')
-            .where('edge.target_action_id', queryBuilder.ref('actions.id')))
-        .where('revisions.created_at', queryBuilder('automation_action_revisions')
+            .where('edge.target_action_id', trx.ref('actions.id')))
+        .where('revisions.created_at', trx('automation_action_revisions')
             .max('created_at')
-            .where('action_id', queryBuilder.ref('actions.id')))
+            .where('action_id', trx.ref('actions.id')))
         .orderBy([
             'actions.created_at',
             'actions.id'
         ])
-        .limit(1)) as NextActionRevisionRow | undefined;
+        .first();
 
     return row ?? null;
 }
 
-function finishStepAndEnqueueNext(
-    database: DatabaseSync,
+async function finishStepAndEnqueueNext(
+    trx: Knex.Transaction,
     step: Pick<AutomationStepToRun, 'id' | 'locked_by' | 'action_id' | 'automation_run_id'>
-): Date | null {
-    const didFinish = markStepTerminal(database, step, 'finished');
+): Promise<Date | null> {
+    const didFinish = await markStepTerminal(trx, step, 'finished');
     if (!didFinish) {
         return null;
     }
 
-    const next = findNextActionRevision(database, step.action_id);
+    const next = await findNextActionRevision(trx, step.action_id);
 
     if (!next) {
         return null;
@@ -491,7 +452,7 @@ function finishStepAndEnqueueNext(
     const now = new Date();
     const nextReadyAt = getReadyAtForAction(next, now);
 
-    insertRunStep(database, {
+    await insertRunStep(trx, {
         automationRunId: step.automation_run_id,
         automationActionRevisionId: next.automation_action_revision_id,
         now,
@@ -501,8 +462,8 @@ function finishStepAndEnqueueNext(
     return nextReadyAt;
 }
 
-function findNextActionRevision(database: DatabaseSync, sourceActionId: string): NextActionRevisionRow | null {
-    const row = getRow(database, queryBuilder('automation_action_edges as edge')
+async function findNextActionRevision(trx: Knex.Transaction, sourceActionId: string): Promise<NextActionRevisionRow | null> {
+    const row = await trx('automation_action_edges as edge')
         .select(
             'action.id as action_id',
             'revision.id as automation_action_revision_id',
@@ -513,36 +474,36 @@ function findNextActionRevision(database: DatabaseSync, sourceActionId: string):
         .innerJoin('automation_action_revisions as revision', 'revision.action_id', 'action.id')
         .where('edge.source_action_id', sourceActionId)
         .whereNull('action.deleted_at')
-        .where('revision.created_at', queryBuilder('automation_action_revisions')
+        .where('revision.created_at', trx('automation_action_revisions')
             .max('created_at')
-            .where('action_id', queryBuilder.ref('action.id')))
+            .where('action_id', trx.ref('action.id')))
         .orderBy('revision.created_at', 'desc')
         .orderBy('revision.id', 'desc')
-        .limit(1)) as NextActionRevisionRow | undefined;
+        .first();
 
     return row ?? null;
 }
 
-function markStepTerminal(
-    database: DatabaseSync,
+async function markStepTerminal(
+    trx: Knex.Transaction,
     step: Pick<AutomationStepToRun, 'id' | 'locked_by'>,
     status: AutomationStepTerminalStatus
-): boolean {
+): Promise<boolean> {
     const nowString = new Date().toISOString();
-    return updateStep(database, step, {
+    return await updateStep(trx, step, {
         status,
         finished_at: nowString,
         updated_at: nowString
     });
 }
 
-function retryStep(
-    database: DatabaseSync,
+async function retryStep(
+    trx: Knex.Transaction,
     step: Pick<AutomationStepToRun, 'id' | 'locked_by'>,
     retryAt: Readonly<Date>
-): boolean {
+): Promise<boolean> {
     const nowString = new Date().toISOString();
-    return updateStep(database, step, {
+    return await updateStep(trx, step, {
         status: 'pending',
         started_at: null,
         finished_at: null,
@@ -587,8 +548,8 @@ function getReadyAtForAction(
  *
  * Worker A has lost its lock, so it shouldn't be updating the step any more.
  */
-function updateStep(
-    database: DatabaseSync,
+async function updateStep(
+    trx: Knex.Transaction,
     step: Pick<AutomationStepToRun, 'id' | 'locked_by'>,
     attrs: {
         status: string;
@@ -597,10 +558,10 @@ function updateStep(
         ready_at?: string;
         updated_at: string;
     }
-): boolean {
+): Promise<boolean> {
     /* eslint-disable camelcase */
     const {started_at, finished_at, ready_at} = attrs;
-    const result = runQuery(database, queryBuilder('automation_run_steps')
+    const changes = await trx('automation_run_steps')
         .update({
             status: attrs.status,
             updated_at: attrs.updated_at,
@@ -612,41 +573,42 @@ function updateStep(
         })
         .where('id', step.id)
         .where('status', 'pending')
-        .where('locked_by', step.locked_by)) as unknown as {changes: number};
+        .where('locked_by', step.locked_by);
     /* eslint-enable camelcase */
-    return result.changes >= 1;
+    return changes >= 1;
 }
 
-function loadAutomation(database: DatabaseSync, automationId: string): AutomationRow | null {
-    const automation = getRow(database, queryBuilder('automations')
+async function loadAutomation(trx: Knex.Transaction, automationId: string): Promise<AutomationRow | null> {
+    const row = await trx('automations')
         .select('id', 'slug', 'name', 'status', 'created_at', 'updated_at')
-        .where('id', automationId)) as AutomationRow | undefined;
-
-    return automation ?? null;
+        .where('id', automationId)
+        .first();
+    return row ?? null;
 }
 
-function loadAutomations(database: DatabaseSync): AutomationRow[] {
-    return getRows(database, queryBuilder('automations')
+async function loadAutomations(trx: Knex.Transaction): Promise<AutomationRow[]> {
+    return await trx('automations')
         .select('id', 'slug', 'name', 'status', 'created_at', 'updated_at')
         .orderBy([
             'created_at',
             'id'
-        ])) as unknown as AutomationRow[];
+        ]);
 }
 
-function updateAutomation(database: DatabaseSync, automation: AutomationRow): AutomationRow {
-    runQuery(database, queryBuilder('automations')
+async function updateAutomation(trx: Knex.Transaction, automation: AutomationRow): Promise<AutomationRow> {
+    await trx('automations')
         .update({
             status: automation.status,
             updated_at: automation.updated_at
         })
-        .where('id', automation.id));
+        .where('id', automation.id);
 
-    return requireAutomation(loadAutomation(database, automation.id), automation.id);
+    return requireAutomation(await loadAutomation(trx, automation.id), automation.id);
 }
 
-function replaceAutomationGraph(database: DatabaseSync, automationId: string, actions: AutomationAction[], edges: AutomationEdge[]) {
-    const existingActions = loadAutomationActionRows(database, automationId);
+async function replaceAutomationGraph(trx: Knex.Transaction, automationId: string, actions: AutomationAction[], edges: AutomationEdge[]): Promise<void> {
+    // TODO(NY-1340): This makes too many round-trips to the database. We should improve that.
+    const existingActions = await loadAutomationActionRows(trx, automationId);
     const existingActionIds = new Set(existingActions.map(action => action.id));
     const submittedActionIds = new Set(actions.map(action => action.id));
     const now = new Date().toISOString();
@@ -664,7 +626,7 @@ function replaceAutomationGraph(database: DatabaseSync, automationId: string, ac
                 });
             }
         } else {
-            if (loadActionOwner(database, action.id)) {
+            if (await loadActionOwner(trx, action.id)) {
                 throw new errors.ValidationError({
                     message: tpl(messages.conflictingAutomationActionId, {
                         actionId: action.id
@@ -673,7 +635,7 @@ function replaceAutomationGraph(database: DatabaseSync, automationId: string, ac
                 });
             }
 
-            insertAction(database, {
+            await insertAction(trx, {
                 id: action.id,
                 created_at: now,
                 updated_at: now,
@@ -682,48 +644,49 @@ function replaceAutomationGraph(database: DatabaseSync, automationId: string, ac
             });
         }
 
-        const latestRevision = loadLatestActionRevision(database, action.id);
+        const latestRevision = await loadLatestActionRevision(trx, action.id);
         if (shouldInsertActionRevision(action, latestRevision)) {
-            insertActionRevision(database, action.id, action, now, latestRevision);
+            await insertActionRevision(trx, action.id, action, now, latestRevision);
         }
     }
 
     for (const existingAction of existingActions) {
         if (!submittedActionIds.has(existingAction.id)) {
-            softDeleteAction(database, existingAction.id, now);
+            await softDeleteAction(trx, existingAction.id, now);
         }
     }
 
-    deleteAutomationEdges(database, automationId);
+    await deleteAutomationEdges(trx, automationId);
 
     for (const edge of edges) {
-        insertActionEdge(database, edge);
+        await insertActionEdge(trx, edge);
     }
 }
 
-function loadAutomationActionRows(database: DatabaseSync, automationId: string): Array<Pick<ActionRow, 'id' | 'type'>> {
-    return getRows(database, queryBuilder('automation_actions')
+async function loadAutomationActionRows(trx: Knex.Transaction, automationId: string): Promise<Array<Pick<ActionRow, 'id' | 'type'>>> {
+    return await trx('automation_actions')
         .select('id', 'type')
         .where('automation_id', automationId)
-        .whereNull('deleted_at')) as unknown as Array<Pick<ActionRow, 'id' | 'type'>>;
+        .whereNull('deleted_at');
 }
 
-function loadActionOwner(database: DatabaseSync, actionId: string): string | null {
-    const row = getRow(database, queryBuilder('automation_actions')
+async function loadActionOwner(trx: Knex.Transaction, actionId: string): Promise<string | null> {
+    const row = await trx('automation_actions')
         .select('automation_id')
-        .where('id', actionId)) as {automation_id: string} | undefined;
+        .where('id', actionId)
+        .first();
 
     return row?.automation_id ?? null;
 }
 
-function insertAction(database: DatabaseSync, action: {
+async function insertAction(trx: Knex.Transaction, action: {
     id: string;
     created_at: string;
     updated_at: string;
     automation_id: string;
     type: string;
 }) {
-    runQuery(database, queryBuilder('automation_actions').insert(action));
+    await trx('automation_actions').insert(action);
 }
 
 function shouldInsertActionRevision(action: AutomationAction, latestRevision: ActionRevisionRow | null): boolean {
@@ -755,8 +718,11 @@ function buildRevisionActionData(action: AutomationAction, revision: ActionRevis
     }
 }
 
-function loadLatestActionRevision(database: DatabaseSync, actionId: string): ActionRevisionRow | null {
-    const row = getRow(database, queryBuilder('automation_action_revisions')
+async function loadLatestActionRevision(
+    trx: Knex.Transaction,
+    actionId: string
+): Promise<ActionRevisionRow | null> {
+    const row = await trx('automation_action_revisions')
         .select(
             'action_id',
             'created_at',
@@ -766,26 +732,37 @@ function loadLatestActionRevision(database: DatabaseSync, actionId: string): Act
             'email_design_setting_id'
         )
         .where('action_id', actionId)
-        .where('created_at', queryBuilder('automation_action_revisions')
+        .where('created_at', trx('automation_action_revisions')
             .max('created_at')
-            .where('action_id', actionId))) as ActionRevisionRow | undefined;
+            .where('action_id', actionId))
+        .first();
 
     return row ?? null;
 }
 
-function softDeleteAction(database: DatabaseSync, actionId: string, deletedAt: string) {
-    runQuery(database, queryBuilder('automation_actions')
+async function softDeleteAction(
+    trx: Knex.Transaction,
+    actionId: string,
+    deletedAt: string
+): Promise<void> {
+    await trx('automation_actions')
         .update({
             deleted_at: deletedAt,
             updated_at: deletedAt
         })
-        .where('id', actionId));
+        .where('id', actionId);
 }
 
-function insertActionRevision(database: DatabaseSync, actionId: string, action: AutomationAction, createdAt: string, latestRevision: ActionRevisionRow | null) {
+async function insertActionRevision(
+    trx: Knex.Transaction,
+    actionId: string,
+    action: AutomationAction,
+    createdAt: string,
+    latestRevision: ActionRevisionRow | null
+): Promise<void> {
     const revision = buildActionRevision(actionId, action, getNextRevisionCreatedAt(latestRevision?.created_at ?? null, createdAt));
 
-    runQuery(database, queryBuilder('automation_action_revisions').insert(revision));
+    await trx('automation_action_revisions').insert(revision);
 }
 
 function getNextRevisionCreatedAt(latestCreatedAt: string | null, requestedCreatedAt: string) {
@@ -827,19 +804,19 @@ function buildActionRevision(actionId: string, action: AutomationAction, created
     };
 }
 
-function deleteAutomationEdges(database: DatabaseSync, automationId: string) {
-    runQuery(database, queryBuilder('automation_action_edges')
+async function deleteAutomationEdges(trx: Knex.Transaction, automationId: string): Promise<void> {
+    await trx('automation_action_edges')
         .delete()
-        .whereIn('source_action_id', queryBuilder('automation_actions')
+        .whereIn('source_action_id', trx('automation_actions')
             .select('id')
-            .where('automation_id', automationId)));
+            .where('automation_id', automationId));
 }
 
-function insertActionEdge(database: DatabaseSync, edge: AutomationEdge) {
-    runQuery(database, queryBuilder('automation_action_edges').insert({
+async function insertActionEdge(trx: Knex.Transaction, edge: Readonly<AutomationEdge>): Promise<void> {
+    await trx('automation_action_edges').insert({
         source_action_id: edge.source_action_id,
         target_action_id: edge.target_action_id
-    }));
+    });
 }
 
 function requireAutomation(automation: AutomationRow | null, id: string): AutomationRow {
@@ -852,11 +829,13 @@ function requireAutomation(automation: AutomationRow | null, id: string): Automa
     return automation;
 }
 
-function buildAutomation(database: DatabaseSync, automation: AutomationRow): Automation {
+async function buildAutomation(trx: Knex.Transaction, automation: AutomationRow): Promise<Automation> {
+    const actionRows = await loadActionRows(trx, automation.id);
+    const edgeRows = await loadEdgeRows(trx, automation.id);
     return {
         ...buildAutomationSummary(automation),
-        actions: loadActionRows(database, automation.id).map(row => buildActionPayload(row)),
-        edges: loadEdgeRows(database, automation.id).map(row => buildEdgePayload(row))
+        actions: actionRows.map(row => buildActionPayload(row)),
+        edges: edgeRows.map(row => buildEdgePayload(row))
     };
 }
 
@@ -877,8 +856,8 @@ function serializeDate(date: string) {
     return normalizedDate.toISOString();
 }
 
-function loadActionRows(database: DatabaseSync, automationId: string): ActionRow[] {
-    return getRows(database, queryBuilder('automation_actions as a')
+async function loadActionRows(trx: Knex.Transaction, automationId: string): Promise<ActionRow[]> {
+    return await trx('automation_actions as a')
         .select(
             'a.id as id',
             'a.type as type',
@@ -890,17 +869,17 @@ function loadActionRows(database: DatabaseSync, automationId: string): ActionRow
         .innerJoin('automation_action_revisions as r', 'r.action_id', 'a.id')
         .where('a.automation_id', automationId)
         .whereNull('a.deleted_at')
-        .where('r.created_at', queryBuilder('automation_action_revisions')
+        .where('r.created_at', trx('automation_action_revisions')
             .max('created_at')
-            .where('action_id', queryBuilder.ref('a.id')))
+            .where('action_id', trx.ref('a.id')))
         .orderBy([
             'a.created_at',
             'a.id'
-        ])) as unknown as ActionRow[];
+        ]);
 }
 
-function loadEdgeRows(database: DatabaseSync, automationId: string): EdgeRow[] {
-    return getRows(database, queryBuilder('automation_action_edges as e')
+async function loadEdgeRows(trx: Knex.Transaction, automationId: string): Promise<EdgeRow[]> {
+    return await trx('automation_action_edges as e')
         .select('e.source_action_id', 'e.target_action_id')
         .innerJoin('automation_actions as source_action', (join) => {
             join
@@ -917,7 +896,7 @@ function loadEdgeRows(database: DatabaseSync, automationId: string): EdgeRow[] {
         .orderBy([
             'e.source_action_id',
             'e.target_action_id'
-        ])) as unknown as EdgeRow[];
+        ]);
 }
 
 function buildActionPayload(row: ActionRow): AutomationAction {

--- a/ghost/core/core/server/services/automations/temporary-fake-database.ts
+++ b/ghost/core/core/server/services/automations/temporary-fake-database.ts
@@ -12,15 +12,18 @@
 
 import * as errors from '@tryghost/errors';
 import ObjectId from 'bson-objectid';
-import type {DatabaseSync} from 'node:sqlite';
+import knex, {type Knex} from 'knex';
 
-export function createTemporaryFakeAutomationsDatabase(): DatabaseSync {
-    // We want to do this import dynamically.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const sqlite = require('node:sqlite');
+export async function createTemporaryFakeAutomationsDatabase(): Promise<Knex> {
+    const database = knex({
+        client: 'sqlite3',
+        connection: {
+            filename: ':memory:'
+        },
+        useNullAsDefault: true
+    });
 
-    const database = new sqlite.DatabaseSync(':memory:');
-    database.exec('PRAGMA foreign_keys = ON;');
+    await database.raw('PRAGMA foreign_keys = ON;');
 
     const id = () => ObjectId().toHexString();
     const now = () => new Date().toISOString();
@@ -43,90 +46,93 @@ export function createTemporaryFakeAutomationsDatabase(): DatabaseSync {
     });
     const fakeEmailDesignSettingId = id();
 
-    database.exec(`
-CREATE TABLE automations (
-  id TEXT PRIMARY KEY,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL,
-  slug TEXT NOT NULL,
-  name TEXT NOT NULL,
-  status TEXT NOT NULL
-) STRICT;
-
-CREATE TABLE automation_actions (
-  id TEXT PRIMARY KEY,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL,
-  deleted_at TEXT,
-  automation_id TEXT NOT NULL REFERENCES automations(id),
-  type TEXT NOT NULL
-) STRICT;
-
-CREATE TABLE automation_action_revisions (
-  id TEXT PRIMARY KEY,
-  created_at TEXT NOT NULL,
-  action_id TEXT NOT NULL REFERENCES automation_actions(id),
-  wait_hours INTEGER,
-  email_subject TEXT,
-  email_lexical TEXT,
-  email_design_setting_id TEXT, -- not a real foreign key here
-  UNIQUE (created_at, action_id)
-) STRICT;
-
-CREATE TABLE automation_action_edges (
-  source_action_id TEXT NOT NULL REFERENCES automation_actions(id),
-  target_action_id TEXT NOT NULL REFERENCES automation_actions(id),
-  PRIMARY KEY (source_action_id, target_action_id)
-) STRICT;
-
-CREATE TABLE automation_runs (
-  id TEXT PRIMARY KEY,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL,
-  automation_id TEXT NOT NULL REFERENCES automations(id),
-  member_id TEXT, -- not a real foreign key here
-  member_email TEXT NOT NULL
-) STRICT;
-
-CREATE TABLE automation_run_steps (
-  id TEXT PRIMARY KEY,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL,
-  automation_run_id TEXT NOT NULL REFERENCES automation_runs(id),
-  automation_action_revision_id TEXT NOT NULL REFERENCES automation_action_revisions(id),
-  ready_at TEXT NOT NULL,
-  step_attempts INTEGER NOT NULL DEFAULT 0,
-  started_at TEXT,
-  finished_at TEXT,
-  status TEXT NOT NULL DEFAULT 'pending',
-  locked_by TEXT,
-  locked_at TEXT
-) STRICT;
-`);
+    for (const createTable of [
+        `
+            CREATE TABLE automations (
+              id TEXT PRIMARY KEY,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              slug TEXT NOT NULL,
+              name TEXT NOT NULL,
+              status TEXT NOT NULL
+            ) STRICT;
+        `,
+        `
+            CREATE TABLE automation_actions (
+              id TEXT PRIMARY KEY,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              deleted_at TEXT,
+              automation_id TEXT NOT NULL REFERENCES automations(id),
+              type TEXT NOT NULL
+            ) STRICT;
+        `,
+        `
+            CREATE TABLE automation_action_revisions (
+              id TEXT PRIMARY KEY,
+              created_at TEXT NOT NULL,
+              action_id TEXT NOT NULL REFERENCES automation_actions(id),
+              wait_hours INTEGER,
+              email_subject TEXT,
+              email_lexical TEXT,
+              email_design_setting_id TEXT, -- not a real foreign key here
+              UNIQUE (created_at, action_id)
+            ) STRICT;
+        `,
+        `
+            CREATE TABLE automation_action_edges (
+              source_action_id TEXT NOT NULL REFERENCES automation_actions(id),
+              target_action_id TEXT NOT NULL REFERENCES automation_actions(id),
+              PRIMARY KEY (source_action_id, target_action_id)
+            ) STRICT;
+        `,
+        `
+            CREATE TABLE automation_runs (
+              id TEXT PRIMARY KEY,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              automation_id TEXT NOT NULL REFERENCES automations(id),
+              member_id TEXT, -- not a real foreign key here
+              member_email TEXT NOT NULL
+            ) STRICT;
+        `,
+        `
+            CREATE TABLE automation_run_steps (
+              id TEXT PRIMARY KEY,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              automation_run_id TEXT NOT NULL REFERENCES automation_runs(id),
+              automation_action_revision_id TEXT NOT NULL REFERENCES automation_action_revisions(id),
+              ready_at TEXT NOT NULL,
+              step_attempts INTEGER NOT NULL DEFAULT 0,
+              started_at TEXT,
+              finished_at TEXT,
+              status TEXT NOT NULL DEFAULT 'pending',
+              locked_by TEXT,
+              locked_at TEXT
+            ) STRICT;
+        `
+    ]) {
+        await database.raw(createTable);
+    }
 
     const freeAutomationId = id();
     const paidAutomationId = id();
-    const insertAutomation = database.prepare(`
-        INSERT INTO automations
-        (id, created_at, updated_at, slug, name, status) VALUES
-        (:id, :created_at, :updated_at, :slug, :name, :status)
-    `);
-    insertAutomation.run({
+    await database('automations').insert([{
         id: freeAutomationId,
         created_at: now(),
         updated_at: now(),
         slug: 'member-welcome-email-free',
         name: 'Welcome Email (Free)',
         status: 'active'
-    });
-    insertAutomation.run({
+    }, {
         id: paidAutomationId,
         created_at: now(),
         updated_at: now(),
         slug: 'member-welcome-email-paid',
         name: 'Welcome Email (Paid)',
         status: 'active'
-    });
+    }]);
 
     const freeAction1Id = id();
     const freeAction2Id = id();
@@ -136,74 +142,57 @@ CREATE TABLE automation_run_steps (
     const paidAction2Id = id();
     const paidAction3Id = id();
     const paidAction4Id = id();
-    const insertAction = database.prepare(`
-        INSERT INTO automation_actions
-        (id, created_at, updated_at, automation_id, type) VALUES
-        (:id, :created_at, :updated_at, :automation_id, :type)
-    `);
-    insertAction.run({
+    await database('automation_actions').insert([{
         id: freeAction1Id,
         created_at: now(),
         updated_at: now(),
         automation_id: freeAutomationId,
         type: 'wait'
-    });
-    insertAction.run({
+    }, {
         id: freeAction2Id,
         created_at: now(),
         updated_at: now(),
         automation_id: freeAutomationId,
         type: 'send_email'
-    });
-    insertAction.run({
+    }, {
         id: freeAction3Id,
         created_at: now(),
         updated_at: now(),
         automation_id: freeAutomationId,
         type: 'wait'
-    });
-    insertAction.run({
+    }, {
         id: freeAction4Id,
         created_at: now(),
         updated_at: now(),
         automation_id: freeAutomationId,
         type: 'send_email'
-    });
-    insertAction.run({
+    }, {
         id: paidAction1Id,
         created_at: now(),
         updated_at: now(),
         automation_id: paidAutomationId,
         type: 'wait'
-    });
-    insertAction.run({
+    }, {
         id: paidAction2Id,
         created_at: now(),
         updated_at: now(),
         automation_id: paidAutomationId,
         type: 'send_email'
-    });
-    insertAction.run({
+    }, {
         id: paidAction3Id,
         created_at: now(),
         updated_at: now(),
         automation_id: paidAutomationId,
         type: 'wait'
-    });
-    insertAction.run({
+    }, {
         id: paidAction4Id,
         created_at: now(),
         updated_at: now(),
         automation_id: paidAutomationId,
         type: 'send_email'
-    });
+    }]);
 
-    const insertActionRevision = database.prepare(`
-        INSERT INTO automation_action_revisions
-        (id, created_at, action_id, wait_hours, email_subject, email_lexical, email_design_setting_id) VALUES
-        (:id, :created_at, :action_id, :wait_hours, :email_subject, :email_lexical, :email_design_setting_id)
-    `);
-    insertActionRevision.run({
+    await database('automation_action_revisions').insert([{
         id: id(),
         created_at: now(),
         action_id: freeAction1Id,
@@ -211,8 +200,7 @@ CREATE TABLE automation_run_steps (
         email_subject: null,
         email_lexical: null,
         email_design_setting_id: null
-    });
-    insertActionRevision.run({
+    }, {
         id: id(),
         created_at: now(),
         action_id: freeAction2Id,
@@ -220,8 +208,7 @@ CREATE TABLE automation_run_steps (
         email_subject: 'Welcome!',
         email_lexical: fakeLexical,
         email_design_setting_id: fakeEmailDesignSettingId
-    });
-    insertActionRevision.run({
+    }, {
         id: id(),
         created_at: now(),
         action_id: freeAction3Id,
@@ -229,8 +216,7 @@ CREATE TABLE automation_run_steps (
         email_subject: null,
         email_lexical: null,
         email_design_setting_id: null
-    });
-    insertActionRevision.run({
+    }, {
         id: id(),
         created_at: now(),
         action_id: freeAction4Id,
@@ -238,8 +224,7 @@ CREATE TABLE automation_run_steps (
         email_subject: 'Follow up',
         email_lexical: fakeLexical,
         email_design_setting_id: fakeEmailDesignSettingId
-    });
-    insertActionRevision.run({
+    }, {
         id: id(),
         created_at: now(),
         action_id: paidAction1Id,
@@ -247,8 +232,7 @@ CREATE TABLE automation_run_steps (
         email_subject: null,
         email_lexical: null,
         email_design_setting_id: null
-    });
-    insertActionRevision.run({
+    }, {
         id: id(),
         created_at: now(),
         action_id: paidAction2Id,
@@ -256,8 +240,7 @@ CREATE TABLE automation_run_steps (
         email_subject: 'Welcome to Paid!',
         email_lexical: fakeLexical,
         email_design_setting_id: fakeEmailDesignSettingId
-    });
-    insertActionRevision.run({
+    }, {
         id: id(),
         created_at: now(),
         action_id: paidAction3Id,
@@ -265,8 +248,7 @@ CREATE TABLE automation_run_steps (
         email_subject: null,
         email_lexical: null,
         email_design_setting_id: null
-    });
-    insertActionRevision.run({
+    }, {
         id: id(),
         created_at: now(),
         action_id: paidAction4Id,
@@ -274,49 +256,39 @@ CREATE TABLE automation_run_steps (
         email_subject: 'Exclusive Insights',
         email_lexical: fakeLexical,
         email_design_setting_id: fakeEmailDesignSettingId
-    });
+    }]);
 
-    const insertActionEdge = database.prepare(`
-        INSERT INTO automation_action_edges
-        (source_action_id, target_action_id) VALUES
-        (:source_action_id, :target_action_id)
-    `);
-    insertActionEdge.run({
+    await database('automation_action_edges').insert([{
         source_action_id: freeAction1Id,
         target_action_id: freeAction2Id
-    });
-    insertActionEdge.run({
+    }, {
         source_action_id: freeAction2Id,
         target_action_id: freeAction3Id
-    });
-    insertActionEdge.run({
+    }, {
         source_action_id: freeAction3Id,
         target_action_id: freeAction4Id
-    });
-    insertActionEdge.run({
+    }, {
         source_action_id: paidAction1Id,
         target_action_id: paidAction2Id
-    });
-    insertActionEdge.run({
+    }, {
         source_action_id: paidAction2Id,
         target_action_id: paidAction3Id
-    });
-    insertActionEdge.run({
+    }, {
         source_action_id: paidAction3Id,
         target_action_id: paidAction4Id
-    });
+    }]);
 
     return database;
 }
 
-let cachedDatabase: DatabaseSync | null = null;
+let cachedDatabase: Knex | null = null;
 
-export function getTemporaryFakeAutomationsDatabase(): DatabaseSync {
+export async function getTemporaryFakeAutomationsDatabase(): Promise<Knex> {
     if (process.env.NODE_ENV !== 'development') {
         throw new errors.IncorrectUsageError({
             message: 'Fake automations database should only be used in development'
         });
     }
-    cachedDatabase ??= createTemporaryFakeAutomationsDatabase();
+    cachedDatabase ??= await createTemporaryFakeAutomationsDatabase();
     return cachedDatabase;
 }

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -1,14 +1,11 @@
 import assert from 'node:assert/strict';
-import sinon from 'sinon';
 import ObjectId from 'bson-objectid';
-import knex, {type Knex} from 'knex';
+import {type Knex} from 'knex';
 import {createTemporaryFakeAutomationsDatabase} from '../../../../../core/server/services/automations/temporary-fake-database';
 import {createFakeDatabaseAutomationsRepository} from '../../../../../core/server/services/automations/fake-database-automations-repository';
 import type {AutomationAction, AutomationsRepository, AutomationStepToRun} from '../../../../../core/server/services/automations/automations-repository';
-import type {DatabaseSync, SQLInputValue} from 'node:sqlite';
 
 const HOUR_MS = 60 * 60 * 1000;
-const queryBuilder = knex({client: 'sqlite', useNullAsDefault: true});
 
 const addHours = (dateCol: unknown, hours: number): Date => {
     assert(typeof dateCol === 'string', 'Expected date column to be a string');
@@ -27,47 +24,31 @@ type RunRow = {
     [key: string]: unknown;
 };
 
+type KnexQuery = {
+    method?: string;
+    response?: unknown;
+    sql?: string;
+};
+
 // These tests are partly coupled to the *fake* repository. We should be able to
 // modify it once we have the real repository.
 describe('automations repository', function () {
-    let database: DatabaseSync;
+    let knex: Knex;
     let repo: AutomationsRepository;
 
-    const toNativeQuery = (builder: Knex.QueryBuilder) => {
-        const {sql, bindings} = builder.toSQL().toNative();
-        return {
-            sql,
-            bindings: bindings as SQLInputValue[]
-        };
-    };
-
-    const getRow = (builder: Knex.QueryBuilder) => {
-        const {sql, bindings} = toNativeQuery(builder);
-        return database.prepare(sql).get(...bindings);
-    };
-
-    const getRows = (builder: Knex.QueryBuilder) => {
-        const {sql, bindings} = toNativeQuery(builder);
-        return database.prepare(sql).all(...bindings);
-    };
-
-    const runQuery = (builder: Knex.QueryBuilder) => {
-        const {sql, bindings} = toNativeQuery(builder);
-        database.prepare(sql).run(...bindings);
-    };
-
-    const getRunByMemberEmail = (email: string) => (
-        getRow(queryBuilder('automation_runs')
+    const getRunByMemberEmail = async (email: string): Promise<RunRow> => (
+        await knex('automation_runs')
             .select(
                 'automation_runs.*',
                 'automations.slug as automation_slug'
             )
             .innerJoin('automations', 'automations.id', 'automation_runs.automation_id')
-            .where('automation_runs.member_email', email)) as RunRow
+            .where('automation_runs.member_email', email)
+            .first()
     );
 
-    const getStepByRunId = (runId: string) => (
-        getRow(queryBuilder('automation_run_steps')
+    const getStepByRunId = async (runId: string) => (
+        await knex('automation_run_steps')
             .select(
                 'automation_run_steps.*',
                 'automation_actions.id as action_id',
@@ -77,7 +58,8 @@ describe('automations repository', function () {
             )
             .innerJoin('automation_action_revisions', 'automation_action_revisions.id', 'automation_run_steps.automation_action_revision_id')
             .innerJoin('automation_actions', 'automation_actions.id', 'automation_action_revisions.action_id')
-            .where('automation_run_steps.automation_run_id', runId))
+            .where('automation_run_steps.automation_run_id', runId)
+            .first()
     );
 
     const getAutomationBySlug = async (slug: string) => {
@@ -89,22 +71,23 @@ describe('automations repository', function () {
         return automation;
     };
 
-    const getRunCountByAutomationId = (automationId: string) => {
-        const result = getRow(queryBuilder('automation_runs')
+    const getRunCountByAutomationId = async (automationId: string) => {
+        const result = await knex('automation_runs')
             .count({count: '*'})
-            .where('automation_id', automationId));
+            .where('automation_id', automationId)
+            .first();
         return result?.count;
     };
 
-    const getRevisionCount = (actionId?: string) => {
-        const builder = queryBuilder('automation_action_revisions').count({count: '*'});
-        const row = getRow(actionId ? builder.where('action_id', actionId) : builder);
+    const getRevisionCount = async (actionId?: string) => {
+        const builder = knex('automation_action_revisions').count({count: '*'});
+        const row = await (actionId ? builder.where('action_id', actionId) : builder).first();
 
         return Number((row as {count: number}).count);
     };
 
-    const getActionByIndex = (automationId: string, index: number) => {
-        const result = getRow(queryBuilder('automation_actions')
+    const getActionByIndex = async (automationId: string, index: number) => {
+        const result = await knex('automation_actions')
             .select(
                 'automation_actions.id as action_id',
                 'automation_actions.type as action_type',
@@ -118,14 +101,14 @@ describe('automations repository', function () {
                 'automation_actions.created_at',
                 'automation_actions.id'
             ])
-            .limit(1)
-            .offset(index));
+            .offset(index)
+            .first();
         assert(result, 'Expected action to exist');
         return result as ActionRow;
     };
 
-    const getLatestActionRevisionByActionId = (actionId: string) => {
-        const result = getRow(queryBuilder('automation_actions')
+    const getLatestActionRevisionByActionId = async (actionId: string) => {
+        const result = await knex('automation_actions')
             .select(
                 'automation_actions.id as action_id',
                 'automation_actions.type as action_type',
@@ -137,12 +120,12 @@ describe('automations repository', function () {
             .whereNull('automation_actions.deleted_at')
             .orderBy('automation_action_revisions.created_at', 'desc')
             .orderBy('automation_action_revisions.id', 'desc')
-            .limit(1));
+            .first();
         assert(result, 'Expected action revision to exist');
         return result;
     };
 
-    const insertRun = (automationId: string) => {
+    const insertRun = async (automationId: string) => {
         const now = new Date().toISOString();
         const run = {
             id: ObjectId().toHexString(),
@@ -153,12 +136,12 @@ describe('automations repository', function () {
             member_email: 'member@example.com'
         };
 
-        runQuery(queryBuilder('automation_runs').insert(run));
+        await knex('automation_runs').insert(run);
 
         return run;
     };
 
-    const insertStep = (runId: string, revisionId: string, attrs = {}) => {
+    const insertStep = async (runId: string, revisionId: string, attrs = {}) => {
         const now = new Date().toISOString();
         const step = {
             id: ObjectId().toHexString(),
@@ -176,27 +159,28 @@ describe('automations repository', function () {
             ...attrs
         };
 
-        runQuery(queryBuilder('automation_run_steps').insert(step));
+        await knex('automation_run_steps').insert(step);
 
         return step;
     };
 
-    const getStepById = (id: string) => {
-        const result = getRow(queryBuilder('automation_run_steps')
+    const getStepById = async (id: string) => {
+        const result = await knex('automation_run_steps')
             .select('*')
-            .where('id', id));
+            .where('id', id)
+            .first();
         assert(result, 'Expected step to exist');
         return result;
     };
 
-    const getStepsByRunId = (runId: string) => (
-        getRows(queryBuilder('automation_run_steps')
+    const getStepsByRunId = async (runId: string) => (
+        await knex('automation_run_steps')
             .select('*')
             .where('automation_run_id', runId)
             .orderBy([
                 'created_at',
                 'id'
-            ]))
+            ])
     );
 
     const getLockedStep = async (stepId: string): Promise<AutomationStepToRun> => {
@@ -223,16 +207,15 @@ describe('automations repository', function () {
         };
     };
 
-    beforeEach(function () {
-        database = createTemporaryFakeAutomationsDatabase();
+    beforeEach(async function () {
+        knex = await createTemporaryFakeAutomationsDatabase();
         repo = createFakeDatabaseAutomationsRepository({
-            getDatabase: () => database
+            getDatabase: () => Promise.resolve(knex)
         });
     });
 
-    afterEach(function () {
-        sinon.restore();
-        database.close();
+    afterEach(async function () {
+        await knex?.destroy();
     });
 
     describe('trigger', function () {
@@ -243,14 +226,14 @@ describe('automations repository', function () {
                 memberStatus: 'free'
             });
 
-            const run = getRunByMemberEmail('free@example.com');
+            const run = await getRunByMemberEmail('free@example.com');
             assert(run);
             assert.equal(run.member_email, 'free@example.com');
             assert.equal(run.member_id, 'member_123');
             assert.equal(run.automation_slug, 'member-welcome-email-free');
             assert.equal(run.created_at, run.updated_at);
 
-            const step = getStepByRunId(run.id);
+            const step = await getStepByRunId(run.id);
             assert(step);
             assert.equal(step.automation_run_id, run.id);
             assert.equal(step.action_type, 'wait');
@@ -273,11 +256,11 @@ describe('automations repository', function () {
                 memberStatus: 'paid'
             });
 
-            const run = getRunByMemberEmail('paid@example.com');
+            const run = await getRunByMemberEmail('paid@example.com');
             assert(run);
             assert.equal(run.automation_slug, 'member-welcome-email-paid');
 
-            const step = getStepByRunId(run.id);
+            const step = await getStepByRunId(run.id);
             assert(step);
             assert.equal(step.automation_run_id, run.id);
             assert.equal(step.action_type, 'wait');
@@ -322,10 +305,10 @@ describe('automations repository', function () {
                 memberStatus: 'free'
             });
 
-            const run = getRunByMemberEmail('free@example.com');
+            const run = await getRunByMemberEmail('free@example.com');
             assert(run);
 
-            const step = getStepByRunId(run.id);
+            const step = await getStepByRunId(run.id);
             assert(step);
             assert.equal(step.action_id, 'main-wait-action');
         });
@@ -343,8 +326,8 @@ describe('automations repository', function () {
                 memberStatus: 'free'
             });
 
-            assert.equal(getRunByMemberEmail('inactive-free@example.com'), undefined);
-            assert.equal(getRunCountByAutomationId(freeAutomation.id), 0);
+            assert.equal(await getRunByMemberEmail('inactive-free@example.com'), undefined);
+            assert.equal(await getRunCountByAutomationId(freeAutomation.id), 0);
         });
 
         it('does not trigger an automation for an automation with no actions', async function () {
@@ -361,22 +344,22 @@ describe('automations repository', function () {
                 memberStatus: 'free'
             });
 
-            assert.equal(getRunByMemberEmail('free-no-actions@example.com'), undefined);
-            assert.equal(getRunCountByAutomationId(freeAutomation.id), 0);
+            assert.equal(await getRunByMemberEmail('free-no-actions@example.com'), undefined);
+            assert.equal(await getRunCountByAutomationId(freeAutomation.id), 0);
         });
     });
 
     describe('edit', function () {
         it('only inserts action revisions when action data changes', async function () {
             const initialAutomation = await getAutomationBySlug('member-welcome-email-free');
-            const initialRevisionCount = getRevisionCount();
+            const initialRevisionCount = await getRevisionCount();
             const waitAction = initialAutomation.actions.find(action => action.type === 'wait');
             const unchangedEmailAction = initialAutomation.actions.find(action => action.type === 'send_email');
 
             assert(waitAction);
             assert(unchangedEmailAction);
-            assert.equal(getRevisionCount(waitAction.id), 1);
-            assert.equal(getRevisionCount(unchangedEmailAction.id), 1);
+            assert.equal(await getRevisionCount(waitAction.id), 1);
+            assert.equal(await getRevisionCount(unchangedEmailAction.id), 1);
 
             await repo.edit(initialAutomation.id, {
                 status: 'inactive',
@@ -384,9 +367,9 @@ describe('automations repository', function () {
                 edges: initialAutomation.edges
             });
 
-            assert.equal(getRevisionCount(), initialRevisionCount);
-            assert.equal(getRevisionCount(waitAction.id), 1);
-            assert.equal(getRevisionCount(unchangedEmailAction.id), 1);
+            assert.equal(await getRevisionCount(), initialRevisionCount);
+            assert.equal(await getRevisionCount(waitAction.id), 1);
+            assert.equal(await getRevisionCount(unchangedEmailAction.id), 1);
 
             const changedWaitAction = changeWaitHours(waitAction, waitAction.data.wait_hours + 24);
 
@@ -399,9 +382,9 @@ describe('automations repository', function () {
                 }]
             });
 
-            assert.equal(getRevisionCount(), initialRevisionCount + 1);
-            assert.equal(getRevisionCount(waitAction.id), 2);
-            assert.equal(getRevisionCount(unchangedEmailAction.id), 1);
+            assert.equal(await getRevisionCount(), initialRevisionCount + 1);
+            assert.equal(await getRevisionCount(waitAction.id), 2);
+            assert.equal(await getRevisionCount(unchangedEmailAction.id), 1);
 
             const addedActionId = ObjectId().toString();
             const addedAction: AutomationAction = {
@@ -427,68 +410,108 @@ describe('automations repository', function () {
                 ]
             });
 
-            assert.equal(getRevisionCount(), initialRevisionCount + 2);
-            assert.equal(getRevisionCount(waitAction.id), 2);
-            assert.equal(getRevisionCount(unchangedEmailAction.id), 1);
-            assert.equal(getRevisionCount(addedActionId), 1);
+            assert.equal(await getRevisionCount(), initialRevisionCount + 2);
+            assert.equal(await getRevisionCount(waitAction.id), 2);
+            assert.equal(await getRevisionCount(unchangedEmailAction.id), 1);
+            assert.equal(await getRevisionCount(addedActionId), 1);
         });
     });
 
     describe('fetchAndLockSteps', function () {
+        const isCandidateStepSelect = (query: KnexQuery) => {
+            const sql = query.sql?.toLowerCase() ?? '';
+            return (
+                query.method === 'select' &&
+                sql.includes('select `id`') &&
+                sql.includes('from `automation_run_steps`')
+            );
+        };
+
+        const includesStepId = (response: unknown, stepId: string) => (
+            Array.isArray(response) &&
+            response.some(row => (
+                typeof row === 'object' &&
+                row !== null &&
+                'id' in row &&
+                row.id === stepId
+            ))
+        );
+
         const simulateLockRace = (contendedStepId: string) => {
             let hasSimulatedLock = false;
-            const originalPrepare = database.prepare.bind(database);
-            sinon.stub(database, 'prepare').callsFake((source) => {
-                const statement = originalPrepare(source);
-                const normalizedSource = source.toLowerCase();
 
-                const shouldSimulateLockBySomeoneElse = (
-                    !hasSimulatedLock &&
-                    normalizedSource.includes('select `id`') &&
-                    normalizedSource.includes('from `automation_run_steps`')
-                );
-                if (!shouldSimulateLockBySomeoneElse) {
-                    return statement;
+            const originalTransaction = knex.transaction.bind(knex);
+
+            const mockTransaction = async (
+                scope: (_trx: Knex.Transaction) => Promise<unknown>,
+                config?: Knex.TransactionConfig
+            ) => (
+                originalTransaction(async (trx: Knex.Transaction) => {
+                    const {client} = trx;
+
+                    const originalQuery = client.query.bind(client);
+                    client.query = async (connection: unknown, query: KnexQuery) => {
+                        const result = await originalQuery(connection, query);
+                        if (
+                            !hasSimulatedLock &&
+                            isCandidateStepSelect(query) &&
+                            includesStepId(result.response, contendedStepId)
+                        ) {
+                            hasSimulatedLock = true;
+                            const lockedAt = new Date().toISOString();
+                            await trx('automation_run_steps')
+                                .update({
+                                    locked_by: 'contending-lock',
+                                    locked_at: lockedAt,
+                                    started_at: lockedAt,
+                                    updated_at: lockedAt
+                                })
+                                .where('id', contendedStepId);
+                            client.query = originalQuery;
+                        }
+                        return result;
+                    };
+
+                    return await scope(trx);
+                }, config)
+            );
+
+            const mockKnex = new Proxy(knex, {
+                get(target, property, receiver) {
+                    if (property === 'transaction') {
+                        return mockTransaction;
+                    }
+                    return Reflect.get(target, property, receiver);
                 }
+            }) as Knex;
 
-                const originalAll = statement.all.bind(statement);
-                sinon.stub(statement, 'all').callsFake((...args) => {
-                    const result = originalAll(...args);
-
-                    hasSimulatedLock = true;
-
-                    const lockedAt = new Date().toISOString();
-                    const {sql, bindings} = toNativeQuery(queryBuilder('automation_run_steps')
-                        .update({
-                            locked_by: 'contending-lock',
-                            locked_at: lockedAt,
-                            started_at: lockedAt,
-                            updated_at: lockedAt
-                        })
-                        .where('id', contendedStepId));
-                    originalPrepare(sql).run(...bindings);
-
-                    return result;
-                });
-
-                return statement;
+            repo = createFakeDatabaseAutomationsRepository({
+                getDatabase: () => Promise.resolve(mockKnex)
             });
+        };
+
+        const assertContendedStepWasLocked = async (stepId: string) => {
+            const step = await getStepById(stepId);
+            assert.equal(step.locked_by, 'contending-lock');
+            assert.equal(typeof step.locked_at, 'string');
+            assert.equal(step.started_at, step.locked_at);
+            assert.equal(step.updated_at, step.locked_at);
         };
 
         it('locks ready and steps with stale locks, but skips future and recently-locked steps', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const readyStep = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const readyStep = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
-            const staleLockStep = insertStep(run.id, action.revision_id, {
+            const staleLockStep = await insertStep(run.id, action.revision_id, {
                 locked_at: new Date(Date.now() - (31 * 60 * 1000)).toISOString(),
                 ready_at: new Date(Date.now() - 1000).toISOString(),
                 locked_by: 'old-lock',
                 step_attempts: 2
             });
-            const finishedStep = insertStep(run.id, action.revision_id, {
+            const finishedStep = await insertStep(run.id, action.revision_id, {
                 finished_at: new Date(Date.now() - 1000).toISOString(),
                 locked_at: new Date(Date.now() - (31 * 60 * 1000)).toISOString(),
                 ready_at: new Date(Date.now() - 1000).toISOString(),
@@ -497,10 +520,10 @@ describe('automations repository', function () {
                 step_attempts: 4
             });
             const futureReadyAt = new Date(Date.now() + 60 * 1000);
-            const notReadyYetStep = insertStep(run.id, action.revision_id, {
+            const notReadyYetStep = await insertStep(run.id, action.revision_id, {
                 ready_at: futureReadyAt.toISOString()
             });
-            const recentlyLockedStep = insertStep(run.id, action.revision_id, {
+            const recentlyLockedStep = await insertStep(run.id, action.revision_id, {
                 locked_at: new Date(Date.now() - (29 * 60 * 1000)).toISOString(),
                 ready_at: new Date(Date.now() - 1000).toISOString(),
                 locked_by: 'fresh-lock'
@@ -515,39 +538,39 @@ describe('automations repository', function () {
 
             const lockId = assertSingleBatchLock(result.steps);
 
-            const lockedReady = getStepById(readyStep.id);
+            const lockedReady = await getStepById(readyStep.id);
             assert.equal(lockedReady.status, 'pending');
             assert.equal(lockedReady.step_attempts, 1);
             assert.equal(lockedReady.locked_by, lockId);
 
-            const lockedStaleLock = getStepById(staleLockStep.id);
+            const lockedStaleLock = await getStepById(staleLockStep.id);
             assert.equal(lockedStaleLock.status, 'pending');
             assert.equal(lockedStaleLock.step_attempts, 3);
             assert.equal(lockedStaleLock.locked_by, lockId);
 
-            const skippedFinished = getStepById(finishedStep.id);
+            const skippedFinished = await getStepById(finishedStep.id);
             assert.equal(skippedFinished.status, 'finished');
             assert.equal(skippedFinished.step_attempts, 4);
             assert.equal(skippedFinished.locked_by, 'finished-lock');
 
-            const skippedNotReadyYet = getStepById(notReadyYetStep.id);
+            const skippedNotReadyYet = await getStepById(notReadyYetStep.id);
             assert.equal(skippedNotReadyYet.step_attempts, 0);
             assert.equal(skippedNotReadyYet.locked_by, null);
 
-            const skippedRecentlyLocked = getStepById(recentlyLockedStep.id);
+            const skippedRecentlyLocked = await getStepById(recentlyLockedStep.id);
             assert.equal(skippedRecentlyLocked.step_attempts, 0);
             assert.equal(skippedRecentlyLocked.locked_by, 'fresh-lock');
         });
 
         it('returns the next future pending ready_at when no steps can be locked', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
             const later = new Date(Date.now() + 60 * 1000);
             const sooner = new Date(Date.now() + 30 * 1000);
 
-            insertStep(run.id, action.revision_id, {ready_at: later.toISOString()});
-            insertStep(run.id, action.revision_id, {ready_at: sooner.toISOString()});
+            await insertStep(run.id, action.revision_id, {ready_at: later.toISOString()});
+            await insertStep(run.id, action.revision_id, {ready_at: sooner.toISOString()});
 
             const result = await repo.fetchAndLockSteps(10);
 
@@ -558,11 +581,11 @@ describe('automations repository', function () {
 
         it('does not schedule an immediate poll when due steps are locked by another worker', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
             const lockedAt = new Date(Date.now() - 60 * 1000);
 
-            insertStep(run.id, action.revision_id, {
+            await insertStep(run.id, action.revision_id, {
                 locked_at: lockedAt.toISOString(),
                 ready_at: new Date(Date.now() - 1000).toISOString(),
                 locked_by: 'fresh-lock'
@@ -576,13 +599,13 @@ describe('automations repository', function () {
 
         it('respects the limit argument', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
             const readyAt1 = new Date(Date.now() - 2000).toISOString();
             const readyAt2 = new Date(Date.now() - 1000).toISOString();
-            const firstStep = insertStep(run.id, action.revision_id, {ready_at: readyAt1});
-            const secondStep = insertStep(run.id, action.revision_id, {ready_at: readyAt1});
-            const thirdStep = insertStep(run.id, action.revision_id, {ready_at: readyAt2});
+            const firstStep = await insertStep(run.id, action.revision_id, {ready_at: readyAt1});
+            const secondStep = await insertStep(run.id, action.revision_id, {ready_at: readyAt1});
+            const thirdStep = await insertStep(run.id, action.revision_id, {ready_at: readyAt2});
 
             const result = await repo.fetchAndLockSteps(2);
 
@@ -591,9 +614,9 @@ describe('automations repository', function () {
 
             const lockId = assertSingleBatchLock(result.steps);
 
-            const first = getStepById(firstStep.id);
-            const second = getStepById(secondStep.id);
-            const third = getStepById(thirdStep.id);
+            const first = await getStepById(firstStep.id);
+            const second = await getStepById(secondStep.id);
+            const third = await getStepById(thirdStep.id);
             const allSteps = [first, second, third];
 
             const lockedSteps = allSteps.filter(step => step.locked_by === lockId);
@@ -609,15 +632,15 @@ describe('automations repository', function () {
 
         it('does not return the same steps to concurrent callers', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
             const readyAt = new Date(Date.now() - 1000).toISOString();
-            const readySteps = [
+            const readySteps = await Promise.all([
                 insertStep(run.id, action.revision_id, {ready_at: readyAt}),
                 insertStep(run.id, action.revision_id, {ready_at: readyAt}),
                 insertStep(run.id, action.revision_id, {ready_at: readyAt}),
                 insertStep(run.id, action.revision_id, {ready_at: readyAt})
-            ];
+            ]);
 
             const [firstResult, secondResult] = await Promise.all([
                 repo.fetchAndLockSteps(2),
@@ -634,7 +657,7 @@ describe('automations repository', function () {
             const secondLockId = assertSingleBatchLock(secondResult.steps);
             assert.notEqual(firstLockId, secondLockId);
 
-            const allSteps = readySteps.map(step => getStepById(step.id));
+            const allSteps = await Promise.all(readySteps.map(step => getStepById(step.id)));
             const lockedSteps = allSteps.filter(step => step.locked_by !== null);
             assert.equal(lockedSteps.length, firstResult.steps.length + secondResult.steps.length);
             assert(lockedSteps.length <= readySteps.length);
@@ -642,11 +665,11 @@ describe('automations repository', function () {
 
         it('handles concurrent locks in the same transaction', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
             const readyAt = new Date(Date.now() - 1000).toISOString();
-            const availableStep = insertStep(run.id, action.revision_id, {ready_at: readyAt});
-            const contendedStep = insertStep(run.id, action.revision_id, {ready_at: readyAt});
+            const availableStep = await insertStep(run.id, action.revision_id, {ready_at: readyAt});
+            const contendedStep = await insertStep(run.id, action.revision_id, {ready_at: readyAt});
 
             simulateLockRace(contendedStep.id);
             const result = await repo.fetchAndLockSteps(2);
@@ -654,18 +677,19 @@ describe('automations repository', function () {
             const actualStepIds = new Set(result.steps.map(step => step.id));
             const expectedStepIds = new Set([availableStep.id]);
             assert.deepEqual(actualStepIds, expectedStepIds);
+            await assertContendedStepWasLocked(contendedStep.id);
         });
 
         it('returns the next unlocked ready_at when selected rows lose the lock race', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
             const readyAt = new Date(Date.now() - 1000).toISOString();
-            const contendedStep = insertStep(run.id, action.revision_id, {
+            const contendedStep = await insertStep(run.id, action.revision_id, {
                 created_at: new Date(Date.now() - 2000).toISOString(),
                 ready_at: readyAt
             });
-            insertStep(run.id, action.revision_id, {
+            await insertStep(run.id, action.revision_id, {
                 created_at: new Date(Date.now() - 1000).toISOString(),
                 ready_at: readyAt
             });
@@ -676,19 +700,20 @@ describe('automations repository', function () {
             assert.deepEqual(result.steps, []);
             assert(result.nextStepReadyAt);
             assert.equal(result.nextStepReadyAt.toISOString(), readyAt);
+            await assertContendedStepWasLocked(contendedStep.id);
         });
     });
 
     describe('finishStepAndEnqueueNext', function () {
         it('finishes a locked step and enqueues the next action revision', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
-            const lockedStep = getStepById(step.id);
+            const lockedStep = await getStepById(step.id);
 
             const beforeFinish = Date.now();
             const nextReadyAt = await repo.finishStepAndEnqueueNext(step);
@@ -698,7 +723,7 @@ describe('automations repository', function () {
             assert(nextReadyAt.getTime() >= beforeFinish);
             assert(nextReadyAt.getTime() <= afterFinish);
 
-            const finished = getStepById(stepRow.id);
+            const finished = await getStepById(stepRow.id);
             assert.equal(finished.status, 'finished');
             assert.equal(finished.locked_by, null);
             assert.equal(finished.locked_at, null);
@@ -707,11 +732,11 @@ describe('automations repository', function () {
             assert.equal(finished.step_attempts, 1);
             assert.equal(typeof finished.finished_at, 'string');
 
-            const allSteps = getStepsByRunId(run.id);
+            const allSteps = await getStepsByRunId(run.id);
             assert.equal(allSteps.length, 2);
             const nextStep = allSteps.find(candidate => candidate.id !== stepRow.id);
             assert(nextStep);
-            const nextAction = getActionByIndex(automation.id, 1);
+            const nextAction = await getActionByIndex(automation.id, 1);
             assert.equal(nextStep.automation_run_id, run.id);
             assert.equal(nextStep.automation_action_revision_id, nextAction.revision_id);
             assert.equal(nextStep.status, 'pending');
@@ -720,10 +745,10 @@ describe('automations repository', function () {
 
         it('uses wait hours when the next action is a wait action', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const sendEmailAction = getActionByIndex(automation.id, 1);
+            const sendEmailAction = await getActionByIndex(automation.id, 1);
             assert.equal(sendEmailAction.action_type, 'send_email');
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, sendEmailAction.revision_id, {
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, sendEmailAction.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
@@ -739,9 +764,9 @@ describe('automations repository', function () {
 
         it('does not enqueue a duplicate next step when called again with the same locked step', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
@@ -752,10 +777,10 @@ describe('automations repository', function () {
             assert(firstNextReadyAt);
             assert.equal(secondNextReadyAt, null);
 
-            const allSteps = getStepsByRunId(run.id);
+            const allSteps = await getStepsByRunId(run.id);
             assert.equal(allSteps.length, 2);
 
-            const finished = getStepById(stepRow.id);
+            const finished = await getStepById(stepRow.id);
             assert.equal(finished.status, 'finished');
             assert.equal(finished.locked_by, null);
             assert.equal(finished.locked_at, null);
@@ -763,41 +788,41 @@ describe('automations repository', function () {
 
         it('does not finish or enqueue if the step lock has been taken by another runner', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
             const otherLockedAt = new Date().toISOString();
 
-            runQuery(queryBuilder('automation_run_steps')
+            await knex('automation_run_steps')
                 .update({
                     locked_by: 'other-runner-lock',
                     locked_at: otherLockedAt,
                     updated_at: otherLockedAt
                 })
-                .where('id', stepRow.id));
+                .where('id', stepRow.id);
 
             const nextReadyAt = await repo.finishStepAndEnqueueNext(step);
 
             assert.equal(nextReadyAt, null);
 
-            const unchanged = getStepById(stepRow.id);
+            const unchanged = await getStepById(stepRow.id);
             assert.equal(unchanged.status, 'pending');
             assert.equal(unchanged.locked_by, 'other-runner-lock');
             assert.equal(unchanged.locked_at, otherLockedAt);
             assert.equal(unchanged.finished_at, null);
 
-            const allSteps = getStepsByRunId(run.id);
+            const allSteps = await getStepsByRunId(run.id);
             assert.equal(allSteps.length, 1);
         });
 
         it('returns null and does not enqueue when there is no next action', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const lastAction = getActionByIndex(automation.id, 3);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, lastAction.revision_id, {
+            const lastAction = await getActionByIndex(automation.id, 3);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, lastAction.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
@@ -806,24 +831,24 @@ describe('automations repository', function () {
 
             assert.equal(nextReadyAt, null);
 
-            const finished = getStepById(stepRow.id);
+            const finished = await getStepById(stepRow.id);
             assert.equal(finished.status, 'finished');
             assert.equal(finished.locked_by, null);
             assert.equal(finished.locked_at, null);
 
-            const allSteps = getStepsByRunId(run.id);
+            const allSteps = await getStepsByRunId(run.id);
             assert.equal(allSteps.length, 1);
         });
 
         it('enqueues the latest revision of the next action', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const sendEmailAction = getActionByIndex(automation.id, 1);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, sendEmailAction.revision_id, {
+            const sendEmailAction = await getActionByIndex(automation.id, 1);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, sendEmailAction.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
-            const nextActionBeforeEdit = getActionByIndex(automation.id, 2);
+            const nextActionBeforeEdit = await getActionByIndex(automation.id, 2);
 
             const waitAction = automation.actions.find(action => action.id === nextActionBeforeEdit.action_id);
             assert(waitAction);
@@ -840,7 +865,7 @@ describe('automations repository', function () {
                 edges: automation.edges
             });
 
-            const updatedNextAction = getLatestActionRevisionByActionId(updatedWaitAction.id);
+            const updatedNextAction = await getLatestActionRevisionByActionId(updatedWaitAction.id);
             assert.equal(updatedNextAction.wait_hours, 96);
 
             const beforeFinish = Date.now();
@@ -851,7 +876,7 @@ describe('automations repository', function () {
             assert(nextReadyAt.getTime() >= beforeFinish + (96 * HOUR_MS));
             assert(nextReadyAt.getTime() <= afterFinish + (96 * HOUR_MS));
 
-            const allSteps = getStepsByRunId(run.id);
+            const allSteps = await getStepsByRunId(run.id);
             assert.equal(allSteps.length, 2);
 
             const nextStep = allSteps.find(candidate => candidate.id !== stepRow.id);
@@ -864,13 +889,13 @@ describe('automations repository', function () {
     describe('markStepTerminal', function () {
         it('marks a locked step with a terminal status and clears the lock', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
-            const lockedStep = getStepById(step.id);
+            const lockedStep = await getStepById(step.id);
             assert.equal(typeof lockedStep.started_at, 'string');
 
             const beforeMark = Date.now();
@@ -879,14 +904,14 @@ describe('automations repository', function () {
 
             assert.equal(didMark, true);
 
-            const marked = getStepById(step.id);
+            const marked = await getStepById(step.id);
             assert.equal(marked.status, 'member unsubscribed');
             assert.equal(marked.locked_by, null);
             assert.equal(marked.locked_at, null);
             assert.equal(marked.started_at, lockedStep.started_at);
             assert.equal(marked.ready_at, lockedStep.ready_at);
             assert.equal(marked.step_attempts, 1);
-            assert.equal(getStepsByRunId(run.id).length, 1);
+            assert.equal((await getStepsByRunId(run.id)).length, 1);
             const markedFinishedAt = marked.finished_at;
             assert(typeof markedFinishedAt === 'string');
             assert(new Date(markedFinishedAt).getTime() >= beforeMark);
@@ -895,27 +920,27 @@ describe('automations repository', function () {
 
         it('does not overwrite a step that is no longer pending', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
             const finishedAt = new Date(Date.now() - 500).toISOString();
 
-            runQuery(queryBuilder('automation_run_steps')
+            await knex('automation_run_steps')
                 .update({
                     status: 'finished',
                     finished_at: finishedAt,
                     locked_at: null
                 })
-                .where('id', step.id));
+                .where('id', step.id);
 
             const didMark = await repo.markStepTerminal(step, 'member unsubscribed');
 
             assert.equal(didMark, false);
 
-            const unchanged = getStepById(step.id);
+            const unchanged = await getStepById(step.id);
             assert.equal(unchanged.status, 'finished');
             assert.equal(unchanged.finished_at, finishedAt);
             assert.equal(unchanged.locked_by, step.locked_by);
@@ -924,28 +949,28 @@ describe('automations repository', function () {
 
         it('does not mark a step terminal if the step lock has been taken by another runner', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
             const otherLockedAt = new Date().toISOString();
 
-            runQuery(queryBuilder('automation_run_steps')
+            await knex('automation_run_steps')
                 .update({
                     locked_by: 'other-runner-lock',
                     locked_at: otherLockedAt,
                     updated_at: otherLockedAt
                 })
-                .where('id', stepRow.id));
+                .where('id', stepRow.id);
 
-            const beforeMark = getStepById(stepRow.id);
+            const beforeMark = await getStepById(stepRow.id);
             const didMark = await repo.markStepTerminal(step, 'member unsubscribed');
 
             assert.equal(didMark, false);
 
-            const unchanged = getStepById(stepRow.id);
+            const unchanged = await getStepById(stepRow.id);
             assert.deepEqual(unchanged, beforeMark);
         });
     });
@@ -953,9 +978,9 @@ describe('automations repository', function () {
     describe('retryStep', function () {
         it('reschedules a locked step for retry and clears the lock', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
@@ -967,7 +992,7 @@ describe('automations repository', function () {
 
             assert.equal(didRetry, true);
 
-            const retried = getStepById(step.id);
+            const retried = await getStepById(step.id);
             assert.equal(retried.status, 'pending');
             assert.equal(retried.ready_at, retryAt.toISOString());
             assert.equal(retried.started_at, null);
@@ -983,27 +1008,27 @@ describe('automations repository', function () {
 
         it('does not retry a locked step that is no longer pending', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
-            const action = getActionByIndex(automation.id, 0);
-            const run = insertRun(automation.id);
-            const stepRow = insertStep(run.id, action.revision_id, {
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
                 ready_at: new Date(Date.now() - 1000).toISOString()
             });
             const step = await getLockedStep(stepRow.id);
             const finishedAt = new Date(Date.now() - 500).toISOString();
 
-            runQuery(queryBuilder('automation_run_steps')
+            await knex('automation_run_steps')
                 .update({
                     status: 'finished',
                     finished_at: finishedAt
                 })
-                .where('id', step.id));
+                .where('id', step.id);
 
-            const beforeRetry = getStepById(step.id);
+            const beforeRetry = await getStepById(step.id);
             const didRetry = await repo.retryStep(step, new Date(Date.now() + 1000));
 
             assert.equal(didRetry, false);
 
-            const unchanged = getStepById(step.id);
+            const unchanged = await getStepById(step.id);
             assert.deepEqual(unchanged, beforeRetry);
         });
     });


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1279
towards https://linear.app/ghost/issue/NY-1311

*This change should have no user impact because it only affects the fake automations database.*

Before this change, the fake automations database used `node:sqlite`. This worked, but was less realistic.

Now, it uses Knex with a (still in-memory) SQLite. This will make our migration to the real database much easier.
