### PR TITLE
Cleaned up comments dislike capability flag

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -55,10 +55,6 @@ export type LabsContextType = {
     [key: string]: boolean | undefined
 }
 
-export type CapabilitiesContextType = {
-    dislikes?: boolean
-}
-
 export type CommentsOptions = {
     locale: string,
     siteUrl: string,
@@ -90,7 +86,6 @@ export type EditableAppContext = {
     openCommentForms: OpenCommentForm[],
     popup: Page | null,
     labs: LabsContextType,
-    capabilities: CapabilitiesContextType,
     order: string,
     adminApi: AdminApi | null,
     commentsIsLoading?: boolean,

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -7,7 +7,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import i18nLib from '@tryghost/i18n';
 import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
-import {AppContext, CapabilitiesContextType, Comment, DispatchActionType, EditableAppContext} from './app-context';
+import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
 import {CommentsFrame} from './components/frame';
 import {setupAdminAPI} from './utils/admin-api';
 import {useOptions} from './utils/options';
@@ -18,12 +18,7 @@ type AppProps = {
 };
 
 const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
-const LIKES_ORDER = 'count__likes desc, created_at desc';
 const NET_SCORE_ORDER = 'count__net_score desc, created_at desc';
-
-function getDefaultOrder(capabilities: CapabilitiesContextType) {
-    return capabilities.dislikes === true ? NET_SCORE_ORDER : LIKES_ORDER;
-}
 
 /**
  * Check if a comment ID exists in the comments array (either as a top-level comment or reply)
@@ -44,8 +39,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId}) => {
         openCommentForms: [],
         popup: null,
         labs: {},
-        capabilities: {},
-        order: LIKES_ORDER,
+        order: NET_SCORE_ORDER,
         adminApi: null,
         commentsIsLoading: false,
         commentIdToHighlight: null,
@@ -162,8 +156,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId}) => {
                             admin,
                             isAdmin: true,
                             comments: adminComments.comments,
-                            pagination: adminComments.meta.pagination,
-                            capabilities: adminComments.meta?.capabilities ?? currentState.capabilities
+                            pagination: adminComments.meta.pagination
                         };
                     });
                 }
@@ -194,8 +187,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId}) => {
         return {
             comments: data.comments,
             pagination: data.meta.pagination,
-            count: count,
-            capabilities: data.meta?.capabilities ?? {}
+            count: count
         };
     };
 
@@ -273,16 +265,8 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId}) => {
     const initSetup = async () => {
         try {
             const {member, labs, supportEmail} = await api.init();
-            let {count, comments: initialComments, pagination: initialPagination, capabilities} = await fetchComments(LIKES_ORDER);
-            const defaultOrder = getDefaultOrder(capabilities);
-
-            if (defaultOrder !== LIKES_ORDER) {
-                const sortedData = await fetchComments(defaultOrder);
-                count = sortedData.count;
-                initialComments = sortedData.comments;
-                initialPagination = sortedData.pagination;
-                capabilities = sortedData.capabilities.dislikes === true ? sortedData.capabilities : capabilities;
-            }
+            const {count, comments: initialComments, pagination: initialPagination} = await fetchComments(NET_SCORE_ORDER);
+            const defaultOrder = NET_SCORE_ORDER;
 
             let comments = initialComments;
             let pagination = initialPagination;
@@ -313,7 +297,6 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId}) => {
                 commentCount: count,
                 order: defaultOrder,
                 labs: labs,
-                capabilities,
                 commentsIsLoading: false,
                 commentIdToHighlight: null,
                 commentIdToScrollTo: scrollTargetFound ? initialCommentId : null,

--- a/apps/comments-ui/src/components/content/buttons/like-button.tsx
+++ b/apps/comments-ui/src/components/content/buttons/like-button.tsx
@@ -1,4 +1,3 @@
-import LikeIcon from '../../../images/icons/like.svg?react';
 import ThumbsDownIcon from '../../../images/icons/thumbs-down.svg?react';
 import ThumbsUpIcon from '../../../images/icons/thumbs-up.svg?react';
 import {Comment, useAppContext} from '../../../app-context';
@@ -10,13 +9,12 @@ type Props = {
     setDisabled?: (disabled: boolean) => void;
 };
 const LikeButton: React.FC<Props> = ({comment, disabled, setDisabled}) => {
-    const {dispatchAction, isMember, hasRequiredTier, capabilities, t} = useAppContext();
+    const {dispatchAction, isMember, hasRequiredTier, t} = useAppContext();
     const [likeAnimation, setLikeAnimation] = useState('');
     const [localDisabled, setLocalDisabled] = useState(false);
 
     const canInteract = isMember && hasRequiredTier;
     const likesCount = comment.count.likes;
-    const dislikesEnabled = capabilities?.dislikes === true;
     const buttonDisabled = disabled ?? localDisabled;
     const setButtonDisabled = setDisabled ?? setLocalDisabled;
 
@@ -50,28 +48,6 @@ const LikeButton: React.FC<Props> = ({comment, disabled, setDisabled}) => {
             setButtonDisabled(false);
         }
     };
-
-    if (!dislikesEnabled) {
-        return (
-            <button
-                aria-label={comment.liked ? t('Remove like') : t('Like')}
-                className={`duration-50 group flex cursor-pointer items-center font-sans text-base outline-0 transition-all ease-linear sm:text-sm ${
-                    comment.liked ? 'text-black/90 dark:text-white/90' : 'text-black/50 hover:text-black/75 dark:text-white/60 dark:hover:text-white/75'
-                }`}
-                data-testid="like-button"
-                disabled={buttonDisabled}
-                type="button"
-                onClick={toggleLike}
-            >
-                <LikeIcon
-                    className={likeAnimation + ` mr-[6px] ${
-                        comment.liked ? 'fill-black dark:fill-white stroke-black dark:stroke-white' : 'stroke-black/50 group-hover:stroke-black/75 dark:stroke-white/60 dark:group-hover:stroke-white/75'
-                    } ${!comment.liked && canInteract && 'group-hover:stroke-black/75 dark:group-hover:stroke-white/75'} transition duration-50 ease-linear`}
-                />
-                {likesCount}
-            </button>
-        );
-    }
 
     return (
         <button

--- a/apps/comments-ui/src/components/content/buttons/like-count.tsx
+++ b/apps/comments-ui/src/components/content/buttons/like-count.tsx
@@ -1,6 +1,4 @@
-import LikeIcon from '../../../images/icons/like.svg?react';
 import ThumbsUpIcon from '../../../images/icons/thumbs-up.svg?react';
-import {useAppContext} from '../../../app-context';
 
 type Props = {
     count: number;
@@ -8,27 +6,6 @@ type Props = {
 };
 
 const LikeCount: React.FC<Props> = ({count, liked}) => {
-    const {capabilities} = useAppContext();
-    const dislikesEnabled = capabilities?.dislikes === true;
-
-    if (!dislikesEnabled) {
-        return (
-            <span
-                className={`flex items-center font-sans text-base sm:text-sm ${
-                    liked ? 'text-black/90 dark:text-white/90' : 'text-black/50 dark:text-white/60'
-                }`}
-                data-testid="like-count"
-            >
-                <LikeIcon
-                    className={`mr-[6px] ${
-                        liked ? 'fill-black stroke-black dark:fill-white dark:stroke-white' : 'stroke-black/50 dark:stroke-white/60'
-                    }`}
-                />
-                {count}
-            </span>
-        );
-    }
-
     return (
         <div
             className="flex items-center gap-1.5"

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -463,7 +463,7 @@ type CommentMenuProps = {
     className?: string;
 };
 const CommentMenu: React.FC<CommentMenuProps> = ({comment, openReplyForm, highlightReplyButton, openEditMode, className = ''}) => {
-    const {member, t, isMember, isAdmin, isCommentingDisabled, capabilities} = useAppContext();
+    const {member, t, isMember, isAdmin, isCommentingDisabled} = useAppContext();
     const [voteDisabled, setVoteDisabled] = React.useState(false);
 
     const isPublished = comment.status === 'published';
@@ -471,7 +471,7 @@ const CommentMenu: React.FC<CommentMenuProps> = ({comment, openReplyForm, highli
 
     // Visibility decisions
     const showLikeButton = !isCommentingDisabled;
-    const showDislikeButton = showLikeButton && capabilities?.dislikes === true;
+    const showDislikeButton = showLikeButton;
     const showReplyButton = !isCommentingDisabled;
     const shouldShowMoreButton = isAdmin || (isMember && isPublished);
     const shouldHideMoreButton = isCommentingDisabled && isOwnComment;

--- a/apps/comments-ui/src/components/content/forms/sorting-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/sorting-form.tsx
@@ -3,17 +3,17 @@ import React, {useEffect, useRef, useState} from 'react';
 import {useAppContext, useOrderChange} from '../../../app-context';
 
 export const SortingForm: React.FC = () => {
-    const {capabilities, order, t} = useAppContext();
+    const {order, t} = useAppContext();
     const changeOrder = useOrderChange();
     const [isOpen, setIsOpen] = useState(false);
     const [selectedOption, setSelectedOption] = useState(order);
     const dropdownRef = useRef<HTMLDivElement>(null);
-    const bestOrder = capabilities?.dislikes === true ? 'count__net_score desc, created_at desc' : 'count__likes desc, created_at desc';
+    const bestOrder = 'count__net_score desc, created_at desc';
 
     useEffect(() => {
         const isBestOrder = order === 'count__likes desc, created_at desc' || order === 'count__net_score desc, created_at desc';
         setSelectedOption(isBestOrder ? bestOrder : order);
-    }, [order, bestOrder]);
+    }, [order]);
 
     const options = [
         {value: bestOrder, label: t('Best')},

--- a/apps/comments-ui/test/unit/components/content/comment.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/comment.test.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import {AppContext} from '../../../../src/app-context';
 import {CommentComponent, RepliedToSnippet} from '../../../../src/components/content/comment';
-import {SortingForm} from '../../../../src/components/content/forms/sorting-form';
 import {buildComment} from '../../../utils/fixtures';
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import {vi} from 'vitest';
 
 vi.mock('../../../../src/components/content/forms/reply-form', () => ({
@@ -15,7 +14,6 @@ const contextualRender = (ui, {appContext, ...renderOptions}) => {
         commentsEnabled: 'all',
         comments: [],
         openCommentForms: [],
-        capabilities: {},
         member: null,
         commentIdToScrollTo: null,
         t: str => str,
@@ -70,28 +68,14 @@ describe('<CommentComponent>', function () {
         expect(container.querySelector('[data-member-uuid="123"]')).not.toBeInTheDocument();
     });
 
-    it('keeps the like-only controls when dislike capability is absent', function () {
-        const comment = buildComment({
-            count: {
-                likes: 3
-            }
-        });
-        const appContext = {comments: [comment], dispatchAction: () => {}};
-
-        contextualRender(<CommentComponent comment={comment} />, {appContext});
-
-        expect(screen.getByTestId('like-button')).toHaveTextContent('3');
-        expect(screen.queryByTestId('dislike-button')).not.toBeInTheDocument();
-    });
-
-    it('renders an icon-only dislike control when dislike capability is present', function () {
+    it('renders an icon-only dislike control', function () {
         const comment = buildComment({
             disliked: true,
             count: {
                 likes: 3
             }
         });
-        const appContext = {comments: [comment], capabilities: {dislikes: true}, dispatchAction: () => {}};
+        const appContext = {comments: [comment], dispatchAction: () => {}};
 
         contextualRender(<CommentComponent comment={comment} />, {appContext});
 
@@ -128,38 +112,6 @@ describe('<CommentComponent>', function () {
         expect(screen.getByText('Second reply')).toBeInTheDocument();
         expect(container.ownerDocument.getElementById(reply2.id)).toHaveTextContent('Second reply');
         expect(screen.queryByTestId('replies-pagination')).not.toBeInTheDocument();
-    });
-
-    it('keeps Best selected when dislike capabilities change the best order', async function () {
-        const appContext = {
-            comments: [],
-            order: 'count__likes desc, created_at desc',
-            dispatchAction: () => {}
-        };
-
-        const {rerender} = contextualRender(<SortingForm />, {appContext});
-
-        expect(screen.getByTestId('comments-sorting-form')).toHaveTextContent('Best');
-
-        rerender(
-            <AppContext.Provider value={{
-                commentsEnabled: 'all',
-                comments: [],
-                openCommentForms: [],
-                capabilities: {dislikes: true},
-                member: null,
-                commentIdToScrollTo: null,
-                t: str => str,
-                ...appContext
-            }}
-            >
-                <SortingForm />
-            </AppContext.Provider>
-        );
-
-        await waitFor(() => {
-            expect(screen.getByTestId('comments-sorting-form')).toHaveTextContent('Best');
-        });
     });
 
     it('hides reply-to-reply context when commentsThreads is enabled', function () {

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -1,7 +1,7 @@
 import CommentsFilters from './components/comments-filters';
 import CommentsList from './components/comments-list';
 import MainLayout from '@components/layout/main-layout';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {Button, EmptyIndicator, LoadingIndicator} from '@tryghost/shade/components';
 import {FilterBar, PageHeader, createFilter} from '@tryghost/shade/patterns';
 import {ListPage} from '@tryghost/shade/page-templates';
@@ -27,7 +27,7 @@ const CommentsPage: React.FC<{timezone: string; singleCommentId?: string}> = ({
 }) => {
     const [searchParams, setSearchParams] = useSearchParams();
     const {filters, nql, setFilters} = useFilterState(timezone);
-    const [dislikesEnabled, setDislikesEnabled] = useState(false);
+    const dislikesEnabled = true;
     const handleAddFilter = useCallback((field: string, value: string, operator: string = 'is') => {
         const nextFilters = [
             ...filters.filter(filter => filter.field !== field),
@@ -78,11 +78,6 @@ const CommentsPage: React.FC<{timezone: string; singleCommentId?: string}> = ({
         },
         keepPreviousData: true
     });
-    useEffect(() => {
-        if (!dislikesEnabled && data?.meta?.capabilities?.dislikes === true) {
-            setDislikesEnabled(true);
-        }
-    }, [dislikesEnabled, data?.meta?.capabilities?.dislikes]);
 
     const shouldShowLoading = isFetching && !isFetchingNextPage && !isRefetching;
     const resetKey = effectiveFilter ?? '';

--- a/ghost/core/core/server/api/endpoints/comments-members.js
+++ b/ghost/core/core/server/api/endpoints/comments-members.js
@@ -1,16 +1,6 @@
 const commentsService = require('../../services/comments');
 const ALLOWED_INCLUDES = ['member', 'replies', 'replies.member', 'replies.count.likes', 'replies.liked', 'replies.disliked', 'count.replies', 'count.direct_replies', 'count.likes', 'liked', 'disliked', 'post', 'parent'];
 
-function withDislikesCapability(response) {
-    response.meta = response.meta || {};
-    response.meta.capabilities = {
-        ...response.meta.capabilities,
-        dislikes: true
-    };
-
-    return response;
-}
-
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
     docName: 'comments',
@@ -35,9 +25,8 @@ const controller = {
             }
         },
         permissions: false,
-        async query(frame) {
-            const response = await commentsService.controller.browse(frame);
-            return withDislikesCapability(response);
+        query(frame) {
+            return commentsService.controller.browse(frame);
         }
     },
 

--- a/ghost/core/core/server/api/endpoints/comments.js
+++ b/ghost/core/core/server/api/endpoints/comments.js
@@ -1,16 +1,6 @@
 const commentsService = require('../../services/comments');
 const errors = require('@tryghost/errors');
 
-function withDislikesCapability(response) {
-    response.meta = response.meta || {};
-    response.meta.capabilities = {
-        ...response.meta.capabilities,
-        dislikes: true
-    };
-
-    return response;
-}
-
 function validateCommentData(data) {
     if (!data.post_id && !data.parent_id) {
         throw new errors.ValidationError({
@@ -85,8 +75,7 @@ const controller = {
         },
         permissions: true,
         async query(frame) {
-            const result = await commentsService.controller.adminBrowse(frame);
-            return withDislikesCapability(result);
+            return await commentsService.controller.adminBrowse(frame);
         }
     },
     browseAll: {
@@ -105,8 +94,7 @@ const controller = {
             method: 'browse'
         },
         async query(frame) {
-            const result = await commentsService.controller.adminBrowseAll(frame);
-            return withDislikesCapability(result);
+            return await commentsService.controller.adminBrowseAll(frame);
         }
     },
     add: {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -83,9 +83,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -185,9 +182,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -247,9 +241,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -309,9 +300,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -413,9 +401,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -475,9 +460,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -549,9 +531,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -611,9 +590,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -715,9 +691,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -831,9 +804,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -893,9 +863,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -997,9 +964,6 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 2,
       "next": 2,
@@ -1701,9 +1665,6 @@ exports[`Admin Comments API browse by post does not return deleted comments 1: [
 Object {
   "comments": Array [],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1823,9 +1784,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1842,9 +1800,6 @@ exports[`Admin Comments API browse by post excludes deleted comments when all re
 Object {
   "comments": Array [],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -1964,9 +1919,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2053,9 +2005,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -336,9 +336,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -356,7 +353,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1524",
+  "content-length": "1491",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -446,9 +443,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -466,7 +460,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1524",
+  "content-length": "1491",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -556,9 +550,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -576,7 +567,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1524",
+  "content-length": "1491",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -666,9 +657,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -686,7 +674,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1524",
+  "content-length": "1491",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1990,9 +1978,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2010,7 +1995,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1029",
+  "content-length": "996",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2049,9 +2034,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2069,7 +2051,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "599",
+  "content-length": "566",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2081,9 +2063,6 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2101,7 +2080,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "136",
+  "content-length": "103",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2113,9 +2092,6 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2133,7 +2109,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "136",
+  "content-length": "103",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2172,9 +2148,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2192,7 +2165,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "599",
+  "content-length": "566",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2204,9 +2177,6 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2224,7 +2194,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "136",
+  "content-length": "103",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2236,9 +2206,6 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2256,7 +2223,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "136",
+  "content-length": "103",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2295,9 +2262,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2315,7 +2279,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "599",
+  "content-length": "566",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2427,9 +2391,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2447,7 +2408,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1978",
+  "content-length": "1945",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2511,9 +2472,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2531,7 +2489,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1029",
+  "content-length": "996",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2595,9 +2553,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2615,7 +2570,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1028",
+  "content-length": "995",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2703,9 +2658,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -2723,7 +2675,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1585",
+  "content-length": "1552",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -3165,9 +3117,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -3185,7 +3134,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1053",
+  "content-length": "1020",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -3249,9 +3198,6 @@ Object {
     },
   ],
   "meta": Object {
-    "capabilities": Object {
-      "dislikes": true,
-    },
     "pagination": Object {
       "limit": 15,
       "next": null,
@@ -3269,7 +3215,7 @@ Object {
   "access-control-allow-credentials": "true",
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1053",
+  "content-length": "1020",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -420,16 +420,6 @@ describe('Comments API', function () {
                 ]);
             });
 
-            it('advertises dislike support on comment list responses', async function () {
-                const {body} = await membersAgent
-                    .get(`/api/comments/post/${postId}/`)
-                    .expectStatus(200);
-
-                assert.deepEqual(body.meta.capabilities, {
-                    dislikes: true
-                });
-            });
-
             it('excludes hidden comments', async function () {
                 const hiddenComment = await dbFns.addComment({
                     post_id: postId,


### PR DESCRIPTION
## Summary
- Removed the backend `meta.capabilities.dislikes` flag from comments API responses.
- Removed frontend capability negotiation for dislike support in comments UI and Posts comments.
- Initialised comments UI directly with the net-score Best order, resolving the duplicate startup comments request.
- Bumped `@tryghost/comments-ui` from `1.5.10` to `1.5.11` for the patch release.
- Updated comments API snapshots for the removed metadata.

## Context
Dislike support and net-score ordering are now established comments API behavior. Keeping a backend capability flag for dislikes meant comments UI still had to discover support at runtime: it loaded the old `count__likes desc, created_at desc` Best order first, then loaded again with `count__net_score desc, created_at desc` after reading capabilities.

Removing the stale capability flag lets the frontend use the net-score order directly, so the capability cleanup also removes the double fetch on post load.

## Testing
- `CI=true pnpm --filter @tryghost/comments-ui test:unit -- test/unit/components/content/comment.test.jsx`
- `CI=true pnpm --filter @tryghost/comments-ui test:acceptance test/e2e/actions.test.ts`
- `CI=true pnpm --filter @tryghost/posts lint`
- `CI=true pnpm --filter @tryghost/comments-ui lint`
- `CI=true pnpm --dir ghost/core test:base --timeout=60000 test/e2e-api/members-comments/comments.test.js test/e2e-api/admin/comments.test.js`

## Notes
- `CI=true pnpm --filter @tryghost/posts build` currently fails on unrelated TypeScript errors in Automations and members import files.

fixes https://linear.app/ghost/issue/BER-3687/duplicate-comments-loads-on-each-post-load
