### PR TITLE
Fixed stale Ghost-CLI update checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,7 +812,22 @@ jobs:
         run: |
           DIR=$(mktemp -d)
           ghost install local -d "$DIR"
-          ghost update -d "$DIR" --archive "$(pwd)/ghost.tgz"
+          INSTALLED_VERSION=$(node -e "console.log(require(process.argv[1]).version)" "$DIR/current/package.json")
+          ARCHIVE_VERSION=$(tar -xOf ghost.tgz package/package.json | node -e "let data = ''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => console.log(JSON.parse(data).version));")
+
+          # Stale PRs can build an archive from an older prerelease after the stable
+          # version has already been published. Ghost-CLI correctly rejects that as
+          # a downgrade, so only run the update path when the archive can upgrade
+          # the installed latest release.
+          HIGHEST_VERSION=$(npm exec --yes --package semver@7.7.4 -- semver "$INSTALLED_VERSION" "$ARCHIVE_VERSION" | tail -n1)
+          ARCHIVE_CAN_UPGRADE_LATEST=$([ "$HIGHEST_VERSION" = "$ARCHIVE_VERSION" ] && [ "$ARCHIVE_VERSION" != "$INSTALLED_VERSION" ] && echo "true" || echo "false")
+
+          if [ "$ARCHIVE_CAN_UPGRADE_LATEST" = "true" ]; then
+            ghost update -d "$DIR" --archive "$(pwd)/ghost.tgz"
+          else
+            echo "Skipping update test because archive version $ARCHIVE_VERSION cannot upgrade latest release $INSTALLED_VERSION"
+          fi
+
           URL=$(ghost config get url -d "$DIR" --no-prompt --no-color | tail -n1)
           curl --retry 10 --retry-connrefused --retry-delay 3 -fsSI "$URL"
           ghost stop -d "$DIR"


### PR DESCRIPTION
## Summary
- skip the Ghost-CLI latest-release update check when the CI archive cannot upgrade the installed latest release
- keep the archive clean-install check running so PR tarball coverage remains intact
- document the stale-PR-after-release case inline in the workflow

## Context
The failing run was a PR event from a fork branch named `main`, not a push to `TryGhost/Ghost`'s `main`. Its tarball was built as `6.45.0-rc.0`, but npm latest had already moved to `6.45.0`, so `ghost update --archive` correctly rejected the archive as a downgrade.

This can happen for any stale PR after a release, not only fork PRs. Checking whether the archive can actually upgrade the installed latest release matches the Ghost-CLI invariant and avoids hiding the clean-install coverage for PR artifacts.