### PR TITLE
Enforced no direct model access from core/frontend

### DIFF
--- a/ghost/core/.eslintrc.js
+++ b/ghost/core/.eslintrc.js
@@ -160,6 +160,18 @@ module.exports = {
             }
         },
         {
+            // Frontend must not access the model layer directly; use the public Content API via services/proxy
+            files: 'core/frontend/**',
+            rules: {
+                'ghost/node/no-restricted-require': ['error', [
+                    {
+                        name: [path.resolve(__dirname, 'core/server/models/**')],
+                        message: 'Invalid require of core/server/models from core/frontend. Fetch content through the public Content API (api.postsPublic / api.pagesPublic), injected via core/frontend/services/proxy — not the model layer directly. See #28420.'
+                    }
+                ]]
+            }
+        },
+        {
             files: 'core/server/**',
             rules: {
                 'ghost/node/no-restricted-require': ['warn', [


### PR DESCRIPTION
## Context

#28420 / #28518 established that `core/frontend` (the server-side public-site rendering layer) must fetch content through the public Content API, not `models.Post.findPage()` directly — going direct skips caching, permission/visibility gating, and URL resolution, and caused member-gated content to leak into `llms-full.txt`. Those PRs removed the last `models.*` require from the frontend and closed with: *"A follow-up will look at how to enforce this boundary so it cannot regress."*

## Summary

- Locks in the no-direct-model-access rule in `core/frontend` so it can't regress: adds a `ghost/node/no-restricted-require` rule at `error` for `core/server/models/**` requires from `core/frontend/**`, leaving the existing broader `off` rule intact.
- Scoped to `models/**` only — there are still 26 direct `core/server` requires in the frontend (image utils, url service, event bus, composition root), but the broader ban can't be enabled yet without a circular-dependency fix in `meta/*`.
- Zero violations today — the rule goes green immediately with no cleanup required.

## Testing

- [x] `cd ghost/core && npx eslint core/frontend --quiet` — exits 0, no violations
- [x] Verified the rule fires: injected `require('../../server/models')` into `core/frontend/meta/url.js`, confirmed the lint error appears with the correct message, then removed it and confirmed clean again

## Follow-ups

1. Extract image/storage utilities from `core/server/lib/image` + `core/server/adapters/storage` (kills ~9 of the 26 remaining requires), which also unblocks routing `meta/*` through the proxy without the circular-dep.
2. Widen the ban to `services/**` + `lib/**` with `services/proxy.js` excluded once that's done.
3. Ban `core/shared/**` only once the frontend is fully independent.

