### PR TITLE
Removed TODO comments from welcome email automation code

### DIFF
--- a/ghost/core/core/server/services/automations/welcome-email-automation-poll.js
+++ b/ghost/core/core/server/services/automations/welcome-email-automation-poll.js
@@ -213,8 +213,6 @@ async function processRun({
             return;
         }
 
-        // TODO(NY-1193): Bail if member is unsubscribed
-
         const eligibleStatuses = MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES[memberStatus];
         if (!eligibleStatuses.includes(member.get('status'))) {
             await markExited(run.id, 'member changed status');
@@ -238,8 +236,6 @@ async function processRun({
                 member_email: member.get('email'),
                 member_name: member.get('name')
             }, {transacting});
-
-            // TODO(NY-1195): Advance to next email when there are additional ones
 
             await markExited(run.id, 'finished', transacting);
         });


### PR DESCRIPTION
no ref

We plan to address these with the new automations system, not here. Removing these comments.

This change should have no user impact.
