### PR TITLE
Shard Ghost core acceptance e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,15 +488,48 @@ jobs:
         env:
           - DB: mysql8
             NODE_ENV: testing-mysql
+        e2e:
+          - name: API Admin 1
+            id: api-admin-1
+          - name: API Admin 2
+            id: api-admin-2
+          - name: API Public
+            id: api-public
+          - name: Site
+            id: site
         include:
           - node: ${{ needs.job_setup.outputs.node_version }}
             env:
               DB: sqlite3
               NODE_ENV: testing
+            e2e:
+              name: API Admin 1
+              id: api-admin-1
+          - node: ${{ needs.job_setup.outputs.node_version }}
+            env:
+              DB: sqlite3
+              NODE_ENV: testing
+            e2e:
+              name: API Admin 2
+              id: api-admin-2
+          - node: ${{ needs.job_setup.outputs.node_version }}
+            env:
+              DB: sqlite3
+              NODE_ENV: testing
+            e2e:
+              name: API Public
+              id: api-public
+          - node: ${{ needs.job_setup.outputs.node_version }}
+            env:
+              DB: sqlite3
+              NODE_ENV: testing
+            e2e:
+              name: Site
+              id: site
     env:
       DB: ${{ matrix.env.DB }}
       NODE_ENV: ${{ matrix.env.NODE_ENV }}
-    name: Acceptance tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
+    name: Acceptance tests / ${{ matrix.e2e.name }} (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -533,7 +566,9 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: E2E tests
-        run: pnpm nx run ghost:test:ci:e2e
+        env:
+          GHOST_E2E_SHARD_ID: ${{ matrix.e2e.id }}
+        run: pnpm nx run ghost:test:ci:e2e:shard
 
       - name: Check for unexpected file changes
         run: |
@@ -546,6 +581,58 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: matrix.node == env.NODE_VERSION && contains(matrix.env.DB, 'mysql')
+        with:
+          name: e2e-v8-coverage-${{ matrix.e2e.id }}
+          path: |
+            ghost/core/coverage-e2e/raw/${{ matrix.e2e.id }}
+
+      - uses: tryghost/actions/actions/slack-build@128d496a57fb11e44e97d690f0d5381c58e52489 # main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  job_acceptance-coverage:
+    runs-on: ubuntu-latest
+    needs: [job_setup, job_acceptance-tests]
+    if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.changed_core == 'true'
+    name: Acceptance coverage
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore E2E V8 coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: e2e-v8-coverage-*
+          path: ghost/core/coverage-e2e/raw
+
+      - name: Prepare merged coverage
+        run: |
+          mkdir -p ghost/core/coverage-e2e/tmp
+          if ! find ghost/core/coverage-e2e/raw -name '*.json' | grep -q .; then
+            echo "No E2E V8 coverage files were downloaded" >&2
+            exit 1
+          fi
+          find ghost/core/coverage-e2e/raw -name '*.json' | while IFS= read -r coverage_file; do
+            shard_dir="$(basename "$(dirname "$coverage_file")")"
+            cp "$coverage_file" "ghost/core/coverage-e2e/tmp/${shard_dir}-$(basename "$coverage_file")"
+          done
+
+      - name: Build E2E coverage report
+        run: pnpm nx run ghost:test:ci:e2e:coverage-report
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-coverage
           path: |
@@ -1589,7 +1676,7 @@ jobs:
     name: Coverage
     needs: [
       job_admin-tests,
-      job_acceptance-tests,
+      job_acceptance-coverage,
       job_integration-tests,
       job_unit-tests
     ]
@@ -1614,7 +1701,7 @@ jobs:
           flags: admin-tests
 
       - name: Restore E2E coverage
-        if: contains(needs.job_acceptance-tests.result, 'success')
+        if: contains(needs.job_acceptance-coverage.result, 'success')
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: e2e-coverage
@@ -1626,12 +1713,12 @@ jobs:
           name: integration-coverage
 
       - name: Move coverage
-        if: contains(needs.job_acceptance-tests.result, 'success') || contains(needs.job_integration-tests.result, 'success')
+        if: contains(needs.job_acceptance-coverage.result, 'success') || contains(needs.job_integration-tests.result, 'success')
         run: |
           rsync -av --remove-source-files core/* ghost/core
 
       - name: Upload E2E test coverage
-        if: contains(needs.job_acceptance-tests.result, 'success') || contains(needs.job_integration-tests.result, 'success')
+        if: contains(needs.job_acceptance-coverage.result, 'success') || contains(needs.job_integration-tests.result, 'success')
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           flags: e2e-tests
@@ -1650,6 +1737,7 @@ jobs:
         job_admin-tests,
         job_unit-tests,
         job_acceptance-tests,
+        job_acceptance-coverage,
         job_integration-tests,
         job_legacy-tests,
         job_apps_acceptance-tests,

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -64,6 +64,8 @@
     "test:e2e": "pnpm test:base ./test/e2e-* --timeout=15000",
     "test:legacy": "pnpm test:base './test/legacy' --timeout=60000",
     "test:ci:e2e": "c8 -c ./.c8rc.e2e.json -o coverage-e2e pnpm test:e2e -b",
+    "test:ci:e2e:shard": "node scripts/run-e2e-shard-with-v8-coverage.js",
+    "test:ci:e2e:coverage-report": "c8 report -c ./.c8rc.e2e.json --temp-directory coverage-e2e/tmp -o coverage-e2e",
     "test:ci:legacy": "pnpm test:legacy -b",
     "test:ci:integration": "c8 -c ./.c8rc.e2e.json -o coverage-integration --lines 52 --functions 47 --branches 73 --statements 52 pnpm test:integration -b",
     "test:int:slow": "pnpm test:integration --reporter=mocha-slow-test-reporter",
@@ -349,6 +351,11 @@
         ]
       },
       "test:ci:e2e": {
+        "dependsOn": [
+          "^build"
+        ]
+      },
+      "test:ci:e2e:shard": {
         "dependsOn": [
           "^build"
         ]

--- a/ghost/core/scripts/run-e2e-shard-with-v8-coverage.js
+++ b/ghost/core/scripts/run-e2e-shard-with-v8-coverage.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+const {spawnSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const shards = {
+    'api-admin-1': [
+        './test/e2e-api/admin/actions.test.js',
+        './test/e2e-api/admin/activity-feed.test.js',
+        './test/e2e-api/admin/api-tokens.test.js',
+        './test/e2e-api/admin/authentication.test.js',
+        './test/e2e-api/admin/automated-email-design.test.js',
+        './test/e2e-api/admin/automated-emails.test.js',
+        './test/e2e-api/admin/automations.test.js',
+        './test/e2e-api/admin/backup.test.js',
+        './test/e2e-api/admin/comments.test.js',
+        './test/e2e-api/admin/config.test.js',
+        './test/e2e-api/admin/custom-theme-settings.test.js',
+        './test/e2e-api/admin/db.test.js',
+        './test/e2e-api/admin/email-preview-rate-limiter.test.js',
+        './test/e2e-api/admin/email-previews.test.js',
+        './test/e2e-api/admin/emails.test.js',
+        './test/e2e-api/admin/explore.test.js',
+        './test/e2e-api/admin/featurebase.test.js',
+        './test/e2e-api/admin/files.test.js',
+        './test/e2e-api/admin/gift-reminders.test.js',
+        './test/e2e-api/admin/images.test.js',
+        './test/e2e-api/admin/integrations.test.js',
+        './test/e2e-api/admin/invites.test.js',
+        './test/e2e-api/admin/key-authentication.test.js',
+        './test/e2e-api/admin/labels.test.js',
+        './test/e2e-api/admin/links.test.js',
+        './test/e2e-api/admin/max-limit-cap.test.js',
+        './test/e2e-api/admin/media.test.js',
+        './test/e2e-api/admin/member-commenting.test.js',
+        './test/e2e-api/admin/members-edit-subscriptions.test.js',
+        './test/e2e-api/admin/members-exporter.test.js',
+        './test/e2e-api/admin/members-importer.test.js',
+        './test/e2e-api/admin/members-newsletters.test.js',
+        './test/e2e-api/admin/members-stripe-connect.test.js',
+        './test/e2e-api/admin/members.test.js',
+        './test/e2e-api/admin/mentions.test.js'
+    ],
+    'api-admin-2': [
+        './test/e2e-api/admin/newsletters.test.js',
+        './test/e2e-api/admin/notifications.test.js',
+        './test/e2e-api/admin/oembed.test.js',
+        './test/e2e-api/admin/offers.test.js',
+        './test/e2e-api/admin/pages-bulk.test.js',
+        './test/e2e-api/admin/pages-legacy.test.js',
+        './test/e2e-api/admin/pages.test.js',
+        './test/e2e-api/admin/post-analytics-export.test.js',
+        './test/e2e-api/admin/posts-bulk.test.js',
+        './test/e2e-api/admin/posts-legacy.test.js',
+        './test/e2e-api/admin/posts.test.js',
+        './test/e2e-api/admin/rate-limiting.test.js',
+        './test/e2e-api/admin/recommendations.test.js',
+        './test/e2e-api/admin/redirects.test.js',
+        './test/e2e-api/admin/roles.test.js',
+        './test/e2e-api/admin/search-index.test.js',
+        './test/e2e-api/admin/session-invalidation.test.js',
+        './test/e2e-api/admin/session.test.js',
+        './test/e2e-api/admin/settings-files.test.js',
+        './test/e2e-api/admin/settings.test.js',
+        './test/e2e-api/admin/site.test.js',
+        './test/e2e-api/admin/slack.test.js',
+        './test/e2e-api/admin/slugs.test.js',
+        './test/e2e-api/admin/snippets.test.js',
+        './test/e2e-api/admin/sso.test.js',
+        './test/e2e-api/admin/stats.test.js',
+        './test/e2e-api/admin/storage-adapter-switching.test.js',
+        './test/e2e-api/admin/tags.test.js',
+        './test/e2e-api/admin/themes.test.js',
+        './test/e2e-api/admin/tiers.test.js',
+        './test/e2e-api/admin/tinybird.test.js',
+        './test/e2e-api/admin/users.test.js',
+        './test/e2e-api/admin/webhooks.test.js'
+    ],
+    'api-public': [
+        './test/e2e-api/content',
+        './test/e2e-api/members',
+        './test/e2e-api/members-comments',
+        './test/e2e-api/webmentions'
+    ],
+    site: [
+        './test/e2e-frontend',
+        './test/e2e-server',
+        './test/e2e-webhooks'
+    ]
+};
+
+const shardId = process.env.GHOST_E2E_SHARD_ID;
+
+if (!shardId) {
+    process.stderr.write('GHOST_E2E_SHARD_ID is required\n');
+    process.exit(1);
+}
+
+const shardPaths = shards[shardId];
+if (!shardPaths) {
+    process.stderr.write(`Unknown GHOST_E2E_SHARD_ID: ${shardId}\n`);
+    process.stderr.write(`Available shards: ${Object.keys(shards).join(', ')}\n`);
+    process.exit(1);
+}
+
+const coverageDir = path.join(process.cwd(), 'coverage-e2e', 'raw', shardId);
+fs.rmSync(coverageDir, {recursive: true, force: true});
+fs.mkdirSync(coverageDir, {recursive: true});
+
+const result = spawnSync('pnpm', ['test:base', ...shardPaths, '--timeout=15000', '-b'], {
+    env: {
+        ...process.env,
+        NODE_V8_COVERAGE: coverageDir
+    },
+    stdio: 'inherit'
+});
+
+if (result.error) {
+    process.stderr.write(`${result.error}\n`);
+    process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- split Ghost core acceptance e2e CI into four explicit shards: API Admin 1, API Admin 2, API Public, and Site
- collect raw V8 coverage per MySQL shard, then aggregate it in a required acceptance coverage job
- keep the existing c8 coverage thresholds enforced once after aggregation, instead of checking partial shard coverage

## Validation
- node -c ghost/core/scripts/run-e2e-shard-with-v8-coverage.js
- node -e "JSON.parse(require('fs').readFileSync('ghost/core/package.json','utf8'))"
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"
- pnpm --silent nx show project ghost --json confirmed test:ci:e2e:shard and test:ci:e2e:coverage-report targets
- actionlint .github/workflows/ci.yml reports only pre-existing shellcheck findings outside the touched acceptance sections
- git diff --check
- env NODE_ENV=testing DB=sqlite3 database__connection__filename=/tmp/ghost-core-shard-api-public.db GHOST_E2E_SHARD_ID=api-public pnpm --silent test:ci:e2e:shard -> 374 passing, 1 pending, real 41.69s
- c8 report smoke test consumed the generated raw V8 shard coverage and failed only the expected full-suite function threshold because it used one shard's partial coverage

## Notes
This PR is stacked on #28527 so the diff focuses on sharding the core e2e phase after integration has been split out.