### PR TITLE
Removed rewire from frontend unit tests

### DIFF
--- a/ghost/core/core/frontend/meta/canonical-url.js
+++ b/ghost/core/core/frontend/meta/canonical-url.js
@@ -1,6 +1,9 @@
 const _ = require('lodash');
 const urlUtils = require('../../shared/url-utils');
-const getUrl = require('./url');
+
+const _private = {
+    getUrl: require('./url')
+};
 
 function getCanonicalUrl(data) {
     if ((_.includes(data.context, 'post') || _.includes(data.context, 'page'))
@@ -12,7 +15,8 @@ function getCanonicalUrl(data) {
         return data.tag.canonical_url;
     }
 
-    return urlUtils.urlJoin(urlUtils.urlFor('home', true), getUrl(data, false));
+    return urlUtils.urlJoin(urlUtils.urlFor('home', true), _private.getUrl(data, false));
 }
 
 module.exports = getCanonicalUrl;
+module.exports._private = _private;

--- a/ghost/core/core/frontend/services/rendering/templates.js
+++ b/ghost/core/core/frontend/services/rendering/templates.js
@@ -199,3 +199,5 @@ module.exports.setTemplate = function setTemplate(req, res, data) {
         res._template = 'index';
     }
 };
+
+module.exports._private = _private;

--- a/ghost/core/core/frontend/services/rss/cache.js
+++ b/ghost/core/core/frontend/services/rss/cache.js
@@ -1,7 +1,10 @@
 const crypto = require('crypto');
-const generateFeed = require('./generate-feed');
 const logging = require('@tryghost/logging');
 const feedCache = {};
+
+const _private = {
+    generateFeed: require('./generate-feed')
+};
 
 /**
  * @returns {string}
@@ -12,7 +15,7 @@ module.exports.getXML = function getFeedXml(baseUrl, data) {
         // We need to regenerate
         feedCache[baseUrl] = {
             hash: dataHash,
-            xml: generateFeed(baseUrl, data)
+            xml: _private.generateFeed(baseUrl, data)
         };
     } else {
         logging.info('[RSS] Serving from in-memory cache');
@@ -20,3 +23,5 @@ module.exports.getXML = function getFeedXml(baseUrl, data) {
 
     return feedCache[baseUrl].xml;
 };
+
+module.exports._private = _private;

--- a/ghost/core/test/unit/frontend/meta/canonical-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/canonical-url.test.js
@@ -1,10 +1,9 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const urlUtils = require('../../../../core/shared/url-utils');
 const testUtils = require('../../../utils');
 
-let getCanonicalUrl = rewire('../../../../core/frontend/meta/canonical-url');
+const getCanonicalUrl = require('../../../../core/frontend/meta/canonical-url');
 
 describe('getCanonicalUrl', function () {
     let getUrlStub;
@@ -12,10 +11,7 @@ describe('getCanonicalUrl', function () {
     let urlForStub;
 
     beforeEach(function () {
-        getUrlStub = sinon.stub();
-
-        getCanonicalUrl = rewire('../../../../core/frontend/meta/canonical-url');
-        getCanonicalUrl.__set__('getUrl', getUrlStub);
+        getUrlStub = sinon.stub(getCanonicalUrl._private, 'getUrl');
 
         urlJoinStub = sinon.stub(urlUtils, 'urlJoin');
         urlForStub = sinon.stub(urlUtils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');

--- a/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
+++ b/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
@@ -2,14 +2,14 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const _ = require('lodash');
 const sinon = require('sinon');
-const rewire = require('rewire');
-const getImageDimensions = rewire('../../../../core/frontend/meta/image-dimensions');
+const getImageDimensions = require('../../../../core/frontend/meta/image-dimensions');
+const imageSizeCache = require('../../../../core/server/lib/image').cachedImageSizeFromUrl;
 
 describe('getImageDimensions', function () {
     let sizeOfStub;
 
     beforeEach(function () {
-        sizeOfStub = sinon.stub();
+        sizeOfStub = sinon.stub(imageSizeCache, 'getCachedImageSizeFromUrl');
     });
 
     afterEach(function () {
@@ -38,10 +38,6 @@ describe('getImageDimensions', function () {
             width: 50,
             height: 50,
             type: 'jpg'
-        });
-
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
         });
 
         const result = await getImageDimensions(metaData);
@@ -91,10 +87,6 @@ describe('getImageDimensions', function () {
 
         sizeOfStub.returns({});
 
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
-        });
-
         const result = await getImageDimensions(metaData);
         assertExists(result);
         sinon.assert.calledWith(sizeOfStub, metaData.coverImage.url);
@@ -133,10 +125,6 @@ describe('getImageDimensions', function () {
             width: 480,
             height: 480,
             type: 'jpg'
-        });
-
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
         });
 
         const result = await getImageDimensions(metaData);
@@ -185,10 +173,6 @@ describe('getImageDimensions', function () {
             width: 80,
             height: 480,
             type: 'jpg'
-        });
-
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
         });
 
         const result = await getImageDimensions(metaData);
@@ -245,10 +229,6 @@ describe('getImageDimensions', function () {
             type: 'jpg'
         }));
 
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
-        });
-
         const result = await getImageDimensions(metaData);
         assertExists(result);
         sinon.assert.calledWith(sizeOfStub, originalMetaData.coverImage.url);
@@ -301,10 +281,6 @@ describe('getImageDimensions', function () {
             type: 'jpg'
         }));
 
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
-        });
-
         const result = await getImageDimensions(metaData);
         assertExists(result);
         assert('url' in result.coverImage);
@@ -343,10 +319,6 @@ describe('getImageDimensions', function () {
             height: 1200,
             type: 'jpg'
         }));
-
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
-        });
 
         const result = await getImageDimensions(metaData);
         assertExists(result);

--- a/ghost/core/test/unit/frontend/services/rendering/templates.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/templates.test.js
@@ -1,14 +1,13 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const rewire = require('rewire');
-const templates = rewire('../../../../../core/frontend/services/rendering/templates');
+const templates = require('../../../../../core/frontend/services/rendering/templates');
 const themeEngine = require('../../../../../core/frontend/services/theme-engine');
 
 describe('templates', function () {
     let getActiveThemeStub;
     let hasTemplateStub;
-    let _private = templates.__get__('_private');
+    const _private = templates._private;
 
     afterEach(function () {
         sinon.restore();

--- a/ghost/core/test/unit/frontend/services/rss/cache.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/cache.test.js
@@ -1,24 +1,20 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const configUtils = require('../../../../utils/config-utils');
-const rssCache = rewire('../../../../../core/frontend/services/rss/cache');
+const rssCache = require('../../../../../core/frontend/services/rss/cache');
 
 describe('RSS: Cache', function () {
     let generateSpy;
-    let generateFeedReset;
 
     afterEach(async function () {
         await configUtils.restore();
         sinon.restore();
-        generateFeedReset();
     });
 
     beforeEach(function () {
         configUtils.set({url: 'http://my-ghost-blog.com'});
 
-        generateSpy = sinon.spy(rssCache.__get__('generateFeed'));
-        generateFeedReset = rssCache.__set__('generateFeed', generateSpy);
+        generateSpy = sinon.spy(rssCache._private, 'generateFeed');
     });
 
     it('should not rebuild xml for same data and url', async function () {


### PR DESCRIPTION
## Why

`rewire` is a CommonJS-only test tool — it can't operate on ES modules — and is one of the test-side blockers for an eventual `ghost/core` ESM migration. This is the first slice of removing it from the unit suite.

## What

De-rewires 4 frontend unit tests, replacing `rewire`'s `__get__`/`__set__` with idiomatic alternatives:

- **`sinon.stub` on the shared required object** where the dependency is already an object — `image-dimensions` stubs `imageSizeCache.getCachedImageSizeFromUrl` directly. No production change.
- **a small `_private` export seam** where the dependency is a module-local object or a bare-function `require` — `templates` exposes its existing `_private`; `canonical-url` and `rss/cache` expose a `_private` holder for `getUrl` / `generateFeed`.

No `vi.mock` / `vi.spyOn`: the unit suite uses neither, because it runs with `isolate: false` where `vi.mock` leaks across files.

## Notes

- No test behaviour changes — all assertions preserved.
- `rewire` stays in `devDependencies` for now; other unit + legacy files still use it and are de-rewired in later slices.

## Testing

- The 4 files pass under Vitest.
- The full `test/unit/frontend/` lane (139 files / 1880 tests) passes, confirming the stub-on-shared-singleton seams don't leak across files.