### PR TITLE
Preferred email design settings when reading welcome emails

### DIFF
--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -16,7 +16,25 @@ const messages = {
 const AUTOMATION_FIELDS = ['status', 'name', 'slug'];
 const EMAIL_FIELDS = ['subject', 'lexical', 'sender_name', 'sender_email', 'sender_reply_to', 'email_design_setting_id'];
 
-function flattenAutomation(automation, email = automation.related('welcomeEmailAutomatedEmail')) {
+function hasSenderValue(value) {
+    if (typeof value === 'string') {
+        return value.trim() !== '';
+    }
+
+    return value !== null && value !== undefined;
+}
+
+function getEffectiveSenderValue(email, designSettings, field) {
+    const designValue = designSettings?.id ? designSettings.get(field) : null;
+
+    if (hasSenderValue(designValue)) {
+        return designValue;
+    }
+
+    return email.get(field);
+}
+
+function flattenAutomation(automation, email = automation.related('welcomeEmailAutomatedEmail'), designSettings = email.related('emailDesignSetting')) {
     const result = {
         id: automation.id,
         status: automation.get('status'),
@@ -24,14 +42,22 @@ function flattenAutomation(automation, email = automation.related('welcomeEmailA
         slug: automation.get('slug'),
         subject: email.get('subject'),
         lexical: email.get('lexical'),
-        sender_name: email.get('sender_name'),
-        sender_email: email.get('sender_email'),
-        sender_reply_to: email.get('sender_reply_to'),
+        sender_name: getEffectiveSenderValue(email, designSettings, 'sender_name'),
+        sender_email: getEffectiveSenderValue(email, designSettings, 'sender_email'),
+        sender_reply_to: getEffectiveSenderValue(email, designSettings, 'sender_reply_to'),
         email_design_setting_id: email.get('email_design_setting_id'),
         created_at: automation.get('created_at'),
         updated_at: automation.get('updated_at')
     };
     return result;
+}
+
+async function getEmailDesignSettings(email, options) {
+    if (!email.get('email_design_setting_id')) {
+        return null;
+    }
+
+    return models.EmailDesignSetting.findOne({id: email.get('email_design_setting_id')}, options);
 }
 
 /** @type {import('@tryghost/api-framework').Controller} */
@@ -53,7 +79,7 @@ const controller = {
         async query(frame) {
             const result = await models.Automation.findPage({
                 ...frame.options,
-                withRelated: ['welcomeEmailAutomatedEmail']
+                withRelated: ['welcomeEmailAutomatedEmail', 'welcomeEmailAutomatedEmail.emailDesignSetting']
             });
             return {
                 ...result,
@@ -77,7 +103,7 @@ const controller = {
         async query(frame) {
             const model = await models.Automation.findOne(frame.data, {
                 ...frame.options,
-                withRelated: ['welcomeEmailAutomatedEmail']
+                withRelated: ['welcomeEmailAutomatedEmail', 'welcomeEmailAutomatedEmail.emailDesignSetting']
             });
             if (!model) {
                 throw new errors.NotFoundError({
@@ -111,7 +137,8 @@ const controller = {
                     },
                     {...frame.options, transacting}
                 );
-                return flattenAutomation(automation, email);
+                const designSettings = await getEmailDesignSettings(email, {...frame.options, transacting});
+                return flattenAutomation(automation, email, designSettings);
             });
         }
     },
@@ -141,7 +168,7 @@ const controller = {
             return models.Base.transaction(async (transacting) => {
                 let automation = await models.Automation.findOne({id: frame.options.id}, {
                     transacting,
-                    withRelated: ['welcomeEmailAutomatedEmail']
+                    withRelated: ['welcomeEmailAutomatedEmail', 'welcomeEmailAutomatedEmail.emailDesignSetting']
                 });
                 if (!automation) {
                     throw new errors.NotFoundError({
@@ -157,6 +184,9 @@ const controller = {
                         id: email.id
                     });
                 }
+                const designSettings = email.related('emailDesignSetting')?.id ?
+                    email.related('emailDesignSetting') :
+                    await getEmailDesignSettings(email, {...frame.options, transacting});
 
                 if (Object.keys(automationData).length > 0) {
                     automation = await models.Automation.edit(automationData, {
@@ -165,7 +195,7 @@ const controller = {
                     });
                 }
 
-                return flattenAutomation(automation, email);
+                return flattenAutomation(automation, email, designSettings);
             });
         }
     },

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -201,7 +201,7 @@ class MemberWelcomeEmailService {
     async #loadWelcomeEmailsCollection() {
         return Automation.findAll({
             filter: WELCOME_EMAIL_FILTER,
-            withRelated: ['welcomeEmailAutomatedEmail']
+            withRelated: ['welcomeEmailAutomatedEmail', 'welcomeEmailAutomatedEmail.emailDesignSetting']
         });
     }
 

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -31,6 +31,24 @@ describe('Automated Emails API', function () {
         return body.automated_emails[0];
     };
 
+    const updateSenderStorage = async (automatedEmailId, {email = {}, designSettings = {}} = {}) => {
+        const welcomeEmail = await models.Base.knex('welcome_email_automated_emails')
+            .where('welcome_email_automation_id', automatedEmailId)
+            .first('id', 'email_design_setting_id');
+
+        if (Object.keys(email).length > 0) {
+            await models.Base.knex('welcome_email_automated_emails')
+                .where('id', welcomeEmail.id)
+                .update(email);
+        }
+
+        if (Object.keys(designSettings).length > 0) {
+            await models.Base.knex('email_design_settings')
+                .where('id', welcomeEmail.email_design_setting_id)
+                .update(designSettings);
+        }
+    };
+
     before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('users');
@@ -41,6 +59,13 @@ describe('Automated Emails API', function () {
         await dbUtils.truncate('brute');
         await dbUtils.truncate('welcome_email_automated_emails');
         await dbUtils.truncate('automations');
+        await models.Base.knex('email_design_settings')
+            .where('slug', 'default-automated-email')
+            .update({
+                sender_name: null,
+                sender_email: null,
+                sender_reply_to: null
+            });
     });
 
     describe('Browse', function () {
@@ -69,6 +94,56 @@ describe('Automated Emails API', function () {
                     etag: anyEtag
                 });
         });
+
+        it('Returns sender details from email design settings before welcome email automated email fields', async function () {
+            const automatedEmail = await createAutomatedEmail();
+            await updateSenderStorage(automatedEmail.id, {
+                email: {
+                    sender_name: 'Welcome Sender',
+                    sender_email: 'welcome@example.com',
+                    sender_reply_to: 'welcome-reply@example.com'
+                },
+                designSettings: {
+                    sender_name: 'Design Sender',
+                    sender_email: 'design@example.com',
+                    sender_reply_to: 'design-reply@example.com'
+                }
+            });
+
+            await agent
+                .get('automated_emails')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.equal(body.automated_emails[0].sender_name, 'Design Sender');
+                    assert.equal(body.automated_emails[0].sender_email, 'design@example.com');
+                    assert.equal(body.automated_emails[0].sender_reply_to, 'design-reply@example.com');
+                });
+        });
+
+        it('Falls back to welcome email sender details when email design sender details are empty', async function () {
+            const automatedEmail = await createAutomatedEmail();
+            await updateSenderStorage(automatedEmail.id, {
+                email: {
+                    sender_name: 'Welcome Sender',
+                    sender_email: 'welcome@example.com',
+                    sender_reply_to: 'welcome-reply@example.com'
+                },
+                designSettings: {
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null
+                }
+            });
+
+            await agent
+                .get('automated_emails')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.equal(body.automated_emails[0].sender_name, 'Welcome Sender');
+                    assert.equal(body.automated_emails[0].sender_email, 'welcome@example.com');
+                    assert.equal(body.automated_emails[0].sender_reply_to, 'welcome-reply@example.com');
+                });
+        });
     });
 
     describe('Read', function () {
@@ -86,6 +161,56 @@ describe('Automated Emails API', function () {
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag
+                });
+        });
+
+        it('Returns sender details from email design settings before welcome email automated email fields', async function () {
+            const automatedEmail = await createAutomatedEmail();
+            await updateSenderStorage(automatedEmail.id, {
+                email: {
+                    sender_name: 'Welcome Sender',
+                    sender_email: 'welcome@example.com',
+                    sender_reply_to: 'welcome-reply@example.com'
+                },
+                designSettings: {
+                    sender_name: 'Design Sender',
+                    sender_email: 'design@example.com',
+                    sender_reply_to: 'design-reply@example.com'
+                }
+            });
+
+            await agent
+                .get(`automated_emails/${automatedEmail.id}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.equal(body.automated_emails[0].sender_name, 'Design Sender');
+                    assert.equal(body.automated_emails[0].sender_email, 'design@example.com');
+                    assert.equal(body.automated_emails[0].sender_reply_to, 'design-reply@example.com');
+                });
+        });
+
+        it('Falls back to welcome email sender details when email design sender details are empty', async function () {
+            const automatedEmail = await createAutomatedEmail();
+            await updateSenderStorage(automatedEmail.id, {
+                email: {
+                    sender_name: 'Welcome Sender',
+                    sender_email: 'welcome@example.com',
+                    sender_reply_to: 'welcome-reply@example.com'
+                },
+                designSettings: {
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null
+                }
+            });
+
+            await agent
+                .get(`automated_emails/${automatedEmail.id}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.equal(body.automated_emails[0].sender_name, 'Welcome Sender');
+                    assert.equal(body.automated_emails[0].sender_email, 'welcome@example.com');
+                    assert.equal(body.automated_emails[0].sender_reply_to, 'welcome-reply@example.com');
                 });
         });
     });
@@ -449,6 +574,33 @@ describe('Automated Emails API', function () {
                         assert.equal(automatedEmail.sender_name, 'Custom Sender');
                         assert.equal(automatedEmail.sender_email, 'sender@example.com');
                         assert.equal(automatedEmail.sender_reply_to, 'reply@example.com');
+                    }
+                });
+        });
+
+        it('Returns sender details from email design settings after editing shared sender settings', async function () {
+            await models.Base.knex('email_design_settings')
+                .where('slug', 'default-automated-email')
+                .update({
+                    sender_name: 'Design Sender',
+                    sender_email: 'design@example.com',
+                    sender_reply_to: 'design-reply@example.com'
+                });
+
+            await agent
+                .put('automated_emails/senders/')
+                .body({
+                    sender_name: 'Custom Sender',
+                    sender_email: 'sender@example.com',
+                    sender_reply_to: 'reply@example.com'
+                })
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.equal(body.automated_emails.length, 2);
+                    for (const automatedEmail of body.automated_emails) {
+                        assert.equal(automatedEmail.sender_name, 'Design Sender');
+                        assert.equal(automatedEmail.sender_email, 'design@example.com');
+                        assert.equal(automatedEmail.sender_reply_to, 'design-reply@example.com');
                     }
                 });
         });


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1304

This change should have no user impact.

Soon we'll move the backend of welcome emails to the new automation system. That system doesn't directly hold email sender details; that data lives on `email_design_settings`.

As part of this transition, we prefer reading from `email_design_settings` in the relevant endpoints, such as `browse` and `read`.
