### PR TITLE
Improved MySQL acceptance test resets

### DIFF
--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -22,6 +22,8 @@ const {sequence} = require('@tryghost/promise');
 const urlServiceUtils = require('./url-service-utils');
 
 let dbInitialized = false;
+let mysqlSnapshotDatabase = null;
+const mysqlSnapshotTablePrefix = '__ghost_snapshot_';
 
 /**
  * Checks if the current active connection is a MySQL database
@@ -69,11 +71,11 @@ module.exports.reset = async ({truncate} = {truncate: false}) => {
         if (truncate) {
             // Perform a fast reset by tearing down all the tables and inserting the fixtures
             try {
-                await truncateAll();
-                await knexMigrator.init({only: 3});
+                await resetMySQLFromSnapshot();
             } catch (err) {
                 // If it fails, try a normal restore
                 await forceReinit();
+                await createMySQLSnapshot();
             }
         } else {
             // Do a full database reset + initialisation
@@ -90,8 +92,12 @@ module.exports.reset = async ({truncate} = {truncate: false}) => {
 module.exports.teardown = async () => {
     try {
         await truncateAll();
+        await dropMySQLSnapshots();
+        invalidateMySQLSnapshot();
     } catch (err) {
         await knexMigrator.reset({force: true});
+        await dropMySQLSnapshots();
+        invalidateMySQLSnapshot();
     }
 };
 
@@ -124,6 +130,99 @@ module.exports.truncate = async (tableName) => {
 const forceReinit = async () => {
     await knexMigrator.reset({force: true});
     await knexMigrator.init();
+    await dropMySQLSnapshots();
+    invalidateMySQLSnapshot();
+};
+
+const getResetTables = () => {
+    return schemaTables.concat(['migrations']);
+};
+
+const getMySQLSnapshotTableName = (table) => {
+    return `${mysqlSnapshotTablePrefix}${table}`;
+};
+
+const getMySQLDatabaseName = () => {
+    return config.get('database:connection:database');
+};
+
+const isMySQLSnapshotCurrent = () => {
+    return mysqlSnapshotDatabase === getMySQLDatabaseName();
+};
+
+const invalidateMySQLSnapshot = () => {
+    mysqlSnapshotDatabase = null;
+};
+
+const resetMySQLFromSnapshot = async () => {
+    if (!isMySQLSnapshotCurrent()) {
+        await truncateAll();
+        await knexMigrator.init({only: 3});
+        await createMySQLSnapshot();
+        return;
+    }
+
+    await restoreMySQLSnapshot();
+};
+
+const createMySQLSnapshot = async () => {
+    if (!module.exports.isMySQL()) {
+        return;
+    }
+
+    const tables = getResetTables();
+
+    await sequence(tables.map(table => async () => {
+        const snapshotTable = getMySQLSnapshotTableName(table);
+
+        await db.knex.schema.dropTableIfExists(snapshotTable);
+        await db.knex.raw('CREATE TABLE ?? LIKE ??', [snapshotTable, table]);
+        await db.knex.raw('INSERT INTO ?? SELECT * FROM ??', [snapshotTable, table]);
+    }));
+
+    mysqlSnapshotDatabase = getMySQLDatabaseName();
+};
+
+const restoreMySQLSnapshot = async () => {
+    debug('Database snapshot restore');
+    urlServiceUtils.reset();
+
+    const tables = getResetTables();
+
+    await db.knex.transaction(async (trx) => {
+        try {
+            await db.knex.raw('SET FOREIGN_KEY_CHECKS=0;').transacting(trx);
+
+            await sequence(tables.map(table => async () => {
+                const snapshotTable = getMySQLSnapshotTableName(table);
+
+                await db.knex.raw('DELETE FROM ??', [table]).transacting(trx);
+                await db.knex.raw('INSERT INTO ?? SELECT * FROM ??', [table, snapshotTable]).transacting(trx);
+            }));
+        } finally {
+            await db.knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(trx);
+            debug('Database snapshot restore end');
+        }
+    });
+};
+
+const dropMySQLSnapshots = async () => {
+    if (!module.exports.isMySQL()) {
+        return;
+    }
+
+    try {
+        await sequence(getResetTables().map(table => () => {
+            return db.knex.schema.dropTableIfExists(getMySQLSnapshotTableName(table));
+        }));
+    } catch (err) {
+        // CASE: table does not exist || DB does not exist
+        if (err.errno === 1146 || err.errno === 1049) {
+            return Promise.resolve();
+        }
+
+        throw err;
+    }
 };
 
 /**
@@ -135,7 +234,7 @@ const truncateAll = async () => {
     debug('Database teardown');
     urlServiceUtils.reset();
 
-    const tables = schemaTables.concat(['migrations']);
+    const tables = getResetTables();
 
     if (module.exports.isSQLite()) {
         try {

--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -92,13 +92,11 @@ module.exports.reset = async ({truncate} = {truncate: false}) => {
 module.exports.teardown = async () => {
     try {
         await truncateAll();
-        await dropMySQLSnapshots();
-        invalidateMySQLSnapshot();
     } catch (err) {
         await knexMigrator.reset({force: true});
-        await dropMySQLSnapshots();
-        invalidateMySQLSnapshot();
     }
+
+    await dropMySQLSnapshots();
 };
 
 /**
@@ -131,7 +129,6 @@ const forceReinit = async () => {
     await knexMigrator.reset({force: true});
     await knexMigrator.init();
     await dropMySQLSnapshots();
-    invalidateMySQLSnapshot();
 };
 
 const getResetTables = () => {
@@ -148,10 +145,6 @@ const getMySQLDatabaseName = () => {
 
 const isMySQLSnapshotCurrent = () => {
     return mysqlSnapshotDatabase === getMySQLDatabaseName();
-};
-
-const invalidateMySQLSnapshot = () => {
-    mysqlSnapshotDatabase = null;
 };
 
 const resetMySQLFromSnapshot = async () => {
@@ -210,6 +203,8 @@ const dropMySQLSnapshots = async () => {
     if (!module.exports.isMySQL()) {
         return;
     }
+
+    mysqlSnapshotDatabase = null;
 
     try {
         await sequence(getResetTables().map(table => () => {

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -105,7 +105,7 @@ const _startGhost = async (options) => {
     // Reset the settings cache and disable listeners so they don't get triggered further
     settingsService.reset();
 
-    await dbUtils.reset();
+    await dbUtils.reset({truncate: true});
 
     await settingsService.init();
 


### PR DESCRIPTION
## Summary

- Cache the initialized MySQL acceptance-test database into in-database snapshot tables after the first truncating reset.
- Restore subsequent MySQL resets from that snapshot instead of rerunning `knexMigrator.init({only: 3})` for every Ghost boot.
- Invalidate and clean snapshot tables when using the full reset/teardown paths, with fallback to the existing slow-safe reinitialization path.
- Move the older `e2e-utils` boot helper onto the truncating reset path so it benefits from the same reset behavior.

## Local runtime data

Initial profiling showed the MySQL suite was spending most of its time in reset lifecycle rather than Ghost boot:

- Baseline full local MySQL E2E profile: 136 modern framework resets took 155.0s total; modern Ghost boot was only 9.6s total.
- With this change, full local MySQL E2E: 136 modern framework resets took 6.5s total.
- The older `e2e-utils` path also improved locally because it now uses the truncating reset path.

## Validation

- `pnpm --dir ghost/core lint:test`
- MySQL admin acceptance bucket: 967 passing; framework reset total 3.9s across 85 boots; `knexMigrator.init` count 5; wall clock 107.3s
- MySQL full core E2E acceptance suite: 1681 passing, 2 pending; framework reset total 6.5s across 136 boots; wall clock 170.0s
- SQLite full core E2E acceptance suite: 1682 passing, 1 pending; wall clock 110.5s


## Notes

- The `e2e-utils.js` change moves every legacy MySQL e2e boot from a full `knexMigrator.reset` + `init` to the truncating reset path. The behavioral difference: a full reset drops stray tables and repairs schema drift, while the truncate path only deletes rows from `schemaTables + migrations`. The full-suite runs above cover this, and the line is severable from the snapshot work if it ever causes flakiness.
