### PR TITLE
Fixed e2e-tests codecov flag including admin coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1512,9 +1512,12 @@ jobs:
           rsync -av --remove-source-files admin/* ghost/admin
 
       - name: Upload Admin test coverage
+        if: contains(needs.job_admin-tests.result, 'success')
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           flags: admin-tests
+          files: ghost/admin/coverage/cobertura-coverage.xml
+          disable_search: true
 
       - name: Restore E2E coverage
         if: contains(needs.job_acceptance-tests.result, 'success')
@@ -1532,6 +1535,8 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           flags: e2e-tests
+          files: ghost/core/coverage-e2e/cobertura-coverage.xml,ghost/core/coverage-integration/cobertura-coverage.xml
+          disable_search: true
 
   job_required_tests:
     name: All required tests passed or skipped


### PR DESCRIPTION
## Problem

The `codecov/project/e2e-tests` check is failing on PRs (e.g. #28517) with `73.76% (-2.18%) compared to 46ddd0c`.

Root cause has two layers:

1. **The `e2e-tests` flag has been polluted for a while.** In the `Coverage` job, the admin and e2e coverage artifacts are restored into the same workspace, and the codecov uploader's auto-search picks up every coverage file it finds. The `e2e-tests` upload therefore includes `ghost/admin/coverage/cobertura-coverage.xml` alongside the two core reports — the CI logs show `Found 3 coverage files to report` for the e2e upload. As a result the `e2e-tests` flag (1541 files, 73.76%) is effectively the whole-project number instead of core-only (1103 files, 75.93%).

2. **A processing hiccup on main created an inconsistent base.** On `46ddd0c` the admin report failed to process on Codecov's side (upload state `error`, admin coverage was carried forward instead). That left `46ddd0c` with a *clean* core-only `e2e-tests` flag of 75.93% — unlike every surrounding main commit at 73.76%. Any PR using it as the comparison base reports a -2.18% "drop" that is purely measurement noise, and fails the 0.2% threshold.

## Solution

Scope each codecov upload to its own coverage files using `files` + `disable_search`, so each flag measures only its own test suite:

- `admin-tests` → `ghost/admin/coverage/cobertura-coverage.xml`
- `e2e-tests` → `ghost/core/coverage-e2e/cobertura-coverage.xml` + `ghost/core/coverage-integration/cobertura-coverage.xml`

Also added the missing `if: success` guard on the admin upload step to match the e2e upload step.

After this lands, the `e2e-tests` flag will go back up to ~75.9% (core-only). The one-time jump is an increase, so it passes the threshold; subsequent PRs compare clean-vs-clean. PRs currently failing against base `46ddd0c` will pass once their merge-base moves past this fix.