### PR TITLE
Removed unused ActivityPub truncate helper

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.40",
+  "version": "3.1.41",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/utils/truncate.ts
+++ b/apps/activitypub/src/utils/truncate.ts
@@ -1,5 +1,0 @@
-const truncate = (text: string, maxLength: number = 30): string => {
-    return text.length > maxLength ? text.slice(0, maxLength) + '...' : text;
-};
-
-export default truncate;


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
  - The ActivityPub truncate utility is no longer referenced after notification text handling moved into component-level layout and clamping.
- What does it do?
  - Removes the unused `apps/activitypub/src/utils/truncate.ts` helper and bumps the ActivityPub package version.
- Why is this something Ghost users or developers need?
  - It keeps the ActivityPub package tidy by removing dead code that no longer has call sites.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏