### PR TITLE
Hid the admin sidebar for the `automations/:id` React route

### DIFF
--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -41,6 +41,10 @@ export type {BaseSourceData, ProcessedSourceData, ExtendSourcesOptions} from './
 // Routing
 export type {RouteObject} from 'react-router';
 export type {RouterProviderProps, NavigateOptions} from './providers/router-provider';
+export type AdminRouteHandle = {
+    allowInForceUpgrade?: boolean;
+    hideAdminSidebar?: boolean;
+};
 export {RouterProvider, useNavigate, useBaseRoute, useRouteHasParams, resetScrollPosition, ScrollRestoration, Navigate} from './providers/router-provider';
 export {useNavigationStack} from './providers/navigation-stack-provider';
 export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, matchPath, useMatch, useMatches} from 'react-router';

--- a/apps/admin/src/layout/admin-layout.tsx
+++ b/apps/admin/src/layout/admin-layout.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {SidebarInset, SidebarProvider} from "@tryghost/shade/components";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { isContributorUser } from "@tryghost/admin-x-framework/api/users";
-import { useSidebarVisibility } from "@/ember-bridge/ember-bridge";
+import { useAdminSidebarVisibility } from "@/layout/sidebar-visibility";
 import AppSidebar from "./app-sidebar";
 import { MobileNavBar } from "./app-sidebar/mobile-nav-bar";
 import { ContributorUserMenu } from "./app-sidebar/user-menu";
@@ -13,7 +13,7 @@ interface AdminLayoutProps {
 
 export function AdminLayout({ children }: AdminLayoutProps) {
     const { data: currentUser } = useCurrentUser();
-    const sidebarVisible = useSidebarVisibility();
+    const sidebarVisible = useAdminSidebarVisibility();
     const isContributor = currentUser && isContributorUser(currentUser);
 
     // Contributors get a floating profile menu instead of the full sidebar
@@ -32,7 +32,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
 
     return (
         <SidebarProvider open={!!currentUser && sidebarVisible}>
-            <AppSidebar />
+            {sidebarVisible && <AppSidebar />}
             <SidebarInset className={`overflow-y-auto bg-background sidebar:max-h-full ${sidebarVisible ? 'max-h-[calc(100%-var(--mobile-navbar-height))]' : 'max-h-full'}`}>
                 <main className="flex-1">{children}</main>
                 <MobileNavBar />

--- a/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
+++ b/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Button, SidebarTrigger, useSidebar} from "@tryghost/shade/components";
 import {LucideIcon} from "@tryghost/shade/utils";
 import { useIsActiveLink } from "./use-is-active-link";
-import { useSidebarVisibility } from "@/ember-bridge/ember-bridge";
+import { useAdminSidebarVisibility } from "@/layout/sidebar-visibility";
 
 const ICON_STROKE_WIDTH = 1.5;
 
@@ -31,7 +31,7 @@ function MobileNavBarButton({ to, activeOnSubpath = false, children, ...props }:
 
 export function MobileNavBar() {
     const { isMobile } = useSidebar();
-    const sidebarVisible = useSidebarVisibility();
+    const sidebarVisible = useAdminSidebarVisibility();
 
 
     if (!isMobile || !sidebarVisible) {

--- a/apps/admin/src/layout/sidebar-visibility.test.tsx
+++ b/apps/admin/src/layout/sidebar-visibility.test.tsx
@@ -1,9 +1,9 @@
 import {renderHook} from "@testing-library/react";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 
-interface RouteMatch {
+type RouteMatch = {
     handle?: unknown;
-}
+};
 
 const useMatchesMock = vi.fn<() => RouteMatch[]>();
 const useEmberSidebarVisibilityMock = vi.fn<() => boolean>();

--- a/apps/admin/src/layout/sidebar-visibility.test.tsx
+++ b/apps/admin/src/layout/sidebar-visibility.test.tsx
@@ -36,7 +36,7 @@ describe("useAdminSidebarVisibility", () => {
         const {useAdminSidebarVisibility} = await import("./sidebar-visibility");
 
         useMatchesMock.mockReturnValue([
-            {handle: undefined},
+            {},
             {handle: {hideAdminSidebar: true}}
         ]);
 

--- a/apps/admin/src/layout/sidebar-visibility.test.tsx
+++ b/apps/admin/src/layout/sidebar-visibility.test.tsx
@@ -1,0 +1,60 @@
+import {renderHook} from "@testing-library/react";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+interface RouteMatch {
+    handle?: unknown;
+}
+
+const useMatchesMock = vi.fn<() => RouteMatch[]>();
+const useEmberSidebarVisibilityMock = vi.fn<() => boolean>();
+
+vi.mock("@tryghost/admin-x-framework", () => ({
+    useMatches: () => useMatchesMock()
+}));
+
+vi.mock("@/ember-bridge/ember-bridge", () => ({
+    useSidebarVisibility: () => useEmberSidebarVisibilityMock()
+}));
+
+describe("useAdminSidebarVisibility", () => {
+    beforeEach(() => {
+        useMatchesMock.mockReturnValue([]);
+        useEmberSidebarVisibilityMock.mockReturnValue(true);
+    });
+
+    it("uses the Ember sidebar visibility by default", async () => {
+        const {useAdminSidebarVisibility} = await import("./sidebar-visibility");
+
+        useEmberSidebarVisibilityMock.mockReturnValue(false);
+
+        const {result} = renderHook(() => useAdminSidebarVisibility());
+
+        expect(result.current).toBe(false);
+    });
+
+    it("hides the sidebar when any matched React route opts out", async () => {
+        const {useAdminSidebarVisibility} = await import("./sidebar-visibility");
+
+        useMatchesMock.mockReturnValue([
+            {handle: undefined},
+            {handle: {hideAdminSidebar: true}}
+        ]);
+
+        const {result} = renderHook(() => useAdminSidebarVisibility());
+
+        expect(result.current).toBe(false);
+    });
+
+    it("keeps the sidebar visible when no matched route opts out", async () => {
+        const {useAdminSidebarVisibility} = await import("./sidebar-visibility");
+
+        useMatchesMock.mockReturnValue([
+            {handle: {allowInForceUpgrade: true}},
+            {handle: {hideAdminSidebar: false}}
+        ]);
+
+        const {result} = renderHook(() => useAdminSidebarVisibility());
+
+        expect(result.current).toBe(true);
+    });
+});

--- a/apps/admin/src/layout/sidebar-visibility.ts
+++ b/apps/admin/src/layout/sidebar-visibility.ts
@@ -1,9 +1,9 @@
 import {useMatches} from "@tryghost/admin-x-framework";
 import {useSidebarVisibility as useEmberSidebarVisibility} from "@/ember-bridge/ember-bridge";
 
-export interface AdminRouteHandle {
+export type AdminRouteHandle = {
     hideAdminSidebar?: boolean;
-}
+};
 
 export function useAdminSidebarVisibility(): boolean {
     const emberSidebarVisible = useEmberSidebarVisibility();

--- a/apps/admin/src/layout/sidebar-visibility.ts
+++ b/apps/admin/src/layout/sidebar-visibility.ts
@@ -5,14 +5,15 @@ export type AdminRouteHandle = {
     hideAdminSidebar?: boolean;
 };
 
+function hidesAdminSidebar(handle: unknown): handle is AdminRouteHandle {
+    return typeof handle === "object" && handle !== null && "hideAdminSidebar" in handle && handle.hideAdminSidebar === true;
+}
+
 export function useAdminSidebarVisibility(): boolean {
     const emberSidebarVisible = useEmberSidebarVisibility();
     const matches = useMatches();
 
-    const routeHidesSidebar = matches.some((match) => {
-        const handle = match.handle as AdminRouteHandle | undefined;
-        return handle?.hideAdminSidebar === true;
-    });
+    const routeHidesSidebar = matches.some(match => hidesAdminSidebar(match.handle));
 
     return emberSidebarVisible && !routeHidesSidebar;
 }

--- a/apps/admin/src/layout/sidebar-visibility.ts
+++ b/apps/admin/src/layout/sidebar-visibility.ts
@@ -1,9 +1,5 @@
-import {useMatches} from "@tryghost/admin-x-framework";
+import {type AdminRouteHandle, useMatches} from "@tryghost/admin-x-framework";
 import {useSidebarVisibility as useEmberSidebarVisibility} from "@/ember-bridge/ember-bridge";
-
-export type AdminRouteHandle = {
-    hideAdminSidebar?: boolean;
-};
 
 function hidesAdminSidebar(handle: unknown): handle is AdminRouteHandle {
     return typeof handle === "object" && handle !== null && "hideAdminSidebar" in handle && handle.hideAdminSidebar === true;

--- a/apps/admin/src/layout/sidebar-visibility.ts
+++ b/apps/admin/src/layout/sidebar-visibility.ts
@@ -1,0 +1,18 @@
+import {useMatches} from "@tryghost/admin-x-framework";
+import {useSidebarVisibility as useEmberSidebarVisibility} from "@/ember-bridge/ember-bridge";
+
+export interface AdminRouteHandle {
+    hideAdminSidebar?: boolean;
+}
+
+export function useAdminSidebarVisibility(): boolean {
+    const emberSidebarVisible = useEmberSidebarVisibility();
+    const matches = useMatches();
+
+    const routeHidesSidebar = matches.some((match) => {
+        const handle = match.handle as AdminRouteHandle | undefined;
+        return handle?.hideAdminSidebar === true;
+    });
+
+    return emberSidebarVisible && !routeHidesSidebar;
+}

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -1,5 +1,5 @@
+import {type AdminRouteHandle, RouteObject, lazyComponent} from '@tryghost/admin-x-framework';
 import {ErrorPage} from '@tryghost/shade/primitives';
-import {RouteObject, lazyComponent} from '@tryghost/admin-x-framework';
 // import {withFeatureFlag} from '@src/hooks/with-feature-flag';
 
 export const APP_ROUTE_PREFIX = '/';
@@ -78,7 +78,7 @@ export const routes: RouteObject[] = [
                     },
                     {
                         path: ':id',
-                        handle: {hideAdminSidebar: true},
+                        handle: {hideAdminSidebar: true} satisfies AdminRouteHandle,
                         lazy: lazyComponent(() => import('@views/Automations/editor'))
                     }
                 ]

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -78,6 +78,7 @@ export const routes: RouteObject[] = [
                     },
                     {
                         path: ':id',
+                        handle: {hideAdminSidebar: true},
                         lazy: lazyComponent(() => import('@views/Automations/editor'))
                     }
                 ]


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1295/wire-up-ability-to-toggle-admin-sidebar-just-in-react-so-its-off-for

## Summary
- Add `useAdminSidebarVisibility` to combine Ember sidebar state with React route handles
- Hide the admin sidebar and mobile nav when a matched route opts out
- Mark the automation editor route to hide the sidebar
- Add unit coverage for the new visibility logic

## Why
The automations editor needs a fullscreen canvas. The previous CSS-only approach visually covered the admin sidebar by positioning the canvas above it, but the sidebar still existed underneath the page. That is not semantically correct: the route behaves like a sidebarless fullscreen editor, while the DOM still contains navigation that is not meant to be available on that screen.

That also creates an accessibility problem. If the sidebar remains mounted and is only visually obscured, assistive technology and keyboard navigation can still encounter sidebar links that are hidden from sighted users. The visual page and the accessibility tree can disagree about what UI is present.

This changes the sidebar behavior into a route-level layout decision. React routes can opt out with `handle: {hideAdminSidebar: true}`, and the admin layout derives whether to render the sidebar from the active route matches. For the automations editor, the sidebar is no longer just covered by the canvas; it is omitted from the rendered layout for that route.

The hook still respects the existing Ember bridge sidebar state so current Ember-driven fullscreen behavior, such as the post editor, keeps working while React routes gain a dedicated pattern that does not add new Ember coupling.

## Testing
- Added unit tests for default visibility and route-based hiding behavior
- Ran `pnpm --filter @tryghost/admin test:unit -- src/layout/sidebar-visibility.test.tsx`
- Ran `pnpm --filter @tryghost/admin typecheck`