### PR TITLE
Improved E2E MySQL setup performance

### DIFF
--- a/e2e/helpers/environment/service-managers/mysql-manager.ts
+++ b/e2e/helpers/environment/service-managers/mysql-manager.ts
@@ -35,12 +35,7 @@ export class MySQLManager {
     } = {}): Promise<void> {
         debug('Setting up test database:', databaseName);
         try {
-            await this.createDatabase(databaseName);
-            await this.restoreDatabaseFromSnapshot(databaseName);
-            await this.updateSiteUuid(databaseName, siteUuid);
-            if (options.stripe) {
-                await this.updateStripeSettings(databaseName, options.stripe.secretKey, options.stripe.publishableKey);
-            }
+            await this.setupDatabaseFromSnapshot(databaseName, siteUuid, options);
 
             debug('Test database setup completed:', databaseName, 'with site_uuid:', siteUuid);
         } catch (error) {
@@ -193,6 +188,68 @@ export class MySQLManager {
         await this.exec(command);
 
         debug('Stripe settings updated in database');
+    }
+
+    private async setupDatabaseFromSnapshot(databaseName: string, siteUuid: string, options: {
+        stripe?: {
+            secretKey: string;
+            publishableKey: string;
+        };
+    } = {}, snapshotPath: string = '/tmp/dump.sql'): Promise<void> {
+        debug('Creating database from snapshot:', databaseName);
+
+        const command = [
+            `mysql -uroot -proot -e ${this.escapeShellArg(this.getCreateDatabaseSql(databaseName))}`,
+            `mysql -uroot -proot ${this.escapeShellArg(databaseName)} < ${this.escapeShellArg(snapshotPath)}`,
+            `mysql -uroot -proot -e ${this.escapeShellArg(this.getSettingsSql(databaseName, siteUuid, options.stripe))}`
+        ].join(' && ');
+
+        await this.exec(command);
+
+        debug('Database created from snapshot:', databaseName);
+    }
+
+    private getCreateDatabaseSql(databaseName: string): string {
+        return `CREATE DATABASE IF NOT EXISTS ${this.escapeSqlIdentifier(databaseName)};`;
+    }
+
+    private getSettingsSql(databaseName: string, siteUuid: string, stripe?: {
+        secretKey: string;
+        publishableKey: string;
+    }): string {
+        const database = this.escapeSqlIdentifier(databaseName);
+        const statements = [
+            `UPDATE ${database}.settings SET value='${this.escapeSqlString(siteUuid)}' WHERE \`key\`='site_uuid';`
+        ];
+
+        if (stripe) {
+            // Use INSERT ... ON DUPLICATE KEY UPDATE so this works whether or not
+            // the settings rows already exist. In dev mode the base DB is empty
+            // (only schema, no seeded rows), so a plain UPDATE would be a no-op.
+            statements.push(
+                `INSERT INTO ${database}.settings ` +
+                '(id, `group`, `key`, value, type, flags, created_at, updated_at) VALUES ' +
+                `(SUBSTRING(REPLACE(UUID(), '-', ''), 1, 24), 'members', 'stripe_secret_key', '${this.escapeSqlString(stripe.secretKey)}', 'string', NULL, NOW(), NOW()), ` +
+                `(SUBSTRING(REPLACE(UUID(), '-', ''), 1, 24), 'members', 'stripe_publishable_key', '${this.escapeSqlString(stripe.publishableKey)}', 'string', NULL, NOW(), NOW()) ` +
+                'ON DUPLICATE KEY UPDATE value = VALUES(value), updated_at = NOW();'
+            );
+        }
+
+        return statements.join(' ');
+    }
+
+    private escapeSqlIdentifier(identifier: string): string {
+        return `\`${identifier.replace(/`/g, '``')}\``;
+    }
+
+    private escapeSqlString(value: string): string {
+        return value
+            .replace(/\\/g, '\\\\')
+            .replace(/'/g, '\\\'');
+    }
+
+    private escapeShellArg(value: string): string {
+        return `'${value.replace(/'/g, '\'\\\'\'')}'`;
     }
 
     private async exec(command: string) {


### PR DESCRIPTION
## Summary
- combined the browser E2E MySQL test database create/restore/configure path into one Docker exec
- kept the existing public MySQL helper methods intact for other callers
- added SQL identifier/string and shell argument escaping for the new combined command

## Why
Every isolated browser E2E environment creates a database, restores the snapshot, updates `site_uuid`, and sometimes writes Stripe settings. Those operations previously used multiple Docker exec calls per environment. Combining the hot setup path preserves the same database isolation model while reducing repeated Docker exec overhead.

## Testing
- `pnpm --filter @tryghost/e2e test:types`
- pre-commit staged ESLint hook for `e2e/helpers/environment/service-managers/mysql-manager.ts`
- `git diff --check`
- Functional smoke with disposable MySQL 8 tmpfs container:
  - created a source DB with a `settings` table
  - created the default `/tmp/dump.sql` snapshot through `MySQLManager.createSnapshot()`
  - ran `MySQLManager.setupTestDatabase()` with Stripe settings enabled
  - verified restored settings rows:
    - `site_uuid = new-site-uuid`
    - `stripe_publishable_key = pk_test_e2e`
    - `stripe_secret_key = sk_test_e2e`
- Synthetic setup loop through the actual method on the same container:
  - `80ms`, `45ms`, `38ms`, `38ms`, `37ms` for five create/restore/configure/drop cycles on the small dump

## Notes
The benchmark loop uses a tiny synthetic dump, so it is a correctness and overhead smoke rather than a full Ghost E2E runtime estimate. Earlier investigation on a Ghost-sized dump showed combining Docker execs saved roughly 0.17s per environment cycle locally.
