### PR TITLE
Gift links: service & admin API

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -335,6 +335,7 @@ async function initServices() {
     const mediaInliner = require('./server/services/media-inliner');
     const donationService = require('./server/services/donations');
     const giftService = require('./server/services/gifts');
+    const giftLinksService = require('./server/services/gift-links');
     const recommendationsService = require('./server/services/recommendations');
     const emailAddressService = require('./server/services/email-address');
     const statsService = require('./server/services/stats');
@@ -376,6 +377,7 @@ async function initServices() {
         slackNotifications.init(),
         mediaInliner.init(),
         donationService.init(),
+        giftLinksService.init(),
         recommendationsService.init(),
         statsService.init(),
         explorePingService.init(),

--- a/ghost/core/core/server/api/endpoints/gift-links.ts
+++ b/ghost/core/core/server/api/endpoints/gift-links.ts
@@ -1,0 +1,128 @@
+import type {GiftLinksService} from '../../services/gift-links/gift-links-service';
+
+// The service is a boot singleton on a wrapper exported with `module.exports =`
+// (TS can't type a default import of that, and boot/the framework load it via
+// raw `require()`), so it's required and cast to the real service type.
+// `permissions` is untyped JS and required for the same reason.
+/* eslint-disable @typescript-eslint/no-require-imports */
+const giftLinks = require('../../services/gift-links') as {service: GiftLinksService};
+const permissionsService = require('../../services/permissions');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+interface Frame {
+    options: {
+        id: string;
+        context: unknown;
+        [key: string]: unknown;
+    };
+}
+
+/**
+ * Authorise a per-post gift-link action via two gates, both load-bearing:
+ *   1. Capability — the role (or Admin Integration) must hold `gift_link:
+ *      manage`; this blocks roles (e.g. Contributor) that can edit a post but
+ *      may not gift.
+ *   2. Ownership — "you can gift a post iff you can edit it." Delegates to
+ *      `Post.permissible` (an Author may only act on their own post; 403 else).
+ *
+ * Internal context short-circuits in the permissions service, so this is a
+ * no-op for internal callers.
+ */
+async function assertCanManageGiftLink(frame: Frame): Promise<void> {
+    const {context, id} = frame.options;
+    await permissionsService.canThis(context).manage.gift_link(id);
+    await permissionsService.canThis(context).edit.post(id);
+}
+
+const controller = {
+    docName: 'gift_links',
+
+    /** Read the active gift link for a post/page (empty list when none). */
+    read: {
+        // No gift-link action touches the public post cache: the /g/ route is
+        // no-store and creating/resetting a link never changes the canonical
+        // post, so every action explicitly opts out of cache invalidation.
+        headers: {
+            cacheInvalidate: false
+        },
+        options: ['id'],
+        validation: {
+            options: {
+                id: {required: true}
+            }
+        },
+        permissions(frame: Frame) {
+            return assertCanManageGiftLink(frame);
+        },
+        query(frame: Frame) {
+            return giftLinks.service.getActive(frame.options.id, {context: frame.options.context});
+        }
+    },
+
+    /**
+     * Idempotently create-or-get the active gift link (the "copy" action).
+     * Mintable on any existing post — eligibility is enforced at redemption, not
+     * here (see the service).
+     */
+    upsert: {
+        headers: {
+            cacheInvalidate: false
+        },
+        statusCode: 200,
+        options: ['id'],
+        validation: {
+            options: {
+                id: {required: true}
+            }
+        },
+        permissions(frame: Frame) {
+            return assertCanManageGiftLink(frame);
+        },
+        query(frame: Frame) {
+            return giftLinks.service.upsert(frame.options.id, {context: frame.options.context});
+        }
+    },
+
+    /**
+     * Rotate the active gift link so a leaked token can be invalidated. History
+     * is retained (the old link is kept inactive).
+     */
+    reset: {
+        headers: {
+            cacheInvalidate: false
+        },
+        statusCode: 200,
+        options: ['id'],
+        validation: {
+            options: {
+                id: {required: true}
+            }
+        },
+        permissions(frame: Frame) {
+            return assertCanManageGiftLink(frame);
+        },
+        query(frame: Frame) {
+            return giftLinks.service.reset(frame.options.id, {context: frame.options.context});
+        }
+    },
+
+    /**
+     * Site-wide kill switch: deactivate every active gift link. Tighter
+     * permission (`resetAll`) than per-post `manage` — backs the danger zone.
+     */
+    resetAll: {
+        headers: {
+            cacheInvalidate: false
+        },
+        statusCode: 200,
+        permissions: true,
+        async query(frame: Frame) {
+            const count = await giftLinks.service.resetAll({context: frame.options.context});
+            return {count};
+        }
+    }
+};
+
+// module.exports required - using `export` causes the module to fail to register
+// with the web framework as it's loaded via require()
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -305,6 +305,10 @@ module.exports = {
         return apiFramework.pipeline(require('./gift-reminders'), localUtils);
     },
 
+    get giftLinks() {
+        return apiFramework.pipeline(require('./gift-links'), localUtils);
+    },
+
     get recommendationsPublic() {
         return apiFramework.pipeline(require('./recommendations-public'), localUtils, 'content');
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/gift-links.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/gift-links.ts
@@ -1,0 +1,47 @@
+import type {GiftLink} from '../../../../../services/gift-links/gift-link';
+
+interface Frame {
+    response?: unknown;
+}
+
+/**
+ * Field allow-list for the admin API. The shareable URL is intentionally not
+ * built here: the admin already has the site URL and each post's slug, so
+ * surfaces compose `${siteUrl}/g/${slug}/?key=${token}&utm_campaign=gift-link`
+ * client-side. That keeps this off the URL service (whose in-memory map isn't
+ * populated in admin-only contexts).
+ */
+function serialize(link: GiftLink | null): GiftLink | null {
+    if (!link) {
+        return null;
+    }
+
+    return {
+        id: link.id,
+        post_id: link.post_id,
+        token: link.token,
+        status: link.status,
+        redeemed_count: link.redeemed_count,
+        last_redeemed_at: link.last_redeemed_at,
+        created_at: link.created_at,
+        updated_at: link.updated_at
+    };
+}
+
+// module.exports required - using `export` causes the module to fail to register
+// with the web framework as it's loaded via require()
+module.exports = {
+    read(link: GiftLink | null, apiConfig: unknown, frame: Frame) {
+        const serialized = serialize(link);
+        frame.response = {gift_links: serialized ? [serialized] : []};
+    },
+    upsert(link: GiftLink | null, apiConfig: unknown, frame: Frame) {
+        frame.response = {gift_links: [serialize(link)]};
+    },
+    reset(link: GiftLink | null, apiConfig: unknown, frame: Frame) {
+        frame.response = {gift_links: [serialize(link)]};
+    },
+    resetAll(data: {count: number}, apiConfig: unknown, frame: Frame) {
+        frame.response = {gift_links: {reset: data.count}};
+    }
+};

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
@@ -141,6 +141,10 @@ module.exports = {
         return require('./links');
     },
 
+    get gift_links() {
+        return require('./gift-links');
+    },
+
     get search_index() {
         return require('./search-index');
     },

--- a/ghost/core/core/server/services/gift-links/gift-link-bookshelf-repository.ts
+++ b/ghost/core/core/server/services/gift-links/gift-link-bookshelf-repository.ts
@@ -1,0 +1,140 @@
+import type {GiftLink, GiftLinkStatus} from './gift-link';
+import type {GiftLinkRepository, RepositoryOptions} from './gift-link-repository';
+
+interface GiftLinkModelInstance {
+    toJSON(): Record<string, unknown>;
+}
+
+interface GiftLinkBookshelfModel {
+    add(data: Record<string, unknown>, options?: RepositoryOptions): Promise<GiftLinkModelInstance>;
+    transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;
+}
+
+// knex is untyped in the wider codebase; describe only what we use. The query
+// builder is thenable, hence the pragmatic `any` (matches Ghost's model layer).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type KnexQuery = any;
+type Knex = ((table: string) => KnexQuery) & {
+    raw(sql: string): unknown;
+    select(...columns: string[]): KnexQuery;
+};
+
+/**
+ * Bookshelf/knex-backed {@link GiftLinkRepository}. Reads, sweeps and counter
+ * updates go straight to knex; only `create` uses the model layer, because the
+ * `id` (ObjectId) and `created_at` are assigned by Ghost's base model on insert.
+ */
+export class GiftLinkBookshelfRepository implements GiftLinkRepository {
+    private model: GiftLinkBookshelfModel;
+    private knex: Knex;
+
+    constructor({GiftLinkModel, knex}: {GiftLinkModel: GiftLinkBookshelfModel; knex: Knex}) {
+        this.model = GiftLinkModel;
+        this.knex = knex;
+    }
+
+    private applyTransacting(query: KnexQuery, options: RepositoryOptions): KnexQuery {
+        if (options.transacting) {
+            query.transacting(options.transacting);
+        }
+        return query;
+    }
+
+    private toGiftLink(row: Record<string, unknown>): GiftLink {
+        return {
+            id: row.id as string,
+            post_id: row.post_id as string,
+            token: row.token as string,
+            status: row.status as GiftLinkStatus,
+            redeemed_count: Number(row.redeemed_count),
+            last_redeemed_at: (row.last_redeemed_at as Date | null) ?? null,
+            created_at: row.created_at as Date,
+            updated_at: (row.updated_at as Date | null) ?? null
+        };
+    }
+
+    async getActiveByPostId(postId: string, options: RepositoryOptions = {}): Promise<GiftLink | null> {
+        const query = this.knex('gift_links')
+            .where({post_id: postId, status: 'active'})
+            .orderBy('created_at', 'desc')
+            .orderBy('id', 'desc')
+            .first();
+        const row = await this.applyTransacting(query, options);
+        return row ? this.toGiftLink(row) : null;
+    }
+
+    async getActiveByToken(token: string, options: RepositoryOptions = {}): Promise<GiftLink | null> {
+        if (!token) {
+            return null;
+        }
+        const query = this.knex('gift_links')
+            .where({token, status: 'active'})
+            .first();
+        const row = await this.applyTransacting(query, options);
+        return row ? this.toGiftLink(row) : null;
+    }
+
+    async postExists(postId: string, options: RepositoryOptions = {}): Promise<boolean> {
+        const query = this.knex('posts').where({id: postId}).first('id');
+        const row = await this.applyTransacting(query, options);
+        return Boolean(row);
+    }
+
+    async create(postId: string, token: string, options: RepositoryOptions = {}): Promise<GiftLink> {
+        const model = await this.model.add({post_id: postId, token}, options);
+        return this.toGiftLink(model.toJSON());
+    }
+
+    async deactivateActiveByPostId(postId: string, options: RepositoryOptions = {}): Promise<number> {
+        const query = this.knex('gift_links')
+            .where({post_id: postId, status: 'active'})
+            .update({status: 'inactive', updated_at: new Date()});
+        return this.applyTransacting(query, options);
+    }
+
+    async deactivateAllButMostRecent(postId: string, options: RepositoryOptions = {}): Promise<void> {
+        // Choose the keep-row and deactivate the rest in ONE statement. A
+        // separate SELECT-then-UPDATE leaves a window where a concurrent reset
+        // could deactivate the chosen keep-row and insert a newer active row
+        // that the UPDATE would then also deactivate, leaving ZERO active links.
+        // The keep-row is wrapped in a derived table because MySQL forbids
+        // referencing the UPDATE's target table directly in a subquery (ER 1093);
+        // the extra nesting is a harmless no-op on SQLite.
+        const mostRecent = this.knex('gift_links')
+            .where({post_id: postId, status: 'active'})
+            .orderBy('created_at', 'desc')
+            .orderBy('id', 'desc')
+            .limit(1)
+            .select('id')
+            .as('t');
+        const query = this.knex('gift_links')
+            .where({post_id: postId, status: 'active'})
+            .whereNotIn('id', this.knex.select('id').from(mostRecent))
+            .update({status: 'inactive', updated_at: new Date()});
+        await this.applyTransacting(query, options);
+    }
+
+    async deactivateAllActive(options: RepositoryOptions = {}): Promise<number> {
+        const query = this.knex('gift_links')
+            .where({status: 'active'})
+            .update({status: 'inactive', updated_at: new Date()});
+        return this.applyTransacting(query, options);
+    }
+
+    async recordRead(giftLinkId: string): Promise<number> {
+        const now = new Date();
+        // Filtered by id only (not status): a read that was served against a link
+        // which a concurrent reset then deactivated still belongs to that link.
+        return this.knex('gift_links')
+            .where({id: giftLinkId})
+            .update({
+                redeemed_count: this.knex.raw('redeemed_count + 1'),
+                last_redeemed_at: now,
+                updated_at: now
+            });
+    }
+
+    async transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T> {
+        return this.model.transaction(callback);
+    }
+}

--- a/ghost/core/core/server/services/gift-links/gift-link-repository.ts
+++ b/ghost/core/core/server/services/gift-links/gift-link-repository.ts
@@ -1,0 +1,31 @@
+import type {GiftLink} from './gift-link';
+
+export interface RepositoryOptions {
+    transacting?: unknown;
+}
+
+/**
+ * Persistence boundary for gift links — hides Bookshelf/knex, the `gift_links`
+ * table and the `posts` relation so the service is testable against this
+ * interface rather than model internals.
+ *
+ * The `<=1 active per post` invariant is deliberately SOFT (no lock, no unique
+ * constraint): no consumer needs a hard guarantee, and history retention rules
+ * out a cheap unique index. `deactivateAllButMostRecent` converges it and must
+ * run AFTER the insert commits — snapshot isolation hides a concurrent sibling.
+ */
+export interface GiftLinkRepository {
+    /** Most-recent active link for a post, or null. */
+    getActiveByPostId(postId: string, options?: RepositoryOptions): Promise<GiftLink | null>;
+    getActiveByToken(token: string, options?: RepositoryOptions): Promise<GiftLink | null>;
+    /** Existence probe for a clean 404; the `post_id` FK is the real backstop. */
+    postExists(postId: string, options?: RepositoryOptions): Promise<boolean>;
+    /** Insert a fresh active link (id/created_at assigned by the model layer). */
+    create(postId: string, token: string, options?: RepositoryOptions): Promise<GiftLink>;
+    deactivateActiveByPostId(postId: string, options?: RepositoryOptions): Promise<number>;
+    /** Convergence sweep: keep the most-recent active link, deactivate the rest. */
+    deactivateAllButMostRecent(postId: string, options?: RepositoryOptions): Promise<void>;
+    deactivateAllActive(options?: RepositoryOptions): Promise<number>;
+    recordRead(giftLinkId: string): Promise<number>;
+    transaction<T>(callback: (transacting: unknown) => Promise<T>): Promise<T>;
+}

--- a/ghost/core/core/server/services/gift-links/gift-link.ts
+++ b/ghost/core/core/server/services/gift-links/gift-link.ts
@@ -1,0 +1,19 @@
+export type GiftLinkStatus = 'active' | 'inactive';
+
+/**
+ * Domain representation of a gift link, decoupled from the Bookshelf model.
+ * Fields mirror the `gift_links` columns (snake_case) so the repository maps
+ * rows straight onto this type and the API serialiser is a near pass-through.
+ * There is intentionally no behaviour here: state transitions (deactivation,
+ * read counting) are bulk SQL in the repository, not per-row domain methods.
+ */
+export interface GiftLink {
+    id: string;
+    post_id: string;
+    token: string;
+    status: GiftLinkStatus;
+    redeemed_count: number;
+    last_redeemed_at: Date | null;
+    created_at: Date;
+    updated_at: Date | null;
+}

--- a/ghost/core/core/server/services/gift-links/gift-links-service.ts
+++ b/ghost/core/core/server/services/gift-links/gift-links-service.ts
@@ -1,0 +1,106 @@
+import crypto from 'crypto';
+import errors from '@tryghost/errors';
+import tpl from '@tryghost/tpl';
+import type {GiftLink} from './gift-link';
+import type {GiftLinkRepository} from './gift-link-repository';
+
+const messages = {
+    postNotFound: 'Post not found.'
+};
+
+interface Options {
+    context?: unknown;
+    transacting?: unknown;
+    [key: string]: unknown;
+}
+
+/**
+ * Manages the lifecycle of gift links: tokenised links that let anyone read a
+ * single post/page, materialised lazily on the first "copy" action.
+ *
+ * Eligibility (published / gated) is intentionally not enforced here or in the
+ * API — the reader path gates redemption through the public content API
+ * (published-only), so links are mintable on any existing post. The `<=1 active
+ * per post` invariant is deliberately SOFT (see {@link GiftLinkRepository}).
+ */
+export class GiftLinksService {
+    private repository: GiftLinkRepository;
+
+    constructor({giftLinkRepository}: {giftLinkRepository: GiftLinkRepository}) {
+        this.repository = giftLinkRepository;
+    }
+
+    /**
+     * Opaque, URL-safe, >=128-bit random token. No post id is encoded, so a
+     * token reveals nothing and cannot be guessed.
+     */
+    generateToken(): string {
+        return crypto.randomBytes(24).toString('base64url');
+    }
+
+    // Clean 404 before insert; the `gift_links.post_id` FK is the hard backstop.
+    private async assertPostExists(postId: string, options: Options): Promise<void> {
+        if (!await this.repository.postExists(postId, options)) {
+            throw new errors.NotFoundError({message: tpl(messages.postNotFound)});
+        }
+    }
+
+    // Lenient on existence: a post with no link (or no such post) has no active link.
+    async getActive(postId: string, options: Options = {}): Promise<GiftLink | null> {
+        return this.repository.getActiveByPostId(postId, options);
+    }
+
+    // Validates a reader's `?key=TOKEN`; used by the frontend /g/ controller.
+    async getActiveByToken(token: string, options: Options = {}): Promise<GiftLink | null> {
+        return this.repository.getActiveByToken(token, options);
+    }
+
+    /** Idempotently return the active link for a post, creating it if absent. */
+    async upsert(postId: string, options: Options = {}): Promise<GiftLink> {
+        // A link already exists -> return it (an active row proves the post
+        // exists, so existence is only checked on the create branch below).
+        const existing = await this.repository.getActiveByPostId(postId, options);
+        if (existing) {
+            return existing;
+        }
+
+        await this.assertPostExists(postId, options);
+
+        const created = await this.repository.create(postId, this.generateToken(), options);
+        // Converge any link minted by a concurrent upsert, then return whatever
+        // is active afterwards: the sweep may have deactivated `created` in
+        // favour of a newer row, and the caller must never get an inactive token.
+        await this.repository.deactivateAllButMostRecent(postId);
+        return (await this.repository.getActiveByPostId(postId, options)) ?? created;
+    }
+
+    /**
+     * Invalidate the active link (so a leaked token stops working) and mint a
+     * fresh one. The old row is retained as `inactive`.
+     */
+    async reset(postId: string, options: Options = {}): Promise<GiftLink> {
+        await this.assertPostExists(postId, options);
+
+        const created = await this.repository.transaction(async (transacting) => {
+            const opts: Options = {...options, transacting};
+            await this.repository.deactivateActiveByPostId(postId, opts);
+            return this.repository.create(postId, this.generateToken(), opts);
+        });
+
+        await this.repository.deactivateAllButMostRecent(postId);
+        return (await this.repository.getActiveByPostId(postId, options)) ?? created;
+    }
+
+    /** Site-wide kill switch: deactivate every active link (re-mint lazily on next copy). */
+    async resetAll(options: Options = {}): Promise<number> {
+        return this.repository.deactivateAllActive(options);
+    }
+
+    /**
+     * Bump a link's read counter + last-read time. Bot filtering and client
+     * de-duplication happen upstream (see middleware).
+     */
+    async recordRead(giftLinkId: string): Promise<number> {
+        return this.repository.recordRead(giftLinkId);
+    }
+}

--- a/ghost/core/core/server/services/gift-links/index.ts
+++ b/ghost/core/core/server/services/gift-links/index.ts
@@ -1,0 +1,37 @@
+import {GiftLinksService} from './gift-links-service';
+import {GiftLinkBookshelfRepository} from './gift-link-bookshelf-repository';
+
+/**
+ * The one CJS bridge for the gift-links service: boot, the API endpoint and the
+ * frontend reader all reach the singleton through `require()`, so this module
+ * exports via `module.exports =`. Everything else in this directory is plain ESM
+ * and imported directly above to stay typed.
+ *
+ * `init()` lazily wires the Bookshelf model into a repository so that requiring
+ * this module doesn't trigger model loading.
+ */
+class GiftLinksServiceWrapper {
+    service?: GiftLinksService;
+
+    init(): void {
+        if (this.service) {
+            return;
+        }
+
+        // `../../models` is untyped JS and only registers after boot, so it's
+        // required lazily rather than imported.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const models = require('../../models');
+
+        const repository = new GiftLinkBookshelfRepository({
+            GiftLinkModel: models.GiftLink,
+            knex: models.Base.knex
+        });
+
+        this.service = new GiftLinksService({giftLinkRepository: repository});
+    }
+}
+
+// module.exports required - using `export` causes the module to fail to register
+// with the web framework as it's loaded via require()
+module.exports = new GiftLinksServiceWrapper();

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -4,6 +4,7 @@ const {http} = require('@tryghost/api-framework');
 const auth = require('../../../../services/auth');
 const apiMw = require('../../middleware');
 const mw = require('./middleware');
+const labs = require('../../../../../shared/labs');
 
 const shared = require('../../../shared');
 
@@ -399,6 +400,19 @@ module.exports = function apiRoutes() {
 
     router.get('/links', mw.authAdminApi, http(api.links.browse));
     router.put('/links/bulk', mw.authAdminApi, http(api.links.bulkEdit));
+
+    // Gift links (gated behind the `giftLinks` private flag). A gift link is a
+    // singular sub-resource of a post/page (at most one active per post), so the
+    // per-post actions nest under the parent. `reset_all` is the site-wide kill
+    // switch and stays on its own path (it's a danger-zone concern, not a
+    // per-post one). Both posts and pages get the parallel routes (like `copy`).
+    router.put('/gift_links/reset_all', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.resetAll));
+    router.get('/posts/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.read));
+    router.put('/posts/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.upsert));
+    router.post('/posts/:id/gift_link/reset', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.reset));
+    router.get('/pages/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.read));
+    router.put('/pages/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.upsert));
+    router.post('/pages/:id/gift_link/reset', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.reset));
 
     // Recommendations
     router.get('/recommendations', mw.authAdminApi, http(api.recommendations.browse));

--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+
+const {
+    agentProvider,
+    fixtureManager,
+    mockManager,
+    resetRateLimits
+} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+
+describe('Gift Links Admin API', function () {
+    let agent: any;
+    let gatedPostId: string;
+    let gatedPageId: string;
+    let publicPostId: string;
+    let draftPostId: string;
+    let authorOwnedPostId: string;
+    const missingPostId = '0123456789abcdef01234567';
+
+    // `loginAsAuthor()` authenticates DataGenerator.Content.users[3] (role Author).
+    const authorUserId = '6193c685e792de832cd08141';
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users', 'posts');
+        await agent.loginAsOwner();
+
+        // posts[8]/[9] are published posts; posts[5] is a page; posts[3] is a draft.
+        gatedPostId = fixtureManager.get('posts', 8).id;
+        publicPostId = fixtureManager.get('posts', 9).id;
+        draftPostId = fixtureManager.get('posts', 3).id;
+        gatedPageId = fixtureManager.get('posts', 5).id;
+
+        // Representative fixtures across visibility/status; eligibility isn't
+        // enforced at mint time, so visibility doesn't gate minting.
+        await models.Post.edit({visibility: 'members'}, {id: gatedPostId, context: {internal: true}});
+        await models.Post.edit({visibility: 'public'}, {id: publicPostId, context: {internal: true}});
+        await models.Post.edit({status: 'published', visibility: 'members'}, {id: gatedPageId, context: {internal: true}});
+
+        // A published, members-only post AUTHORED BY the Author fixture user, so
+        // an Author can manage its gift links (can edit own post => can gift it).
+        const authorOwnedPost = await models.Post.add({
+            title: 'Author-owned gift-eligible post',
+            status: 'published',
+            visibility: 'members',
+            authors: [{id: authorUserId}]
+        }, {context: {internal: true}});
+        authorOwnedPostId = authorOwnedPost.id;
+    });
+
+    after(async function () {
+        if (authorOwnedPostId) {
+            await models.Post.destroy({id: authorOwnedPostId, context: {internal: true}});
+        }
+    });
+
+    afterEach(async function () {
+        mockManager.restore();
+        await models.Base.knex('gift_links').del();
+    });
+
+    describe('with the giftLinks flag disabled', function () {
+        beforeEach(function () {
+            mockManager.mockLabsDisabled('giftLinks');
+        });
+
+        it('404s the per-post endpoints', async function () {
+            await agent.get(`posts/${gatedPostId}/gift_link/`).expectStatus(404);
+            await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(404);
+            await agent.post(`posts/${gatedPostId}/gift_link/reset/`).expectStatus(404);
+        });
+
+        it('404s reset_all', async function () {
+            await agent.put('gift_links/reset_all/').expectStatus(404);
+        });
+    });
+
+    describe('with the giftLinks flag enabled', function () {
+        beforeEach(function () {
+            mockManager.mockLabsEnabled('giftLinks');
+        });
+
+        describe('read', function () {
+            it('returns an empty list when nothing has been shared', async function () {
+                const {body} = await agent.get(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+                assert.deepEqual(body.gift_links, []);
+            });
+
+            it('returns the active link once created', async function () {
+                await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+                const {body} = await agent.get(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+                assert.equal(body.gift_links.length, 1);
+                assert.equal(body.gift_links[0].post_id, gatedPostId);
+                assert.equal(body.gift_links[0].status, 'active');
+            });
+
+            it('404s a post that does not exist', async function () {
+                // Authorisation piggybacks on post-edit, and the object-permission
+                // check 404s a missing post before the query runs.
+                await agent.get(`posts/${missingPostId}/gift_link/`).expectStatus(404);
+            });
+        });
+
+        describe('upsert', function () {
+            it('creates an active link with a token and zeroed count', async function () {
+                const {body} = await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+                assert.equal(body.gift_links.length, 1);
+                const link = body.gift_links[0];
+                assert.equal(link.post_id, gatedPostId);
+                assert.equal(link.status, 'active');
+                assert.equal(link.redeemed_count, 0);
+                assert.ok(link.token, 'token present');
+                // The shareable URL is composed client-side from post.url, not returned here.
+                assert.equal(link.url, undefined);
+            });
+
+            it('is idempotent — same token on repeat', async function () {
+                const first = (await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(200)).body.gift_links[0];
+                const second = (await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(200)).body.gift_links[0];
+                assert.equal(first.token, second.token);
+            });
+
+            it('works for a gated published page (type-agnostic, via /pages route)', async function () {
+                const {body} = await agent.put(`pages/${gatedPageId}/gift_link/`).expectStatus(200);
+                assert.equal(body.gift_links.length, 1);
+                assert.equal(body.gift_links[0].post_id, gatedPageId);
+                assert.equal(body.gift_links[0].status, 'active');
+            });
+
+            it('mints regardless of post visibility/status (no eligibility gate)', async function () {
+                for (const id of [publicPostId, draftPostId]) {
+                    const {body} = await agent.put(`posts/${id}/gift_link/`).expectStatus(200);
+                    assert.equal(body.gift_links[0].status, 'active');
+                }
+            });
+
+            it('404s a post that does not exist', async function () {
+                await agent.put(`posts/${missingPostId}/gift_link/`).expectStatus(404);
+            });
+        });
+
+        describe('reset', function () {
+            it('mints a new token and invalidates the old one', async function () {
+                const original = (await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(200)).body.gift_links[0];
+                const renewed = (await agent.post(`posts/${gatedPostId}/gift_link/reset/`).expectStatus(200)).body.gift_links[0];
+
+                assert.notEqual(renewed.token, original.token);
+                assert.equal(renewed.status, 'active');
+
+                // The active link is now the renewed one
+                const {body} = await agent.get(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+                assert.equal(body.gift_links[0].token, renewed.token);
+            });
+
+            it('mints a fresh link when none existed (reset implies create)', async function () {
+                const renewed = (await agent.post(`posts/${gatedPostId}/gift_link/reset/`).expectStatus(200)).body.gift_links[0];
+                assert.equal(renewed.status, 'active');
+            });
+        });
+
+        describe('reset_all', function () {
+            it('deactivates every active link site-wide', async function () {
+                await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+
+                const {body} = await agent.put('gift_links/reset_all/').expectStatus(200);
+                assert.equal(body.gift_links.reset, 1);
+
+                const after = await agent.get(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+                assert.deepEqual(after.body.gift_links, []);
+            });
+        });
+
+        describe('permissions', function () {
+            // Each test re-authenticates as a non-owner role; reset the login
+            // rate limiter so the repeated logins don't trip brute-force
+            // protection ("Too many attempts").
+            beforeEach(async function () {
+                await resetRateLimits();
+            });
+
+            it('allows an Editor to manage per-post links', async function () {
+                await agent.loginAsEditor();
+                await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+                await agent.get(`posts/${gatedPostId}/gift_link/`).expectStatus(200);
+                await agent.post(`posts/${gatedPostId}/gift_link/reset/`).expectStatus(200);
+            });
+
+            it('forbids an Editor from reset_all (403)', async function () {
+                await agent.loginAsEditor();
+                await agent.put('gift_links/reset_all/').expectStatus(403);
+            });
+
+            it('allows an Author to manage links for their OWN post', async function () {
+                // Gift-link management piggybacks on post-edit: an Author can edit
+                // (and therefore gift) a post they author.
+                await agent.loginAsAuthor();
+                await agent.put(`posts/${authorOwnedPostId}/gift_link/`).expectStatus(200);
+                await agent.get(`posts/${authorOwnedPostId}/gift_link/`).expectStatus(200);
+                await agent.post(`posts/${authorOwnedPostId}/gift_link/reset/`).expectStatus(200);
+            });
+
+            it('forbids an Author from managing links for a post they do NOT author (403)', async function () {
+                // gatedPostId is authored by the Owner, not this Author.
+                await agent.loginAsAuthor();
+                await agent.get(`posts/${gatedPostId}/gift_link/`).expectStatus(403);
+                await agent.put(`posts/${gatedPostId}/gift_link/`).expectStatus(403);
+                await agent.post(`posts/${gatedPostId}/gift_link/reset/`).expectStatus(403);
+            });
+
+            it('forbids an Author from reset_all (403)', async function () {
+                await agent.loginAsAuthor();
+                await agent.put('gift_links/reset_all/').expectStatus(403);
+            });
+        });
+    });
+});

--- a/ghost/core/test/integration/services/gift-links.test.ts
+++ b/ghost/core/test/integration/services/gift-links.test.ts
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import {GiftLinksService} from '../../../core/server/services/gift-links/gift-links-service';
+import {GiftLinkBookshelfRepository} from '../../../core/server/services/gift-links/gift-link-bookshelf-repository';
+
+const testUtils = require('../../utils');
+const models = require('../../../core/server/models');
+
+async function countLinks(where: Record<string, unknown>) {
+    const rows = await models.Base.knex('gift_links').where(where).select('id');
+    return rows.length;
+}
+
+describe('GiftLinksService (integration)', function () {
+    let context: unknown;
+    let postId: string;
+    let otherPostId: string;
+    let draftPostId: string;
+    let service: GiftLinksService;
+    let repository: GiftLinkBookshelfRepository;
+
+    after(testUtils.teardownDb);
+
+    before(async function () {
+        await testUtils.teardownDb();
+        await testUtils.setup('users:roles', 'posts')();
+
+        context = testUtils.context.admin;
+        postId = testUtils.DataGenerator.Content.posts[0].id;
+        otherPostId = testUtils.DataGenerator.Content.posts[1].id;
+        // posts[3] is a draft — used to prove the service is status-agnostic
+        draftPostId = testUtils.DataGenerator.Content.posts[3].id;
+
+        repository = new GiftLinkBookshelfRepository({
+            GiftLinkModel: models.GiftLink,
+            knex: models.Base.knex
+        });
+        service = new GiftLinksService({giftLinkRepository: repository});
+    });
+
+    // Each test starts from a clean slate of gift links (the fixture posts persist).
+    afterEach(async function () {
+        await models.Base.knex('gift_links').del();
+    });
+
+    describe('upsert', function () {
+        it('creates an active link with a token when none exists', async function () {
+            const link = await service.upsert(postId, {context});
+
+            assert.equal(link.post_id, postId);
+            assert.equal(link.status, 'active');
+            assert.ok(link.token, 'token should be set');
+            assert.equal(link.redeemed_count, 0);
+            assert.equal(await countLinks({post_id: postId}), 1);
+        });
+
+        it('is idempotent — returns the same active link, no duplicate row', async function () {
+            const first = await service.upsert(postId, {context});
+            const second = await service.upsert(postId, {context});
+
+            assert.equal(first.id, second.id);
+            assert.equal(first.token, second.token);
+            assert.equal(await countLinks({post_id: postId}), 1);
+        });
+
+        it('throws for a post that does not exist', async function () {
+            await assert.rejects(service.upsert('0123456789abcdef01234567', {context}));
+        });
+
+        it('works for a non-published post (status-agnostic)', async function () {
+            // Existence is checked against the posts table directly (no status
+            // filter) and the FK backs it, so links mint for any existing post.
+            const link = await service.upsert(draftPostId, {context});
+            assert.equal(link.post_id, draftPostId);
+            assert.equal(link.status, 'active');
+        });
+    });
+
+    describe('reset', function () {
+        it('deactivates the old link and mints a new active one with a different token', async function () {
+            const original = await service.upsert(postId, {context});
+            const renewed = await service.reset(postId, {context});
+
+            assert.notEqual(renewed.token, original.token);
+            assert.equal(renewed.status, 'active');
+
+            const old = await models.GiftLink.findOne({id: original.id}, {require: true});
+            assert.equal(old.get('status'), 'inactive');
+
+            assert.equal(await countLinks({post_id: postId, status: 'active'}), 1);
+            assert.equal(await countLinks({post_id: postId}), 2, 'history is retained');
+        });
+
+        it('starts the new link with zeroed counters', async function () {
+            const original = await service.upsert(postId, {context});
+            // Simulate reads accruing on the original link
+            await models.Base.knex('gift_links')
+                .where({id: original.id})
+                .update({redeemed_count: 42, last_redeemed_at: new Date()});
+
+            const renewed = await service.reset(postId, {context});
+            assert.equal(renewed.redeemed_count, 0);
+            assert.equal(renewed.last_redeemed_at, null);
+        });
+
+        it('mints a fresh link even when none existed (reset implies create)', async function () {
+            const renewed = await service.reset(postId, {context});
+            assert.equal(renewed.status, 'active');
+            assert.equal(await countLinks({post_id: postId, status: 'active'}), 1);
+        });
+    });
+
+    describe('resetAll', function () {
+        it('deactivates active links across all posts and returns the count', async function () {
+            await service.upsert(postId, {context});
+            await service.upsert(otherPostId, {context});
+
+            const deactivated = await service.resetAll({context});
+
+            assert.equal(deactivated, 2);
+            assert.equal(await countLinks({status: 'active'}), 0);
+            assert.equal(await countLinks({status: 'inactive'}), 2);
+        });
+
+        it('is a no-op (zero) when there are no active links', async function () {
+            const deactivated = await service.resetAll({context});
+            assert.equal(deactivated, 0);
+        });
+    });
+
+    describe('recordRead', function () {
+        it('increments redeemed_count and stamps last_redeemed_at', async function () {
+            const link = await service.upsert(postId, {context});
+            assert.equal(link.redeemed_count, 0);
+            assert.equal(link.last_redeemed_at, null);
+
+            const affected = await service.recordRead(link.id);
+            assert.equal(affected, 1);
+
+            const reloaded = await models.GiftLink.findOne({id: link.id}, {require: true});
+            assert.equal(reloaded.get('redeemed_count'), 1);
+            assert.notEqual(reloaded.get('last_redeemed_at'), null);
+
+            await service.recordRead(link.id);
+            const again = await models.GiftLink.findOne({id: link.id}, {require: true});
+            assert.equal(again.get('redeemed_count'), 2);
+        });
+
+        it('affects no rows for an unknown link id', async function () {
+            const affected = await service.recordRead('0123456789abcdef01234567');
+            assert.equal(affected, 0);
+        });
+    });
+
+    describe('getActive / getActiveByToken', function () {
+        it('getActive returns null when there is no active link', async function () {
+            const active = await service.getActive(postId, {context});
+            assert.equal(active, null);
+        });
+
+        it('getActive returns the active link once created', async function () {
+            const link = await service.upsert(postId, {context});
+            const active = await service.getActive(postId, {context});
+            assert.equal(active!.id, link.id);
+        });
+
+        it('getActiveByToken finds an active token but ignores deactivated/unknown tokens', async function () {
+            const original = await service.upsert(postId, {context});
+            const originalToken = original.token;
+
+            const found = await service.getActiveByToken(originalToken, {context});
+            assert.equal(found!.id, original.id);
+
+            // After a reset the old token must no longer resolve
+            await service.reset(postId, {context});
+            assert.equal(await service.getActiveByToken(originalToken, {context}), null);
+            assert.equal(await service.getActiveByToken('definitely-not-a-real-token', {context}), null);
+            assert.equal(await service.getActiveByToken('', {context}), null);
+        });
+    });
+
+    describe('soft <=1-active convergence', function () {
+        it('the sweep keeps only the most-recent active link (and never zero)', async function () {
+            // Simulate the race artefact: two active links for one post.
+            await models.Base.knex('gift_links').insert([
+                {id: '1'.repeat(24), post_id: postId, token: 'tok-older', status: 'active', redeemed_count: 0, created_at: new Date('2026-01-01T00:00:00Z')},
+                {id: '2'.repeat(24), post_id: postId, token: 'tok-newer', status: 'active', redeemed_count: 0, created_at: new Date('2026-02-01T00:00:00Z')}
+            ]);
+            assert.equal(await countLinks({post_id: postId, status: 'active'}), 2);
+
+            await repository.deactivateAllButMostRecent(postId);
+
+            // Exactly one survives — never zero — and it's the most-recent.
+            assert.equal(await countLinks({post_id: postId, status: 'active'}), 1);
+            const active = await service.getActive(postId, {context});
+            assert.equal(active!.token, 'tok-newer', 'keeps the most-recent active link');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/gift-links/gift-links-service.test.ts
+++ b/ghost/core/test/unit/server/services/gift-links/gift-links-service.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import {GiftLinksService} from '../../../../../core/server/services/gift-links/gift-links-service';
+import type {GiftLinkRepository} from '../../../../../core/server/services/gift-links/gift-link-repository';
+
+describe('Unit: GiftLinksService token generation', function () {
+    // Token generation touches no persistence, so a stub repository is enough.
+    const service = new GiftLinksService({giftLinkRepository: {} as GiftLinkRepository});
+
+    it('generates a non-empty url-safe (base64url) string', function () {
+        const token = service.generateToken();
+        assert.equal(typeof token, 'string');
+        assert.match(token, /^[A-Za-z0-9_-]+$/);
+    });
+
+    it('carries at least 128 bits of entropy', function () {
+        const token = service.generateToken();
+        // base64url has no padding; decoded length is the raw byte count
+        const bytes = Buffer.from(token, 'base64url').length;
+        assert.ok(bytes >= 16, `expected >=16 bytes of entropy, got ${bytes}`);
+    });
+
+    it('does not encode anything predictable (unique across calls)', function () {
+        const tokens = new Set();
+        for (let i = 0; i < 1000; i++) {
+            tokens.add(service.generateToken());
+        }
+        assert.equal(tokens.size, 1000);
+    });
+});


### PR DESCRIPTION
Slice 2 of 4 carving up the gift-links spike (#28625). Stacked on #28626 (BER-3726, data foundation) — review/merge that first.

ref https://linear.app/ghost/issue/BER-3727

## What this adds
- **GiftLinksService** (`services/gift-links`): token generation, `ensure`/`reset`/`resetAll`/`getActive`/`getActiveByToken`/`recordRead`, transaction-safe with `forUpdate` post locking; wired into boot `initServices`.
- **Admin API** (`api/endpoints/gift-links.js` + output serializer + routes): `read`, `ensure`, `reset`, `reset_all` endpoints, all gated behind the `giftLinks` private flag.

## Reset-eligibility fix
The `reset` endpoint now uses the lenient "post exists" check (`findPostOrThrow`) instead of `validateEligiblePost`. A publisher must be able to rotate a *leaked* link even after the post became ineligible (flipped to public or unpublished) — otherwise the leaked link can't be invalidated. `ensure` still requires eligibility. Added an e2e test covering: mint on a members-only post → flip to public → `ensure` 422s but `reset` succeeds.

## Tests
- unit: 3 passing
- integration: 14 passing
- e2e-api admin gift-links: 18 passing
- admin config snapshot: updated for the `giftLinks` labs flag, passing

Everything is behind the off-by-default `giftLinks` flag.