### PR TITLE
🐛 Fixed double-escaped tag names in social sharing meta tags

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -34,8 +34,7 @@ function finaliseStructuredData(meta) {
             _.each(meta.keywords, function (keyword) {
                 if (keyword !== '') {
                     keyword = escapeExpression(keyword);
-                    head.push(writeMetaTag(property,
-                        escapeExpression(keyword)));
+                    head.push(writeMetaTag(property, keyword));
                 }
             });
             head.push('');

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
@@ -4888,6 +4888,84 @@ Object {
 }
 `;
 
+exports[`{{ghost_head}} helper without Code Injection single-escapes special characters in article:tag meta values 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:tag\\" content=\\"Tom &amp; Jerry\\">
+    
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:label2\\" content=\\"Filed under\\">
+    <meta name=\\"twitter:data2\\" content=\\"Tom &amp; Jerry\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"Article\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://localhost:65530/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://localhost:65530/favicon.ico\\"
+        }
+    },
+    \\"author\\": {
+        \\"@type\\": \\"Person\\",
+        \\"name\\": \\"Author name\\",
+        \\"image\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://localhost:65530/content/images/test-author-image.png\\"
+        },
+        \\"url\\": \\"https://mysite.com/fakeauthor/\\",
+        \\"sameAs\\": [
+            \\"http://authorwebsite.com\\",
+            \\"https://www.facebook.com/testuser\\",
+            \\"https://x.com/testuser\\"
+        ]
+    },
+    \\"headline\\": \\"Welcome to Ghost\\",
+    \\"url\\": \\"http://localhost:65530/post/\\",
+    \\"datePublished\\": \\"1970-01-01T00:00:00.000Z\\",
+    \\"dateModified\\": \\"1970-01-01T00:00:00.000Z\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://localhost:65530/content/images/test-image.png\\"
+    },
+    \\"keywords\\": \\"Tom & Jerry\\",
+    \\"description\\": \\"site description\\",
+    \\"mainEntityOfPage\\": \\"http://localhost:65530/post/\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
+}
+`;
+
 exports[`{{ghost_head}} helper without Code Injection tag first page without meta and model description returns no description fields 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\">

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -373,6 +373,21 @@ describe('{{ghost_head}} helper', function () {
             published_at: new Date(0),
             updated_at: new Date(0)
         }));
+
+        posts.push(createPost({ // Post 11
+            meta_description: 'site description',
+            title: 'Welcome to Ghost',
+            feature_image: '/content/images/test-image.png',
+            tags: [
+                createTag({name: 'Tom & Jerry'})
+            ],
+            authors: [
+                authors[3]
+            ],
+            primary_author: authors[3],
+            published_at: new Date(0),
+            updated_at: new Date(0)
+        }));
     };
 
     beforeEach(function () {
@@ -595,6 +610,27 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             }));
+        });
+
+        it('single-escapes special characters in article:tag meta values', async function () {
+            const renderObject = {
+                post: posts[11]
+            };
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                renderObject: renderObject,
+                locals: {
+                    relativeUrl: '/post/',
+                    context: ['post'],
+                    safeVersion: '0.3'
+                }
+            }));
+
+            // The tag name "Tom & Jerry" must be HTML-escaped exactly once, so that
+            // consumers decode it back to the original "Tom & Jerry".
+            assert.match(rendered, /<meta property="article:tag" content="Tom &amp; Jerry">/);
+            // Guard against the double-escaping regression (&amp;amp;).
+            assert.doesNotMatch(rendered, /&amp;amp;/);
         });
 
         it('returns structured data without tags if there are no tags', async function () {


### PR DESCRIPTION
`article:tag` Open Graph meta values were HTML-escaped twice in
`finaliseStructuredData()`, so a tag like `Q&A` was emitted as `Q&amp;amp;A` instead of `Q&amp;A` — corrupting social sharing previews and SEO for any post whose tags contain `&`, `<`, `>`, or quotes.

The tag name reaching this code is already raw, and the sibling `twitter:data2` branch escapes it only once, so the second escape was redundant.

## Changes

- Removed the redundant second `escapeExpression()` call.
- Added a regression test for a tag name containing `&`.

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
