### PR TITLE
Fixed Renovate digest updates clogging the queue on an unmeetable soak

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -466,6 +466,48 @@
             "automergeType": "pr"
         },
 
+        // Digest and pin updates (Docker image digests, action SHAs) usually
+        // have no release timestamp — Docker Hub library images skip label
+        // lookup entirely — so the 72h soak can never be satisfied. Worse,
+        // digest updates bypass internalChecksFilter's lookup-time pending
+        // state (it only filters version releases), so the PR opens
+        // immediately anyway and then sits unmergeable forever on a pending
+        // renovate/stability-days status, getting rebased every run. A time
+        // gate is unmeasurable here, so exempt these update types from the
+        // soak; the automerge rules around this one decide what merges on
+        // green CI vs what waits for a human.
+        {
+            "description": "No release-age soak for digest/pin updates (no usable release timestamp)",
+            "matchUpdateTypes": [
+                "digest",
+                "pin",
+                "pinDigest"
+            ],
+            "minimumReleaseAge": "0 days"
+        },
+
+        // The shared preset automerges all `action`-type deps, which would
+        // quietly convert our SHA pins on third-party actions back into
+        // "trust whatever upstream publishes next" — the exact attack class
+        // SHA-pinning defends against (codecov 2021, tj-actions 2025). Keep
+        // own-org and GitHub-owned actions automerging; bumps to everything
+        // else (codecov, docker, pnpm, peter-evans, ...) wait for a human
+        // review per GitHub's Actions hardening guidance. Placed before the
+        // security-update rule below so vulnerability-alert action bumps can
+        // still automerge.
+        {
+            "description": "Third-party action bumps require human merge",
+            "matchDepTypes": [
+                "action"
+            ],
+            "matchPackageNames": [
+                "!tryghost/**",
+                "!actions/**",
+                "!github/**"
+            ],
+            "automerge": false
+        },
+
         // Security patches and minors automerge after CI passes regardless
         // of any other automerge exclusion (e.g. the CSS preprocessor rule
         // in the shared preset). Security majors are intentionally left


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/28528

## Problem

The 72h `minimumReleaseAge` soak can't work for digest updates, in two compounding ways:

1. **Digest updates skip `internalChecksFilter`.** The strict filter holds *version* updates branchless during the soak via lookup-time pending state, but digest updates are evaluated later, at branch-processing time, where an unmet release age only sets a `renovate/stability-days` status — it doesn't block PR creation under the default `prCreation: "immediate"`. So digest PRs open immediately regardless of the soak.
2. **Digests usually have no release timestamp to measure.** Docker Hub library images skip label lookup entirely, and action SHAs carry no registry-side publish time. Under `minimumReleaseAgeBehaviour=timestamp-required` (the default), that means the stability check is pending *forever*.

Net effect: the five open Docker/actions digest PRs (#28432, #28446, #28447, #28448, #28499) opened same-day, can never automerge, and get rebased every Renovate window — burning CI indefinitely. Debug logs from run 27313892623 confirm the mechanism.

## Changes

- **Exempted `digest`/`pin`/`pinDigest` updates from the release-age soak.** A time gate is unmeasurable without a trustworthy publish timestamp (and an image-config `created` field is self-reported by the publisher — exactly the party the soak distrusts). Safety for these update types comes from automerge policy instead. The `pin`/`pinDigest` types are included because the `renovate/pin-dependencies` branch hits the same timestamp-less pending state.
- **Removed automerge from third-party action bumps.** The shared preset automerges all `action`-type deps, which silently converts our SHA pins back into "trust whatever upstream publishes next" — the attack class pinning defends against (codecov 2021, tj-actions 2025). Own-org (`tryghost/**`) and GitHub-owned (`actions/**`, `github/**`) actions keep automerging (85 of 107 action usages in our workflows); bumps to codecov, docker, pnpm, peter-evans, etc. now wait for a human. The rule sits before the security-update rule so vulnerability-alert action bumps still automerge.

Once merged, the next Renovate tick should flip the stuck digest PRs' stability checks green and automerge them via the existing internal-image allowlist.