### PR TITLE
Don't trigger legacy automations if new ones are on

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -12,6 +12,7 @@ const hasActiveOffer = require('../utils/has-active-offer');
 const StartAutomationsPollEvent = require('../../../automations/events/start-automations-poll-event');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../member-welcome-emails/constants');
 const db = require('../../../../data/db');
+const labs = require('../../../../../shared/labs');
 /** @import {Knex} from 'knex' */
 /** @import * as automationsApi from '../../../automations/automations-api' */
 
@@ -221,6 +222,10 @@ module.exports = class MemberRepository {
      */
     async #triggerMemberSignupLegacyAutomation(memberId, memberStatus, options) {
         if (!this._Automation || !this._WelcomeEmailAutomationRun) {
+            return;
+        }
+
+        if (labs.isSet('automations')) {
             return;
         }
 

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -733,6 +733,8 @@ describe('Gift Subscriptions', function () {
         describe('Anonymous visitor (gift redemption via magic link)', function () {
             describe('New member', function () {
                 it('signs up and redeems a gift during magic link confirmation', async function () {
+                    mockManager.mockLabsDisabled('automations');
+
                     const email = 'gift-redemption-member@test.com';
                     const gift = await createGift();
                     const originalWelcomePageUrl = paidProduct.get('welcome_page_url');
@@ -863,6 +865,8 @@ describe('Gift Subscriptions', function () {
 
             describe('Existing member', function () {
                 it('signs in and redeems a gift during magic link confirmation', async function () {
+                    mockManager.mockLabsDisabled('automations');
+
                     const email = 'gift-existing-member@test.com';
 
                     // Create member first
@@ -1162,6 +1166,8 @@ describe('Gift Subscriptions', function () {
         });
 
         it('does not enqueue a second paid welcome email when a gift member upgrades to paid', async function () {
+            mockManager.mockLabsDisabled('automations');
+
             const {member, gift} = await setupGiftMember({cadence: 'month', consumesInDays: 30});
 
             let paidWelcomeAutomation;

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const ObjectId = require('bson-objectid').default;
 const testUtils = require('../../utils');
+const {mockManager} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 const {OUTBOX_STATUSES} = require('../../../core/server/models/outbox');
 const db = require('../../../core/server/data/db');
@@ -39,6 +40,8 @@ describe('Member Welcome Emails Integration', function () {
     });
 
     beforeEach(async function () {
+        mockManager.mockLabsDisabled('automations');
+
         const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
         if (defaultNewsletter) {
             defaultNewsletterSenderState = {
@@ -106,6 +109,7 @@ describe('Member Welcome Emails Integration', function () {
     });
 
     afterEach(async function () {
+        mockManager.restore();
         sinon.restore();
 
         if (defaultNewsletterSenderState) {
@@ -137,7 +141,7 @@ describe('Member Welcome Emails Integration', function () {
             await db.knex('welcome_email_automation_runs').del();
         });
 
-        it('creates automation run when member source is "member"', async function () {
+        it('creates legacy automation run when automations labs flag is disabled', async function () {
             await db.knex.transaction(async (trx) => {
                 const before = new Date(Date.now() - 1000);
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const DomainEvents = require('@tryghost/domain-events');
+const labs = require('../../../../../../../core/shared/labs');
 const MemberRepository = require('../../../../../../../core/server/services/members/members-api/repositories/member-repository');
 const {SubscriptionCreatedEvent, OfferRedemptionEvent} = require('../../../../../../../core/shared/events');
 
@@ -26,6 +27,7 @@ describe('MemberRepository', function () {
     let productRepository;
     let stripeAPIService;
     let tokenService;
+    let labsIsSet;
 
     /**
      * @param {Partial<Record<keyof ConstructorParameters<typeof MemberRepository>[0], any>>} overrides
@@ -56,6 +58,8 @@ describe('MemberRepository', function () {
     });
 
     beforeEach(function () {
+        labsIsSet = sinon.stub(labs, 'isSet').returns(false);
+
         mockOfferRedemption = {
             add: sinon.stub().resolves(),
             findOne: sinon.stub().resolves(null)
@@ -1750,6 +1754,32 @@ describe('MemberRepository', function () {
                 assert.equal(runCall.exit_reason, null);
             });
 
+            it('does NOT create automation run when the automations labs flag is enabled', async function () {
+                labsIsSet.withArgs('automations').returns(true);
+
+                const repo = buildRepo({
+                    Member,
+                    Outbox,
+                    WelcomeEmailAutomationRun,
+                    MemberStatusEvent,
+                    MemberSubscribeEventModel: MemberSubscribeEvent,
+                    newslettersService,
+                    Automation,
+                    OfferRedemption: mockOfferRedemption
+                });
+
+                await repo.create({email: 'test@example.com', name: 'Test Member'}, {});
+
+                sinon.assert.calledOnceWithExactly(automationsApi.trigger, {
+                    event: 'member_sign_up',
+                    memberId: 'member_id_123',
+                    memberEmail: 'test@example.com',
+                    memberStatus: 'free'
+                });
+                sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
+                sinon.assert.notCalled(Automation.findOne);
+            });
+
             it('does not create automation run for disallowed sources', async function () {
                 const repo = buildRepo({
                     Member,
@@ -2101,6 +2131,54 @@ describe('MemberRepository', function () {
                 assert.equal(runCall.step_started_at, null);
                 assert.equal(runCall.step_attempts, 0);
                 assert.equal(runCall.exit_reason, null);
+            });
+
+            it('does NOT create automation run when the automations labs flag is enabled', async function () {
+                labsIsSet.withArgs('automations').returns(true);
+
+                Member.edit.resolves({
+                    attributes: {status: 'paid'},
+                    _previousAttributes: {status: 'free'},
+                    get: sinon.stub().callsFake((key) => {
+                        const data = {status: 'paid'};
+                        return data[key];
+                    })
+                });
+
+                const repo = buildRepo({
+                    Member,
+                    Outbox,
+                    WelcomeEmailAutomationRun,
+                    MemberPaidSubscriptionEvent,
+                    StripeCustomerSubscription,
+                    MemberProductEvent,
+                    MemberStatusEvent,
+                    stripeAPIService,
+                    productRepository,
+                    Automation,
+                    OfferRedemption: mockOfferRedemption
+                });
+
+                sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
+
+                await repo.linkSubscription({
+                    id: 'member_id_123',
+                    subscription: subscriptionData
+                }, {
+                    transacting: {
+                        executionPromise: Promise.resolve()
+                    },
+                    context: {}
+                });
+
+                sinon.assert.calledOnceWithExactly(automationsApi.trigger, {
+                    event: 'member_sign_up',
+                    memberId: 'member_id_123',
+                    memberEmail: 'test@example.com',
+                    memberStatus: 'paid'
+                });
+                sinon.assert.notCalled(WelcomeEmailAutomationRun.add);
+                sinon.assert.notCalled(Automation.findOne);
             });
 
             it('does NOT create automation run for disallowed sources', async function () {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1279

This change should only affect users who enabled the `automations` labs flag.

We have two automations systems: the new one (about to go to beta) and the old one.

If the beta flag is on, we shouldn't trigger automations in the old system.

## Manual test

I ensured that welcome emails aren't sent when the `automations` flag is on.

https://github.com/user-attachments/assets/9e077ed4-895d-4b8d-8ac6-a4a5e2de2ed6