### PR TITLE
Added `automation_action_revision_id` foreign key column to `automated_email_recipients` table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.46/2026-06-15-16-49-31-add-automation-action-revision-id-to-automated-email-recipients.js
+++ b/ghost/core/core/server/data/migrations/versions/6.46/2026-06-15-16-49-31-add-automation-action-revision-id-to-automated-email-recipients.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('automated_email_recipients', 'automation_action_revision_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true,
+    references: 'automation_action_revisions.id'
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1271,6 +1271,7 @@ module.exports = {
     automated_email_recipients: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         automated_email_id: {type: 'string', maxlength: 24, nullable: true, references: 'welcome_email_automated_emails.id'},
+        automation_action_revision_id: {type: 'string', maxlength: 24, nullable: true, references: 'automation_action_revisions.id'},
         member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
         member_uuid: {type: 'string', maxlength: 36, nullable: false},
         member_email: {type: 'string', maxlength: 191, nullable: false},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c35d4c05893f208ab95b59d8d3eb59bf';
+    const currentSchemaHash = 'ded1ed3d1c650680c8fb88b3c6ba17de';
     const currentFixturesHash = '823aa0e8a8f083e80e271c47836a7e5d';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
towards [NY-1334](https://linear.app/ghost/issue/NY-1334/readwrite-automated-email-recipients-table-to-populate-member-details)
closes [NY-1337](https://linear.app/ghost/issue/NY-1337/update-automated-email-recipients-with-a-nullable-fk-reference-to)

## Summary

_This change should have no user-facing impact._

This change adds a nullable `automation_action_revision_id` foreign-key column to the `automated_email_recipients` table. This will soon support showing sent emails in the member activity feed, and lays the groundwork for (eventually, maybe) adding email analytics for emails sent via automations. 

Nothing is using this column yet, but that will change soon!