### PR TITLE
Added UI for multiple active paid subscriptions filter

### DIFF
--- a/apps/posts/src/views/filters/filter-types.ts
+++ b/apps/posts/src/views/filters/filter-types.ts
@@ -24,7 +24,7 @@ export interface FilterField {
     parseKeys?: readonly string[];
     ui: {
         label: string;
-        type: 'text' | 'select' | 'multiselect' | 'date' | 'number' | 'custom';
+        type: 'text' | 'select' | 'multiselect' | 'date' | 'number' | 'boolean' | 'custom';
         [key: string]: unknown;
     };
     options?: Array<{value: string; label: string}>;

--- a/apps/posts/src/views/filters/filter-types.ts
+++ b/apps/posts/src/views/filters/filter-types.ts
@@ -24,7 +24,7 @@ export interface FilterField {
     parseKeys?: readonly string[];
     ui: {
         label: string;
-        type: 'text' | 'select' | 'multiselect' | 'date' | 'number' | 'boolean' | 'custom';
+        type: 'text' | 'select' | 'multiselect' | 'date' | 'number' | 'custom';
         [key: string]: unknown;
     };
     options?: Array<{value: string; label: string}>;

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -15,6 +15,7 @@ import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters'
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useEmailPostValueSource} from '@src/hooks/filter-sources/use-email-post-value-source';
 import {useLabelValueSource} from '@src/hooks/filter-sources/use-label-value-source';
+import {useMultipleActiveSubscriptionsCount} from '../hooks/use-multiple-active-subscriptions-count';
 import {usePostResourceValueSource} from '@src/hooks/filter-sources/use-post-resource-value-source';
 import {useTierValueSource} from '@src/hooks/filter-sources/use-tier-value-source';
 import type {MemberView} from '../hooks/use-member-views';
@@ -94,6 +95,9 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const emailValueSource = useEmailPostValueSource();
     const labelValueSource = useLabelValueSource();
     const {valueSource: tierValueSource, hasMultipleTiers} = useTierValueSource();
+    const {count: multipleActiveSubscriptionsCount} = useMultipleActiveSubscriptionsCount({
+        enabled: paidMembersEnabled
+    });
 
     const filterFields = useMemberFilterFields({
         newsletters,
@@ -104,6 +108,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         labelValueSource,
         tierValueSource,
         offers,
+        multipleActiveSubscriptionsCount,
         postValueSource,
         emailValueSource,
         membersTrackSources,

--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -15,13 +15,13 @@ import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters'
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useEmailPostValueSource} from '@src/hooks/filter-sources/use-email-post-value-source';
 import {useLabelValueSource} from '@src/hooks/filter-sources/use-label-value-source';
-import {useMultipleActiveSubscriptionsCount} from '../hooks/use-multiple-active-subscriptions-count';
 import {usePostResourceValueSource} from '@src/hooks/filter-sources/use-post-resource-value-source';
 import {useTierValueSource} from '@src/hooks/filter-sources/use-tier-value-source';
 import type {MemberView} from '../hooks/use-member-views';
 
 interface MembersFiltersProps {
     filters: Filter[];
+    multipleActiveSubscriptionsCount: number;
     nql?: string;
     onFiltersChange: (filters: Filter[]) => void;
     savedViews?: MemberView[];
@@ -49,6 +49,7 @@ function mapOfferRedemptionFilters(
 
 const MembersFilters: React.FC<MembersFiltersProps> = ({
     filters,
+    multipleActiveSubscriptionsCount,
     nql,
     onFiltersChange,
     savedViews = [],
@@ -95,9 +96,6 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const emailValueSource = useEmailPostValueSource();
     const labelValueSource = useLabelValueSource();
     const {valueSource: tierValueSource, hasMultipleTiers} = useTierValueSource();
-    const {count: multipleActiveSubscriptionsCount} = useMultipleActiveSubscriptionsCount({
-        enabled: paidMembersEnabled
-    });
 
     const filterFields = useMemberFilterFields({
         newsletters,

--- a/apps/posts/src/views/members/components/multiple-active-subscriptions-banner.tsx
+++ b/apps/posts/src/views/members/components/multiple-active-subscriptions-banner.tsx
@@ -3,15 +3,21 @@ import {formatNumber} from '@tryghost/shade/utils';
 import {useMultipleActiveSubscriptionsBanner} from '../hooks/use-multiple-active-subscriptions-banner';
 
 interface MultipleActiveSubscriptionsBannerProps {
+    count: number;
+    hasResolvedCount: boolean;
     nql?: string;
     search: string;
 }
 
 const MultipleActiveSubscriptionsBanner = ({
+    count,
+    hasResolvedCount,
     nql,
     search
 }: MultipleActiveSubscriptionsBannerProps) => {
     const banner = useMultipleActiveSubscriptionsBanner({
+        count,
+        hasResolvedCount,
         nql,
         search
     });

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.test.tsx
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.test.tsx
@@ -79,7 +79,7 @@ describe('useMembersFilterState', () => {
                 id: 'count.active_stripe_customers:1',
                 field: 'count.active_stripe_customers',
                 operator: 'is',
-                values: [true]
+                values: ['true']
             }
         ]);
         expect(result.current.query).toBe('filter=count.active_stripe_customers%3A%3E1');
@@ -108,7 +108,7 @@ describe('useMembersFilterState', () => {
                 id: 'count.active_stripe_customers:1',
                 field: 'count.active_stripe_customers',
                 operator: 'is',
-                values: [false]
+                values: ['false']
             }
         ]);
         expect(result.current.query).toBe('filter=count.active_stripe_customers%3A%3C2');

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.test.tsx
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.test.tsx
@@ -78,11 +78,40 @@ describe('useMembersFilterState', () => {
             {
                 id: 'count.active_stripe_customers:1',
                 field: 'count.active_stripe_customers',
-                operator: 'is-greater',
-                values: [1]
+                operator: 'is',
+                values: [true]
             }
         ]);
         expect(result.current.query).toBe('filter=count.active_stripe_customers%3A%3E1');
+        expect(result.current.hasFilterOrSearch).toBe(true);
+    });
+
+    it('parses the inverted multiple active Stripe customers filter into a predicate', async () => {
+        const {result} = renderHook(() => {
+            const state = useMembersFilterState('UTC');
+            const [searchParams] = useSearchParams();
+
+            return {
+                ...state,
+                query: searchParams.toString()
+            };
+        }, {
+            wrapper: createWrapper('/?filter=count.active_stripe_customers%3A%3C2')
+        });
+
+        await waitFor(() => {
+            expect(result.current.nql).toBe('count.active_stripe_customers:<2');
+        });
+
+        expect(result.current.filters).toEqual([
+            {
+                id: 'count.active_stripe_customers:1',
+                field: 'count.active_stripe_customers',
+                operator: 'is',
+                values: [false]
+            }
+        ]);
+        expect(result.current.query).toBe('filter=count.active_stripe_customers%3A%3C2');
         expect(result.current.hasFilterOrSearch).toBe(true);
     });
 

--- a/apps/posts/src/views/members/hooks/use-multiple-active-subscriptions-banner.ts
+++ b/apps/posts/src/views/members/hooks/use-multiple-active-subscriptions-banner.ts
@@ -7,9 +7,9 @@ import {
 import {buildMembersUrl} from '../member-route';
 import {canManageMembers, useEditUser} from '@tryghost/admin-x-framework/api/users';
 import {toast} from 'sonner';
-import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useMultipleActiveSubscriptionsCount} from './use-multiple-active-subscriptions-count';
 import {useNavigate} from 'react-router';
 
 interface UseMultipleActiveSubscriptionsBannerOptions {
@@ -38,23 +38,9 @@ export function useMultipleActiveSubscriptionsBanner({
     // affected members themselves — any other filter/search hides the banner.
     const shouldConsiderBanner = !search && (!nql || isViewingFilter);
 
-    // Count-only query: we just need pagination.total, not the members.
-    const {
-        data
-    } = useBrowseMembers({
-        searchParams: {
-            filter: MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER,
-            limit: '1',
-            fields: 'id',
-            order: 'id'
-        },
-        defaultErrorHandler: false,
-        enabled: canManageMemberList && shouldConsiderBanner,
-        refetchOnMount: 'always',
-        staleTime: 0
+    const {count, hasResolvedCount} = useMultipleActiveSubscriptionsCount({
+        enabled: canManageMemberList && shouldConsiderBanner
     });
-
-    const count = data?.meta?.pagination?.total ?? 0;
     const preference = useMemo(() => {
         return getMultipleActiveSubscriptionsBannerPreference(currentUser?.accessibility);
     }, [currentUser?.accessibility]);
@@ -80,7 +66,7 @@ export function useMultipleActiveSubscriptionsBanner({
             || optimisticDismissedCount !== null
             || isDismissing
             || storedDismissedCount === undefined
-            || data === undefined
+            || !hasResolvedCount
             || count >= storedDismissedCount
         ) {
             return;
@@ -103,8 +89,8 @@ export function useMultipleActiveSubscriptionsBanner({
     }, [
         count,
         currentUser,
-        data,
         editUser,
+        hasResolvedCount,
         isDismissing,
         optimisticDismissedCount,
         preference.dismissedAt,

--- a/apps/posts/src/views/members/hooks/use-multiple-active-subscriptions-banner.ts
+++ b/apps/posts/src/views/members/hooks/use-multiple-active-subscriptions-banner.ts
@@ -5,14 +5,15 @@ import {
     isMultipleActiveSubscriptionsFilter
 } from '../multiple-active-subscriptions';
 import {buildMembersUrl} from '../member-route';
-import {canManageMembers, useEditUser} from '@tryghost/admin-x-framework/api/users';
 import {toast} from 'sonner';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
-import {useMultipleActiveSubscriptionsCount} from './use-multiple-active-subscriptions-count';
+import {useEditUser} from '@tryghost/admin-x-framework/api/users';
 import {useNavigate} from 'react-router';
 
 interface UseMultipleActiveSubscriptionsBannerOptions {
+    count: number;
+    hasResolvedCount: boolean;
     nql?: string;
     search: string;
 }
@@ -24,6 +25,8 @@ interface UseMultipleActiveSubscriptionsBannerOptions {
  * what the user last acknowledged.
  */
 export function useMultipleActiveSubscriptionsBanner({
+    count,
+    hasResolvedCount,
     nql,
     search
 }: UseMultipleActiveSubscriptionsBannerOptions) {
@@ -32,15 +35,11 @@ export function useMultipleActiveSubscriptionsBanner({
     const {mutateAsync: editUser, isLoading: isDismissing} = useEditUser();
     const [optimisticDismissedCount, setOptimisticDismissedCount] = useState<number | null>(null);
 
-    const canManageMemberList = currentUser ? canManageMembers(currentUser) : false;
     const isViewingFilter = isMultipleActiveSubscriptionsFilter(nql);
     // Only relevant on the unfiltered member list or when viewing the
     // affected members themselves — any other filter/search hides the banner.
     const shouldConsiderBanner = !search && (!nql || isViewingFilter);
 
-    const {count, hasResolvedCount} = useMultipleActiveSubscriptionsCount({
-        enabled: canManageMemberList && shouldConsiderBanner
-    });
     const preference = useMemo(() => {
         return getMultipleActiveSubscriptionsBannerPreference(currentUser?.accessibility);
     }, [currentUser?.accessibility]);

--- a/apps/posts/src/views/members/hooks/use-multiple-active-subscriptions-count.ts
+++ b/apps/posts/src/views/members/hooks/use-multiple-active-subscriptions-count.ts
@@ -1,0 +1,30 @@
+import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER} from '../multiple-active-subscriptions';
+import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
+
+interface UseMultipleActiveSubscriptionsCountOptions {
+    enabled: boolean;
+}
+
+/**
+ * Counts the members that have active subscriptions across multiple Stripe
+ * customers. Count-only query: we just need pagination.total, not the members.
+ */
+export function useMultipleActiveSubscriptionsCount({enabled}: UseMultipleActiveSubscriptionsCountOptions) {
+    const {data} = useBrowseMembers({
+        searchParams: {
+            filter: MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER,
+            limit: '1',
+            fields: 'id',
+            order: 'id'
+        },
+        defaultErrorHandler: false,
+        enabled,
+        refetchOnMount: 'always',
+        staleTime: 0
+    });
+
+    return {
+        count: data?.meta?.pagination?.total ?? 0,
+        hasResolvedCount: data !== undefined
+    };
+}

--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -148,7 +148,23 @@ describe('multipleActiveSubscriptionsCodec', () => {
         timezone: 'UTC'
     };
 
-    it('serializes the boolean predicate to count comparisons', () => {
+    it('serializes the Yes/No predicate to count comparisons', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'count.active_stripe_customers',
+            operator: 'is',
+            values: ['true']
+        };
+
+        expect(field.codec.serialize(predicate, context)).toEqual([
+            'count.active_stripe_customers:>1'
+        ]);
+        expect(field.codec.serialize({...predicate, values: ['false']}, context)).toEqual([
+            'count.active_stripe_customers:<2'
+        ]);
+    });
+
+    it('rejects unknown values and other operators', () => {
         const predicate: FilterPredicate = {
             id: '1',
             field: 'count.active_stripe_customers',
@@ -156,36 +172,21 @@ describe('multipleActiveSubscriptionsCodec', () => {
             values: [true]
         };
 
-        expect(field.codec.serialize(predicate, context)).toEqual([
-            'count.active_stripe_customers:>1'
-        ]);
-        expect(field.codec.serialize({...predicate, values: [false]}, context)).toEqual([
-            'count.active_stripe_customers:<2'
-        ]);
-    });
-
-    it('rejects non-boolean values and other operators', () => {
-        const predicate: FilterPredicate = {
-            id: '1',
-            field: 'count.active_stripe_customers',
-            operator: 'is',
-            values: [1]
-        };
-
         expect(field.codec.serialize(predicate, context)).toBeNull();
-        expect(field.codec.serialize({...predicate, operator: 'is-greater', values: [true]}, context)).toBeNull();
+        expect(field.codec.serialize({...predicate, values: [1]}, context)).toBeNull();
+        expect(field.codec.serialize({...predicate, operator: 'is-greater', values: ['true']}, context)).toBeNull();
     });
 
     it('parses only the comparisons it serializes', () => {
         expect(field.codec.parse({'count.active_stripe_customers': {$gt: 1}}, context)).toEqual({
             field: 'count.active_stripe_customers',
             operator: 'is',
-            values: [true]
+            values: ['true']
         });
         expect(field.codec.parse({'count.active_stripe_customers': {$lt: 2}}, context)).toEqual({
             field: 'count.active_stripe_customers',
             operator: 'is',
-            values: [false]
+            values: ['false']
         });
         expect(field.codec.parse({'count.active_stripe_customers': {$gt: 2}}, context)).toBeNull();
         expect(field.codec.parse({'count.active_stripe_customers': 1}, context)).toBeNull();

--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -139,6 +139,59 @@ describe('dateCodec', () => {
     });
 });
 
+describe('multipleActiveSubscriptionsCodec', () => {
+    const field = memberFields['count.active_stripe_customers'];
+    const context: CodecContext = {
+        key: 'count.active_stripe_customers',
+        pattern: 'count.active_stripe_customers',
+        params: {},
+        timezone: 'UTC'
+    };
+
+    it('serializes the boolean predicate to count comparisons', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'count.active_stripe_customers',
+            operator: 'is',
+            values: [true]
+        };
+
+        expect(field.codec.serialize(predicate, context)).toEqual([
+            'count.active_stripe_customers:>1'
+        ]);
+        expect(field.codec.serialize({...predicate, values: [false]}, context)).toEqual([
+            'count.active_stripe_customers:<2'
+        ]);
+    });
+
+    it('rejects non-boolean values and other operators', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'count.active_stripe_customers',
+            operator: 'is',
+            values: [1]
+        };
+
+        expect(field.codec.serialize(predicate, context)).toBeNull();
+        expect(field.codec.serialize({...predicate, operator: 'is-greater', values: [true]}, context)).toBeNull();
+    });
+
+    it('parses only the comparisons it serializes', () => {
+        expect(field.codec.parse({'count.active_stripe_customers': {$gt: 1}}, context)).toEqual({
+            field: 'count.active_stripe_customers',
+            operator: 'is',
+            values: [true]
+        });
+        expect(field.codec.parse({'count.active_stripe_customers': {$lt: 2}}, context)).toEqual({
+            field: 'count.active_stripe_customers',
+            operator: 'is',
+            values: [false]
+        });
+        expect(field.codec.parse({'count.active_stripe_customers': {$gt: 2}}, context)).toBeNull();
+        expect(field.codec.parse({'count.active_stripe_customers': 1}, context)).toBeNull();
+    });
+});
+
 describe('newsletterCodec', () => {
     it('serializes newsletter subscription state from a pattern field', () => {
         const predicate: FilterPredicate = {

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -1,5 +1,5 @@
 import {DATE_FILTER_OPERATORS, DEFAULT_DATE_OPERATOR} from '../filters/filter-date';
-import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD, MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER} from './multiple-active-subscriptions';
+import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD, MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER, NO_MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER} from './multiple-active-subscriptions';
 import {dateCodec, numberCodec, scalarCodec, setCodec, textCodec} from '../filters/filter-codecs';
 import {defineFields} from '../filters/filter-types';
 import {escapeNqlString} from '../filters/filter-normalization';
@@ -97,23 +97,42 @@ const multipleActiveSubscriptionsCodec: FilterCodec = {
     parse(node, ctx) {
         const comparator = extractComparator(node as Record<string, unknown>);
 
-        // The API only supports the exact `count.active_stripe_customers:>1` form
-        if (!comparator || comparator.field !== ctx.key || comparator.operator !== '$gt' || comparator.value !== 1) {
+        if (!comparator || comparator.field !== ctx.key) {
             return null;
         }
 
-        return {
-            field: ctx.key,
-            operator: 'is-greater',
-            values: [1]
-        };
+        if (comparator.operator === '$gt' && comparator.value === 1) {
+            return {
+                field: ctx.key,
+                operator: 'is',
+                values: [true]
+            };
+        }
+
+        if (comparator.operator === '$lt' && comparator.value === 2) {
+            return {
+                field: ctx.key,
+                operator: 'is',
+                values: [false]
+            };
+        }
+
+        return null;
     },
     serialize(predicate) {
-        if (predicate.operator !== 'is-greater' || predicate.values[0] !== 1) {
+        if (predicate.operator !== 'is') {
             return null;
         }
 
-        return [MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER];
+        if (predicate.values[0] === true) {
+            return [MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER];
+        }
+
+        if (predicate.values[0] === false) {
+            return [NO_MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER];
+        }
+
+        return null;
     }
 };
 
@@ -424,14 +443,13 @@ const baseMemberFields = defineFields({
         },
         codec: setCodec({quoteStrings: true, serializeSingletonAsScalar: true})
     },
-    // Intentionally absent from `useMemberFilterFields`, so it never appears
-    // in the filter UI — it's only reachable via the multiple active
-    // subscriptions banner's "View members" link.
     [MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD]: {
-        operators: ['is-greater'],
+        operators: ['is'],
         ui: {
             label: 'Multiple active subscriptions',
-            type: 'number'
+            type: 'boolean',
+            defaultValue: true,
+            hideOperatorSelect: true
         },
         codec: multipleActiveSubscriptionsCodec
     }

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -105,7 +105,7 @@ const multipleActiveSubscriptionsCodec: FilterCodec = {
             return {
                 field: ctx.key,
                 operator: 'is',
-                values: [true]
+                values: ['true']
             };
         }
 
@@ -113,22 +113,24 @@ const multipleActiveSubscriptionsCodec: FilterCodec = {
             return {
                 field: ctx.key,
                 operator: 'is',
-                values: [false]
+                values: ['false']
             };
         }
 
         return null;
     },
     serialize(predicate) {
+        const value = predicate.values[0];
+
         if (predicate.operator !== 'is') {
             return null;
         }
 
-        if (predicate.values[0] === true) {
+        if (value === 'true') {
             return [MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER];
         }
 
-        if (predicate.values[0] === false) {
+        if (value === 'false') {
             return [NO_MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER];
         }
 
@@ -447,10 +449,14 @@ const baseMemberFields = defineFields({
         operators: ['is'],
         ui: {
             label: 'Multiple active subscriptions',
-            type: 'boolean',
-            defaultValue: true,
+            type: 'select',
+            searchable: false,
             hideOperatorSelect: true
         },
+        options: [
+            {value: 'true', label: 'Yes'},
+            {value: 'false', label: 'No'}
+        ],
         codec: multipleActiveSubscriptionsCodec
     }
 });

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -15,7 +15,6 @@ import {buildMemberListSearchParams, getMemberActiveColumns} from './member-quer
 import {canBulkDeleteMembers, shouldShowMembersLoading} from './members-view-state';
 import {checkStripeEnabled, getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
-import {isMultipleActiveSubscriptionsPredicate} from './multiple-active-subscriptions';
 import {shouldDelayMembersDateFilterHydration, useMembersFilterState} from './hooks/use-members-filter-state';
 import {useActiveMemberView, useMemberViews} from './hooks/use-member-views';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
@@ -52,12 +51,6 @@ const MembersPage: React.FC<MembersPageProps> = ({
     const [searchInput, setSearchInput] = useState(search);
     const [debouncedSearch] = useDebounce(searchInput, SEARCH_DEBOUNCE_MS);
 
-    // The multiple active subscriptions predicate is applied via the banner's
-    // "View members" link and has no filter UI, so keep it out of the filter bar.
-    const visibleFilters = useMemo(() => {
-        return filters.filter(filter => !isMultipleActiveSubscriptionsPredicate(filter));
-    }, [filters]);
-
     const activeColumns = useMemo(() => {
         return getMemberActiveColumns(filters);
     }, [filters]);
@@ -93,7 +86,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
     });
 
     const totalMembers = data?.meta?.pagination?.total ?? 0;
-    const hasFilters = visibleFilters.length > 0;
+    const hasFilters = filters.length > 0;
     const shouldShowMobileSearchRow = showMobileSearch;
     const shouldShowFiltersRow = hasFilters;
     const shouldShowMemberControls = hasFilterOrSearch || totalMembers > 0;
@@ -162,7 +155,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                             {!hasFilters && (
                                                 <MembersFilters
                                                     activeView={activeView}
-                                                    filters={visibleFilters}
+                                                    filters={filters}
                                                     iconOnly={true}
                                                     nql={nql}
                                                     savedViews={savedViews}
@@ -202,7 +195,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                 {shouldShowFiltersRow && (
                                     <MembersFilters
                                         activeView={activeView}
-                                        filters={visibleFilters}
+                                        filters={filters}
                                         nql={nql}
                                         savedViews={savedViews}
                                         onFiltersChange={setFilters}

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -21,6 +21,7 @@ import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useBrowseMembersInfinite} from '@tryghost/admin-x-framework/api/members';
 import {useDebounce} from 'use-debounce';
 import {useLocation, useSearchParams} from 'react-router';
+import {useMultipleActiveSubscriptionsCount} from './hooks/use-multiple-active-subscriptions-count';
 
 const SEARCH_DEBOUNCE_MS = 250;
 const MEMBERS_HELP_CARDS_LIMIT = 6;
@@ -50,6 +51,13 @@ const MembersPage: React.FC<MembersPageProps> = ({
     const [mobileSearchOpenedByUser, setMobileSearchOpenedByUser] = useState(false);
     const [searchInput, setSearchInput] = useState(search);
     const [debouncedSearch] = useDebounce(searchInput, SEARCH_DEBOUNCE_MS);
+
+    // Fetched once at page level so the banner, and both filter bar instances,
+    // share a single request per visit and always agree on the count.
+    const {
+        count: multipleActiveSubscriptionsCount,
+        hasResolvedCount: hasResolvedMultipleActiveSubscriptionsCount
+    } = useMultipleActiveSubscriptionsCount({enabled: hasStripeEnabled});
 
     const activeColumns = useMemo(() => {
         return getMemberActiveColumns(filters);
@@ -157,6 +165,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                                     activeView={activeView}
                                                     filters={filters}
                                                     iconOnly={true}
+                                                    multipleActiveSubscriptionsCount={multipleActiveSubscriptionsCount}
                                                     nql={nql}
                                                     savedViews={savedViews}
                                                     onFiltersChange={setFilters}
@@ -196,6 +205,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
                                     <MembersFilters
                                         activeView={activeView}
                                         filters={filters}
+                                        multipleActiveSubscriptionsCount={multipleActiveSubscriptionsCount}
                                         nql={nql}
                                         savedViews={savedViews}
                                         onFiltersChange={setFilters}
@@ -205,6 +215,8 @@ const MembersPage: React.FC<MembersPageProps> = ({
                         )}
                         {hasStripeEnabled && (
                             <MultipleActiveSubscriptionsBanner
+                                count={multipleActiveSubscriptionsCount}
+                                hasResolvedCount={hasResolvedMultipleActiveSubscriptionsCount}
                                 nql={nql}
                                 search={search}
                             />

--- a/apps/posts/src/views/members/multiple-active-subscriptions.test.ts
+++ b/apps/posts/src/views/members/multiple-active-subscriptions.test.ts
@@ -1,10 +1,8 @@
 import {
-    MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD,
     MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER,
     buildDismissedMultipleActiveSubscriptionsPreference,
     getMultipleActiveSubscriptionsBannerPreference,
     isMultipleActiveSubscriptionsFilter,
-    isMultipleActiveSubscriptionsPredicate,
     parseAccessibilityPreferences
 } from './multiple-active-subscriptions';
 import {describe, expect, it} from 'vitest';
@@ -14,11 +12,6 @@ describe('multiple active subscriptions helpers', () => {
         expect(isMultipleActiveSubscriptionsFilter(MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER)).toBe(true);
         expect(isMultipleActiveSubscriptionsFilter(`${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER}+status:paid`)).toBe(false);
         expect(isMultipleActiveSubscriptionsFilter(undefined)).toBe(false);
-    });
-
-    it('matches predicates by field', () => {
-        expect(isMultipleActiveSubscriptionsPredicate({field: MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD})).toBe(true);
-        expect(isMultipleActiveSubscriptionsPredicate({field: 'status'})).toBe(false);
     });
 
     it('parses invalid accessibility JSON as empty preferences', () => {

--- a/apps/posts/src/views/members/multiple-active-subscriptions.ts
+++ b/apps/posts/src/views/members/multiple-active-subscriptions.ts
@@ -3,6 +3,7 @@ import type {User} from '@tryghost/admin-x-framework/api/users';
 
 export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD = 'count.active_stripe_customers';
 export const MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER = `${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD}:>1`;
+export const NO_MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER = `${MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD}:<2`;
 
 const MultipleActiveSubscriptionsBannerPreferenceSchema = z.looseObject({
     dismissedCount: z.number().finite().optional().catch(undefined),
@@ -18,10 +19,6 @@ export type MultipleActiveSubscriptionsBannerPreference = z.infer<typeof Multipl
 
 export function isMultipleActiveSubscriptionsFilter(nql: string | undefined): boolean {
     return nql === MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER;
-}
-
-export function isMultipleActiveSubscriptionsPredicate(predicate: {field: string}): boolean {
-    return predicate.field === MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD;
 }
 
 export function parseAccessibilityPreferences(accessibility: string | null | undefined): AccessibilityPreferences {

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -188,6 +188,40 @@ describe('useMemberFilterFields', () => {
         });
     });
 
+    it('includes the multiple active subscriptions filter after member status when affected members exist', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            paidMembersEnabled: true,
+            multipleActiveSubscriptionsCount: 2,
+            siteTimezone: 'UTC'
+        }));
+
+        const subscriptionFields = result.current.find(group => group.group === 'Subscription')?.fields ?? [];
+        const fieldKeys = subscriptionFields.map(field => field.key);
+
+        expect(fieldKeys.indexOf('count.active_stripe_customers')).toBe(fieldKeys.indexOf('status') + 1);
+
+        const multipleSubscriptionsField = subscriptionFields.find(field => field.key === 'count.active_stripe_customers');
+
+        expect(multipleSubscriptionsField).toMatchObject({
+            label: 'Multiple active subscriptions',
+            type: 'boolean',
+            defaultValue: true,
+            hideOperatorSelect: true
+        });
+    });
+
+    it('omits the multiple active subscriptions filter when no affected members exist', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            paidMembersEnabled: true,
+            multipleActiveSubscriptionsCount: 0,
+            siteTimezone: 'UTC'
+        }));
+
+        const subscriptionFields = result.current.find(group => group.group === 'Subscription')?.fields ?? [];
+
+        expect(subscriptionFields.map(field => field.key)).not.toContain('count.active_stripe_customers');
+    });
+
     it('hydrates grouped retention offers on the offer field', () => {
         const {result} = renderHook(() => useMemberFilterFields({
             paidMembersEnabled: true,

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -204,9 +204,12 @@ describe('useMemberFilterFields', () => {
 
         expect(multipleSubscriptionsField).toMatchObject({
             label: 'Multiple active subscriptions',
-            type: 'boolean',
-            defaultValue: true,
-            hideOperatorSelect: true
+            type: 'select',
+            hideOperatorSelect: true,
+            options: [
+                {value: 'true', label: 'Yes'},
+                {value: 'false', label: 'No'}
+            ]
         });
     });
 

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -3,6 +3,7 @@ import {DATE_OPERATOR_LABELS} from '../filters/filter-date';
 import {FilterFieldConfig, FilterFieldGroup, FilterOption, ValueSource} from '@tryghost/shade/patterns';
 import {LabelFilterRenderer} from '@src/components/label-picker';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD} from './multiple-active-subscriptions';
 import {RELATIVE_DATE_OPERATOR_LABELS, createRelativeDateRenderer, fieldHasRelativeOperator} from '../filters/filter-relative-date';
 import {createOperatorOptions} from '../filters/filter-operator-options';
 import {getMemberFields} from './member-fields';
@@ -20,6 +21,7 @@ interface UseMemberFilterFieldsOptions {
     postValueSource?: ValueSource<string>;
     emailValueSource?: ValueSource<string>;
     offers?: Offer[];
+    multipleActiveSubscriptionsCount?: number;
     membersTrackSources?: boolean;
     emailTrackOpens?: boolean;
     emailTrackClicks?: boolean;
@@ -86,6 +88,8 @@ function getFieldIcon(key: string) {
         return React.createElement(LucideIcon.MessageSquare, {className: 'size-4'});
     case 'offer_redemptions':
         return React.createElement(LucideIcon.Ticket, {className: 'size-4'});
+    case MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD:
+        return React.createElement(LucideIcon.Layers, {className: 'size-4'});
     default:
         if (key.startsWith('newsletters.')) {
             return React.createElement(LucideIcon.Newspaper, {className: 'size-4'});
@@ -250,6 +254,7 @@ export function useMemberFilterFields({
     postValueSource,
     emailValueSource,
     offers = [],
+    multipleActiveSubscriptionsCount = 0,
     membersTrackSources = false,
     emailTrackOpens = false,
     emailTrackClicks = false,
@@ -377,10 +382,15 @@ export function useMemberFilterFields({
                 subscriptionFields.push(createFieldConfig('tier_id', createSearchableFieldOverrides([], tierValueSource)));
             }
 
+            subscriptionFields.push(createFieldConfig('status', {
+                options: [...fields.status.options, {value: 'gift', label: 'Gift subscription'}]
+            }));
+
+            if (multipleActiveSubscriptionsCount > 0) {
+                subscriptionFields.push(createFieldConfig(MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD));
+            }
+
             subscriptionFields.push(
-                createFieldConfig('status', {
-                    options: [...fields.status.options, {value: 'gift', label: 'Gift subscription'}]
-                }),
                 createFieldConfig('subscriptions.plan_interval'),
                 createFieldConfig('subscriptions.status'),
                 createDateFieldConfig('subscriptions.start_date', today),
@@ -450,6 +460,7 @@ export function useMemberFilterFields({
         hasMultipleTiers,
         labelValueSource,
         membersTrackSources,
+        multipleActiveSubscriptionsCount,
         newsletters,
         offers,
         hydratedNewsletterSlugs,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3720/cleanupimprove-multi-sub-filter-implementation

The multiple active subscriptions filter was only reachable through the warning banner's "View members" link and was deliberately hidden from the filter bar, because the API only accepted the one hardcoded `count.active_stripe_customers:>1` filter string — exposing it in the UI would have produced unrepresentable or broken states.

With https://github.com/TryGhost/Ghost/pull/28547 making the filter a composable NQL field, that restriction is gone, so this makes it behave like any other members filter:

- "Multiple active subscriptions" appears in the Subscription filter group directly after "Member status", as a Yes/No select following the same pattern as the comments moderation "Reported" filter. Yes serializes to `count.active_stripe_customers:>1`; No inverts it to `count.active_stripe_customers:<2` to find unaffected members.
- It now shows as a normal removable filter chip and can be combined with other filters — including when arriving via the banner's "View members" link, which previously landed on a filtered list with an invisible filter applied.
- Following the same conditional pattern as the "Offer" filter, it's only offered when relevant: the count-only query that drives the warning banner is now shared (extracted to `useMultipleActiveSubscriptionsCount`) and fetched once at page level, and the filter stays hidden while that count is zero.