### PR TITLE
🎨 Used NQL $all operator for member label is-all-of filters

### DIFF
--- a/apps/posts/src/views/filters/filter-codecs.test.ts
+++ b/apps/posts/src/views/filters/filter-codecs.test.ts
@@ -272,7 +272,15 @@ describe('setCodec', () => {
         expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[alpha,vip]']);
     });
 
-    it('serializes all-of set membership as AND clauses', () => {
+    it('parses all-of set membership ($all) into an is-all predicate', () => {
+        expect(setCodec().parse(nql.parse('label:[vip+alpha]') as never, labelContext)).toEqual({
+            field: 'label',
+            operator: 'is-all',
+            values: ['vip', 'alpha']
+        });
+    });
+
+    it('serializes all-of set membership as a +-separated value list', () => {
         const predicate: FilterPredicate = {
             id: '1',
             field: 'label',
@@ -280,7 +288,20 @@ describe('setCodec', () => {
             values: ['vip', 'alpha']
         };
 
-        expect(setCodec().serialize(predicate, labelContext)).toEqual(['(label:alpha+label:vip)']);
+        expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[alpha+vip]']);
+    });
+
+    it('serializes a single-value all-of as any-of (a one-value all is identical to any)', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'label',
+            operator: 'is-all',
+            values: ['alpha']
+        };
+
+        // `[alpha]` is `$in` regardless, so emit the any-of form rather than a
+        // one-element all-of that would just round-trip back to is-any anyway.
+        expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[alpha]']);
     });
 
     it('can serialize singleton string values as quoted scalars', () => {

--- a/apps/posts/src/views/filters/filter-codecs.ts
+++ b/apps/posts/src/views/filters/filter-codecs.ts
@@ -61,10 +61,21 @@ function serializeSetMembership(symbol: string): SetOperatorSerializer {
     };
 }
 
+const serializeAnyMembership = serializeSetMembership('');
+
 const SET_OPERATOR_SERIALIZERS: Record<string, SetOperatorSerializer> = {
-    'is-any': serializeSetMembership(''),
+    'is-any': serializeAnyMembership,
     'is-not-any': serializeSetMembership('-'),
-    'is-all': (field, values, config) => `(${values.map(value => `${field}:${serializeScalarValue(value, config)}`).join('+')})`
+    'is-all': (field, values, config) => {
+        // NQL's all-of operator is a `+`-separated value list: `label:[a+b]`.
+        // A single value is identical to any-of (and `[a]` is `$in` regardless),
+        // so only emit the all-of form for two or more values.
+        if (values.length === 1) {
+            return serializeAnyMembership(field, values, config);
+        }
+
+        return `${field}:[${values.map(value => serializeScalarValue(value, config)).join('+')}]`;
+    }
 };
 
 const UNQUOTED_TOKEN_PATTERN = /^[A-Za-z0-9_.-]+$/;
@@ -135,7 +146,7 @@ export function scalarCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field) {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey) {
                 return null;
             }
 
@@ -178,7 +189,7 @@ export function textCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field) {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey) {
                 return null;
             }
 
@@ -237,7 +248,7 @@ export function setCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field) {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey) {
                 return null;
             }
 
@@ -245,6 +256,14 @@ export function setCodec(config?: CodecConfig): FilterCodec {
                 return {
                     field: ctx.key,
                     operator: 'is-any',
+                    values: comparator.value
+                };
+            }
+
+            if (comparator.operator === '$all' && Array.isArray(comparator.value)) {
+                return {
+                    field: ctx.key,
+                    operator: 'is-all',
                     values: comparator.value
                 };
             }
@@ -299,7 +318,7 @@ export function numberCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field || typeof comparator.value !== 'number') {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey || typeof comparator.value !== 'number') {
                 return null;
             }
 
@@ -371,7 +390,7 @@ export function dateCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field) {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey) {
                 return null;
             }
 

--- a/apps/posts/src/views/filters/filter-query-core.test.ts
+++ b/apps/posts/src/views/filters/filter-query-core.test.ts
@@ -1,7 +1,7 @@
 import {defineFields} from './filter-types';
 import {describe, expect, it} from 'vitest';
-import {dispatchSimpleNodes, extractAllOfPredicates, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates} from './filter-query-core';
-import {numberCodec, scalarCodec, setCodec} from './filter-codecs';
+import {dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates} from './filter-query-core';
+import {numberCodec, scalarCodec} from './filter-codecs';
 import type {AstNode} from './filter-ast';
 import type {FilterPredicate} from './filter-types';
 
@@ -118,40 +118,5 @@ describe('filter-query-core', () => {
 
         expect([...fieldKeys]).toEqual(['created_at', 'created_at_utc']);
         expect(hasFieldKey(ast, fieldKeys)).toBe(true);
-    });
-});
-
-describe('extractAllOfPredicates', () => {
-    const allOfFields = defineFields({
-        label: {
-            operators: ['is-any', 'is-all', 'is-not-any'],
-            parseKeys: ['labels'],
-            ui: {
-                label: 'Label',
-                type: 'multiselect'
-            },
-            codec: setCodec()
-        },
-        tier: {
-            operators: ['is-any', 'is-not-any'],
-            ui: {
-                label: 'Tier',
-                type: 'multiselect'
-            },
-            codec: setCodec()
-        }
-    });
-
-    it('groups repeated clauses for fields declaring is-all, resolving alias keys', () => {
-        const result = extractAllOfPredicates([{label: 'alpha'}, {labels: 'vip'}, {status: 'paid'}], allOfFields, 'UTC');
-
-        expect(result).toEqual({
-            predicates: [{field: 'label', operator: 'is-all', values: ['alpha', 'vip']}],
-            remaining: [{status: 'paid'}]
-        });
-    });
-
-    it('returns null when no field accumulates at least two all-of clauses', () => {
-        expect(extractAllOfPredicates([{label: 'alpha'}, {tier: 'gold'}, {tier: 'silver'}], allOfFields, 'UTC')).toBeNull();
     });
 });

--- a/apps/posts/src/views/filters/filter-query-core.ts
+++ b/apps/posts/src/views/filters/filter-query-core.ts
@@ -76,64 +76,6 @@ export function dispatchSimpleNodes<TFields extends Record<string, FilterField>>
     });
 }
 
-/**
- * Pulls repeated positive scalar clauses for the same field out of a grouped
- * AND's children, e.g. `(label:a+label:b)` → one all-of predicate. A field is
- * eligible when it declares the `is-all` operator; alias keys come from
- * `parseKeys`. Fields need at least two clauses to form a group — lone
- * clauses stay in `remaining`. Returns null when nothing qualifies.
- */
-export function extractAllOfPredicates<TFields extends Record<string, FilterField>>(
-    children: AstNode[],
-    fields: TFields,
-    timezone: string
-): {predicates: ParsedPredicate[]; remaining: AstNode[]} | null {
-    const clauses = children.map((child) => {
-        const keys = Object.keys(child);
-        const value = child[keys[0]];
-
-        if (keys.length !== 1 || keys[0].startsWith('$') || typeof value !== 'string') {
-            return {child, allOf: null};
-        }
-
-        const resolved = resolveField(fields, keys[0], timezone);
-
-        if (!resolved?.definition.operators.includes('is-all')) {
-            return {child, allOf: null};
-        }
-
-        return {child, allOf: {field: resolved.context.key, value}};
-    });
-
-    const clauseCounts = new Map<string, number>();
-
-    for (const {allOf} of clauses) {
-        if (allOf) {
-            clauseCounts.set(allOf.field, (clauseCounts.get(allOf.field) ?? 0) + 1);
-        }
-    }
-
-    const predicatesByField = new Map<string, ParsedPredicate>();
-    const remaining: AstNode[] = [];
-
-    for (const {child, allOf} of clauses) {
-        if (!allOf || (clauseCounts.get(allOf.field) ?? 0) < 2) {
-            remaining.push(child);
-            continue;
-        }
-
-        const predicate = predicatesByField.get(allOf.field) ?? {field: allOf.field, operator: 'is-all', values: []};
-        predicate.values.push(allOf.value);
-        predicatesByField.set(allOf.field, predicate);
-    }
-
-    if (!predicatesByField.size) {
-        return null;
-    }
-
-    return {predicates: [...predicatesByField.values()], remaining};
-}
-
 function canonicalizeClauses(clauses: string[]): string[] {
     return [...clauses].sort((left, right) => left.localeCompare(right));
 }

--- a/apps/posts/src/views/filters/filter-types.ts
+++ b/apps/posts/src/views/filters/filter-types.ts
@@ -8,7 +8,13 @@ export interface FilterPredicate {
 export type ParsedPredicate = Omit<FilterPredicate, 'id'>;
 
 export interface CodecContext {
+    // Canonical field key the codec serializes to / reports predicates under.
     key: string;
+    // The key actually matched in the source NQL — equals `key` for an exact or
+    // pattern match, but is the alias (a `parseKeys` entry) when one was used.
+    // Codecs additionally accept a node whose field is this key. Set by
+    // `resolveField`; absent on hand-built contexts (which use canonical keys).
+    matchedKey?: string;
     pattern: string;
     params: Record<string, string>;
     timezone: string;

--- a/apps/posts/src/views/filters/resolve-field.test.ts
+++ b/apps/posts/src/views/filters/resolve-field.test.ts
@@ -47,6 +47,7 @@ describe('resolveField', () => {
             definition: fields.status,
             context: {
                 key: 'status',
+                matchedKey: 'status',
                 pattern: 'status',
                 params: {},
                 timezone: 'UTC'
@@ -61,6 +62,7 @@ describe('resolveField', () => {
             definition: fields['newsletters.:slug'],
             context: {
                 key: 'newsletters.weekly',
+                matchedKey: 'newsletters.weekly',
                 pattern: 'newsletters.:slug',
                 params: {
                     slug: 'weekly'
@@ -84,6 +86,7 @@ describe('resolveField', () => {
             definition: fields.author,
             context: {
                 key: 'author',
+                matchedKey: 'member_id',
                 pattern: 'author',
                 params: {},
                 timezone: 'UTC'

--- a/apps/posts/src/views/filters/resolve-field.ts
+++ b/apps/posts/src/views/filters/resolve-field.ts
@@ -40,6 +40,7 @@ export function resolveField<TFields extends Record<string, FilterField>>(fields
             definition: exactDefinition,
             context: {
                 key,
+                matchedKey: key,
                 pattern: key,
                 params: {},
                 timezone
@@ -56,6 +57,7 @@ export function resolveField<TFields extends Record<string, FilterField>>(fields
             definition,
             context: {
                 key: fieldKey,
+                matchedKey: key,
                 pattern: fieldKey,
                 params: {},
                 timezone
@@ -78,6 +80,7 @@ export function resolveField<TFields extends Record<string, FilterField>>(fields
             definition,
             context: {
                 key,
+                matchedKey: key,
                 pattern,
                 params,
                 timezone

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -52,35 +52,34 @@ describe('member-filter-query', () => {
         ]);
     });
 
-    it('parses grouped positive label filters into an all-of predicate', () => {
-        expect(stripIds(parseMemberFilter('(label:alpha+label:vip)', 'UTC'))).toEqual([
+    it('parses all-of label filters ($all) into an all-of predicate', () => {
+        expect(stripIds(parseMemberFilter('label:[alpha+vip]', 'UTC'))).toEqual([
             {field: 'label', operator: 'is-all', values: ['alpha', 'vip']}
         ]);
     });
 
-    it('parses grouped label all-of filters using the labels alias key', () => {
-        expect(stripIds(parseMemberFilter('(labels:alpha+labels:vip)', 'UTC'))).toEqual([
+    it('parses all-of label filters using the labels alias key', () => {
+        expect(stripIds(parseMemberFilter('labels:[alpha+vip]', 'UTC'))).toEqual([
             {field: 'label', operator: 'is-all', values: ['alpha', 'vip']}
         ]);
     });
 
-    it('parses grouped label all-of filters alongside other predicates', () => {
-        expect(stripIds(parseMemberFilter('(label:alpha+label:vip)+status:paid', 'UTC'))).toEqual([
+    it('parses all-of label filters alongside other predicates', () => {
+        expect(stripIds(parseMemberFilter('label:[alpha+vip]+status:paid', 'UTC'))).toEqual([
             {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
             {field: 'status', operator: 'is', values: ['paid']}
         ]);
     });
 
-    it('parses grouped label all-of filters with quoted values containing special characters', () => {
-        expect(stripIds(parseMemberFilter('(label:\'a (b)\'+label:\'trail\\\')', 'UTC'))).toEqual([
+    it('parses all-of label filters with quoted values containing special characters', () => {
+        expect(stripIds(parseMemberFilter('label:[\'a (b)\'+\'trail\\\']', 'UTC'))).toEqual([
             {field: 'label', operator: 'is-all', values: ['a (b)', 'trail\\']}
         ]);
     });
 
-    it('keeps ungrouped repeated positive label filters as separate predicates', () => {
-        expect(stripIds(parseMemberFilter('label:alpha+label:vip', 'UTC'))).toEqual([
-            {field: 'label', operator: 'is-any', values: ['alpha']},
-            {field: 'label', operator: 'is-any', values: ['vip']}
+    it('keeps comma value lists as any-of, not all-of', () => {
+        expect(stripIds(parseMemberFilter('label:[alpha,vip]', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-any', values: ['alpha', 'vip']}
         ]);
     });
 
@@ -171,13 +170,60 @@ describe('member-filter-query', () => {
         expect(serializeMemberFilters(predicates, 'UTC')).toBe('label:[alpha,vip]+status:paid');
     });
 
-    it('serializes label all-of filters as repeated AND clauses', () => {
+    it('serializes label all-of filters as a +-separated value list', () => {
         const predicates: FilterPredicate[] = [
             {id: '1', field: 'label', operator: 'is-all', values: ['vip', 'alpha']},
             {id: '2', field: 'status', operator: 'is', values: ['paid']}
         ];
 
-        expect(serializeMemberFilters(predicates, 'UTC')).toBe('(label:alpha+label:vip)+status:paid');
+        expect(serializeMemberFilters(predicates, 'UTC')).toBe('label:[alpha+vip]+status:paid');
+    });
+
+    it('round-trips an all-of label filter alongside a scalar filter', () => {
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {id: '2', field: 'status', operator: 'is', values: ['paid']}
+        ];
+
+        const serialized = serializeMemberFilters(predicates, 'UTC');
+
+        expect(serialized).toBe('label:[alpha+vip]+status:paid');
+        expect(stripIds(parseMemberFilter(serialized, 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+    });
+
+    it('round-trips multiple all-of label filters on the same field', () => {
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {id: '2', field: 'label', operator: 'is-all', values: ['gold', 'silver']},
+            {id: '3', field: 'status', operator: 'is', values: ['paid']}
+        ];
+
+        const serialized = serializeMemberFilters(predicates, 'UTC');
+
+        expect(serialized).toBe('label:[alpha+vip]+label:[gold+silver]+status:paid');
+        expect(stripIds(parseMemberFilter(serialized, 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {field: 'label', operator: 'is-all', values: ['gold', 'silver']},
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+    });
+
+    it('round-trips a single-value all-of label filter as the equivalent any-of', () => {
+        // A one-value all-of is identical to any-of (`[alpha]` is `$in`), so it
+        // serializes to the any-of form and parses back as is-any.
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['alpha']}
+        ];
+
+        const serialized = serializeMemberFilters(predicates, 'UTC');
+
+        expect(serialized).toBe('label:[alpha]');
+        expect(stripIds(parseMemberFilter(serialized, 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-any', values: ['alpha']}
+        ]);
     });
 
     it('round-trips canonical member examples', () => {

--- a/apps/posts/src/views/members/member-filter-query.ts
+++ b/apps/posts/src/views/members/member-filter-query.ts
@@ -1,4 +1,4 @@
-import {dispatchSimpleNodes, extractAllOfPredicates, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates, stampPredicates} from '../filters/filter-query-core';
+import {dispatchSimpleNodes, getFieldKeysByType, hasFieldKey, parseFilterToAst, serializePredicates, stampPredicates} from '../filters/filter-query-core';
 import {memberFields} from './member-fields';
 import {resolveField} from '../filters/resolve-field';
 import type {AstNode} from '../filters/filter-ast';
@@ -189,30 +189,7 @@ const MEMBER_COMPOUND_MATCHERS: CompoundMatcher[] = [
     matchFeedbackGroupedNode
 ];
 
-/**
- * NQL flattens redundant parentheses, so the AST for `(label:a+label:b)` is
- * identical to `label:a+label:b`. To detect the outer grouping without
- * re-implementing NQL's quoting rules, parse the filter with a probe predicate
- * AND-ed alongside: the grouping is no longer redundant, so it survives as a
- * nested `$and` in the probed AST.
- */
-function hasOuterGrouping(filter: string): boolean {
-    const probed = parseFilterToAst(`${filter.trim()}+__outer_grouping_probe__:1`);
-
-    if (!probed) {
-        return false;
-    }
-
-    const compound = getCompoundChildren(probed);
-
-    if (compound?.operator !== '$and' || compound.children.length !== 2) {
-        return false;
-    }
-
-    return getCompoundChildren(compound.children[0])?.operator === '$and';
-}
-
-function parseMemberNode(node: AstNode, timezone: string, isGroupedContext = false): ParsedPredicate[] {
+function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {
     for (const matcher of MEMBER_COMPOUND_MATCHERS) {
         const parsed = matcher(node);
 
@@ -224,16 +201,7 @@ function parseMemberNode(node: AstNode, timezone: string, isGroupedContext = fal
     const compound = getCompoundChildren(node);
 
     if (compound?.operator === '$and') {
-        const allOf = isGroupedContext ? extractAllOfPredicates(compound.children, memberFields, timezone) : null;
-
-        if (allOf) {
-            return [
-                ...allOf.predicates,
-                ...allOf.remaining.flatMap(child => parseMemberNode(child, timezone, true))
-            ];
-        }
-
-        return compound.children.flatMap(child => parseMemberNode(child, timezone, true));
+        return compound.children.flatMap(child => parseMemberNode(child, timezone));
     }
 
     return dispatchSimpleNodes([node], memberFields, timezone);
@@ -250,7 +218,7 @@ export function parseMemberFilter(filter: string | undefined, timezone: string):
         return [];
     }
 
-    return stampPredicates(parseMemberNode(ast, timezone, hasOuterGrouping(filter ?? '')));
+    return stampPredicates(parseMemberNode(ast, timezone));
 }
 
 export function hasTimezoneSensitiveMemberFilter(filter: string | undefined): boolean {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -687,6 +687,55 @@ describe('Members API', function () {
             });
     });
 
+    it('Can browse with an all-of label filter (label:[a+b]) returning only members with every label', async function () {
+        // Exercises the NQL "all of" operator end to end: the admin API string
+        // `label:[a+b]` -> @tryghost/nql ($all -> $and of equalities) -> mongo-knex
+        // (a separate subquery per label) -> the database, and back as JSON.
+        const emails = [
+            'all-of-both@example.com',
+            'all-of-alpha-only@example.com',
+            'all-of-beta-only@example.com'
+        ];
+
+        const alpha = await models.Label.add({name: 'All Of Alpha'});
+        const beta = await models.Label.add({name: 'All Of Beta'});
+        const alphaSlug = alpha.get('slug');
+        const betaSlug = beta.get('slug');
+
+        try {
+            await createMember({email: emails[0], labels: [{name: 'All Of Alpha'}, {name: 'All Of Beta'}]});
+            await createMember({email: emails[1], labels: [{name: 'All Of Alpha'}]});
+            await createMember({email: emails[2], labels: [{name: 'All Of Beta'}]});
+
+            // all-of: only the member carrying BOTH labels
+            const allOfFilter = encodeURIComponent(`label:[${alphaSlug}+${betaSlug}]`);
+            const allOfRes = await agent
+                .get(`/members/?filter=${allOfFilter}&fields=id,email`)
+                .expectStatus(200);
+
+            assert.equal(allOfRes.body.meta.pagination.total, 1);
+            assert.deepEqual(allOfRes.body.members.map(member => member.email), [emails[0]]);
+
+            // any-of (comma list) stays "either label" — proves the two are distinct
+            const anyOfFilter = encodeURIComponent(`label:[${alphaSlug},${betaSlug}]`);
+            const anyOfRes = await agent
+                .get(`/members/?filter=${anyOfFilter}&fields=id,email`)
+                .expectStatus(200);
+
+            assert.equal(anyOfRes.body.meta.pagination.total, 3);
+            assert.deepEqual(anyOfRes.body.members.map(member => member.email).sort(), [...emails].sort());
+        } finally {
+            for (const email of emails) {
+                const member = await models.Member.findOne({email});
+                if (member) {
+                    await models.Member.destroy({id: member.id});
+                }
+            }
+            await models.Label.destroy({id: alpha.id});
+            await models.Label.destroy({id: beta.id});
+        }
+    });
+
     it('Can filter members with active subscriptions across multiple Stripe customers', async function () {
         const emails = [
             'multiple-active-stripe-customers@example.com',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,12 +102,6 @@ catalogs:
     '@tryghost/limit-service':
       specifier: 1.5.6
       version: 1.5.6
-    '@tryghost/nql':
-      specifier: 0.13.0
-      version: 0.13.0
-    '@tryghost/nql-lang':
-      specifier: 0.6.5
-      version: 0.6.5
     '@tryghost/string':
       specifier: 0.3.5
       version: 0.3.5
@@ -308,6 +302,8 @@ catalogs:
       version: 3.4.19
 
 overrides:
+  '@tryghost/nql': 0.13.1-pr156.0
+  '@tryghost/nql-lang': 0.6.6-pr156.0
   '@tryghost/errors': ^1.3.7
   '@tryghost/logging': 4.2.1
   jackspeak: 4.2.3
@@ -979,8 +975,8 @@ importers:
         specifier: 'catalog:'
         version: 1.5.6
       '@tryghost/nql':
-        specifier: 'catalog:'
-        version: 0.13.0
+        specifier: 0.13.1-pr156.0
+        version: 0.13.1-pr156.0
       '@tryghost/string':
         specifier: 'catalog:'
         version: 0.3.5
@@ -1183,8 +1179,8 @@ importers:
         specifier: workspace:*
         version: link:../../ghost/i18n
       '@tryghost/nql':
-        specifier: 'catalog:'
-        version: 0.13.0
+        specifier: 0.13.1-pr156.0
+        version: 0.13.1-pr156.0
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 4.7.0(vite@7.3.2(@types/node@25.9.1)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -1325,8 +1321,8 @@ importers:
         specifier: 'catalog:'
         version: 1.8.2
       '@tryghost/nql-lang':
-        specifier: 'catalog:'
-        version: 0.6.5
+        specifier: 0.6.6-pr156.0
+        version: 0.6.6-pr156.0
       '@tryghost/shade':
         specifier: workspace:*
         version: link:../shade
@@ -2015,8 +2011,8 @@ importers:
         specifier: 'catalog:'
         version: 1.5.6
       '@tryghost/nql':
-        specifier: 'catalog:'
-        version: 0.13.0
+        specifier: 0.13.1-pr156.0
+        version: 0.13.1-pr156.0
       '@tryghost/string':
         specifier: 'catalog:'
         version: 0.3.5
@@ -2438,11 +2434,11 @@ importers:
         specifier: 2.2.4
         version: 2.2.4(babel-core@6.26.3)(handlebars@4.7.9)(lodash@4.18.1)(underscore@1.13.8)
       '@tryghost/nql':
-        specifier: 'catalog:'
-        version: 0.13.0
+        specifier: 0.13.1-pr156.0
+        version: 0.13.1-pr156.0
       '@tryghost/nql-lang':
-        specifier: 'catalog:'
-        version: 0.6.5
+        specifier: 0.6.6-pr156.0
+        version: 0.6.6-pr156.0
       '@tryghost/parse-email-address':
         specifier: workspace:*
         version: link:../parse-email-address
@@ -8576,9 +8572,6 @@ packages:
   '@tryghost/mongo-knex@0.10.0':
     resolution: {integrity: sha512-m9yvVWbJHfZpPi6R0as1RfRu7bPJwhf9j4ZHF1hEZWJgRKfycSH8wUKvK7eS45fxINicEk2CXSFMRDd4IM6N2Q==}
 
-  '@tryghost/mongo-knex@0.9.5':
-    resolution: {integrity: sha512-etO6Kz8a1dgMV6yapD2C2JsoeLrUjkIoIUdXrkV9ELHQsMjMhtI2SAUnMV9AcLhxv0P7h8UWWD2rlNBwo8JJig==}
-
   '@tryghost/mongo-utils@0.6.4':
     resolution: {integrity: sha512-4ZGl9QXoMTQb9qb5HGjMjVLkV39FO0F/0cM4Z3i/9gUXXfdmGZwPdcAMBRT7oRhqng3/4uSRpvQ/Rk0oASM+kg==}
 
@@ -8591,14 +8584,11 @@ packages:
   '@tryghost/nodemailer@2.2.4':
     resolution: {integrity: sha512-sYFbDS6ceS72qXVeHiE+23Si+JwfDo3Gx+UcGLfmXPR+mW5VvkehoL1QFg/VOKv6mB2kA2Dknk2lPmJuQAw3Jw==}
 
-  '@tryghost/nql-lang@0.6.5':
-    resolution: {integrity: sha512-13Loz2yH7GCMAfpVawD6KNWNPIVTc4STnP+MeCwbrWg8htv/CPOB0u+i9Eap0qEi8h6TC2aoOvbQV0EvjidQaQ==}
+  '@tryghost/nql-lang@0.6.6-pr156.0':
+    resolution: {integrity: sha512-0pvTr7zxLnb7tR+7qF4YgRzYG9WZMAyT3hs8G4e9lNPmDQbnv95MXQ4vSzItknyQPkFjyFb7I8v5SLypFBcH2g==}
 
-  '@tryghost/nql@0.12.11':
-    resolution: {integrity: sha512-8Cb10OpQWT+v0Xvfrov9IkBwzyPlARsjF1EIC8f3ET/JZD3G+ARoQ3GEBQ7XeW6YcUd7MIh3zqJTv5ST+aDjZA==}
-
-  '@tryghost/nql@0.13.0':
-    resolution: {integrity: sha512-Aa2vJBPBK5WltmO4ifkeNNG/XedmyeN9B0CT4HLHEIjUARc8wKKntzmRtzSJCSL5moyX40vJ95yTnUNwA1wxew==}
+  '@tryghost/nql@0.13.1-pr156.0':
+    resolution: {integrity: sha512-fc6PX28oEqUKUsGIVYOYKe88fSKu/WrdSlbXNwec4/2wgY1k4PD2uuTO64P98kCX59dfCZz3WZll4pujKBm2ag==}
 
   '@tryghost/pretty-cli@3.2.2':
     resolution: {integrity: sha512-S0W7UW3wRWquLVg0zQ/UfTy1pMM1NnSJkJB2hNMqWWnzLqSdk9yadCNfal0dsQh0QT/5XpAWKir5Mtzt04oQLQ==}
@@ -20753,6 +20743,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -27999,7 +27990,7 @@ snapshots:
     dependencies:
       '@tryghost/debug': 2.2.3
       '@tryghost/errors': 1.3.13
-      '@tryghost/nql': 0.13.0
+      '@tryghost/nql': 0.13.1-pr156.0
       '@tryghost/tpl': 2.2.3
     transitivePeerDependencies:
       - supports-color
@@ -28395,13 +28386,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/mongo-knex@0.9.5':
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-      lodash: 4.18.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@tryghost/mongo-utils@0.6.4':
     dependencies:
       lodash: 4.18.1
@@ -28483,25 +28467,15 @@ snapshots:
       - walrus
       - whiskers
 
-  '@tryghost/nql-lang@0.6.5':
+  '@tryghost/nql-lang@0.6.6-pr156.0':
     dependencies:
       date-fns: 2.30.0
 
-  '@tryghost/nql@0.12.11':
-    dependencies:
-      '@tryghost/mongo-knex': 0.9.5
-      '@tryghost/mongo-utils': 0.6.4
-      '@tryghost/nql-lang': 0.6.5
-      lodash: 4.18.1
-      mingo: 2.5.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@tryghost/nql@0.13.0':
+  '@tryghost/nql@0.13.1-pr156.0':
     dependencies:
       '@tryghost/mongo-knex': 0.10.0
       '@tryghost/mongo-utils': 0.6.4
-      '@tryghost/nql-lang': 0.6.5
+      '@tryghost/nql-lang': 0.6.6-pr156.0
       lodash: 4.18.1
       mingo: 2.5.3
     transitivePeerDependencies:
@@ -37098,7 +37072,7 @@ snapshots:
       '@tryghost/debug': 2.2.2
       '@tryghost/errors': 1.3.13
       '@tryghost/logging': 4.2.1
-      '@tryghost/nql': 0.12.11
+      '@tryghost/nql': 0.13.1-pr156.0
       '@tryghost/pretty-cli': 3.2.2
       '@tryghost/server': 3.0.2
       '@tryghost/zip': 3.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,8 +58,10 @@ catalog:
   '@tryghost/koenig-lexical': 1.8.2
   '@tryghost/limit-service': 1.5.6
   '@tryghost/logging': 4.2.1
-  '@tryghost/nql': 0.13.0
-  '@tryghost/nql-lang': 0.6.5
+  # Prerelease of the NQL "all of" ($all) operator (TryGhost/NQL#156), published
+  # under the `next` dist-tag. Bump to the released versions once #156 merges.
+  '@tryghost/nql': 0.13.1-pr156.0
+  '@tryghost/nql-lang': 0.6.6-pr156.0
   '@tryghost/string': 0.3.5
   '@tryghost/timezone-data': 1.0.0
   '@types/express': 4.17.25
@@ -132,6 +134,13 @@ catalogs:
     eslint-plugin-tailwindcss: 3.18.3
 
 overrides:
+  # Force the NQL "all of" ($all) prerelease (TryGhost/NQL#156) onto every
+  # consumer, including transitive ones like @tryghost/bookshelf-filter that
+  # `require('@tryghost/nql')` directly — the filter->SQL path is the one that
+  # desugars $all. Plain ranges (^0.x) exclude prereleases, so both packages need
+  # forcing here. Remove once NQL#156 is released and the catalog uses stable.
+  '@tryghost/nql': 0.13.1-pr156.0
+  '@tryghost/nql-lang': 0.6.6-pr156.0
   '@tryghost/errors': ^1.3.7
   '@tryghost/logging': 'catalog:'
   jackspeak: 4.2.3


### PR DESCRIPTION
## Problem

Member filtering supports an "is all of" mode for labels, where a member must carry every selected label. Until now the admin serialized this intent by hand-rolling a parenthesised group of separate clauses (one clause per label, ANDed together). That workaround was brittle: it duplicated NQL's grouping semantics in the admin, made outer-grouping detection fiddly (especially for quoted label values), and drifted from how the rest of the filter pipeline expresses queries.

## Solution

This change replaces the parentheses-grouping workaround with first-class support for NQL's native "all of" operator, so an "is all of" label filter is now expressed as a single clause that lists every required label. The admin's filter codecs, query core, and member filter query all serialize and parse this form directly, and the field config drives whether a field is eligible for all-of handling rather than special-casing it in the query builder.

An end-to-end test drives the Members admin API over HTTP to prove the round trip: members are created with overlapping labels, and an "all of" filter returns only the member carrying every label, while the comma list still returns members carrying either.

This depends on the "all of" operator landing in NQL (TryGhost/NQL#156). While that is in review it is consumed as a prerelease published to npm under the `next` dist-tag (`@tryghost/nql@0.13.1-pr156.0`, `@tryghost/nql-lang@0.6.6-pr156.0`). The catalog points at those versions and a workspace override forces them onto transitive consumers too (the filter-to-SQL path lives in a transitive dependency). Once NQL#156 is released to `latest`, the catalog and override get bumped to the stable versions and the override can be dropped.

This PR is stacked on #27945.
