### PR TITLE
Backfilled sender details on email design settings

### DIFF
--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -17,24 +17,6 @@ const AUTOMATION_FIELDS = ['status', 'name', 'slug'];
 const EMAIL_FIELDS = ['subject', 'lexical', 'email_design_setting_id'];
 const SENDER_FIELDS = ['sender_name', 'sender_email', 'sender_reply_to'];
 
-function hasSenderValue(value) {
-    if (typeof value === 'string') {
-        return value.trim() !== '';
-    }
-
-    return value !== null && value !== undefined;
-}
-
-function getEffectiveSenderValue(email, designSettings, field) {
-    const designValue = designSettings?.id ? designSettings.get(field) : null;
-
-    if (hasSenderValue(designValue)) {
-        return designValue;
-    }
-
-    return email.get(field);
-}
-
 function flattenAutomation(automation, email = automation.related('welcomeEmailAutomatedEmail'), designSettings = email.related('emailDesignSetting')) {
     const result = {
         id: automation.id,
@@ -43,9 +25,9 @@ function flattenAutomation(automation, email = automation.related('welcomeEmailA
         slug: automation.get('slug'),
         subject: email.get('subject'),
         lexical: email.get('lexical'),
-        sender_name: getEffectiveSenderValue(email, designSettings, 'sender_name'),
-        sender_email: getEffectiveSenderValue(email, designSettings, 'sender_email'),
-        sender_reply_to: getEffectiveSenderValue(email, designSettings, 'sender_reply_to'),
+        sender_name: designSettings?.get('sender_name') || null,
+        sender_email: designSettings?.get('sender_email') || null,
+        sender_reply_to: designSettings?.get('sender_reply_to') || null,
         email_design_setting_id: email.get('email_design_setting_id'),
         created_at: automation.get('created_at'),
         updated_at: automation.get('updated_at')

--- a/ghost/core/core/server/data/migrations/versions/6.46/2026-06-14-03-36-21-backfill-welcome-email-sender-fields-to-email-design-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/6.46/2026-06-14-03-36-21-backfill-welcome-email-sender-fields-to-email-design-settings.js
@@ -1,0 +1,59 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+const SOURCE_TABLE = 'welcome_email_automated_emails';
+const TARGET_TABLE = 'email_design_settings';
+const SENDER_FIELDS = ['sender_name', 'sender_email', 'sender_reply_to'];
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const rows = await knex(SOURCE_TABLE)
+            .select(['id', 'email_design_setting_id', ...SENDER_FIELDS])
+            .whereNotNull('sender_name')
+            .orWhereNotNull('sender_email')
+            .orWhereNotNull('sender_reply_to');
+
+        if (!rows.length) {
+            logging.info('No welcome email sender details found to backfill');
+            return;
+        }
+
+        logging.info(`Backfilling welcome email sender details for ${rows.length} rows`);
+
+        // Only 2 rows exist (free + paid welcome emails), so sequential iteration is fine
+        // eslint-disable-next-line no-restricted-syntax
+        for (const row of rows) {
+            const existingSettings = await knex(TARGET_TABLE)
+                .where({id: row.email_design_setting_id})
+                .first(['id', ...SENDER_FIELDS]);
+
+            if (!existingSettings) {
+                logging.warn(`Skipping welcome email ${row.id} sender details backfill - email design settings row ${row.email_design_setting_id} does not exist`);
+                continue;
+            }
+
+            const attrs = SENDER_FIELDS.reduce((memo, field) => {
+                if (existingSettings[field] === null && row[field] !== null) {
+                    memo[field] = row[field];
+                }
+
+                return memo;
+            }, {});
+
+            if (!Object.keys(attrs).length) {
+                logging.info(`Skipping welcome email ${row.id} sender details backfill - no missing sender details to copy`);
+                continue;
+            }
+
+            logging.info(`Backfilling welcome email ${row.id} sender details to email design settings row ${row.email_design_setting_id}`);
+
+            await knex(TARGET_TABLE)
+                .where({id: row.email_design_setting_id})
+                .update(attrs);
+        }
+    },
+
+    async function down() {
+        logging.info('Skipping rollback for welcome email sender details backfill');
+    }
+);

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -35,12 +35,12 @@ const getSenderDetailsFromDesignSettings = (designSettingsJson) => {
     };
 };
 
-const getSenderDetails = (senderDetails = {}, designSettingsJson) => {
+const getSenderDetails = (designSettingsJson) => {
     const designSenderDetails = getSenderDetailsFromDesignSettings(designSettingsJson);
     return {
-        senderName: trimValue(designSenderDetails.senderName) || trimValue(senderDetails.senderName),
-        senderEmail: trimValue(designSenderDetails.senderEmail) || trimValue(senderDetails.senderEmail),
-        senderReplyTo: trimValue(designSenderDetails.senderReplyTo) || trimValue(senderDetails.senderReplyTo)
+        senderName: trimValue(designSenderDetails.senderName),
+        senderEmail: trimValue(designSenderDetails.senderEmail),
+        senderReplyTo: trimValue(designSenderDetails.senderReplyTo)
     };
 };
 
@@ -259,10 +259,7 @@ class MemberWelcomeEmailService {
     #hasSharedSenderFieldChanged(rows, field, value) {
         return rows.some((row) => {
             const email = row.related('welcomeEmailAutomatedEmail');
-            const currentValue = (
-                email?.related('emailDesignSetting')?.get(field) ??
-                email?.get(field)
-            );
+            const currentValue = email?.related('emailDesignSetting')?.get(field);
             return trimValue(currentValue) !== trimValue(value);
         });
     }
@@ -387,12 +384,7 @@ class MemberWelcomeEmailService {
                 lexical: email.get('lexical'),
                 subject: email.get('subject'),
                 status: row.get('status'),
-                designSettings: designSettings?.id ? designSettings.toJSON() : null,
-                senderDetails: {
-                    senderName: email.get('sender_name'),
-                    senderEmail: email.get('sender_email'),
-                    senderReplyTo: email.get('sender_reply_to')
-                }
+                designSettings: designSettings?.id ? designSettings.toJSON() : null
             };
         }
     }
@@ -408,10 +400,6 @@ class MemberWelcomeEmailService {
      * @param {string} options.email.lexical
      * @param {string} options.email.subject
      * @param {null | object} options.email.designSettings
-     * @param {object} options.email.senderDetails
-     * @param {undefined | null | string} options.email.senderDetails.senderName
-     * @param {undefined | null | string} options.email.senderDetails.senderEmail
-     * @param {undefined | null | string} options.email.senderDetails.senderReplyTo
      * @param {'welcome' | 'automation'} options.emailType
      * @returns {Promise<void>}
      */
@@ -443,7 +431,7 @@ class MemberWelcomeEmailService {
         });
 
         const senderOptions = await this.#getEffectiveSenderOptions(
-            getSenderDetails(email.senderDetails, email.designSettings)
+            getSenderDetails(email.designSettings)
         );
 
         await this.#mailer.send({
@@ -508,8 +496,7 @@ class MemberWelcomeEmailService {
             email: {
                 lexical: email.lexical,
                 subject: email.subject,
-                designSettings: designSettingsJson,
-                senderDetails: getSenderDetailsFromDesignSettings(designSettingsJson)
+                designSettings: designSettingsJson
             }
         });
     }
@@ -573,8 +560,7 @@ class MemberWelcomeEmailService {
 
         return {
             ...preview,
-            designSettings,
-            automatedEmail
+            designSettings
         };
     }
 
@@ -597,7 +583,6 @@ class MemberWelcomeEmailService {
             html,
             text,
             subject: renderedSubject,
-            automatedEmail,
             designSettings
         } = await this.#renderWelcomeEmailPreview({
             automatedEmailId,
@@ -610,11 +595,7 @@ class MemberWelcomeEmailService {
         this.#defaultNewsletterSenderOptions = await this.#getDefaultNewsletterSenderOptions();
         const designSettingsJson = designSettings?.id ? designSettings.toJSON() : null;
         const senderOptions = await this.#getEffectiveSenderOptions(
-            getSenderDetails({
-                senderName: automatedEmail.get('sender_name'),
-                senderEmail: automatedEmail.get('sender_email'),
-                senderReplyTo: automatedEmail.get('sender_reply_to')
-            }, designSettingsJson)
+            getSenderDetails(designSettingsJson)
         );
 
         await this.#mailer.send({

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -132,7 +132,7 @@ describe('Automated Emails API', function () {
                 });
         });
 
-        it('Falls back to welcome email sender details when email design sender details are empty', async function () {
+        it('Does not return welcome email sender details when email design sender details are empty', async function () {
             const automatedEmail = await createAutomatedEmail();
             await updateSenderStorage(automatedEmail.id, {
                 email: {
@@ -151,9 +151,9 @@ describe('Automated Emails API', function () {
                 .get('automated_emails')
                 .expectStatus(200)
                 .expect(({body}) => {
-                    assert.equal(body.automated_emails[0].sender_name, 'Welcome Sender');
-                    assert.equal(body.automated_emails[0].sender_email, 'welcome@example.com');
-                    assert.equal(body.automated_emails[0].sender_reply_to, 'welcome-reply@example.com');
+                    assert.equal(body.automated_emails[0].sender_name, null);
+                    assert.equal(body.automated_emails[0].sender_email, null);
+                    assert.equal(body.automated_emails[0].sender_reply_to, null);
                 });
         });
     });
@@ -201,7 +201,7 @@ describe('Automated Emails API', function () {
                 });
         });
 
-        it('Falls back to welcome email sender details when email design sender details are empty', async function () {
+        it('Does not return welcome email sender details when email design sender details are empty', async function () {
             const automatedEmail = await createAutomatedEmail();
             await updateSenderStorage(automatedEmail.id, {
                 email: {
@@ -220,9 +220,9 @@ describe('Automated Emails API', function () {
                 .get(`automated_emails/${automatedEmail.id}`)
                 .expectStatus(200)
                 .expect(({body}) => {
-                    assert.equal(body.automated_emails[0].sender_name, 'Welcome Sender');
-                    assert.equal(body.automated_emails[0].sender_email, 'welcome@example.com');
-                    assert.equal(body.automated_emails[0].sender_reply_to, 'welcome-reply@example.com');
+                    assert.equal(body.automated_emails[0].sender_name, null);
+                    assert.equal(body.automated_emails[0].sender_email, null);
+                    assert.equal(body.automated_emails[0].sender_reply_to, null);
                 });
         });
     });

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -495,7 +495,7 @@ describe('Member Welcome Emails Integration', function () {
             assert.equal(sendCall.args[0].replyTo, 'design-reply@example.com');
         });
 
-        it('uses welcome email sender details for member welcome emails when email design sender details are empty', async function () {
+        it('uses newsletter sender details for member welcome emails when email design sender details are empty', async function () {
             const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
 
             await db.knex('newsletters')
@@ -541,8 +541,8 @@ describe('Member Welcome Emails Integration', function () {
             await scheduleInlineJob();
 
             sinon.assert.calledOnceWithExactly(mailService.GhostMailer.prototype.send, sinon.match({
-                from: '"Welcome Sender" <welcome@example.com>',
-                replyTo: 'welcome-reply@example.com'
+                from: '"Newsletter Sender" <newsletter@example.com>',
+                replyTo: 'newsletter-reply@example.com'
             }));
         });
 
@@ -705,8 +705,18 @@ describe('Member Welcome Emails Integration', function () {
             assert.equal(sendCall.args[0].replyTo, 'design-reply@example.com');
         });
 
-        it('uses welcome email sender details for test welcome emails when email design sender details are empty', async function () {
+        it('uses newsletter sender details for test welcome emails when email design sender details are empty', async function () {
             memberWelcomeEmailService.init();
+
+            const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
+
+            await db.knex('newsletters')
+                .where('id', defaultNewsletter.id)
+                .update({
+                    sender_name: 'Newsletter Sender',
+                    sender_email: 'newsletter@example.com',
+                    sender_reply_to: 'newsletter-reply@example.com'
+                });
 
             await db.knex('email_design_settings')
                 .where('id', defaultEmailDesignSettingId)
@@ -749,8 +759,8 @@ describe('Member Welcome Emails Integration', function () {
 
             sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
             const sendCall = mailService.GhostMailer.prototype.send.firstCall;
-            assert.equal(sendCall.args[0].from, '"Welcome Sender" <welcome@example.com>');
-            assert.equal(sendCall.args[0].replyTo, 'welcome-reply@example.com');
+            assert.equal(sendCall.args[0].from, '"Newsletter Sender" <newsletter@example.com>');
+            assert.equal(sendCall.args[0].replyTo, 'newsletter-reply@example.com');
         });
     });
 


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1304
ref https://github.com/TryGhost/Ghost/issues/28589

This change should have no user impact.

Soon we'll move the backend of welcome emails to the new automation system. That system doesn't directly hold email sender details; that data lives on `email_design_settings`.

As part of this transition, we migrate this data from `welcome_email_automated_emails` into `email_design_settings`. Now, those fields in `welcome_email_automated_emails` are completely unused.
