### PR TITLE
✨ Added IndexNow to notify search engines of content changes

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -48,10 +48,6 @@ const features: Feature[] = [{
     description: 'Enable theme translation using i18next instead of the old translation package.',
     flag: 'themeTranslation'
 }, {
-    title: 'IndexNow',
-    description: 'Automatically notify search engines when content is published or updated for faster indexing.',
-    flag: 'indexnow'
-}, {
     title: 'Featurebase Feedback',
     description: 'Display a Feedback menu item in the admin sidebar. Requires the new admin experience.',
     flag: 'featurebaseFeedback'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -26,7 +26,8 @@ const GA_FEATURES = [
     'commentsThreads',
     'commentsPinning',
     'featurebaseFeedback',
-    'dangerZoneResetAuth'
+    'dangerZoneResetAuth',
+    'indexnow'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -49,7 +50,6 @@ const PRIVATE_FEATURES = [
     'tagsX',
     'emailUniqueid',
     'themeTranslation',
-    'indexnow',
     'pictureImageFormats',
     'smarterCounts',
     'llmsTxt',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1803,7 +1803,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5431",
+  "content-length": "5449",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
## Summary

GA the IndexNow feature. It's been running as a private developer experiment and is proven in production, so this:

- moves `indexnow` from `PRIVATE_FEATURES` to `GA_FEATURES` (always on), so Ghost pings the IndexNow API when posts are published or updated
- removes the now-redundant developer-experiments toggle from the labs private features list

Pings still respect existing privacy controls: the `config.isPrivacyDisabled('useIndexNow')` gate (added in #28408) and the `is_private` site check both suppress pings where appropriate.

## Status

Draft — held pending a rate-limiting review before flipping on.
