### PR TITLE
🐛 Fixed Preview button being unavailable on mobile in the editor

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -72,10 +72,8 @@
                 type="button"
                 class="gh-btn gh-btn-editor gh-editor-preview-trigger gh-post-preview-close active"
                 {{on "click" @close}}
-                aria-label="Close preview"
             >
-                <span class="gh-post-preview-close-text">Close</span>
-                <span class="gh-post-preview-close-icon">{{svg-jar "close"}}</span>
+                <span>Close</span>
             </button>
 
             {{#if @data.publishOptions.user.isContributor}}

--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -13,7 +13,7 @@
                 {{/if}}
             </div>
             <div class="gh-contentfilter-divider"></div>
-            <div class="gh-contentfilter gh-btn-group">
+            <div class="gh-contentfilter gh-btn-group gh-post-preview-sizes">
                 <button type="button" class="gh-btn {{if (eq this.previewSize "desktop") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changePreviewSize "desktop")}}><span>{{svg-jar "laptop"}}</span></button>
                 <button type="button" class="gh-btn {{if (eq this.previewSize "mobile") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changePreviewSize "mobile")}}><span>{{svg-jar "mobile-phone"}}</span></button>
             </div>
@@ -70,10 +70,12 @@
             <div class="gh-contentfilter-divider"></div>
             <button
                 type="button"
-                class="gh-btn gh-btn-editor gh-editor-preview-trigger active"
+                class="gh-btn gh-btn-editor gh-editor-preview-trigger gh-post-preview-close active"
                 {{on "click" @close}}
+                aria-label="Close preview"
             >
-                <span>Close</span>
+                <span class="gh-post-preview-close-text">Close</span>
+                <span class="gh-post-preview-close-icon">{{svg-jar "close"}}</span>
             </button>
 
             {{#if @data.publishOptions.user.isContributor}}

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -421,6 +421,11 @@
         gap: 1.6rem;
     }
 
+    .gh-editor-mobile-menu .gh-editor-preview-trigger {
+        display: inline-flex;
+        align-items: center;
+    }
+
     .gh-editor-mobile-menu .gh-btn-editor:hover {
         background: none !important;
     }

--- a/ghost/admin/app/styles/layouts/post-preview.css
+++ b/ghost/admin/app/styles/layouts/post-preview.css
@@ -74,6 +74,9 @@
 .gh-post-preview-close .gh-post-preview-close-icon svg {
     width: 14px;
     height: 14px;
+    /* close.svg has no fill of its own; follow the button's text colour so it
+       stays visible on both the light and dark (theme-flipped) header */
+    fill: currentColor;
 }
 
 @media (max-width: 640px) {
@@ -99,6 +102,11 @@
     .gh-post-preview-header .right {
         position: static;
         margin-left: auto;
+    }
+
+    /* move Close ahead of share so share sits directly left of Publish */
+    .gh-post-preview-close {
+        order: -1;
     }
 
     /* the desktop/mobile size toggle is meaningless on a phone */

--- a/ghost/admin/app/styles/layouts/post-preview.css
+++ b/ghost/admin/app/styles/layouts/post-preview.css
@@ -60,6 +60,65 @@
     }
 }
 
+/* The Close button shares .gh-editor-preview-trigger, which is hidden below 500px
+   for the editor toolbar; the modal needs it visible so the preview can be dismissed */
+.gh-post-preview-header .gh-editor-preview-trigger {
+    display: inline-flex;
+    align-items: center;
+}
+
+.gh-post-preview-close .gh-post-preview-close-icon {
+    display: none;
+}
+
+.gh-post-preview-close .gh-post-preview-close-icon svg {
+    width: 14px;
+    height: 14px;
+}
+
+@media (max-width: 640px) {
+    /* lay the header out in flow so the centered controls can't slide under the
+       absolutely-positioned action group and overlap it */
+    .gh-post-preview-header {
+        justify-content: flex-start;
+        padding: 1.2rem;
+    }
+
+    .gh-post-preview-header .left {
+        position: static;
+    }
+
+    .gh-post-preview-header h2 {
+        font-size: 1.6rem;
+    }
+
+    .gh-post-preview-btn-group {
+        margin-left: 8px;
+    }
+
+    .gh-post-preview-header .right {
+        position: static;
+        margin-left: auto;
+    }
+
+    /* the desktop/mobile size toggle is meaningless on a phone */
+    .gh-post-preview-sizes,
+    .gh-post-preview-btn-group .gh-contentfilter-divider,
+    .gh-post-preview-header .right .gh-contentfilter-divider {
+        display: none;
+    }
+
+    /* a compact X replaces the "Close" label to save horizontal space */
+    .gh-post-preview-close .gh-post-preview-close-text {
+        display: none;
+    }
+
+    .gh-post-preview-close .gh-post-preview-close-icon {
+        display: inline-flex;
+        align-items: center;
+    }
+}
+
 .gh-post-preview-btn-group .gh-btn-group {
     gap: .2rem;
     margin: 0 4px;

--- a/ghost/admin/app/styles/layouts/post-preview.css
+++ b/ghost/admin/app/styles/layouts/post-preview.css
@@ -90,9 +90,10 @@
         margin-left: auto;
     }
 
-    /* move Close ahead of share so share sits directly left of Publish */
+    /* push Close to the far-right corner so it isn't stranded mid-header; share
+       still sits directly left of Publish */
     .gh-post-preview-close {
-        order: -1;
+        order: 1;
     }
 
     /* the desktop/mobile size toggle is meaningless on a phone */

--- a/ghost/admin/app/styles/layouts/post-preview.css
+++ b/ghost/admin/app/styles/layouts/post-preview.css
@@ -67,18 +67,6 @@
     align-items: center;
 }
 
-.gh-post-preview-close .gh-post-preview-close-icon {
-    display: none;
-}
-
-.gh-post-preview-close .gh-post-preview-close-icon svg {
-    width: 14px;
-    height: 14px;
-    /* close.svg has no fill of its own; follow the button's text colour so it
-       stays visible on both the light and dark (theme-flipped) header */
-    fill: currentColor;
-}
-
 @media (max-width: 640px) {
     /* lay the header out in flow so the centered controls can't slide under the
        absolutely-positioned action group and overlap it */
@@ -87,16 +75,14 @@
         padding: 1.2rem;
     }
 
+    /* the "Preview" title is redundant inside the preview modal; drop it on phones
+       so the Close/share/Publish controls fit without crowding */
     .gh-post-preview-header .left {
-        position: static;
-    }
-
-    .gh-post-preview-header h2 {
-        font-size: 1.6rem;
+        display: none;
     }
 
     .gh-post-preview-btn-group {
-        margin-left: 8px;
+        margin-left: 0;
     }
 
     .gh-post-preview-header .right {
@@ -114,16 +100,6 @@
     .gh-post-preview-btn-group .gh-contentfilter-divider,
     .gh-post-preview-header .right .gh-contentfilter-divider {
         display: none;
-    }
-
-    /* a compact X replaces the "Close" label to save horizontal space */
-    .gh-post-preview-close .gh-post-preview-close-text {
-        display: none;
-    }
-
-    .gh-post-preview-close .gh-post-preview-close-icon {
-        display: inline-flex;
-        align-items: center;
     }
 }
 


### PR DESCRIPTION
## Why

Mobile users can't preview a draft. The editor's mobile bottom bar already renders a Preview button, but a blanket `.gh-editor-preview-trigger { display: none }` rule below 500px hid it everywhere — so on a phone a draft has no preview path at all. The only post link that survives on mobile is the "Published →" link, which exists only *after* publishing (this is what the "can only preview after hitting publish" report was actually seeing).

## What

**1. Show Preview on mobile.** Scopes the un-hide to the mobile menu (`.gh-editor-mobile-menu .gh-editor-preview-trigger`) so the desktop header and the publish-flow preview trigger are unaffected. This matches the two-button layout already shipped in that bar for published posts (Update + Unpublish), so it adds no clutter. Preview only renders for drafts (`post.isDraft`), exactly the reported gap.

**2. Fix the preview modal header on mobile.** Opening the modal on a phone surfaced several issues, now fixed:
- The header packed the title, Web/Email tabs, a desktop/mobile size toggle, share, Close and Publish into one row with the side groups absolutely positioned, so the centered controls slid *under* the action group and overlapped. Below 640px the header now lays out in flow (no absolute positioning) so groups can't overlap.
- The desktop/mobile size toggle is hidden on phones (meaningless there), and the redundant "Preview" title is hidden so the remaining controls fit comfortably down to ~320px.
- The Close button reuses `.gh-editor-preview-trigger`, so the same below-500px rule hid it — meaning the preview couldn't be dismissed on a phone at all. It's now revealed for the modal, kept as the same "Close" text button used on desktop, and moved to the far-right corner so it isn't stranded mid-header. Share sits directly left of Publish.

## Notes

- The preview modal content (iframe) was already responsive, so the previewed post renders fine at phone widths.
- All header changes are scoped to ≤640px; desktop is unchanged.

## Recording
<img width="405" height="800" alt="CleanShot 2026-06-15 at 12 08 59" src="https://github.com/user-attachments/assets/d7836e10-2cb1-4c78-b105-72feb11f2a29" />