### PR TITLE
Improved E2E environment check caching

### DIFF
--- a/e2e/helpers/environment/service-availability.ts
+++ b/e2e/helpers/environment/service-availability.ts
@@ -3,6 +3,7 @@ import baseDebug from '@tryghost/debug';
 import {DEV_ENVIRONMENT, TINYBIRD} from './constants';
 
 const debug = baseDebug('e2e:ServiceAvailability');
+let tinybirdAvailability: Promise<boolean> | null = null;
 
 async function isServiceAvailable(docker: Docker, serviceName: string) {
     const containers = await docker.listContainers({
@@ -26,8 +27,17 @@ export async function isTinybirdAvailable(): Promise<boolean> {
         return false;
     }
 
-    const docker = new Docker();
-    const tinybirdAvailable = await isServiceAvailable(docker, TINYBIRD.LOCAL_HOST);
-    debug(`Tinybird availability for compose project ${DEV_ENVIRONMENT.projectNamespace}:`, tinybirdAvailable);
-    return tinybirdAvailable;
+    if (!tinybirdAvailability) {
+        tinybirdAvailability = (async () => {
+            const docker = new Docker();
+            const tinybirdAvailable = await isServiceAvailable(docker, TINYBIRD.LOCAL_HOST);
+            debug(`Tinybird availability for compose project ${DEV_ENVIRONMENT.projectNamespace}:`, tinybirdAvailable);
+            return tinybirdAvailable;
+        })().catch((error) => {
+            tinybirdAvailability = null;
+            throw error;
+        });
+    }
+
+    return tinybirdAvailability;
 }

--- a/e2e/helpers/environment/service-managers/ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/ghost-manager.ts
@@ -50,6 +50,7 @@ export interface GhostManagerConfig {
  * Creates worker-scoped containers that persist across tests.
  */
 export class GhostManager {
+    private static verifiedBuildImageKey: string | null = null;
     private readonly docker: Docker;
     private readonly config: GhostManagerConfig;
     private ghostContainer: Container | null = null;
@@ -96,6 +97,12 @@ export class GhostManager {
      * Fails early with a helpful error message if the image is not available.
      */
     async verifyBuildImageExists(): Promise<void> {
+        const buildImageKey = `${BUILD_IMAGE}\n${BUILD_GATEWAY_IMAGE}`;
+        if (GhostManager.verifiedBuildImageKey === buildImageKey) {
+            debug(`Build images already verified: ${BUILD_IMAGE}, ${BUILD_GATEWAY_IMAGE}`);
+            return;
+        }
+
         try {
             const image = this.docker.getImage(BUILD_IMAGE);
             await image.inspect();
@@ -125,6 +132,8 @@ export class GhostManager {
                 `  2. Use a different gateway image: GHOST_E2E_MODE=build GHOST_E2E_GATEWAY_IMAGE=<image> pnpm --filter @tryghost/e2e test`
             );
         }
+
+        GhostManager.verifiedBuildImageKey = buildImageKey;
     }
 
     /**


### PR DESCRIPTION
## Summary
- cached Tinybird availability checks within the e2e process
- cached successful build image verification by the exact Ghost/gateway image pair
- preserved failure behavior by only caching successful image checks and clearing the Tinybird cache if Docker lookup fails

## Why
E2E setup can recreate Ghost containers repeatedly, but Tinybird service availability and the selected build images are stable during a worker process. Avoiding repeated Docker `listContainers()` and image `inspect()` calls removes small setup overhead from each environment cycle without changing the isolation model.

## Testing
- `pnpm --filter @tryghost/e2e test:types`
- `pnpm --dir e2e exec eslint --cache -- helpers/environment/service-availability.ts helpers/environment/service-managers/ghost-manager.ts`
- `git diff --check`
- Runtime smoke with `GHOST_E2E_ANALYTICS=false` calling `isTinybirdAvailable()` twice and verifying both calls return `false`
