### PR TITLE
Improved llms service content API queries

### DIFF
--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -219,6 +219,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
 
         const response = await controller.browse({
             ...options,
+            context: {member: null},
             filter: 'status:published+visibility:public',
             order: type === 'post' ? 'published_at desc' : 'id asc'
         });
@@ -230,8 +231,13 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
     }
 
     async function fetchIndexEntries(type) {
+        // Without `fields` the content API selects every posts column (except
+        // mobiledoc/lexical), pulling the full html of every post into memory.
+        // The format columns (plaintext here) are appended to `fields` by the
+        // input serializer, and `url` is resolved at serialization time.
         const {entries} = await browsePublicEntries(type, {
             limit: 'all',
+            fields: 'id,title,slug,custom_excerpt,featured,published_at,url',
             formats: 'plaintext'
         });
 
@@ -246,6 +252,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         const {entries, pagination} = await browsePublicEntries(type, {
             limit: FULL_PAGE_SIZE,
             page: pageNum,
+            fields: 'id,title,slug,featured,published_at,updated_at,created_at,url',
             formats: 'html,plaintext'
         });
 

--- a/ghost/core/test/e2e-frontend/llms-routes.test.js
+++ b/ghost/core/test/e2e-frontend/llms-routes.test.js
@@ -1,0 +1,76 @@
+// # llms.txt Frontend Routing Tests
+// The llms service fetches content through the public Posts/Pages API with
+// narrowed `fields` + `formats` options. These tests boot a full Ghost
+// instance so the request runs through the real controllers and serializers,
+// covering the fields/formats/url interaction the unit tests mock away.
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const supertest = require('supertest');
+const testUtils = require('../utils');
+const configUtils = require('../utils/config-utils');
+const settingsCache = require('../../core/shared/settings-cache');
+
+describe('llms.txt routing', function () {
+    let request;
+    let siteUrl;
+
+    before(async function () {
+        await testUtils.startGhost();
+        siteUrl = configUtils.config.get('url').replace(/\/$/, '');
+        request = supertest.agent(configUtils.config.get('url'));
+    });
+
+    beforeEach(function () {
+        const originalGet = settingsCache.get;
+        sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
+            if (key === 'labs') {
+                return {llmsTxt: true};
+            }
+
+            return originalGet(key, options);
+        });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('serves llms.txt with published public entries and absolute urls', async function () {
+        const res = await request.get('/llms.txt')
+            .expect('Content-Type', /text\/plain/)
+            .expect(200);
+
+        // entries are linked via absolute urls resolved by the public API serializer
+        assert.match(res.text, new RegExp(`\\[About this site\\]\\(${siteUrl}/about\\.md\\)`));
+        assert.match(res.text, new RegExp(`\\[Start here for a quick overview of everything you need to know\\]\\(${siteUrl}/welcome\\.md\\)`));
+
+        // descriptions come from plaintext, which is requested via `formats`
+        // on top of the narrowed `fields`
+        assert.match(res.text, /\[Start here for a quick overview of everything you need to know\]\([^)]+\) - We've crammed the most important information/);
+    });
+
+    it('serves llms-full.txt with entry bodies and absolute urls', async function () {
+        const res = await request.get('/llms-full.txt')
+            .expect('Content-Type', /text\/plain/)
+            .expect(200);
+
+        assert.match(res.text, /### About this site/);
+        assert.match(res.text, /### Start here for a quick overview of everything you need to know/);
+        assert.match(res.text, new RegExp(`URL: ${siteUrl}/about/`));
+
+        // entry bodies are rendered from html, which is requested via
+        // `formats` on top of the narrowed `fields`
+        assert.match(res.text, /An about page is a great example of one you might want to set up early on/);
+    });
+
+    it('does not serve llms.txt when the labs flag is disabled', async function () {
+        sinon.restore();
+
+        // with the flag off the handler defers to the rest of the routing
+        // stack, which treats the path like any other unknown frontend route
+        // (the trailing-slash middleware redirects it)
+        const res = await request.get('/llms.txt');
+
+        assert.equal(res.status, 302);
+    });
+});

--- a/ghost/core/test/e2e-frontend/llms-routes.test.js
+++ b/ghost/core/test/e2e-frontend/llms-routes.test.js
@@ -41,8 +41,8 @@ describe('llms.txt routing', function () {
             .expect(200);
 
         // entries are linked via absolute urls resolved by the public API serializer
-        assert.match(res.text, new RegExp(`\\[About this site\\]\\(${siteUrl}/about\\.md\\)`));
-        assert.match(res.text, new RegExp(`\\[Start here for a quick overview of everything you need to know\\]\\(${siteUrl}/welcome\\.md\\)`));
+        assert.ok(res.text.includes(`[About this site](${siteUrl}/about.md)`), 'expected absolute .md link for the about page');
+        assert.ok(res.text.includes(`[Start here for a quick overview of everything you need to know](${siteUrl}/welcome.md)`), 'expected absolute .md link for the welcome post');
 
         // descriptions come from plaintext, which is requested via `formats`
         // on top of the narrowed `fields`
@@ -56,7 +56,7 @@ describe('llms.txt routing', function () {
 
         assert.match(res.text, /### About this site/);
         assert.match(res.text, /### Start here for a quick overview of everything you need to know/);
-        assert.match(res.text, new RegExp(`URL: ${siteUrl}/about/`));
+        assert.ok(res.text.includes(`URL: ${siteUrl}/about/`), 'expected absolute url for the about page entry');
 
         // entry bodies are rendered from html, which is requested via
         // `formats` on top of the narrowed `fields`

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -413,5 +413,34 @@ describe('Unit: frontend/services/llms/service', function () {
         assert.equal(pageCall.options.filter, 'status:published+visibility:public');
         assert.equal(postCall.options.filter, 'status:published+visibility:public');
         assert.equal(postCall.options.limit, 'all');
+        assert.equal(pageCall.options.order, 'id asc');
+        assert.equal(postCall.options.order, 'published_at desc');
+        assert.deepEqual(pageCall.options.context, {member: null});
+        assert.deepEqual(postCall.options.context, {member: null});
+        assert.equal(postCall.options.formats, 'plaintext');
+        assert.equal(postCall.options.fields, 'id,title,slug,custom_excerpt,featured,published_at,url');
+    });
+
+    it('requests narrow fields and html for llms-full.txt entries', async function () {
+        const calls = [];
+        const recordingBrowse = key => async (options) => {
+            calls.push({key, options});
+            return {[key]: [], meta: {pagination: {next: null}}};
+        };
+        const api = {
+            pagesPublic: {browse: recordingBrowse('pages')},
+            postsPublic: {browse: recordingBrowse('posts')}
+        };
+
+        const service = createService({api});
+
+        await service.getLlmsFullTxt();
+
+        const postCall = calls.find(call => call.key === 'posts');
+
+        assert.ok(postCall, 'expected postsPublic.browse to be called');
+        assert.equal(postCall.options.formats, 'html,plaintext');
+        assert.equal(postCall.options.fields, 'id,title,slug,featured,published_at,updated_at,created_at,url');
+        assert.equal(postCall.options.limit, 100);
     });
 });


### PR DESCRIPTION
## Why

Completes #28420 — the squash merge predated a review-fix commit that was never pushed, so main is missing the `fields` narrowing, explicit anonymous context, and llms e2e coverage that the merged commit message already describes.

## What

- Browse requests pass `fields` so the `limit: 'all'` index fetch doesn't pull the full html of every post into memory (without it the Content API selects every column except mobiledoc/lexical). The requested `formats` are appended to the select by the input serializer, and `url` is resolved at serialization time.
- Requests pass an explicit anonymous `context: {member: null}`, matching how the frontend calls these controllers elsewhere.
- Added `test/e2e-frontend/llms-routes.test.js`, which boots a full Ghost instance and verifies the `fields`/`formats`/`url` interaction through the real controllers and serializers, plus unit assertions pinning the browse options.