### PR TITLE
🐛 Fixed mobile admin nav bar reloading admin and its dark-mode active state

### DIFF
--- a/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
+++ b/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
@@ -13,6 +13,9 @@ interface MobileNavBarButtonProps extends Omit<React.ComponentProps<typeof Butto
 
 function MobileNavBarButton({ to, activeOnSubpath = false, children, ...props }: MobileNavBarButtonProps) {
     const isActive = useIsActiveLink({ path: to, activeOnSubpath });
+    // Use a hash route (e.g. "#/posts") so navigation stays client-side; a bare
+    // relative href like "posts" triggers a full page load and reloads all of admin.
+    const href = `#/${to?.replace(/^\/?#\//, '')}`;
 
     return (
         <Button
@@ -22,7 +25,7 @@ function MobileNavBarButton({ to, activeOnSubpath = false, children, ...props }:
             size="icon"
             data-active={isActive}
         >
-            <a href={to}>
+            <a href={href}>
                 {children}
             </a>
         </Button>

--- a/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
+++ b/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
@@ -17,7 +17,7 @@ function MobileNavBarButton({ to, activeOnSubpath = false, children, ...props }:
     return (
         <Button
             asChild
-            className={`w-full max-w-16 min-w-9 rounded-full hover:bg-gray-200 ${isActive ? 'bg-gray-200' : 'bg-transparent'}`} {...props}
+            className={`w-full max-w-16 min-w-9 rounded-full hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ${isActive ? 'bg-sidebar-accent text-sidebar-accent-foreground' : 'bg-transparent'}`} {...props}
             variant="ghost"
             size="icon"
             data-active={isActive}


### PR DESCRIPTION
Two fixes to the mobile admin nav bar (`mobile-nav-bar.tsx`), both stemming from it not following the patterns the rest of the sidebar nav already uses.

## 1. Tapping an item reloaded all of admin

The nav buttons linked with a bare relative href — `<a href="posts">` — so the browser navigated to a real path (`/ghost/posts`) and did a full page load: the whole admin reloaded, with a white-screen flash before the dark theme re-applied.

The canonical `NavMenuItem.Link` avoids this by building a hash href (`#/posts`), which is a client-side hash change. This now does the same:

```jsx
const href = `#/${to?.replace(/^\/?#\//, '')}`;
<a href={href}>
```

## 2. Active item rendered a light pill in dark mode

The active/hover state hardcoded `bg-gray-200` — a fixed light gray that ignores the theme — so the active item showed as a bright pill on the dark bar (with a low-contrast icon). Every other style here already uses theme tokens (`bg-sidebar`, `border-sidebar-border`); the active state just got a literal gray.

Swapped to the theme-aware sidebar tokens (`bg-sidebar-accent` / `text-sidebar-accent-foreground`), matching shade's canonical `SidebarMenuButton`.

## Notes

A grep of the admin shell turned up a few other hardcoded grays (`text-gray-700` on some sidebar action buttons; `text-gray-*` with `dark:` variants in the header). Those are text colors on hover/focus or already carry `dark:` overrides, so they're milder and more of a design call — left out to keep this focused.
