### PR TITLE
🐛 Fixed newsletter feedback buttons breaking after a slug change

### DIFF
--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-controller.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-controller.js
@@ -20,13 +20,38 @@ const messages = {
 class AudienceFeedbackController {
     /** @type IFeedbackRepository */
     #repository;
+    /** @type {import('./audience-feedback-service')} */
+    #audienceFeedbackService;
 
     /**
      * @param {object} deps
      * @param {IFeedbackRepository} deps.repository
+     * @param {import('./audience-feedback-service')} deps.audienceFeedbackService
      */
     constructor(deps) {
         this.#repository = deps.repository;
+        this.#audienceFeedbackService = deps.audienceFeedbackService;
+    }
+
+    /**
+     * Express handler for the durable, id-based feedback link in newsletters.
+     * Resolves the post's *current* URL from its id and redirects to the Portal
+     * feedback flow, so changing a post's slug never breaks feedback buttons.
+     * Authentication happens later when Portal submits to the feedback API — this
+     * endpoint only forwards the uuid/key through to the destination.
+     */
+    redirectToPost(req, res, next) {
+        try {
+            const {postId} = req.params;
+            const score = req.params.score === '1' ? 1 : 0;
+            const uuid = req.query.uuid;
+            const key = req.query.key;
+
+            const target = this.#audienceFeedbackService.buildLink(uuid, {id: postId}, score, key);
+            return res.redirect(target.toString());
+        } catch (err) {
+            return next(err);
+        }
     }
 
     /**

--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
@@ -32,6 +32,25 @@ class AudienceFeedbackService {
         url.hash = `#/feedback/${postData.id}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
         return url;
     }
+
+    /**
+     * Build the feedback link embedded in a newsletter. It targets the members
+     * feedback redirect endpoint keyed by post id (never the slug), so it
+     * survives slug/permalink changes — the endpoint resolves the post's current
+     * URL at click time. uuid/key are Mailgun placeholders substituted per member.
+     *
+     * @param {{id: string}} post
+     * @param {0 | 1} score
+     * @returns {string}
+     */
+    buildEmailLink(post, score) {
+        const {id} = toPlain(post);
+        const url = new URL(this.#baseURL.href);
+        url.pathname = url.pathname.replace(/\/+$/, '') + `/members/feedback/${id}/${score}/`;
+        // Append placeholders by string concatenation so the %%{...}%% tokens are
+        // not percent-encoded by the URL serializer (Mailgun substitutes them).
+        return `${url.href}?uuid=%%{uuid}%%&key=%%{key}%%`;
+    }
 }
 
 module.exports = AudienceFeedbackService;

--- a/ghost/core/core/server/services/audience-feedback/index.js
+++ b/ghost/core/core/server/services/audience-feedback/index.js
@@ -30,7 +30,10 @@ class AudienceFeedbackServiceWrapper {
                 baseURL: new URL(urlUtils.urlFor('home', true))
             }
         });
-        this.controller = new AudienceFeedbackController({repository: this.repository});
+        this.controller = new AudienceFeedbackController({
+            repository: this.repository,
+            audienceFeedbackService: this.service
+        });
     }
 }
 

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1055,19 +1055,10 @@ class EmailRenderer {
         const signupUrl = new URL(postUrl);
         signupUrl.hash = `/portal/signup`;
 
-        // Audience feedback
-        const positiveLink = this.#audienceFeedbackService.buildLink(
-            '--uuid--',
-            post,
-            1,
-            '--key--'
-        ).href.replace('--uuid--', '%%{uuid}%%').replace('--key--', '%%{key}%%');
-        const negativeLink = this.#audienceFeedbackService.buildLink(
-            '--uuid--',
-            post,
-            0,
-            '--key--'
-        ).href.replace('--uuid--', '%%{uuid}%%').replace('--key--', '%%{key}%%');
+        // Audience feedback — durable, id-based links resolved to the post's
+        // current URL at click time so they survive slug changes
+        const positiveLink = this.#audienceFeedbackService.buildEmailLink(post, 1);
+        const negativeLink = this.#audienceFeedbackService.buildEmailLink(post, 0);
 
         const commentUrl = new URL(postUrl);
         commentUrl.hash = '#ghost-comments-root';

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -4,6 +4,7 @@ const express = require('../../../shared/express');
 const sentry = require('../../../shared/sentry');
 const membersService = require('../../services/members');
 const stripeService = require('../../services/stripe');
+const audienceFeedbackService = require('../../services/audience-feedback');
 const middleware = membersService.middleware;
 const shared = require('../shared');
 const errorHandler = require('@tryghost/mw-error-handler');
@@ -133,6 +134,13 @@ module.exports = function setupMembersApp() {
         middleware.loadMemberSession,
         middleware.authMemberByUuid,
         http(api.feedbackMembers.add)
+    );
+
+    // Durable, id-based feedback link from newsletters. Resolves the post's
+    // current URL at click time so changing a slug never breaks feedback buttons.
+    membersApp.get(
+        '/feedback/:postId/:score',
+        (req, res, next) => audienceFeedbackService.controller.redirectToPost(req, res, next)
     );
 
     // Gifts

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-controller.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-controller.test.js
@@ -1,0 +1,56 @@
+const sinon = require('sinon');
+const AudienceFeedbackController = require('../../../../../core/server/services/audience-feedback/audience-feedback-controller');
+
+describe('AudienceFeedbackController', function () {
+    describe('redirectToPost', function () {
+        const postId = '634fc3901e0a291855d8b135';
+        const uuid = '7b11de3c-dff9-4563-82ae-a281122d201d';
+        const key = 'a'.repeat(64);
+
+        function createController(buildLink) {
+            return new AudienceFeedbackController({
+                repository: {},
+                audienceFeedbackService: {buildLink}
+            });
+        }
+
+        it('resolves the post by id and redirects to the feedback flow', function () {
+            const buildLink = sinon.stub().returns(
+                new URL(`https://site.com/current-slug/#/feedback/${postId}/1/?uuid=${uuid}&key=${key}`)
+            );
+            const controller = createController(buildLink);
+            const req = {params: {postId, score: '1'}, query: {uuid, key}};
+            const res = {redirect: sinon.fake()};
+
+            controller.redirectToPost(req, res, () => {});
+
+            sinon.assert.calledOnceWithExactly(buildLink, uuid, {id: postId}, 1, key);
+            sinon.assert.calledOnceWithExactly(
+                res.redirect,
+                `https://site.com/current-slug/#/feedback/${postId}/1/?uuid=${uuid}&key=${key}`
+            );
+        });
+
+        it('coerces any non-"1" score to 0', function () {
+            const buildLink = sinon.stub().returns(new URL('https://site.com/'));
+            const controller = createController(buildLink);
+            const req = {params: {postId, score: 'bogus'}, query: {uuid, key}};
+            controller.redirectToPost(req, {redirect: sinon.fake()}, () => {});
+
+            sinon.assert.calledOnceWithExactly(buildLink, uuid, {id: postId}, 0, key);
+        });
+
+        it('forwards errors to next', function () {
+            const error = new Error('boom');
+            const buildLink = sinon.stub().throws(error);
+            const controller = createController(buildLink);
+            const next = sinon.fake();
+            const res = {redirect: sinon.fake()};
+
+            controller.redirectToPost({params: {postId, score: '1'}, query: {}}, res, next);
+
+            sinon.assert.notCalled(res.redirect);
+            sinon.assert.calledOnceWithExactly(next, error);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
@@ -100,4 +100,47 @@ describe('audienceFeedbackService', function () {
             assert.match(link.href, new RegExp(`#/feedback/${mockData.postId}/`));
         });
     });
+
+    describe('build email link', function () {
+        function createInstance(baseURL) {
+            return new AudienceFeedbackService({
+                urlService: {facade: {}},
+                config: {baseURL: new URL(baseURL)}
+            });
+        }
+
+        it('builds an id-based redirect link with placeholders (no slug)', async function () {
+            const instance = createInstance('https://localhost:2368/');
+            const link = instance.buildEmailLink(mockPost, mockData.score);
+            assert.equal(
+                link,
+                `https://localhost:2368/members/feedback/${mockData.postId}/${mockData.score}/?uuid=%%{uuid}%%&key=%%{key}%%`
+            );
+        });
+
+        it('does not depend on the url service / post slug', async function () {
+            const instance = createInstance('https://localhost:2368/');
+            const link = instance.buildEmailLink(mockPost, 0);
+            assert.match(link, new RegExp(`/members/feedback/${mockData.postId}/0/`));
+            assert(!link.includes(mockData.postTitle));
+        });
+
+        it('respects a subdirectory base URL', async function () {
+            const instance = createInstance('https://localhost:2368/blog/');
+            const link = instance.buildEmailLink(mockPost, 1);
+            assert.equal(
+                link,
+                `https://localhost:2368/blog/members/feedback/${mockData.postId}/1/?uuid=%%{uuid}%%&key=%%{key}%%`
+            );
+        });
+
+        it('serialises Bookshelf-model input so spread does not lose the id', async function () {
+            const instance = createInstance('https://localhost:2368/');
+            const fakeBookshelfModel = {
+                toJSON: () => ({id: mockData.postId, slug: mockData.postTitle, type: 'post'})
+            };
+            const link = instance.buildEmailLink(fakeBookshelfModel, 1);
+            assert.match(link, new RegExp(`/members/feedback/${mockData.postId}/1/`));
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1305,8 +1305,8 @@ describe('Email renderer', function () {
             };
             emailRenderer = new EmailRenderer({
                 audienceFeedbackService: {
-                    buildLink: (_uuid, _postId, score, key) => {
-                        return new URL('http://feedback-link.com/?score=' + encodeURIComponent(score) + '&uuid=' + encodeURIComponent(_uuid) + '&key=' + encodeURIComponent(key));
+                    buildEmailLink: (_post, score) => {
+                        return 'http://feedback-link.com/?score=' + score + '&uuid=%%{uuid}%%&key=%%{key}%%';
                     }
                 },
                 urlUtils: {
@@ -2473,8 +2473,8 @@ describe('Email renderer', function () {
             labsEnabled = false;
             emailRenderer = new EmailRenderer({
                 audienceFeedbackService: {
-                    buildLink: (_uuid, _postId, score) => {
-                        return new URL('http://feedback-link.com/?score=' + encodeURIComponent(score) + '&uuid=' + encodeURIComponent(_uuid));
+                    buildEmailLink: (_post, score) => {
+                        return 'http://feedback-link.com/?score=' + score + '&uuid=%%{uuid}%%';
                     }
                 },
                 urlUtils: {
@@ -3638,8 +3638,8 @@ describe('Email renderer', function () {
             });
             emailRenderer = new EmailRenderer({
                 audienceFeedbackService: {
-                    buildLink: (_uuid, _postId, score, key) => {
-                        return new URL('http://feedback-link.com/?score=' + encodeURIComponent(score) + '&uuid=' + encodeURIComponent(_uuid) + '&key=' + encodeURIComponent(key));
+                    buildEmailLink: (_post, score) => {
+                        return 'http://feedback-link.com/?score=' + score + '&uuid=%%{uuid}%%&key=%%{key}%%';
                     }
                 },
                 urlUtils: {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/23196

## Problem
Newsletter feedback buttons ("More like this" / "Less like this") stop working once a post's slug/permalink is changed after the newsletter was sent — and they can't be repaired.

## Root cause
The feedback link was built from the post's **permalink** (which contains the slug) plus a `#/feedback/<postId>/<score>/` hash. But the slug was only ever the page Portal loads on — Portal reads the feedback route entirely from the hash, and the post is identified by its **id**, which is already in the link. So the slug was never load-bearing; it just made the link fragile: change the slug and the old URL 404s.

## Approach
Newsletters now link to a durable, **id-based** members redirect:

```
/members/feedback/:postId/:score?uuid=%%{uuid}%%&key=%%{key}%%
```

On click, a small controller resolves the post's **current** URL from the in-memory URL service (by id) and 302s to the Portal feedback flow. Because the link is keyed on the immutable post id and the slug is resolved at click time, feedback buttons survive any number of slug changes — with no broken-link-tool fixup, no stored redirect rows, and no migration.

This supersedes the earlier approach (storing feedback links as editable redirects), which only made broken links _fixable_; this makes them _unbreakable_.

## Testing
- `audience-feedback-service` unit tests — `buildEmailLink`: id-based shape, subdirectory support, slug independence
- `audience-feedback-controller` unit tests — `redirectToPost`: id resolution, score coercion, error passthrough
- `email-renderer` unit tests — feedback links stay untracked and carry the uuid/key placeholders

### Manual testing
1. Enable feedback buttons and send a newsletter for a post.
2. Change the post's permalink.
3. Click an old feedback button in the already-sent email and confirm it lands on the feedback flow for the post at its new URL.
