### PR TITLE
Gift links: admin UI (editor + settings)

### DIFF
--- a/apps/admin-x-framework/src/api/gift-links.ts
+++ b/apps/admin-x-framework/src/api/gift-links.ts
@@ -1,0 +1,18 @@
+import {createMutation} from '../utils/api/hooks';
+
+export type RevokeAllGiftLinksResponseType = {
+    meta: {
+        count: number;
+    };
+};
+
+const dataType = 'GiftLinksResponseType';
+
+// PUT /gift_links/revoke_all/ — site-wide kill switch (Owner/Admin), danger zone.
+export const useRevokeAllGiftLinks = createMutation<RevokeAllGiftLinksResponseType, null>({
+    method: 'PUT',
+    path: () => '/gift_links/revoke_all/',
+    invalidateQueries: {
+        dataType
+    }
+});

--- a/apps/admin-x-settings/src/components/settings/advanced/advanced-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/advanced-settings.tsx
@@ -13,7 +13,7 @@ export const searchKeywords = {
     codeInjection: ['advanced', 'code injection', 'head', 'footer'],
     labs: ['advanced', 'labs', 'alpha', 'private', 'beta', 'flag', 'routes', 'redirect', 'translation', 'editor', 'portal'],
     history: ['advanced', 'history', 'log', 'events', 'user events', 'staff', 'audit', 'action'],
-    dangerzone: ['danger zone', 'delete all content', 'delete site', 'reset all authentication', 'reset api keys', 'reset password', 'compromised credentials', 'lock staff users', 'sign out all staff']
+    dangerzone: ['danger zone', 'delete all content', 'delete site', 'reset all authentication', 'reset api keys', 'reset password', 'compromised credentials', 'lock staff users', 'sign out all staff', 'revoke all gift links', 'reset all gift links', 'gift links', 'invalidate gift links']
 };
 
 const AdvancedSettings: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
@@ -1,6 +1,7 @@
 import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
+import trackEvent from '../../../utils/analytics';
 import useStaffUsers from '../../../hooks/use-staff-users';
 import {Button, ConfirmationModal, ListItem, SettingGroupHeader, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
@@ -9,16 +10,19 @@ import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tryghost/admin-x-framework';
 import {useResetAuth} from '@tryghost/admin-x-framework/api/security';
+import {useRevokeAllGiftLinks} from '@tryghost/admin-x-framework/api/gift-links';
 
 const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {mutateAsync: deleteAllContent} = useDeleteAllContent();
     const {mutateAsync: resetAuth} = useResetAuth();
+    const {mutateAsync: revokeAllGiftLinks} = useRevokeAllGiftLinks();
     const client = useQueryClient();
     const handleError = useHandleError();
     const {config} = useGlobalData();
     const {totalUsers} = useStaffUsers();
 
     const resetAuthEnabled = Boolean(config?.labs?.dangerZoneResetAuth);
+    const giftLinksEnabled = Boolean(config?.labs?.giftLinks);
 
     const resetAuthStaffSentence = totalUsers === 1
         ? 'You will be signed out and must reset your password before signing back in.'
@@ -83,6 +87,39 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
         });
     };
 
+    const handleRevokeAllGiftLinks = () => {
+        NiceModal.show(ConfirmationModal, {
+            title: 'Revoke all gift links?',
+            prompt: (
+                <>
+                    <p className='mb-4'>
+                        This immediately deactivates every gift link across your site. Anyone holding a shared link loses access, and any links you&apos;ve posted publicly stop working.
+                    </p>
+                    <p>
+                        A fresh link is created automatically the next time you copy one for a post. Use this if a link has leaked.
+                    </p>
+                </>
+            ),
+            okLabel: 'Revoke all gift links',
+            okRunningLabel: 'Revoking...',
+            okColor: 'red',
+            onOk: async (modal) => {
+                try {
+                    const response = await revokeAllGiftLinks(null);
+                    const count = response?.meta?.count ?? 0;
+                    showToast({
+                        title: `Revoked ${count} gift ${count === 1 ? 'link' : 'links'}.`,
+                        type: 'success'
+                    });
+                    trackEvent('gift_link_revoke_all', {surface: 'danger-zone'});
+                    modal?.remove();
+                } catch (e) {
+                    handleError(e);
+                }
+            }
+        });
+    };
+
     return (
         <TopLevelGroup
             customHeader={
@@ -107,6 +144,15 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         detail='Rotate every API key, sign out every staff user, and require a password reset. Use after a suspected credential compromise.'
                         testId='reset-all-authentication'
                         title='Reset all authentication'
+                    />
+                )}
+                {giftLinksEnabled && (
+                    <ListItem
+                        action={<Button aria-label='Revoke all gift links' color='red' label='Revoke' onClick={handleRevokeAllGiftLinks} />}
+                        bgOnHover={false}
+                        detail='Deactivate every gift link across your site. New links are created automatically on next copy. Use if a link has leaked.'
+                        testId='revoke-all-gift-links'
+                        title='Revoke all gift links'
                     />
                 )}
             </div>

--- a/apps/admin-x-settings/test/acceptance/advanced/dangerzone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/dangerzone.test.ts
@@ -45,4 +45,29 @@ test.describe('DangerZone', async () => {
 
         expect(lastApiRequests.resetAuth).toBeTruthy();
     });
+
+    test('Revoke all gift links', async ({page}) => {
+        toggleLabsFlag('giftLinks', true);
+
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            revokeAllGiftLinks: {
+                method: 'PUT',
+                path: '/gift_links/revoke_all/',
+                response: {meta: {count: 3}}
+            }
+        }});
+
+        await page.goto('/');
+
+        const dangerZone = page.getByTestId('dangerzone');
+        await dangerZone.getByRole('button', {name: 'Revoke all gift links'}).click();
+
+        const modal = page.getByTestId('confirmation-modal');
+        await modal.getByRole('button', {name: 'Revoke all gift links'}).click();
+
+        await expect(page.getByTestId('toast-success')).toContainText('Revoked 3 gift links');
+
+        expect(lastApiRequests.revokeAllGiftLinks).toBeTruthy();
+    });
 });

--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -93,6 +93,28 @@
                             {{/if}}
                         {{/if}}
 
+                        {{#if this.canCopyGiftLink}}
+                            <div class="form-group gh-psm-gift-link" {{did-insert this.loadGiftLink}}>
+                                {{#if this.giftLinkResetConfirming}}
+                                    <div class="gh-psm-gift-link-row">
+                                        <span class="gh-psm-gift-link-warning">Current gift link will stop working</span>
+                                        <span class="gh-psm-gift-link-usage">
+                                            <button type="button" class="gh-psm-gift-link-action" {{on "click" this.cancelResetGiftLink}} data-test-button="cancel-reset-gift-link">Cancel</button>
+                                            <button type="button" class="gh-psm-gift-link-action gh-psm-gift-link-confirm" {{on "click" this.confirmResetGiftLink}} data-test-button="confirm-reset-gift-link">Confirm</button>
+                                        </span>
+                                    </div>
+                                {{else}}
+                                    <div class="gh-psm-gift-link-row">
+                                        <button type="button" class="gh-psm-gift-link-action gh-psm-gift-link-copy" {{on "click" this.copyGiftLink}} data-test-button="copy-gift-link">{{if this.giftLinkCopied "Link copied" "Copy gift link"}}</button>
+                                        <span class="gh-psm-gift-link-usage">
+                                            <span class="gh-psm-gift-link-count" data-test-text="gift-link-uses">{{this.giftLinkUsesLabel}}</span>
+                                            <button type="button" class="gh-psm-gift-link-action" {{on "click" this.startResetGiftLink}} data-test-button="reset-gift-link">Reset</button>
+                                        </span>
+                                    </div>
+                                {{/if}}
+                            </div>
+                        {{/if}}
+
                         {{#unless (feature 'editorExcerpt')}}
                         <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="customExcerpt">
                             <label for="custom-excerpt">Excerpt</label>

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -4,9 +4,11 @@ import classic from 'ember-classic-decorator';
 import moment from 'moment-timezone';
 import {action, computed} from '@ember/object';
 import {alias, or} from '@ember/object/computed';
+import {canCopyGiftLink, giftLinkUrl} from 'ghost-admin/utils/gift-link';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 import {tagName} from '@ember-decorators/component';
+import {trackEvent} from 'ghost-admin/utils/analytics';
 import {tracked} from '@glimmer/tracking';
 
 @classic
@@ -26,6 +28,10 @@ export default class GhPostSettingsMenu extends Component {
     @inject config;
 
     @tracked showPostHistory = false;
+    @tracked giftLink = null;
+    @tracked giftLinkCopied = false;
+    @tracked giftLinkResetConfirming = false;
+    @tracked giftLinkResetting = false;
 
     post = null;
     isViewingSubview = false;
@@ -186,6 +192,104 @@ export default class GhPostSettingsMenu extends Component {
         }
 
         this.setSidebarWidthVariable(0);
+    }
+
+    // Gift links: only for a published, gated (non-public) post/page, and only
+    // for users who can manage them (Owner/Administrator/Editor). Eligibility
+    // and URL shape are shared with the posts-list context menu via
+    // app/utils/gift-link.js.
+    @computed('feature.giftLinks', 'session.user.{isAdmin,isEitherEditor,isAuthor}', 'post.{isPublished,visibility}')
+    get canCopyGiftLink() {
+        return canCopyGiftLink({feature: this.feature, user: this.session.user, post: this.post});
+    }
+
+    get giftLinkUrl() {
+        return giftLinkUrl({
+            blogUrl: this.config.blogUrl,
+            slug: this.post?.slug,
+            token: this.giftLink?.token
+        });
+    }
+
+    get giftLinkUsesLabel() {
+        const count = this.giftLink ? this.giftLink.redeemed_count : 0;
+        if (count === 0) {
+            return 'Not used yet';
+        }
+        return `${count} ${count === 1 ? 'use' : 'uses'}`;
+    }
+
+    // Load the post's existing gift link (if any) when the control is shown, so
+    // the usage counter is populated without the author having to copy first.
+    @action
+    async loadGiftLink() {
+        if (!this.canCopyGiftLink) {
+            return;
+        }
+        try {
+            const url = this.ghostPaths.url.api('posts', this.post.id, 'gift_link');
+            const response = await this.ajax.request(url);
+            this.giftLink = response.gift_links[0] || null;
+        } catch (e) {
+            // Non-fatal: leave unset so the counter reads "0 uses".
+        }
+    }
+
+    // Copy is a creation intent: the post may not have a link yet, so the
+    // idempotent PUT creates it when missing and otherwise returns the current
+    // active token, which also refreshes the usage counter.
+    @action
+    async copyGiftLink() {
+        try {
+            const url = this.ghostPaths.url.api('posts', this.post.id, 'gift_link');
+            const response = await this.ajax.put(url);
+            this.giftLink = response.gift_links[0];
+            // Await the clipboard write so we only show "copied" on real
+            // success — in Safari/Firefox the write can reject after the awaited
+            // POST loses the user-activation, and we must not claim success then.
+            await navigator.clipboard.writeText(this.giftLinkUrl);
+            trackEvent('gift_link_copied', {surface: 'editor-psm'});
+            this.giftLinkCopied = true;
+            setTimeout(() => {
+                if (this.isDestroying || this.isDestroyed) {
+                    return;
+                }
+                this.giftLinkCopied = false;
+            }, 2000);
+        } catch (e) {
+            this.notifications.showAPIError(e, {key: 'gift-link.copy'});
+        }
+    }
+
+    @action
+    startResetGiftLink() {
+        this.giftLinkResetConfirming = true;
+    }
+
+    @action
+    cancelResetGiftLink() {
+        this.giftLinkResetConfirming = false;
+    }
+
+    @action
+    async confirmResetGiftLink() {
+        if (this.giftLinkResetting) {
+            return;
+        }
+        this.giftLinkResetting = true;
+        try {
+            // Rotate the post's link (reissue) — POST /posts/:id/gift_link.
+            // Distinct from copy's idempotent PUT to the same path.
+            const url = this.ghostPaths.url.api('posts', this.post.id, 'gift_link');
+            const response = await this.ajax.post(url);
+            this.giftLink = response.gift_links[0];
+            trackEvent('gift_link_reset', {surface: 'editor-psm'});
+        } catch (e) {
+            this.notifications.showAPIError(e, {key: 'gift-link.reset'});
+        } finally {
+            this.giftLinkResetting = false;
+            this.giftLinkResetConfirming = false;
+        }
     }
 
     @action

--- a/ghost/admin/app/components/posts-list/context-menu.hbs
+++ b/ghost/admin/app/components/posts-list/context-menu.hbs
@@ -8,6 +8,13 @@
                 </button>
             </li>
         {{/if}}
+        {{#if this.canCopyGiftLink}}
+            <li>
+                <button class="mr2" type="button" {{on "click" this.copyGiftLink}} data-test-button="copy-gift-link">
+                    <span>{{svg-jar "link"}}Copy gift link</span>
+                </button>
+            </li>
+        {{/if}}
         <li>
             <button class="mr2" type="button" {{on "click" this.unpublishPosts}} data-test-button="unpublish">
                 <span>{{svg-jar "undo"}}Unpublish</span>

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -7,9 +7,11 @@ import UnschedulePostsModal from './modals/unschedule-posts';
 import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
 import nql from '@tryghost/nql';
 import {action} from '@ember/object';
+import {canCopyGiftLink, giftLinkUrl} from 'ghost-admin/utils/gift-link';
 import {capitalizeFirstLetter} from 'ghost-admin/helpers/capitalize-first-letter';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
+import {trackEvent} from 'ghost-admin/utils/analytics';
 
 /**
  * @tryghost/tpl doesn't work in admin yet (Safari)
@@ -55,17 +57,37 @@ const messages = {
     },
     copiedPreviewUrl: {
         single: 'Preview link copied'
+    },
+    copiedGiftLink: {
+        single: 'Gift link copied'
     }
 };
 
 export default class PostsContextMenu extends Component {
     @service ajax;
+    @service config;
     @service ghostPaths;
     @service session;
     @service infinity;
     @service store;
     @service notifications;
     @service membersUtils;
+    @service feature;
+
+    // Gift links: only for a single published, gated (non-public) post/page, and
+    // only for users who can manage them (Owner/Administrator/Editor).
+    // Eligibility and URL shape are shared with the post-settings menu via
+    // app/utils/gift-link.js.
+    get canCopyGiftLink() {
+        if (!this.selectionList.isSingle) {
+            return false;
+        }
+        return canCopyGiftLink({
+            feature: this.feature,
+            user: this.session.user,
+            post: this.selectionList.first
+        });
+    }
 
     get menu() {
         return this.args.menu;
@@ -94,6 +116,11 @@ export default class PostsContextMenu extends Component {
     @action
     async copyPreviewLink() {
         this.menu.performTask(this.copyPreviewLinkTask);
+    }
+
+    @action
+    async copyGiftLink() {
+        this.menu.performTask(this.copyGiftLinkTask);
     }
 
     @action
@@ -426,6 +453,30 @@ export default class PostsContextMenu extends Component {
         copyTextToClipboard(this.selectionList.availableModels[0].url);
         this.notifications.showNotification(this.#getToastMessage('copiedPreviewUrl'), {type: 'success'});
         yield timeout(1000);
+        return true;
+    }
+
+    @task
+    *copyGiftLinkTask() {
+        try {
+            const post = this.selectionList.availableModels[0];
+            // Idempotent ensure (issue): returns the live gift link, creating it
+            // if absent — PUT /{posts|pages}/:id/gift_link, mirroring the editor PSM.
+            const resource = this.type === 'page' ? 'pages' : 'posts';
+            const url = this.ghostPaths.url.api(resource, post.id, 'gift_link');
+            const response = yield this.ajax.put(url);
+            const token = response.gift_links[0].token;
+            const giftUrl = giftLinkUrl({blogUrl: this.config.blogUrl, slug: post.slug, token});
+            // Await the clipboard write so we only show "copied" on real
+            // success — in Safari/Firefox the write can reject after the awaited
+            // POST loses the user-activation, and we must not claim success then.
+            yield navigator.clipboard.writeText(giftUrl);
+            trackEvent('gift_link_copied', {surface: 'posts-list-context-menu'});
+            this.notifications.showNotification(this.#getToastMessage('copiedGiftLink'), {type: 'success'});
+            yield timeout(1000);
+        } catch (error) {
+            this.notifications.showAPIError(error, {key: 'gift-link.copy.failed'});
+        }
         return true;
     }
 

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -68,6 +68,7 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('tagsX') tagsX;
     @feature('commentModeration') commentModeration;
+    @feature('giftLinks') giftLinks;
     _user = null;
 
     @computed('settings.labs')

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -10,6 +10,7 @@ const emberDataTypeMapping = {
     AutomatedEmailsResponseType: null, // automated emails only exist in React admin
     AutomationsResponseType: null, // automations only exist in React admin
     CommentsResponseType: null, // comments only exist in React admin
+    GiftLinksResponseType: null, // gift links only exist in React admin
     IntegrationsResponseType: {type: 'integration'},
     InvitesResponseType: {type: 'invite'},
     LabelsResponseType: null, // labels only exist in React admin

--- a/ghost/admin/app/styles/components/settings-menu.css
+++ b/ghost/admin/app/styles/components/settings-menu.css
@@ -214,6 +214,61 @@
     padding: 0 24px;
 }
 
+/* Gift link controls under the post access setting — inline copy on the left,
+   usage counter + reset on the right, pulled up tight beneath the access select.
+   Reset swaps in an inline confirmation (warning + Cancel/Confirm). */
+.gh-psm-gift-link {
+    margin-top: -14px;
+}
+
+.gh-psm-gift-link-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 1.3rem;
+    line-height: 1.5;
+}
+
+.gh-psm-gift-link-usage {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+}
+
+.gh-psm-gift-link-count,
+.gh-psm-gift-link-warning {
+    color: var(--midgrey);
+}
+
+.gh-psm-gift-link-action {
+    padding: 0;
+    border: none;
+    background: none;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    color: var(--midgrey);
+    cursor: pointer;
+}
+
+.gh-psm-gift-link-action:hover {
+    color: var(--darkgrey);
+}
+
+/* Copy is the primary action */
+.gh-psm-gift-link-copy,
+.gh-psm-gift-link-copy:hover {
+    color: var(--blue);
+    font-weight: 500;
+}
+
+/* Confirm is emphasized within the reset confirmation */
+.gh-psm-gift-link-confirm {
+    color: var(--darkgrey);
+    font-weight: 600;
+}
+
 @media (max-width: 1024px) {
     .settings-menu-content {
         padding-top: 0;

--- a/ghost/admin/app/utils/gift-link.js
+++ b/ghost/admin/app/utils/gift-link.js
@@ -1,0 +1,33 @@
+// Shared helpers for the gift-link editor surfaces (post-settings-menu and the
+// posts-list context menu) so the URL shape and eligibility rules stay in sync.
+
+// Build the public gift-link URL for a post.
+//
+// Gift links live at /g/<slug>/?key=TOKEN — a dedicated path prefix (not a
+// `?gift=` param on the canonical URL) so Fastly's cache bypass is path-based
+// and slug-change behaviour matches the rest of Ghost. The blog URL carries any
+// subdirectory; the trailing slash on the slug matches Ghost's canonical post
+// URLs. Returns '' when any input is missing so callers can guard the UI.
+export function giftLinkUrl({blogUrl, slug, token} = {}) {
+    if (!blogUrl || !slug || !token) {
+        return '';
+    }
+    const base = blogUrl.replace(/\/+$/, '');
+    return `${base}/g/${encodeURIComponent(slug)}/?key=${encodeURIComponent(token)}&utm_campaign=gift-link`;
+}
+
+// Whether the current user can copy a gift link for the given post.
+//
+// Requires the giftLinks flag, a user who can manage links
+// (Owner/Administrator/Editor/Super Editor/Author), and a published, gated
+// (non-public) post/page. Authors are limited to their own posts server-side;
+// in the editor they only ever open posts they can edit, so the role check is
+// sufficient for surfacing the control here.
+export function canCopyGiftLink({feature, user, post} = {}) {
+    if (!feature || !feature.giftLinks || !post) {
+        return false;
+    }
+    const canManage = Boolean(user && (user.isAdmin || user.isEitherEditor || user.isAuthor));
+    const eligible = Boolean(post.isPublished && post.visibility && post.visibility !== 'public');
+    return canManage && eligible;
+}


### PR DESCRIPTION
Slice 4 of 4 carving up the gift-links spike (#28625). Stacked on #28629.

ref https://linear.app/ghost/issue/BER-3729

## What this adds (all behind the off `giftLinks` flag)
- **Editor:** post-settings-menu inline gift-link control (copy / usage counter / reset-with-confirm) and a posts-list context-menu "Copy gift link" action.
- **Settings:** "Reset all gift links" action in the danger zone (site-wide kill switch), with search keywords.
- Consumes the admin API from slice 2.

## Review fixes folded in
- **Dedup:** extracted the gift-link URL builder and the `canCopyGiftLink` eligibility predicate (previously copy-pasted and already drifting between the two editor components) into a shared `ghost/admin/app/utils/gift-link.js`. Both components use it; published-check is now `post.isPublished` consistently.
- **Clipboard:** the clipboard write is now awaited and success state only flips on a real successful write — fixes the Safari/Firefox silent-false-success where the write rejects (lost user-activation after the awaited POST) but the UI still claimed "Link copied". Failures surface an error notification.
- **Context-menu error handling:** `copyGiftLinkTask` is wrapped in try/catch (mirroring `copyPostsTask`) and surfaces `showAPIError` instead of leaving the menu stuck in the loading state on a failed ensure POST.

## Dead code dropped
- The removed React modal leftovers (`apps/posts/src/utils/{gift-link,copy-to-clipboard,analytics}.ts` + tests, the `giftLinkSlot` prop) are confirmed absent and not referenced.
- `gift-links.ts` keeps only `useResetAllGiftLinks` (the sole consumer is the danger zone); the three unused hooks were deleted.

## Checks
- `tsc --noEmit` passes for admin-x-framework and admin-x-settings.
- eslint + ember-template-lint pass for all touched Ember files.
- The new dangerzone "Reset all gift links" Playwright acceptance test passes.