### PR TITLE
🐛 Fixed comment counts for lazy loaded posts

### DIFF
--- a/ghost/core/core/frontend/src/comment-counts/comment-counts.js
+++ b/ghost/core/core/frontend/src/comment-counts/comment-counts.js
@@ -88,13 +88,15 @@
         renderCounts();
     };
 
+    const debouncedFetchCounts = debounce(fetchCounts);
+
     const countElemObserver = new MutationObserver((mutationsList) => {
         mutationsList.forEach((mutation) => {
             mutation.addedNodes.forEach((addedNode) => {
                 addIdsFromElement(addedNode);
-                debounce(fetchCounts);
             });
         });
+        debouncedFetchCounts();
     });
 
     countElemObserver.observe(document.body, {subtree: true, childList: true});

--- a/ghost/core/test/unit/frontend/src/comment-counts.test.js
+++ b/ghost/core/test/unit/frontend/src/comment-counts.test.js
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const sinon = require('sinon');
+const {createBrowserEnvironment, loadScript} = require('../../../utils/browser-test-utils');
+
+describe('comment-counts.js', function () {
+    let env;
+    let scriptContent;
+
+    const countMarker = id => `
+        <script
+            data-ghost-comment-count="${id}"
+            data-ghost-comment-count-empty="No comments"
+            data-ghost-comment-count-singular="comment"
+            data-ghost-comment-count-plural="comments"
+            data-ghost-comment-count-tag="span"
+            data-ghost-comment-count-class-name="comment-count"
+            data-ghost-comment-count-autowrap="true"
+        ></script>
+    `;
+
+    before(function () {
+        scriptContent = fs.readFileSync(path.join(__dirname, '../../../../core/frontend/src/comment-counts/comment-counts.js'), 'utf8');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+
+        if (env) {
+            env.dom.window.close();
+            env = null;
+        }
+    });
+
+    function setupEnvironment() {
+        env = createBrowserEnvironment({
+            html: `<!DOCTYPE html><html><body><article class="post-card">${countMarker('post-1')}</article></body></html>`
+        });
+
+        env.window.fetch = sinon.stub();
+        env.window.fetch.withArgs('https://example.com/members/api/comments/counts/?ids=post-1').resolves({
+            status: 200,
+            json: async () => ({'post-1': 1})
+        });
+        env.window.fetch.withArgs('https://example.com/members/api/comments/counts/?ids=post-2').resolves({
+            status: 200,
+            json: async () => ({'post-2': 2})
+        });
+    }
+
+    async function flushAsyncWork() {
+        await Promise.resolve();
+        await new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+    }
+
+    it('fetches and renders counts for post cards added after initial page load', async function () {
+        setupEnvironment();
+
+        loadScript(env, scriptContent, {
+            dataAttributes: {
+                'ghost-comments-counts-api': 'https://example.com/members/api/comments/counts/'
+            }
+        });
+
+        await flushAsyncWork();
+        assert.match(env.document.body.textContent, /1 comment/);
+
+        const article = env.document.createElement('article');
+        article.className = 'post-card';
+        article.innerHTML = countMarker('post-2');
+        env.document.body.appendChild(article);
+
+        await new Promise((resolve) => {
+            env.window.setTimeout(resolve, 150);
+        });
+        await flushAsyncWork();
+
+        sinon.assert.calledWith(env.window.fetch, 'https://example.com/members/api/comments/counts/?ids=post-2');
+        assert.match(article.textContent, /2 comments/);
+    });
+});

--- a/ghost/core/test/unit/frontend/src/comment-counts.test.js
+++ b/ghost/core/test/unit/frontend/src/comment-counts.test.js
@@ -1,7 +1,7 @@
-const assert = require('node:assert/strict');
+/* global expect, vi */
+
 const fs = require('fs');
 const path = require('path');
-const sinon = require('sinon');
 const {createBrowserEnvironment, loadScript} = require('../../../utils/browser-test-utils');
 
 describe('comment-counts.js', function () {
@@ -20,12 +20,12 @@ describe('comment-counts.js', function () {
         ></script>
     `;
 
-    before(function () {
+    beforeAll(function () {
         scriptContent = fs.readFileSync(path.join(__dirname, '../../../../core/frontend/src/comment-counts/comment-counts.js'), 'utf8');
     });
 
     afterEach(function () {
-        sinon.restore();
+        vi.restoreAllMocks();
 
         if (env) {
             env.dom.window.close();
@@ -38,14 +38,16 @@ describe('comment-counts.js', function () {
             html: `<!DOCTYPE html><html><body><article class="post-card">${countMarker('post-1')}</article></body></html>`
         });
 
-        env.window.fetch = sinon.stub();
-        env.window.fetch.withArgs('https://example.com/members/api/comments/counts/?ids=post-1').resolves({
-            status: 200,
-            json: async () => ({'post-1': 1})
-        });
-        env.window.fetch.withArgs('https://example.com/members/api/comments/counts/?ids=post-2').resolves({
-            status: 200,
-            json: async () => ({'post-2': 2})
+        env.window.fetch = vi.fn(async (url) => {
+            const counts = {
+                'https://example.com/members/api/comments/counts/?ids=post-1': {'post-1': 1},
+                'https://example.com/members/api/comments/counts/?ids=post-2': {'post-2': 2}
+            };
+
+            return {
+                status: 200,
+                json: async () => counts[url]
+            };
         });
     }
 
@@ -66,7 +68,7 @@ describe('comment-counts.js', function () {
         });
 
         await flushAsyncWork();
-        assert.match(env.document.body.textContent, /1 comment/);
+        expect(env.document.body.textContent).toMatch(/1 comment/);
 
         const article = env.document.createElement('article');
         article.className = 'post-card';
@@ -78,7 +80,7 @@ describe('comment-counts.js', function () {
         });
         await flushAsyncWork();
 
-        sinon.assert.calledWith(env.window.fetch, 'https://example.com/members/api/comments/counts/?ids=post-2');
-        assert.match(article.textContent, /2 comments/);
+        expect(env.window.fetch).toHaveBeenCalledWith('https://example.com/members/api/comments/counts/?ids=post-2', expect.any(Object));
+        expect(article.textContent).toMatch(/2 comments/);
     });
 });


### PR DESCRIPTION
## What changed

- Fixed the frontend comment-count loader so it fetches counts for markers inserted after initial page load.
- Added a JSDOM regression test covering lazy-loaded post cards.

## Why

Archive pagination inserts post cards after the initial page load. The mutation observer detected those new comment count markers, but it created a debounced fetch function without invoking it, so the counts for lazy loaded posts were never requested.

## Testing

- `CI=true pnpm --dir ghost/core test:single test/unit/frontend/src/comment-counts.test.js`
- Pre-commit hook ran ESLint for the changed JS files.

ref https://linear.app/ghost/issue/ONC-1832/comment-counts-missing-for-post-cards-on-archive-pages
