### PR TITLE
Removed unused Automation model relation

### DIFF
--- a/ghost/core/core/server/models/automation.js
+++ b/ghost/core/core/server/models/automation.js
@@ -17,10 +17,6 @@ const Automation = ghostBookshelf.Model.extend({
         return this.hasOne('WelcomeEmailAutomatedEmail', 'welcome_email_automation_id');
     },
 
-    welcomeEmailAutomatedEmails() {
-        return this.hasMany('WelcomeEmailAutomatedEmail', 'welcome_email_automation_id');
-    },
-
     onSaved(model) {
         if (!model?.id) {
             return;


### PR DESCRIPTION
no ref

This change should have no user impact.

`welcomeEmailAutomatedEmails` was never used. Let's remove it. (Note that the singular `welcomeEmailAutomatedEmail` *was* used.)
