### PR TITLE
Changed release-age config to exempt TryGhost packages and align pnpm at 3 days

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -379,6 +379,27 @@
             ]
         },
 
+        // These are published by us but live outside the @tryghost/ npm scope,
+        // so they miss the shared preset's "0 days" trusted-package exemption
+        // and would otherwise soak for 72h like third-party releases. Mirrors
+        // the pnpm-workspace.yaml minimumReleaseAgeExclude list. knex-migrator
+        // is currently in ignoreDeps, but is listed for when that's lifted.
+        // Deliberately NOT listed: sqlite3 — TryGhost stewards it, but legacy
+        // (Mapbox-era) npm maintainer accounts can still publish, so the soak
+        // retains value there.
+        {
+            "description": "No release-age soak for unscoped TryGhost-published packages",
+            "matchPackageNames": [
+                "bookshelf-relations",
+                "eslint-plugin-ghost",
+                "express-hbs",
+                "ghost-storage-base",
+                "gscan",
+                "knex-migrator"
+            ],
+            "minimumReleaseAge": "0 days"
+        },
+
         // Group each pinned-version pnpm catalog into a single PR per catalog.
         //
         // The named catalogs in pnpm-workspace.yaml (react17, eslint9,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
 strictDepBuilds: true
 catalogMode: strict
 
-minimumReleaseAge: 1440 # 1 day in minutes; pnpm 11 default
+minimumReleaseAge: 4320 # 3 days in minutes; matches Renovate's minimumReleaseAge
 blockExoticSubdeps: true
 
 allowBuilds:
@@ -197,3 +197,13 @@ packageExtensions:
 minimumReleaseAgeExclude:
   # Our own packages are published by us, so the release-age delay doesn't apply
   - "@tryghost/*"
+  # TryGhost-published packages that live outside the @tryghost/ npm scope.
+  # Deliberately NOT listed: sqlite3 — TryGhost stewards it, but legacy
+  # (Mapbox-era) npm maintainer accounts can still publish, so the soak
+  # retains value there.
+  - "bookshelf-relations"
+  - "eslint-plugin-ghost"
+  - "express-hbs"
+  - "ghost-storage-base"
+  - "gscan"
+  - "knex-migrator"


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/28503

## Problem

The release-age soak's trusted-package exemptions only matched the `@tryghost/*` npm scope, in both layers:

- the shared Renovate preset's `minimumReleaseAge: "0 days"` rules
- `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`

TryGhost-published packages with unscoped npm names fell through and soaked for 72h like third-party releases. This bit on #28503: the gscan 6.3.0 bump was dashboard-approved past Renovate's soak, but pnpm (still on its 1-day default) refused to resolve the too-young version, so the PR shipped without a lockfile update.

pnpm's `minimumReleaseAge` was also still `1440` (the pnpm 11 default) while the Renovate config promises a 3-day soak, so the lockfile-level guard wasn't backing the same window.

## Changes

- Exempted the unscoped TryGhost-published packages from the soak in both layers: gscan, knex-migrator, bookshelf-relations, express-hbs, ghost-storage-base, eslint-plugin-ghost. Found by sweeping the npm `repository` metadata of all 406 direct workspace dependencies for TryGhost-org repos.
- **Deliberately not exempted: sqlite3.** TryGhost stewards it, but legacy Mapbox-era npm maintainer accounts remain on the package and can still publish, so the soak retains value there.
- Raised pnpm's `minimumReleaseAge` to `4320` (3 days) to match Renovate. Note this also applies to local `pnpm add` of versions published <3 days ago (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`); the escape hatch is the same exclude list.

Once merged, the next Renovate tick should rebase #28503, regenerate its lockfile cleanly, flip its stability check green, and automerge it.