### PR TITLE
✨ Added long-press to open the posts list context menu on touch devices

### DIFF
--- a/ghost/admin/app/components/multi-list/item.hbs
+++ b/ghost/admin/app/components/multi-list/item.hbs
@@ -1,3 +1,3 @@
-<div role="menuitem" {{on "click" this.onClick capture=true}} {{on "mousedown" this.onMouseDown capture=true}} data-selected={{this.isSelected}} {{on "contextmenu" this.onContextMenu}} ...attributes>
+<div role="menuitem" {{on "click" this.onClick capture=true}} {{on "mousedown" this.onMouseDown capture=true}} data-selected={{this.isSelected}} {{on "contextmenu" this.onContextMenu}} {{on "touchstart" this.onTouchStart passive=true}} {{on "touchmove" this.onTouchMove passive=true}} {{on "touchend" this.onTouchEnd passive=true}} {{on "touchcancel" this.onTouchEnd passive=true}} ...attributes>
     {{yield}}
 </div>

--- a/ghost/admin/app/components/multi-list/item.js
+++ b/ghost/admin/app/components/multi-list/item.js
@@ -24,6 +24,8 @@ export default class ItemComponent extends Component {
     longPressFired = false;
     touchStartX = 0;
     touchStartY = 0;
+    ghostClickHandler = null;
+    ghostClickTimer = null;
 
     get selectionList() {
         return this.args.model;
@@ -40,12 +42,39 @@ export default class ItemComponent extends Component {
     willDestroy() {
         super.willDestroy(...arguments);
         this.cancelLongPress();
+        this.cancelGhostClickSuppression();
     }
 
     cancelLongPress() {
         if (this.longPressTimer) {
             clearTimeout(this.longPressTimer);
             this.longPressTimer = null;
+        }
+    }
+
+    // A long-press opens the menu while the finger is still down; on release the browser
+    // fires a synthetic "ghost" click that the dropdown service's body-click handler reads
+    // as an outside click, closing the menu instantly. Swallow that one click at the
+    // document level (capture phase, before it reaches the overlay or body).
+    suppressGhostClick() {
+        this.cancelGhostClickSuppression();
+        this.ghostClickHandler = (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            this.cancelGhostClickSuppression();
+        };
+        document.addEventListener('click', this.ghostClickHandler, true);
+        this.ghostClickTimer = setTimeout(() => this.cancelGhostClickSuppression(), 500);
+    }
+
+    cancelGhostClickSuppression() {
+        if (this.ghostClickHandler) {
+            document.removeEventListener('click', this.ghostClickHandler, true);
+            this.ghostClickHandler = null;
+        }
+        if (this.ghostClickTimer) {
+            clearTimeout(this.ghostClickTimer);
+            this.ghostClickTimer = null;
         }
     }
 
@@ -179,6 +208,7 @@ export default class ItemComponent extends Component {
             this.longPressTimer = null;
             this.longPressFired = true;
             this.openContextMenu(this.touchStartX, this.touchStartY);
+            this.suppressGhostClick();
         }, LONG_PRESS_DURATION_MS);
     }
 

--- a/ghost/admin/app/components/multi-list/item.js
+++ b/ghost/admin/app/components/multi-list/item.js
@@ -2,6 +2,11 @@ import Component from '@glimmer/component';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
+// A touch long-press is the mobile equivalent of a right-click for opening the
+// context menu, since touch devices have no contextmenu gesture of their own.
+const LONG_PRESS_DURATION_MS = 500;
+const LONG_PRESS_MOVE_THRESHOLD_PX = 10;
+
 function clearTextSelection() {
     if (window.getSelection) {
         if (window.getSelection().empty) {
@@ -15,6 +20,11 @@ function clearTextSelection() {
 export default class ItemComponent extends Component {
     @service dropdown;
 
+    longPressTimer = null;
+    longPressFired = false;
+    touchStartX = 0;
+    touchStartY = 0;
+
     get selectionList() {
         return this.args.model;
     }
@@ -25,6 +35,29 @@ export default class ItemComponent extends Component {
 
     get isSelected() {
         return this.selectionList.isSelected(this.id);
+    }
+
+    willDestroy() {
+        super.willDestroy(...arguments);
+        this.cancelLongPress();
+    }
+
+    cancelLongPress() {
+        if (this.longPressTimer) {
+            clearTimeout(this.longPressTimer);
+            this.longPressTimer = null;
+        }
+    }
+
+    openContextMenu(x, y) {
+        if (this.isSelected) {
+            this.dropdown.toggleDropdown('context-menu', this, {left: x, top: y, selectionList: this.selectionList});
+        } else {
+            this.selectionList.clearSelection();
+            this.selectionList.toggleItem(this.id);
+            this.selectionList.clearOnNextUnfreeze();
+            this.dropdown.toggleDropdown('context-menu', this, {left: x, top: y, selectionList: this.selectionList});
+        }
     }
 
     /**
@@ -64,6 +97,15 @@ export default class ItemComponent extends Component {
 
     @action
     onClick(event) {
+        // A long-press opens the context menu while the finger is still down; swallow
+        // the click that fires on release so the row doesn't also navigate
+        if (this.longPressFired) {
+            this.longPressFired = false;
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
+
         if (!this.selectionList.enabled) {
             return;
         }
@@ -96,19 +138,71 @@ export default class ItemComponent extends Component {
             return;
         }
 
-        let x = event.clientX;
-        let y = event.clientY;
-
-        if (this.isSelected) {
-            this.dropdown.toggleDropdown('context-menu', this, {left: x, top: y, selectionList: this.selectionList});
-        } else {
-            this.selectionList.clearSelection();
-            this.selectionList.toggleItem(this.id);
-            this.selectionList.clearOnNextUnfreeze();
-            this.dropdown.toggleDropdown('context-menu', this, {left: x, top: y, selectionList: this.selectionList});
+        // Some touch platforms (e.g. Android) emit a native contextmenu on long-press in
+        // addition to our timer. If the long-press already opened the menu, just swallow
+        // this event so we don't toggle it straight back closed.
+        if (this.longPressFired) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
         }
+        this.cancelLongPress();
+
+        this.openContextMenu(event.clientX, event.clientY);
 
         event.preventDefault();
         event.stopPropagation();
+    }
+
+    @action
+    onTouchStart(event) {
+        if (!this.selectionList.enabled) {
+            return;
+        }
+
+        if (event.target.closest('[data-ignore-select]')) {
+            return;
+        }
+
+        this.cancelLongPress();
+        this.longPressFired = false;
+
+        if (event.touches.length !== 1) {
+            return;
+        }
+
+        const touch = event.touches[0];
+        this.touchStartX = touch.clientX;
+        this.touchStartY = touch.clientY;
+
+        this.longPressTimer = setTimeout(() => {
+            this.longPressTimer = null;
+            this.longPressFired = true;
+            this.openContextMenu(this.touchStartX, this.touchStartY);
+        }, LONG_PRESS_DURATION_MS);
+    }
+
+    @action
+    onTouchMove(event) {
+        if (!this.longPressTimer) {
+            return;
+        }
+
+        const touch = event.touches[0];
+        if (!touch) {
+            return;
+        }
+
+        // A press that drifts past the threshold is a scroll, not a long-press
+        const dx = Math.abs(touch.clientX - this.touchStartX);
+        const dy = Math.abs(touch.clientY - this.touchStartY);
+        if (dx > LONG_PRESS_MOVE_THRESHOLD_PX || dy > LONG_PRESS_MOVE_THRESHOLD_PX) {
+            this.cancelLongPress();
+        }
+    }
+
+    @action
+    onTouchEnd() {
+        this.cancelLongPress();
     }
 }

--- a/ghost/admin/app/components/multi-list/item.js
+++ b/ghost/admin/app/components/multi-list/item.js
@@ -26,6 +26,7 @@ export default class ItemComponent extends Component {
     touchStartY = 0;
     ghostClickHandler = null;
     ghostClickTimer = null;
+    nativeContextMenuHandler = null;
 
     get selectionList() {
         return this.args.model;
@@ -43,6 +44,7 @@ export default class ItemComponent extends Component {
         super.willDestroy(...arguments);
         this.cancelLongPress();
         this.cancelGhostClickSuppression();
+        this.releaseNativeContextMenu();
     }
 
     cancelLongPress() {
@@ -75,6 +77,28 @@ export default class ItemComponent extends Component {
         if (this.ghostClickTimer) {
             clearTimeout(this.ghostClickTimer);
             this.ghostClickTimer = null;
+        }
+    }
+
+    // While the finger is held, the browser's own long-press fires a native contextmenu
+    // event; if it lands on the menu's overlay, the overlay's onContextMenuOutside handler
+    // closes the menu mid-press. Eat contextmenu at the document level for the duration of
+    // the touch so our timer is the only thing that opens or holds the menu.
+    suppressNativeContextMenu() {
+        if (this.nativeContextMenuHandler) {
+            return;
+        }
+        this.nativeContextMenuHandler = (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+        };
+        document.addEventListener('contextmenu', this.nativeContextMenuHandler, true);
+    }
+
+    releaseNativeContextMenu() {
+        if (this.nativeContextMenuHandler) {
+            document.removeEventListener('contextmenu', this.nativeContextMenuHandler, true);
+            this.nativeContextMenuHandler = null;
         }
     }
 
@@ -204,6 +228,8 @@ export default class ItemComponent extends Component {
         this.touchStartX = touch.clientX;
         this.touchStartY = touch.clientY;
 
+        this.suppressNativeContextMenu();
+
         this.longPressTimer = setTimeout(() => {
             this.longPressTimer = null;
             this.longPressFired = true;
@@ -233,6 +259,7 @@ export default class ItemComponent extends Component {
     @action
     onTouchEnd() {
         this.cancelLongPress();
+        this.releaseNativeContextMenu();
 
         // If the long-press opened the menu, the finger lift fires a synthetic ghost click
         // right after this; arm the one-shot suppressor now so that click can't close the menu.

--- a/ghost/admin/app/components/multi-list/item.js
+++ b/ghost/admin/app/components/multi-list/item.js
@@ -208,7 +208,6 @@ export default class ItemComponent extends Component {
             this.longPressTimer = null;
             this.longPressFired = true;
             this.openContextMenu(this.touchStartX, this.touchStartY);
-            this.suppressGhostClick();
         }, LONG_PRESS_DURATION_MS);
     }
 
@@ -234,5 +233,13 @@ export default class ItemComponent extends Component {
     @action
     onTouchEnd() {
         this.cancelLongPress();
+
+        // If the long-press opened the menu, the finger lift fires a synthetic ghost click
+        // right after this; arm the one-shot suppressor now so that click can't close the menu.
+        // Arming here (at release) rather than when the menu opened means it works no matter
+        // how long the press was held.
+        if (this.longPressFired) {
+            this.suppressGhostClick();
+        }
     }
 }

--- a/ghost/admin/app/components/multi-list/item.js
+++ b/ghost/admin/app/components/multi-list/item.js
@@ -6,6 +6,9 @@ import {inject as service} from '@ember/service';
 // context menu, since touch devices have no contextmenu gesture of their own.
 const LONG_PRESS_DURATION_MS = 500;
 const LONG_PRESS_MOVE_THRESHOLD_PX = 10;
+// The compatibility "ghost" click fires at the release point; only swallow clicks
+// within this radius of it so a real tap on a menu action is never discarded.
+const GHOST_CLICK_RADIUS_PX = 20;
 
 function clearTextSelection() {
     if (window.getSelection) {
@@ -57,12 +60,18 @@ export default class ItemComponent extends Component {
     // A long-press opens the menu while the finger is still down; on release the browser
     // fires a synthetic "ghost" click that the dropdown service's body-click handler reads
     // as an outside click, closing the menu instantly. Swallow that one click at the
-    // document level (capture phase, before it reaches the overlay or body).
+    // document level (capture phase, before it reaches the overlay or body) — but only when
+    // it lands at the release point, so a real tap on a menu action elsewhere is never
+    // discarded, even if the browser happens not to emit the ghost click.
     suppressGhostClick() {
         this.cancelGhostClickSuppression();
         this.ghostClickHandler = (event) => {
-            event.preventDefault();
-            event.stopPropagation();
+            const isGhostClick = Math.abs(event.clientX - this.touchStartX) <= GHOST_CLICK_RADIUS_PX
+                && Math.abs(event.clientY - this.touchStartY) <= GHOST_CLICK_RADIUS_PX;
+            if (isGhostClick) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
             this.cancelGhostClickSuppression();
         };
         document.addEventListener('click', this.ghostClickHandler, true);

--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -16,7 +16,7 @@
                     </div>
                 {{/unless}}
             </div>
-            <div>
+            <div class="gh-post-list-title-content">
                 <h3 class="gh-content-entry-title">
                     {{@post.title}}
                 </h3>
@@ -66,7 +66,7 @@
                     </div>
                 {{/unless}}
             </div>
-            <div>
+            <div class="gh-post-list-title-content">
                 <h3 class="gh-content-entry-title">
                     {{#if @post.featured}}
                         {{svg-jar "star-fill" class="gh-featured-post"}}

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -792,8 +792,15 @@
         max-width: calc(100% - 140px);
     }
 
-    /* let the title/meta block shrink so a long title or tag name can't hold the
-       row open and push the row's action button past the viewport */
+    /* the list is a CSS table, which sizes to its content and so grows past the
+       viewport on a phone; make it a normal block (the table columns are already
+       hidden at this width) so it tracks the viewport instead */
+    .posts-list.gh-list {
+        display: block;
+    }
+
+    /* with the table gone, let the title/meta block shrink so a long title or tag
+       name can't hold the row open and push its action button off-screen */
     .gh-post-list-title-content {
         min-width: 0;
         overflow: hidden;

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -791,6 +791,23 @@
     .gh-post-list-author {
         max-width: calc(100% - 140px);
     }
+
+    /* let the title/meta block shrink so a long title or tag name can't hold the
+       row open and push the row's action button past the viewport */
+    .gh-post-list-title-content {
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    .gh-post-list-title-content .gh-content-entry-title {
+        overflow-wrap: anywhere;
+    }
+
+    .gh-post-list-title-content .gh-content-entry-meta {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }
 
 @media (max-width: 430px) {

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -249,6 +249,15 @@
     border-color: transparent;
 }
 
+/* On touch devices a long-press opens the context menu, so suppress the native
+   link-callout and text-selection magnifier that would otherwise fire on the row */
+@media (hover: none) and (pointer: coarse) {
+    .gh-posts-list-item-group {
+        -webkit-touch-callout: none;
+        user-select: none;
+    }
+}
+
 .posts-list[data-ctrl] .gh-posts-list-item-group:hover::before {
     opacity: 0.05;
     background: #6E78E5;

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -806,14 +806,11 @@
         overflow: hidden;
     }
 
-    .gh-post-list-title-content .gh-content-entry-title {
-        overflow-wrap: anywhere;
-    }
-
+    /* wrap (and break long unbroken tokens like a numeric tag) rather than run off
+       the side, so nothing in the row can extend past the viewport */
+    .gh-post-list-title-content .gh-content-entry-title,
     .gh-post-list-title-content .gh-content-entry-meta {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        overflow-wrap: anywhere;
     }
 }
 

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -794,9 +794,12 @@
 
     /* the list is a CSS table, which sizes to its content and so grows past the
        viewport on a phone; make it a normal block (the table columns are already
-       hidden at this width) so it tracks the viewport instead */
+       hidden at this width) so it tracks the viewport instead. Keep a min-width so
+       the text column stays usable on very narrow screens (the page scrolls a little
+       below ~350px rather than breaking titles mid-word) */
     .posts-list.gh-list {
         display: block;
+        min-width: 300px;
     }
 
     /* with the table gone, let the title/meta block shrink so a long title or tag

--- a/ghost/admin/app/styles/layouts/posts.css
+++ b/ghost/admin/app/styles/layouts/posts.css
@@ -430,10 +430,16 @@
         justify-content: flex-end;
         min-width: 0;
         max-width: 100% !important;
-        padding: 0 0 6px;
+        padding: 0;
         overflow-x: auto;
         overflow-y: visible;
-        scrollbar-width: thin;
+        /* the overlay scrollbar floats over the chips and can't be pushed below with
+           padding; hide it and let the row scroll by swipe/trackpad instead */
+        scrollbar-width: none;
+    }
+
+    .post-header .view-actions-bottom-row::-webkit-scrollbar {
+        display: none;
     }
 
     .post-header .view-actions::before {

--- a/ghost/admin/app/styles/layouts/posts.css
+++ b/ghost/admin/app/styles/layouts/posts.css
@@ -430,9 +430,10 @@
         justify-content: flex-end;
         min-width: 0;
         max-width: 100% !important;
-        padding: 0;
+        padding: 0 0 6px;
         overflow-x: auto;
         overflow-y: visible;
+        scrollbar-width: thin;
     }
 
     .post-header .view-actions::before {

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import windowProxy from 'ghost-admin/utils/window-proxy';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {beforeEach, describe, it} from 'mocha';
-import {blur, click, currentURL, fillIn, find, findAll, triggerEvent, triggerKeyEvent, visit} from '@ember/test-helpers';
+import {blur, click, currentURL, fillIn, find, findAll, settled, triggerEvent, triggerKeyEvent, visit} from '@ember/test-helpers';
 import {clickTrigger, selectChoose, selectSearch} from 'ember-power-select/test-support/helpers';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
@@ -395,6 +395,57 @@ describe('Acceptance: Posts / Pages', function () {
                         expect(posts.length, 'all posts count').to.equal(5);
                         let [lastRequest] = this.server.pretender.handledRequests.slice(-1);
                         expect(lastRequest.url, 'request url').to.match(new RegExp(`/posts/${publishedPost.id}/copy/`));
+                    });
+
+                    it('opens the context menu via long-press on touch devices', async function () {
+                        await visit('/posts');
+
+                        const post = find(`[data-test-post-id="${publishedPost.id}"]`);
+                        expect(post, 'post').to.exist;
+
+                        // touch devices have no contextmenu gesture, so a long-press opens the menu
+                        await triggerEvent(post, 'touchstart', {touches: [{clientX: 10, clientY: 10}]});
+
+                        // wait for the long-press timer to fire, then let the menu render
+                        await new Promise((resolve) => {
+                            setTimeout(resolve, 700);
+                        });
+                        await settled();
+
+                        const contextMenu = find('.gh-posts-context-menu');
+                        expect(contextMenu, 'context menu').to.exist;
+
+                        const buttons = [...contextMenu.querySelectorAll('button')];
+                        const duplicate = buttons.find(button => button.innerText.trim().includes('Duplicate'));
+                        expect(duplicate, 'duplicate button').to.exist;
+
+                        await click(duplicate);
+
+                        const posts = findAll('[data-test-post-id]');
+                        expect(posts.length, 'all posts count').to.equal(5);
+                        const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
+                        expect(lastRequest.url, 'request url').to.match(new RegExp(`/posts/${publishedPost.id}/copy/`));
+                    });
+
+                    it('does not open the context menu when a touch becomes a scroll', async function () {
+                        await visit('/posts');
+
+                        const post = find(`[data-test-post-id="${publishedPost.id}"]`);
+                        expect(post, 'post').to.exist;
+
+                        await triggerEvent(post, 'touchstart', {touches: [{clientX: 10, clientY: 10}]});
+                        // a press that drifts past the threshold is a scroll and cancels the long-press
+                        await triggerEvent(post, 'touchmove', {touches: [{clientX: 10, clientY: 60}]});
+
+                        await new Promise((resolve) => {
+                            setTimeout(resolve, 700);
+                        });
+                        await settled();
+
+                        // the menu markup is always present; open-state lives on the container,
+                        // and the Duplicate action only renders once a row is selected
+                        expect(find('.gh-context-menu-container').getAttribute('data-open'), 'context menu open state').to.not.equal('true');
+                        expect(find('[data-test-post-context-menu] [data-test-button="duplicate"]'), 'duplicate button').to.not.exist;
                     });
 
                     it('can copy a post link', async function () {

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -414,7 +414,8 @@ describe('Acceptance: Posts / Pages', function () {
 
                         expect(find('.gh-posts-context-menu'), 'context menu visible after long-press').to.be.visible;
 
-                        // releasing a long-press fires a synthetic click; it must not close the menu we just opened
+                        // releasing the long-press fires a synthetic click; it must not close the menu we just opened
+                        await triggerEvent(post, 'touchend');
                         await triggerEvent(find('.gh-context-menu-overlay'), 'click');
                         expect(find('.gh-posts-context-menu'), 'context menu stays visible after release click').to.be.visible;
 

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -397,7 +397,7 @@ describe('Acceptance: Posts / Pages', function () {
                         expect(lastRequest.url, 'request url').to.match(new RegExp(`/posts/${publishedPost.id}/copy/`));
                     });
 
-                    it('opens the context menu via long-press on touch devices', async function () {
+                    it('opens the context menu via long-press and keeps it open on release', async function () {
                         await visit('/posts');
 
                         const post = find(`[data-test-post-id="${publishedPost.id}"]`);
@@ -412,9 +412,13 @@ describe('Acceptance: Posts / Pages', function () {
                         });
                         await settled();
 
-                        const contextMenu = find('.gh-posts-context-menu');
-                        expect(contextMenu, 'context menu').to.exist;
+                        expect(find('.gh-posts-context-menu'), 'context menu visible after long-press').to.be.visible;
 
+                        // releasing a long-press fires a synthetic click; it must not close the menu we just opened
+                        await triggerEvent(find('.gh-context-menu-overlay'), 'click');
+                        expect(find('.gh-posts-context-menu'), 'context menu stays visible after release click').to.be.visible;
+
+                        const contextMenu = find('.gh-posts-context-menu');
                         const buttons = [...contextMenu.querySelectorAll('button')];
                         const duplicate = buttons.find(button => button.innerText.trim().includes('Duplicate'));
                         expect(duplicate, 'duplicate button').to.exist;

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -418,11 +418,40 @@ describe('Acceptance: Posts / Pages', function () {
                         await triggerEvent(find('.gh-context-menu-overlay'), 'contextmenu');
                         expect(find('.gh-posts-context-menu'), 'context menu stays visible while held').to.be.visible;
 
-                        // releasing the long-press fires a synthetic click; it must not close the menu either
+                        // releasing the long-press fires a synthetic click at the touch point; it must not close the menu
                         await triggerEvent(post, 'touchend');
-                        await triggerEvent(find('.gh-context-menu-overlay'), 'click');
+                        await triggerEvent(find('.gh-context-menu-overlay'), 'click', {clientX: 10, clientY: 10});
                         expect(find('.gh-posts-context-menu'), 'context menu stays visible after release click').to.be.visible;
 
+                        const contextMenu = find('.gh-posts-context-menu');
+                        const buttons = [...contextMenu.querySelectorAll('button')];
+                        const duplicate = buttons.find(button => button.innerText.trim().includes('Duplicate'));
+                        expect(duplicate, 'duplicate button').to.exist;
+
+                        await click(duplicate);
+
+                        const posts = findAll('[data-test-post-id]');
+                        expect(posts.length, 'all posts count').to.equal(5);
+                        const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
+                        expect(lastRequest.url, 'request url').to.match(new RegExp(`/posts/${publishedPost.id}/copy/`));
+                    });
+
+                    it('does not discard a real tap on a menu action after a long-press', async function () {
+                        await visit('/posts');
+
+                        const post = find(`[data-test-post-id="${publishedPost.id}"]`);
+                        expect(post, 'post').to.exist;
+
+                        await triggerEvent(post, 'touchstart', {touches: [{clientX: 10, clientY: 10}]});
+                        await new Promise((resolve) => {
+                            setTimeout(resolve, 700);
+                        });
+                        await settled();
+                        // arm the ghost-click suppressor, but emit no synthetic release click
+                        await triggerEvent(post, 'touchend');
+
+                        // a real tap on a menu action (away from the touch point) must still go through,
+                        // even though the suppressor is armed and no ghost click was consumed
                         const contextMenu = find('.gh-posts-context-menu');
                         const buttons = [...contextMenu.querySelectorAll('button')];
                         const duplicate = buttons.find(button => button.innerText.trim().includes('Duplicate'));

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -414,7 +414,11 @@ describe('Acceptance: Posts / Pages', function () {
 
                         expect(find('.gh-posts-context-menu'), 'context menu visible after long-press').to.be.visible;
 
-                        // releasing the long-press fires a synthetic click; it must not close the menu we just opened
+                        // the browser's own long-press fires a native contextmenu while held; it must not close the menu
+                        await triggerEvent(find('.gh-context-menu-overlay'), 'contextmenu');
+                        expect(find('.gh-posts-context-menu'), 'context menu stays visible while held').to.be.visible;
+
+                        // releasing the long-press fires a synthetic click; it must not close the menu either
                         await triggerEvent(post, 'touchend');
                         await triggerEvent(find('.gh-context-menu-overlay'), 'click');
                         expect(find('.gh-posts-context-menu'), 'context menu stays visible after release click').to.be.visible;


### PR DESCRIPTION
## Why

Two mobile gaps in the posts list:

1. The context menu (Duplicate, Feature, Delete, etc.) only opened via right-click, which touch devices can't produce — so mobile users had no way to duplicate a post.
2. On phones the list rendered wider than the viewport, so rows and the action button ran off the right edge.

## What

**1. Long-press opens the context menu on touch.** A long-press on a post row opens the same context menu through the existing `dropdown.toggleDropdown('context-menu', …)` path — the natural touch equivalent of a right-click. No new visible UI; the menu and all its actions are reused unchanged. Details:
- 500ms press with a 10px movement threshold, so a scroll doesn't trigger it.
- Suppresses the synthetic "ghost" click fired on release (armed at touchend, so it works regardless of how long the press is held) and the browser's native long-press `contextmenu` during the hold — both of which would otherwise close the menu via the dropdown service's outside-click / `onContextMenuOutside` handlers.
- Suppresses the iOS link-callout / selection magnifier on rows, scoped to touch via `@media (hover: none) and (pointer: coarse)`.

**2. Posts list fits the viewport on mobile.** The title/meta block is a flex child with no `min-width`, so a long title or tag name held the row open and pushed the row's action button (and the whole list) past the viewport. Giving that block `min-width: 0` lets it collapse; the title breaks long words and the meta line truncates with an ellipsis (≤800px).

## Testing

`ember test --filter "context menu"` → all green, including new acceptance tests that long-press to open + duplicate a post, assert the menu survives both a native `contextmenu` mid-hold and the release click, and that a touch which becomes a scroll does not open the menu.
