### PR TITLE
🐛 Fixed content import failures being silently swallowed

### DIFF
--- a/ghost/core/core/server/data/importer/email-template.ts
+++ b/ghost/core/core/server/data/importer/email-template.ts
@@ -11,7 +11,25 @@ type EmailTemplateData = ReadonlyDeep<{
     emailRecipient: string;
 }>;
 
-export const emailTemplate = ({result, siteUrl, postsUrl, emailRecipient}: EmailTemplateData): string => `
+const escapeHtml = (value: string): string => value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const getFirstErrorMessage = (importErrors?: ReadonlyDeep<unknown[]>): string | null => {
+    const firstError = importErrors?.[0];
+    if (firstError && typeof firstError === 'object' && 'message' in firstError && typeof firstError.message === 'string') {
+        return firstError.message;
+    }
+    return null;
+};
+
+export const emailTemplate = ({result, siteUrl, postsUrl, emailRecipient}: EmailTemplateData): string => {
+    const errorMessage = getFirstErrorMessage(result?.data?.errors);
+
+    return `
 <!doctype html>
 <html>
   <head>
@@ -142,6 +160,11 @@ export const emailTemplate = ({result, siteUrl, postsUrl, emailRecipient}: Email
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-bottom: 16px;">One or more error occured while importing your content. Please contact support or report on the <a href="https://forum.ghost.org/">Ghost Community Forum</a>.</td>
                     </tr>
+                    ${errorMessage ? `
+                    <tr>
+                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-bottom: 16px; color: #738A94;">Error: ${escapeHtml(errorMessage)}</td>
+                    </tr>
+                    ` : ''}
                     ` : `
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-bottom: 12px; padding-top: 16px;">
@@ -173,3 +196,4 @@ export const emailTemplate = ({result, siteUrl, postsUrl, emailRecipient}: Email
   </body>
 </html>
 `;
+};

--- a/ghost/core/core/server/data/importer/importers/data/data-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/data-importer.js
@@ -190,7 +190,8 @@ DataImporter = {
                     message: errors[0].message,
                     context: errors[0].context,
                     help: errors[0].help,
-                    errorDetails: errors
+                    errorDetails: errors,
+                    err: errors[0]
                 });
             }
 

--- a/ghost/core/core/server/data/importer/importers/data/data-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/data-importer.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const ObjectId = require('bson-objectid').default;
 const semver = require('semver');
-const {IncorrectUsageError} = require('@tryghost/errors');
+const {IncorrectUsageError, DataImportError} = require('@tryghost/errors');
 const debug = require('@tryghost/debug')('importer:data');
 const {sequence} = require('@tryghost/promise');
 const models = require('../../../../models');
@@ -186,7 +186,12 @@ DataImporter = {
             // Errors preventing import:
             if (errors.length > 0) {
                 debug(errors);
-                throw errors;
+                throw new DataImportError({
+                    message: errors[0].message,
+                    context: errors[0].context,
+                    help: errors[0].help,
+                    errorDetails: errors
+                });
             }
 
             return {

--- a/ghost/core/test/unit/server/data/importer/email-template.test.ts
+++ b/ghost/core/test/unit/server/data/importer/email-template.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import {emailTemplate} from '../../../../../core/server/data/importer/email-template';
+
+describe('Importer email template', function () {
+    const siteUrl = new URL('http://example.com');
+    const postsUrl = new URL('http://example.com/ghost/#/posts');
+    const emailRecipient = 'recipient@example.com';
+
+    it('renders the success email when there are no errors', function () {
+        const html = emailTemplate({result: {data: {}}, siteUrl, postsUrl, emailRecipient});
+
+        assert.match(html, /Your content import has finished successfully/);
+        assert.doesNotMatch(html, /Import unsuccessful/);
+    });
+
+    it('includes the error message in the failure email', function () {
+        const result = {
+            data: {
+                errors: [new Error('Value in [posts.title] exceeds maximum length of 2000 characters.')]
+            }
+        };
+
+        const html = emailTemplate({result, siteUrl, postsUrl, emailRecipient});
+
+        assert.match(html, /Import unsuccessful/);
+        assert.match(html, /Error: Value in \[posts\.title\] exceeds maximum length of 2000 characters\./);
+    });
+
+    it('escapes HTML in the error message', function () {
+        const result = {
+            data: {
+                errors: [new Error('Invalid value <script>alert("xss")</script> & more')]
+            }
+        };
+
+        const html = emailTemplate({result, siteUrl, postsUrl, emailRecipient});
+
+        assert.doesNotMatch(html, /<script>alert/);
+        assert.match(html, /Error: Invalid value &lt;script&gt;alert\(&quot;xss&quot;\)&lt;\/script&gt; &amp; more/);
+    });
+
+    it('renders the generic failure email when the error has no message', function () {
+        const result = {
+            data: {
+                errors: [{}]
+            }
+        };
+
+        const html = emailTemplate({result, siteUrl, postsUrl, emailRecipient});
+
+        assert.match(html, /Import unsuccessful/);
+        assert.doesNotMatch(html, /Error: /);
+    });
+});

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -18,6 +18,7 @@ const MarkdownHandler = require('../../../../../core/server/data/importer/handle
 const RevueHandler = require('../../../../../core/server/data/importer/handlers/revue');
 const DataImporter = require('../../../../../core/server/data/importer/importers/data');
 const RevueImporter = require('../../../../../core/server/data/importer/importers/importer-revue');
+const models = require('../../../../../core/server/models');
 const configUtils = require('../../../../utils/config-utils');
 const logging = require('@tryghost/logging');
 
@@ -681,6 +682,44 @@ describe('Importer', function () {
             assert.deepEqual(inputData.data.data.posts[0], outputData.data.data.posts[0]);
             assert.deepEqual(inputData.data.data.tags[0], outputData.data.data.tags[0]);
             assert.deepEqual(inputData.data.data.users[0], outputData.data.data.users[0]);
+        });
+
+        it('rejects with a DataImportError carrying the importer errors when the import fails', async function () {
+            const RewiredDataImporter = rewire('../../../../../core/server/data/importer/importers/data/data-importer');
+            const importError = new errors.ValidationError({
+                message: 'Value in [posts.title] exceeds maximum length of 2000 characters.',
+                context: '{"title":"..."}'
+            });
+
+            const fakeImporter = (importerErrors = []) => ({
+                options: {requiredImportedData: [], requiredExistingData: []},
+                fetchExisting: sinon.stub().resolves(),
+                beforeImport: sinon.stub().resolves(),
+                replaceIdentifiers: sinon.stub().resolves(),
+                doImport: sinon.stub().resolves(),
+                errors: importerErrors,
+                problems: [],
+                importedData: []
+            });
+
+            sinon.stub(models.Base, 'transaction').callsFake(fn => fn({fake: 'transacting'}));
+            sinon.stub(RewiredDataImporter, 'init').callsFake(function (importData) {
+                RewiredDataImporter.__set__('importers', {
+                    posts: fakeImporter([importError]),
+                    products: fakeImporter(),
+                    stripe_prices: fakeImporter()
+                });
+                return importData;
+            });
+
+            await assert.rejects(RewiredDataImporter.doImport({meta: {version: '4.0.0'}, data: {}}, {}), (err) => {
+                assert(err instanceof Error);
+                assert(err instanceof errors.DataImportError);
+                assert.equal(err.message, importError.message);
+                assert.equal(err.context, importError.context);
+                assert.deepEqual(err.errorDetails, [importError]);
+                return true;
+            });
         });
     });
 });


### PR DESCRIPTION
fixes #26268

When a content import failed, the data importer threw a raw **array** of error objects instead of an `Error`. Upstream, `import-manager` passes whatever it catches to `logging.error()`, which can't do anything useful with a non-Error — no message, no stack, no context — so import failures were effectively silent in the logs. The notification email was equally unhelpful: a generic "Import unsuccessful" with zero detail, leaving users with nothing actionable.

This change:
- wraps the collected importer errors in a proper `DataImportError` (message/context/help taken from the first error, the full list attached as `errorDetails`) so logging works and no information is lost
- surfaces the primary error message in the failure email, HTML-escaped, as a single extra line in the existing template
- adds unit tests for the rejection shape and the email rendering (including escaping)

Supersedes the diagnosis in #27651 — same underlying issue, but fixed at the throw site and in the email template rather than reworking the import pipeline.