### PR TITLE
Fixed automations poll settling

### DIFF
--- a/ghost/core/core/shared/one-at-a-time.ts
+++ b/ghost/core/core/shared/one-at-a-time.ts
@@ -1,58 +1,55 @@
-import {InternalServerError} from '@tryghost/errors';
-
-type State = 'idle' | 'running' | 'running+queued';
-
 /**
  * Wraps an async function so it runs at most one invocation at a time, with at
  * most one additional invocation queued.
  *
- * Possible states:
+ * If called while idle, it starts a run immediately. If called while a run is
+ * active, it queues one follow-up run. Additional calls while that follow-up is
+ * already queued do not queue more work; they return the same queued promise.
  *
- * - idle: nothing is running
- * - running: function is active, nothing is queued
- * - running + queued: function is active, another invocation enqueued
- *
- * Errors are silently swallowed.
- *
+ * The returned promise resolves when the current or queued run associated with
+ * the call settles. It does not wait for later queued runs. Errors are silently
+ * swallowed.
  */
-export const oneAtATime = (fn: () => PromiseLike<unknown>): () => void => {
-    let state: State = 'idle';
+export const oneAtATime = (fn: () => PromiseLike<unknown>): () => Promise<void> => {
+    let isRunning = false;
+    let queuedPromise: Promise<void> | null = null;
+    let resolveQueuedPromise: (() => void) | null = null;
 
-    const run = async () => {
+    const run = async (resolveCurrentPromise: () => void) => {
         try {
             await fn();
         } catch {
             // noop
         }
 
-        switch (state) {
-        case 'running+queued':
-            state = 'running';
-            run();
-            break;
-        case 'running':
-            state = 'idle';
-            break;
-        default:
-            throw new InternalServerError({message: `Unexpected state: ${state}`});
+        resolveCurrentPromise();
+
+        if (resolveQueuedPromise) {
+            const resolveNextPromise = resolveQueuedPromise;
+            queuedPromise = null;
+            resolveQueuedPromise = null;
+            void run(resolveNextPromise);
+            return;
         }
+
+        isRunning = false;
     };
 
     return () => {
-        switch (state) {
-        case 'idle':
-            state = 'running';
-            run();
-            break;
-        case 'running':
-            state = 'running+queued';
-            break;
-        case 'running+queued':
-            break;
-        default: {
-            const _exhaustive: never = state;
-            throw new InternalServerError({message: `Unexpected state: ${_exhaustive}`});
+        if (!isRunning) {
+            isRunning = true;
+
+            return new Promise((resolve) => {
+                void run(resolve);
+            });
         }
+
+        if (!queuedPromise) {
+            queuedPromise = new Promise((resolve) => {
+                resolveQueuedPromise = resolve;
+            });
         }
+
+        return queuedPromise;
     };
 };

--- a/ghost/core/test/unit/server/services/automations/service.test.js
+++ b/ghost/core/test/unit/server/services/automations/service.test.js
@@ -1,13 +1,24 @@
 const sinon = require('sinon');
+const rewire = require('rewire');
+const DomainEvents = require('@tryghost/domain-events');
 
 const StartAutomationsPollEvent = require('../../../../../core/server/services/automations/events/start-automations-poll-event');
-const AutomationsService = require('../../../../../core/server/services/automations/service');
+
+const serviceModule = rewire('../../../../../core/server/services/automations/service');
+const AutomationsService = serviceModule;
+
+const eventLoop = () => Promise.resolve();
+const nextEventLoopTurn = () => new Promise((resolve) => {
+    setImmediate(resolve);
+});
+const defaultDomainEventsTrackingEnabled = process.env.NODE_ENV?.startsWith('test') || false;
 
 describe('automations service', function () {
     let automations;
     let domainEvents;
     let schedulerAdapter;
     let initOptions;
+    let restoreServiceDependencies;
 
     beforeEach(function () {
         automations = new AutomationsService();
@@ -27,9 +38,16 @@ describe('automations service', function () {
                 ['ghost-scheduler', Promise.resolve({id: 'k1', secret: 'aaaa'})]
             ])
         };
+        restoreServiceDependencies = [];
     });
 
     afterEach(function () {
+        restoreServiceDependencies.forEach((restore) => {
+            restore();
+        });
+        DomainEvents.ee.removeAllListeners(StartAutomationsPollEvent.name);
+        DomainEvents.resetTrackingStateForTest();
+        DomainEvents.setTrackingEnabledForTest(defaultDomainEventsTrackingEnabled);
         sinon.restore();
     });
 
@@ -51,6 +69,100 @@ describe('automations service', function () {
             automations.init(initOptions);
             automations.init(initOptions);
             sinon.assert.calledTwice(domainEvents.subscribe);
+        });
+
+        it('subscribes awaitable poll handlers', async function () {
+            const pollResult = Promise.withResolvers();
+            const welcomeEmailPollResult = Promise.withResolvers();
+            restoreServiceDependencies.push(
+                serviceModule.__set__('poll', sinon.stub().returns(pollResult.promise)),
+                serviceModule.__set__('welcomeEmailAutomationPoll', sinon.stub().returns(welcomeEmailPollResult.promise))
+            );
+            automations.init(initOptions);
+            const [pollHandler, welcomeEmailPollHandler] = domainEvents.subscribe.getCalls().map(call => call.args[1]);
+            const pollSettled = sinon.stub();
+            const welcomeEmailPollSettled = sinon.stub();
+
+            const pollPromise = pollHandler();
+            const welcomeEmailPollPromise = welcomeEmailPollHandler();
+            pollPromise.then(pollSettled);
+            welcomeEmailPollPromise.then(welcomeEmailPollSettled);
+
+            await eventLoop();
+            sinon.assert.notCalled(pollSettled);
+            sinon.assert.notCalled(welcomeEmailPollSettled);
+
+            pollResult.resolve();
+            welcomeEmailPollResult.resolve();
+            await Promise.all([pollPromise, welcomeEmailPollPromise]);
+            sinon.assert.calledOnce(pollSettled);
+            sinon.assert.calledOnce(welcomeEmailPollSettled);
+        });
+
+        it('coalesces concurrent poll requests into an awaitable queued poll', async function () {
+            const firstPoll = Promise.withResolvers();
+            const queuedPoll = Promise.withResolvers();
+            const poll = sinon.stub()
+                .onFirstCall().returns(firstPoll.promise)
+                .onSecondCall().returns(queuedPoll.promise);
+            restoreServiceDependencies.push(
+                serviceModule.__set__('poll', poll),
+                serviceModule.__set__('welcomeEmailAutomationPoll', sinon.stub().resolves())
+            );
+            automations.init(initOptions);
+            const pollHandler = domainEvents.subscribe.firstCall.args[1];
+            const queuedPollSettled = sinon.stub();
+
+            pollHandler();
+            const queuedPollPromise = pollHandler();
+            pollHandler();
+            queuedPollPromise.then(queuedPollSettled);
+
+            sinon.assert.calledOnce(poll);
+            firstPoll.resolve();
+            await nextEventLoopTurn();
+            sinon.assert.calledTwice(poll);
+            sinon.assert.notCalled(queuedPollSettled);
+
+            queuedPoll.resolve();
+            await queuedPollPromise;
+            sinon.assert.calledOnce(queuedPollSettled);
+            sinon.assert.calledTwice(poll);
+        });
+
+        it('keeps DomainEvents.allSettled pending until a queued poll settles', async function () {
+            const firstPoll = Promise.withResolvers();
+            const queuedPoll = Promise.withResolvers();
+            const poll = sinon.stub()
+                .onFirstCall().returns(firstPoll.promise)
+                .onSecondCall().returns(queuedPoll.promise);
+            restoreServiceDependencies.push(
+                serviceModule.__set__('poll', poll),
+                serviceModule.__set__('welcomeEmailAutomationPoll', sinon.stub().resolves())
+            );
+            DomainEvents.ee.removeAllListeners(StartAutomationsPollEvent.name);
+            DomainEvents.setTrackingEnabledForTest(true);
+            DomainEvents.resetTrackingStateForTest();
+            automations.init({
+                ...initOptions,
+                domainEvents: DomainEvents
+            });
+            await nextEventLoopTurn();
+            sinon.assert.calledOnce(poll);
+
+            DomainEvents.dispatch(StartAutomationsPollEvent.create());
+            const allSettledPromise = DomainEvents.allSettled();
+            const allSettled = sinon.stub();
+            allSettledPromise.then(allSettled);
+
+            firstPoll.resolve();
+            await nextEventLoopTurn();
+            sinon.assert.calledTwice(poll);
+            sinon.assert.notCalled(allSettled);
+
+            queuedPoll.resolve();
+            await allSettledPromise;
+            sinon.assert.calledOnce(allSettled);
         });
     });
 

--- a/ghost/core/test/unit/shared/one-at-a-time.test.js
+++ b/ghost/core/test/unit/shared/one-at-a-time.test.js
@@ -1,4 +1,5 @@
 // @ts-check
+const assert = require('assert/strict');
 const sinon = require('sinon');
 const {oneAtATime} = require('../../../core/shared/one-at-a-time');
 
@@ -47,6 +48,79 @@ describe('oneAtATime', function () {
         sinon.assert.calledTwice(fn);
     });
 
+    it('returns a promise that settles after the running invocation completes', async function () {
+        const first = Promise.withResolvers();
+        const fn = sinon.stub().returns(first.promise);
+        const run = oneAtATime(fn);
+        const settled = sinon.stub();
+
+        const promise = run();
+        promise.then(settled);
+
+        await eventLoop();
+        sinon.assert.notCalled(settled);
+
+        first.resolve();
+        await promise;
+        sinon.assert.calledOnce(settled);
+    });
+
+    it('returns a promise that settles after a queued invocation completes', async function () {
+        const first = Promise.withResolvers();
+        const second = Promise.withResolvers();
+        const fn = sinon.stub()
+            .onFirstCall().returns(first.promise)
+            .onSecondCall().returns(second.promise);
+        const run = oneAtATime(fn);
+        const settled = sinon.stub();
+
+        run();
+        const promise = run();
+        const coalescedPromise = run();
+        promise.then(settled);
+
+        assert.equal(coalescedPromise, promise);
+
+        first.resolve();
+        await eventLoop();
+        sinon.assert.calledTwice(fn);
+        sinon.assert.notCalled(settled);
+
+        second.resolve();
+        await promise;
+        sinon.assert.calledOnce(settled);
+        sinon.assert.calledTwice(fn);
+    });
+
+    it('settles a queued promise without waiting for a later queued invocation', async function () {
+        const first = Promise.withResolvers();
+        const second = Promise.withResolvers();
+        const third = Promise.withResolvers();
+        const fn = sinon.stub()
+            .onFirstCall().returns(first.promise)
+            .onSecondCall().returns(second.promise)
+            .onThirdCall().returns(third.promise);
+        const run = oneAtATime(fn);
+        const secondSettled = sinon.stub();
+
+        run();
+        const secondPromise = run();
+        secondPromise.then(secondSettled);
+
+        first.resolve();
+        await eventLoop();
+        sinon.assert.calledTwice(fn);
+
+        const thirdPromise = run();
+        second.resolve();
+        await secondPromise;
+        sinon.assert.calledOnce(secondSettled);
+        sinon.assert.calledThrice(fn);
+
+        third.resolve();
+        await thirdPromise;
+    });
+
     it('only enqueues, at most, one additional call', async function () {
         const first = Promise.withResolvers();
         const second = Promise.withResolvers();
@@ -90,21 +164,27 @@ describe('oneAtATime', function () {
             .onFirstCall().returns(first.promise)
             .onSecondCall().returns(second.promise);
         const run = oneAtATime(fn);
+        const firstSettled = sinon.stub();
+        const secondSettled = sinon.stub();
 
         // idle -> running
-        run();
+        const firstPromise = run();
+        firstPromise.then(firstSettled);
         sinon.assert.calledOnce(fn);
 
         // running -> running+queued
-        run();
+        const secondPromise = run();
+        secondPromise.then(secondSettled);
 
         // running+queued -> running
         first.reject(new Error('failure'));
-        await eventLoop();
+        await firstPromise;
+        sinon.assert.calledOnce(firstSettled);
         sinon.assert.calledTwice(fn);
 
         // running -> idle
         second.reject(new Error('failure'));
-        await eventLoop();
+        await secondPromise;
+        sinon.assert.calledOnce(secondSettled);
     });
 });


### PR DESCRIPTION
## Summary

- updates `oneAtATime` to return awaitable promises while preserving one-active/one-queued coalescing
- keeps automations subscribed through `oneAtATime` so `DomainEvents.allSettled()` can observe poll completion
- adds regression coverage for active, queued, coalesced, rejected, and later-queued invocations
- adds an automations service regression using real `DomainEvents.allSettled()` tracking

## Why

The flaky `Members Automations > runs every step in the free member signup automation` CI failure came from `DomainEvents.allSettled()` returning before automation poll handlers had actually finished. The automations service subscribed poll handlers through `oneAtATime()`, but that wrapper previously returned `undefined` immediately after starting async work, so the domain event dispatcher had nothing to await when polls queued follow-up work under CI load.

This keeps the existing helper as the single coalescing implementation and makes its completion contract explicit.

## Review

A separate sub-agent did a grumpy senior-dev review focused on async race conditions, promise ownership, queue/coalescing semantics, and test quality. Its findings were addressed, then re-reviewed with no remaining findings.

## Verification

- `CI=true pnpm --dir ghost/core test:single test/unit/shared/one-at-a-time.test.js`
- `CI=true pnpm --dir ghost/core test:single test/unit/server/services/automations/service.test.js`
- `DB=sqlite3 NODE_ENV=testing pnpm --dir ghost/core test:single test/e2e-api/members/automations.test.js`
- `pnpm --dir ghost/core exec tsc --noEmit --pretty false --skipLibCheck core/shared/one-at-a-time.ts`
- `pnpm --dir ghost/core exec eslint --ignore-path .eslintignore core/server/services/automations/service.js core/shared/one-at-a-time.ts`
- `pnpm --dir ghost/core exec eslint -c test/.eslintrc.js --ignore-path test/.eslintignore test/unit/server/services/automations/service.test.js test/unit/shared/one-at-a-time.test.js`