### PR TITLE
✨ Added "is all of" operator to member label filters

### DIFF
--- a/apps/posts/src/views/filters/filter-codecs.test.ts
+++ b/apps/posts/src/views/filters/filter-codecs.test.ts
@@ -272,6 +272,38 @@ describe('setCodec', () => {
         expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[alpha,vip]']);
     });
 
+    it('parses all-of set membership ($all) into an is-all predicate', () => {
+        expect(setCodec().parse(nql.parse('label:[vip+alpha]') as never, labelContext)).toEqual({
+            field: 'label',
+            operator: 'is-all',
+            values: ['vip', 'alpha']
+        });
+    });
+
+    it('serializes all-of set membership as a +-separated value list', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'label',
+            operator: 'is-all',
+            values: ['vip', 'alpha']
+        };
+
+        expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[alpha+vip]']);
+    });
+
+    it('serializes a single-value all-of as any-of (a one-value all is identical to any)', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'label',
+            operator: 'is-all',
+            values: ['alpha']
+        };
+
+        // `[alpha]` is `$in` regardless, so emit the any-of form rather than a
+        // one-element all-of that would just round-trip back to is-any anyway.
+        expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[alpha]']);
+    });
+
     it('can serialize singleton string values as quoted scalars', () => {
         const predicate: FilterPredicate = {
             id: '1',
@@ -292,6 +324,24 @@ describe('setCodec', () => {
         };
 
         expect(setCodec().serialize(predicate, labelContext)).toEqual(['label:[beta,\'vip,alpha\']']);
+    });
+
+    it('quotes all-of values that contain reserved characters and round-trips them', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'label',
+            operator: 'is-all',
+            values: ['a b', 'c+d']
+        };
+
+        const [serialized] = setCodec().serialize(predicate, labelContext)!;
+
+        expect(serialized).toBe('label:[\'a b\'+\'c+d\']');
+        expect(setCodec().parse(nql.parse(serialized) as never, labelContext)).toEqual({
+            field: 'label',
+            operator: 'is-all',
+            values: ['a b', 'c+d']
+        });
     });
 });
 

--- a/apps/posts/src/views/filters/filter-codecs.ts
+++ b/apps/posts/src/views/filters/filter-codecs.ts
@@ -49,9 +49,33 @@ const DATE_OPERATOR_SYMBOLS: Record<string, string> = {
     'is-or-greater': '>='
 };
 
-const SET_OPERATOR_SYMBOLS: Record<string, string> = {
-    'is-any': '',
-    'is-not-any': '-'
+type SetOperatorSerializer = (field: string, values: string[], config?: CodecConfig) => string;
+
+function serializeSetMembership(symbol: string): SetOperatorSerializer {
+    return (field, values, config) => {
+        if (config?.serializeSingletonAsScalar && values.length === 1) {
+            return `${field}:${symbol}${serializeScalarValue(values[0], config)}`;
+        }
+
+        return `${field}:${symbol}[${values.map(value => serializeScalarValue(value, config)).join(',')}]`;
+    };
+}
+
+const serializeAnyMembership = serializeSetMembership('');
+
+const SET_OPERATOR_SERIALIZERS: Record<string, SetOperatorSerializer> = {
+    'is-any': serializeAnyMembership,
+    'is-not-any': serializeSetMembership('-'),
+    'is-all': (field, values, config) => {
+        // NQL's all-of operator is a `+`-separated value list: `label:[a+b]`.
+        // A single value is identical to any-of (and `[a]` is `$in` regardless),
+        // so only emit the all-of form for two or more values.
+        if (values.length === 1) {
+            return serializeAnyMembership(field, values, config);
+        }
+
+        return `${field}:[${values.map(value => serializeScalarValue(value, config)).join('+')}]`;
+    }
 };
 
 const UNQUOTED_TOKEN_PATTERN = /^[A-Za-z0-9_.-]+$/;
@@ -122,7 +146,7 @@ export function scalarCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field) {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey) {
                 return null;
             }
 
@@ -165,7 +189,7 @@ export function textCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field) {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey) {
                 return null;
             }
 
@@ -224,7 +248,7 @@ export function setCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field) {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey) {
                 return null;
             }
 
@@ -232,6 +256,14 @@ export function setCodec(config?: CodecConfig): FilterCodec {
                 return {
                     field: ctx.key,
                     operator: 'is-any',
+                    values: comparator.value
+                };
+            }
+
+            if (comparator.operator === '$all' && Array.isArray(comparator.value)) {
+                return {
+                    field: ctx.key,
+                    operator: 'is-all',
                     values: comparator.value
                 };
             }
@@ -269,19 +301,13 @@ export function setCodec(config?: CodecConfig): FilterCodec {
                 return null;
             }
 
-            const operator = SET_OPERATOR_SYMBOLS[predicate.operator];
+            const serializeOperator = SET_OPERATOR_SERIALIZERS[predicate.operator];
 
-            if (operator === undefined) {
+            if (serializeOperator === undefined) {
                 return null;
             }
 
-            const values = normalizeMultiValue(predicate.values);
-
-            if (config?.serializeSingletonAsScalar && values.length === 1) {
-                return [`${field}:${operator}${serializeScalarValue(values[0], config)}`];
-            }
-
-            return [`${field}:${operator}[${values.map(value => serializeScalarValue(value, config)).join(',')}]`];
+            return [serializeOperator(field, normalizeMultiValue(predicate.values), config)];
         }
     };
 }
@@ -292,7 +318,7 @@ export function numberCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field || typeof comparator.value !== 'number') {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey || typeof comparator.value !== 'number') {
                 return null;
             }
 
@@ -364,7 +390,7 @@ export function dateCodec(config?: CodecConfig): FilterCodec {
             const comparator = extractComparator(node as Record<string, unknown>);
             const field = getCodecField(config, ctx.key);
 
-            if (!comparator || comparator.field !== field) {
+            if (!comparator || comparator.field !== field && comparator.field !== ctx.matchedKey) {
                 return null;
             }
 

--- a/apps/posts/src/views/filters/filter-types.ts
+++ b/apps/posts/src/views/filters/filter-types.ts
@@ -8,7 +8,13 @@ export interface FilterPredicate {
 export type ParsedPredicate = Omit<FilterPredicate, 'id'>;
 
 export interface CodecContext {
+    // Canonical field key the codec serializes to / reports predicates under.
     key: string;
+    // The key actually matched in the source NQL — equals `key` for an exact or
+    // pattern match, but is the alias (a `parseKeys` entry) when one was used.
+    // Codecs additionally accept a node whose field is this key. Set by
+    // `resolveField`; absent on hand-built contexts (which use canonical keys).
+    matchedKey?: string;
     pattern: string;
     params: Record<string, string>;
     timezone: string;

--- a/apps/posts/src/views/filters/resolve-field.test.ts
+++ b/apps/posts/src/views/filters/resolve-field.test.ts
@@ -47,6 +47,7 @@ describe('resolveField', () => {
             definition: fields.status,
             context: {
                 key: 'status',
+                matchedKey: 'status',
                 pattern: 'status',
                 params: {},
                 timezone: 'UTC'
@@ -61,6 +62,7 @@ describe('resolveField', () => {
             definition: fields['newsletters.:slug'],
             context: {
                 key: 'newsletters.weekly',
+                matchedKey: 'newsletters.weekly',
                 pattern: 'newsletters.:slug',
                 params: {
                     slug: 'weekly'
@@ -84,6 +86,7 @@ describe('resolveField', () => {
             definition: fields.author,
             context: {
                 key: 'author',
+                matchedKey: 'member_id',
                 pattern: 'author',
                 params: {},
                 timezone: 'UTC'

--- a/apps/posts/src/views/filters/resolve-field.ts
+++ b/apps/posts/src/views/filters/resolve-field.ts
@@ -40,6 +40,7 @@ export function resolveField<TFields extends Record<string, FilterField>>(fields
             definition: exactDefinition,
             context: {
                 key,
+                matchedKey: key,
                 pattern: key,
                 params: {},
                 timezone
@@ -56,6 +57,7 @@ export function resolveField<TFields extends Record<string, FilterField>>(fields
             definition,
             context: {
                 key: fieldKey,
+                matchedKey: key,
                 pattern: fieldKey,
                 params: {},
                 timezone
@@ -78,6 +80,7 @@ export function resolveField<TFields extends Record<string, FilterField>>(fields
             definition,
             context: {
                 key,
+                matchedKey: key,
                 pattern,
                 params,
                 timezone

--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -47,7 +47,7 @@ describe('memberFields', () => {
     });
 
     it('keeps the expected operators for key member fields', () => {
-        expect(memberFields.label.operators).toEqual(['is-any', 'is-not-any']);
+        expect(memberFields.label.operators).toEqual(['is-any', 'is-all', 'is-not-any']);
         expect(memberFields.tier_id.operators).toEqual(['is-any', 'is-not-any']);
         expect(memberFields['newsletters.:slug'].operators).toEqual(['is']);
         expect(memberFields.newsletter_feedback.operators).toEqual(['1', '0']);

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -11,6 +11,7 @@ const TEXT_OPERATORS = ['is', 'contains', 'does-not-contain', 'starts-with', 'en
 const NUMBER_OPERATORS = ['is', 'is-greater', 'is-less'] as const;
 const SCALAR_OPERATORS = ['is', 'is-not'] as const;
 const SET_OPERATORS = ['is-any', 'is-not-any'] as const;
+const LABEL_SET_OPERATORS = ['is-any', 'is-all', 'is-not-any'] as const;
 const SUBSCRIPTION_STATUS_OPTIONS: Array<{value: string; label: string}> = [
     {value: 'active', label: 'Active'},
     {value: 'trialing', label: 'Trialing'},
@@ -141,7 +142,8 @@ const baseMemberFields = defineFields({
         codec: textCodec()
     },
     label: {
-        operators: SET_OPERATORS,
+        operators: LABEL_SET_OPERATORS,
+        parseKeys: ['labels'],
         ui: {
             label: 'Label',
             type: 'multiselect',

--- a/apps/posts/src/views/members/member-filter-query.test.ts
+++ b/apps/posts/src/views/members/member-filter-query.test.ts
@@ -52,6 +52,37 @@ describe('member-filter-query', () => {
         ]);
     });
 
+    it('parses all-of label filters ($all) into an all-of predicate', () => {
+        expect(stripIds(parseMemberFilter('label:[alpha+vip]', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']}
+        ]);
+    });
+
+    it('parses all-of label filters using the labels alias key', () => {
+        expect(stripIds(parseMemberFilter('labels:[alpha+vip]', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']}
+        ]);
+    });
+
+    it('parses all-of label filters alongside other predicates', () => {
+        expect(stripIds(parseMemberFilter('label:[alpha+vip]+status:paid', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+    });
+
+    it('parses all-of label filters with quoted values containing special characters', () => {
+        expect(stripIds(parseMemberFilter('label:[\'a (b)\'+\'trail\\\']', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['a (b)', 'trail\\']}
+        ]);
+    });
+
+    it('keeps comma value lists as any-of, not all-of', () => {
+        expect(stripIds(parseMemberFilter('label:[alpha,vip]', 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-any', values: ['alpha', 'vip']}
+        ]);
+    });
+
     it('best-effort parses compat subscribed booleans into subscribed filters', () => {
         expect(stripIds(parseMemberFilter('subscribed:true', 'UTC'))).toEqual([
             {field: 'subscribed', operator: 'is', values: ['subscribed']}
@@ -137,6 +168,62 @@ describe('member-filter-query', () => {
         ];
 
         expect(serializeMemberFilters(predicates, 'UTC')).toBe('label:[alpha,vip]+status:paid');
+    });
+
+    it('serializes label all-of filters as a +-separated value list', () => {
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['vip', 'alpha']},
+            {id: '2', field: 'status', operator: 'is', values: ['paid']}
+        ];
+
+        expect(serializeMemberFilters(predicates, 'UTC')).toBe('label:[alpha+vip]+status:paid');
+    });
+
+    it('round-trips an all-of label filter alongside a scalar filter', () => {
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {id: '2', field: 'status', operator: 'is', values: ['paid']}
+        ];
+
+        const serialized = serializeMemberFilters(predicates, 'UTC');
+
+        expect(serialized).toBe('label:[alpha+vip]+status:paid');
+        expect(stripIds(parseMemberFilter(serialized, 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+    });
+
+    it('round-trips multiple all-of label filters on the same field', () => {
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {id: '2', field: 'label', operator: 'is-all', values: ['gold', 'silver']},
+            {id: '3', field: 'status', operator: 'is', values: ['paid']}
+        ];
+
+        const serialized = serializeMemberFilters(predicates, 'UTC');
+
+        expect(serialized).toBe('label:[alpha+vip]+label:[gold+silver]+status:paid');
+        expect(stripIds(parseMemberFilter(serialized, 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-all', values: ['alpha', 'vip']},
+            {field: 'label', operator: 'is-all', values: ['gold', 'silver']},
+            {field: 'status', operator: 'is', values: ['paid']}
+        ]);
+    });
+
+    it('round-trips a single-value all-of label filter as the equivalent any-of', () => {
+        // A one-value all-of is identical to any-of (`[alpha]` is `$in`), so it
+        // serializes to the any-of form and parses back as is-any.
+        const predicates: FilterPredicate[] = [
+            {id: '1', field: 'label', operator: 'is-all', values: ['alpha']}
+        ];
+
+        const serialized = serializeMemberFilters(predicates, 'UTC');
+
+        expect(serialized).toBe('label:[alpha]');
+        expect(stripIds(parseMemberFilter(serialized, 'UTC'))).toEqual([
+            {field: 'label', operator: 'is-any', values: ['alpha']}
+        ]);
     });
 
     it('round-trips canonical member examples', () => {

--- a/apps/posts/src/views/members/use-member-filter-fields.test.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.test.ts
@@ -52,6 +52,11 @@ describe('useMemberFilterFields', () => {
         const emailPostField = emailFields.find(field => field.key === 'emails.post_id');
 
         expect(labelField?.operators?.map(operator => operator.value)).toEqual(memberFields.label.operators);
+        expect(labelField?.operators?.map(operator => operator.label)).toEqual([
+            'is any of',
+            'is all of',
+            'is none of'
+        ]);
         expect(labelField).toMatchObject({
             options: [],
             valueSource: labelValueSource

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -31,6 +31,7 @@ type SearchableFieldOverrides = Pick<FilterFieldConfig, 'options' | 'valueSource
 
 const MEMBER_OPERATOR_LABELS: Record<string, string> = {
     'is-any': 'is any of',
+    'is-all': 'is all of',
     'is-not-any': 'is none of',
     'does-not-contain': 'does not contain',
     ...DATE_OPERATOR_LABELS,


### PR DESCRIPTION
## Problem

Member label filters could only express "has any of these labels" or "has none of these labels". There was no way to find members that carry every selected label.

## Solution

Adds an "is all of" operator to the member Label filter. It serializes to NQL's all-of operator (`label:[a+b]`) and parses back into a single filter row. The behaviour is driven by field config — any set field that declares the all-of operator gets serialization and parsing for free — rather than being special-cased for labels.

This is the frontend half of the feature and it **emits** the operator, so it must be merged only **after** the server support (#28599) has fully rolled out — otherwise an admin ahead of the server rollout would send filter syntax older servers reject. Kept as a draft and stacked on #28599 for that reason.