### PR TITLE
Started batch inserting automation action edges

### DIFF
--- a/ghost/core/core/server/services/automations/fake-database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/fake-database-automations-repository.ts
@@ -658,9 +658,7 @@ async function replaceAutomationGraph(trx: Knex.Transaction, automationId: strin
 
     await deleteAutomationEdges(trx, automationId);
 
-    for (const edge of edges) {
-        await insertActionEdge(trx, edge);
-    }
+    await insertActionEdges(trx, edges);
 }
 
 async function loadAutomationActionRows(trx: Knex.Transaction, automationId: string): Promise<Array<Pick<ActionRow, 'id' | 'type'>>> {
@@ -812,11 +810,14 @@ async function deleteAutomationEdges(trx: Knex.Transaction, automationId: string
             .where('automation_id', automationId));
 }
 
-async function insertActionEdge(trx: Knex.Transaction, edge: Readonly<AutomationEdge>): Promise<void> {
-    await trx('automation_action_edges').insert({
+async function insertActionEdges(trx: Knex.Transaction, edges: ReadonlyArray<AutomationEdge>): Promise<void> {
+    if (edges.length === 0) {
+        return;
+    }
+    await trx('automation_action_edges').insert(edges.map(edge => ({
         source_action_id: edge.source_action_id,
         target_action_id: edge.target_action_id
-    });
+    })));
 }
 
 function requireAutomation(automation: AutomationRow | null, id: string): AutomationRow {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1340

`replaceAutomationGraph` makes a number of trips to the database when it doesn't need to. We should fix this for performance.

This fixes one of those spots: inserting a batch of action edges, instead of doing them one-by-one.

We'll do more [soon][0].

[0]: https://linear.app/ghost/issue/NY-1340
