### PR TITLE
Switched email sender detail writes to design settings, not welcome emails

### DIFF
--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -10,11 +10,12 @@ const messages = {
 
 // NOTE: This file is in a transitionary state. The `automated_emails` database table was split into
 // `automations` (automation metadata: status, name, slug) and
-// `welcome_email_automated_emails` (email content: subject, lexical, sender fields). This controller
+// `welcome_email_automated_emails` (email content: subject, lexical). This controller
 // acts as a facade that joins/splits data between those two models while preserving the original
 // `automated_emails` API shape externally.
 const AUTOMATION_FIELDS = ['status', 'name', 'slug'];
-const EMAIL_FIELDS = ['subject', 'lexical', 'sender_name', 'sender_email', 'sender_reply_to', 'email_design_setting_id'];
+const EMAIL_FIELDS = ['subject', 'lexical', 'email_design_setting_id'];
+const SENDER_FIELDS = ['sender_name', 'sender_email', 'sender_reply_to'];
 
 function hasSenderValue(value) {
     if (typeof value === 'string') {
@@ -52,12 +53,17 @@ function flattenAutomation(automation, email = automation.related('welcomeEmailA
     return result;
 }
 
-async function getEmailDesignSettings(email, options) {
-    if (!email.get('email_design_setting_id')) {
-        return null;
+async function updateEmailDesignSenderFields(email, senderData, options) {
+    const id = email.get('email_design_setting_id');
+
+    if (Object.keys(senderData).length > 0) {
+        return models.EmailDesignSetting.edit(senderData, {
+            ...options,
+            id
+        });
     }
 
-    return models.EmailDesignSetting.findOne({id: email.get('email_design_setting_id')}, options);
+    return models.EmailDesignSetting.findOne({id}, options);
 }
 
 /** @type {import('@tryghost/api-framework').Controller} */
@@ -125,6 +131,7 @@ const controller = {
             const data = frame.data.automated_emails[0];
 
             const emailData = _.pick(data, EMAIL_FIELDS);
+            const senderData = _.pick(data, SENDER_FIELDS);
             const automationData = _.pick(data, AUTOMATION_FIELDS);
 
             return models.Base.transaction(async (transacting) => {
@@ -137,7 +144,7 @@ const controller = {
                     },
                     {...frame.options, transacting}
                 );
-                const designSettings = await getEmailDesignSettings(email, {...frame.options, transacting});
+                const designSettings = await updateEmailDesignSenderFields(email, senderData, {...frame.options, transacting});
                 return flattenAutomation(automation, email, designSettings);
             });
         }
@@ -163,6 +170,7 @@ const controller = {
             const data = frame.data.automated_emails[0];
 
             const emailData = _.pick(data, EMAIL_FIELDS);
+            const senderData = _.pick(data, SENDER_FIELDS);
             const automationData = _.pick(data, AUTOMATION_FIELDS);
 
             return models.Base.transaction(async (transacting) => {
@@ -184,9 +192,12 @@ const controller = {
                         id: email.id
                     });
                 }
-                const designSettings = email.related('emailDesignSetting')?.id ?
-                    email.related('emailDesignSetting') :
-                    await getEmailDesignSettings(email, {...frame.options, transacting});
+
+                const designSettings = await updateEmailDesignSenderFields(
+                    email,
+                    senderData,
+                    {...frame.options, transacting}
+                );
 
                 if (Object.keys(automationData).length > 0) {
                     automation = await models.Automation.edit(automationData, {

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -9,7 +9,7 @@ const emailAddressService = require('../email-address');
 const settingsHelpers = require('../settings-helpers');
 const EmailAddressParser = require('../email-address/email-address-parser');
 const mail = require('../mail');
-const {Automation, EmailDesignSetting, WelcomeEmailAutomatedEmail, Newsletter} = require('../../models');
+const {Automation, EmailDesignSetting, Newsletter} = require('../../models');
 const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
 const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_TAG, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
 
@@ -258,7 +258,11 @@ class MemberWelcomeEmailService {
 
     #hasSharedSenderFieldChanged(rows, field, value) {
         return rows.some((row) => {
-            const currentValue = row.related('welcomeEmailAutomatedEmail')?.get(field);
+            const email = row.related('welcomeEmailAutomatedEmail');
+            const currentValue = (
+                email?.related('emailDesignSetting')?.get(field) ??
+                email?.get(field)
+            );
             return trimValue(currentValue) !== trimValue(value);
         });
     }
@@ -314,9 +318,13 @@ class MemberWelcomeEmailService {
             return;
         }
 
-        await Promise.all(rows.map((row) => {
-            const email = row.related('welcomeEmailAutomatedEmail');
-            return WelcomeEmailAutomatedEmail.edit(attrs, {id: email.id});
+        // De-dupe so we don't write to the same design row twice.
+        const designSettingIds = new Set(
+            rows.map(row => row.related('welcomeEmailAutomatedEmail')?.get('email_design_setting_id')).filter(Boolean)
+        );
+
+        await Promise.all([...designSettingIds].map(async (id) => {
+            await EmailDesignSetting.edit(attrs, {id});
         }));
     }
 

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -31,6 +31,18 @@ describe('Automated Emails API', function () {
         return body.automated_emails[0];
     };
 
+    const getSenderStorage = async (automatedEmailId) => {
+        const email = await models.Base.knex('welcome_email_automated_emails')
+            .where('welcome_email_automation_id', automatedEmailId)
+            .first('sender_name', 'sender_email', 'sender_reply_to', 'email_design_setting_id');
+
+        const designSettings = await models.Base.knex('email_design_settings')
+            .where('id', email.email_design_setting_id)
+            .first('sender_name', 'sender_email', 'sender_reply_to');
+
+        return {email, designSettings};
+    };
+
     const updateSenderStorage = async (automatedEmailId, {email = {}, designSettings = {}} = {}) => {
         const welcomeEmail = await models.Base.knex('welcome_email_automated_emails')
             .where('welcome_email_automation_id', automatedEmailId)
@@ -237,6 +249,31 @@ describe('Automated Emails API', function () {
                 });
         });
 
+        it('Writes sender settings to email design settings on add', async function () {
+            const automatedEmail = await createAutomatedEmail({
+                sender_name: 'Custom Sender',
+                sender_email: 'sender@example.com',
+                sender_reply_to: 'reply@example.com'
+            });
+
+            const {email, designSettings} = await getSenderStorage(automatedEmail.id);
+
+            assert.deepEqual({
+                sender_name: email.sender_name,
+                sender_email: email.sender_email,
+                sender_reply_to: email.sender_reply_to
+            }, {
+                sender_name: null,
+                sender_email: null,
+                sender_reply_to: null
+            });
+            assert.deepEqual(designSettings, {
+                sender_name: 'Custom Sender',
+                sender_email: 'sender@example.com',
+                sender_reply_to: 'reply@example.com'
+            });
+        });
+
         it('Validates status on add', async function () {
             await agent
                 .post('automated_emails')
@@ -377,6 +414,37 @@ describe('Automated Emails API', function () {
                     'content-version': anyContentVersion,
                     etag: anyEtag
                 });
+        });
+
+        it('Writes sender settings to email design settings on edit', async function () {
+            const automatedEmail = await createAutomatedEmail();
+
+            await agent
+                .put(`automated_emails/${automatedEmail.id}`)
+                .body({automated_emails: [{
+                    name: 'Welcome Email (Free)',
+                    sender_name: 'Custom Sender',
+                    sender_email: 'sender@example.com',
+                    sender_reply_to: 'reply@example.com'
+                }]})
+                .expectStatus(200);
+
+            const {email, designSettings} = await getSenderStorage(automatedEmail.id);
+
+            assert.deepEqual({
+                sender_name: email.sender_name,
+                sender_email: email.sender_email,
+                sender_reply_to: email.sender_reply_to
+            }, {
+                sender_name: null,
+                sender_email: null,
+                sender_reply_to: null
+            });
+            assert.deepEqual(designSettings, {
+                sender_name: 'Custom Sender',
+                sender_email: 'sender@example.com',
+                sender_reply_to: 'reply@example.com'
+            });
         });
 
         it('Validates status on edit', async function () {
@@ -576,6 +644,26 @@ describe('Automated Emails API', function () {
                         assert.equal(automatedEmail.sender_reply_to, 'reply@example.com');
                     }
                 });
+
+            const automatedEmails = await models.Base.knex('welcome_email_automated_emails')
+                .select('sender_name', 'sender_email', 'sender_reply_to');
+            assert.equal(automatedEmails.length, 2);
+            for (const automatedEmail of automatedEmails) {
+                assert.deepEqual(automatedEmail, {
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null
+                });
+            }
+
+            const designSettings = await models.Base.knex('email_design_settings')
+                .where('slug', 'default-automated-email')
+                .first('sender_name', 'sender_email', 'sender_reply_to');
+            assert.deepEqual(designSettings, {
+                sender_name: 'Custom Sender',
+                sender_email: 'sender@example.com',
+                sender_reply_to: 'reply@example.com'
+            });
         });
 
         it('Returns sender details from email design settings after editing shared sender settings', async function () {
@@ -598,9 +686,9 @@ describe('Automated Emails API', function () {
                 .expect(({body}) => {
                     assert.equal(body.automated_emails.length, 2);
                     for (const automatedEmail of body.automated_emails) {
-                        assert.equal(automatedEmail.sender_name, 'Design Sender');
-                        assert.equal(automatedEmail.sender_email, 'design@example.com');
-                        assert.equal(automatedEmail.sender_reply_to, 'design-reply@example.com');
+                        assert.equal(automatedEmail.sender_name, 'Custom Sender');
+                        assert.equal(automatedEmail.sender_email, 'sender@example.com');
+                        assert.equal(automatedEmail.sender_reply_to, 'reply@example.com');
                     }
                 });
         });
@@ -619,6 +707,26 @@ describe('Automated Emails API', function () {
                         assert.equal(automatedEmail.sender_reply_to, 'verified-reply@example.com');
                     }
                 });
+
+            const automatedEmails = await models.Base.knex('welcome_email_automated_emails')
+                .select('sender_name', 'sender_email', 'sender_reply_to');
+            assert.equal(automatedEmails.length, 2);
+            for (const automatedEmail of automatedEmails) {
+                assert.deepEqual(automatedEmail, {
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null
+                });
+            }
+
+            const designSettings = await models.Base.knex('email_design_settings')
+                .where('slug', 'default-automated-email')
+                .first('sender_name', 'sender_email', 'sender_reply_to');
+            assert.deepEqual(designSettings, {
+                sender_name: null,
+                sender_email: null,
+                sender_reply_to: 'verified-reply@example.com'
+            });
         });
     });
 


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1304
ref https://github.com/TryGhost/Ghost/pull/28592

This change should have no user impact.

Soon we'll move the backend of welcome emails to the new automation system. That system doesn't directly hold email sender details; that data lives on `email_design_settings`.

As part of this, we stop writing new changes to `welcome_email_automated_emails` and start writing them to `email_design_settings`. In a future patch, we'll do a migration so we can drop these columns.
