### PR TITLE
Added automation step ID to "step failed" log message

### DIFF
--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -241,9 +241,10 @@ export const poll = async ({
             logging.error({
                 err,
                 system: {
-                    event: 'automations.poll.step_failed'
+                    event: 'automations.poll.step_failed',
+                    step_id: step.id
                 }
-            }, '[AUTOMATIONS] Failed to process automation step');
+            }, `[AUTOMATIONS] Failed to process automation step ${step.id}`);
             return;
         }
     }));


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1326

This log-only change should have no user impact.
