### PR TITLE
Recorded automated email recipient row for automation `send_email` actions

### DIFF
--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -166,13 +166,24 @@ const processStep = async ({
                 },
                 memberStatus
             });
-            await AutomatedEmailRecipient.add({
-                member_id: step.member_id,
-                member_uuid: member.get('uuid'),
-                member_email: member.get('email'),
-                member_name: member.get('name'),
-                automation_action_revision_id: step.automation_action_revision_id
-            });
+            try {
+                await AutomatedEmailRecipient.add({
+                    member_id: step.member_id,
+                    member_uuid: member.get('uuid'),
+                    member_email: member.get('email'),
+                    member_name: member.get('name'),
+                    automation_action_revision_id: step.automation_action_revision_id
+                });
+            } catch (err) {
+                logging.error({
+                    err,
+                    system: {
+                        event: 'automations.poll.recipient_persistence_failed',
+                        member_id: step.member_id,
+                        step_id: step.id
+                    }
+                }, `[AUTOMATIONS] Failed to record automated email recipient for step ${step.id}`);
+            }
             nextReadyAt = await automationsApi.finishStepAndEnqueueNext(step);
             break;
         }

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -4,7 +4,7 @@ import errors from '@tryghost/errors';
 import {MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES, MEMBER_WELCOME_EMAIL_SLUGS} from '../member-welcome-emails/constants';
 import {MAX_ATTEMPTS, MAX_STEPS_PER_BATCH, RETRY_DELAY_MS} from './constants';
 // @ts-expect-error Models currently lack type definitions.
-import {Member} from '../../models';
+import {AutomatedEmailRecipient, Member} from '../../models';
 
 type MemberWelcomeEmailService = {
     init: () => unknown;
@@ -165,6 +165,13 @@ const processStep = async ({
                     uuid: member.get('uuid')
                 },
                 memberStatus
+            });
+            await AutomatedEmailRecipient.add({
+                member_id: step.member_id,
+                member_uuid: member.get('uuid'),
+                member_email: member.get('email'),
+                member_name: member.get('name'),
+                automation_action_revision_id: step.automation_action_revision_id
             });
             nextReadyAt = await automationsApi.finishStepAndEnqueueNext(step);
             break;

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -1052,7 +1052,8 @@ module.exports = class EventRepository {
         options = {
             ...options,
             withRelated: ['member', 'automatedEmail.automation'],
-            filter: 'custom:true',
+            // TODO(NY-1338): Handle rows where automated_email_id is null.
+            filter: 'automated_email_id:-null+custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(
                 replaceCustomFilterTransformer(filter),

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -5,7 +5,7 @@ import {poll} from '../../../../../core/server/services/automations/poll';
 import type {AutomationStepToRun} from '../../../../../core/server/services/automations/automations-repository';
 import {MEMBER_WELCOME_EMAIL_SLUGS} from '../../../../../core/server/services/member-welcome-emails/constants';
 // @ts-expect-error Models currently lack type definitions.
-import {Member} from '../../../../../core/server/models';
+import {AutomatedEmailRecipient, Member} from '../../../../../core/server/models';
 
 const MAX_STEPS_PER_BATCH = 100;
 const RETRY_DELAY_MS = 10 * 60 * 1000;
@@ -41,6 +41,7 @@ type PollOptionsStubs = PollOptions & {
     enqueueAnotherPollAt: StubbedFunction<PollOptions['enqueueAnotherPollAt']>;
     memberWelcomeEmailService: MemberWelcomeEmailServiceStubs;
 };
+type AutomatedEmailRecipientAdd = typeof AutomatedEmailRecipient.add;
 
 type MemberFixture = {
     email: string;
@@ -109,6 +110,7 @@ function buildEmailStep(attrs: Partial<SendEmailStep> = {}): SendEmailStep {
 
 describe('automations poll', function () {
     let automationsApi: AutomationsApiStubs;
+    let automatedEmailRecipientAdd: sinon.SinonStub<Parameters<AutomatedEmailRecipientAdd>, ReturnType<AutomatedEmailRecipientAdd>>;
     let memberWelcomeEmailService: MemberWelcomeEmailServiceStubs;
     let options: PollOptionsStubs;
 
@@ -137,6 +139,7 @@ describe('automations poll', function () {
         };
 
         sinon.stub(Member, 'findOne').resolves(buildMember());
+        automatedEmailRecipientAdd = sinon.stub(AutomatedEmailRecipient, 'add').resolves();
     });
 
     afterEach(function () {
@@ -285,6 +288,28 @@ describe('automations poll', function () {
             memberStatus: 'free'
         }));
         sinon.assert.calledOnceWithExactly(options.enqueueAnotherPollAt, nextReadyAt);
+    });
+
+    it('records the automated email recipient after sending email revision content', async function () {
+        const step = buildEmailStep({
+            automation_action_revision_id: 'revision-id'
+        });
+        automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+
+        await poll(options);
+
+        sinon.assert.calledOnceWithExactly(automatedEmailRecipientAdd, {
+            member_id: step.member_id,
+            member_uuid: '00000000-0000-4000-8000-000000000001',
+            member_email: 'member@example.com',
+            member_name: 'Test Member',
+            automation_action_revision_id: 'revision-id'
+        });
+        sinon.assert.callOrder(
+            memberWelcomeEmailService.api.sendAutomationEmail,
+            automatedEmailRecipientAdd,
+            automationsApi.finishStepAndEnqueueNext
+        );
     });
 
     it('enqueues the earlier pending step instead of a later processed next step', async function () {

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -312,6 +312,20 @@ describe('automations poll', function () {
         );
     });
 
+    it('does not retry the email send when recording the automated email recipient fails', async function () {
+        const step = buildEmailStep();
+        automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+        automatedEmailRecipientAdd.rejects(new Error('recipient persistence failed'));
+
+        await poll(options);
+
+        sinon.assert.calledOnce(memberWelcomeEmailService.api.sendAutomationEmail);
+        sinon.assert.calledOnce(automatedEmailRecipientAdd);
+        sinon.assert.calledOnceWithExactly(automationsApi.finishStepAndEnqueueNext, step);
+        sinon.assert.notCalled(automationsApi.retryStep);
+        sinon.assert.notCalled(automationsApi.markStepTerminal);
+    });
+
     it('enqueues the earlier pending step instead of a later processed next step', async function () {
         const pendingReadyAt = new Date(Date.now() + 30 * 1000);
         const processedNextReadyAt = new Date(Date.now() + 60 * 1000);

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -357,7 +357,7 @@ describe('EventRepository', function () {
 
             sinon.assert.calledOnceWithMatch(fake, {
                 withRelated: ['member', 'automatedEmail.automation'],
-                filter: 'custom:true',
+                filter: 'automated_email_id:-null+custom:true',
                 order: 'created_at desc, id desc'
             });
         });
@@ -371,7 +371,7 @@ describe('EventRepository', function () {
 
             sinon.assert.calledOnceWithMatch(fake, {
                 withRelated: ['member', 'automatedEmail.automation'],
-                filter: 'custom:true',
+                filter: 'automated_email_id:-null+custom:true',
                 order: 'created_at desc, id desc'
             });
         });
@@ -386,8 +386,18 @@ describe('EventRepository', function () {
 
             sinon.assert.calledOnceWithMatch(fake, {
                 withRelated: ['member', 'automatedEmail.automation'],
-                filter: 'custom:true',
+                filter: 'automated_email_id:-null+custom:true',
                 order: 'created_at desc, id desc'
+            });
+        });
+
+        it('excludes automation action revision recipients until they are supported in the activity feed', async function () {
+            await eventRepository.getAutomatedEmailSentEvents({
+                order: 'created_at desc, id desc'
+            }, {});
+
+            sinon.assert.calledOnceWithMatch(fake, {
+                filter: 'automated_email_id:-null+custom:true'
             });
         });
 

--- a/ghost/core/test/utils/automations-fixtures.js
+++ b/ghost/core/test/utils/automations-fixtures.js
@@ -89,6 +89,16 @@ async function cleanupAutomationsFixture() {
     }
 
     if (actionIds.length > 0) {
+        const revisionIds = await db.knex('automation_action_revisions')
+            .whereIn('action_id', actionIds)
+            .pluck('id');
+
+        if (revisionIds.length > 0) {
+            await db.knex('automated_email_recipients')
+                .whereIn('automation_action_revision_id', revisionIds)
+                .del();
+        }
+
         await db.knex('automation_action_edges')
             .whereIn('source_action_id', actionIds)
             .orWhereIn('target_action_id', actionIds)


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1334/readwrite-automated-email-recipients-table-to-populate-member-details
closes https://linear.app/ghost/issue/NY-1339/insert-automated-email-recipients-row-when-automation-email-is-sent

_This change should have no user-facing impact._

## Summary
- Insert an `AutomatedEmailRecipient` row after sending an email via automation
- Capture member ID, UUID, email, name, and automation action revision ID