### PR TITLE
Fixed `pnpm dev` failing due to announcement-bar race condition

### DIFF
--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -18,7 +18,7 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
+    "dev": "pnpm build && concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "test": "vitest run",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -15,7 +15,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
+    "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
     "dev:test": "vite build && vite preview --port 7175",
     "build": "vite build",
     "build:watch": "vite build --watch",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -14,7 +14,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "concurrently --kill-others --names preview,build \"pnpm preview -l silent\" \"pnpm build:watch\"",
+    "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "preview": "vite preview",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -14,7 +14,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "concurrently --kill-others --names dev,preview,build \"vite --port 6173\" \"vite preview -l silent\" \"vite build --watch\"",
+    "dev": "pnpm build && concurrently --kill-others --names dev,preview,build \"vite --port 6173\" \"vite preview -l silent\" \"vite build --watch\"",
     "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch\"",
     "dev:test": "vite build && vite preview --port 6175",
     "build": "tsc && vite build",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -21,7 +21,7 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "concurrently --kill-others --names preview,build,tailwind \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
+    "dev": "pnpm build && concurrently --kill-others --names preview,build,tailwind \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
     "build": "vite build && pnpm tailwind:base",
     "build:watch": "vite build --watch",
     "tailwind": "pnpm tailwind:base --watch ",


### PR DESCRIPTION
no refs

On a fresh clone or worktree of Ghost, `pnpm dev` is currently failing in the announcement bar app. The announcement-bar dev script runs `pnpm build:watch` and `pnpm preview` concurrently, and `vite preview` will fail if the `/umd` build output directory doesn't exist yet. I'm not sure if this is flaky or failing 100% of the time, but regardless this change forces the `/umd` directory to exist before `vite preview` can run. 